### PR TITLE
In examples, do not use StatusOr<T>::value().

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -412,6 +412,7 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
 
   //! [write object]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      long desired_line_count) {
     std::string const text = "Lorem ipsum dolor sit amet";
@@ -425,8 +426,17 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
     }
 
     stream.Close();
-    gcs::ObjectMetadata meta = stream.metadata().value();
-    std::cout << "The resulting object size is: " << meta.size() << std::endl;
+
+    StatusOr<gcs::ObjectMetadata> metadata = std::move(stream).metadata();
+    if (!metadata) {
+      std::cerr << "Error while writing to object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << metadata.status() << std::endl;
+      return;
+    }
+    std::cout << "Successfully wrote to object " << metadata->name()
+              << " its size is: " << metadata->size()
+              << "\nFull metadata: " << *metadata << std::endl;
   }
   //! [write object]
   (std::move(client), bucket_name, object_name, desired_line_count);
@@ -1021,6 +1031,7 @@ void WriteObjectWithKmsKey(google::cloud::storage::Client client, int& argc,
 
   //! [write object with kms key] [START storage_upload_with_kms_key]
   namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string kms_key_name) {
     gcs::ObjectWriteStream stream = client.WriteObject(
@@ -1032,8 +1043,17 @@ void WriteObjectWithKmsKey(google::cloud::storage::Client client, int& argc,
     }
 
     stream.Close();
-    gcs::ObjectMetadata meta = stream.metadata().value();
-    std::cout << "The resulting object size is: " << meta.size() << std::endl;
+
+    StatusOr<gcs::ObjectMetadata> metadata = std::move(stream).metadata();
+    if (!metadata) {
+      std::cerr << "Error while writing to object " << object_name
+                << " in bucket " << bucket_name
+                << ", status=" << metadata.status() << std::endl;
+      return;
+    }
+    std::cout << "Successfully wrote to object " << metadata->name()
+              << " its size is: " << metadata->size()
+              << "\nFull metadata: " << *metadata << std::endl;
   }
   //! [write object with kms key] [END storage_upload_with_kms_key]
   (std::move(client), bucket_name, object_name, kms_key_name);


### PR DESCRIPTION
We want to be explicit about error handling code. The remaining `.ok()` calls are for `Status` not for `StatusOr`, so they need to stay.

This fixes #1900.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1934)
<!-- Reviewable:end -->
