### PR TITLE
Remove unnecessary code from example.

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -152,13 +152,6 @@ void InsertObjectModifiedRetry(google::cloud::storage::Client unused, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](std::string bucket_name, std::string object_name, std::string contents) {
-    StatusOr<std::shared_ptr<gcs::oauth2::Credentials>> credentials =
-        gcs::oauth2::GoogleDefaultCredentials();
-
-    if (!credentials) {
-      throw std::runtime_error(credentials.status().message());
-    }
-
     // Create a client that only gives up on the third error. The default policy
     // is to retry for several minutes.
     StatusOr<gcs::ClientOptions> options =


### PR DESCRIPTION
One of the examples was explicitly loading the default credentials,
though it did not use them. That broke one of my local builds, because
the credentials file did not exist at all.  Strangely it seems to work
without trouble in the CI build :shrug:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1971)
<!-- Reviewable:end -->
