### PR TITLE
Use random port for Bigtable emulator.

### DIFF
--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -535,10 +535,13 @@ int run_server(int argc, char* argv[]) {
   if (argc == 2) {
     server_address += argv[1];
   } else {
-    server_address += "9090";
+    server_address += "0";
   }
   DefaultEmbeddedServer server(server_address);
-  std::cout << "Listening on " << server.address();
+  // Need to flush so the output becomes immediately visible to the driver
+  // scripts.
+  std::cout << "Cloud Bigtable emulator running on " << server.address()
+            << std::endl;
   server.Wait();
 
   return 0;

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -540,8 +540,8 @@ int run_server(int argc, char* argv[]) {
   DefaultEmbeddedServer server(server_address);
   // Need to flush so the output becomes immediately visible to the driver
   // scripts.
-  std::cout << "Cloud Bigtable emulator running on " << server.address()
-            << std::endl;
+  std::cout << "Cloud Bigtable emulator running on " << server.address() << '\n'
+            << std::flush;
   server.Wait();
 
   return 0;

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -52,11 +52,13 @@ wait_for_port() {
   local emulator_port="0"
   local -r expected='Cloud Bigtable emulator running on'
   for attempt in $(seq 1 8); do
-    if head -1 "${logfile}" | grep -q "${expected}"; then
+    if grep -q "${expected}" "${logfile}"; then
        # The port number is whatever is after the last ':'. Note that on IPv6
        # there may be multiple ':' characters, and recall that regular
-       # expressions are greedy.
-       emulator_port=$(head -1 "${logfile}" | sed 's/^.*://')
+       # expressions are greedy. If grep has multiple matches this breaks,
+       # which is Okay because then the emulator is exhibiting unexpected
+       # behavior.
+       emulator_port=$(grep "${expected}" "${logfile}" | sed 's/^.*://')
        break
     fi
     sleep 1

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -35,60 +35,97 @@ function kill_emulators {
   echo " done."
 }
 
+################################################
+# Wait until the port number is printed in the log file for one of the
+# emulators
+# Globals:
+#   None
+# Arguments:
+#   logfile: the name of the logfile to wait on.
+# Returns:
+#   None
+################################################
+wait_for_port() {
+  local -r logfile="$1"
+  shift
+
+  local emulator_port="0"
+  local -r expected='Cloud Bigtable emulator running on'
+  for attempt in $(seq 1 8); do
+    if head -1 "${logfile}" | grep -q "${expected}"; then
+       # The port number is whatever is after the last ':'. Note that on IPv6
+       # there may be multiple ':' characters, and recall that regular
+       # expressions are greedy.
+       emulator_port=$(head -1 "${logfile}" | sed 's/^.*://')
+       break
+    fi
+    sleep 1
+  done
+
+  if [[ "${emulator_port}" = "0"  ]]; then
+    echo "Cannot determine Bigtable emulator port." >&2
+    kill_emulators
+    exit 1
+  fi
+
+  echo ${emulator_port}
+}
+
+################################################
+# Wait until it can successfully connect to the emulator.
+# Globals:
+#   None
+# Arguments:
+#   address: the expected address for the emulator
+#   subcmd: the Cloud Bigtable command-line tool sub-command to test with.
+# Returns:
+#   None
+################################################
+function wait_until_emulator_connects {
+  local address=$1
+  local subcmd=$2
+  shift 2
+
+  local -r CBT_ARGS="-project emulated -instance emulated -creds default"
+  # Wait until the emulator starts responding.
+  delay=1
+  connected=no
+  local -r attempts=$(seq 1 8)
+  for attempt in ${attempts}; do
+    if env BIGTABLE_EMULATOR_HOST="${address}" \
+           "${CBT_CMD}" ${CBT_ARGS} "${subcmd}" >/dev/null 2>&1; then
+      connected=yes
+      break
+    fi
+    sleep $delay
+    delay=$((delay * 2))
+  done
+
+  if [[ "${connected}" = "no" ]]; then
+    echo "Cannot connect to Cloud Bigtable emulator; aborting test." >&2
+    exit 1
+  fi
+
+  echo "Successfully connected to the Cloud Bigtable emulator on ${address}."
+}
+
+
 function start_emulators {
   echo "Launching Cloud Bigtable emulators in the background"
   trap kill_emulators EXIT
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
-  local -r emulator_port=${EMULATOR_PORT:-9000}
-  "${CBT_EMULATOR_CMD}" -port "${emulator_port}" >emulator.log 2>&1 </dev/null &
+  "${CBT_EMULATOR_CMD}" -port 0 >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
+  local -r emulator_port="$(wait_for_port emulator.log)"
 
-  local -r instance_admin_port=${INSTANCE_ADMIN_EMULATOR_PORT:-9090}
-  "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${instance_admin_port}" >instance-admin-emulator.log 2>&1 </dev/null &
+  "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
+  local -r instance_admin_port="$(wait_for_port instance-admin-emulator.log)"
 
-  export BIGTABLE_EMULATOR_HOST="localhost:${emulator_port}"
-  # Avoid repetition
-  readonly CBT_ARGS="-project emulated -instance emulated -creds default"
-  # Wait until the emulator starts responding.
-  delay=1
-  connected=no
-  local -r attempts=$(seq 1 8)
-  for attempt in ${attempts}; do
-    if "${CBT_CMD}" $CBT_ARGS ls >/dev/null 2>&1; then
-      connected=yes
-      break
-    fi
-    sleep $delay
-    delay=$((delay * 2))
-  done
-
-  if [ "${connected}" = "no" ]; then
-    echo "Cannot connect to Cloud Bigtable emulator; aborting test." >&2
-    exit 1
-  fi
-
-  echo "Successfully connected to the Cloud Bigtable emulator."
-
-  export BIGTABLE_EMULATOR_HOST="localhost:${instance_admin_port}"
-  delay=1
-  connected=no
-  for attempt in ${attempts}; do
-    if "${CBT_CMD}" $CBT_ARGS listinstances >/dev/null 2>&1; then
-      connected=yes
-      break
-    fi
-    sleep $delay
-    delay=$((delay * 2))
-  done
-
-  if [ "${connected}" = "no" ]; then
-    echo "Cannot connect to Cloud Bigtable Instance Admin emulator; aborting test." >&2
-    exit 1
-  fi
-  echo "Successfully connected to the Cloud Bigtable Instance Admin emulator."
+  wait_until_emulator_connects "localhost:${emulator_port}" "ls"
+  wait_until_emulator_connects "localhost:${instance_admin_port}" "listinstances"
 
   export BIGTABLE_EMULATOR_HOST="localhost:${emulator_port}"
   export BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST="localhost:${instance_admin_port}"


### PR DESCRIPTION
This should reduce the flakiness of the Kokoro builds.

Part of the work for #1197.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2010)
<!-- Reviewable:end -->
