### PR TITLE
Homogenize failed_locations handling in samples.

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -153,8 +153,8 @@ void ListInstances(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "The Cloud Bigtable service reports that the following "
                  "locations are temporarily unavailable and no information "
                  "about instances in these locations can be obtained:\n";
-    for (std::string const& location : instances->failed_locations) {
-      std::cout << location << "\n";
+    for (auto const& failed_location : instances->failed_locations) {
+      std::cout << failed_location << "\n";
     }
   }
 }
@@ -232,8 +232,8 @@ void ListClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "The Cloud Bigtable service reports that the following "
                  "locations are temporarily unavailable and no information "
                  "about clusters in these locations can be obtained:\n";
-    for (std::string const& location : cluster_list->failed_locations) {
-      std::cout << location << "\n";
+    for (auto const& failed_location : cluster_list->failed_locations) {
+      std::cout << failed_location << "\n";
     }
   }
 }
@@ -258,8 +258,8 @@ void ListAllClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "The Cloud Bigtable service reports that the following "
                  "locations are temporarily unavailable and no information "
                  "about clusters in these locations can be obtained:\n";
-    for (std::string const& location : cluster_list->failed_locations) {
-      std::cout << location << "\n";
+    for (auto const& failed_location : cluster_list->failed_locations) {
+      std::cout << failed_location << "\n";
     }
   }
 }
@@ -359,11 +359,11 @@ void RunInstanceOperations(
     std::cout << instance.name() << "\n";
   }
   if (!instances->failed_locations.empty()) {
-    std::cerr << "The Cloud Bigtable service reports that the following "
+    std::cout << "The Cloud Bigtable service reports that the following "
                  "locations are temporarily unavailable and no information "
                  "about instances in these locations can be obtained:\n";
-    for (auto& failed_location : instances->failed_locations) {
-      std::cerr << failed_location << "\n";
+    for (auto const& failed_location : instances->failed_locations) {
+      std::cout << failed_location << "\n";
     }
   }
 
@@ -386,11 +386,11 @@ void RunInstanceOperations(
     std::cout << "Cluster Name: " << cluster.name() << "\n";
   }
   if (!cluster_list->failed_locations.empty()) {
-    std::cerr << "The Cloud Bigtable service reports that the following "
+    std::cout << "The Cloud Bigtable service reports that the following "
                  "locations are temporarily unavailable and no information "
                  "about clusters in these locations can be obtained:\n";
-    for (auto& failed_location : cluster_list->failed_locations) {
-      std::cerr << failed_location << "\n";
+    for (auto const& failed_location : cluster_list->failed_locations) {
+      std::cout << failed_location << "\n";
     }
   }
 

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin_ext.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin_ext.cc
@@ -78,8 +78,8 @@ void RunInstanceOperations(std::string project_id, int argc, char* argv[]) {
   if (!instances->failed_locations.empty()) {
     std::cerr
         << "The service tells us it has no information about these locations:";
-    for (std::string const& location : instances->failed_locations) {
-      std::cout << " " << location;
+    for (auto const& failed_location : instances->failed_locations) {
+      std::cerr << " " << failed_location;
     }
     std::cerr << ". Continuing anyway\n";
   }
@@ -119,8 +119,8 @@ void RunInstanceOperations(std::string project_id, int argc, char* argv[]) {
   if (!instances_after->failed_locations.empty()) {
     std::cerr
         << "The service tells us it has no information about these locations:";
-    for (std::string const& location : instances_after->failed_locations) {
-      std::cout << " " << location << "\n";
+    for (auto const& failed_location : instances_after->failed_locations) {
+      std::cerr << " " << failed_location;
     }
     std::cerr << ". Continuing anyway\n";
   }
@@ -151,8 +151,8 @@ void RunInstanceOperations(std::string project_id, int argc, char* argv[]) {
     std::cout << "The Cloud Bigtable service reports that the following "
                  "locations are temporarily unavailable and no information "
                  "about clusters in these locations can be obtained:\n";
-    for (std::string const& location : cluster_list->failed_locations) {
-      std::cout << location << "\n";
+    for (auto const& failed_location : cluster_list->failed_locations) {
+      std::cout << failed_location << "\n";
     }
   }
   // [END bigtable_get_clusters]
@@ -189,8 +189,8 @@ void CreateDevInstance(std::string project_id, int argc, char* argv[]) {
   if (!instances->failed_locations.empty()) {
     std::cerr
         << "The service tells us it has no information about these locations:";
-    for (std::string const& location : instances->failed_locations) {
-      std::cout << " " << location << "\n";
+    for (auto const& failed_location : instances->failed_locations) {
+      std::cerr << " " << failed_location;
     }
     std::cerr << ". Continuing anyway\n";
   }
@@ -272,8 +272,8 @@ void CreateCluster(std::string project_id, int argc, char* argv[]) {
   if (!instances->failed_locations.empty()) {
     std::cerr
         << "The service tells us it has no information about these locations:";
-    for (std::string const& location : instances->failed_locations) {
-      std::cout << " " << location << "\n";
+    for (auto const& failed_location : instances->failed_locations) {
+      std::cerr << " " << failed_location;
     }
     std::cerr << ". Continuing anyway\n";
   }


### PR DESCRIPTION
From now on:
 * `auto const&` is used in iteration
 * `failed_location` loop variable's name
 * `cerr` is used when ignoring the errors
 * `cout` is used to show to the user what there is in the responses

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1995)
<!-- Reviewable:end -->
