### PR TITLE
removed unneeded virtual functions

### DIFF
--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -61,8 +61,6 @@ class DummyOperation {
 
   DummyOperation(std::shared_ptr<DummyOperationImpl> impl) : impl_(impl) {}
 
-  virtual ~DummyOperation() = default;
-
   template <typename F,
             typename std::enable_if<
                 google::cloud::internal::is_invocable<F, CompletionQueue&, bool,
@@ -75,7 +73,7 @@ class DummyOperation {
     return impl_->Start(cq, context_moved, std::move(callback));
   }
 
-  virtual int AccumulatedResult() { return impl_->AccumulatedResult(); }
+  int AccumulatedResult() { return impl_->AccumulatedResult(); }
 
  private:
   std::shared_ptr<DummyOperationImpl> impl_;

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -74,8 +74,6 @@ class DummyOperation {
 
   DummyOperation(std::shared_ptr<DummyOperationImpl> impl) : state_(impl) {}
 
-  virtual ~DummyOperation() = default;
-
   template <typename F,
             typename std::enable_if<
                 google::cloud::internal::is_invocable<F, CompletionQueue&, bool,
@@ -88,7 +86,7 @@ class DummyOperation {
     return state_->Start(cq, context_moved, std::move(callback));
   }
 
-  virtual int AccumulatedResult() { return state_->AccumulatedResult(); }
+  int AccumulatedResult() { return state_->AccumulatedResult(); }
 
  private:
   std::shared_ptr<DummyOperationImpl> state_;

--- a/google/cloud/bigtable/internal/async_retry_op_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_op_test.cc
@@ -60,8 +60,6 @@ class DummyOperation {
 
   DummyOperation(std::shared_ptr<DummyOperationImpl> impl) : impl_(impl) {}
 
-  virtual ~DummyOperation() = default;
-
   template <typename F, typename std::enable_if<
                             google::cloud::internal::is_invocable<
                                 F, CompletionQueue&, grpc::Status&>::value,
@@ -73,7 +71,7 @@ class DummyOperation {
     return impl_->Start(cq, context_moved, std::move(callback));
   }
 
-  virtual int AccumulatedResult() { return impl_->AccumulatedResult(); }
+  int AccumulatedResult() { return impl_->AccumulatedResult(); }
 
  private:
   std::shared_ptr<DummyOperationImpl> impl_;


### PR DESCRIPTION
Following up on @devbww 's comment from a previous PR #1984

It turns out that Brad was correct and the virtual function (and therefore virtual d'tor) did not need to be virtual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1986)
<!-- Reviewable:end -->
