### PR TITLE
Support scripts for Kokoro+Docker.

### DIFF
--- a/ci/kokoro/docker/asan-presubmit.cfg
+++ b/ci/kokoro/docker/asan-presubmit.cfg
@@ -1,0 +1,46 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_TYPE"
+  value: "Debug"
+}
+
+env_vars {
+  key: "CC"
+  value: "clang"
+}
+
+env_vars {
+  key: "CXX"
+  value: "clang++"
+}
+
+env_vars {
+  key: "CMAKE_FLAGS"
+  value: "-DSANITIZE_ADDRESS=yes"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "18.04"
+}

--- a/ci/kokoro/docker/asan.cfg
+++ b/ci/kokoro/docker/asan.cfg
@@ -1,0 +1,54 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+  }
+}
+
+env_vars {
+  key: "BUILD_TYPE"
+  value: "Debug"
+}
+
+env_vars {
+  key: "CC"
+  value: "clang"
+}
+
+env_vars {
+  key: "CXX"
+  value: "clang++"
+}
+
+env_vars {
+  key: "CMAKE_FLAGS"
+  value: "-DSANITIZE_ADDRESS=yes"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "18.04"
+}

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
+source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+
+echo "================================================================"
+printenv
+echo "================================================================"
+
+echo "================================================================"
+echo "Updating submodules."
+cd "${PROJECT_ROOT}"
+git submodule update --init
+echo "================================================================"
+
+echo "================================================================"
+echo "Creating Docker image with all the development tools."
+set +e
+"${PROJECT_ROOT}/ci/travis/install-linux.sh" \
+    >create-build-docker-image.log 2>&1 </dev/null
+if [[ "$?" != 0 ]]; then
+  dump_log create-build-docker-image.log
+  exit 1
+fi
+echo "================================================================"
+
+set -e
+echo "================================================================"
+echo "Running the full build."
+
+export NEEDS_CCACHE=no
+"${PROJECT_ROOT}/ci/travis/build-linux.sh"
+echo "================================================================"
+
+echo "================================================================"
+"${PROJECT_ROOT}/ci/travis/dump-logs.sh"
+echo "================================================================"

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -44,7 +44,9 @@ if [[ -z "${ccache_command}" ]]; then
 fi
 
 bootstrap_ccache="no"
-if ${ccache_command} --show-stats | grep '^cache size' | grep -q '0.0 kB'; then
+if [[ "${NEEDS_CCACHE:-}" = "no" ]]; then
+  bootstrap_ccache="no"
+elif ${ccache_command} --show-stats | grep '^cache size' | grep -q '0.0 kB'; then
   echo "${COLOR_RED}"
   echo "The ccache is empty. The builds cannot finish in the time allocated by"
   echo "Travis without a warm cache. As a workaround, until #1800 is fixed,"
@@ -233,8 +235,8 @@ scan-build detected errors.  Please read the log for details. To
 run scan-build locally and examine the HTML output install and configure Docker,
 then run:
 
-DISTRO=ubuntu DISTRO_VERSION=18.04 SCAN_BUILD=yes NCPU=8 TRAVIS_OS_NAME=linux \
-    CXX=clang++ CC=clang ./ci/travis/build-linux.sh
+DISTRO=ubuntu DISTRO_VERSION=18.04 SCAN_BUILD=yes NCPU=8 CXX=clang++ CC=clang \
+    ./ci/travis/build-linux.sh
 
 The HTML output will be copied into the scan-build-output subdirectory.
 ${COLOR_RESET}

--- a/ci/travis/linux-config.sh
+++ b/ci/travis/linux-config.sh
@@ -16,11 +16,6 @@
 
 set -eu
 
-if [[ "${TRAVIS_OS_NAME}" != "linux" ]]; then
-  echo "Not a Linux-based build, skipping Linux-specific build steps."
-  exit 0
-fi
-
 if [[ -n "${IMAGE+x}" ]]; then
   echo "IMAGE is already defined."
 else


### PR DESCRIPTION
These scripts will allow us to move builds from Travis CI to Kokoro.
As they are, these scripts have no effect, a separate configuration
change inside Google will activate them.

As much as possible I reused the builds for Travis, at some point
we may want to refactor the scripts to different directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1920)
<!-- Reviewable:end -->
