### PR TITLE
Use {EXPECT,ASSERT}_STATUS_OK where applicable.

### DIFF
--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/grpc_error.h"
 #include "google/cloud/bigtable/testing/mock_admin_client.h"
 #include "google/cloud/internal/make_unique.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -202,7 +203,7 @@ TEST_F(TableAdminTest, ListTables) {
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btadmin::Table::FULL);
-  ASSERT_TRUE(actual) << actual.status();
+  ASSERT_STATUS_OK(actual);
   auto const& v = *actual;
   std::string instance_name = tested.instance_name();
   ASSERT_EQ(2UL, v.size());
@@ -231,7 +232,7 @@ TEST_F(TableAdminTest, ListTablesRecoverableFailures) {
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btadmin::Table::FULL);
-  ASSERT_TRUE(actual) << actual.status();
+  ASSERT_STATUS_OK(actual);
   auto const& v = *actual;
   std::string instance_name = tested.instance_name();
   ASSERT_EQ(4UL, v.size());
@@ -315,7 +316,7 @@ initial_splits { key: 'p' }
       {{"f1", GC::MaxNumVersions(1)}, {"f2", GC::MaxAge(1_s)}},
       {"a", "c", "p"});
   auto table = tested.CreateTable("new-table", std::move(config));
-  EXPECT_TRUE(table) << table.status();
+  EXPECT_STATUS_OK(table);
 }
 
 /**

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -66,7 +67,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
   std::string const table_id = RandomTableId();
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(previous_table_list);
+  ASSERT_STATUS_OK(previous_table_list);
   auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/instance_admin_client.h"
 #include "google/cloud/bigtable/internal/endian.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 
@@ -66,7 +67,7 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
   std::string const table_id = RandomTableId();
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(previous_table_list);
+  ASSERT_STATUS_OK(previous_table_list);
   auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"
@@ -159,7 +160,7 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
 
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(current_table_list);
+  ASSERT_STATUS_OK(current_table_list);
   auto table_count = CountMatchingTables(table_id, *current_table_list);
   EXPECT_EQ(0, table_count);
 

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -65,7 +66,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
   // Get the current list of tables.
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(previous_table_list);
+  ASSERT_STATUS_OK(previous_table_list);
 
   int const TABLE_COUNT = 5;
   for (int index = 0; index < TABLE_COUNT; ++index) {
@@ -79,7 +80,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
     expected_table_list.emplace_back(table_id);
   }
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(current_table_list);
+  ASSERT_STATUS_OK(current_table_list);
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
     EXPECT_EQ(1, CountMatchingTables(table_id, *current_table_list));
@@ -88,7 +89,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTablesTest) {
     DeleteTable(table_id);
   }
   current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(current_table_list);
+  ASSERT_STATUS_OK(current_table_list);
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
     EXPECT_EQ(0, CountMatchingTables(table_id, *current_table_list));
@@ -177,7 +178,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
   // verify new table id in current table list
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(previous_table_list);
+  ASSERT_STATUS_OK(previous_table_list);
   auto previous_count = CountMatchingTables(table_id, *previous_table_list);
   ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
                                << " This is unexpected, as the table ids are"
@@ -233,7 +234,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
   DeleteTable(table_id);
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
-  ASSERT_TRUE(current_table_list);
+  ASSERT_STATUS_OK(current_table_list);
   auto table_count = CountMatchingTables(table_id, *current_table_list);
   EXPECT_EQ(0, table_count);
 }

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/status_or.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/expect_exception.h"
 #include "google/cloud/testing_util/testing_types.h"
 #include <gmock/gmock.h>
@@ -49,7 +50,7 @@ TEST(StatusOrTest, StatusConstructorInvalid) {
 
 TEST(StatusOrTest, ValueConstructor) {
   StatusOr<int> actual(42);
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_TRUE(actual);
   EXPECT_EQ(42, actual.value());
   EXPECT_EQ(42, std::move(actual).value());
@@ -57,7 +58,7 @@ TEST(StatusOrTest, ValueConstructor) {
 
 TEST(StatusOrTest, ValueConstAccessors) {
   StatusOr<int> const actual(42);
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(42, actual.value());
   EXPECT_EQ(42, std::move(actual).value());
 }
@@ -110,27 +111,27 @@ TEST(StatusOrTest, StatusConstAccessors) {
 
 TEST(StatusOrTest, ValueDeference) {
   StatusOr<std::string> actual("42");
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ("42", *actual);
   EXPECT_EQ("42", std::move(actual).value());
 }
 
 TEST(StatusOrTest, ValueConstDeference) {
   StatusOr<std::string> const actual("42");
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ("42", *actual);
   EXPECT_EQ("42", std::move(actual).value());
 }
 
 TEST(StatusOrTest, ValueArrow) {
   StatusOr<std::string> actual("42");
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(std::string("42"), actual->c_str());
 }
 
 TEST(StatusOrTest, ValueConstArrow) {
   StatusOr<std::string> const actual("42");
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(std::string("42"), actual->c_str());
 }
 
@@ -144,7 +145,7 @@ TEST(StatusOrNoDefaultConstructor, DefaultConstructed) {
 TEST(StatusOrNoDefaultConstructor, ValueConstructed) {
   StatusOr<NoDefaultConstructor> actual(
       NoDefaultConstructor(std::string("foo")));
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(actual->str(), "foo");
 }
 
@@ -168,8 +169,8 @@ TEST(StatusOrObservableTest, Copy) {
   Observable::reset_counters();
   StatusOr<Observable> copy(other);
   EXPECT_EQ(1, Observable::copy_constructor);
-  EXPECT_TRUE(copy.ok());
-  EXPECT_TRUE(other.ok());
+  EXPECT_STATUS_OK(copy);
+  EXPECT_STATUS_OK(other);
   EXPECT_EQ("foo", copy->str());
 }
 
@@ -183,9 +184,9 @@ TEST(StatusOrObservableTest, MoveCopy) {
   Observable::reset_counters();
   StatusOr<Observable> copy(std::move(other));
   EXPECT_EQ(1, Observable::move_constructor);
-  EXPECT_TRUE(copy.ok());
+  EXPECT_STATUS_OK(copy);
   EXPECT_EQ("foo", copy->str());
-  EXPECT_TRUE(other.ok());
+  EXPECT_STATUS_OK(other);
   EXPECT_EQ("moved-out", other->str());
 }
 
@@ -211,13 +212,13 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_NoValue) {
 TEST(StatusOrObservableTest, MoveAssignment_NoValue_Value) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned;
-  EXPECT_TRUE(other.ok());
+  EXPECT_STATUS_OK(other);
   EXPECT_FALSE(assigned.ok());
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_TRUE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
   EXPECT_EQ(0, Observable::destructor);
@@ -235,7 +236,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_T) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other.str());
   EXPECT_EQ(0, Observable::destructor);
@@ -250,7 +251,7 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_NoValue) {
   StatusOr<Observable> other;
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_FALSE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
 
   Observable::reset_counters();
   assigned = std::move(other);
@@ -267,13 +268,13 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_NoValue) {
 TEST(StatusOrObservableTest, MoveAssignment_Value_Value) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned(Observable("bar"));
-  EXPECT_TRUE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(assigned);
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_TRUE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(1, Observable::move_assignment);
   EXPECT_EQ(0, Observable::copy_assignment);
@@ -287,11 +288,11 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_Value) {
 TEST(StatusOrObservableTest, MoveAssignment_Value_T) {
   Observable other("foo");
   StatusOr<Observable> assigned(Observable("bar"));
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(1, Observable::move_assignment);
   EXPECT_EQ(0, Observable::copy_assignment);
@@ -323,13 +324,13 @@ TEST(StatusOrObservableTest, CopyAssignment_NoValue_NoValue) {
 TEST(StatusOrObservableTest, CopyAssignment_NoValue_Value) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned;
-  EXPECT_TRUE(other.ok());
+  EXPECT_STATUS_OK(other);
   EXPECT_FALSE(assigned.ok());
 
   Observable::reset_counters();
   assigned = other;
-  EXPECT_TRUE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
   EXPECT_EQ(0, Observable::destructor);
@@ -347,7 +348,7 @@ TEST(StatusOrObservableTest, CopyAssignment_NoValue_T) {
 
   Observable::reset_counters();
   assigned = other;
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other.str());
   EXPECT_EQ(0, Observable::destructor);
@@ -362,7 +363,7 @@ TEST(StatusOrObservableTest, CopyAssignment_Value_NoValue) {
   StatusOr<Observable> other;
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_FALSE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
 
   Observable::reset_counters();
   assigned = other;
@@ -379,13 +380,13 @@ TEST(StatusOrObservableTest, CopyAssignment_Value_NoValue) {
 TEST(StatusOrObservableTest, CopyAssignment_Value_Value) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned(Observable("bar"));
-  EXPECT_TRUE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(assigned);
 
   Observable::reset_counters();
   assigned = other;
-  EXPECT_TRUE(other.ok());
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
   EXPECT_EQ(1, Observable::copy_assignment);
@@ -399,11 +400,11 @@ TEST(StatusOrObservableTest, CopyAssignment_Value_Value) {
 TEST(StatusOrObservableTest, CopyAssignment_Value_T) {
   Observable other("foo");
   StatusOr<Observable> assigned(Observable("bar"));
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
 
   Observable::reset_counters();
   assigned = other;
-  EXPECT_TRUE(assigned.ok());
+  EXPECT_STATUS_OK(assigned);
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
   EXPECT_EQ(1, Observable::copy_assignment);
@@ -420,7 +421,7 @@ TEST(StatusOrObservableTest, MoveValue) {
   Observable::reset_counters();
   auto observed = std::move(other).value();
   EXPECT_EQ("foo", observed.str());
-  EXPECT_TRUE(other.ok());
+  EXPECT_STATUS_OK(other);
   EXPECT_EQ("moved-out", other->str());
 }
 

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -95,7 +96,7 @@ TEST_F(BucketTest, CreateBucket) {
   auto actual = client.CreateBucket(
       "test-bucket-name",
       BucketMetadata().set_location("US").set_storage_class("STANDARD"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -150,7 +151,7 @@ TEST_F(BucketTest, GetBucketMetadata) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto actual = client.GetBucketMetadata("foo-bar-baz");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -183,7 +184,7 @@ TEST_F(BucketTest, DeleteBucket) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto status = client.DeleteBucket("foo-bar-baz");
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(BucketTest, DeleteBucketTooManyFailures) {
@@ -234,7 +235,7 @@ TEST_F(BucketTest, UpdateBucket) {
   auto actual = client.UpdateBucket(
       "test-bucket-name",
       BucketMetadata().set_location("US").set_storage_class("STANDARD"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -293,7 +294,7 @@ TEST_F(BucketTest, PatchBucket) {
   auto actual = client.PatchBucket(
       "test-bucket-name",
       BucketMetadataPatchBuilder().SetStorageClass("STANDARD"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -341,7 +342,7 @@ TEST_F(BucketTest, GetBucketIamPolicy) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto actual = client.GetBucketIamPolicy("test-bucket-name");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -380,7 +381,7 @@ TEST_F(BucketTest, SetBucketIamPolicy) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto actual = client.SetBucketIamPolicy("test-bucket-name", expected);
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -428,7 +429,7 @@ TEST_F(BucketTest, TestBucketIamPermissions) {
 
   auto actual = client.TestBucketIamPermissions("test-bucket-name",
                                                 {"storage.buckets.delete"});
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_THAT(*actual, ElementsAreArray(expected.permissions));
 }
 
@@ -480,7 +481,7 @@ TEST_F(BucketTest, LockBucketRetentionPolicy) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto metadata = client.LockBucketRetentionPolicy("test-bucket-name", 42U);
-  ASSERT_TRUE(metadata.ok()) << "status=" << metadata.status();
+  ASSERT_STATUS_OK(metadata);
   EXPECT_EQ(expected, *metadata);
 }
 

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -120,7 +121,7 @@ TEST_F(BucketAccessControlsTest, ListBucketAcl) {
 
   StatusOr<std::vector<BucketAccessControl>> actual =
       client.ListBucketAcl("test-bucket");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -163,7 +164,7 @@ TEST_F(BucketAccessControlsTest, CreateBucketAcl) {
 
   StatusOr<BucketAccessControl> actual = client.CreateBucketAcl(
       "test-bucket", "user-test-user-1", BucketAccessControl::ROLE_READER());
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   // Compare just a few fields because the values for most of the fields are
   // hard to predict when testing against the production environment.
@@ -212,7 +213,7 @@ TEST_F(BucketAccessControlsTest, DeleteBucketAcl) {
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
   auto status = client.DeleteBucketAcl("test-bucket", "user-test-user-1");
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(BucketAccessControlsTest, DeleteBucketAclTooManyFailures) {
@@ -258,7 +259,7 @@ TEST_F(BucketAccessControlsTest, GetBucketAcl) {
 
   StatusOr<BucketAccessControl> actual =
       client.GetBucketAcl("test-bucket", "user-test-user-1");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   EXPECT_EQ(expected, *actual);
 }
@@ -306,7 +307,7 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAcl) {
   StatusOr<BucketAccessControl> actual = client.UpdateBucketAcl(
       "test-bucket",
       BucketAccessControl().set_entity("user-test-user-1").set_role("OWNER"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   EXPECT_EQ(expected, *actual);
 }
@@ -371,7 +372,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
   StatusOr<BucketAccessControl> actual = client.PatchBucketAcl(
       "test-bucket", "user-test-user-1",
       BucketAccessControlPatchBuilder().set_role("OWNER"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   EXPECT_EQ(result, *actual);
 }

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -83,7 +84,7 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
 
   StatusOr<std::vector<ObjectAccessControl>> actual =
       client.ListDefaultObjectAcl("test-bucket");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -127,7 +128,7 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
 
   StatusOr<ObjectAccessControl> actual = client.CreateDefaultObjectAcl(
       "test-bucket", "user-test-user-1", ObjectAccessControl::ROLE_READER());
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   // Compare just a few fields because the values for most of the fields are
   // hard to predict when testing against the production environment.
   EXPECT_EQ(expected.bucket(), actual->bucket());
@@ -178,7 +179,7 @@ TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
   auto status = client.DeleteDefaultObjectAcl("test-bucket", "user-test-user");
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAclTooManyFailures) {
@@ -228,7 +229,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
 
   StatusOr<ObjectAccessControl> actual =
       client.GetDefaultObjectAcl("test-bucket", "user-test-user-1");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -278,7 +279,7 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
       "test-bucket", ObjectAccessControl()
                          .set_entity("user-test-user-1")
                          .set_role(ObjectAccessControl::ROLE_READER()));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   // Compare just a few fields because the values for most of the fields are
   // hard to predict when testing against the production environment.
   EXPECT_EQ(expected.bucket(), actual->bucket());
@@ -340,7 +341,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
   auto actual = client.PatchDefaultObjectAcl(
       "test-bucket", "user-test-user-1",
       ObjectAccessControlPatchBuilder().set_role("OWNER"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(result, *actual);
 }
 

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -84,7 +85,7 @@ TEST_F(NotificationsTest, ListNotifications) {
 
   StatusOr<std::vector<NotificationMetadata>> actual =
       client.ListNotifications("test-bucket");
-  ASSERT_TRUE(actual.ok());
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, actual.value());
 }
 
@@ -136,7 +137,7 @@ TEST_F(NotificationsTest, CreateNotification) {
       NotificationMetadata()
           .set_object_name_prefix("test-object-prefix-")
           .append_event_type(event_type::ObjectFinalize()));
-  ASSERT_TRUE(actual.ok());
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, actual.value());
 }
 
@@ -189,7 +190,7 @@ TEST_F(NotificationsTest, GetNotification) {
 
   StatusOr<NotificationMetadata> actual =
       client.GetNotification("test-bucket", "test-notification-1");
-  ASSERT_TRUE(actual.ok());
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, actual.value());
 }
 
@@ -225,7 +226,7 @@ TEST_F(NotificationsTest, DeleteNotification) {
   Client client{std::shared_ptr<internal::RawClient>(mock_)};
 
   auto status = client.DeleteNotification("test-bucket", "test-notification-1");
-  ASSERT_TRUE(status.ok());
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(NotificationsTest, DeleteNotificationTooManyFailures) {

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -84,7 +85,7 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
 
   StatusOr<std::vector<ObjectAccessControl>> actual =
       client.ListObjectAcl("test-bucket", "test-object");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -132,7 +133,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
   StatusOr<ObjectAccessControl> actual =
       client.CreateObjectAcl("test-bucket", "test-object", "user-test-user-1",
                              ObjectAccessControl::ROLE_READER());
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   // Compare just a few fields because the values for most of the fields are
   // hard to predict when testing against the production environment.
   EXPECT_EQ(expected.bucket(), actual->bucket());
@@ -233,7 +234,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
 
   StatusOr<ObjectAccessControl> actual =
       client.GetObjectAcl("test-bucket", "test-object", "user-test-user-1");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -284,7 +285,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
   ObjectAccessControl acl =
       ObjectAccessControl().set_role("OWNER").set_entity("user-test-user");
   auto actual = client.UpdateObjectAcl("test-bucket", "test-object", acl);
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -343,7 +344,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
   auto actual = client.PatchObjectAcl(
       "test-bucket", "test-object", "user-test-user-1",
       ObjectAccessControlPatchBuilder().set_role("OWNER"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(result, *actual);
 }
 

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -61,7 +62,8 @@ class ObjectCopyTest : public ::testing::Test {
 
 TEST_F(ObjectCopyTest, CopyObject) {
   std::string text = R"""({"name": "test-bucket-name/test-object-name/1"})""";
-  auto expected = storage::internal::ObjectMetadataParser::FromString(text).value();
+  auto expected =
+      storage::internal::ObjectMetadataParser::FromString(text).value();
 
   EXPECT_CALL(*mock, CopyObject(_))
       .WillOnce(Invoke([&expected](internal::CopyObjectRequest const& request) {
@@ -77,7 +79,7 @@ TEST_F(ObjectCopyTest, CopyObject) {
   StatusOr<ObjectMetadata> actual =
       client.CopyObject("source-bucket-name", "source-object-name",
                         "test-bucket-name", "test-object-name");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -156,7 +158,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
 
   auto actual = client.ComposeObject(
       "test-bucket-name", {{"object1"}, {"object2"}}, "test-object-name");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -258,25 +260,25 @@ TEST_F(ObjectCopyTest, RewriteObject) {
       WithObjectMetadata(
           ObjectMetadata().upsert_metadata("test-key", "test-value")));
   auto actual = copier.Iterate();
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_FALSE(actual->done);
   EXPECT_EQ(1048576UL, actual->total_bytes_rewritten);
   EXPECT_EQ(10485760UL, actual->object_size);
 
   auto current = copier.CurrentProgress();
-  ASSERT_TRUE(current.ok()) << "status=" << current.status();
+  ASSERT_STATUS_OK(current);
   EXPECT_FALSE(current->done);
   EXPECT_EQ(1048576UL, current->total_bytes_rewritten);
   EXPECT_EQ(10485760UL, current->object_size);
 
   actual = copier.Iterate();
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_FALSE(actual->done);
   EXPECT_EQ(2097152UL, actual->total_bytes_rewritten);
   EXPECT_EQ(10485760UL, actual->object_size);
 
   auto metadata = copier.Result();
-  ASSERT_TRUE(metadata.ok()) << "status=" << metadata.status();
+  ASSERT_STATUS_OK(metadata);
   EXPECT_EQ("test-destination-bucket-name", metadata->bucket());
   EXPECT_EQ("test-destination-object-name", metadata->name());
 }

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -70,8 +71,9 @@ TEST_F(ServiceAccountTest, GetProjectServiceAccount) {
           }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
-  StatusOr<ServiceAccount> actual = client.GetServiceAccountForProject("test-project");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  StatusOr<ServiceAccount> actual =
+      client.GetServiceAccountForProject("test-project");
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -43,11 +44,11 @@ constexpr char kJsonKeyfileContents[] = R"""({
 TEST(SignedUrlIntegrationTest, Sign) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
-  ASSERT_TRUE(creds.ok()) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   Client client(*creds);
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test-object");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   EXPECT_THAT(*actual, HasSubstr("test-bucket"));
   EXPECT_THAT(*actual, HasSubstr("test-object"));
@@ -56,11 +57,11 @@ TEST(SignedUrlIntegrationTest, Sign) {
 TEST(SignedUrlIntegrationTest, BucketOnly) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
-  ASSERT_TRUE(creds.ok()) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   Client client(*creds);
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "", WithAcl());
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   EXPECT_THAT(*actual, HasSubstr("test-bucket?GoogleAccessId="));
 }
@@ -68,11 +69,11 @@ TEST(SignedUrlIntegrationTest, BucketOnly) {
 TEST(SignedUrlIntegrationTest, SignEscape) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
-  ASSERT_TRUE(creds.ok()) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   Client client(*creds);
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test+object");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
 
   EXPECT_THAT(*actual, HasSubstr("test-bucket"));
   EXPECT_THAT(*actual, HasSubstr("test%2Bobject"));

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/curl_resumable_upload_session.h"
 #include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -67,12 +68,12 @@ TEST(CurlResumableUploadSessionTest, Simple) {
       }));
 
   auto upload = session.UploadChunk(payload, 0U);
-  EXPECT_TRUE(upload.ok());
+  EXPECT_STATUS_OK(upload);
   EXPECT_EQ(size - 1, upload->last_committed_byte);
   EXPECT_EQ(size, session.next_expected_byte());
 
   upload = session.UploadChunk(payload, 2 * size);
-  EXPECT_TRUE(upload.ok());
+  EXPECT_STATUS_OK(upload);
   EXPECT_EQ(2 * size - 1, upload->last_committed_byte);
   EXPECT_EQ(2 * size, session.next_expected_byte());
 }
@@ -134,7 +135,7 @@ TEST(CurlResumableUploadSessionTest, SessionUpdatedInChunkUpload) {
   auto upload = session.UploadChunk(payload, 0U);
   EXPECT_EQ(size, session.next_expected_byte());
   upload = session.UploadChunk(payload, 0U);
-  EXPECT_TRUE(upload.ok());
+  EXPECT_STATUS_OK(upload);
   EXPECT_EQ(2 * size, session.next_expected_byte());
   EXPECT_EQ(url2, session.session_id());
 }

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include <gmock/gmock.h>
 
@@ -121,15 +122,15 @@ TEST_F(RetryResumableUploadSessionTest, HandleTransient) {
 
   StatusOr<ResumableUploadResponse> response;
   response = session.UploadChunk(payload, 3 * quantum);
-  EXPECT_TRUE(response.ok());
+  EXPECT_STATUS_OK(response);
   EXPECT_EQ(quantum - 1, response->last_committed_byte);
 
   response = session.UploadChunk(payload, 3 * quantum);
-  EXPECT_TRUE(response.ok());
+  EXPECT_STATUS_OK(response);
   EXPECT_EQ(2 * quantum - 1, response->last_committed_byte);
 
   response = session.UploadChunk(payload, 3 * quantum);
-  EXPECT_TRUE(response.ok());
+  EXPECT_STATUS_OK(response);
   EXPECT_EQ(3 * quantum - 1, response->last_committed_byte);
 }
 
@@ -337,7 +338,7 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnReset) {
 
   StatusOr<ResumableUploadResponse> response =
       session.UploadChunk(payload, 3 * quantum);
-  EXPECT_TRUE(response.ok());
+  EXPECT_STATUS_OK(response);
   EXPECT_EQ(quantum - 1, response->last_committed_byte);
 
   response = session.UploadChunk(payload, 3 * quantum);

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -35,8 +36,7 @@ namespace {
 BucketMetadata CreateElement(int index) {
   std::string id = "bucket-" + std::to_string(index);
   std::string name = id;
-  std::string link =
-      "https://www.googleapis.com/storage/v1/b/" + id;
+  std::string link = "https://www.googleapis.com/storage/v1/b/" + id;
   internal::nl::json metadata{
       {"id", id},
       {"name", name},
@@ -79,7 +79,7 @@ TEST(ListBucketsReaderTest, Basic) {
   ListBucketsReader reader(mock, "foo-bar-baz", Prefix("dir/"));
   std::vector<BucketMetadata> actual;
   for (auto&& bucket : reader) {
-    ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+    ASSERT_STATUS_OK(bucket);
     actual.push_back(*bucket);
   }
   EXPECT_THAT(actual, ContainerEq(expected));

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -82,7 +83,7 @@ TEST(ListObjectsReaderTest, Basic) {
   ListObjectsReader reader(mock, "foo-bar-baz", Prefix("dir/"));
   std::vector<ObjectMetadata> actual;
   for (auto&& object : reader) {
-    ASSERT_TRUE(object.ok());
+    ASSERT_STATUS_OK(object);
     actual.emplace_back(std::move(object).value());
   }
   EXPECT_THAT(actual, ContainerEq(expected));

--- a/google/cloud/storage/oauth2/anonymous_credentials_test.cc
+++ b/google/cloud/storage/oauth2/anonymous_credentials_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -28,7 +29,7 @@ class AnonymousCredentialsTest : public ::testing::Test {};
 TEST_F(AnonymousCredentialsTest, AuthorizationHeaderReturnsEmptyString) {
   AnonymousCredentials credentials;
   auto header = credentials.AuthorizationHeader();
-  ASSERT_TRUE(header.ok());
+  ASSERT_STATUS_OK(header);
   EXPECT_EQ("", header.value());
 }
 

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstring>
 
@@ -88,7 +89,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
 })""";
 
   auto info = ParseAuthorizedUserCredentials(config, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(*info);
   EXPECT_EQ("Authorization: Type access-token-value",
             credentials.AuthorizationHeader().value());
@@ -140,7 +141,7 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
       "type": "magic_type"
 })""";
   auto info = ParseAuthorizedUserCredentials(config, "test");
-  ASSERT_TRUE(info.ok()) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   AuthorizedUserCredentials<MockHttpRequestBuilder> credentials(*info);
   EXPECT_EQ("Authorization: Type access-token-r1",
             credentials.AuthorizationHeader().value());
@@ -162,7 +163,7 @@ TEST_F(AuthorizedUserCredentialsTest, ParseSimple) {
 
   auto actual =
       ParseAuthorizedUserCredentials(config, "test-data", "unused-uri");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ("a-client-id.example.com", actual->client_id);
   EXPECT_EQ("a-123456ABCDEF", actual->client_secret);
   EXPECT_EQ("1/THETOKEN", actual->refresh_token);
@@ -181,7 +182,7 @@ TEST_F(AuthorizedUserCredentialsTest, ParseUsesExplicitDefaultTokenUri) {
 
   auto actual = ParseAuthorizedUserCredentials(
       config, "test-data", "https://oauth2.googleapis.com/test_endpoint");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ("a-client-id.example.com", actual->client_id);
   EXPECT_EQ("a-123456ABCDEF", actual->client_secret);
   EXPECT_EQ("1/THETOKEN", actual->refresh_token);
@@ -200,7 +201,7 @@ TEST_F(AuthorizedUserCredentialsTest, ParseUsesImplicitDefaultTokenUri) {
 
   // No token_uri passed in here, either.
   auto actual = ParseAuthorizedUserCredentials(config, "test-data");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ("a-client-id.example.com", actual->client_id);
   EXPECT_EQ("a-123456ABCDEF", actual->client_secret);
   EXPECT_EQ("1/THETOKEN", actual->refresh_token);

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
 #include <fstream>
@@ -99,7 +100,7 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaEnvVar) {
   // specified via the well known environment variable.
   SetEnv(GoogleAdcEnvVar(), filename.c_str());
   auto creds = GoogleDefaultCredentials();
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   // Need to create a temporary for the pointer because clang-tidy warns about
   // using expressions with (potential) side-effects inside typeid().
   auto* ptr = creds->get();
@@ -114,7 +115,7 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsViaGcloudFile) {
   UnsetEnv(GoogleAdcEnvVar());
   SetEnv(GoogleGcloudAdcFileEnvVar(), filename.c_str());
   auto creds = GoogleDefaultCredentials();
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
 }
@@ -123,7 +124,7 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsFromFilename) {
   std::string filename = ::testing::TempDir() + AUTHORIZED_USER_CRED_FILENAME;
   SetupAuthorizedUserCredentialsFileForTest(filename);
   auto creds = CreateAuthorizedUserCredentialsFromJsonFilePath(filename);
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
 }
@@ -133,7 +134,7 @@ TEST_F(GoogleCredentialsTest, LoadValidAuthorizedUserCredentialsFromContents) {
   // representing JSON contents.
   auto creds = CreateAuthorizedUserCredentialsFromJsonContents(
       AUTHORIZED_USER_CRED_CONTENTS);
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(AuthorizedUserCredentials<>));
 }
@@ -177,7 +178,7 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaEnvVar) {
   // specified via the well known environment variable.
   SetEnv(GoogleAdcEnvVar(), filename.c_str());
   auto creds = GoogleDefaultCredentials();
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   // Need to create a temporary for the pointer because clang-tidy warns about
   // using expressions with (potential) side-effects inside typeid().
   auto* ptr = creds->get();
@@ -193,7 +194,7 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
   UnsetEnv(GoogleAdcEnvVar());
   SetEnv(GoogleGcloudAdcFileEnvVar(), filename.c_str());
   auto creds = GoogleDefaultCredentials();
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
@@ -204,7 +205,7 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
 
   // Test that the service account credentials are loaded from a file.
   auto creds = CreateServiceAccountCredentialsFromJsonFilePath(filename);
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
@@ -220,7 +221,7 @@ TEST_F(GoogleCredentialsTest,
       google::cloud::optional<std::set<std::string>>(
           {"https://www.googleapis.com/auth/devstorage.full_control"}),
       google::cloud::optional<std::string>("user@foo.bar"));
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
@@ -233,7 +234,7 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
       google::cloud::optional<std::set<std::string>>(
           {"https://www.googleapis.com/auth/devstorage.full_control"}),
       google::cloud::optional<std::string>("user@foo.bar"));
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
@@ -248,7 +249,7 @@ TEST_F(GoogleCredentialsTest, LoadComputeEngineCredentialsFromADCFlow) {
   SetEnv(GceCheckOverrideEnvVar(), "1");
 
   auto creds = GoogleDefaultCredentials();
-  ASSERT_TRUE(creds) << "status=" << creds.status();
+  ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ComputeEngineCredentials<>));
 }

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <chrono>
 #include <cstring>
@@ -143,7 +144,7 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
 TEST_F(ServiceAccountCredentialsTest,
        RefreshingSendsCorrectRequestBodyAndParsesResponse) {
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   CheckInfoYieldsExpectedAssertion(*info, kExpectedAssertionParam);
 }
 
@@ -151,7 +152,7 @@ TEST_F(ServiceAccountCredentialsTest,
 TEST_F(ServiceAccountCredentialsTest,
        RefreshingSendsCorrectRequestBodyAndParsesResponseForNonDefaultVals) {
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   info->scopes = {kAltScopeForTest};
   info->subject = std::string(kSubjectForGrant);
   CheckInfoYieldsExpectedAssertion(*info,
@@ -201,7 +202,7 @@ TEST_F(ServiceAccountCredentialsTest,
           }));
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   ServiceAccountCredentials<MockHttpRequestBuilder> credentials(*info);
   // Calls Refresh to obtain the access token for our authorization header.
   EXPECT_EQ("Authorization: Type access-token-r1",
@@ -236,7 +237,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseSimple) {
 
   auto actual =
       ParseServiceAccountCredentials(contents, "test-data", "unused-uri");
-  ASSERT_TRUE(actual) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ("not-a-key-id-just-for-testing", actual->private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual->private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual->client_email);
@@ -255,7 +256,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseUsesExplicitDefaultTokenUri) {
 
   auto actual = ParseServiceAccountCredentials(
       contents, "test-data", "https://oauth2.googleapis.com/test_endpoint");
-  ASSERT_TRUE(actual) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ("not-a-key-id-just-for-testing", actual->private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual->private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual->client_email);
@@ -274,7 +275,7 @@ TEST_F(ServiceAccountCredentialsTest, ParseUsesImplicitDefaultTokenUri) {
 
   // No token_uri passed in here, either.
   auto actual = ParseServiceAccountCredentials(contents, "test-data");
-  ASSERT_TRUE(actual) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ("not-a-key-id-just-for-testing", actual->private_key_id);
   EXPECT_EQ("not-a-valid-key-just-for-testing", actual->private_key);
   EXPECT_EQ("test-only@test-group.example.com", actual->client_email);
@@ -358,7 +359,7 @@ TEST_F(ServiceAccountCredentialsTest, SignBlob) {
   }));
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
       *info);
 
@@ -371,7 +372,7 @@ x-goog-meta-foo:bar,baz
 /bucket/objectname)""";
 
   auto actual = credentials.SignString(blob);
-  ASSERT_TRUE(actual.first.ok());
+  ASSERT_STATUS_OK(actual.first);
 
   // To generate the expected output I used:
   //   openssl dgst -sha256 -sign private.pem blob.txt | openssl base64 -A
@@ -412,7 +413,7 @@ TEST_F(ServiceAccountCredentialsTest, ClientId) {
   }));
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
-  ASSERT_TRUE(info) << "status=" << info.status();
+  ASSERT_STATUS_OK(info);
   ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
       *info);
 

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -77,7 +78,7 @@ TEST_F(ObjectTest, InsertObjectMedia) {
 
   auto actual = client->InsertObject("test-bucket-name", "test-object-name",
                                      "test object contents");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -149,7 +150,7 @@ TEST_F(ObjectTest, GetObjectMetadata) {
 
   auto actual =
       client.GetObjectMetadata("test-bucket-name", "test-object-name");
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -186,7 +187,7 @@ TEST_F(ObjectTest, DeleteObject) {
                 ExponentialBackoffPolicy(ms(100), ms(500), 2)};
 
   auto status = client.DeleteObject("test-bucket-name", "test-object-name");
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectTest, DeleteObjectTooManyFailures) {
@@ -276,7 +277,7 @@ TEST_F(ObjectTest, UpdateObject) {
   update.mutable_metadata().emplace("test-label", "test-value");
   auto actual =
       client.UpdateObject("test-bucket-name", "test-object-name", update);
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 
@@ -352,7 +353,7 @@ TEST_F(ObjectTest, PatchObject) {
                                    ObjectMetadataPatchBuilder()
                                        .SetContentDisposition("new-disposition")
                                        .SetContentLanguage("x-made-up-lang"));
-  ASSERT_TRUE(actual.ok()) << "status=" << actual.status();
+  ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
 

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
 
@@ -114,7 +115,7 @@ TEST_F(ClientOptionsTest, SetProjectId) {
 
 TEST_F(ClientOptionsTest, SetdownloadBufferSize) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   ClientOptions client_options = *opts;
   auto default_size = client_options.download_buffer_size();
   EXPECT_NE(0U, default_size);
@@ -126,7 +127,7 @@ TEST_F(ClientOptionsTest, SetdownloadBufferSize) {
 
 TEST_F(ClientOptionsTest, SetUploadBufferSize) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   ClientOptions client_options = *opts;
   auto default_size = client_options.upload_buffer_size();
   EXPECT_NE(0U, default_size);
@@ -147,7 +148,7 @@ TEST_F(ClientOptionsTest, UserAgentPrefix) {
 
 TEST_F(ClientOptionsTest, SetMaximumSimpleUploadSize) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   ClientOptions client_options = *opts;
   auto default_size = client_options.maximum_simple_upload_size();
   EXPECT_NE(0U, default_size);
@@ -159,7 +160,7 @@ TEST_F(ClientOptionsTest, SetMaximumSimpleUploadSize) {
 
 TEST_F(ClientOptionsTest, SetEnableLockingCallbacks) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   ClientOptions client_options = *opts;
   auto default_value = client_options.enable_ssl_locking_callbacks();
   EXPECT_TRUE(default_value);

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -551,8 +551,7 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
   ASSERT_STATUS_OK(meta);
 
   auto current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_TRUE(current_notifications.ok())
-      << "status=" << current_notifications.status();
+  ASSERT_STATUS_OK(current_notifications);
   EXPECT_TRUE(current_notifications->empty())
       << "Test aborted. Non-empty notification list returned from newly"
       << " created bucket <" << bucket_name
@@ -567,8 +566,7 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
   EXPECT_THAT(create->topic(), HasSubstr(BucketTestEnvironment::topic()));
 
   current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_TRUE(current_notifications.ok())
-      << "status=" << current_notifications.status();
+  ASSERT_STATUS_OK(current_notifications);
   auto count = std::count_if(current_notifications->begin(),
                              current_notifications->end(),
                              [create](NotificationMetadata const& x) {
@@ -584,8 +582,7 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
   ASSERT_STATUS_OK(status);
 
   current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_TRUE(current_notifications.ok())
-      << "status=" << current_notifications.status();
+  ASSERT_STATUS_OK(current_notifications);
   count = std::count_if(current_notifications->begin(),
                         current_notifications->end(),
                         [create](NotificationMetadata const& x) {
@@ -646,8 +643,7 @@ TEST_F(BucketIntegrationTest, IamCRUD) {
       "storage.objects.list", "storage.objects.get", "storage.objects.delete"};
   StatusOr<std::vector<std::string>> actual_permissions =
       client->TestBucketIamPermissions(bucket_name, expected_permissions);
-  ASSERT_TRUE(actual_permissions.ok())
-      << "status=" << actual_permissions.status();
+  ASSERT_STATUS_OK(actual_permissions);
   EXPECT_THAT(*actual_permissions, ElementsAreArray(expected_permissions));
 
   auto status = client->DeleteBucket(bucket_name);
@@ -669,8 +665,7 @@ TEST_F(BucketIntegrationTest, BucketLock) {
       bucket_name,
       BucketMetadataPatchBuilder().SetRetentionPolicy(std::chrono::seconds(30)),
       IfMetagenerationMatch(meta->metageneration()));
-  ASSERT_TRUE(after_setting_retention_policy.ok())
-      << "status=" << after_setting_retention_policy.status();
+  ASSERT_STATUS_OK(after_setting_retention_policy);
 
   auto after_locking = client->LockBucketRetentionPolicy(
       bucket_name, after_setting_retention_policy->metageneration());

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/log.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdlib>
 #include <vector>
@@ -51,7 +52,7 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
   std::iterator_traits<std::string::iterator>::difference_type count = 0;
   do {
     response = download.GetMore(buffer);
-    EXPECT_TRUE(response.ok());
+    EXPECT_STATUS_OK(response);
     count += std::count(buffer.begin(), buffer.end(), '\n');
   } while (response->status_code == 100);
 

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/log.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdlib>
 #include <vector>
@@ -43,7 +44,7 @@ TEST(CurlRequestTest, SimpleGET) {
   request.AddHeader("charsets: utf-8");
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -72,7 +73,7 @@ TEST(CurlRequestTest, RepeatedGET) {
 
   auto req = request.BuildRequest();
   auto response = req.MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
 
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
@@ -111,7 +112,7 @@ TEST(CurlRequestTest, SimplePOST) {
   request.AddHeader("charsets: utf-8");
 
   auto response = request.BuildRequest().MakeRequest(data);
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json form = parsed["form"];
@@ -128,7 +129,7 @@ TEST(CurlRequestTest, Handle404) {
   request.AddHeader("charsets: utf-8");
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(404, response->status_code);
 }
 
@@ -141,7 +142,7 @@ TEST(CurlRequestTest, HandleTeapot) {
   request.AddHeader("charsets: utf-8");
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(418, response->status_code);
   EXPECT_THAT(response->payload, HasSubstr("[ teapot ]"));
 }
@@ -162,7 +163,7 @@ TEST(CurlRequestTest, CheckResponseHeaders) {
   request.AddHeader("charsets: utf-8");
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   EXPECT_EQ(1U, response->headers.count("x-test-empty"));
   EXPECT_EQ("", response->headers.find("x-test-empty")->second);
@@ -184,7 +185,7 @@ TEST(CurlRequestTest, UserAgentPrefix) {
   builder.AddHeader("charsets: utf-8");
 
   auto response = builder.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   auto payload = nl::json::parse(response->payload);
   ASSERT_EQ(1U, payload.count("headers"));
@@ -202,7 +203,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Projection) {
   request.AddOption(storage::Projection("full"));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -225,7 +226,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_UserProject) {
   request.AddOption(storage::UserProject("a-project"));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -248,7 +249,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationMatch) {
   request.AddOption(storage::IfGenerationMatch(42));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -271,7 +272,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationNotMatch) {
   request.AddOption(storage::IfGenerationNotMatch(42));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -294,7 +295,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationMatch) {
   request.AddOption(storage::IfMetagenerationMatch(42));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -317,7 +318,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationNotMatch) {
   request.AddOption(storage::IfMetagenerationNotMatch(42));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -342,7 +343,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Multiple) {
   request.AddOption(storage::IfGenerationNotMatch(42));
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   nl::json args = parsed["args"];
@@ -387,7 +388,7 @@ TEST(CurlRequestTest, Logging) {
     request.AddHeader("x-test-header: foo");
 
     auto response = request.BuildRequest().MakeRequest("this is some text");
-    ASSERT_TRUE(response.ok());
+    ASSERT_STATUS_OK(response);
     EXPECT_EQ(200, response->status_code);
   }
 

--- a/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/curl_resumable_streambuf.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
@@ -47,7 +48,7 @@ class CurlResumableStreambufIntegrationTest
  protected:
   void CheckUpload(int line_count, int line_size) {
     StatusOr<Client> client = Client::CreateDefaultClient();
-    ASSERT_TRUE(client.ok()) << "status=" << client.status();
+    ASSERT_STATUS_OK(client);
     auto bucket_name = ResumableStreambufTestEnvironment::bucket_name();
     auto object_name = MakeRandomObjectName();
 
@@ -56,7 +57,7 @@ class CurlResumableStreambufIntegrationTest
 
     StatusOr<std::unique_ptr<ResumableUploadSession>> session =
         client->raw_client()->CreateResumableSession(request);
-    ASSERT_TRUE(session.ok());
+    ASSERT_STATUS_OK(session);
 
     ObjectWriteStream writer(
         google::cloud::internal::make_unique<CurlResumableStreambuf>(
@@ -81,7 +82,7 @@ class CurlResumableStreambufIntegrationTest
 
     auto status = client->DeleteObject(bucket_name, object_name,
                                        Generation(metadata.generation()));
-    ASSERT_TRUE(status.ok()) << "status=" << status;
+    ASSERT_STATUS_OK(status);
   }
 };
 

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/curl_streambuf.h"
 #include "google/cloud/storage/object_stream.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -61,10 +62,9 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
     expected += random;
   }
   writer.Close();
-  ASSERT_TRUE(writer.metadata().ok())
+  ASSERT_STATUS_OK(writer.metadata())
       << ", status=" << writer.metadata().status()
-      << ", payload=" << writer.payload()
-      << ", headers={" << [&writer] {
+      << ", payload=" << writer.payload() << ", headers={" << [&writer] {
            std::string result;
            char const* sep = "";
            for (auto&& kv : writer.headers()) {

--- a/google/cloud/storage/tests/curl_upload_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_upload_request_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdlib>
 #include <vector>
@@ -77,7 +78,7 @@ TEST(CurlUploadRequestTest, UploadPartial) {
   expected_data += current_message;
   upload.NextBuffer(current_message);
   auto response = upload.Close();
-  ASSERT_TRUE(response.ok());
+  ASSERT_STATUS_OK(response);
   ASSERT_EQ(200, response->status_code)
       << ", status_code=" << response->status_code
       << ", payload=" << response->payload << ", headers={" << [&response] {

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -58,7 +59,7 @@ bool UsingTestbench() {
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32c) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -69,7 +70,7 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32c) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0),
       Crc32cChecksumValue("6Y46Mg=="));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
@@ -80,12 +81,12 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32c) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -96,7 +97,7 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0), Fields(""),
       Crc32cChecksumValue("6Y46Mg=="));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
@@ -107,12 +108,12 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -128,7 +129,7 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
 
 TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32cFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -144,7 +145,7 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32cFailure) {
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithComputedCrc32c) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -155,7 +156,7 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithComputedCrc32c) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0),
       Crc32cChecksumValue(ComputeCrc32cChecksum(expected)));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
@@ -166,13 +167,13 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithComputedCrc32c) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksums are computed by default.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client((*client_options)
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -183,7 +184,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
   auto id = LogSink::Instance().AddBackend(backend);
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0), Fields(""));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -195,13 +196,13 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
   EXPECT_EQ(1, count);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksums are computed by default.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client((*client_options)
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -212,7 +213,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
   auto id = LogSink::Instance().AddBackend(backend);
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -237,13 +238,13 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
   }
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksums are computed by default on downloads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadXML) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -252,7 +253,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadXML) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(bucket_name, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
@@ -263,13 +264,13 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadXML) {
   EXPECT_THAT(stream.received_hash(), HasSubstr(meta->crc32c()));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksums are computed by default on downloads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadJSON) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -278,7 +279,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadJSON) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream =
       client->ReadObject(bucket_name, object_name, IfMetagenerationNotMatch(0));
@@ -290,13 +291,13 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadJSON) {
   EXPECT_THAT(stream.received_hash(), HasSubstr(meta->crc32c()));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksums are computed by default on uploads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingWriteXML) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -317,13 +318,13 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingWriteXML) {
   EXPECT_THAT(os.received_hash(), HasSubstr(expected_crc32c));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksums are computed by default on uploads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingWriteJSON) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -343,7 +344,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingWriteJSON) {
   EXPECT_THAT(os.received_hash(), HasSubstr(expected_crc32c));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksum mismatches are reported by default on
@@ -355,7 +356,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadXML) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -364,7 +365,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadXML) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(
       bucket_name, object_name,
@@ -390,7 +391,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadXML) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksum mismatches are reported by default on
@@ -402,7 +403,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -411,7 +412,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(
       bucket_name, object_name, DisableMD5Hash(true),
@@ -437,7 +438,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksum mismatches are reported by default on
@@ -449,7 +450,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingWriteXML) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -465,11 +466,11 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingWriteXML) {
 
   stream.Close();
   EXPECT_TRUE(stream.bad());
-  EXPECT_TRUE(stream.metadata().ok());
+  EXPECT_STATUS_OK(stream.metadata());
   EXPECT_NE(stream.received_hash(), stream.computed_hash());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that CRC32C checksum mismatches are reported by default on
@@ -481,7 +482,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingWriteJSON) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectChecksumTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -496,11 +497,11 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingWriteJSON) {
 
   stream.Close();
   EXPECT_TRUE(stream.bad());
-  EXPECT_TRUE(stream.metadata().ok());
+  EXPECT_STATUS_OK(stream.metadata());
   EXPECT_NE(stream.received_hash(), stream.computed_hash());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"
 #include "google/cloud/testing_util/init_google_mock.h"
@@ -61,7 +62,7 @@ bool UsingTestbench() {
 /// @test Verify that MD5 hashes are computed by default.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client((*client_options)
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -72,7 +73,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
   auto id = LogSink::Instance().AddBackend(backend);
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0), Fields(""));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -84,13 +85,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
   EXPECT_EQ(1, count);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hashes are computed by default.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client((*client_options)
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -101,7 +102,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
   auto id = LogSink::Instance().AddBackend(backend);
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -126,13 +127,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
   }
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that `DisableMD5Hash` actually disables the header.
 TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client((*client_options)
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -144,7 +145,7 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       DisableMD5Hash(true), Fields(""));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -156,13 +157,13 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
   EXPECT_EQ(0U, count);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that `DisableMD5Hash` actually disables the payload.
 TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client((*client_options)
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -174,7 +175,7 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name, object_name, LoremIpsum(),
                           IfGenerationMatch(0), DisableMD5Hash(true));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -197,13 +198,13 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
   }
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hashes are computed by default on downloads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadXML) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -212,7 +213,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadXML) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(bucket_name, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
@@ -223,13 +224,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadXML) {
   EXPECT_THAT(stream.received_hash(), HasSubstr(meta->md5_hash()));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hashes are computed by default on downloads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadJSON) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -238,7 +239,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadJSON) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream =
       client->ReadObject(bucket_name, object_name, IfMetagenerationNotMatch(0));
@@ -250,13 +251,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadJSON) {
   EXPECT_THAT(stream.received_hash(), HasSubstr(meta->md5_hash()));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that hashes and checksums can be disabled on downloads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadXML) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -265,7 +266,7 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadXML) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream =
       client->ReadObject(bucket_name, object_name, DisableMD5Hash(true),
@@ -278,13 +279,13 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadXML) {
   EXPECT_TRUE(stream.received_hash().empty());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that hashes and checksums can be disabled on downloads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadJSON) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -293,7 +294,7 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadJSON) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(
       bucket_name, object_name, DisableMD5Hash(true),
@@ -306,13 +307,13 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadJSON) {
   EXPECT_TRUE(stream.received_hash().empty());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hashes are computed by default on uploads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingWriteXML) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -333,13 +334,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingWriteXML) {
   EXPECT_THAT(os.received_hash(), HasSubstr(expected_md5hash));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hashes are computed by default on uploads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingWriteJSON) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -359,13 +360,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingWriteJSON) {
   EXPECT_THAT(os.received_hash(), HasSubstr(expected_md5hash));
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that hashes and checksums can be disabled in uploads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteXML) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -385,13 +386,13 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteXML) {
   EXPECT_TRUE(os.computed_hash().empty());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that hashes and checksums can be disabled in uploads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteJSON) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -411,7 +412,7 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteJSON) {
   EXPECT_TRUE(os.computed_hash().empty());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
@@ -422,7 +423,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -431,7 +432,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(
       bucket_name, object_name, DisableCrc32cChecksum(true),
@@ -456,7 +457,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
@@ -467,7 +468,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -476,7 +477,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   auto stream = client->ReadObject(
       bucket_name, object_name, DisableCrc32cChecksum(true),
@@ -502,7 +503,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
@@ -513,7 +514,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteXML) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -529,11 +530,11 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteXML) {
 
   stream.Close();
   EXPECT_TRUE(stream.bad());
-  EXPECT_TRUE(stream.metadata().ok());
+  EXPECT_STATUS_OK(stream.metadata());
   EXPECT_NE(stream.received_hash(), stream.computed_hash());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
@@ -544,7 +545,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteJSON) {
     return;
   }
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectHashTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -560,11 +561,11 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteJSON) {
 
   stream.Close();
   EXPECT_TRUE(stream.bad());
-  EXPECT_TRUE(stream.metadata().ok());
+  EXPECT_STATUS_OK(stream.metadata());
   EXPECT_NE(stream.received_hash(), stream.computed_hash());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -53,7 +54,7 @@ class ObjectInsertIntegrationTest
 
 TEST_F(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = "name-+-&-=- -%-" + MakeRandomObjectName();
@@ -64,7 +65,7 @@ TEST_F(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0),
       DisableCrc32cChecksum(true), DisableMD5Hash(true));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
 
@@ -74,12 +75,12 @@ TEST_F(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = "name-+-&-=- -%-" + MakeRandomObjectName();
@@ -89,7 +90,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0), Fields(""));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
 
@@ -99,12 +100,12 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = "name-+-&-=- -%-" + MakeRandomObjectName();
@@ -114,7 +115,7 @@ TEST_F(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
 
@@ -124,12 +125,12 @@ TEST_F(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithMD5) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -140,7 +141,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithMD5) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0),
       MD5HashValue("96HF9K981B+JfoQuTVnyCg=="));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
 
@@ -150,12 +151,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithMD5) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -166,7 +167,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0),
       MD5HashValue(ComputeMD5Hash(expected)));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
 
@@ -176,12 +177,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -192,7 +193,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0), Fields(""),
       MD5HashValue("96HF9K981B+JfoQuTVnyCg=="));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
 
@@ -202,12 +203,12 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithMetadata) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -220,7 +221,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithMetadata) {
       WithObjectMetadata(ObjectMetadata()
                              .upsert_metadata("test-key", "test-value")
                              .set_content_type("text/plain")));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   EXPECT_TRUE(meta->has_metadata("test-key"));
@@ -233,12 +234,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithMetadata) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -246,7 +247,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::AuthenticatedRead(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
@@ -254,52 +255,52 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
   StatusOr<BucketMetadata> bucket =
       client->GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_STATUS_OK(bucket);
   ASSERT_TRUE(bucket->has_owner());
   std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerFullControl(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
   StatusOr<BucketMetadata> bucket =
       client->GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_STATUS_OK(bucket);
   ASSERT_TRUE(bucket->has_owner());
   std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerRead(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
@@ -307,12 +308,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -320,7 +321,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::Private(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
@@ -330,12 +331,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -343,7 +344,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::ProjectPrivate(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
@@ -352,12 +353,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -365,7 +366,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::PublicRead(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(
       0, CountMatchingEntities(
              meta->acl(),
@@ -373,12 +374,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -386,11 +387,11 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::AuthenticatedRead(), Fields(""));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
@@ -398,73 +399,73 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest,
        XmlInsertPredefinedAclBucketOwnerFullControl) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
   StatusOr<BucketMetadata> bucket =
       client->GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_STATUS_OK(bucket);
   ASSERT_TRUE(bucket->has_owner());
   std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerFullControl(), Fields(""));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
 
   StatusOr<BucketMetadata> bucket =
       client->GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_STATUS_OK(bucket);
   ASSERT_TRUE(bucket->has_owner());
   std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::BucketOwnerRead(), Fields(""));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("READER")))
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -472,11 +473,11 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::Private(), Fields(""));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
@@ -485,12 +486,12 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -498,11 +499,11 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::ProjectPrivate(), Fields(""));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
@@ -511,12 +512,12 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -524,11 +525,11 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0),
       PredefinedAcl::PublicRead(), Fields(""));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   StatusOr<ObjectMetadata> meta =
       client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(
       0, CountMatchingEntities(
              meta->acl(),
@@ -536,7 +537,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /**
@@ -550,7 +551,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
  */
 TEST_F(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   Client client((*std::move(opts))
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -562,7 +563,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name, object_name, LoremIpsum(),
                           IfGenerationMatch(0), QuotaUser("test-quota-user"));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -580,7 +581,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
   EXPECT_LT(0, count);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /**
@@ -594,7 +595,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
  */
 TEST_F(ObjectInsertIntegrationTest, InsertWithUserIp) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   Client client((*std::move(opts))
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -606,7 +607,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithUserIp) {
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name, object_name, LoremIpsum(),
                           IfGenerationMatch(0), UserIp("127.0.0.1"));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -624,7 +625,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithUserIp) {
   EXPECT_LT(0, count);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 /**
@@ -638,7 +639,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithUserIp) {
  */
 TEST_F(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
   auto opts = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(opts.ok()) << "status=" << opts.status();
+  ASSERT_STATUS_OK(opts);
   Client client((*std::move(opts))
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
@@ -652,16 +653,16 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
     auto seed_object_name = MakeRandomObjectName();
     auto insert =
         client.InsertObject(bucket_name, seed_object_name, LoremIpsum());
-    ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+    ASSERT_STATUS_OK(insert);
     auto status = client.DeleteObject(bucket_name, seed_object_name);
-    ASSERT_TRUE(status.ok()) << "status=" << status;
+    ASSERT_STATUS_OK(status);
   }
 
   auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
   auto id = LogSink::Instance().AddBackend(backend);
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0), UserIp(""));
-  ASSERT_TRUE(insert_meta.ok()) << "status=" << insert_meta.status();
+  ASSERT_STATUS_OK(insert_meta);
 
   LogSink::Instance().RemoveBackend(id);
 
@@ -679,12 +680,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
   EXPECT_LT(0, count);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithContentType) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -693,17 +694,17 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithContentType) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), ContentType("text/plain"));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ("text/plain", meta->content_type());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -713,7 +714,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertFailure) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
   EXPECT_EQ(object_name, insert->name());
   EXPECT_EQ(bucket_name, insert->bucket());
 
@@ -723,12 +724,12 @@ TEST_F(ObjectInsertIntegrationTest, InsertFailure) {
   EXPECT_FALSE(failure.ok()) << "metadata=" << *failure;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertXmlFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -738,7 +739,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertXmlFailure) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> insert = client->InsertObject(
       bucket_name, object_name, expected, Fields(""), IfGenerationMatch(0));
-  ASSERT_TRUE(insert.ok()) << "status=" << insert.status();
+  ASSERT_STATUS_OK(insert);
 
   EXPECT_EQ(object_name, insert->name());
   EXPECT_EQ(bucket_name, insert->bucket());
@@ -749,7 +750,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertXmlFailure) {
   EXPECT_FALSE(failure.ok()) << "metadata=" << *failure;
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -63,7 +64,7 @@ bool UsingTestbench() {
 
 TEST_F(ObjectMediaIntegrationTest, XmlDownloadFile) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -80,7 +81,7 @@ TEST_F(ObjectMediaIntegrationTest, XmlDownloadFile) {
   ObjectMetadata meta = upload.metadata().value();
 
   auto status = client->DownloadToFile(bucket_name, object_name, file_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   // Create a iostream to read the object back.
   std::ifstream stream(file_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
@@ -90,13 +91,13 @@ TEST_F(ObjectMediaIntegrationTest, XmlDownloadFile) {
   EXPECT_EQ(expected_str, actual);
 
   status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, JsonDownloadFile) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -113,7 +114,7 @@ TEST_F(ObjectMediaIntegrationTest, JsonDownloadFile) {
 
   auto status = client->DownloadToFile(bucket_name, object_name, file_name,
                                        IfMetagenerationNotMatch(0));
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   // Create a iostream to read the object back.
   std::ifstream stream(file_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
@@ -123,13 +124,13 @@ TEST_F(ObjectMediaIntegrationTest, JsonDownloadFile) {
   EXPECT_EQ(expected_str, actual);
 
   status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, DownloadFileFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -142,14 +143,14 @@ TEST_F(ObjectMediaIntegrationTest, DownloadFileFailure) {
 
 TEST_F(ObjectMediaIntegrationTest, DownloadFileCannotOpenFile) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   // Create an invalid path for the destination object.
   auto file_name = MakeRandomObjectName() + "/" + MakeRandomObjectName();
@@ -159,20 +160,20 @@ TEST_F(ObjectMediaIntegrationTest, DownloadFileCannotOpenFile) {
   EXPECT_THAT(status.message(), HasSubstr(object_name));
 
   status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectMediaIntegrationTest, DownloadFileCannotWriteToFile) {
 #if GTEST_OS_LINUX
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   // We want to test that the code handles write errors *after* the file is
   // successfully opened for writing. Such errors are hard to get, typically
@@ -190,13 +191,13 @@ TEST_F(ObjectMediaIntegrationTest, DownloadFileCannotWriteToFile) {
   EXPECT_THAT(status.message(), HasSubstr(object_name));
 
   status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 #endif  // GTEST_OS_LINUX
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFile) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -211,7 +212,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFile) {
 
   StatusOr<ObjectMetadata> meta = client->UploadFile(
       file_name, bucket_name, object_name, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   auto expected_str = expected.str();
@@ -225,13 +226,13 @@ TEST_F(ObjectMediaIntegrationTest, UploadFile) {
   EXPECT_EQ(expected_str, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileEmpty) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -242,7 +243,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileEmpty) {
 
   StatusOr<ObjectMetadata> meta = client->UploadFile(
       file_name, bucket_name, object_name, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   EXPECT_EQ(0U, meta->size());
@@ -255,13 +256,13 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileEmpty) {
   EXPECT_EQ("", actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileMissingFileFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -276,7 +277,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileMissingFileFailure) {
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileUploadFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -288,7 +289,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileUploadFailure) {
   // Create the object.
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   // Trying to upload the file to the same object with the IfGenerationMatch(0)
   // condition should fail because the object already exists.
@@ -298,7 +299,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileUploadFailure) {
   EXPECT_EQ(StatusCode::kFailedPrecondition, upload.status().code());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
@@ -308,7 +309,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
   // the test there.
 #if GTEST_OS_LINUX || GTEST_OS_MAC
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -328,7 +329,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
   StatusOr<ObjectMetadata> meta =
       client->UploadFile(file_name, bucket_name, object_name,
                          IfGenerationMatch(0), DisableMD5Hash(true));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   LogSink::Instance().RemoveBackend(id);
 
   auto count = std::count_if(
@@ -341,14 +342,14 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileNonRegularWarning) {
 
   t.join();
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 #endif  // GTEST_OS_LINUX
 }
 
 TEST_F(ObjectMediaIntegrationTest, XmlUploadFile) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -377,7 +378,7 @@ TEST_F(ObjectMediaIntegrationTest, XmlUploadFile) {
 
   StatusOr<ObjectMetadata> meta = client->UploadFile(
       file_name, bucket_name, object_name, IfGenerationMatch(0), Fields(""));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   auto expected_str = expected.str();
 
   // Create a iostream to read the object back.
@@ -388,14 +389,14 @@ TEST_F(ObjectMediaIntegrationTest, XmlUploadFile) {
   EXPECT_EQ(expected_str, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileResumableBySize) {
   // Create a client that always uses resumable uploads.
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -410,7 +411,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableBySize) {
 
   StatusOr<ObjectMetadata> meta = client.UploadFile(
       file_name, bucket_name, object_name, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   auto expected_str = expected.str();
@@ -429,13 +430,13 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableBySize) {
   EXPECT_EQ(expected_str, actual);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileResumableByOption) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -451,7 +452,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableByOption) {
   StatusOr<ObjectMetadata> meta =
       client->UploadFile(file_name, bucket_name, object_name,
                          IfGenerationMatch(0), NewResumableUploadSession());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   auto expected_str = expected.str();
@@ -470,14 +471,14 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableByOption) {
   EXPECT_EQ(expected_str, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileResumableQuantum) {
   // Create a client that always uses resumable uploads.
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -497,7 +498,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableQuantum) {
 
   StatusOr<ObjectMetadata> meta = client.UploadFile(
       file_name, bucket_name, object_name, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   auto expected_str = expected.str();
@@ -511,14 +512,14 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableQuantum) {
   EXPECT_EQ(expected_str, actual);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileResumableNonQuantum) {
   // Create a client that always uses resumable uploads.
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
@@ -537,7 +538,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableNonQuantum) {
 
   StatusOr<ObjectMetadata> meta = client.UploadFile(
       file_name, bucket_name, object_name, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   auto expected_str = expected.str();
@@ -551,14 +552,14 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableNonQuantum) {
   EXPECT_EQ(expected_str, actual);
 
   auto status = client.DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
 TEST_F(ObjectMediaIntegrationTest, UploadFileResumableUploadFailure) {
   // Create a client that always uses resumable uploads.
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
   auto bucket_name = MakeRandomBucketName();
@@ -577,7 +578,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableUploadFailure) {
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -597,7 +598,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
   // Create an object with the contents to download.
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name, object_name, large_text, IfGenerationMatch(0));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   // Create a iostream to read the object back.
   auto stream = client->ReadObject(bucket_name, object_name);
@@ -607,17 +608,17 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
 
   EXPECT_EQ(large_text.substr(0, 1024), actual);
   stream.Close();
-  EXPECT_TRUE(stream.status().ok()) << "status=" << stream.status();
+  EXPECT_STATUS_OK(stream.status());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a portion of a relatively large object using the JSON API.
 TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   // The testbench always requires multiple iterations to copy this object.
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -638,7 +639,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name, object_name, large_text, IfGenerationMatch(0));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   EXPECT_EQ(object_name, source_meta->name());
   EXPECT_EQ(bucket_name, source_meta->bucket());
@@ -652,14 +653,14 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   EXPECT_EQ(large_text.substr(1 * chunk, 1 * chunk), actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 /// @test Read a portion of a relatively large object using the XML API.
 TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   // The testbench always requires multiple iterations to copy this object.
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectMediaTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -680,7 +681,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name, object_name, large_text, IfGenerationMatch(0));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   EXPECT_EQ(object_name, source_meta->name());
   EXPECT_EQ(bucket_name, source_meta->bucket());
@@ -693,7 +694,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   EXPECT_EQ(large_text.substr(1 * chunk, 1 * chunk), actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
@@ -51,7 +52,7 @@ bool UsingTestbench() {
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentType) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectResumableWriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -77,12 +78,12 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentType) {
   }
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentTypeFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
@@ -104,7 +105,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentTypeFailure) {
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithUseResumable) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectResumableWriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -128,12 +129,12 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithUseResumable) {
   }
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectResumableWriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -167,12 +168,12 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
   }
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectResumableWriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -182,7 +183,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, expected, IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
@@ -198,7 +199,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
   EXPECT_EQ(StatusCode::kFailedPrecondition, os.metadata().status().code());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  EXPECT_TRUE(status.ok()) << "status=" << status;
+  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"
 #include "google/cloud/testing_util/init_google_mock.h"
@@ -54,7 +55,7 @@ class ObjectRewriteIntegrationTest
 
 TEST_F(ObjectRewriteIntegrationTest, Copy) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto source_object_name = MakeRandomObjectName();
@@ -64,7 +65,7 @@ TEST_F(ObjectRewriteIntegrationTest, Copy) {
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name, source_object_name, expected, IfGenerationMatch(0));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   EXPECT_EQ(source_object_name, source_meta->name());
   EXPECT_EQ(bucket_name, source_meta->bucket());
@@ -72,7 +73,7 @@ TEST_F(ObjectRewriteIntegrationTest, Copy) {
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, source_object_name, bucket_name, destination_object_name,
       WithObjectMetadata(ObjectMetadata().set_content_type("text/plain")));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_EQ(destination_object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
   EXPECT_EQ("text/plain", meta->content_type());
@@ -82,14 +83,14 @@ TEST_F(ObjectRewriteIntegrationTest, Copy) {
   EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, destination_object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, source_object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -97,12 +98,12 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
 
   StatusOr<ObjectMetadata> original = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(original.ok()) << "status=" << original.status();
+  ASSERT_STATUS_OK(original);
 
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, object_name, bucket_name, copy_name, IfGenerationMatch(0),
       DestinationPredefinedAcl::AuthenticatedRead(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
                                          .set_entity("allAuthenticatedUsers")
@@ -110,14 +111,14 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, copy_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -125,32 +126,32 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
 
   StatusOr<BucketMetadata> bucket =
       client->GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_STATUS_OK(bucket);
   ASSERT_TRUE(bucket->has_owner());
   std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> original = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(original.ok()) << "status=" << original.status();
+  ASSERT_STATUS_OK(original);
 
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, object_name, bucket_name, copy_name, IfGenerationMatch(0),
       DestinationPredefinedAcl::BucketOwnerFullControl(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("OWNER")))
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, copy_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -158,32 +159,32 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
 
   StatusOr<BucketMetadata> bucket =
       client->GetBucketMetadata(bucket_name, Projection::Full());
-  ASSERT_TRUE(bucket.ok()) << "status=" << bucket.status();
+  ASSERT_STATUS_OK(bucket);
   ASSERT_TRUE(bucket->has_owner());
   std::string owner = bucket->owner().entity;
 
   StatusOr<ObjectMetadata> original = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(original.ok()) << "status=" << original.status();
+  ASSERT_STATUS_OK(original);
 
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, object_name, bucket_name, copy_name, IfGenerationMatch(0),
       DestinationPredefinedAcl::BucketOwnerRead(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(0, CountMatchingEntities(
                    meta->acl(),
                    ObjectAccessControl().set_entity(owner).set_role("READER")))
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, copy_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -191,12 +192,12 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
 
   StatusOr<ObjectMetadata> original = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(original.ok()) << "status=" << original.status();
+  ASSERT_STATUS_OK(original);
 
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, object_name, bucket_name, copy_name, IfGenerationMatch(0),
       DestinationPredefinedAcl::Private(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
@@ -205,14 +206,14 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, copy_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -220,12 +221,12 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
 
   StatusOr<ObjectMetadata> original = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(original.ok()) << "status=" << original.status();
+  ASSERT_STATUS_OK(original);
 
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, object_name, bucket_name, copy_name, IfGenerationMatch(0),
       DestinationPredefinedAcl::ProjectPrivate(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   ASSERT_TRUE(meta->has_owner());
   EXPECT_LT(0, CountMatchingEntities(meta->acl(),
                                      ObjectAccessControl()
@@ -234,14 +235,14 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, copy_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -249,12 +250,12 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
 
   StatusOr<ObjectMetadata> original = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(original.ok()) << "status=" << original.status();
+  ASSERT_STATUS_OK(original);
 
   StatusOr<ObjectMetadata> meta = client->CopyObject(
       bucket_name, object_name, bucket_name, copy_name, IfGenerationMatch(0),
       DestinationPredefinedAcl::PublicRead(), Projection::Full());
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
   EXPECT_LT(
       0, CountMatchingEntities(
              meta->acl(),
@@ -262,14 +263,14 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
       << *meta;
 
   auto status = client->DeleteObject(bucket_name, copy_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -277,7 +278,7 @@ TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> meta = client->InsertObject(
       bucket_name, object_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
@@ -289,18 +290,18 @@ TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
   StatusOr<ObjectMetadata> composed_meta = client->ComposeObject(
       bucket_name, source_objects, composed_object_name,
       WithObjectMetadata(ObjectMetadata().set_content_type("plain/text")));
-  ASSERT_TRUE(composed_meta.ok()) << "status=" << composed_meta.status();
+  ASSERT_STATUS_OK(composed_meta);
   EXPECT_EQ(meta->size() * 2, composed_meta->size());
 
   auto status = client->DeleteObject(bucket_name, composed_object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposedUsingEncryptedObject) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -312,7 +313,7 @@ TEST_F(ObjectRewriteIntegrationTest, ComposedUsingEncryptedObject) {
   StatusOr<ObjectMetadata> meta =
       client->InsertObject(bucket_name, object_name, content,
                            IfGenerationMatch(0), EncryptionKey(key));
-  ASSERT_TRUE(meta.ok()) << "status=" << meta.status();
+  ASSERT_STATUS_OK(meta);
 
   EXPECT_EQ(object_name, meta->name());
   EXPECT_EQ(bucket_name, meta->bucket());
@@ -326,18 +327,18 @@ TEST_F(ObjectRewriteIntegrationTest, ComposedUsingEncryptedObject) {
                                                      {object_name}};
   StatusOr<ObjectMetadata> composed_meta = client->ComposeObject(
       bucket_name, source_objects, composed_object_name, EncryptionKey(key));
-  ASSERT_TRUE(composed_meta.ok()) << "status=" << composed_meta.status();
+  ASSERT_STATUS_OK(composed_meta);
 
   EXPECT_EQ(meta->size() * 2, composed_meta->size());
   auto status = client->DeleteObject(bucket_name, composed_object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteSimple) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto source_name = MakeRandomObjectName();
@@ -345,7 +346,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteSimple) {
   // Create the object, but only if it does not exist already.
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name, source_name, LoremIpsum(), IfGenerationMatch(0));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   EXPECT_EQ(source_name, source_meta->name());
   EXPECT_EQ(bucket_name, source_meta->bucket());
@@ -354,20 +355,20 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteSimple) {
   auto object_name = MakeRandomObjectName();
   StatusOr<ObjectMetadata> rewritten_meta = client->RewriteObjectBlocking(
       bucket_name, source_name, bucket_name, object_name);
-  ASSERT_TRUE(rewritten_meta.ok()) << "status=" << rewritten_meta.status();
+  ASSERT_STATUS_OK(rewritten_meta);
 
   EXPECT_EQ(bucket_name, rewritten_meta->bucket());
   EXPECT_EQ(object_name, rewritten_meta->name());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, source_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteEncrypted) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto source_name = MakeRandomObjectName();
@@ -377,7 +378,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteEncrypted) {
   StatusOr<ObjectMetadata> source_meta =
       client->InsertObject(bucket_name, source_name, LoremIpsum(),
                            IfGenerationMatch(0), EncryptionKey(source_key));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   EXPECT_EQ(source_name, source_meta->name());
   EXPECT_EQ(bucket_name, source_meta->bucket());
@@ -390,21 +391,21 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteEncrypted) {
       SourceEncryptionKey(source_key), EncryptionKey(dest_key));
 
   StatusOr<ObjectMetadata> rewritten_meta = rewriter.Result();
-  ASSERT_TRUE(rewritten_meta.ok()) << "status=" << rewritten_meta.status();
+  ASSERT_STATUS_OK(rewritten_meta);
 
   EXPECT_EQ(bucket_name, rewritten_meta->bucket());
   EXPECT_EQ(object_name, rewritten_meta->name());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, source_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
   // The testbench always requires multiple iterations to copy this object.
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto source_name = MakeRandomObjectName();
@@ -421,7 +422,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name, source_name, large_text, IfGenerationMatch(0));
-  ASSERT_TRUE(source_meta.ok()) << "status=" << source_meta.status();
+  ASSERT_STATUS_OK(source_meta);
 
   EXPECT_EQ(source_name, source_meta->name());
   EXPECT_EQ(bucket_name, source_meta->bucket());
@@ -433,25 +434,25 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
 
   StatusOr<ObjectMetadata> rewritten_meta =
       writer.ResultWithProgressCallback([](StatusOr<RewriteProgress> const& p) {
-        ASSERT_TRUE(p.ok()) << "progress status=" << p.status();
+        ASSERT_STATUS_OK(p);
         EXPECT_TRUE((p->total_bytes_rewritten < p->object_size) xor p->done)
             << "p.done=" << p->done << ", p.object_size=" << p->object_size
             << ", p.total_bytes_rewritten=" << p->total_bytes_rewritten;
       });
-  ASSERT_TRUE(rewritten_meta.ok()) << "status=" << rewritten_meta.status();
+  ASSERT_STATUS_OK(rewritten_meta);
 
   EXPECT_EQ(bucket_name, rewritten_meta->bucket());
   EXPECT_EQ(object_name, rewritten_meta->name());
 
   auto status = client->DeleteObject(bucket_name, object_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
   status = client->DeleteObject(bucket_name, source_name);
-  ASSERT_TRUE(status.ok()) << "status=" << status;
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto source_object_name = MakeRandomObjectName();
@@ -465,7 +466,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyFailure) {
 
 TEST_F(ObjectRewriteIntegrationTest, ComposeFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto object_name = MakeRandomObjectName();
@@ -481,7 +482,7 @@ TEST_F(ObjectRewriteIntegrationTest, ComposeFailure) {
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteFailure) {
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   auto bucket_name = ObjectRewriteTestEnvironment::bucket_name();
   auto source_object_name = MakeRandomObjectName();

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
@@ -41,13 +42,13 @@ std::string ServiceAccountTestEnvironment::project_id_;
 TEST(ServiceAccountIntegrationTest, Get) {
   auto project_id = ServiceAccountTestEnvironment::project_id();
   StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_TRUE(client.ok()) << "status=" << client.status();
+  ASSERT_STATUS_OK(client);
 
   StatusOr<ServiceAccount> a1 = client->GetServiceAccountForProject(project_id);
   EXPECT_FALSE(a1->email_address().empty());
 
   auto client_options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_TRUE(client_options.ok()) << "status=" << client_options.status();
+  ASSERT_STATUS_OK(client_options);
   Client client_with_default(client_options->set_project_id(project_id));
   StatusOr<ServiceAccount> a2 = client_with_default.GetServiceAccount();
   EXPECT_FALSE(a2->email_address().empty());


### PR DESCRIPTION
This fixes #1990.

Occurrences of `grpc::Status` are untouched. They should disappear once
the transition to `StatusOr<>` is complete and `internal/*` removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1996)
<!-- Reviewable:end -->
