### PR TITLE
Create Kokoro configs for more builds.

### DIFF
--- a/ci/kokoro/docker/centos-7-presubmit.cfg
+++ b/ci/kokoro/docker/centos-7-presubmit.cfg
@@ -1,0 +1,44 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+  }
+}
+
+env_vars {
+  key: "CC"
+  value: "gcc"
+}
+
+env_vars {
+  key: "CXX"
+  value: "g++"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "centos"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "7"
+}

--- a/ci/kokoro/docker/centos-7.cfg
+++ b/ci/kokoro/docker/centos-7.cfg
@@ -1,0 +1,44 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+  }
+}
+
+env_vars {
+  key: "CC"
+  value: "gcc"
+}
+
+env_vars {
+  key: "CXX"
+  value: "g++"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "centos"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "7"
+}

--- a/ci/kokoro/docker/noex-presubmit.cfg
+++ b/ci/kokoro/docker/noex-presubmit.cfg
@@ -1,0 +1,49 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+  }
+}
+
+env_vars {
+  key: "CC"
+  value: "gcc"
+}
+
+env_vars {
+  key: "CXX"
+  value: "g++"
+}
+
+env_vars {
+  key: "CMAKE_FLAGS"
+  value: "DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "16.04"
+}

--- a/ci/kokoro/docker/noex.cfg
+++ b/ci/kokoro/docker/noex.cfg
@@ -1,0 +1,49 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+  }
+}
+
+env_vars {
+  key: "CC"
+  value: "gcc"
+}
+
+env_vars {
+  key: "CXX"
+  value: "g++"
+}
+
+env_vars {
+  key: "CMAKE_FLAGS"
+  value: "DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "16.04"
+}

--- a/ci/kokoro/docker/ubsan-presubmit.cfg
+++ b/ci/kokoro/docker/ubsan-presubmit.cfg
@@ -1,0 +1,46 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_TYPE"
+  value: "Debug"
+}
+
+env_vars {
+  key: "CC"
+  value: "clang"
+}
+
+env_vars {
+  key: "CXX"
+  value: "clang++"
+}
+
+env_vars {
+  key: "CMAKE_FLAGS"
+  value: "-DSANITIZE_UNDEFINED=yes"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "18.04"
+}

--- a/ci/kokoro/docker/ubsan.cfg
+++ b/ci/kokoro/docker/ubsan.cfg
@@ -1,0 +1,54 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+  }
+}
+
+env_vars {
+  key: "BUILD_TYPE"
+  value: "Debug"
+}
+
+env_vars {
+  key: "CC"
+  value: "clang"
+}
+
+env_vars {
+  key: "CXX"
+  value: "clang++"
+}
+
+env_vars {
+  key: "CMAKE_FLAGS"
+  value: "-DSANITIZE_UNDEFINED=yes"
+}
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}
+
+env_vars {
+  key: "DISTRO_VERSION"
+  value: "18.04"
+}


### PR DESCRIPTION
This creates the Kokoro configurations for the
UndefinedBehaviorSanitizer build, the build without exceptions, and the
build for CentOS 7. These are simple builds to move out of Travis, so we
start with them. The first step is to create these configs. Once merged
I will add the internal to Google configuration files, and once I verify
those work I will remove the corresponding builds for the .travis.yml
file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1928)
<!-- Reviewable:end -->
