### PR TITLE
Changed Client::ListBuckets() to not return StatusOr

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -228,18 +228,15 @@ class Client {
   /**
    * Fetches the list of buckets for the default project.
    *
-   * The default project is configured in the `ClientOptions` used to construct
-   * this object. If the application does not set the project id in the
-   * `ClientOptions`, the value of the `GOOGLE_CLOUD_PROJECT` is used. If
-   * neither the environment variable is set, nor a value is set explicitly by
-   * the application this function raises an exception.
+   * The default project is required to be configured in the `ClientOptions`
+   * used to construct this object. If the application does not set the project
+   * id in the `ClientOptions`, the value of the `GOOGLE_CLOUD_PROJECT` is
+   * used. If neither the environment variable is set, nor a value is set
+   * explicitly by the application this function raises an exception.
    *
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `MaxResults`, `Prefix`,
    *     `UserProject`, and `Projection`.
-   *
-   * @throw std::logic_error if the function is called without a default
-   *     project id set.
    *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
@@ -248,18 +245,15 @@ class Client {
    * @snippet storage_bucket_samples.cc list buckets
    */
   template <typename... Options>
-  StatusOr<ListBucketsReader> ListBuckets(Options&&... options) {
+  ListBucketsReader ListBuckets(Options&&... options) {
     auto const& project_id = raw_client_->client_options().project_id();
-    if (project_id.empty()) {
-      std::string msg = "Default project id not set in ";
-      msg += __func__;
-      return Status(StatusCode::kFailedPrecondition, msg);
-    }
     return ListBucketsForProject(project_id, std::forward<Options>(options)...);
   }
 
   /**
-   * Creates a new Google Cloud Storage Bucket using the default project.
+   * Creates a new Google Cloud Storage Bucket using the default project. The
+   * default project is required to be configured in the `ClientOptions` used
+   * to construct this object.
    *
    * @param bucket_name the name of the new bucket.
    * @param metadata the metadata for the new Bucket.  The `name` field is
@@ -279,11 +273,6 @@ class Client {
                                         BucketMetadata metadata,
                                         Options&&... options) {
     auto const& project_id = raw_client_->client_options().project_id();
-    if (project_id.empty()) {
-      std::string msg = "Default project id not set in ";
-      msg += __func__;
-      return Status(StatusCode::kFailedPrecondition, msg);
-    }
     return CreateBucketForProject(std::move(bucket_name), project_id,
                                   std::move(metadata),
                                   std::forward<Options>(options)...);
@@ -2187,11 +2176,11 @@ class Client {
    * behalf.  This API allows you to discover the GCS service account for the
    * default project associated with this object.
    *
-   * The default project is configured in the `ClientOptions` used to construct
-   * this object. If the application does not set the project id in the
-   * `ClientOptions`, the value of the `GOOGLE_CLOUD_PROJECT` is used. If
-   * neither the environment variable is set, nor a value is set explicitly by
-   * the application this function raises an exception.
+   * The default project is required to be configured in the `ClientOptions`
+   * used to construct this object. If the application does not set the project
+   * id in the `ClientOptions`, the value of the `GOOGLE_CLOUD_PROJECT` is
+   * used. If neither the environment variable is set, nor a value is set
+   * explicitly by the application this function raises an exception.
    *
    * @param options a list of optional query parameters and/or request headers.
    *     Valid types for this operation include `UserProject`.
@@ -2208,11 +2197,6 @@ class Client {
   template <typename... Options>
   StatusOr<ServiceAccount> GetServiceAccount(Options&&... options) {
     auto const& project_id = raw_client_->client_options().project_id();
-    if (project_id.empty()) {
-      std::string msg = "Default project id not set in ";
-      msg += __func__;
-      return Status(StatusCode::kFailedPrecondition, std::move(msg));
-    }
     return GetServiceAccountForProject(project_id,
                                        std::forward<Options>(options)...);
   }

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -54,15 +54,8 @@ void ListBuckets(google::cloud::storage::Client client, int& argc,
   using google::cloud::StatusOr;
   [](gcs::Client client) {
     int count = 0;
-    StatusOr<gcs::ListBucketsReader> bucket_list = client.ListBuckets();
-
-    if (!bucket_list) {
-      std::cerr << "Error reading bucket list for default project"
-                << ", status=" << bucket_list.status() << std::endl;
-      return;
-    }
-
-    for (auto&& bucket_metadata : *bucket_list) {
+    gcs::ListBucketsReader bucket_list = client.ListBuckets();
+    for (auto&& bucket_metadata : bucket_list) {
       if (!bucket_metadata) {
         std::cerr << "Error reading bucket list for default project"
                   << ", status=" << bucket_metadata.status() << std::endl;


### PR DESCRIPTION
Fixes #1904.

Also, as per the discussion in #1904, removes some unnecessary checks for empty project IDs, which were the reason we previously needed a StatusOr on ListBuckets(). But per [this ADR](https://github.com/googleapis/google-cloud-cpp/blob/master/doc/adr/2018-06-19-do-not-duplicate-server-side-validation.md) we don't needed to validate empty project IDs on the client side.