### PR TITLE
Change the storage examples to throw a std::runtime_error on failure.

### DIFF
--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -214,13 +214,13 @@ In these cases no `StatusOr` wrapper is used.
 
 @par Error Handling Example (without exceptions):
 
-Application developers that cannot or prefer not to use exceptions to signal
-errors can check if the `StatusOr<T>` contains an error using `.ok()`. The error
-details are available using the `.status()` member function. If the
-`StatusOr<T>` does not contain an error then the application can use the
-`StatusOr<T>` as a smart pointer to `T`, that is, `operator->()` and
-`operator*()` work as you would expect. Note that accessing the value of a
-`StatusOr<T>` that contains an error is undefined behavior.
+Applications that do not use exceptions to signal errors should check if the
+`StatusOr<T>` contains a value before using it. If the `StatusOr<T>` does
+contain a value then the `StatusOr<T>` can be used as a smart pointer to `T`.
+That is, `operator->()` and `operator*()` work as you would expect. If the
+`StatusOr<T>` does not contain a value then the error details are available
+using the `.status()` member function (and trying to access the value produces
+undefined behavior).
 
 @code {.cpp}
 using namespace google::cloud;
@@ -228,35 +228,30 @@ using namespace google::cloud;
   StatusOr<storage::BucketMetadata> metadata = client.GetBucketMetadata(
       "my-bucket");
 
-  if (!metadata.ok()) {
-    std::cerr << "Error retrieving metadata for my-bucket: "
-              << metadata.status() << std::endl;
+  if (!metadata) {
+    std::cerr << "GetBucketMetadata: " << metadata.status() << "\n";
     return;
   }
 
-  // here, use `metadata` as a smart pointer to `T`, for example:
-  std::cout << "The bucket " << metadata->name()
-            << " default storage class is " << metadata->storage_class()
-            << "\n";
-
-  // alternatively capture as a local variable and use normally:
-  storage::BucketMetadata bucket_metadata = *metadata;
-  std::cout << "Full metadata: " << bucket_metadata << "\n";
+  // use `metadata` as a smart pointer to `BucketMetadata`
+  std::cout << "The metadata for bucket " << metadata->name()
+            << " is " << *metadata << "\n";
 }
 @endcode
 
 @par Error Handling Example (with exceptions):
 
-Applications that prefer to use
-exceptions to signal errors can simply call `.value()` on the `StatusOr<T>`
-object. This will return a `T` if there was no error, and throw an exception if
-the `StatusOr<T>` object contains an error.
+Applications that use exceptions to signal errors can simply call `.value()` on
+the `StatusOr<T>` object. This will return a `T` if the `StatusOr<T>` object
+contains a value, and will otherwise throw an exception.
 
 @code {.cpp}
 using namespace google::cloud;
 [](storage::Client client) {
   storage::BucketMetadata metadata = client.GetBucketMetadata(
         "my-bucket").value(); // throws on error
+  std::cout << "The metadata for bucket " << metadata.name()
+            << " is " << metadata << "\n";
 }
 @endcode
 

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -58,9 +58,7 @@ void ListBucketAcl(google::cloud::storage::Client client, int& argc,
         client.ListBucketAcl(bucket_name);
 
     if (!items) {
-      std::cerr << "Error getting ACL entries for bucket " << bucket_name
-                << ", status=" << items.status() << std::endl;
-      return;
+      throw std::runtime_error(items.status().message());
     }
 
     std::cout << "ACLs for bucket=" << bucket_name << std::endl;
@@ -89,10 +87,7 @@ void CreateBucketAcl(google::cloud::storage::Client client, int& argc,
         client.CreateBucketAcl(bucket_name, entity, role);
 
     if (!bucket_acl) {
-      std::cerr << "Failure getting bucket ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << bucket_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(bucket_acl.status().message());
     }
 
     std::cout << "Role " << bucket_acl->role() << " granted to "
@@ -117,9 +112,7 @@ void DeleteBucketAcl(google::cloud::storage::Client client, int& argc,
     google::cloud::Status status = client.DeleteBucketAcl(bucket_name, entity);
 
     if (!status.ok()) {
-      std::cerr << "Failure deleting ACL for entity " << entity << " in bucket "
-                << bucket_name << ", status=" << status << std::endl;
-      return;
+      throw std::runtime_error(status.message());
     }
 
     std::cout << "Deleted ACL entry for " << entity << " in bucket "
@@ -144,9 +137,7 @@ void GetBucketAcl(google::cloud::storage::Client client, int& argc,
         client.GetBucketAcl(bucket_name, entity);
 
     if (!acl) {
-      std::cerr << "Failure getting ACL for entity " << entity << " in bucket "
-                << bucket_name << ", status=" << acl.status() << std::endl;
-      return;
+      throw std::runtime_error(acl.status().message());
     }
 
     std::cout << "ACL entry for " << acl->entity() << " in bucket "
@@ -176,10 +167,7 @@ void UpdateBucketAcl(google::cloud::storage::Client client, int& argc,
         client.UpdateBucketAcl(bucket_name, desired_acl);
 
     if (!updated_acl) {
-      std::cerr << "Error updating ACL for entity " << entity << " in bucket "
-                << bucket_name << ", status=" << updated_acl.status()
-                << std::endl;
-      return;
+      throw std::runtime_error(updated_acl.status().message());
     }
 
     std::cout << "Bucket ACL updated. The ACL entry for "
@@ -207,10 +195,7 @@ void PatchBucketAcl(google::cloud::storage::Client client, int& argc,
         client.GetBucketAcl(bucket_name, entity);
 
     if (!original_acl) {
-      std::cerr << "Failure getting ACL for entity " << entity << " in bucket "
-                << bucket_name << ", status=" << original_acl.status()
-                << std::endl;
-      return;
+      throw std::runtime_error(original_acl.status().message());
     }
 
     auto new_acl = *original_acl;
@@ -220,10 +205,7 @@ void PatchBucketAcl(google::cloud::storage::Client client, int& argc,
         client.PatchBucketAcl(bucket_name, entity, *original_acl, new_acl);
 
     if (!patched_acl) {
-      std::cerr << "Failure patching ACL for entity " << entity << " in bucket "
-                << bucket_name << ", status=" << patched_acl.status()
-                << std::endl;
-      return;
+      throw std::runtime_error(patched_acl.status().message());
     }
 
     std::cout << "ACL entry for " << patched_acl->entity() << " in bucket "
@@ -252,10 +234,7 @@ void PatchBucketAclNoRead(google::cloud::storage::Client client, int& argc,
         gcs::BucketAccessControlPatchBuilder().set_role(role));
 
     if (!patched_acl) {
-      std::cerr << "Failure patching ACL for entity " << entity << " in bucket "
-                << bucket_name << ", status=" << patched_acl.status()
-                << std::endl;
-      return;
+      throw std::runtime_error(patched_acl.status().message());
     }
 
     std::cout << "ACL entry for " << patched_acl->entity() << " in bucket "

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -58,9 +58,7 @@ void GetBucketIamPolicy(google::cloud::storage::Client client, int& argc,
         client.GetBucketIamPolicy(bucket_name);
 
     if (!policy) {
-      std::cerr << "Error getting IAM policy for bucket " << bucket_name
-                << ", status=" << policy.status() << std::endl;
-      return;
+      throw std::runtime_error(policy.status().message());
     }
 
     std::cout << "The IAM policy for bucket " << bucket_name << " is "
@@ -87,9 +85,7 @@ void AddBucketIamMember(google::cloud::storage::Client client, int& argc,
         client.GetBucketIamPolicy(bucket_name);
 
     if (!policy) {
-      std::cerr << "Error getting current IAM policy for bucket " << bucket_name
-                << ", status=" << policy.status() << std::endl;
-      return;
+      throw std::runtime_error(policy.status().message());
     }
 
     policy->bindings.AddMember(role, member);
@@ -98,9 +94,7 @@ void AddBucketIamMember(google::cloud::storage::Client client, int& argc,
         client.SetBucketIamPolicy(bucket_name, *policy);
 
     if (!updated_policy) {
-      std::cerr << "Error setting IAM policy for bucket " << bucket_name
-                << ", status=" << updated_policy.status() << std::endl;
-      return;
+      throw std::runtime_error(updated_policy.status().message());
     }
 
     std::cout << "Updated IAM policy bucket " << bucket_name
@@ -126,9 +120,7 @@ void RemoveBucketIamMember(google::cloud::storage::Client client, int& argc,
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
     if (!policy) {
-      std::cerr << "Error getting current IAM policy for bucket " << bucket_name
-                << ", status=" << policy.status() << std::endl;
-      return;
+      throw std::runtime_error(policy.status().message());
     }
 
     policy->bindings.RemoveMember(role, member);
@@ -137,9 +129,7 @@ void RemoveBucketIamMember(google::cloud::storage::Client client, int& argc,
         client.SetBucketIamPolicy(bucket_name, *policy);
 
     if (!updated_policy) {
-      std::cerr << "Error setting IAM policy for bucket " << bucket_name
-                << ", status=" << updated_policy.status() << std::endl;
-      return;
+      throw std::runtime_error(updated_policy.status().message());
     }
 
     std::cout << "Updated IAM policy bucket " << bucket_name
@@ -170,9 +160,7 @@ void TestBucketIamPermissions(google::cloud::storage::Client client, int& argc,
         client.TestBucketIamPermissions(bucket_name, permissions);
 
     if (!actual_permissions) {
-      std::cerr << "Error checking IAM permissions for bucket " << bucket_name
-                << ", status=" << actual_permissions.status() << std::endl;
-      return;
+      throw std::runtime_error(actual_permissions.status().message());
     }
 
     if (actual_permissions->empty()) {

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -58,9 +58,7 @@ void ListDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.ListDefaultObjectAcl(bucket_name);
 
     if (!items) {
-      std::cerr << "Error getting default object ACL entries for bucket "
-                << bucket_name << ", status=" << items.status() << std::endl;
-      return;
+      throw std::runtime_error(items.status().message());
     }
 
     std::cout << "ACLs for bucket=" << bucket_name << std::endl;
@@ -89,10 +87,7 @@ void CreateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.CreateDefaultObjectAcl(bucket_name, entity, role);
 
     if (!default_object_acl) {
-      std::cerr << "Failure getting default object ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << default_object_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(default_object_acl.status().message());
     }
 
     std::cout << "Role " << default_object_acl->role()
@@ -119,10 +114,7 @@ void DeleteDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.DeleteDefaultObjectAcl(bucket_name, entity);
 
     if (!status.ok()) {
-      std::cerr << "Failure deleting default object ACL for entity " << entity
-                << " in bucket " << bucket_name << ", status=" << status
-                << std::endl;
-      return;
+      throw std::runtime_error(status.message());
     }
 
     std::cout << "Deleted ACL entry for " << entity << " in bucket "
@@ -147,10 +139,7 @@ void GetDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.GetDefaultObjectAcl(bucket_name, entity);
 
     if (!acl) {
-      std::cerr << "Failure getting default object ACL for entity " << entity
-                << " in bucket " << bucket_name << ", status=" << acl.status()
-                << std::endl;
-      return;
+      throw std::runtime_error(acl.status().message());
     }
 
     std::cout << "Default Object ACL entry for " << acl->entity()
@@ -177,10 +166,7 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.GetDefaultObjectAcl(bucket_name, entity);
 
     if (!original_acl) {
-      std::cerr << "Failure getting default object ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << original_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(original_acl.status().message());
     }
 
     original_acl->set_role(role);
@@ -189,10 +175,7 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.UpdateDefaultObjectAcl(bucket_name, *original_acl);
 
     if (!updated_acl) {
-      std::cerr << "Failure updating default object ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << updated_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(updated_acl.status().message());
     }
 
     std::cout << "Default Object ACL entry for " << updated_acl->entity()
@@ -220,10 +203,7 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
         client.GetDefaultObjectAcl(bucket_name, entity);
 
     if (!original_acl) {
-      std::cerr << "Failure getting default object ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << original_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(original_acl.status().message());
     }
 
     auto new_acl = *original_acl;
@@ -234,10 +214,7 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
                                      new_acl);
 
     if (!patched_acl) {
-      std::cerr << "Failure patching default object ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << patched_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(patched_acl.status().message());
     }
 
     std::cout << "Default Object ACL entry for " << patched_acl->entity()
@@ -268,10 +245,7 @@ void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
             gcs::ObjectAccessControlPatchBuilder().set_role(role));
 
     if (!patched_acl) {
-      std::cerr << "Failure patching default object ACL for entity " << entity
-                << " in bucket " << bucket_name
-                << ", status=" << patched_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(patched_acl.status().message());
     }
 
     std::cout << "Default Object ACL entry for " << patched_acl->entity()

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -58,9 +58,7 @@ void ListNotifications(google::cloud::storage::Client client, int& argc,
         client.ListNotifications(bucket_name);
 
     if (!items) {
-      std::cerr << "Error reading notification list for " << bucket_name
-                << ", status=" << items.status() << std::endl;
-      return;
+      throw std::runtime_error(items.status().message());
     }
 
     std::cout << "Notifications for bucket=" << bucket_name << std::endl;
@@ -89,10 +87,7 @@ void CreateNotification(google::cloud::storage::Client client, int& argc,
                                   gcs::NotificationMetadata());
 
     if (!notification) {
-      std::cerr << "Error creating notification for " << bucket_name
-                << " on topic " << topic_name
-                << ", status=" << notification.status() << std::endl;
-      return;
+      throw std::runtime_error(notification.status().message());
     }
 
     std::cout << "Successfully created notification " << notification->id()
@@ -127,10 +122,7 @@ void GetNotification(google::cloud::storage::Client client, int& argc,
         client.GetNotification(bucket_name, notification_id);
 
     if (!notification) {
-      std::cerr << "Error getting notification metadata for notification id "
-                << notification_id << " on bucket " << bucket_name
-                << ", status=" << notification.status() << std::endl;
-      return;
+      throw std::runtime_error(notification.status().message());
     }
 
     std::cout << "Notification " << notification->id() << " for bucket "
@@ -162,10 +154,7 @@ void DeleteNotification(google::cloud::storage::Client client, int& argc,
         client.DeleteNotification(bucket_name, notification_id);
 
     if (!status.ok()) {
-      std::cerr << "Error delete notification id " << notification_id
-                << " on bucket " << bucket_name << ", status=" << status
-                << std::endl;
-      return;
+      throw std::runtime_error(status.message());
     }
 
     std::cout << "Successfully deleted notification " << notification_id

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -60,10 +60,7 @@ void ListObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.ListObjectAcl(bucket_name, object_name);
 
     if (!items) {
-      std::cerr << "Error reading ACL for object " << object_name
-                << " in bucket " << bucket_name << ", status=" << items.status()
-                << std::endl;
-      return;
+      throw std::runtime_error(items.status().message());
     }
 
     std::cout << "ACLs for object=" << object_name << " in bucket "
@@ -94,10 +91,7 @@ void CreateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.CreateObjectAcl(bucket_name, object_name, entity, role);
 
     if (!object_acl) {
-      std::cerr << "Error creating object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << object_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(object_acl.status().message());
     }
 
     std::cout << "Role " << object_acl->role() << " granted to "
@@ -123,10 +117,7 @@ void DeleteObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.DeleteObjectAcl(bucket_name, object_name, entity);
 
     if (!status.ok()) {
-      std::cerr << "Error deleting object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << status << std::endl;
-      return;
+      throw std::runtime_error(status.message());
     }
 
     std::cout << "Deleted ACL entry for " << entity << " in object "
@@ -152,10 +143,7 @@ void GetObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.GetObjectAcl(bucket_name, object_name, entity);
 
     if (!acl) {
-      std::cerr << "Error getting object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << acl.status() << std::endl;
-      return;
+      throw std::runtime_error(acl.status().message());
     }
 
     std::cout << "ACL entry for " << acl->entity() << " in object "
@@ -184,10 +172,7 @@ void UpdateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.GetObjectAcl(bucket_name, object_name, entity);
 
     if (!current_acl) {
-      std::cerr << "Error getting object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << current_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(current_acl.status().message());
     }
 
     current_acl->set_role(role);
@@ -196,10 +181,7 @@ void UpdateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.UpdateObjectAcl(bucket_name, object_name, *current_acl);
 
     if (!updated_acl) {
-      std::cerr << "Error updating object ACL for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << updated_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(updated_acl.status().message());
     }
 
     std::cout << "ACL entry for " << updated_acl->entity() << " in object "
@@ -227,10 +209,7 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         client.GetObjectAcl(bucket_name, object_name, entity);
 
     if (!original_acl) {
-      std::cerr << "Error getting object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << original_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(original_acl.status().message());
     }
 
     gcs::ObjectAccessControl new_acl = *original_acl;
@@ -240,10 +219,7 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
         bucket_name, object_name, entity, *original_acl, new_acl);
 
     if (!patched_acl) {
-      std::cerr << "Error patching object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << patched_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(patched_acl.status().message());
     }
 
     std::cout << "ACL entry for " << patched_acl->entity() << " in object "
@@ -273,10 +249,7 @@ void PatchObjectAclNoRead(gcs::Client client, int& argc, char* argv[]) {
         gcs::ObjectAccessControlPatchBuilder().set_role(role));
 
     if (!patched_acl) {
-      std::cerr << "Error patching object ACL entry for entity " << entity
-                << " in object " << object_name << " and bucket " << bucket_name
-                << ", status=" << patched_acl.status() << std::endl;
-      return;
+      throw std::runtime_error(patched_acl.status().message());
     }
 
     std::cout << "ACL entry for " << patched_acl->entity() << " in object "


### PR DESCRIPTION
Throw std::runtime_error(status.message()) in the examples.  This helps clarify how to deal with failures for exception and non-exception users alike.

Fixes #1956.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1957)
<!-- Reviewable:end -->
