### PR TITLE
UploadFile() can be forced to use resumable uploads.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(google_cloud_cpp_common
             internal/big_endian.h
             internal/build_info.h
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
+            internal/disjunction.h
             internal/filesystem.h
             internal/filesystem.cc
             internal/future_base.h

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -9,6 +9,7 @@ google_cloud_cpp_common_HDRS = [
     "internal/backoff_policy.h",
     "internal/big_endian.h",
     "internal/build_info.h",
+    "internal/disjunction.h",
     "internal/filesystem.h",
     "internal/future_base.h",
     "internal/future_fwd.h",

--- a/google/cloud/internal/disjunction.h
+++ b/google/cloud/internal/disjunction.h
@@ -1,0 +1,46 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_DISJUNCTION_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_DISJUNCTION_H_
+
+#include "google/cloud/version.h"
+#include <type_traits>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// A metafunction that folds || across a list of types, the specialization for
+/// an empty list.
+template <typename...>
+struct disjunction : std::false_type {};
+
+/// A metafunction that folds || across a list of types, the specialization for
+/// a single element.
+template <typename B1>
+struct disjunction<B1> : B1 {};
+
+/// A metafunction that folds || across a list of types.
+template <typename B1, typename... Bn>
+struct disjunction<B1, Bn...>
+    : std::conditional<bool(B1::value), B1, disjunction<Bn...>>::type {};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_DISJUNCTION_H_

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H_
 
+#include "google/cloud/internal/disjunction.h"
 #include "google/cloud/storage/internal/logging_client.h"
 #include "google/cloud/storage/internal/retry_client.h"
 #include "google/cloud/storage/list_buckets_reader.h"
@@ -25,6 +26,7 @@
 #include "google/cloud/storage/object_rewriter.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/retry_policy.h"
+#include "google/cloud/storage/upload_options.h"
 
 namespace google {
 namespace cloud {
@@ -753,21 +755,24 @@ class Client {
    *
    * @par Example
    * @snippet storage_object_samples.cc upload file
+   *
+   * @par Example: manually selecting a resumable upload
+   * @snippet storage_object_samples.cc upload file resumable
    */
   template <typename... Options>
   ObjectMetadata UploadFile(std::string const& file_name,
                             std::string const& bucket_name,
                             std::string const& object_name,
                             Options&&... options) {
-    if (UseSimpleUpload(file_name)) {
-      internal::InsertObjectMediaRequest request(bucket_name, object_name,
-                                                 std::string{});
-      request.set_multiple_options(std::forward<Options>(options)...);
-      return UploadFileSimple(file_name, request);
-    }
-    internal::ResumableUploadRequest request(bucket_name, object_name);
-    request.set_multiple_options(std::forward<Options>(options)...);
-    return UploadFileResumable(file_name, request);
+    // Determine, at compile time, which version of UploadFileImpl we should
+    // call. This needs to be done at compile time because ObjectInsertMedia
+    // does not support (nor should it support) the UseResumableUploadSession
+    // option.
+    using HasUseResumableUpload = google::cloud::internal::disjunction<
+        std::is_same<UseResumableUploadSession, Options>...>;
+    return UploadFileImpl(file_name, bucket_name, object_name,
+                          HasUseResumableUpload{},
+                          std::forward<Options>(options)...);
   }
 
   /**
@@ -1970,6 +1975,39 @@ class Client {
     auto retry = std::make_shared<internal::RetryClient>(
         std::move(logging), std::forward<Policies>(policies)...);
     return retry;
+  }
+
+  // The version of UploadFile() where UseResumableUploadSession is one of the
+  // options. Note how this does not use InsertObjectMedia at all.
+  template <typename... Options>
+  ObjectMetadata UploadFileImpl(std::string const& file_name,
+                                std::string const& bucket_name,
+                                std::string const& object_name,
+                                std::true_type has_resumable_option,
+                                Options&&... options) {
+    internal::ResumableUploadRequest request(bucket_name, object_name);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return UploadFileResumable(file_name, request);
+  }
+
+  // The version of UploadFile() where UseResumableUploadSession is *not* one of
+  // the options. In this case we can use InsertObjectMediaRequest because it
+  // is safe.
+  template <typename... Options>
+  ObjectMetadata UploadFileImpl(std::string const& file_name,
+                                std::string const& bucket_name,
+                                std::string const& object_name,
+                                std::false_type does_not_have_resumable_option,
+                                Options&&... options) {
+    if (UseSimpleUpload(file_name)) {
+      internal::InsertObjectMediaRequest request(bucket_name, object_name,
+                                                 std::string{});
+      request.set_multiple_options(std::forward<Options>(options)...);
+      return UploadFileSimple(file_name, request);
+    }
+    internal::ResumableUploadRequest request(bucket_name, object_name);
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return UploadFileResumable(file_name, request);
   }
 
   bool UseSimpleUpload(std::string const& file_name) const;

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -375,6 +375,42 @@ _EOF_
 }
 
 ################################################
+# Run upload and download examples.
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+#   EXIT_STATUS: control the final exit status for the program.
+# Arguments:
+#   bucket_name: the name of the bucket to run the examples against.
+# Returns:
+#   None
+################################################
+run_upload_resumable_examples() {
+  local bucket_name=$1
+  shift
+
+  local object_name="uploaded-resumable-$(date +%s)-${RANDOM}.txt"
+  local upload_file_name="$(mktemp -t "upload.XXXXXX")"
+  local download_file_name="$(mktemp -t "download.XXXXXX")"
+  cat > "${upload_file_name}" <<_EOF_
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+_EOF_
+
+  run_example ./storage_object_samples upload-file-resumable \
+      "${upload_file_name}" "${bucket_name}" "${object_name}"
+  run_example ./storage_object_samples download-file \
+      "${bucket_name}" "${object_name}" "${download_file_name}"
+  diff "${upload_file_name}" "${download_file_name}"
+
+  run_example ./storage_object_samples delete-object \
+      "${bucket_name}" "${object_name}"
+}
+
+################################################
 # Run the example showing how to rewrite one object.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
@@ -772,6 +808,7 @@ run_all_storage_examples() {
   run_all_requester_pays_examples
   run_all_object_examples "${BUCKET_NAME}"
   run_upload_and_download_examples "${BUCKET_NAME}"
+  run_upload_resumable_examples "${BUCKET_NAME}"
   run_all_object_rewrite_examples "${BUCKET_NAME}" "${DESTINATION_BUCKET_NAME}"
   run_all_public_object_examples "${BUCKET_NAME}"
   run_event_based_hold_examples "${BUCKET_NAME}"

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -345,6 +345,30 @@ void UploadFile(google::cloud::storage::Client client, int& argc,
   (std::move(client), file_name, bucket_name, object_name);
 }
 
+void UploadFileResumable(google::cloud::storage::Client client, int& argc,
+                         char* argv[]) {
+  if (argc != 4) {
+    throw Usage{"upload-file-resumable <file-name> <bucket-name> <object-name>"};
+  }
+  auto file_name = ConsumeArg(argc, argv);
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+
+  //! [upload file resumable]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string file_name, std::string bucket_name,
+     std::string object_name) {
+    // Note that the client library automatically computes a hash on the
+    // client-side to verify data integrity during transmission.
+    gcs::ObjectMetadata meta = client.UploadFile(
+        file_name, bucket_name, object_name, gcs::IfGenerationMatch(0),
+        gcs::NewResumableUploadSession());
+    std::cout << "Uploaded " << file_name << " to " << object_name << std::endl;
+  }
+  //! [upload file resumable]
+  (std::move(client), file_name, bucket_name, object_name);
+}
+
 void DownloadFile(google::cloud::storage::Client client, int& argc,
                   char* argv[]) {
   if (argc != 4) {
@@ -965,6 +989,7 @@ int main(int argc, char* argv[]) try {
       {"write-object", &WriteObject},
       {"write-large-object", &WriteLargeObject},
       {"upload-file", &UploadFile},
+      {"upload-file-resumable", &UploadFileResumable},
       {"download-file", &DownloadFile},
       {"update-object-metadata", &UpdateObjectMetadata},
       {"patch-object-delete-metadata", &PatchObjectDeleteMetadata},


### PR DESCRIPTION
With this change the application developer can decide force the library
to use resumable uploads in UploadFile(). I added the usual integration
tests and examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1594)
<!-- Reviewable:end -->
