### PR TITLE
Changed TableAdmin's CreateTable and ListTables to return StatusOr

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -41,7 +41,11 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Listing tables: " << std::endl;
   auto tables =
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
-  for (auto const& table : tables) {
+  if (!tables) {
+    std::cerr << "ListTables failed: " << tables.status() << std::endl;
+    return;
+  }
+  for (auto const& table : *tables) {
     std::cout << table.name() << std::endl;
   }
 
@@ -105,7 +109,11 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Listing tables: " << std::endl;
   auto tables =
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
-  for (auto const& table : tables) {
+  if (!tables) {
+    std::cerr << "ListTables failed: " << tables.status() << std::endl;
+    return;
+  }
+  for (auto const& table : *tables) {
     std::cout << table.name() << std::endl;
   }
   // [END bigtable_list_table]

--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -41,6 +41,7 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Listing tables: " << std::endl;
   auto tables =
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+
   if (!tables) {
     std::cerr << "ListTables failed: " << tables.status() << std::endl;
     return;
@@ -109,6 +110,7 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Listing tables: " << std::endl;
   auto tables =
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+
   if (!tables) {
     std::cerr << "ListTables failed: " << tables.status() << std::endl;
     return;

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -74,14 +74,19 @@ void CreateTable(google::cloud::bigtable::TableAdmin admin, int argc,
 void ListTables(google::cloud::bigtable::TableAdmin admin, int argc,
                 char* argv[]) {
   if (argc != 1) {
-    throw Usage{"list-tables: <project-id> <instance-id>"};
+    std::cerr << "list-tables: <project-id> <instance-id>\n";
+    return;
   }
 
   //! [list tables]
   [](google::cloud::bigtable::TableAdmin admin) {
     auto tables =
         admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
-    for (auto const& table : tables) {
+    if (!tables) {
+      std::cerr << "ListTables failed: " << tables.status() << std::endl;
+      return;
+    }
+    for (auto const& table : *tables) {
       std::cout << table.name() << std::endl;
     }
   }

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -74,14 +74,14 @@ void CreateTable(google::cloud::bigtable::TableAdmin admin, int argc,
 void ListTables(google::cloud::bigtable::TableAdmin admin, int argc,
                 char* argv[]) {
   if (argc != 1) {
-    std::cerr << "list-tables: <project-id> <instance-id>\n";
-    return;
+    throw Usage{"list-tables: <project-id> <instance-id>"};
   }
 
   //! [list tables]
   [](google::cloud::bigtable::TableAdmin admin) {
     auto tables =
         admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+
     if (!tables) {
       std::cerr << "ListTables failed: " << tables.status() << std::endl;
       return;

--- a/google/cloud/bigtable/internal/grpc_error_delegate.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.cc
@@ -22,6 +22,58 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
+
+namespace {
+StatusCode MapStatusCode(grpc::StatusCode const& code) {
+  switch (code) {
+    case grpc::StatusCode::OK:
+      return StatusCode::kOk;
+    case grpc::StatusCode::CANCELLED:
+      return StatusCode::kCancelled;
+    case grpc::StatusCode::UNKNOWN:
+      return StatusCode::kUnknown;
+    case grpc::StatusCode::INVALID_ARGUMENT:
+      return StatusCode::kInvalidArgument;
+    case grpc::StatusCode::DEADLINE_EXCEEDED:
+      return StatusCode::kDeadlineExceeded;
+    case grpc::StatusCode::NOT_FOUND:
+      return StatusCode::kNotFound;
+    case grpc::StatusCode::ALREADY_EXISTS:
+      return StatusCode::kAlreadyExists;
+    case grpc::StatusCode::PERMISSION_DENIED:
+      return StatusCode::kPermissionDenied;
+    case grpc::StatusCode::UNAUTHENTICATED:
+      return StatusCode::kUnauthenticated;
+    case grpc::StatusCode::RESOURCE_EXHAUSTED:
+      return StatusCode::kResourceExhausted;
+    case grpc::StatusCode::FAILED_PRECONDITION:
+      return StatusCode::kFailedPrecondition;
+    case grpc::StatusCode::ABORTED:
+      return StatusCode::kAborted;
+    case grpc::StatusCode::OUT_OF_RANGE:
+      return StatusCode::kOutOfRange;
+    case grpc::StatusCode::UNIMPLEMENTED:
+      return StatusCode::kUnimplemented;
+    case grpc::StatusCode::INTERNAL:
+      return StatusCode::kInternal;
+    case grpc::StatusCode::UNAVAILABLE:
+      return StatusCode::kUnavailable;
+    case grpc::StatusCode::DATA_LOSS:
+      return StatusCode::kDataLoss;
+    case grpc::StatusCode::DO_NOT_USE:
+    default:
+      return StatusCode::kDoNotUse;
+  }
+}
+}  // namespace
+
+google::cloud::Status MakeStatusFromRpcError(grpc::Status const& status) {
+  StatusCode code = MapStatusCode(status.error_code());
+  // TODO(devjgm): Pass along status.error_details() once we have absl::Status
+  // or some version that supports binary blobs of data.
+  return google::cloud::Status(code, status.error_message());
+}
+
 void ThrowRpcError(grpc::Status const& status, char const* msg) {
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   throw bigtable::GRpcError(msg, status);

--- a/google/cloud/bigtable/internal/grpc_error_delegate.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.cc
@@ -69,7 +69,7 @@ StatusCode MapStatusCode(grpc::StatusCode const& code) {
 
 google::cloud::Status MakeStatusFromRpcError(grpc::Status const& status) {
   StatusCode code = MapStatusCode(status.error_code());
-  // TODO(devjgm): Pass along status.error_details() once we have absl::Status
+  // TODO(#1912): Pass along status.error_details() once we have absl::Status
   // or some version that supports binary blobs of data.
   return google::cloud::Status(code, status.error_message());
 }

--- a/google/cloud/bigtable/internal/grpc_error_delegate.h
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_GRPC_ERROR_DELEGATE_H_
 
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/status.h"
 #include <grpcpp/grpcpp.h>
 
 namespace google {
@@ -23,6 +24,10 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
+/**
+ * Creates a google::cloud::Status from a grpc::Status.
+ */
+google::cloud::Status MakeStatusFromRpcError(grpc::Status const& status);
 
 //@{
 /**

--- a/google/cloud/bigtable/internal/grpc_error_delegate_test.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate_test.cc
@@ -23,6 +23,41 @@ std::string const cmsg("testing with std::string const&");
 char const* msg = "testing with char const*";
 }  // anonymous namespace
 
+TEST(MakeStatusFromRpcError, AllCodes) {
+  using google::cloud::StatusCode;
+
+  struct {
+    grpc::StatusCode grpc;
+    StatusCode expected;
+  } expected_codes[]{
+      {grpc::StatusCode::OK, StatusCode::kOk},
+      {grpc::StatusCode::CANCELLED, StatusCode::kCancelled},
+      {grpc::StatusCode::UNKNOWN, StatusCode::kUnknown},
+      {grpc::StatusCode::INVALID_ARGUMENT, StatusCode::kInvalidArgument},
+      {grpc::StatusCode::DEADLINE_EXCEEDED, StatusCode::kDeadlineExceeded},
+      {grpc::StatusCode::NOT_FOUND, StatusCode::kNotFound},
+      {grpc::StatusCode::ALREADY_EXISTS, StatusCode::kAlreadyExists},
+      {grpc::StatusCode::PERMISSION_DENIED, StatusCode::kPermissionDenied},
+      {grpc::StatusCode::UNAUTHENTICATED, StatusCode::kUnauthenticated},
+      {grpc::StatusCode::RESOURCE_EXHAUSTED, StatusCode::kResourceExhausted},
+      {grpc::StatusCode::FAILED_PRECONDITION, StatusCode::kFailedPrecondition},
+      {grpc::StatusCode::ABORTED, StatusCode::kAborted},
+      {grpc::StatusCode::OUT_OF_RANGE, StatusCode::kOutOfRange},
+      {grpc::StatusCode::UNIMPLEMENTED, StatusCode::kUnimplemented},
+      {grpc::StatusCode::INTERNAL, StatusCode::kInternal},
+      {grpc::StatusCode::UNAVAILABLE, StatusCode::kUnavailable},
+      {grpc::StatusCode::DATA_LOSS, StatusCode::kDataLoss},
+  };
+
+  for (auto const& codes : expected_codes) {
+    std::string const message = "test message";
+    auto const original = grpc::Status(codes.grpc, message);
+    auto const expected = google::cloud::Status(codes.expected, message);
+    auto const actual = MakeStatusFromRpcError(original);
+    EXPECT_EQ(expected, actual);
+  }
+}
+
 TEST(ThrowDelegateTest, RpcError) {
   grpc::Status status(grpc::StatusCode::UNAVAILABLE, "try-again");
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -33,13 +33,13 @@ static_assert(std::is_copy_constructible<bigtable::TableAdmin>::value,
 static_assert(std::is_copy_assignable<bigtable::TableAdmin>::value,
               "bigtable::TableAdmin must be assignable");
 
-btadmin::Table TableAdmin::CreateTable(std::string table_id,
-                                       TableConfig config) {
+StatusOr<btadmin::Table> TableAdmin::CreateTable(std::string table_id,
+                                                 TableConfig config) {
   grpc::Status status;
   auto result =
       impl_.CreateTable(std::move(table_id), std::move(config), status);
   if (!status.ok()) {
-    internal::ThrowRpcError(status, status.error_message());
+    return internal::MakeStatusFromRpcError(status);
   }
   return result;
 }
@@ -70,11 +70,12 @@ future<google::bigtable::admin::v2::Table> TableAdmin::AsyncGetTable(
   return result;
 }
 
-std::vector<btadmin::Table> TableAdmin::ListTables(btadmin::Table::View view) {
+StatusOr<std::vector<btadmin::Table>> TableAdmin::ListTables(
+    btadmin::Table::View view) {
   grpc::Status status;
   auto result = impl_.ListTables(view, status);
   if (!status.ok()) {
-    internal::ThrowRpcError(status, status.error_message());
+    return internal::MakeStatusFromRpcError(status);
   }
   return result;
 }

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -23,6 +23,7 @@
 #include "google/cloud/bigtable/polling_policy.h"
 #include "google/cloud/bigtable/table_config.h"
 #include "google/cloud/future.h"
+#include "google/cloud/status_or.h"
 #include <future>
 #include <memory>
 
@@ -31,7 +32,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /**
- * Implements the API to administer tables instance a Cloud Bigtable instance.
+ * Implements the API to administer tables in a Cloud Bigtable instance.
  */
 class TableAdmin {
  public:
@@ -100,13 +101,12 @@ class TableAdmin {
    * @param config the initial schema for the table.
    * @return the attributes of the newly created table.  Notice that the server
    *     only populates the table_name() field at this time.
-   * @throws std::exception if the operation cannot be completed.
    *
    * @par Example
    * @snippet table_admin_snippets.cc create table
    */
-  ::google::bigtable::admin::v2::Table CreateTable(std::string table_id,
-                                                   TableConfig config);
+  StatusOr<::google::bigtable::admin::v2::Table> CreateTable(
+      std::string table_id, TableConfig config);
 
   /**
    * Sends an asynchronous request to create a new table in the instance.
@@ -151,7 +151,7 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc list tables
    */
-  std::vector<::google::bigtable::admin::v2::Table> ListTables(
+  StatusOr<std::vector<::google::bigtable::admin::v2::Table>> ListTables(
       ::google::bigtable::admin::v2::Table::View view);
 
   /**

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -202,7 +202,7 @@ TEST_F(TableAdminTest, ListTables) {
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btadmin::Table::FULL);
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(actual) << actual.status();
   auto const& v = *actual;
   std::string instance_name = tested.instance_name();
   ASSERT_EQ(2UL, v.size());
@@ -231,7 +231,7 @@ TEST_F(TableAdminTest, ListTablesRecoverableFailures) {
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btadmin::Table::FULL);
-  ASSERT_TRUE(actual);
+  ASSERT_TRUE(actual) << actual.status();
   auto const& v = *actual;
   std::string instance_name = tested.instance_name();
   ASSERT_EQ(4UL, v.size());
@@ -315,7 +315,7 @@ initial_splits { key: 'p' }
       {{"f1", GC::MaxNumVersions(1)}, {"f2", GC::MaxAge(1_s)}},
       {"a", "c", "p"});
   auto table = tested.CreateTable("new-table", std::move(config));
-  EXPECT_TRUE(table);
+  EXPECT_TRUE(table) << table.status();
 }
 
 /**

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -66,7 +66,8 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
   std::string const table_id = RandomTableId();
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  auto previous_count = CountMatchingTables(table_id, previous_table_list);
+  ASSERT_TRUE(previous_table_list);
+  auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"
                                << " generated at random.";

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -66,7 +66,8 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
   std::string const table_id = RandomTableId();
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  auto previous_count = CountMatchingTables(table_id, previous_table_list);
+  ASSERT_TRUE(previous_table_list);
+  auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"
                                << " generated at random.";
@@ -158,7 +159,8 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
 
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  auto table_count = CountMatchingTables(table_id, current_table_list);
+  ASSERT_TRUE(current_table_list);
+  auto table_count = CountMatchingTables(table_id, *current_table_list);
   EXPECT_EQ(0, table_count);
 
   cq.Shutdown();

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -177,6 +177,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
   // verify new table id in current table list
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
+  ASSERT_TRUE(previous_table_list);
   auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -65,11 +65,12 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
   // Get the current list of tables.
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
+  ASSERT_TRUE(previous_table_list);
 
   int const TABLE_COUNT = 5;
   for (int index = 0; index < TABLE_COUNT; ++index) {
     std::string table_id = table_prefix + "-" + std::to_string(index);
-    auto previous_count = CountMatchingTables(table_id, previous_table_list);
+    auto previous_count = CountMatchingTables(table_id, *previous_table_list);
     ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                  << " This is unexpected, as the table ids are"
                                  << " generated at random.";
@@ -78,17 +79,19 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
     expected_table_list.emplace_back(table_id);
   }
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
+  ASSERT_TRUE(current_table_list);
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
-    EXPECT_EQ(1, CountMatchingTables(table_id, current_table_list));
+    EXPECT_EQ(1, CountMatchingTables(table_id, *current_table_list));
   }
   for (auto const& table_id : expected_table_list) {
     DeleteTable(table_id);
   }
   current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
+  ASSERT_TRUE(current_table_list);
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
-    EXPECT_EQ(0, CountMatchingTables(table_id, current_table_list));
+    EXPECT_EQ(0, CountMatchingTables(table_id, *current_table_list));
   }
 }
 
@@ -174,7 +177,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
   // verify new table id in current table list
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  auto previous_count = CountMatchingTables(table_id, previous_table_list);
+  auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"
                                << " generated at random.";
@@ -229,7 +232,8 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
   DeleteTable(table_id);
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  auto table_count = CountMatchingTables(table_id, current_table_list);
+  ASSERT_TRUE(current_table_list);
+  auto table_count = CountMatchingTables(table_id, *current_table_list);
   EXPECT_EQ(0, table_count);
 }
 


### PR DESCRIPTION
This PR is an initial foray into changing the bigtable library to return StatusOr instead of throwing. In this PR I changed two non-async member functions in TableAdmin. CreateTable() and ListTables(). I also changed the unit tests and any related samples. 

PTAL and let me know if this seems like it's on the right track.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1908)
<!-- Reviewable:end -->
