### PR TITLE
Bulk mutator fixes

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -149,9 +149,11 @@ std::vector<FailedMutation> BulkMutator::ExtractFinalFailures() {
   std::vector<FailedMutation> result(std::move(failures_));
   google::rpc::Status ok_status;
   ok_status.set_code(grpc::StatusCode::OK);
+  int idx = 0;
   for (auto& mutation : *pending_mutations_.mutable_entries()) {
-    result.emplace_back(
-        FailedMutation(SingleRowMutation(std::move(mutation)), ok_status));
+    auto &annotation = pending_annotations_[idx++];
+    result.emplace_back(FailedMutation(SingleRowMutation(std::move(mutation)),
+                                       ok_status, annotation.original_index));
   }
   return result;
 }

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -162,9 +162,9 @@ std::vector<FailedMutation> BulkMutator::ExtractFinalFailures() {
       "broken before its status was sent.");
   int idx = 0;
   for (auto& mutation : *pending_mutations_.mutable_entries()) {
-    auto &annotation = pending_annotations_[idx++];
+    int original_index = pending_annotations_[idx++].original_index;
     result.emplace_back(FailedMutation(SingleRowMutation(std::move(mutation)),
-                                       status, annotation.original_index));
+                                       status, original_index));
   }
   return result;
 }

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -300,8 +300,6 @@ class SingleRowMutation {
  */
 class FailedMutation {
  public:
-  FailedMutation(SingleRowMutation mut, google::rpc::Status status)
-      : FailedMutation(std::move(mut), std::move(status), -1) {}
   FailedMutation(SingleRowMutation mut, google::rpc::Status status, int index)
       : mutation_(std::move(mut)),
         status_(ToGrpcStatus(status)),

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -163,11 +163,12 @@ TEST(MutationsTest, FailedMutation) {
   status.add_details()->PackFrom(retry);
   status.add_details()->PackFrom(debug_info);
 
-  bigtable::FailedMutation fm(std::move(mut), std::move(status));
+  bigtable::FailedMutation fm(std::move(mut), std::move(status), 27);
   EXPECT_EQ(grpc::StatusCode::FAILED_PRECONDITION, fm.status().error_code());
   EXPECT_EQ("something failed", fm.status().error_message());
   EXPECT_FALSE(fm.status().error_details().empty());
   EXPECT_EQ("foo", fm.mutation().row_key());
+  EXPECT_EQ(27, fm.original_index());
 }
 
 /// @test Verify that MultipleRowMutations works as expected.


### PR DESCRIPTION
This addresses two issues in `BulkMutator`:
* -1 as index in mutations which have never been confirmed by the service
* OK status returned for such mutations.

Whenever a mutation was not confirmed by the service (e.g. because the stream was broken every retry), it was returned as failed (correct) with -1 as original index (incorrect).

In such cases OK was returned, which was very confusing - it broke the invariant that every failure has a non-zero exit code, which I believe users would assume.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1880)
<!-- Reviewable:end -->
