### PR TITLE
Package version config work without a version.

### DIFF
--- a/ci/test-install/CMakeLists.txt
+++ b/ci/test-install/CMakeLists.txt
@@ -27,13 +27,15 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Threads REQUIRED)
-find_package(bigtable_client 0.7.0 REQUIRED)
+find_package(bigtable_client REQUIRED)
 
-# Defining new targets should be easy.
+# Once the bigtable_client package is found, define new targets.
 add_executable(bigtable_install_test bigtable_install_test.cc)
 target_link_libraries(bigtable_install_test bigtable::client)
 
 find_package(CURL REQUIRED)
-find_package(storage_client 0.5.0 REQUIRED)
+find_package(storage_client REQUIRED)
+
+# Once the packages are found, define the targets.
 add_executable(storage_install_test storage_install_test.cc)
 target_link_libraries(storage_install_test storage_client)

--- a/google/cloud/bigtable/config.cmake.in
+++ b/google/cloud/bigtable/config.cmake.in
@@ -15,7 +15,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(protobuf)
 find_dependency(gRPC)
-find_dependency(google_cloud_cpp_common 0.4.0)
+find_dependency(google_cloud_cpp_common)
 
 include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
 

--- a/google/cloud/config-version.cmake.in
+++ b/google/cloud/config-version.cmake.in
@@ -14,24 +14,22 @@
 
 set(PACKAGE_VERSION @DOXYGEN_PROJECT_NUMBER@)
 
+# This package has not reached 1.0, there are no compatibility guarantees
+# before then.
 if (@GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR@ EQUAL 0)
-    # Only exact matches for the 0.x.y releases, i.e., no backwards
-    # compatibility guarantees.
-    if (("${PACKAGE_FIND_VERSION_MAJOR}" EQUAL "@GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR@")
-         AND ("${PACKAGE_FIND_VERSION_MINOR}" EQUAL "@GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR@"))
-        set(PACKAGE_VERSION_EXACT TRUE)
-    else ()
-        set(PACKAGE_VERSION_UNSUITABLE TRUE)
-    endif ()
-elseif ("${PACKAGE_FIND_VERSION_MAJOR}" EQUAL "@GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR@")
-    # For versions after 1.x.y we will require backwards compatibility.
-    if ("${PACKAGE_FIND_VERSION_MINOR}" EQUAL "@GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR@")
-        set(PACKAGE_VERSION_EXACT TRUE)
-    elseif("${PACKAGE_FIND_VERSION_MINOR}" LESS "@GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR@")
+    if ("${PACKAGE_FIND_VERSION}" STREQUAL "")
         set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    elseif ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+        set(PACKAGE_VERSION_EXACT TRUE)
     else ()
         set(PACKAGE_VERSION_UNSUITABLE TRUE)
     endif ()
-else ()
-    set(PACKAGE_VERSION_UNSUITABLE TRUE)
-endif ()
+elseif("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+        set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+endif()

--- a/google/cloud/storage/config.cmake.in
+++ b/google/cloud/storage/config.cmake.in
@@ -15,7 +15,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(CURL)
 find_dependency(Crc32c)
-find_dependency(google_cloud_cpp_common 0.4.0)
+find_dependency(google_cloud_cpp_common)
 
 # Some versions of FindCURL do not define CURL::CURL, so we define it ourselves.
 if (NOT TARGET CURL::CURL)


### PR DESCRIPTION
Our package version config files were requiring an explicit version,
i.e., we always rejected:

```CMake
find_package(bigtable_client)
```

because of "version mismatch". With this change we allow any versions to
match when the user does not express a preference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1972)
<!-- Reviewable:end -->
