### PR TITLE
README.md: fix typo in command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Reformatting all the files in a specific directory should be safe too, for
 example:
 
 ```console
-$ find google/cloud -o -name '*.h' -o -name '*.cc' -print0 \
+$ find google/cloud -name '*.h' -o -name '*.cc' -print0 \
     | xargs -0 clang-format -i
 ```
 


### PR DESCRIPTION
There is a stray `-o` which is invalid syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1975)
<!-- Reviewable:end -->
