### PR TITLE
Disable `make install` for external projects.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -424,25 +424,27 @@ endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
 if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external"
     OR "${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "external")
-    set(GOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL "ON")
-else()
     set(GOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL "OFF")
-    message(WARNING [===[
-The install target has been disabled for the bigtable_client library because
-one of the dependencies is set to use external projects. When building against
-external projects the resulting libraries are not installable. The necessary
-dependencies may not installed in your system, or the versions installed in your
-system may not match the version used to compile the google-cloud-cpp libraries.
-Please consult the README.md file for details on how to compile against
-pre-installed versions of the google-cloud-cpp dependencies.
-
+    message(
+        WARNING
+            "The install target has been disabled for the bigtable_client"
+            " library because one of the dependencies is set to use external"
+            " projects. When building against external projects the resulting"
+            " libraries are not installable. The necessary dependencies may"
+            " not installed in your system, or the versions installed in your"
+            " system may not match the version used to compile the"
+            " google-cloud-cpp libraries. "
+            ""
+            "Please consult the README.md file for details on how to compile "
+            "against pre-installed versions of the google-cloud-cpp "
+            "dependencies.
 GPRC     PROVIDER = ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}
-PROTOBUF PROVIDER = ${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}
-
-]===])
+PROTOBUF PROVIDER = ${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}")
+else()
+    set(GOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL "ON")
 endif ()
 
-if ($"{GOOGLE_CLOUD_CPP_BIGTABLE_DISABLE_INSTALL}")
+if ("${GOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL}")
     # Install the libraries and headers in the locations determined by
     # GNUInstallDirs
     install(TARGETS bigtable_protos bigtable_common_options

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -422,48 +422,72 @@ if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_subdirectory(examples)
 endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(TARGETS bigtable_protos bigtable_common_options
-        EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external"
+    OR "${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "external")
+    set(GOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL "ON")
+else()
+    set(GOOGLE_CLOUD_CPP_BIGTABLE_ENABLE_INSTALL "OFF")
+    message(WARNING [===[
+The install target has been disabled for the bigtable_client library because
+one of the dependencies is set to use external projects. When building against
+external projects the resulting libraries are not installable. The necessary
+dependencies may not installed in your system, or the versions installed in your
+system may not match the version used to compile the google-cloud-cpp libraries.
+Please consult the README.md file for details on how to compile against
+pre-installed versions of the google-cloud-cpp dependencies.
 
-# Install proto generated files into include/google.
-google_cloud_cpp_install_headers(bigtable_protos include)
+GPRC     PROVIDER = ${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}
+PROTOBUF PROVIDER = ${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}
 
-# Export the CMake targets to make it easy to create configuration files.
-install(EXPORT bigtable-targets
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/bigtable_client")
+]===])
+endif ()
 
-install(TARGETS bigtable_client
-        EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-google_cloud_cpp_install_headers(bigtable_client include/google/cloud/bigtable)
+if ($"{GOOGLE_CLOUD_CPP_BIGTABLE_DISABLE_INSTALL}")
+    # Install the libraries and headers in the locations determined by
+    # GNUInstallDirs
+    install(TARGETS bigtable_protos bigtable_common_options
+            EXPORT bigtable-targets
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${BIGTABLE_CLIENT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR ${BIGTABLE_CLIENT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${BIGTABLE_CLIENT_VERSION_PATCH})
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Bigtable C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud Bigtable.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lbigtable_client -lbigtable_protos")
+    # Install proto generated files into include/google.
+    google_cloud_cpp_install_headers(bigtable_protos include)
 
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
-               "bigtable_client.pc" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client.pc" DESTINATION
-              "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    # Export the CMake targets to make it easy to create configuration files.
+    install(EXPORT bigtable-targets
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/bigtable_client")
 
-# Create and install the CMake configuration files.
-configure_file("config.cmake.in" "bigtable_client-config.cmake" @ONLY)
-configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config-version.cmake.in"
-               "bigtable_client-config-version.cmake" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config.cmake"
+    install(TARGETS bigtable_client
+            EXPORT bigtable-targets
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    google_cloud_cpp_install_headers(bigtable_client
+                                     include/google/cloud/bigtable)
+
+    # Setup global variables used in the following *.in files.
+    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${BIGTABLE_CLIENT_VERSION_MAJOR})
+    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR ${BIGTABLE_CLIENT_VERSION_MINOR})
+    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${BIGTABLE_CLIENT_VERSION_PATCH})
+    set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Bigtable C++ Client Library")
+    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+        "Provides C++ APIs to access Google Cloud Bigtable.")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lbigtable_client -lbigtable_protos")
+
+    # Create and install the pkg-config files.
+    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
+                   "bigtable_client.pc" @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client.pc" DESTINATION
+                  "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+    # Create and install the CMake configuration files.
+    configure_file("config.cmake.in" "bigtable_client-config.cmake" @ONLY)
+    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config-version.cmake.in"
+                   "bigtable_client-config-version.cmake" @ONLY)
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/bigtable_client-config-version.cmake"
               DESTINATION
               "${CMAKE_INSTALL_LIBDIR}/cmake/bigtable_client")
+endif ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -386,25 +386,28 @@ endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
 if ("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" STREQUAL "external"
     OR "${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "external")
-    set(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL "ON")
-else()
     set(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL "OFF")
-    message(WARNING [===[
-The install target has been disabled for the storage_client library because
-one of the dependencies is set to use external projects. When building against
-external projects the resulting libraries are not installable. The necessary
-dependencies may not installed in your system, or the versions installed in your
-system may not match the version used to compile the google-cloud-cpp libraries.
-Please consult the README.md file for details on how to compile against
-pre-installed versions of the google-cloud-cpp dependencies.
+    message(
+        WARNING
+            "The install target has been disabled for the storage_client"
+            " library because one of the dependencies is set to use external"
+            " projects. When building against external projects the resulting"
+            " libraries are not installable. The necessary dependencies may"
+            " not installed in your system, or the versions installed in your"
+            " system may not match the version used to compile the"
+            " google-cloud-cpp libraries. "
+            ""
+            "Please consult the README.md file for details on how to compile "
+            "against pre-installed versions of the google-cloud-cpp "
+            "dependencies.
 
 CRC32C PROVIDER = ${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}
-CURL   PROVIDER = ${GOOGLE_CLOUD_CPP_CURL_PROVIDER}
-
-]===])
+CURL   PROVIDER = ${GOOGLE_CLOUD_CPP_CURL_PROVIDER}")
+else()
+    set(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL "ON")
 endif ()
 
-if ($"{GOOGLE_CLOUD_CPP_STORAGE_DISABLE_INSTALL}")
+if ("${GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL}")
     # Install the libraries and headers in the locations determined by
     # GNUInstallDirs
     install(TARGETS storage_common_options nlohmann_json

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -384,49 +384,73 @@ if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
     add_subdirectory(examples)
 endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 
-# Install the libraries and headers in the locations determined by
-# GNUInstallDirs
-install(TARGETS storage_common_options nlohmann_json
-        EXPORT storage-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if ("${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}" STREQUAL "external"
+    OR "${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "external")
+    set(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL "ON")
+else()
+    set(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL "OFF")
+    message(WARNING [===[
+The install target has been disabled for the storage_client library because
+one of the dependencies is set to use external projects. When building against
+external projects the resulting libraries are not installable. The necessary
+dependencies may not installed in your system, or the versions installed in your
+system may not match the version used to compile the google-cloud-cpp libraries.
+Please consult the README.md file for details on how to compile against
+pre-installed versions of the google-cloud-cpp dependencies.
 
-# Export the CMake targets to make it easy to create configuration files.
-install(EXPORT storage-targets
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/storage_client")
+CRC32C PROVIDER = ${GOOGLE_CLOUD_CPP_CRC32C_PROVIDER}
+CURL   PROVIDER = ${GOOGLE_CLOUD_CPP_CURL_PROVIDER}
 
-install(TARGETS storage_client
-        EXPORT storage-targets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-google_cloud_cpp_install_headers(storage_client include/google/cloud/storage)
-install(
-    FILES
-        ${CMAKE_BINARY_DIR}/external/nlohmann_json/include/google/cloud/storage/internal/nlohmann_json.hpp
-        DESTINATION include/google/cloud/storage/internal)
+]===])
+endif ()
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${STORAGE_CLIENT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR ${STORAGE_CLIENT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${STORAGE_CLIENT_VERSION_PATCH})
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Storage C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud Storage.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lstorage_client")
+if ($"{GOOGLE_CLOUD_CPP_STORAGE_DISABLE_INSTALL}")
+    # Install the libraries and headers in the locations determined by
+    # GNUInstallDirs
+    install(TARGETS storage_common_options nlohmann_json
+            EXPORT storage-targets
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
-               "storage_client.pc" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/storage_client.pc" DESTINATION
-              "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    # Export the CMake targets to make it easy to create configuration files.
+    install(EXPORT storage-targets
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/storage_client")
 
-# Create and install the CMake configuration files.
-configure_file("config.cmake.in" "storage_client-config.cmake" @ONLY)
-configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config-version.cmake.in"
-               "storage_client-config-version.cmake" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/storage_client-config.cmake"
+    install(TARGETS storage_client
+            EXPORT storage-targets
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    google_cloud_cpp_install_headers(
+        storage_client include/google/cloud/storage)
+    install(
+        FILES
+            ${CMAKE_BINARY_DIR}/external/nlohmann_json/include/google/cloud/storage/internal/nlohmann_json.hpp
+            DESTINATION include/google/cloud/storage/internal)
+
+    # Setup global variables used in the following *.in files.
+    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${STORAGE_CLIENT_VERSION_MAJOR})
+    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR ${STORAGE_CLIENT_VERSION_MINOR})
+    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${STORAGE_CLIENT_VERSION_PATCH})
+    set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Storage C++ Client Library")
+    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+        "Provides C++ APIs to access Google Cloud Storage.")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lstorage_client")
+
+    # Create and install the pkg-config files.
+    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
+                   "storage_client.pc" @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/storage_client.pc" DESTINATION
+                  "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+    # Create and install the CMake configuration files.
+    configure_file("config.cmake.in" "storage_client-config.cmake" @ONLY)
+    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config-version.cmake.in"
+                   "storage_client-config-version.cmake" @ONLY)
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/storage_client-config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/storage_client-config-version.cmake"
               DESTINATION
               "${CMAKE_INSTALL_LIBDIR}/cmake/storage_client")
+endif ()


### PR DESCRIPTION
When compiling against dependencies obtained via `ExternalProject_Add`
we should disable the `make install` rule: the dependencies may not be
installed in the system, or may not be the same version used to compile
the code. A future PR will improve the documentation to explain how to
build the system with `make install` support.

This fixes #1883

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/google-cloud-cpp/1885)
<!-- Reviewable:end -->
