### PR TITLE
Pin the Google Cloud SDK version.

### DIFF
--- a/ci/travis/Dockerfile.centos
+++ b/ci/travis/Dockerfile.centos
@@ -48,10 +48,10 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
-RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
+RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
+    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
+RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
-    echo "Ignoring update failure for Google Cloud SDK"
 
 RUN yum makecache && yum install -y make

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -50,8 +50,8 @@ RUN pip install httpbin flask gevent gunicorn crc32c
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
-RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
+RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
+    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
+RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
-    echo "Ignoring update failure for Google Cloud SDK"

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -72,8 +72,8 @@ RUN pip install flask httpbin gevent gunicorn crc32c
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
-RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
+RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
+    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
+RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
-    echo "Ignoring update failure for Google Cloud SDK"

--- a/ci/travis/Dockerfile.ubuntu-install
+++ b/ci/travis/Dockerfile.ubuntu-install
@@ -72,11 +72,11 @@ RUN pip install flask httpbin gevent gunicorn crc32c
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
-RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
+RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
+    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
+RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
-    echo "Ignoring update failure for Google Cloud SDK"
 
 # Parallelize the builds if possible. The default is chosen to work well on
 # Travis, but developers may want to override this value when building on their

--- a/ci/travis/Dockerfile.ubuntu-trusty
+++ b/ci/travis/Dockerfile.ubuntu-trusty
@@ -54,8 +54,8 @@ RUN pip install flask httpbin gevent gunicorn crc32c
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
 WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
-RUN tar x -C /usr/local -f google-cloud-sdk-201.0.0-linux-x86_64.tar.gz
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
+RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
+    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
+RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components update || \
-    echo "Ignoring update failure for Google Cloud SDK"


### PR DESCRIPTION
Currently we update the Cloud SDK on each build, that takes time, and it
risks breaking the build just because a newer SDK is broken (has
happened before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1976)
<!-- Reviewable:end -->
