### PR TITLE
Treat 502s as retryable errors.

### DIFF
--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -112,11 +112,11 @@ Status AsStatus(HttpResponse const& http_response) {
   }
   if (http_response.status_code == 500) {
     // 500 - Internal Server Error
-    return Status(StatusCode::kInternal, http_response.payload);
+    return Status(StatusCode::kUnavailable, http_response.payload);
   }
   if (http_response.status_code == 502) {
     // 502 - Bad Gateway
-    return Status(StatusCode::kInternal, http_response.payload);
+    return Status(StatusCode::kUnavailable, http_response.payload);
   }
   if (http_response.status_code == 503) {
     // 503 - Service Unavailable

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -76,9 +76,9 @@ TEST(HttpResponseTest, AsStatus) {
             AsStatus(HttpResponse{429, "too many requests"}).code());
   EXPECT_EQ(StatusCode::kInvalidArgument,
             AsStatus(HttpResponse{499, "some 4XX error"}).code());
-  EXPECT_EQ(StatusCode::kInternal,
+  EXPECT_EQ(StatusCode::kUnavailable,
             AsStatus(HttpResponse{500, "internal server error"}).code());
-  EXPECT_EQ(StatusCode::kInternal,
+  EXPECT_EQ(StatusCode::kUnavailable,
             AsStatus(HttpResponse{502, "bad gateway"}).code());
   EXPECT_EQ(StatusCode::kUnavailable,
             AsStatus(HttpResponse{503, "service unavailable"}).code());


### PR DESCRIPTION
A second reading of

https://cloud.google.com/storage/docs/json_api/v1/status-codes#500_Internal_Server_Error

shows that 500s, 502s, and 503s are retryable errors, so treat them as
such.

This fixes #1807.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1913)
<!-- Reviewable:end -->
