### PR TITLE
Fix handling of StatusCode vs. HTTP status code.

### DIFF
--- a/google/cloud/storage/internal/curl_resumable_streambuf.cc
+++ b/google/cloud/storage/internal/curl_resumable_streambuf.cc
@@ -124,8 +124,9 @@ StatusOr<HttpResponse> CurlResumableStreambuf::Flush(bool final_chunk) {
     upload_session_.reset();
   }
 
-  last_response_ = HttpResponse{
-      result.status().code(), std::move(result).value().payload, {}};
+  // If `result.ok() == false` we never get to this point, so the last response
+  // was actually successful, represent that by a HTTP 200 status code.
+  last_response_ = HttpResponse{200, std::move(result).value().payload, {}};
   return last_response_;
 }
 


### PR DESCRIPTION
We were using a StatusCode as a HTTP code, that is not what we need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1844)
<!-- Reviewable:end -->
