### PR TITLE
Remove ASAN build from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,15 +76,6 @@ matrix:
         BUILD_TYPE=Debug
         DISTRO=ubuntu
         DISTRO_VERSION=18.04
-    - # Build with the AddressSanitizer.
-      os: linux
-      compiler: clang
-      env:
-        CMAKE_FLAGS=-DSANITIZE_ADDRESS=yes
-        BUILD_TYPE=Debug
-        DISTRO=ubuntu
-        DISTRO_VERSION=18.04
-      if: repo =~ ^googleapis/ or head_repo =~ ^googleapis/
     - # Build with the UndefinedBehaviorSanitizer.
       os: linux
       compiler: clang


### PR DESCRIPTION
Now that it is working on Kokoro we do not need to waste the Travis
bandwidth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1927)
<!-- Reviewable:end -->
