### PR TITLE
Link documentation to google/cloud symbols.

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -93,6 +93,8 @@ else()
         set(DOXYGEN_SHOW_USED_FILES NO)
         set(DOXYGEN_REFERENCES_LINK_SOURCE NO)
         set(DOXYGEN_SOURCE_BROWSER YES)
+        set(DOXYGEN_GENERATE_TAGFILE
+            "${CMAKE_CURRENT_BINARY_DIR}/${GOOGLE_CLOUD_CPP_SUBPROJECT}.tag")
 
         doxygen_add_docs(${GOOGLE_CLOUD_CPP_SUBPROJECT}-docs
                          ${CMAKE_CURRENT_SOURCE_DIR}

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -45,6 +45,7 @@ set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v${GOOGLE_CLOUD_CPP_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/README.md"
     "*/google/cloud/internal/*"
+    "*/google/cloud/testing_util/*"
     "*/google/cloud/bigtable/*"
     "*/google/cloud/firestore/*"
     "*/google/cloud/storage/*"

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -37,8 +37,12 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/bigtable/tests/*"
     "*/google/cloud/bigtable/tools/*"
     "*/google/cloud/bigtable/*_test.cc")
+set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 
 include(GoogleCloudCppCommon)
+if (TARGET bigtable-docs AND TARGET cloud-docs)
+    add_dependencies(bigtable-docs cloud-docs)
+endif ()
 
 # Define an interface library, i.e., a library that really has no sources, and
 # add public target options to it.  The targets then use the library via

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -35,8 +35,13 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/storage/testing/*"
     "*/google/cloud/storage/tests/*"
     "*/google/cloud/storage/*_test.cc")
+set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 
 include(GoogleCloudCppCommon)
+if (TARGET storage-docs AND TARGET cloud-docs)
+    add_dependencies(storage-docs cloud-docs)
+endif ()
+
 include(IncludeNlohmannJson)
 include(IncludeCrc32c)
 

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -86,9 +86,8 @@ inline namespace STORAGE_CLIENT_NS {
  * This class uses `StatusOr<T>` to report errors. When an operation fails to
  * perform its work the returned `StatusOr<T>` contains the error details. If
  * the `ok()` member function in the `StatusOr<T>` returns `true` then it
- * contains the expected result. Please consult the `StatusOr<T>`
- * [documentation](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/status_or.h)
- * for more details.
+ * contains the expected result. Please consult the
+ * [`StatusOr<T>` documentation](#google::cloud::v0::StatusOr) for more details.
  *
  * @code
  * namespace gcs = google::cloud::storage;
@@ -121,6 +120,7 @@ inline namespace STORAGE_CLIENT_NS {
  * @see https://cloud.google.com/docs/authentication/production for details
  *     about Application Default %Credentials.
  *
+ * @see #google::cloud::v0::StatusOr.
  */
 class Client {
  public:
@@ -471,7 +471,7 @@ class Client {
   }
 
   /**
-   * Fetches the IAM policy for a Bucket.
+   * Fetches the [IAM policy](@ref google::cloud::v0::IamPolicy) for a Bucket.
    *
    * Google Cloud Identity & Access Management (IAM) lets administrators
    * authorize who can take action on specific resources, including Google
@@ -499,6 +499,7 @@ class Client {
    * @par Example
    * @snippet storage_bucket_iam_samples.cc get bucket iam policy
    *
+   * @see #google::cloud::v0::IamPolicy for details about the `IamPolicy` class.
    */
   template <typename... Options>
   StatusOr<IamPolicy> GetBucketIamPolicy(std::string const& bucket_name,
@@ -509,7 +510,7 @@ class Client {
   }
 
   /**
-   * Sets the IamPolicy for a Bucket.
+   * Sets the [IAM Policy](@ref google::cloud::v0::IamPolicy) for a Bucket.
    *
    * Google Cloud Identity & Access Management (IAM) lets administrators
    * authorize who can take action on specific resources, including Google
@@ -549,6 +550,8 @@ class Client {
    *
    * @par Example: removing a IAM member
    * @snippet storage_bucket_iam_samples.cc remove bucket iam member
+   *
+   * @see #google::cloud::v0::IamPolicy for details about the `IamPolicy` class.
    */
   template <typename... Options>
   StatusOr<IamPolicy> SetBucketIamPolicy(std::string const& bucket_name,


### PR DESCRIPTION
With this change the documentation in google/cloud/storage and/or
google/cloud/bigtable can reference symbols in the google/cloud docset.

This fixes #1914.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1917)
<!-- Reviewable:end -->
