### PR TITLE
Allow specifying non-default scopes and subject.

### DIFF
--- a/google/cloud/storage/oauth2/credential_constants.h
+++ b/google/cloud/storage/oauth2/credential_constants.h
@@ -50,13 +50,13 @@ constexpr std::chrono::seconds GoogleOAuthAccessTokenExpirationSlack() {
   return std::chrono::seconds(500);
 }
 
-/// The endpoint to fetch an OAuth access token from.
+/// The endpoint to fetch an OAuth 2.0 access token from.
 inline char const* GoogleOAuthRefreshEndpoint() {
   static constexpr char kEndpoint[] = "https://oauth2.googleapis.com/token";
   return kEndpoint;
 }
 
-/// String representing the "cloud-platform" OAuth scope.
+/// String representing the "cloud-platform" OAuth 2.0 scope.
 inline char const* GoogleOAuthScopeCloudPlatform() {
   static constexpr char kScope[] =
       "https://www.googleapis.com/auth/cloud-platform";

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -172,23 +172,35 @@ CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
 }
 
 StatusOr<std::shared_ptr<Credentials>>
-CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path) {
+CreateServiceAccountCredentialsFromJsonFilePath(
+    std::string const& path, std::set<std::string> const& scopes,
+    std::string const& subject) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   auto info = ParseServiceAccountCredentials(contents, path);
   if (!info) {
     return StatusOr<std::shared_ptr<Credentials>>(info.status());
   }
+  // These are supplied as extra parameters to this method, not in the JSON
+  // file.
+  info->scopes = scopes;
+  info->subject = subject;
   return StatusOr<std::shared_ptr<Credentials>>(
       std::make_shared<ServiceAccountCredentials<>>(*info));
 }
 
 StatusOr<std::shared_ptr<Credentials>>
-CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
+CreateServiceAccountCredentialsFromJsonContents(
+    std::string const& contents, std::set<std::string> const& scopes,
+    std::string const& subject) {
   auto info = ParseServiceAccountCredentials(contents, "memory");
   if (!info) {
     return StatusOr<std::shared_ptr<Credentials>>(info.status());
   }
+  // These are supplied as extra parameters to this method, not in the JSON
+  // contents.
+  info->scopes = scopes;
+  info->subject = subject;
   return StatusOr<std::shared_ptr<Credentials>>(
       std::make_shared<ServiceAccountCredentials<>>(*info));
 }

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -174,13 +174,15 @@ CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path) {
   return CreateServiceAccountCredentialsFromJsonFilePath(
-      path, {}, google::cloud::optional<std::string>());
+      path, google::cloud::optional<std::set<std::string>>(),
+      google::cloud::optional<std::string>());
 }
 
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(
-    std::string const& path, std::set<std::string> const& scopes,
-    google::cloud::optional<std::string> const& subject) {
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   auto info = ParseServiceAccountCredentials(contents, path);
@@ -189,8 +191,8 @@ CreateServiceAccountCredentialsFromJsonFilePath(
   }
   // These are supplied as extra parameters to this method, not in the JSON
   // file.
-  info->scopes = scopes;
-  info->subject = subject;
+  info->subject = std::move(subject);
+  info->scopes = std::move(scopes);
   return StatusOr<std::shared_ptr<Credentials>>(
       std::make_shared<ServiceAccountCredentials<>>(*info));
 }
@@ -198,21 +200,23 @@ CreateServiceAccountCredentialsFromJsonFilePath(
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
   return CreateServiceAccountCredentialsFromJsonContents(
-      contents, {}, google::cloud::optional<std::string>());
+      contents, google::cloud::optional<std::set<std::string>>(),
+      google::cloud::optional<std::string>());
 }
 
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
-    std::string const& contents, std::set<std::string> const& scopes,
-    google::cloud::optional<std::string> const& subject) {
+    std::string const& contents,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
   auto info = ParseServiceAccountCredentials(contents, "memory");
   if (!info) {
     return StatusOr<std::shared_ptr<Credentials>>(info.status());
   }
   // These are supplied as extra parameters to this method, not in the JSON
-  // contents.
-  info->scopes = scopes;  // Constructor will populate default scopes if empty.
-  info->subject = subject;
+  // file.
+  info->subject = std::move(subject);
+  info->scopes = std::move(scopes);
   return StatusOr<std::shared_ptr<Credentials>>(
       std::make_shared<ServiceAccountCredentials<>>(*info));
 }

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -172,9 +172,15 @@ CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
 }
 
 StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path) {
+  return CreateServiceAccountCredentialsFromJsonFilePath(
+      path, {}, google::cloud::optional<std::string>());
+}
+
+StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(
     std::string const& path, std::set<std::string> const& scopes,
-    std::string const& subject) {
+    google::cloud::optional<std::string> const& subject) {
   std::ifstream is(path);
   std::string contents(std::istreambuf_iterator<char>{is}, {});
   auto info = ParseServiceAccountCredentials(contents, path);
@@ -190,16 +196,22 @@ CreateServiceAccountCredentialsFromJsonFilePath(
 }
 
 StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
+  return CreateServiceAccountCredentialsFromJsonContents(
+      contents, {}, google::cloud::optional<std::string>());
+}
+
+StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
     std::string const& contents, std::set<std::string> const& scopes,
-    std::string const& subject) {
+    google::cloud::optional<std::string> const& subject) {
   auto info = ParseServiceAccountCredentials(contents, "memory");
   if (!info) {
     return StatusOr<std::shared_ptr<Credentials>>(info.status());
   }
   // These are supplied as extra parameters to this method, not in the JSON
   // contents.
-  info->scopes = scopes;
+  info->scopes = scopes;  // Constructor will populate default scopes if empty.
   info->subject = subject;
   return StatusOr<std::shared_ptr<Credentials>>(
       std::make_shared<ServiceAccountCredentials<>>(*info));

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_GOOGLE_CREDENTIALS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_GOOGLE_CREDENTIALS_H_
 
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include <memory>
 #include <set>
@@ -68,25 +69,44 @@ CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents);
 /**
  * Creates a ServiceAccountCredentials from a JSON file at the specified path.
  *
+ * These credentials use the cloud-platform OAuth 2.0 scope, defined by
+ * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
+ * overloaded version of this function.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
+
+/**
+ * Creates a ServiceAccountCredentials from a JSON file at the specified path.
+ *
  * @param path the path to the file containing service account JSON credentials.
  * @param scopes the scopes to request during the authorization grant. If
  *     omitted or an empty set is provided, the cloud-platform scope,
  *     defined by `GoogleOAuthScopeCloudPlatform()`, is used.
  * @param subject for domain-wide delegation; the email address of the user for
- *     which to request delegated access. If omitted or an empty string is
- *     provided, no "subject" attribute is included in the authorization grant.
- *
- * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
- *     for more information about domain-wide delegation.
+ *     which to request delegated access. If omitted, no "subject" attribute
+ *     is included in the authorization grant.
  *
  * @see https://developers.google.com/identity/protocols/googlescopes for a list
  *     of OAuth 2.0 scopes used with Google APIs.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(
-    std::string const& path,
-    std::set<std::string> const& scopes = std::set<std::string>(),
-    std::string const& subject = "");
+    std::string const& path, std::set<std::string> const& scopes,
+    google::cloud::optional<std::string> const& subject);
+
+/**
+ * Creates a ServiceAccountCredentials from a JSON string.
+ *
+ * These credentials use the cloud-platform OAuth 2.0 scope, defined by
+ * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
+ * overloaded version of this function.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromJsonContents(std::string const& contents);
 
 /**
  * Creates a ServiceAccountCredentials from a JSON string.
@@ -100,17 +120,16 @@ CreateServiceAccountCredentialsFromJsonFilePath(
  *     which to request delegated access. If omitted or an empty string is
  *     provided, no "subject" attribute is included in the authorization grant.
  *
- * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
- *     for more information about domain-wide delegation.
- *
  * @see https://developers.google.com/identity/protocols/googlescopes for a list
  *     of OAuth 2.0 scopes used with Google APIs.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
-    std::string const& contents,
-    std::set<std::string> const& scopes = std::set<std::string>(),
-    std::string const& subject = "");
+    std::string const& contents, std::set<std::string> const& scopes,
+    google::cloud::optional<std::string> const& subject);
 
 /// Creates a ComputeEngineCredentials for the VM's default service account.
 std::shared_ptr<Credentials> CreateComputeEngineCredentials();

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -81,11 +81,11 @@ CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
  *
  * @param path the path to the file containing service account JSON credentials.
  * @param scopes the scopes to request during the authorization grant. If
- *     omitted or an empty set is provided, the cloud-platform scope,
- *     defined by `GoogleOAuthScopeCloudPlatform()`, is used.
+ *     omitted, the cloud-platform scope, defined by
+ *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
  * @param subject for domain-wide delegation; the email address of the user for
- *     which to request delegated access. If omitted, no "subject" attribute
- *     is included in the authorization grant.
+ *     which to request delegated access. If omitted, no "subject" attribute is
+ *     included in the authorization grant.
  *
  * @see https://developers.google.com/identity/protocols/googlescopes for a list
  *     of OAuth 2.0 scopes used with Google APIs.
@@ -95,15 +95,16 @@ CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path);
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(
-    std::string const& path, std::set<std::string> const& scopes,
-    google::cloud::optional<std::string> const& subject);
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject);
 
 /**
  * Creates a ServiceAccountCredentials from a JSON string.
  *
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by
- * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
- * overloaded version of this function.
+ * `GoogleOAuthScopeCloudPlatform()`. To specify an alternate set of scopes, use
+ * the overloaded version of this function.
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(std::string const& contents);
@@ -114,11 +115,11 @@ CreateServiceAccountCredentialsFromJsonContents(std::string const& contents);
  * @param contents the string containing the JSON contents of a service account
  *     credentials file.
  * @param scopes the scopes to request during the authorization grant. If
- *     omitted or an empty set is provided, the cloud-platform scope,
- *     defined by `GoogleOAuthScopeCloudPlatform()`, is used.
+ *     omitted, the cloud-platform scope, defined by
+ *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
  * @param subject for domain-wide delegation; the email address of the user for
- *     which to request delegated access. If omitted or an empty string is
- *     provided, no "subject" attribute is included in the authorization grant.
+ *     which to request delegated access. If omitted, no "subject" attribute is
+ *     included in the authorization grant.
  *
  * @see https://developers.google.com/identity/protocols/googlescopes for a list
  *     of OAuth 2.0 scopes used with Google APIs.
@@ -128,8 +129,9 @@ CreateServiceAccountCredentialsFromJsonContents(std::string const& contents);
  */
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(
-    std::string const& contents, std::set<std::string> const& scopes,
-    google::cloud::optional<std::string> const& subject);
+    std::string const& contents,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject);
 
 /// Creates a ComputeEngineCredentials for the VM's default service account.
 std::shared_ptr<Credentials> CreateComputeEngineCredentials();

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/oauth2/credentials.h"
 #include <memory>
+#include <set>
 
 namespace google {
 namespace cloud {
@@ -53,7 +54,7 @@ std::shared_ptr<Credentials> CreateAnonymousCredentials();
  * with Cloud Storage client libraries.
  */
 StatusOr<std::shared_ptr<Credentials>>
-CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const&);
+CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path);
 
 /**
  * Creates an AuthorizedUserCredentials from a JSON string.
@@ -62,21 +63,61 @@ CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const&);
  * with Cloud Storage client libraries.
  */
 StatusOr<std::shared_ptr<Credentials>>
-CreateAuthorizedUserCredentialsFromJsonContents(std::string const&);
+CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents);
 
-/// Creates a ServiceAccountCredentials rom a JSON file at the specified path.
+/**
+ * Creates a ServiceAccountCredentials from a JSON file at the specified path.
+ *
+ * @param path the path to the file containing service account JSON credentials.
+ * @param scopes the scopes to request during the authorization grant. If
+ *     omitted or an empty set is provided, the cloud-platform scope,
+ *     defined by `GoogleOAuthScopeCloudPlatform()`, is used.
+ * @param subject for domain-wide delegation; the email address of the user for
+ *     which to request delegated access. If omitted or an empty string is
+ *     provided, no "subject" attribute is included in the authorization grant.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
+ *
+ * @see https://developers.google.com/identity/protocols/googlescopes for a list
+ *     of OAuth 2.0 scopes used with Google APIs.
+ */
 StatusOr<std::shared_ptr<Credentials>>
-CreateServiceAccountCredentialsFromJsonFilePath(std::string const&);
+CreateServiceAccountCredentialsFromJsonFilePath(
+    std::string const& path,
+    std::set<std::string> const& scopes = std::set<std::string>(),
+    std::string const& subject = "");
 
-/// Creates a ServiceAccountCredentials from a JSON string.
+/**
+ * Creates a ServiceAccountCredentials from a JSON string.
+ *
+ * @param contents the string containing the JSON contents of a service account
+ *     credentials file.
+ * @param scopes the scopes to request during the authorization grant. If
+ *     omitted or an empty set is provided, the cloud-platform scope,
+ *     defined by `GoogleOAuthScopeCloudPlatform()`, is used.
+ * @param subject for domain-wide delegation; the email address of the user for
+ *     which to request delegated access. If omitted or an empty string is
+ *     provided, no "subject" attribute is included in the authorization grant.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
+ *
+ * @see https://developers.google.com/identity/protocols/googlescopes for a list
+ *     of OAuth 2.0 scopes used with Google APIs.
+ */
 StatusOr<std::shared_ptr<Credentials>>
-CreateServiceAccountCredentialsFromJsonContents(std::string const&);
+CreateServiceAccountCredentialsFromJsonContents(
+    std::string const& contents,
+    std::set<std::string> const& scopes = std::set<std::string>(),
+    std::string const& subject = "");
 
 /// Creates a ComputeEngineCredentials for the VM's default service account.
 std::shared_ptr<Credentials> CreateComputeEngineCredentials();
 
 /// Creates a ComputeEngineCredentials for the VM's specified service account.
-std::shared_ptr<Credentials> CreateComputeEngineCredentials(std::string const&);
+std::shared_ptr<Credentials> CreateComputeEngineCredentials(
+    std::string const& service_account_email);
 
 //@}
 

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -217,8 +217,8 @@ TEST_F(GoogleCredentialsTest,
   // Test that the service account credentials are loaded from a file.
   auto creds = CreateServiceAccountCredentialsFromJsonFilePath(
       filename,
-      std::set<std::string>{
-          "https://www.googleapis.com/auth/devstorage.full_control"},
+      google::cloud::optional<std::set<std::string>>(
+          {"https://www.googleapis.com/auth/devstorage.full_control"}),
       google::cloud::optional<std::string>("user@foo.bar"));
   ASSERT_TRUE(creds) << "status=" << creds.status();
   auto* ptr = creds->get();
@@ -230,8 +230,8 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
   // representing JSON contents.
   auto creds = CreateServiceAccountCredentialsFromJsonContents(
       SERVICE_ACCOUNT_CRED_CONTENTS,
-      std::set<std::string>{
-          "https://www.googleapis.com/auth/devstorage.full_control"},
+      google::cloud::optional<std::set<std::string>>(
+          {"https://www.googleapis.com/auth/devstorage.full_control"}),
       google::cloud::optional<std::string>("user@foo.bar"));
   ASSERT_TRUE(creds) << "status=" << creds.status();
   auto* ptr = creds->get();

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -204,7 +204,7 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
 }
 
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
-  std::string filename = ::testing::TempDir() + AUTHORIZED_USER_CRED_FILENAME;
+  std::string filename = ::testing::TempDir() + SERVICE_ACCOUNT_CRED_FILENAME;
   SetupServiceAccountCredentialsFileForTest(filename);
 
   // Test that the service account credentials are loaded from a file.
@@ -215,11 +215,31 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
 
+TEST_F(GoogleCredentialsTest,
+       LoadValidServiceAccountCredentialsFromFilenameWithOptionalArgs) {
+  std::string filename = ::testing::TempDir() + SERVICE_ACCOUNT_CRED_FILENAME;
+  SetupServiceAccountCredentialsFileForTest(filename);
+
+  // Test that the service account credentials are loaded from a file.
+  auto creds = CreateServiceAccountCredentialsFromJsonFilePath(
+      filename,
+      std::set<std::string>{
+          "https://www.googleapis.com/auth/devstorage.full_control"},
+      "user@foo.bar");
+  ASSERT_TRUE(creds.ok()) << "status=" << creds.status();
+  auto credentials = std::move(*creds);
+  auto ptr = credentials.get();
+  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
+}
+
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
   // Test that the service account credentials are loaded from a string
   // representing JSON contents.
   auto creds = CreateServiceAccountCredentialsFromJsonContents(
-      SERVICE_ACCOUNT_CRED_CONTENTS);
+      SERVICE_ACCOUNT_CRED_CONTENTS,
+      std::set<std::string>{
+          "https://www.googleapis.com/auth/devstorage.full_control"},
+      "user@foo.bar");
   ASSERT_TRUE(creds.ok()) << "status=" << creds.status();
   auto credentials = std::move(*creds);
   auto ptr = credentials.get();

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_SERVICE_ACCOUNT_CREDENTIALS_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_SERVICE_ACCOUNT_CREDENTIALS_H_
 
+#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/openssl_util.h"
@@ -41,7 +42,7 @@ struct ServiceAccountCredentialsInfo {
   // Optional; if empty, a default set of scopes will be used.
   std::set<std::string> scopes;
   // See https://developers.google.com/identity/protocols/OAuth2ServiceAccount.
-  std::string subject;
+  google::cloud::optional<std::string> subject;
 };
 
 /// Parses the contents of a JSON keyfile into a ServiceAccountCredentialsInfo.
@@ -172,8 +173,8 @@ class ServiceAccountCredentials : public Credentials {
         {"iat", now_from_epoch},
         // Resulting access token should be expire after one hour.
         {"exp", expiration_from_epoch}};
-    if (!info.subject.empty()) {
-      assertion_payload["sub"] = info.subject;
+    if (info.subject) {
+      assertion_payload["sub"] = *(info.subject);
     }
 
     return std::make_pair(std::move(assertion_header),

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -39,8 +39,8 @@ struct ServiceAccountCredentialsInfo {
   std::string private_key_id;
   std::string private_key;
   std::string token_uri;
-  // Optional; if empty, a default set of scopes will be used.
-  std::set<std::string> scopes;
+  // If no set is supplied, a default set of scopes will be used.
+  google::cloud::optional<std::set<std::string>> scopes;
   // See https://developers.google.com/identity/protocols/OAuth2ServiceAccount.
   google::cloud::optional<std::string> subject;
 };
@@ -147,11 +147,11 @@ class ServiceAccountCredentials : public Credentials {
 
     // Scopes must be specified in a comma-delimited string.
     std::string scope_str;
-    if (info.scopes.empty()) {
+    if (!info.scopes) {
       scope_str = GoogleOAuthScopeCloudPlatform();
     } else {
       std::string sep = "";
-      for (const auto& scope : info.scopes) {
+      for (const auto& scope : *(info.scopes)) {
         scope_str += sep + scope;
         sep = ",";
       }

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -153,7 +153,7 @@ TEST_F(ServiceAccountCredentialsTest,
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
   ASSERT_TRUE(info.ok()) << "status=" << info.status();
   info->scopes = std::set<std::string>{kAltScopeForTest};
-  info->subject = kSubjectForGrant;
+  info->subject = google::cloud::optional<std::string>(kSubjectForGrant);
   CheckInfoYieldsExpectedAssertion(*info,
                                    kExpectedAssertionWithOptionalArgsParam);
 }

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -143,7 +143,7 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
 TEST_F(ServiceAccountCredentialsTest,
        RefreshingSendsCorrectRequestBodyAndParsesResponse) {
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
+  ASSERT_TRUE(info) << "status=" << info.status();
   CheckInfoYieldsExpectedAssertion(*info, kExpectedAssertionParam);
 }
 
@@ -151,9 +151,9 @@ TEST_F(ServiceAccountCredentialsTest,
 TEST_F(ServiceAccountCredentialsTest,
        RefreshingSendsCorrectRequestBodyAndParsesResponseForNonDefaultVals) {
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
-  info->scopes = std::set<std::string>{kAltScopeForTest};
-  info->subject = google::cloud::optional<std::string>(kSubjectForGrant);
+  ASSERT_TRUE(info) << "status=" << info.status();
+  info->scopes = {kAltScopeForTest};
+  info->subject = std::string(kSubjectForGrant);
   CheckInfoYieldsExpectedAssertion(*info,
                                    kExpectedAssertionWithOptionalArgsParam);
 }
@@ -201,7 +201,7 @@ TEST_F(ServiceAccountCredentialsTest,
           }));
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
+  ASSERT_TRUE(info) << "status=" << info.status();
   ServiceAccountCredentials<MockHttpRequestBuilder> credentials(*info);
   // Calls Refresh to obtain the access token for our authorization header.
   EXPECT_EQ("Authorization: Type access-token-r1",
@@ -236,7 +236,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseSimple) {
 
   auto actual =
       ParseServiceAccountCredentials(contents, "test-data", "unused-uri");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual) << "status=" << actual.status();
   EXPECT_EQ("not-a-key-id-just-for-testing", actual->private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual->private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual->client_email);
@@ -255,7 +255,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseUsesExplicitDefaultTokenUri) {
 
   auto actual = ParseServiceAccountCredentials(
       contents, "test-data", "https://oauth2.googleapis.com/test_endpoint");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual) << "status=" << actual.status();
   EXPECT_EQ("not-a-key-id-just-for-testing", actual->private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual->private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual->client_email);
@@ -274,7 +274,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseUsesImplicitDefaultTokenUri) {
 
   // No token_uri passed in here, either.
   auto actual = ParseServiceAccountCredentials(contents, "test-data");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_TRUE(actual) << "status=" << actual.status();
   EXPECT_EQ("not-a-key-id-just-for-testing", actual->private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual->private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual->client_email);
@@ -286,7 +286,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseInvalidContentsFails) {
   std::string config = R"""( not-a-valid-json-string )""";
 
   auto actual = ParseServiceAccountCredentials(config, "test-as-a-source");
-  ASSERT_FALSE(actual.ok()) << "status=" << actual.status();
+  ASSERT_FALSE(actual) << "status=" << actual.status();
   EXPECT_THAT(actual.status().message(),
               HasSubstr("Invalid ServiceAccountCredentials"));
   EXPECT_THAT(actual.status().message(), HasSubstr("test-as-a-source"));
@@ -307,7 +307,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseEmptyFieldFails) {
     internal::nl::json json = internal::nl::json::parse(contents);
     json[field] = "";
     auto actual = ParseServiceAccountCredentials(json.dump(), "test-data", "");
-    ASSERT_FALSE(actual.ok()) << "status=" << actual.status();
+    ASSERT_FALSE(actual) << "status=" << actual.status();
     EXPECT_THAT(actual.status().message(), HasSubstr(field));
     EXPECT_THAT(actual.status().message(), HasSubstr(" field is empty"));
     EXPECT_THAT(actual.status().message(), HasSubstr("test-data"));
@@ -328,7 +328,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseMissingFieldFails) {
     internal::nl::json json = internal::nl::json::parse(contents);
     json.erase(field);
     auto actual = ParseServiceAccountCredentials(json.dump(), "test-data", "");
-    ASSERT_FALSE(actual.ok()) << "status=" << actual.status();
+    ASSERT_FALSE(actual) << "status=" << actual.status();
     EXPECT_THAT(actual.status().message(), HasSubstr(field));
     EXPECT_THAT(actual.status().message(), HasSubstr(" field is missing"));
     EXPECT_THAT(actual.status().message(), HasSubstr("test-data"));
@@ -358,7 +358,7 @@ TEST_F(ServiceAccountCredentialsTest, SignBlob) {
   }));
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
+  ASSERT_TRUE(info) << "status=" << info.status();
   ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
       *info);
 
@@ -412,7 +412,7 @@ TEST_F(ServiceAccountCredentialsTest, ClientId) {
   }));
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
+  ASSERT_TRUE(info) << "status=" << info.status();
   ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
       *info);
 


### PR DESCRIPTION
Fixes #1866, which mentions that the default scopes for
ServiceAccountCredentials are not always enough. Also allows specifying
the subject (for domain-wide delegation purposes) used for authorization
grants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1987)
<!-- Reviewable:end -->
