### PR TITLE
Add streaming to (Async)BulkMutator.

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -81,8 +81,9 @@ void BulkMutator::PrepareForRequest() {
   pending_annotations_ = {};
 }
 
-void BulkMutator::ProcessResponse(
+std::vector<int> BulkMutator::ProcessResponse(
     google::bigtable::v2::MutateRowsResponse& response) {
+  std::vector<int> res;
   for (auto& entry : *response.mutable_entries()) {
     auto index = entry.index();
     if (index < 0 || annotations_.size() <= std::size_t(index)) {
@@ -97,6 +98,7 @@ void BulkMutator::ProcessResponse(
     // the failures.  The data for successful responses is discarded, because
     // this class takes ownership in the constructor.
     if (grpc::StatusCode::OK == code) {
+      res.push_back(annotation.original_index);
       continue;
     }
     auto& original = *mutations_.mutable_entries(index);
@@ -116,6 +118,7 @@ void BulkMutator::ProcessResponse(
                              annotation.original_index);
     }
   }
+  return res;
 }
 
 void BulkMutator::FinishRequest() {
@@ -148,6 +151,12 @@ void BulkMutator::FinishRequest() {
     }
     ++index;
   }
+}
+
+std::vector<FailedMutation> BulkMutator::ConsumeAccumulatedFailures() {
+  std::vector<FailedMutation> res;
+  res.swap(failures_);
+  return res;
 }
 
 std::vector<FailedMutation> BulkMutator::ExtractFinalFailures() {

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -517,6 +517,51 @@ class Table {
   //@}
 
  private:
+  friend class NoexTableStreamingAsyncBulkApplyTest_SimpleTest_Test;
+  /**
+   * Make an asynchronous request to mutate a multiple rows and stream results.
+   *
+   * @param mut the bulk mutation to apply.
+   * @param cq the completion queue that will execute the asynchronous calls,
+   *     the application must ensure that one or more threads are blocked on
+   *     `cq.Run()`.
+   * @param callback a functor to be called when the operation completes. It
+   *     must satisfy (using C++17 types):
+   *     static_assert(std::is_invocable_v<
+   *         Functor, CompletionQueue&, std::vector<FailedMutation>&,
+   *             grpc::Status&>);
+   * @return a handle to the submitted operation
+   *
+   * @tparam Functor the type of the callback.
+   */
+  template <typename Functor,
+            typename std::enable_if<
+                google::cloud::internal::is_invocable<
+                    Functor, CompletionQueue&, std::vector<FailedMutation>&,
+                    grpc::Status&>::value,
+                int>::type valid_callback_type = 0>
+  std::shared_ptr<AsyncOperation> StreamingAsyncBulkApply(
+      CompletionQueue& cq,
+      typename internal::AsyncRetryBulkApply<
+          Functor>::MutationsSucceededFunctor&& mutations_succeeded_callback,
+      typename internal::AsyncRetryBulkApply<Functor>::MutationsFailedFunctor&&
+          mutations_failed_callback,
+      typename internal::AsyncRetryBulkApply<Functor>::AttemptFinishedFunctor&&
+          attempt_finished_callback,
+      Functor&& callback, BulkMutation&& mut) {
+    auto op =
+        std::make_shared<bigtable::internal::AsyncRetryBulkApply<Functor>>(
+            rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
+            *idempotent_mutation_policy_, metadata_update_policy_, client_,
+            app_profile_id_, table_name_, std::move(mut),
+            std::move(mutations_succeeded_callback),
+            std::move(mutations_failed_callback),
+            std::move(attempt_finished_callback),
+            std::forward<Functor>(callback));
+
+    return op->Start(cq);
+  }
+
   //@{
   /// @name Helper functions to implement constructors with changed policies.
   void ChangePolicy(RPCRetryPolicy& policy) {

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/bigtable/testing/mock_completion_queue.h"
 #include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
 #include "google/cloud/testing_util/chrono_literals.h"
+#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 #include <thread>
 
@@ -25,7 +26,6 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace noex {
-namespace {
 
 namespace bt = ::google::cloud::bigtable;
 namespace btproto = google::bigtable::v2;
@@ -193,7 +193,8 @@ TEST_F(NoexTableAsyncBulkApplyTest, Cancelled) {
                           EXPECT_EQ(grpc::StatusCode::CANCELLED,
                                     status.error_code());
                           mutator_finished = true;
-                        }, std::move(mut));
+                        },
+                        std::move(mut));
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, false);
@@ -336,7 +337,240 @@ TEST_F(NoexTableAsyncBulkApplyTest, CancelledInTimer) {
   EXPECT_TRUE(mutator_finished);
 }
 
-}  // namespace
+class NoexTableStreamingAsyncBulkApplyTest
+    : public bigtable::testing::internal::TableTestFixture {};
+
+// @test Verify that noex::Table::StreamingAsyncBulkApply() works.
+TEST_F(NoexTableStreamingAsyncBulkApplyTest, SimpleTest) {
+  // Will succeed in the first batch in the first attempt
+  SingleRowMutation succeed_first_batch("r1",
+                                        {SetCell("fam", "col", 0_ms, "qux")});
+  // Will succeed in the second batch in the first attempt
+  SingleRowMutation succeed_second_batch("r2",
+                                         {SetCell("fam", "col", 0_ms, "qux")});
+  // Will transiently fail in the first attempt and succeed in the second
+  SingleRowMutation transient_failure("r3",
+                                      {SetCell("fam", "col", 0_ms, "qux")});
+  // Will permanently fail in the first attempt
+  SingleRowMutation permanent_failure("r5",
+                                      {SetCell("fam", "col", 0_ms, "qux")});
+  // Will never be confirmed
+  SingleRowMutation never_confirmed("r6", {SetCell("fam", "col", 0_ms, "qux")});
+
+  std::vector<SingleRowMutation> mutations{
+      succeed_first_batch, succeed_second_batch, transient_failure,
+      permanent_failure, never_confirmed};
+  bt::BulkMutation mut(mutations.begin(), mutations.end());
+
+  using bigtable::testing::MockClientAsyncReaderInterface;
+
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader1 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  MockClientAsyncReaderInterface<btproto::MutateRowsResponse>* reader2 =
+      new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
+  EXPECT_CALL(*reader1, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          // succeed_first_batch
+          auto& e = *r->add_entries();
+          e.set_index(0);
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+        {
+          // transient_failure
+          auto& e = *r->add_entries();
+          e.set_index(2);
+          e.mutable_status()->set_code(grpc::StatusCode::UNAVAILABLE);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          // succeed_second_batch
+          auto& e = *r->add_entries();
+          e.set_index(1);
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+        {
+          // permanent_failure
+          auto& e = *r->add_entries();
+          e.set_index(3);
+          e.mutable_status()->set_code(grpc::StatusCode::PERMISSION_DENIED);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
+  EXPECT_CALL(*reader1, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "mocked-status");
+      }));
+
+  EXPECT_CALL(*reader2, Read(_, _))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {
+        {
+          // transient_failure now succeds
+          auto& e = *r->add_entries();
+          e.set_index(0);  // used to be index 2, but in the second attempt is 0
+          e.mutable_status()->set_code(grpc::StatusCode::OK);
+        }
+      }))
+      .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
+  EXPECT_CALL(*reader2, Finish(_, _))
+      .WillOnce(Invoke([](grpc::Status* status, void*) {
+        // this should make the retry loop stop
+        *status =
+            grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "mocked-status");
+      }));
+
+  EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
+      .WillOnce(Invoke([&reader1, mutations](
+                           grpc::ClientContext*,
+                           btproto::MutateRowsRequest const& req,
+                           grpc::CompletionQueue*, void*) {
+        int i = 0;
+        std::vector<SingleRowMutation> mutations_copy(mutations);
+        for (auto& m : mutations_copy) {
+          google::bigtable::v2::MutateRowsRequest::Entry expected;
+          m.MoveTo(&expected);
+          std::string delta;
+          google::protobuf::util::MessageDifferencer differencer;
+          differencer.ReportDifferencesToString(&delta);
+          EXPECT_TRUE(differencer.Compare(expected, req.entries(i++))) << delta;
+        }
+        return std::unique_ptr<
+            MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>(
+            reader1);
+      }))
+      .WillOnce(Invoke([&reader2, transient_failure, never_confirmed](
+                           grpc::ClientContext*,
+                           btproto::MutateRowsRequest const& req,
+                           grpc::CompletionQueue*, void*) {
+        EXPECT_EQ(2, req.entries_size());
+        {
+          google::bigtable::v2::MutateRowsRequest::Entry expected;
+          SingleRowMutation transient_failure_copy(transient_failure);
+          transient_failure_copy.MoveTo(&expected);
+          std::string delta;
+          google::protobuf::util::MessageDifferencer differencer;
+          differencer.ReportDifferencesToString(&delta);
+          EXPECT_TRUE(differencer.Compare(expected, req.entries(0))) << delta;
+        }
+        {
+          google::bigtable::v2::MutateRowsRequest::Entry expected;
+          SingleRowMutation never_confirmed_copy(never_confirmed);
+          never_confirmed_copy.MoveTo(&expected);
+          std::string delta;
+          google::protobuf::util::MessageDifferencer differencer;
+          differencer.ReportDifferencesToString(&delta);
+          EXPECT_TRUE(differencer.Compare(expected, req.entries(1))) << delta;
+        }
+        return std::unique_ptr<
+            MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>(
+            reader2);
+      }));
+
+  auto policy = bt::DefaultIdempotentMutationPolicy();
+  auto cq_impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
+  using bigtable::CompletionQueue;
+  bigtable::CompletionQueue cq(cq_impl);
+
+  std::vector<int> succeeded_mutations;
+  std::vector<FailedMutation> failed_mutations_intermediate;
+  std::vector<FailedMutation> failed_mutations_final;
+  bool attempt_finished = false;
+  bool whole_op_finished = false;
+  table_.StreamingAsyncBulkApply(
+      cq,
+      [&succeeded_mutations](CompletionQueue& cq, std::vector<int> succeeded) {
+        succeeded_mutations.swap(succeeded);
+      },
+      [&failed_mutations_intermediate](CompletionQueue& cq,
+                                       std::vector<FailedMutation> failed) {
+        failed_mutations_intermediate.swap(failed);
+      },
+      [&attempt_finished](CompletionQueue& cq, grpc::Status&) {
+        attempt_finished = true;
+      },
+      [&whole_op_finished, &failed_mutations_final](
+          CompletionQueue& cq, std::vector<FailedMutation>& failed,
+          grpc::Status& status) {
+        EXPECT_FALSE(status.ok());
+        EXPECT_EQ(grpc::StatusCode::PERMISSION_DENIED, status.error_code());
+        whole_op_finished = true;
+        failed_mutations_final.swap(failed);
+      },
+      std::move(mut));
+
+  cq_impl->SimulateCompletion(cq, true);
+  // state == PROCESSING
+  cq_impl->SimulateCompletion(cq, true);
+  // state == PROCESSING, 1 read
+
+  ASSERT_EQ(1, succeeded_mutations.size());
+  // succeed_first_batch
+  ASSERT_EQ(0, succeeded_mutations[0]);
+  succeeded_mutations.clear();
+
+  ASSERT_TRUE(failed_mutations_intermediate.empty());
+  ASSERT_FALSE(whole_op_finished);
+  ASSERT_TRUE(failed_mutations_final.empty());
+  ASSERT_FALSE(attempt_finished);
+
+  cq_impl->SimulateCompletion(cq, true);
+  // state == PROCESSING, 2 read
+
+  // succeed_second_batch
+  ASSERT_EQ(1, succeeded_mutations.size());
+  EXPECT_EQ(1, succeeded_mutations[0]);
+  succeeded_mutations.clear();
+
+  // permanent_failure
+  ASSERT_EQ(1, failed_mutations_intermediate.size());
+  ASSERT_EQ(3, failed_mutations_intermediate[0].original_index());
+  failed_mutations_intermediate.clear();
+
+  ASSERT_FALSE(whole_op_finished);
+  ASSERT_TRUE(failed_mutations_final.empty());
+  ASSERT_FALSE(attempt_finished);
+
+  cq_impl->SimulateCompletion(cq, false);
+  // state == FINISHING
+
+  cq_impl->SimulateCompletion(cq, true);
+  // in timer
+
+  ASSERT_FALSE(whole_op_finished);
+  ASSERT_TRUE(failed_mutations_final.empty());
+  ASSERT_TRUE(attempt_finished);
+  attempt_finished = false;
+
+  cq_impl->SimulateCompletion(cq, true);
+  // timer finished
+  cq_impl->SimulateCompletion(cq, true);
+  // state == PROCESSING
+  cq_impl->SimulateCompletion(cq, true);
+  // state == PROCESSING, 1 read
+
+  ASSERT_EQ(1, succeeded_mutations.size());
+  // transient_failure
+  ASSERT_EQ(2, succeeded_mutations[0]);
+  succeeded_mutations.clear();
+  ASSERT_FALSE(whole_op_finished);
+  ASSERT_FALSE(attempt_finished);
+  ASSERT_TRUE(failed_mutations_intermediate.empty());
+  ASSERT_TRUE(failed_mutations_final.empty());
+
+  cq_impl->SimulateCompletion(cq, false);
+  // state == FINISHING
+  cq_impl->SimulateCompletion(cq, true);
+  ASSERT_EQ(0, cq_impl->size());
+
+  ASSERT_TRUE(whole_op_finished);
+  ASSERT_TRUE(attempt_finished);
+  ASSERT_TRUE(failed_mutations_intermediate.empty());
+  ASSERT_EQ(1, failed_mutations_final.size());
+  // never_confirmed
+  ASSERT_EQ(4, failed_mutations_final[0].original_index());
+}
+
 }  // namespace noex
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable


### PR DESCRIPTION
This is going to be needed for efficient flow control in
MutationBatcher. It allows for releasing resources for mutations which
we know are finished.

The rationale is that without it the whole batch will hold the resources
until all requests are finished (either successfully or failed or time
out). Given that batches can contain up to 100K mutations, an outlier
taking ridiculously long would be the common case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1881)
<!-- Reviewable:end -->
