### PR TITLE
LockBucketRetentionPolicy returns a BucketMetadata.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -647,13 +647,13 @@ class Client {
    *     of how to use the Bucket Lock and retention policy features.
    */
   template <typename... Options>
-  StatusOr<void> LockBucketRetentionPolicy(std::string const& bucket_name,
-                                           std::uint64_t metageneration,
-                                           Options&&... options) {
+  StatusOr<BucketMetadata> LockBucketRetentionPolicy(
+      std::string const& bucket_name, std::uint64_t metageneration,
+      Options&&... options) {
     internal::LockBucketRetentionPolicyRequest request(bucket_name,
                                                        metageneration);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->LockBucketRetentionPolicy(request).status();
+    return raw_client_->LockBucketRetentionPolicy(request);
   }
   //@}
 

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -1028,18 +1028,31 @@ void LockRetentionPolicy(google::cloud::storage::Client client, int& argc,
       return;
     }
 
-    StatusOr<gcs::BucketMetadata> updated = client.LockBucketRetentionPolicy(
-        bucket_name, original->metageneration());
+    StatusOr<gcs::BucketMetadata> updated_metadata =
+        client.LockBucketRetentionPolicy(bucket_name,
+                                         original->metageneration());
 
-    if (!updated) {
+    if (!updated_metadata) {
       std::cerr << "Error locking bucket retention policy for bucket "
-                << bucket_name << ", status=" << updated.status() << std::endl;
+                << bucket_name << ", status=" << updated_metadata.status()
+                << std::endl;
+      return;
+    }
+
+    if (!updated_metadata->has_retention_policy()) {
+      std::cerr << "The bucket " << updated_metadata->name()
+                << " does not have a retention policy, even though the"
+                << " operation to set it was successful.\n"
+                << "This is unexpected, and may indicate that another"
+                << " application has modified the bucket concurrently."
+                << std::endl;
       return;
     }
 
     std::cout << "Retention policy successfully locked for bucket "
-              << updated->name() << "\nFull metadata: " << *updated
-              << std::endl;
+              << updated_metadata->name() << "\nNew retention policy is: "
+              << updated_metadata->retention_policy()
+              << "\nFull metadata: " << *updated_metadata << std::endl;
   }
   // [END storage_lock_retention_policy]
   //! [lock retention policy]

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -1028,16 +1028,18 @@ void LockRetentionPolicy(google::cloud::storage::Client client, int& argc,
       return;
     }
 
-    StatusOr<void> status = client.LockBucketRetentionPolicy(
+    StatusOr<gcs::BucketMetadata> updated = client.LockBucketRetentionPolicy(
         bucket_name, original->metageneration());
 
-    if (!status) {
+    if (!updated) {
       std::cerr << "Error locking bucket retention policy for bucket "
-                << bucket_name << ", status=" << status.status() << std::endl;
+                << bucket_name << ", status=" << updated.status() << std::endl;
+      return;
     }
 
     std::cout << "Retention policy successfully locked for bucket "
-              << bucket_name << std::endl;
+              << updated->name() << "\nFull metadata: " << *updated
+              << std::endl;
   }
   // [END storage_lock_retention_policy]
   //! [lock retention policy]

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -452,7 +452,7 @@ StatusOr<TestBucketIamPermissionsResponse> CurlClient::TestBucketIamPermissions(
   return TestBucketIamPermissionsResponse::FromHttpResponse(*response);
 }
 
-StatusOr<EmptyResponse> CurlClient::LockBucketRetentionPolicy(
+StatusOr<BucketMetadata> CurlClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b/" + request.bucket_name() +
                                  "/lockRetentionPolicy",
@@ -464,7 +464,8 @@ StatusOr<EmptyResponse> CurlClient::LockBucketRetentionPolicy(
   builder.AddHeader("content-type: application/json");
   builder.AddHeader("content-length: 0");
   builder.AddOption(IfMetagenerationMatch(request.metageneration()));
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return CheckedFromString<BucketMetadataParser>(
+      builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMedia(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -85,7 +85,7 @@ class CurlClient : public RawClient,
       SetBucketIamPolicyRequest const& request) override;
   StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) override;
-  StatusOr<EmptyResponse> LockBucketRetentionPolicy(
+  StatusOr<BucketMetadata> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) override;
 
   StatusOr<ObjectMetadata> InsertObjectMedia(

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -134,7 +134,7 @@ LoggingClient::TestBucketIamPermissions(
                   __func__);
 }
 
-StatusOr<EmptyResponse> LoggingClient::LockBucketRetentionPolicy(
+StatusOr<BucketMetadata> LoggingClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
   return MakeCall(*client_, &RawClient::LockBucketRetentionPolicy, request,
                   __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -49,7 +49,7 @@ class LoggingClient : public RawClient {
       SetBucketIamPolicyRequest const& request) override;
   StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) override;
-  StatusOr<EmptyResponse> LockBucketRetentionPolicy(
+  StatusOr<BucketMetadata> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) override;
 
   StatusOr<ObjectMetadata> InsertObjectMedia(

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -65,7 +65,7 @@ class RawClient {
       SetBucketIamPolicyRequest const& request) = 0;
   virtual StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) = 0;
-  virtual StatusOr<EmptyResponse> LockBucketRetentionPolicy(
+  virtual StatusOr<BucketMetadata> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) = 0;
   //@}
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -216,7 +216,7 @@ RetryClient::TestBucketIamPermissions(
                    __func__);
 }
 
-StatusOr<EmptyResponse> RetryClient::LockBucketRetentionPolicy(
+StatusOr<BucketMetadata> RetryClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -63,7 +63,7 @@ class RetryClient : public RawClient {
       SetBucketIamPolicyRequest const& request) override;
   StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
       TestBucketIamPermissionsRequest const& request) override;
-  StatusOr<EmptyResponse> LockBucketRetentionPolicy(
+  StatusOr<BucketMetadata> LockBucketRetentionPolicy(
       LockBucketRetentionPolicyRequest const& request) override;
 
   StatusOr<ObjectMetadata> InsertObjectMedia(

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -356,7 +356,7 @@ def bucket_lock_retention_policy(bucket_name):
     """Implement the 'Buckets: lockRetentionPolicy' API."""
     bucket = testbench_utils.lookup_bucket(bucket_name)
     bucket.lock_retention_policy(flask.request)
-    return testbench_utils.filtered_response(flask.request, {})
+    return testbench_utils.filtered_response(flask.request, bucket.metadata)
 
 
 @gcs.route('/b/<bucket_name>/o')

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -48,7 +48,7 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                StatusOr<internal::TestBucketIamPermissionsResponse>(
                    internal::TestBucketIamPermissionsRequest const&));
   MOCK_METHOD1(LockBucketRetentionPolicy,
-               StatusOr<internal::EmptyResponse>(
+               StatusOr<BucketMetadata>(
                    internal::LockBucketRetentionPolicyRequest const&));
 
   MOCK_METHOD1(InsertObjectMedia,

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -660,9 +660,12 @@ TEST_F(BucketIntegrationTest, BucketLock) {
   ASSERT_TRUE(after_setting_retention_policy.ok())
       << "status=" << after_setting_retention_policy.status();
 
-  auto lock_status = client.LockBucketRetentionPolicy(
+  auto after_locking = client.LockBucketRetentionPolicy(
       bucket_name, after_setting_retention_policy->metageneration());
-  ASSERT_TRUE(lock_status.ok()) << "status=" << lock_status.status();
+  ASSERT_TRUE(after_locking.ok()) << "status=" << after_locking.status();
+
+  ASSERT_TRUE(after_locking->has_retention_policy());
+  ASSERT_TRUE(after_locking->retention_policy().is_locked);
 
   auto status = client.DeleteBucket(bucket_name);
   ASSERT_TRUE(status.ok()) << "status=" << status.status();
@@ -674,7 +677,7 @@ TEST_F(BucketIntegrationTest, BucketLockFailure) {
   Client client;
 
   // This should fail because the bucket does not exist.
-  StatusOr<void> status = client.LockBucketRetentionPolicy(bucket_name, 42U);
+  StatusOr<BucketMetadata> status = client.LockBucketRetentionPolicy(bucket_name, 42U);
   EXPECT_FALSE(status.ok());
 }
 


### PR DESCRIPTION
This fixes #1859.  The return type for `LockBucketRetentionPolicy()` should be
`StatusOr<BucketMetadata>`, the documentation for the JSON API used to be
wrong and we implemented based on the old docs.
