### PR TITLE
Change TableAdmin API to use StatusOr<>.

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -79,8 +79,8 @@ void Benchmark::DeleteTable() {
       setup_.instance_id());
   auto status = admin.DeleteTable(setup_.table_id());
   if (!status.ok()) {
-    std::cerr << "Failed to delete table: " << status << ". Continuing anyway."
-              << std::endl;
+    std::cerr << "Failed to delete table: " << status
+              << ". Continuing anyway.\n";
   }
 }
 

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -77,7 +77,11 @@ void Benchmark::DeleteTable() {
   bigtable::TableAdmin admin(
       bigtable::CreateDefaultAdminClient(setup_.project_id(), client_options_),
       setup_.instance_id());
-  admin.DeleteTable(setup_.table_id());
+  auto status = admin.DeleteTable(setup_.table_id());
+  if (!status.ok()) {
+    std::cerr << "Failed to delete table: " << status << ". Continuing anyway."
+              << std::endl;
+  }
 }
 
 std::shared_ptr<bigtable::DataClient> Benchmark::MakeDataClient() {

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -119,8 +119,7 @@ int main(int argc, char* argv[]) try {
   //! [delete table] [START deleting_a_table]
   google::cloud::Status status = table_admin.DeleteTable(table_id);
   if (!status.ok()) {
-    std::cerr << "DeleteTable failed: " << status << "\n";
-    return 1;
+    throw std::runtime_error(status.message());
   }
   //! [delete table] [END deleting_a_table]
 

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -117,7 +117,11 @@ int main(int argc, char* argv[]) try {
 
   // Delete the table
   //! [delete table] [START deleting_a_table]
-  table_admin.DeleteTable(table_id);
+  google::cloud::Status status = table_admin.DeleteTable(table_id);
+  if (!status.ok()) {
+    std::cerr << "DeleteTable failed: " << status << std::endl;
+    return 1;
+  }
   //! [delete table] [END deleting_a_table]
 
   return 0;

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) try {
   //! [delete table] [START deleting_a_table]
   google::cloud::Status status = table_admin.DeleteTable(table_id);
   if (!status.ok()) {
-    std::cerr << "DeleteTable failed: " << status << std::endl;
+    std::cerr << "DeleteTable failed: " << status << "\n";
     return 1;
   }
   //! [delete table] [END deleting_a_table]

--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -53,11 +53,15 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Get table:\n";
   auto table =
       admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
-  std::cout << table.name() << "\n";
-  std::cout << "Table name : " << table.name() << "\n";
+  if (!table) {
+    std::cerr << "GetTable failed: " << table.status() << "\n";
+    return;
+  }
+  std::cout << table->name() << "\n";
+  std::cout << "Table name : " << table->name() << "\n";
 
   std::cout << "List table families and GC rules:\n";
-  for (auto const& family : table.column_families()) {
+  for (auto const& family : table->column_families()) {
     std::string const& family_name = family.first;
     std::string gc_rule;
     google::protobuf::TextFormat::PrintToString(family.second.gc_rule(),
@@ -79,13 +83,21 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::GcRule::MaxNumVersions(3),
                       google::cloud::bigtable::GcRule::MaxAge(
                           std::chrono::hours(72))))});
+  if (!schema1) {
+    std::cerr << "ModifyColumnFamilies failed: " << schema1.status() << "\n";
+    return;
+  }
 
   std::string formatted;
-  google::protobuf::TextFormat::PrintToString(schema1, &formatted);
+  google::protobuf::TextFormat::PrintToString(*schema1, &formatted);
   std::cout << "Schema modified to: " << formatted << "\n";
 
   std::cout << "Deleting table:\n";
-  admin.DeleteTable(table_id);
+  google::cloud::Status status = admin.DeleteTable(table_id);
+  if (!status.ok()) {
+    std::cerr << "DeleteTable failed: " << status << "\n";
+    return;
+  }
   std::cout << " Done\n";
 }
 //! [run table operations]
@@ -123,12 +135,16 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Get table:\n";
   auto table =
       admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
-  std::cout << table.name() << "\n";
-  std::cout << "Table name : " << table.name() << "\n";
+  if (!table) {
+    std::cerr << "GetTable failed: " << table.status() << "\n";
+    return;
+  }
+  std::cout << table->name() << "\n";
+  std::cout << "Table name : " << table->name() << "\n";
   // [END bigtable_get_table]
 
   // [START bigtable_table_famalies]
-  for (auto const& family : table.column_families()) {
+  for (auto const& family : table->column_families()) {
     std::string const& family_name = family.first;
     std::string gc_rule;
     google::protobuf::TextFormat::PrintToString(family.second.gc_rule(),
@@ -153,14 +169,23 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::GcRule::MaxAge(
                           std::chrono::hours(72))))});
 
+  if (!schema1) {
+    std::cerr << "ModifyColumnFamilies failed: " << schema1.status() << "\n";
+    return;
+  }
+
   std::string formatted;
-  google::protobuf::TextFormat::PrintToString(schema1, &formatted);
+  google::protobuf::TextFormat::PrintToString(*schema1, &formatted);
   std::cout << "Schema modified to: " << formatted << "\n";
   // [END bigtable_update_column_famaly]
 
   // [START bigtable_delete_table]
   std::cout << "Deleting table:\n";
-  admin.DeleteTable(table_id);
+  google::cloud::Status status = admin.DeleteTable(table_id);
+  if (!status.ok()) {
+    std::cerr << "DeleteTable failed: " << status << "\n";
+    return;
+  }
   std::cout << " Done\n";
   // [END bigtable_delete_table]
 }

--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -43,8 +43,7 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
 
   if (!tables) {
-    std::cerr << "ListTables failed: " << tables.status() << "\n";
-    return;
+    throw std::runtime_error(tables.status().message());
   }
   for (auto const& table : *tables) {
     std::cout << table.name() << "\n";
@@ -54,10 +53,8 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
   auto table =
       admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
   if (!table) {
-    std::cerr << "GetTable failed: " << table.status() << "\n";
-    return;
+    throw std::runtime_error(table.status().message());
   }
-  std::cout << table->name() << "\n";
   std::cout << "Table name : " << table->name() << "\n";
 
   std::cout << "List table families and GC rules:\n";
@@ -84,8 +81,7 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::GcRule::MaxAge(
                           std::chrono::hours(72))))});
   if (!schema1) {
-    std::cerr << "ModifyColumnFamilies failed: " << schema1.status() << "\n";
-    return;
+    throw std::runtime_error(schema1.status().message());
   }
 
   std::string formatted;
@@ -95,8 +91,7 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Deleting table:\n";
   google::cloud::Status status = admin.DeleteTable(table_id);
   if (!status.ok()) {
-    std::cerr << "DeleteTable failed: " << status << "\n";
-    return;
+    throw std::runtime_error(status.message());
   }
   std::cout << " Done\n";
 }
@@ -123,8 +118,7 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
       admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
 
   if (!tables) {
-    std::cerr << "ListTables failed: " << tables.status() << "\n";
-    return;
+    throw std::runtime_error(tables.status().message());
   }
   for (auto const& table : *tables) {
     std::cout << table.name() << "\n";
@@ -136,10 +130,8 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
   auto table =
       admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
   if (!table) {
-    std::cerr << "GetTable failed: " << table.status() << "\n";
-    return;
+    throw std::runtime_error(table.status().message());
   }
-  std::cout << table->name() << "\n";
   std::cout << "Table name : " << table->name() << "\n";
   // [END bigtable_get_table]
 
@@ -170,8 +162,7 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
                           std::chrono::hours(72))))});
 
   if (!schema1) {
-    std::cerr << "ModifyColumnFamilies failed: " << schema1.status() << "\n";
-    return;
+    throw std::runtime_error(schema1.status().message());
   }
 
   std::string formatted;
@@ -183,8 +174,7 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
   std::cout << "Deleting table:\n";
   google::cloud::Status status = admin.DeleteTable(table_id);
   if (!status.ok()) {
-    std::cerr << "DeleteTable failed: " << status << "\n";
-    return;
+    throw std::runtime_error(status.message());
   }
   std::cout << " Done\n";
   // [END bigtable_delete_table]

--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -156,7 +156,11 @@ int main(int argc, char* argv[]) try {
 
   // Delete the table
   //! [delete table]
-  table_admin.DeleteTable(table_id);
+  google::cloud::Status status = table_admin.DeleteTable(table_id);
+  if (!status.ok()) {
+    std::cerr << "DeleteTable failed: " << status << std::endl;
+    return 1;
+  }
   //! [delete table]
 
   // Stop tracing because the remaining RPCs are OpenCensus related.

--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -158,8 +158,7 @@ int main(int argc, char* argv[]) try {
   //! [delete table]
   google::cloud::Status status = table_admin.DeleteTable(table_id);
   if (!status.ok()) {
-    std::cerr << "DeleteTable failed: " << status << "\n";
-    return 1;
+    throw std::runtime_error(status.message());
   }
   //! [delete table]
 

--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -158,7 +158,7 @@ int main(int argc, char* argv[]) try {
   //! [delete table]
   google::cloud::Status status = table_admin.DeleteTable(table_id);
   if (!status.ok()) {
-    std::cerr << "DeleteTable failed: " << status << std::endl;
+    std::cerr << "DeleteTable failed: " << status << "\n";
     return 1;
   }
   //! [delete table]

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -83,8 +83,7 @@ void ListTables(google::cloud::bigtable::TableAdmin admin, int argc,
         admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
 
     if (!tables) {
-      std::cerr << "ListTables failed: " << tables.status() << "\n";
-      return;
+      throw std::runtime_error(tables.status().message());
     }
     for (auto const& table : *tables) {
       std::cout << table.name() << "\n";
@@ -106,8 +105,7 @@ void GetTable(google::cloud::bigtable::TableAdmin admin, int argc,
     auto table =
         admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
     if (!table) {
-      std::cerr << "GetTable failed: " << table.status() << "\n";
-      return;
+      throw std::runtime_error(table.status().message());
     }
     std::cout << table->name() << "\n";
     for (auto const& family : table->column_families()) {
@@ -133,8 +131,7 @@ void DeleteTable(google::cloud::bigtable::TableAdmin admin, int argc,
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
     google::cloud::Status status = admin.DeleteTable(table_id);
     if (!status.ok()) {
-      std::cerr << "DeleteTable failed: " << status << "\n";
-      return;
+      throw std::runtime_error(status.message());
     }
   }
   //! [delete table]
@@ -165,8 +162,7 @@ void ModifyTable(google::cloud::bigtable::TableAdmin admin, int argc,
                             std::chrono::hours(72))))});
 
     if (!schema) {
-      std::cerr << "ModifyColumnFamilies failed: " << schema.status() << "\n";
-      return;
+      throw std::runtime_error(schema.status().message());
     }
     std::string formatted;
     google::protobuf::TextFormat::PrintToString(*schema, &formatted);
@@ -187,8 +183,7 @@ void DropAllRows(google::cloud::bigtable::TableAdmin admin, int argc,
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
     google::cloud::Status status = admin.DropAllRows(table_id);
     if (!status.ok()) {
-      std::cerr << "DropAllRows failed: " << status << "\n";
-      return;
+      throw std::runtime_error(status.message());
     }
   }
   //! [drop all rows]
@@ -207,8 +202,7 @@ void DropRowsByPrefix(google::cloud::bigtable::TableAdmin admin, int argc,
     google::cloud::Status status =
         admin.DropRowsByPrefix(table_id, "key-00004");
     if (!status.ok()) {
-      std::cerr << "DropRowsByPrefix failed: " << status << "\n";
-      return;
+      throw std::runtime_error(status.message());
     }
   }
   //! [drop rows by prefix]
@@ -228,9 +222,7 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
     google::cloud::bigtable::TableId table_id(table_id_param);
     auto consistency_token(admin.GenerateConsistencyToken(table_id.get()));
     if (!consistency_token) {
-      std::cerr << "GenerateConsistencyToken failed: "
-                << consistency_token.status() << "\n";
-      return;
+      throw std::runtime_error(consistency_token.status().message());
     }
     auto result = admin.WaitForConsistencyCheck(table_id, *consistency_token);
     if (result.get()) {
@@ -261,8 +253,7 @@ void CheckConsistency(google::cloud::bigtable::TableAdmin admin, int argc,
         consistency_token_param);
     auto result = admin.CheckConsistency(table_id, consistency_token);
     if (!result) {
-      std::cerr << "CheckConsistency failed: " << result.status() << "\n";
-      return;
+      throw std::runtime_error(result.status().message());
     }
     if (*result == google::cloud::bigtable::Consistency::kConsistent) {
       std::cout << "Table is consistent\n";
@@ -289,9 +280,7 @@ void GenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
     auto token = admin.GenerateConsistencyToken(table_id);
     if (!token) {
-      std::cerr << "GenerateConsistencyToken failed: " << token.status()
-                << "\n";
-      return;
+      throw std::runtime_error(token.status().message());
     }
     std::cout << "\n"
               << "generated token is : " << token->get() << "\n";
@@ -316,8 +305,7 @@ void GetSnapshot(google::cloud::bigtable::TableAdmin admin, int argc,
     google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
     auto snapshot = admin.GetSnapshot(cluster_id, snapshot_id);
     if (!snapshot) {
-      std::cerr << "GetSnapshot failed: " << snapshot.status() << "\n";
-      return;
+      throw std::runtime_error(snapshot.status().message());
     }
     std::cout << "GetSnapshot name : " << snapshot->name() << "\n";
   }
@@ -338,8 +326,7 @@ void ListSnapshots(google::cloud::bigtable::TableAdmin admin, int argc,
 
     auto snapshot_list = admin.ListSnapshots(cluster_id);
     if (!snapshot_list) {
-      std::cerr << "ListSnapshots failed: " << snapshot_list.status() << "\n";
-      return;
+      throw std::runtime_error(snapshot_list.status().message());
     }
     std::cout << "Snapshot Name List\n";
     for (auto const& snapshot : *snapshot_list) {
@@ -368,8 +355,7 @@ void DeleteSnapshot(google::cloud::bigtable::TableAdmin admin, int argc,
     google::cloud::Status status =
         admin.DeleteSnapshot(cluster_id, snapshot_id);
     if (!status.ok()) {
-      std::cerr << "DeleteSnapshot failed: " << status << "\n";
-      return;
+      throw std::runtime_error(status.message());
     }
   }
   //! [delete snapshot]

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -260,7 +260,11 @@ void CheckConsistency(google::cloud::bigtable::TableAdmin admin, int argc,
     google::cloud::bigtable::ConsistencyToken consistency_token(
         consistency_token_param);
     auto result = admin.CheckConsistency(table_id, consistency_token);
-    if (result) {
+    if (!result) {
+      std::cerr << "CheckConsistency failed: " << result.status() << "\n";
+      return;
+    }
+    if (*result == google::cloud::bigtable::Consistency::kConsistent) {
       std::cout << "Table is consistent\n";
     } else {
       std::cout

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -105,8 +105,12 @@ void GetTable(google::cloud::bigtable::TableAdmin admin, int argc,
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
     auto table =
         admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
-    std::cout << table.name() << "\n";
-    for (auto const& family : table.column_families()) {
+    if (!table) {
+      std::cerr << "GetTable failed: " << table.status() << "\n";
+      return;
+    }
+    std::cout << table->name() << "\n";
+    for (auto const& family : table->column_families()) {
       std::string const& family_name = family.first;
       std::string gc_rule;
       google::protobuf::TextFormat::PrintToString(family.second.gc_rule(),
@@ -127,7 +131,11 @@ void DeleteTable(google::cloud::bigtable::TableAdmin admin, int argc,
 
   //! [delete table]
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
-    admin.DeleteTable(table_id);
+    google::cloud::Status status = admin.DeleteTable(table_id);
+    if (!status.ok()) {
+      std::cerr << "DeleteTable failed: " << status << "\n";
+      return;
+    }
   }
   //! [delete table]
   (std::move(admin), table_id);
@@ -156,8 +164,12 @@ void ModifyTable(google::cloud::bigtable::TableAdmin admin, int argc,
                         google::cloud::bigtable::GcRule::MaxAge(
                             std::chrono::hours(72))))});
 
+    if (!schema) {
+      std::cerr << "ModifyColumnFamilies failed: " << schema.status() << "\n";
+      return;
+    }
     std::string formatted;
-    google::protobuf::TextFormat::PrintToString(schema, &formatted);
+    google::protobuf::TextFormat::PrintToString(*schema, &formatted);
     std::cout << "Schema modified to: " << formatted << "\n";
   }
   //! [modify table]
@@ -173,7 +185,11 @@ void DropAllRows(google::cloud::bigtable::TableAdmin admin, int argc,
 
   //! [drop all rows]
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
-    admin.DropAllRows(table_id);
+    google::cloud::Status status = admin.DropAllRows(table_id);
+    if (!status.ok()) {
+      std::cerr << "DropAllRows failed: " << status << "\n";
+      return;
+    }
   }
   //! [drop all rows]
   (std::move(admin), table_id);
@@ -188,7 +204,12 @@ void DropRowsByPrefix(google::cloud::bigtable::TableAdmin admin, int argc,
 
   //! [drop rows by prefix]
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
-    admin.DropRowsByPrefix(table_id, "key-00004");
+    google::cloud::Status status =
+        admin.DropRowsByPrefix(table_id, "key-00004");
+    if (!status.ok()) {
+      std::cerr << "DropRowsByPrefix failed: " << status << "\n";
+      return;
+    }
   }
   //! [drop rows by prefix]
   (std::move(admin), table_id);
@@ -205,9 +226,13 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
   //! [wait for consistency check]
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id_param) {
     google::cloud::bigtable::TableId table_id(table_id_param);
-    google::cloud::bigtable::ConsistencyToken consistency_token(
-        admin.GenerateConsistencyToken(table_id.get()));
-    auto result = admin.WaitForConsistencyCheck(table_id, consistency_token);
+    auto consistency_token(admin.GenerateConsistencyToken(table_id.get()));
+    if (!consistency_token) {
+      std::cerr << "GenerateConsistencyToken failed: "
+                << consistency_token.status() << "\n";
+      return;
+    }
+    auto result = admin.WaitForConsistencyCheck(table_id, *consistency_token);
     if (result.get()) {
       std::cout << "Table is consistent\n";
     } else {
@@ -258,9 +283,14 @@ void GenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
 
   //! [generate consistency token]
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
-    std::string token = admin.GenerateConsistencyToken(table_id);
+    auto token = admin.GenerateConsistencyToken(table_id);
+    if (!token) {
+      std::cerr << "GenerateConsistencyToken failed: " << token.status()
+                << "\n";
+      return;
+    }
     std::cout << "\n"
-              << "generated token is : " << token << "\n";
+              << "generated token is : " << token->get() << "\n";
   }
   //! [generate consistency token]
   (std::move(admin), table_id);
@@ -281,7 +311,11 @@ void GetSnapshot(google::cloud::bigtable::TableAdmin admin, int argc,
     google::cloud::bigtable::ClusterId cluster_id(cluster_id_str);
     google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
     auto snapshot = admin.GetSnapshot(cluster_id, snapshot_id);
-    std::cout << "GetSnapshot name : " << snapshot.name() << "\n";
+    if (!snapshot) {
+      std::cerr << "GetSnapshot failed: " << snapshot.status() << "\n";
+      return;
+    }
+    std::cout << "GetSnapshot name : " << snapshot->name() << "\n";
   }
   //! [get snapshot]
   (std::move(admin), cluster_id_str, snapshot_id_str);
@@ -299,8 +333,12 @@ void ListSnapshots(google::cloud::bigtable::TableAdmin admin, int argc,
     google::cloud::bigtable::ClusterId cluster_id(cluster_id_str);
 
     auto snapshot_list = admin.ListSnapshots(cluster_id);
+    if (!snapshot_list) {
+      std::cerr << "ListSnapshots failed: " << snapshot_list.status() << "\n";
+      return;
+    }
     std::cout << "Snapshot Name List\n";
-    for (auto const& snapshot : snapshot_list) {
+    for (auto const& snapshot : *snapshot_list) {
       std::cout << "Snapshot Name:" << snapshot.name() << "\n";
     }
   }
@@ -323,7 +361,12 @@ void DeleteSnapshot(google::cloud::bigtable::TableAdmin admin, int argc,
      std::string snapshot_id_str) {
     google::cloud::bigtable::ClusterId cluster_id(cluster_id_str);
     google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
-    admin.DeleteSnapshot(cluster_id, snapshot_id);
+    google::cloud::Status status =
+        admin.DeleteSnapshot(cluster_id, snapshot_id);
+    if (!status.ok()) {
+      std::cerr << "DeleteSnapshot failed: " << status << "\n";
+      return;
+    }
   }
   //! [delete snapshot]
   (std::move(admin), cluster_id_str, snapshot_id_str);

--- a/google/cloud/bigtable/internal/table_admin.h
+++ b/google/cloud/bigtable/internal/table_admin.h
@@ -360,19 +360,17 @@ class TableAdmin {
                       bigtable::SnapshotId const& snapshot_id,
                       grpc::Status& status);
 
-  template <template <typename...> class Collection = std::vector>
-  Collection<google::bigtable::admin::v2::Snapshot> ListSnapshots(
+  /**
+   * List snapshots in the given instance.
+   *
+   * @param status status of the operation
+   * @param cluster_id the name of the cluster for which snapshots should be
+   * listed.
+   * @return vector containing the snapshots for the given cluster.
+   */
+  std::vector<google::bigtable::admin::v2::Snapshot> ListSnapshots(
       grpc::Status& status,
-      bigtable::ClusterId const& cluster_id = bigtable::ClusterId("-")) {
-    Collection<::google::bigtable::admin::v2::Snapshot> result;
-    ListSnapshotsImpl(
-        cluster_id,
-        [&result](::google::bigtable::admin::v2::Snapshot snapshot) {
-          result.emplace_back(std::move(snapshot));
-        },
-        status);
-    return result;
-  }
+      bigtable::ClusterId const& cluster_id = bigtable::ClusterId("-"));
 
   /**
    * Make an asynchronous request to modify the column families of a table.
@@ -711,24 +709,6 @@ class TableAdmin {
   std::string ClusterName(bigtable::ClusterId const& cluster_id) {
     return instance_name() + "/clusters/" + cluster_id.get();
   }
-
-  /**
-   * Refactor implementation to `.cc` file.
-   *
-   * Provides a compilation barrier so that the application is not
-   * exposed to all the implementation details.
-   *
-   * @param cluster_id cluster_id which contains the snapshots.
-   * @param inserter Function to insert the object to result.
-   * @param clearer Function to clear the result object if RPC fails.
-   * @param status Status which contains the information whether the operation
-   * succeeded successfully or not.
-   */
-  void ListSnapshotsImpl(
-      bigtable::ClusterId const& cluster_id,
-      std::function<void(google::bigtable::admin::v2::Snapshot)> const&
-          inserter,
-      grpc::Status& status);
 
   bool WaitForConsistencyCheckHelper(
       bigtable::TableId const& table_id,

--- a/google/cloud/bigtable/internal/table_admin_test.cc
+++ b/google/cloud/bigtable/internal/table_admin_test.cc
@@ -823,31 +823,6 @@ parent: 'projects/the-project/instances/the-instance/clusters/the-cluster'
 }
 
 /**
- * @test Verify that `bigtable::noex::TableAdmin::ListSnapshots` works for
- * std::list container.
- */
-TEST_F(TableAdminTest, ListSnapshots_SimpleList) {
-  using namespace ::testing;
-  bigtable::noex::TableAdmin tested(client_, kInstanceId);
-  auto mock_list_snapshots = create_list_snapshots_lambda("", "", {"s0", "s1"});
-  EXPECT_CALL(*client_, ListSnapshots(_, _, _))
-      .WillOnce(Invoke(mock_list_snapshots));
-
-  bigtable::ClusterId cluster_id("the-cluster");
-  grpc::Status status;
-  std::list<btadmin::Snapshot> actual_snapshots =
-      tested.ListSnapshots<std::list>(status, cluster_id);
-  ASSERT_EQ(2UL, actual_snapshots.size());
-  std::string instance_name = tested.instance_name();
-  std::list<btadmin::Snapshot>::iterator it = actual_snapshots.begin();
-  EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s0", it->name());
-  it++;
-  EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s1", it->name());
-  it++;
-  EXPECT_EQ(actual_snapshots.end(), it);
-}
-
-/**
  * @test Verify that `bigtable::TableAdmin::ListSnapshots` handles failures.
  */
 TEST_F(TableAdminTest, ListSnapshots_RecoverableFailure) {

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -188,7 +188,7 @@ StatusOr<ConsistencyToken> TableAdmin::GenerateConsistencyToken(
   return ConsistencyToken(token);
 }
 
-StatusOr<bool> TableAdmin::CheckConsistency(
+StatusOr<Consistency> TableAdmin::CheckConsistency(
     bigtable::TableId const& table_id,
     bigtable::ConsistencyToken const& consistency_token) {
   grpc::Status status;
@@ -196,7 +196,7 @@ StatusOr<bool> TableAdmin::CheckConsistency(
   if (!status.ok()) {
     return internal::MakeStatusFromRpcError(status);
   }
-  return consistent;
+  return consistent ? Consistency::kConsistent : Consistency::kInconsistent;
 }
 
 bool TableAdmin::WaitForConsistencyCheckImpl(

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -264,7 +264,7 @@ btadmin::Table TableAdmin::CreateTableFromSnapshotImpl(
 }
 
 StatusOr<std::vector<::google::bigtable::admin::v2::Snapshot>>
-TableAdmin::ListSnapshots(bigtable::ClusterId cluster_id) {
+TableAdmin::ListSnapshots(bigtable::ClusterId const& cluster_id) {
   grpc::Status status;
   auto res = impl_.ListSnapshots(status, cluster_id);
 

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -31,6 +31,8 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+enum class Consistency { kConsistent, kInconsistent };
+
 /**
  * Implements the API to administer tables in a Cloud Bigtable instance.
  */
@@ -275,7 +277,7 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc check consistency
    */
-  StatusOr<bool> CheckConsistency(
+  StatusOr<Consistency> CheckConsistency(
       bigtable::TableId const& table_id,
       bigtable::ConsistencyToken const& consistency_token);
 

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -420,7 +420,7 @@ class TableAdmin {
    * @snippet table_admin_snippets.cc list snapshots
    */
   StatusOr<std::vector<::google::bigtable::admin::v2::Snapshot>> ListSnapshots(
-      bigtable::ClusterId cluster_id = bigtable::ClusterId("-"));
+      bigtable::ClusterId const& cluster_id = bigtable::ClusterId("-"));
 
  private:
   /**

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -381,16 +381,8 @@ TEST_F(TableAdminTest, CopyConstructibleAssignablePolicyTest) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(table_admin.GetTable("other-table"), bigtable::GRpcError);
-  EXPECT_THROW(table_admin_assign.GetTable("other-table"), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(table_admin.GetTable("other-table"),
-                            "exceptions are disabled");
-  EXPECT_DEATH_IF_SUPPORTED(table_admin_assign.GetTable("other-table"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(table_admin.GetTable("other-table"));
+  EXPECT_FALSE(table_admin_assign.GetTable("other-table"));
 }
 
 /// @test Verify that `bigtable::TableAdmin::GetTable` works in the easy case.
@@ -427,13 +419,8 @@ TEST_F(TableAdminTest, GetTableUnrecoverableFailures) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::NOT_FOUND, "uh oh")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GetTable("other-table"), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.GetTable("other-table"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.GetTable("other-table"));
 }
 
 /**
@@ -451,13 +438,8 @@ TEST_F(TableAdminTest, GetTableTooManyFailures) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GetTable("other-table"), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.GetTable("other-table"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.GetTable("other-table"));
 }
 
 /// @test Verify that bigtable::TableAdmin::DeleteTable works as expected.
@@ -474,7 +456,7 @@ TEST_F(TableAdminTest, DeleteTable) {
   EXPECT_CALL(*client_, DeleteTable(_, _, _)).WillOnce(Invoke(mock));
 
   // After all the setup, make the actual call we want to test.
-  tested.DeleteTable("the-table");
+  EXPECT_TRUE(tested.DeleteTable("the-table").ok());
 }
 
 /**
@@ -489,13 +471,8 @@ TEST_F(TableAdminTest, DeleteTableFailure) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.DeleteTable("other-table"), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.DeleteTable("other-table"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.DeleteTable("other-table").ok());
 }
 
 /**
@@ -549,15 +526,7 @@ TEST_F(TableAdminTest, ModifyColumnFamiliesFailure) {
   std::vector<M> changes{M::Create("foo", GC::MaxAge(48_h)),
                          M::Update("bar", GC::MaxAge(24_h))};
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.ModifyColumnFamilies("other-table", std::move(changes)),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(
-      tested.ModifyColumnFamilies("other-table", std::move(changes)),
-      "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.ModifyColumnFamilies("other-table", std::move(changes)));
 }
 
 /// @test Verify that bigtable::TableAdmin::DropRowsByPrefix works as expected.
@@ -575,7 +544,7 @@ TEST_F(TableAdminTest, DropRowsByPrefix) {
   EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(Invoke(mock));
 
   // After all the setup, make the actual call we want to test.
-  tested.DropRowsByPrefix("the-table", "foobar");
+  EXPECT_TRUE(tested.DropRowsByPrefix("the-table", "foobar").ok());
 }
 
 /**
@@ -590,14 +559,7 @@ TEST_F(TableAdminTest, DropRowsByPrefixFailure) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.DropRowsByPrefix("other-table", "prefix"),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.DropRowsByPrefix("other-table", "prefix"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.DropRowsByPrefix("other-table", "prefix").ok());
 }
 
 /// @test Verify that bigtable::TableAdmin::DropRowsByPrefix works as expected.
@@ -615,7 +577,7 @@ TEST_F(TableAdminTest, DropAllRows) {
   EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(Invoke(mock));
 
   // After all the setup, make the actual call we want to test.
-  tested.DropAllRows("the-table");
+  EXPECT_TRUE(tested.DropAllRows("the-table").ok());
 }
 
 /**
@@ -630,13 +592,8 @@ TEST_F(TableAdminTest, DropAllRowsFailure) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.DropAllRows("other-table"), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.DropAllRows("other-table"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.DropAllRows("other-table").ok());
 }
 
 /**
@@ -672,14 +629,8 @@ TEST_F(TableAdminTest, GenerateConsistencyTokenFailure) {
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GenerateConsistencyToken("other-table"),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.GenerateConsistencyToken("other-table"),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.GenerateConsistencyToken("other-table"));
 }
 
 /**
@@ -719,15 +670,8 @@ TEST_F(TableAdminTest, CheckConsistencyFailure) {
 
   bigtable::TableId table_id("other-table");
   bigtable::ConsistencyToken consistency_token("test-token");
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.CheckConsistency(table_id, consistency_token),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(
-      tested.CheckConsistency(table_id, consistency_token),
-      "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.CheckConsistency(table_id, consistency_token));
 }
 
 /**
@@ -831,14 +775,8 @@ TEST_F(TableAdminTest, GetSnapshotUnrecoverableFailures) {
           Return(grpc::Status(grpc::StatusCode::NOT_FOUND, "No snapshot.")));
   bigtable::ClusterId cluster_id("other-cluster");
   bigtable::SnapshotId snapshot_id("other-snapshot");
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GetSnapshot(cluster_id, snapshot_id),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.GetSnapshot(cluster_id, snapshot_id),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.GetSnapshot(cluster_id, snapshot_id));
 }
 
 /**
@@ -857,14 +795,8 @@ TEST_F(TableAdminTest, GetSnapshotTooManyFailures) {
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
   bigtable::ClusterId cluster_id("other-cluster");
   bigtable::SnapshotId snapshot_id("other-snapshot");
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.GetSnapshot(cluster_id, snapshot_id),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.GetSnapshot(cluster_id, snapshot_id),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.GetSnapshot(cluster_id, snapshot_id));
 }
 
 /// @test Verify that bigtable::TableAdmin::DeleteSnapshot works as expected.
@@ -883,7 +815,7 @@ TEST_F(TableAdminTest, DeleteSnapshotSimple) {
   // After all the setup, make the actual call we want to test.
   bigtable::ClusterId cluster_id("the-cluster");
   bigtable::SnapshotId snapshot_id("random-snapshot");
-  tested.DeleteSnapshot(cluster_id, snapshot_id);
+  EXPECT_TRUE(tested.DeleteSnapshot(cluster_id, snapshot_id).ok());
 }
 
 /**
@@ -900,14 +832,8 @@ TEST_F(TableAdminTest, DeleteSnapshotFailure) {
   bigtable::ClusterId cluster_id("other-cluster");
   bigtable::SnapshotId snapshot_id("other-snapshot");
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.DeleteSnapshot(cluster_id, snapshot_id),
-               bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.DeleteSnapshot(cluster_id, snapshot_id),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.DeleteSnapshot(cluster_id, snapshot_id).ok());
 }
 
 /// @test Verify that bigtable::TableAdmin::SnapshotTable works as expected.
@@ -1224,36 +1150,13 @@ TEST_F(TableAdminTest, ListSnapshots_Simple) {
 
   bigtable::ClusterId cluster_id("the-cluster");
   auto actual_snapshots = tested.ListSnapshots(cluster_id);
-  ASSERT_EQ(2UL, actual_snapshots.size());
+  EXPECT_TRUE(actual_snapshots);
+  ASSERT_EQ(2UL, actual_snapshots->size());
   std::string instance_name = tested.instance_name();
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s0",
-            actual_snapshots[0].name());
+            (*actual_snapshots)[0].name());
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s1",
-            actual_snapshots[1].name());
-}
-
-/**
- * @test Verify that `bigtable::TableAdmin::ListSnapshots` works for std::list
- * container.
- */
-TEST_F(TableAdminTest, ListSnapshots_SimpleList) {
-  using namespace ::testing;
-  bigtable::TableAdmin tested(client_, kInstanceId);
-  auto mock_list_snapshots = create_list_snapshots_lambda("", "", {"s0", "s1"});
-  EXPECT_CALL(*client_, ListSnapshots(_, _, _))
-      .WillOnce(Invoke(mock_list_snapshots));
-
-  bigtable::ClusterId cluster_id("the-cluster");
-  std::list<btadmin::Snapshot> actual_snapshots =
-      tested.ListSnapshots<std::list>(cluster_id);
-  ASSERT_EQ(2UL, actual_snapshots.size());
-  std::string instance_name = tested.instance_name();
-  std::list<btadmin::Snapshot>::iterator it = actual_snapshots.begin();
-  EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s0", it->name());
-  it++;
-  EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s1", it->name());
-  it++;
-  EXPECT_EQ(actual_snapshots.end(), it);
+            (*actual_snapshots)[1].name());
 }
 
 /**
@@ -1280,16 +1183,17 @@ TEST_F(TableAdminTest, ListSnapshots_RecoverableFailure) {
 
   bigtable::ClusterId cluster_id("the-cluster");
   auto actual_snapshots = tested.ListSnapshots(cluster_id);
-  ASSERT_EQ(4UL, actual_snapshots.size());
+  EXPECT_TRUE(actual_snapshots);
+  ASSERT_EQ(4UL, actual_snapshots->size());
   std::string instance_name = tested.instance_name();
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s0",
-            actual_snapshots[0].name());
+            (*actual_snapshots)[0].name());
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s1",
-            actual_snapshots[1].name());
+            (*actual_snapshots)[1].name());
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s2",
-            actual_snapshots[2].name());
+            (*actual_snapshots)[2].name());
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s3",
-            actual_snapshots[3].name());
+            (*actual_snapshots)[3].name());
 }
 
 /**
@@ -1305,13 +1209,7 @@ TEST_F(TableAdminTest, ListSnapshots_UnrecoverableFailures) {
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
 
   bigtable::ClusterId cluster_id("other-cluster");
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  // After all the setup, make the actual call we want to test.
-  EXPECT_THROW(tested.ListSnapshots(cluster_id), bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(tested.ListSnapshots(cluster_id),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_FALSE(tested.ListSnapshots(cluster_id));
 }
 
 /**

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -456,7 +456,7 @@ TEST_F(TableAdminTest, DeleteTable) {
   EXPECT_CALL(*client_, DeleteTable(_, _, _)).WillOnce(Invoke(mock));
 
   // After all the setup, make the actual call we want to test.
-  EXPECT_TRUE(tested.DeleteTable("the-table").ok());
+  EXPECT_STATUS_OK(tested.DeleteTable("the-table"));
 }
 
 /**
@@ -544,7 +544,7 @@ TEST_F(TableAdminTest, DropRowsByPrefix) {
   EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(Invoke(mock));
 
   // After all the setup, make the actual call we want to test.
-  EXPECT_TRUE(tested.DropRowsByPrefix("the-table", "foobar").ok());
+  EXPECT_STATUS_OK(tested.DropRowsByPrefix("the-table", "foobar"));
 }
 
 /**
@@ -577,7 +577,7 @@ TEST_F(TableAdminTest, DropAllRows) {
   EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(Invoke(mock));
 
   // After all the setup, make the actual call we want to test.
-  EXPECT_TRUE(tested.DropAllRows("the-table").ok());
+  EXPECT_STATUS_OK(tested.DropAllRows("the-table"));
 }
 
 /**
@@ -654,7 +654,7 @@ TEST_F(TableAdminTest, CheckConsistencySimple) {
   bigtable::ConsistencyToken consistency_token("test-token");
   // After all the setup, make the actual call we want to test.
   auto result = tested.CheckConsistency(table_id, consistency_token);
-  ASSERT_TRUE(result);
+  ASSERT_STATUS_OK(result);
 }
 
 /**
@@ -816,7 +816,7 @@ TEST_F(TableAdminTest, DeleteSnapshotSimple) {
   // After all the setup, make the actual call we want to test.
   bigtable::ClusterId cluster_id("the-cluster");
   bigtable::SnapshotId snapshot_id("random-snapshot");
-  EXPECT_TRUE(tested.DeleteSnapshot(cluster_id, snapshot_id).ok());
+  EXPECT_STATUS_OK(tested.DeleteSnapshot(cluster_id, snapshot_id));
 }
 
 /**
@@ -1151,7 +1151,7 @@ TEST_F(TableAdminTest, ListSnapshots_Simple) {
 
   bigtable::ClusterId cluster_id("the-cluster");
   auto actual_snapshots = tested.ListSnapshots(cluster_id);
-  EXPECT_TRUE(actual_snapshots);
+  EXPECT_STATUS_OK(actual_snapshots);
   ASSERT_EQ(2UL, actual_snapshots->size());
   std::string instance_name = tested.instance_name();
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s0",
@@ -1184,7 +1184,7 @@ TEST_F(TableAdminTest, ListSnapshots_RecoverableFailure) {
 
   bigtable::ClusterId cluster_id("the-cluster");
   auto actual_snapshots = tested.ListSnapshots(cluster_id);
-  EXPECT_TRUE(actual_snapshots);
+  EXPECT_STATUS_OK(actual_snapshots);
   ASSERT_EQ(4UL, actual_snapshots->size());
   std::string instance_name = tested.instance_name();
   EXPECT_EQ(instance_name + "/clusters/the-cluster/snapshots/s0",

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -653,7 +653,8 @@ TEST_F(TableAdminTest, CheckConsistencySimple) {
   bigtable::TableId table_id("the-table");
   bigtable::ConsistencyToken consistency_token("test-token");
   // After all the setup, make the actual call we want to test.
-  tested.CheckConsistency(table_id, consistency_token);
+  auto result = tested.CheckConsistency(table_id, consistency_token);
+  ASSERT_TRUE(result);
 }
 
 /**

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -51,8 +51,8 @@ std::unique_ptr<bigtable::Table> TableIntegrationTest::CreateTable(
                                                                table_name);
 }
 
-void TableIntegrationTest::DeleteTable(std::string const& table_name) {
-  table_admin_->DeleteTable(table_name);
+Status TableIntegrationTest::DeleteTable(std::string const& table_name) {
+  return table_admin_->DeleteTable(table_name);
 }
 
 std::vector<bigtable::Cell> TableIntegrationTest::ReadRows(

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -78,7 +78,7 @@ class TableIntegrationTest : public ::testing::Test {
       std::string const& table_name, bigtable::TableConfig& table_config);
 
   /// Deletes the table passed via arguments.
-  void DeleteTable(std::string const& table_name);
+  Status DeleteTable(std::string const& table_name);
 
   /// Return all the cells in @p table that pass @p filter.
   std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -109,7 +109,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
 
   chain.get();
   SUCCEED();  // we expect that previous operations do not fail.
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   cq.Shutdown();
   pool.join();

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -109,7 +109,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
 
   chain.get();
   SUCCEED();  // we expect that previous operations do not fail.
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   cq.Shutdown();
   pool.join();

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -230,7 +230,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
 
   promise_drop_row.get_future().get();
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 
@@ -290,7 +290,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
   promise_drop_row.get_future().get();
 
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   ASSERT_TRUE(actual_cells.empty());
   cq.Shutdown();
@@ -383,7 +383,7 @@ TEST_F(AdminAsyncIntegrationTest, CheckConsistencyIntegrationTest) {
   cq.Shutdown();
   pool.join();
 
-  EXPECT_TRUE(table_admin.DeleteTable(table_id.get()).ok());
+  EXPECT_STATUS_OK(table_admin.DeleteTable(table_id.get()));
   instance_admin.DeleteInstance(id);
 }
 

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -230,7 +230,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
 
   promise_drop_row.get_future().get();
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 
@@ -290,7 +290,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
   promise_drop_row.get_future().get();
 
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   ASSERT_TRUE(actual_cells.empty());
   cq.Shutdown();
@@ -383,7 +383,7 @@ TEST_F(AdminAsyncIntegrationTest, CheckConsistencyIntegrationTest) {
   cq.Shutdown();
   pool.join();
 
-  table_admin.DeleteTable(table_id.get());
+  EXPECT_TRUE(table_admin.DeleteTable(table_id.get()).ok());
   instance_admin.DeleteInstance(id);
 }
 

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -86,7 +86,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
     EXPECT_EQ(1, CountMatchingTables(table_id, *current_table_list));
   }
   for (auto const& table_id : expected_table_list) {
-    DeleteTable(table_id);
+    EXPECT_TRUE(DeleteTable(table_id).ok());
   }
   current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(current_table_list);
@@ -131,9 +131,9 @@ TEST_F(AdminIntegrationTest, DropRowsByPrefixTest) {
   // Create records
   CreateCells(*table, created_cells);
   // Delete all the records for a row
-  table_admin_->DropRowsByPrefix(table_id, row_key1_prefix);
+  EXPECT_TRUE(table_admin_->DropRowsByPrefix(table_id, row_key1_prefix).ok());
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -163,9 +163,9 @@ TEST_F(AdminIntegrationTest, DropAllRowsTest) {
   // Create records
   CreateCells(*table, created_cells);
   // Delete all the records from a table
-  table_admin_->DropAllRows(table_id);
+  EXPECT_TRUE(table_admin_->DropAllRows(table_id).ok());
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   ASSERT_TRUE(actual_cells.empty());
 }
@@ -194,12 +194,14 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
 
   // verify new table was created
   auto table_result = table_admin_->GetTable(table_id);
-  EXPECT_EQ(table->table_name(), table_result.name())
+  ASSERT_TRUE(table_result);
+  EXPECT_EQ(table->table_name(), table_result->name())
       << "Mismatched names for GetTable(" << table_id
-      << "): " << table->table_name() << " != " << table_result.name();
+      << "): " << table->table_name() << " != " << table_result->name();
 
   // get table
   auto table_detailed = table_admin_->GetTable(table_id, btadmin::Table::FULL);
+  ASSERT_TRUE(table_detailed);
   auto count_matching_families = [](btadmin::Table const& table,
                                     std::string const& name) {
     int count = 0;
@@ -210,8 +212,8 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
     }
     return count;
   };
-  EXPECT_EQ(1, count_matching_families(table_detailed, "fam"));
-  EXPECT_EQ(1, count_matching_families(table_detailed, "foo"));
+  EXPECT_EQ(1, count_matching_families(*table_detailed, "fam"));
+  EXPECT_EQ(1, count_matching_families(*table_detailed, "foo"));
 
   // update table
   std::vector<bigtable::ColumnFamilyModification> column_modification_list = {
@@ -223,15 +225,16 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
 
   auto table_modified =
       table_admin_->ModifyColumnFamilies(table_id, column_modification_list);
-  EXPECT_EQ(1, count_matching_families(table_modified, "fam"));
-  EXPECT_EQ(0, count_matching_families(table_modified, "foo"));
-  EXPECT_EQ(1, count_matching_families(table_modified, "newfam"));
-  auto const& gc = table_modified.column_families().at("newfam").gc_rule();
+  ASSERT_TRUE(table_modified);
+  EXPECT_EQ(1, count_matching_families(*table_modified, "fam"));
+  EXPECT_EQ(0, count_matching_families(*table_modified, "foo"));
+  EXPECT_EQ(1, count_matching_families(*table_modified, "newfam"));
+  auto const& gc = table_modified->column_families().at("newfam").gc_rule();
   EXPECT_TRUE(gc.has_intersection());
   EXPECT_EQ(2, gc.intersection().rules_size());
 
   // delete table
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(current_table_list);
@@ -306,15 +309,15 @@ TEST_F(AdminIntegrationTest, CheckConsistencyIntegrationTest) {
 
   CreateCells(table, created_cells);
 
-  google::cloud::bigtable::ConsistencyToken consistency_token(
-      table_admin.GenerateConsistencyToken(table_id.get()));
+  auto consistency_token(table_admin.GenerateConsistencyToken(table_id.get()));
+  ASSERT_TRUE(consistency_token);
 
   auto result =
-      table_admin.WaitForConsistencyCheck(table_id, consistency_token);
+      table_admin.WaitForConsistencyCheck(table_id, *consistency_token);
 
   EXPECT_TRUE(result.get());
 
-  table_admin.DeleteTable(table_id.get());
+  EXPECT_TRUE(table_admin.DeleteTable(table_id.get()).ok());
   instance_admin.DeleteInstance(id);
 }
 

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -86,7 +86,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
     EXPECT_EQ(1, CountMatchingTables(table_id, *current_table_list));
   }
   for (auto const& table_id : expected_table_list) {
-    EXPECT_TRUE(DeleteTable(table_id).ok());
+    EXPECT_STATUS_OK(DeleteTable(table_id));
   }
   current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(current_table_list);
@@ -131,9 +131,9 @@ TEST_F(AdminIntegrationTest, DropRowsByPrefixTest) {
   // Create records
   CreateCells(*table, created_cells);
   // Delete all the records for a row
-  EXPECT_TRUE(table_admin_->DropRowsByPrefix(table_id, row_key1_prefix).ok());
+  EXPECT_STATUS_OK(table_admin_->DropRowsByPrefix(table_id, row_key1_prefix));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -163,9 +163,9 @@ TEST_F(AdminIntegrationTest, DropAllRowsTest) {
   // Create records
   CreateCells(*table, created_cells);
   // Delete all the records from a table
-  EXPECT_TRUE(table_admin_->DropAllRows(table_id).ok());
+  EXPECT_STATUS_OK(table_admin_->DropAllRows(table_id));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   ASSERT_TRUE(actual_cells.empty());
 }
@@ -194,14 +194,14 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
 
   // verify new table was created
   auto table_result = table_admin_->GetTable(table_id);
-  ASSERT_TRUE(table_result);
+  ASSERT_STATUS_OK(table_result);
   EXPECT_EQ(table->table_name(), table_result->name())
       << "Mismatched names for GetTable(" << table_id
       << "): " << table->table_name() << " != " << table_result->name();
 
   // get table
   auto table_detailed = table_admin_->GetTable(table_id, btadmin::Table::FULL);
-  ASSERT_TRUE(table_detailed);
+  ASSERT_STATUS_OK(table_detailed);
   auto count_matching_families = [](btadmin::Table const& table,
                                     std::string const& name) {
     int count = 0;
@@ -225,7 +225,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
 
   auto table_modified =
       table_admin_->ModifyColumnFamilies(table_id, column_modification_list);
-  ASSERT_TRUE(table_modified);
+  ASSERT_STATUS_OK(table_modified);
   EXPECT_EQ(1, count_matching_families(*table_modified, "fam"));
   EXPECT_EQ(0, count_matching_families(*table_modified, "foo"));
   EXPECT_EQ(1, count_matching_families(*table_modified, "newfam"));
@@ -234,7 +234,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
   EXPECT_EQ(2, gc.intersection().rules_size());
 
   // delete table
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(current_table_list);
@@ -310,14 +310,14 @@ TEST_F(AdminIntegrationTest, CheckConsistencyIntegrationTest) {
   CreateCells(table, created_cells);
 
   auto consistency_token(table_admin.GenerateConsistencyToken(table_id.get()));
-  ASSERT_TRUE(consistency_token);
+  ASSERT_STATUS_OK(consistency_token);
 
   auto result =
       table_admin.WaitForConsistencyCheck(table_id, *consistency_token);
 
   EXPECT_TRUE(result.get());
 
-  EXPECT_TRUE(table_admin.DeleteTable(table_id.get()).ok());
+  EXPECT_STATUS_OK(table_admin.DeleteTable(table_id.get()));
   instance_admin.DeleteInstance(id);
 }
 

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -69,7 +69,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -126,7 +126,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 
@@ -69,7 +70,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -126,7 +127,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 

--- a/google/cloud/bigtable/tests/data_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 
@@ -84,7 +85,7 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -150,7 +151,7 @@ TEST_F(DataAsyncIntegrationTest, TableBulkApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -201,7 +202,7 @@ TEST_F(DataAsyncIntegrationTest, SampleRowKeys) {
 
   cq.Shutdown();
   pool.join();
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   // It is somewhat hard to verify that the values returned here are correct.
   // We cannot check the specific values, not even the format, of the row keys
@@ -247,7 +248,7 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowPass) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c2", 0, "v2000", {}}};
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -278,7 +279,7 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowFail) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c3", 0, "v3000", {}}};
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -336,7 +337,7 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
   auto actual_cells_ignore_timestamp =
       GetCellsIgnoringTimestamp(result_row.cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_cells_ignore_timestamp,
                       actual_cells_ignore_timestamp);
 }
@@ -380,7 +381,7 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowIncrementAmountTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row.cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -443,7 +444,7 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowMultipleTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row.cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -488,7 +489,7 @@ TEST_F(DataAsyncIntegrationTest, TableReadRowsAllRows) {
   cq.Shutdown();
   pool.join();
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(created, actual);
 }
 
@@ -526,7 +527,7 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRow) {
   cq.Shutdown();
   pool.join();
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
   EXPECT_TRUE(response.first);
 }
@@ -559,7 +560,7 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRowForNoRow) {
   cq.Shutdown();
   pool.join();
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   EXPECT_FALSE(response.first);
   EXPECT_EQ(0, response.second.cells().size());
 }

--- a/google/cloud/bigtable/tests/data_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_integration_test.cc
@@ -84,7 +84,7 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -150,7 +150,7 @@ TEST_F(DataAsyncIntegrationTest, TableBulkApply) {
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -201,7 +201,7 @@ TEST_F(DataAsyncIntegrationTest, SampleRowKeys) {
 
   cq.Shutdown();
   pool.join();
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   // It is somewhat hard to verify that the values returned here are correct.
   // We cannot check the specific values, not even the format, of the row keys
@@ -247,7 +247,7 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowPass) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c2", 0, "v2000", {}}};
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -278,7 +278,7 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowFail) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c3", 0, "v3000", {}}};
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -336,7 +336,7 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
   auto actual_cells_ignore_timestamp =
       GetCellsIgnoringTimestamp(result_row.cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_cells_ignore_timestamp,
                       actual_cells_ignore_timestamp);
 }
@@ -380,7 +380,7 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowIncrementAmountTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row.cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -443,7 +443,7 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowMultipleTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row.cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -488,7 +488,7 @@ TEST_F(DataAsyncIntegrationTest, TableReadRowsAllRows) {
   cq.Shutdown();
   pool.join();
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(created, actual);
 }
 
@@ -526,7 +526,7 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRow) {
   cq.Shutdown();
   pool.join();
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
   EXPECT_TRUE(response.first);
 }
@@ -559,7 +559,7 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRowForNoRow) {
   cq.Shutdown();
   pool.join();
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   EXPECT_FALSE(response.first);
   EXPECT_EQ(0, response.second.cells().size());
 }

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -122,7 +122,7 @@ TEST_F(DataIntegrationTest, TableApply) {
       {row_key, family, "c1", 2000, "v2000", {}}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -151,7 +151,7 @@ TEST_F(DataIntegrationTest, TableBulkApply) {
       {"row-key-4", family, "c1", 2000, "v2000", {}}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -171,7 +171,7 @@ TEST_F(DataIntegrationTest, TableSingleRow) {
       {row_key, family, "c3", 3000, "V3000", {}}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -191,7 +191,7 @@ TEST_F(DataIntegrationTest, TableReadRowTest) {
   auto row_cell = table->ReadRow(row_key1, bigtable::Filter::PassAllFilter());
   std::vector<bigtable::Cell> actual;
   actual.emplace_back(row_cell.second.cells().at(0));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -206,7 +206,7 @@ TEST_F(DataIntegrationTest, TableReadRowNotExistTest) {
 
   CreateCells(*table, created);
   auto row_cell = table->ReadRow(row_key2, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   EXPECT_FALSE(row_cell.first);
 }
 
@@ -248,7 +248,7 @@ TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
         table->ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
     CheckEqualUnordered(created, MoveCellsFromReader(read4));
   }
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
@@ -289,7 +289,7 @@ TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
       table->ReadRows(std::move(rs3), bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
@@ -321,7 +321,7 @@ TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
                                bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
@@ -362,7 +362,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c2", 0, "v2000", {}}};
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -382,7 +382,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowFail) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c3", 0, "v3000", {}}};
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -423,7 +423,7 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
   auto actual_cells_ignore_timestamp =
       GetCellsIgnoringTimestamp(result_row->cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_cells_ignore_timestamp,
                       actual_cells_ignore_timestamp);
 }
@@ -453,7 +453,7 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -500,7 +500,7 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowMultipleTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -539,7 +539,7 @@ TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -633,6 +633,6 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp =
       GetCellsIgnoringTimestamp(result.second.cells());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -122,7 +122,7 @@ TEST_F(DataIntegrationTest, TableApply) {
       {row_key, family, "c1", 2000, "v2000", {}}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -151,7 +151,7 @@ TEST_F(DataIntegrationTest, TableBulkApply) {
       {"row-key-4", family, "c1", 2000, "v2000", {}}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -171,7 +171,7 @@ TEST_F(DataIntegrationTest, TableSingleRow) {
       {row_key, family, "c3", 3000, "V3000", {}}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -191,7 +191,7 @@ TEST_F(DataIntegrationTest, TableReadRowTest) {
   auto row_cell = table->ReadRow(row_key1, bigtable::Filter::PassAllFilter());
   std::vector<bigtable::Cell> actual;
   actual.emplace_back(row_cell.second.cells().at(0));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -206,7 +206,7 @@ TEST_F(DataIntegrationTest, TableReadRowNotExistTest) {
 
   CreateCells(*table, created);
   auto row_cell = table->ReadRow(row_key2, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   EXPECT_FALSE(row_cell.first);
 }
 
@@ -248,7 +248,7 @@ TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
         table->ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
     CheckEqualUnordered(created, MoveCellsFromReader(read4));
   }
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
@@ -289,7 +289,7 @@ TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
       table->ReadRows(std::move(rs3), bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
@@ -321,7 +321,7 @@ TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
                                bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
@@ -362,7 +362,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c2", 0, "v2000", {}}};
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -382,7 +382,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowFail) {
   std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
                                        {key, family, "c3", 0, "v3000", {}}};
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -423,7 +423,7 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
   auto actual_cells_ignore_timestamp =
       GetCellsIgnoringTimestamp(result_row->cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_cells_ignore_timestamp,
                       actual_cells_ignore_timestamp);
 }
@@ -453,7 +453,7 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -500,7 +500,7 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowMultipleTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -539,7 +539,7 @@ TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
@@ -572,8 +572,8 @@ TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
     table->BulkApply(std::move(bulk));
   }
   auto samples = table->SampleRows<std::vector>();
-  DeleteTable(table_id);
   ASSERT_STATUS_OK(samples);
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   // It is somewhat hard to verify that the values returned here are correct.
   // We cannot check the specific values, not even the format, of the row keys
@@ -633,6 +633,6 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp =
       GetCellsIgnoringTimestamp(result.second.cells());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 
@@ -103,7 +104,7 @@ TEST_F(FilterIntegrationTest, PassAll) {
   CreateCells(*table, expected);
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -123,7 +124,7 @@ TEST_F(FilterIntegrationTest, BlockAll) {
   std::vector<bigtable::Cell> expected{};
 
   auto actual = ReadRows(*table, bigtable::Filter::BlockAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -150,7 +151,7 @@ TEST_F(FilterIntegrationTest, Latest) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::Latest(2));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -175,7 +176,7 @@ TEST_F(FilterIntegrationTest, FamilyRegex) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::FamilyRegex("fam[02]"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -200,7 +201,7 @@ TEST_F(FilterIntegrationTest, ColumnRegex) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::ColumnRegex("(abc|.*h.*)"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -225,7 +226,7 @@ TEST_F(FilterIntegrationTest, ColumnRange) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::ColumnRange("fam0", "b00", "b02"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -251,7 +252,7 @@ TEST_F(FilterIntegrationTest, TimestampRange) {
   auto actual = ReadRows(
       *table, bigtable::Filter::TimestampRange(std::chrono::milliseconds(3),
                                                std::chrono::milliseconds(6)));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -274,7 +275,7 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::RowKeysRegex(row_key + "/bc.*"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -297,7 +298,7 @@ TEST_F(FilterIntegrationTest, ValueRegex) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::ValueRegex("v[34][0-9].*"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -323,7 +324,7 @@ TEST_F(FilterIntegrationTest, ValueRange) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::ValueRange("v2000", "v6000"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -347,7 +348,7 @@ TEST_F(FilterIntegrationTest, CellsRowLimit) {
                                       {prefix + "/complex", 3}};
 
   EXPECT_THAT(expected, ::testing::ContainerEq(actual));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(FilterIntegrationTest, CellsRowOffset) {
@@ -370,7 +371,7 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
                                       {prefix + "/complex", 78}};
 
   EXPECT_THAT(expected, ::testing::ContainerEq(actual));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(FilterIntegrationTest, RowSample) {
@@ -430,7 +431,7 @@ TEST_F(FilterIntegrationTest, RowSample) {
   // Search in the range [row_key_prefix, row_key_prefix + "0"), we used '/' as
   // the separator and the successor of "/" is "0".
   auto result = ReadRows(*table, bigtable::Filter::RowSample(kSampleRate));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   EXPECT_LE(kMinCount, result.size());
   EXPECT_GE(kMaxCount, result.size());
 }
@@ -458,7 +459,7 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::StripValueTransformer());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -491,7 +492,7 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::ApplyLabelTransformer("foo"));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -521,7 +522,7 @@ TEST_F(FilterIntegrationTest, Condition) {
       ReadRows(*table, F::Condition(F::ValueRangeClosed("v2000", "v4000"),
                                     F::StripValueTransformer(),
                                     F::FamilyRegex("fam[01]")));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -547,7 +548,7 @@ TEST_F(FilterIntegrationTest, Chain) {
       ReadRows(*table, F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                                 F::StripValueTransformer(),
                                 F::ColumnRangeClosed("fam0", "c2", "c3")));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -577,7 +578,7 @@ TEST_F(FilterIntegrationTest, Interleave) {
       *table, F::Interleave(F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                                      F::StripValueTransformer()),
                             F::ColumnRangeClosed("fam0", "c2", "c3")));
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -103,7 +103,7 @@ TEST_F(FilterIntegrationTest, PassAll) {
   CreateCells(*table, expected);
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -123,7 +123,7 @@ TEST_F(FilterIntegrationTest, BlockAll) {
   std::vector<bigtable::Cell> expected{};
 
   auto actual = ReadRows(*table, bigtable::Filter::BlockAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -150,7 +150,7 @@ TEST_F(FilterIntegrationTest, Latest) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::Latest(2));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -175,7 +175,7 @@ TEST_F(FilterIntegrationTest, FamilyRegex) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::FamilyRegex("fam[02]"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -200,7 +200,7 @@ TEST_F(FilterIntegrationTest, ColumnRegex) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::ColumnRegex("(abc|.*h.*)"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -225,7 +225,7 @@ TEST_F(FilterIntegrationTest, ColumnRange) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::ColumnRange("fam0", "b00", "b02"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -251,7 +251,7 @@ TEST_F(FilterIntegrationTest, TimestampRange) {
   auto actual = ReadRows(
       *table, bigtable::Filter::TimestampRange(std::chrono::milliseconds(3),
                                                std::chrono::milliseconds(6)));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -274,7 +274,7 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::RowKeysRegex(row_key + "/bc.*"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -297,7 +297,7 @@ TEST_F(FilterIntegrationTest, ValueRegex) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::ValueRegex("v[34][0-9].*"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -323,7 +323,7 @@ TEST_F(FilterIntegrationTest, ValueRange) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::ValueRange("v2000", "v6000"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -347,7 +347,7 @@ TEST_F(FilterIntegrationTest, CellsRowLimit) {
                                       {prefix + "/complex", 3}};
 
   EXPECT_THAT(expected, ::testing::ContainerEq(actual));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 }
 
 TEST_F(FilterIntegrationTest, CellsRowOffset) {
@@ -370,7 +370,7 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
                                       {prefix + "/complex", 78}};
 
   EXPECT_THAT(expected, ::testing::ContainerEq(actual));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 }
 
 TEST_F(FilterIntegrationTest, RowSample) {
@@ -430,7 +430,7 @@ TEST_F(FilterIntegrationTest, RowSample) {
   // Search in the range [row_key_prefix, row_key_prefix + "0"), we used '/' as
   // the separator and the successor of "/" is "0".
   auto result = ReadRows(*table, bigtable::Filter::RowSample(kSampleRate));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   EXPECT_LE(kMinCount, result.size());
   EXPECT_GE(kMaxCount, result.size());
 }
@@ -458,7 +458,7 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::StripValueTransformer());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -491,7 +491,7 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
 
   auto actual =
       ReadRows(*table, bigtable::Filter::ApplyLabelTransformer("foo"));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -521,7 +521,7 @@ TEST_F(FilterIntegrationTest, Condition) {
       ReadRows(*table, F::Condition(F::ValueRangeClosed("v2000", "v4000"),
                                     F::StripValueTransformer(),
                                     F::FamilyRegex("fam[01]")));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -547,7 +547,7 @@ TEST_F(FilterIntegrationTest, Chain) {
       ReadRows(*table, F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                                 F::StripValueTransformer(),
                                 F::ColumnRangeClosed("fam0", "c2", "c3")));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -577,7 +577,7 @@ TEST_F(FilterIntegrationTest, Interleave) {
       *table, F::Interleave(F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                                      F::StripValueTransformer()),
                             F::ColumnRangeClosed("fam0", "c2", "c3")));
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
   CheckEqualUnordered(expected, actual);
 }
 

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 
@@ -84,7 +85,7 @@ TEST_F(MutationIntegrationTest, SetCellTest) {
 
   CreateCells(*table, created_cells);
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -124,7 +125,7 @@ TEST_F(MutationIntegrationTest, SetCellNumericValueTest) {
 
   CreateCells(*table, created_cells);
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -172,7 +173,7 @@ TEST_F(MutationIntegrationTest, SetCellIgnoreTimestampTest) {
 
   CreateCellsIgnoringTimestamp(*table, created_cells);
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   // Create the expected_cells and actual_cells with same timestamp
   auto expected_cells_ignore_time = GetCellsIgnoringTimestamp(expected_cells);
@@ -221,7 +222,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForTimestampRangeTest) {
       row_key, bigtable::DeleteFromColumn(column_family2, "column_id2", 2000_us,
                                           4000_us)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -268,7 +269,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -309,7 +310,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -342,7 +343,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForAllTest) {
   table->Apply(bigtable::SingleRowMutation(
       row_key, bigtable::DeleteFromColumn(column_family1, "column_id3")));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -379,7 +380,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnStartingFromTest) {
       row_key, bigtable::DeleteFromColumnStartingFrom(column_family1,
                                                       "column_id1", 1000_us)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -418,7 +419,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnEndingAtTest) {
       row_key, bigtable::DeleteFromColumnEndingAt(column_family1, "column_id1",
                                                   2000_us)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -450,7 +451,7 @@ TEST_F(MutationIntegrationTest, DeleteFromFamilyTest) {
   table->Apply(bigtable::SingleRowMutation(
       row_key, bigtable::DeleteFromFamily(column_family1)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -483,7 +484,7 @@ TEST_F(MutationIntegrationTest, DeleteFromRowTest) {
   table->Apply(
       bigtable::SingleRowMutation(row_key1, bigtable::DeleteFromRow()));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_TRUE(DeleteTable(table_id).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -84,7 +84,7 @@ TEST_F(MutationIntegrationTest, SetCellTest) {
 
   CreateCells(*table, created_cells);
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -124,7 +124,7 @@ TEST_F(MutationIntegrationTest, SetCellNumericValueTest) {
 
   CreateCells(*table, created_cells);
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -172,7 +172,7 @@ TEST_F(MutationIntegrationTest, SetCellIgnoreTimestampTest) {
 
   CreateCellsIgnoringTimestamp(*table, created_cells);
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   // Create the expected_cells and actual_cells with same timestamp
   auto expected_cells_ignore_time = GetCellsIgnoringTimestamp(expected_cells);
@@ -221,7 +221,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForTimestampRangeTest) {
       row_key, bigtable::DeleteFromColumn(column_family2, "column_id2", 2000_us,
                                           4000_us)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -268,7 +268,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -309,7 +309,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
       "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(created_cells, actual_cells);
 }
@@ -342,7 +342,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForAllTest) {
   table->Apply(bigtable::SingleRowMutation(
       row_key, bigtable::DeleteFromColumn(column_family1, "column_id3")));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -379,7 +379,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnStartingFromTest) {
       row_key, bigtable::DeleteFromColumnStartingFrom(column_family1,
                                                       "column_id1", 1000_us)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -418,7 +418,7 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnEndingAtTest) {
       row_key, bigtable::DeleteFromColumnEndingAt(column_family1, "column_id1",
                                                   2000_us)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -450,7 +450,7 @@ TEST_F(MutationIntegrationTest, DeleteFromFamilyTest) {
   table->Apply(bigtable::SingleRowMutation(
       row_key, bigtable::DeleteFromFamily(column_family1)));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }
@@ -483,7 +483,7 @@ TEST_F(MutationIntegrationTest, DeleteFromRowTest) {
   table->Apply(
       bigtable::SingleRowMutation(row_key1, bigtable::DeleteFromRow()));
   auto actual_cells = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  DeleteTable(table_id);
+  EXPECT_TRUE(DeleteTable(table_id).ok());
 
   CheckEqualUnordered(expected_cells, actual_cells);
 }

--- a/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
@@ -108,7 +108,8 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
 
   // verify new snapshot id in list of snapshot
   auto snapshots_before = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_FALSE(IsSnapshotPresent(snapshots_before, snapshot_id_str))
+  ASSERT_TRUE(snapshots_before);
+  ASSERT_FALSE(IsSnapshotPresent(*snapshots_before, snapshot_id_str))
       << "Snapshot (" << snapshot_id_str << ") already exists."
       << " This is unexpected, as the snapshot ids are"
       << " generated at random.";
@@ -118,7 +119,8 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
       table_admin_->SnapshotTable(cluster_id, snapshot_id, table_id, 36000_s)
           .get();
   auto snapshots_current = table_admin_->ListSnapshots(cluster_id);
-  EXPECT_TRUE(IsSnapshotPresent(snapshots_current, snapshot.name()));
+  ASSERT_TRUE(snapshots_current);
+  EXPECT_TRUE(IsSnapshotPresent(*snapshots_current, snapshot.name()));
 
   // get snapshot
   std::promise<btadmin::Snapshot> promise_get_snapshot;
@@ -146,10 +148,11 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   promise_delete_snapshot.get_future().get();
 
   auto snapshots_after_delete = table_admin_->ListSnapshots(cluster_id);
-  EXPECT_FALSE(IsSnapshotPresent(snapshots_after_delete, snapshot.name()));
+  ASSERT_TRUE(snapshots_after_delete);
+  EXPECT_FALSE(IsSnapshotPresent(*snapshots_after_delete, snapshot.name()));
 
   // delete table
-  DeleteTable(table_id.get());
+  EXPECT_TRUE(DeleteTable(table_id.get()).ok());
 
   cq.Shutdown();
   pool.join();

--- a/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -108,7 +109,7 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
 
   // verify new snapshot id in list of snapshot
   auto snapshots_before = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_TRUE(snapshots_before);
+  ASSERT_STATUS_OK(snapshots_before);
   ASSERT_FALSE(IsSnapshotPresent(*snapshots_before, snapshot_id_str))
       << "Snapshot (" << snapshot_id_str << ") already exists."
       << " This is unexpected, as the snapshot ids are"
@@ -119,7 +120,7 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
       table_admin_->SnapshotTable(cluster_id, snapshot_id, table_id, 36000_s)
           .get();
   auto snapshots_current = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_TRUE(snapshots_current);
+  ASSERT_STATUS_OK(snapshots_current);
   EXPECT_TRUE(IsSnapshotPresent(*snapshots_current, snapshot.name()));
 
   // get snapshot
@@ -148,11 +149,11 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   promise_delete_snapshot.get_future().get();
 
   auto snapshots_after_delete = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_TRUE(snapshots_after_delete);
+  ASSERT_STATUS_OK(snapshots_after_delete);
   EXPECT_FALSE(IsSnapshotPresent(*snapshots_after_delete, snapshot.name()));
 
   // delete table
-  EXPECT_TRUE(DeleteTable(table_id.get()).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id.get()));
 
   cq.Shutdown();
   pool.join();

--- a/google/cloud/bigtable/tests/snapshot_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -100,9 +101,9 @@ TEST_F(SnapshotIntegrationTest, SnapshotOperationsTableTest) {
 
   CheckEqualUnordered(created_cells, actual_cells);
 
-  EXPECT_TRUE(table_admin_->DeleteSnapshot(cluster_id, snapshot_id).ok());
-  EXPECT_TRUE(DeleteTable(table_id.get()).ok());
-  EXPECT_TRUE(DeleteTable(table_id_new.get()).ok());
+  EXPECT_STATUS_OK(table_admin_->DeleteSnapshot(cluster_id, snapshot_id));
+  EXPECT_STATUS_OK(DeleteTable(table_id.get()));
+  EXPECT_STATUS_OK(DeleteTable(table_id_new.get()));
 }
 
 /// @test Verify that Snapshot CRUD operations work as expected.
@@ -138,7 +139,7 @@ TEST_F(SnapshotIntegrationTest, CreateListGetDeleteSnapshot) {
 
   // verify new snapshot id in list of snapshot
   auto snapshots_before = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_TRUE(snapshots_before);
+  ASSERT_STATUS_OK(snapshots_before);
   ASSERT_FALSE(IsSnapshotPresent(*snapshots_before, snapshot_id_str))
       << "Snapshot (" << snapshot_id_str << ") already exists."
       << " This is unexpected, as the snapshot ids are"
@@ -149,23 +150,23 @@ TEST_F(SnapshotIntegrationTest, CreateListGetDeleteSnapshot) {
       table_admin_->SnapshotTable(cluster_id, snapshot_id, table_id, 36000_s)
           .get();
   auto snapshots_current = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_TRUE(snapshots_current);
+  ASSERT_STATUS_OK(snapshots_current);
   EXPECT_TRUE(IsSnapshotPresent(*snapshots_current, snapshot.name()));
 
   // get snapshot
   auto snapshot_check = table_admin_->GetSnapshot(cluster_id, snapshot_id);
   auto const npos = std::string::npos;
-  ASSERT_TRUE(snapshot_check);
+  ASSERT_STATUS_OK(snapshot_check);
   EXPECT_NE(npos, snapshot_check->name().find(snapshot_id_str));
 
   // Delete snapshot
-  EXPECT_TRUE(table_admin_->DeleteSnapshot(cluster_id, snapshot_id).ok());
+  EXPECT_STATUS_OK(table_admin_->DeleteSnapshot(cluster_id, snapshot_id));
   auto snapshots_after_delete = table_admin_->ListSnapshots(cluster_id);
-  ASSERT_TRUE(snapshots_after_delete);
+  ASSERT_STATUS_OK(snapshots_after_delete);
   EXPECT_FALSE(IsSnapshotPresent(*snapshots_after_delete, snapshot.name()));
 
   // delete table
-  EXPECT_TRUE(DeleteTable(table_id.get()).ok());
+  EXPECT_STATUS_OK(DeleteTable(table_id.get()));
 }
 
 // Test Cases Finished


### PR DESCRIPTION
This fixes #1943
This fixes #1944
This fixes #1945
This fixes #1946 
This fixes #1947
This fixes #1948
This fixes #1949
This fixes #1950
This fixes #1951
This fixes #1952

In #1948 (`CheckConsistency`) I used `StatusOr<bool>` because I anticipate we remove it. This is simply the least effort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1958)
<!-- Reviewable:end -->
