### PR TITLE
Remove ciso646 include.

### DIFF
--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -89,7 +89,7 @@ class RowSet {
     using value_type = T;
     using type =
         std::integral_constant<bool,
-                               std::is_convertible<T, std::string>::value or
+                               std::is_convertible<T, std::string>::value ||
                                    std::is_convertible<T, RowRange>::value>;
     static constexpr bool value = type::value;
   };

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/firestore/field_path.h"
 #include <array>
 #include <cctype>
-#include <ciso646>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -29,7 +29,7 @@ using testing_util::ExpectFutureError;
 TEST(FutureTestInt, conform_30_6_5_3) {
   // TODO(coryan) - allocators are not supported for now.
   static_assert(
-      not std::uses_allocator<promise<int>, std::allocator<int>>::value,
+      !std::uses_allocator<promise<int>, std::allocator<int>>::value,
       "promise<int> should use allocators if provided");
 }
 

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -36,7 +36,7 @@ static_assert(
 TEST(FutureTestVoid, conform_30_6_5_3) {
   // TODO(#1364) - allocators are not supported for now.
   static_assert(
-      not std::uses_allocator<promise<void>, std::allocator<int>>::value,
+      !std::uses_allocator<promise<void>, std::allocator<int>>::value,
       "promise<void> should use allocators if provided");
 }
 

--- a/google/cloud/internal/build_info.cc.in
+++ b/google/cloud/internal/build_info.cc.in
@@ -50,7 +50,7 @@ bool is_release() {
     std::transform(
         value.begin(), value.end(), value.begin(),
         [](char c) -> char { return static_cast<char>(std::tolower(c)); });
-    return value == "yes" or value == "1" or value == "true";
+    return value == "yes" || value == "1" || value == "true";
   }();
 
  return is_release;

--- a/google/cloud/internal/make_unique.h
+++ b/google/cloud/internal/make_unique.h
@@ -38,7 +38,7 @@ namespace internal {
 template <typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... a) {
   static_assert(
-      not std::is_array<T>::value,
+      !std::is_array<T>::value,
       "Sorry, array types not supported in bigtable::internal::make_unique<T>");
   return std::unique_ptr<T>(new T(std::forward<Args>(a)...));
 }

--- a/google/cloud/internal/port_platform.h
+++ b/google/cloud/internal/port_platform.h
@@ -26,10 +26,6 @@
  * of the platform problems.
  */
 
-// With Microsoft Visual Studio we need an extra header for the word boolean
-// operators.
-#include <ciso646>
-
 // Turn off clang-format because these nested #if/#endif blocks are more
 // readable with indentation.
 // clang-format off

--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -118,7 +118,7 @@ class optional {
   // it first.
   template <typename U = T>
   typename std::enable_if<
-      not std::is_same<optional, typename std::decay<U>::type>::value,
+      !std::is_same<optional, typename std::decay<U>::type>::value,
       optional>::type&
   operator=(U&& rhs) {
     // There may be shorter ways to express this, but this is fairly readable,

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -181,7 +181,7 @@ class StatusOr final {
   // it first.
   template <typename U = T>
   typename std::enable_if<
-      not std::is_same<StatusOr, typename std::decay<U>::type>::value,
+      !std::is_same<StatusOr, typename std::decay<U>::type>::value,
       StatusOr>::type&
   operator=(U&& rhs) {
     // There may be shorter ways to express this, but this is fairly readable,

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -364,6 +364,9 @@ if (BUILD_TESTING)
                        target
                        ${target})
         add_executable(${target} ${fname})
+        if (MSVC)
+            target_compile_options(${target} PRIVATE "/bigobj")
+        endif ()
         if (BUILD_TESTING)
             target_link_libraries(${target}
                                   PRIVATE storage_client_testing

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -176,7 +176,7 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
   //    https://curl.haxx.se/libcurl/c/threadsafe.html
   // Only these library prefixes require special configuration for using safely
   // with multiple threads.
-  return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 or
+  return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 ||
           curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
 }
 


### PR DESCRIPTION
This included is needed with MSVC to support the alternative boolean
operators (`and`, `xor`, `not`, etc). Removing the #include will force
us to use the traditional spellings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2011)
<!-- Reviewable:end -->
