### PR TITLE
Standardize {EXPECT,ASSERT}_STATUS_OK description.

### DIFF
--- a/google/cloud/testing_util/assert_ok.cc
+++ b/google/cloud/testing_util/assert_ok.cc
@@ -24,8 +24,7 @@ testing::AssertionResult IsOkPredFormat(char const* expr,
     return testing::AssertionSuccess();
   }
   return testing::AssertionFailure()
-         << "Value of: " << expr << "\nExpected: is OK\n"
-         << "Actual: " << status.message() << " (code " << status.code() << ")";
+         << "Value of: " << expr << "\nExpected: is OK\nActual: " << status;
 }
 
 }  // namespace internal

--- a/google/cloud/testing_util/assert_ok.cc
+++ b/google/cloud/testing_util/assert_ok.cc
@@ -24,9 +24,8 @@ testing::AssertionResult IsOkPredFormat(char const* expr,
     return testing::AssertionSuccess();
   }
   return testing::AssertionFailure()
-         << "Status of \"" << expr
-         << "\" is expected to be OK, but evaluates to \"" << status.message()
-         << "\" (code " << status.code() << ")";
+         << "Value of: " << expr << "\nExpected: is OK\n"
+         << "Actual: " << status.message() << " (code " << status.code() << ")";
 }
 
 }  // namespace internal

--- a/google/cloud/testing_util/assert_ok_test.cc
+++ b/google/cloud/testing_util/assert_ok_test.cc
@@ -47,7 +47,7 @@ TEST(AssertOkTest, AssertionFailed) {
         Status status(StatusCode::kInternal, "oh no!");
         ASSERT_STATUS_OK(status);
       },
-      "Value of: status\nExpected: is OK\nActual: oh no! (code INTERNAL)");
+      "Value of: status\nExpected: is OK\nActual: oh no! [INTERNAL]");
 }
 
 TEST(AssertOkTest, AssertionFailedStatusOr) {
@@ -56,7 +56,7 @@ TEST(AssertOkTest, AssertionFailedStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         ASSERT_STATUS_OK(status_or);
       },
-      "Value of: status_or\nExpected: is OK\nActual: oh no! (code INTERNAL)");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! [INTERNAL]");
 }
 
 TEST(AssertOkTest, AssertionFailedDescription) {
@@ -65,8 +65,8 @@ TEST(AssertOkTest, AssertionFailedDescription) {
         Status status(StatusCode::kInternal, "oh no!");
         ASSERT_STATUS_OK(status) << "my precious assertion failed";
       },
-      "Value of: status\nExpected: is OK\nActual: oh no! (code "
-      "INTERNAL)\nmy precious assertion failed");
+      "Value of: status\nExpected: is OK\nActual: oh no! [INTERNAL]\nmy "
+      "precious assertion failed");
 }
 
 TEST(AssertOkTest, AssertionFailedDescriptionStatusOr) {
@@ -75,8 +75,8 @@ TEST(AssertOkTest, AssertionFailedDescriptionStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         ASSERT_STATUS_OK(status_or) << "my precious assertion failed";
       },
-      "Value of: status_or\nExpected: is OK\nActual: oh no! (code "
-      "INTERNAL)\nmy precious assertion failed");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! [INTERNAL]\nmy "
+      "precious assertion failed");
 }
 
 TEST(ExpectOkTest, ExpectOk) {
@@ -105,7 +105,7 @@ TEST(ExpectOkTest, ExpectionFailed) {
         Status status(StatusCode::kInternal, "oh no!");
         EXPECT_STATUS_OK(status);
       },
-      "Value of: status\nExpected: is OK\nActual: oh no! (code INTERNAL)");
+      "Value of: status\nExpected: is OK\nActual: oh no! [INTERNAL]");
 }
 
 TEST(ExpectOkTest, ExpectionFailedStatusOr) {
@@ -114,7 +114,7 @@ TEST(ExpectOkTest, ExpectionFailedStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         EXPECT_STATUS_OK(status_or);
       },
-      "Value of: status_or\nExpected: is OK\nActual: oh no! (code INTERNAL)");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! [INTERNAL]");
 }
 
 TEST(ExpectOkTest, ExpectionFailedDescription) {
@@ -123,8 +123,8 @@ TEST(ExpectOkTest, ExpectionFailedDescription) {
         Status status(StatusCode::kInternal, "oh no!");
         EXPECT_STATUS_OK(status) << "my precious assertion failed";
       },
-      "Value of: status\nExpected: is OK\nActual: oh no! (code "
-      "INTERNAL)\nmy precious assertion failed");
+      "Value of: status\nExpected: is OK\nActual: oh no! [INTERNAL]\nmy "
+      "precious assertion failed");
 }
 
 TEST(ExpectOkTest, ExpectionFailedDescriptionStatusOr) {
@@ -133,6 +133,6 @@ TEST(ExpectOkTest, ExpectionFailedDescriptionStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         EXPECT_STATUS_OK(status_or) << "my precious assertion failed";
       },
-      "Value of: status_or\nExpected: is OK\nActual: oh no! (code "
-      "INTERNAL)\nmy precious assertion failed");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! [INTERNAL]\nmy "
+      "precious assertion failed");
 }

--- a/google/cloud/testing_util/assert_ok_test.cc
+++ b/google/cloud/testing_util/assert_ok_test.cc
@@ -47,8 +47,7 @@ TEST(AssertOkTest, AssertionFailed) {
         Status status(StatusCode::kInternal, "oh no!");
         ASSERT_STATUS_OK(status);
       },
-      "Status of \"status\" is expected to be OK, but evaluates to \"oh no!\" "
-      "(code INTERNAL)");
+      "Value of: status\nExpected: is OK\nActual: oh no! (code INTERNAL)");
 }
 
 TEST(AssertOkTest, AssertionFailedStatusOr) {
@@ -57,8 +56,7 @@ TEST(AssertOkTest, AssertionFailedStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         ASSERT_STATUS_OK(status_or);
       },
-      "Status of \"status_or\" is expected to be OK, but evaluates to \"oh "
-      "no!\" (code INTERNAL)");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! (code INTERNAL)");
 }
 
 TEST(AssertOkTest, AssertionFailedDescription) {
@@ -67,8 +65,8 @@ TEST(AssertOkTest, AssertionFailedDescription) {
         Status status(StatusCode::kInternal, "oh no!");
         ASSERT_STATUS_OK(status) << "my precious assertion failed";
       },
-      "Status of \"status\" is expected to be OK, but evaluates to \"oh no!\" "
-      "(code INTERNAL)\nmy precious assertion failed");
+      "Value of: status\nExpected: is OK\nActual: oh no! (code "
+      "INTERNAL)\nmy precious assertion failed");
 }
 
 TEST(AssertOkTest, AssertionFailedDescriptionStatusOr) {
@@ -77,9 +75,8 @@ TEST(AssertOkTest, AssertionFailedDescriptionStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         ASSERT_STATUS_OK(status_or) << "my precious assertion failed";
       },
-      "Status of \"status_or\" is expected to be OK, but evaluates to \"oh "
-      "no!\" "
-      "(code INTERNAL)\nmy precious assertion failed");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! (code "
+      "INTERNAL)\nmy precious assertion failed");
 }
 
 TEST(ExpectOkTest, ExpectOk) {
@@ -108,8 +105,7 @@ TEST(ExpectOkTest, ExpectionFailed) {
         Status status(StatusCode::kInternal, "oh no!");
         EXPECT_STATUS_OK(status);
       },
-      "Status of \"status\" is expected to be OK, but evaluates to \"oh no!\" "
-      "(code INTERNAL)");
+      "Value of: status\nExpected: is OK\nActual: oh no! (code INTERNAL)");
 }
 
 TEST(ExpectOkTest, ExpectionFailedStatusOr) {
@@ -118,9 +114,7 @@ TEST(ExpectOkTest, ExpectionFailedStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         EXPECT_STATUS_OK(status_or);
       },
-      "Status of \"status_or\" is expected to be OK, but evaluates to \"oh "
-      "no!\" "
-      "(code INTERNAL)");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! (code INTERNAL)");
 }
 
 TEST(ExpectOkTest, ExpectionFailedDescription) {
@@ -129,8 +123,8 @@ TEST(ExpectOkTest, ExpectionFailedDescription) {
         Status status(StatusCode::kInternal, "oh no!");
         EXPECT_STATUS_OK(status) << "my precious assertion failed";
       },
-      "Status of \"status\" is expected to be OK, but evaluates to \"oh no!\" "
-      "(code INTERNAL)\nmy precious assertion failed");
+      "Value of: status\nExpected: is OK\nActual: oh no! (code "
+      "INTERNAL)\nmy precious assertion failed");
 }
 
 TEST(ExpectOkTest, ExpectionFailedDescriptionStatusOr) {
@@ -139,6 +133,6 @@ TEST(ExpectOkTest, ExpectionFailedDescriptionStatusOr) {
         StatusOr<int> status_or(Status(StatusCode::kInternal, "oh no!"));
         EXPECT_STATUS_OK(status_or) << "my precious assertion failed";
       },
-      "Status of \"status_or\" is expected to be OK, but evaluates to \"oh "
-      "no!\" (code INTERNAL)\nmy precious assertion failed");
+      "Value of: status_or\nExpected: is OK\nActual: oh no! (code "
+      "INTERNAL)\nmy precious assertion failed");
 }


### PR DESCRIPTION
This way it is consistent with other gtest assertions/expectations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/1998)
<!-- Reviewable:end -->
