### PR TITLE
Run storage testbench on unused port.

### DIFF
--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -83,18 +83,16 @@ start_testbench() {
       >testbench.log 2>&1 </dev/null &
   TESTBENCH_PID=$!
 
-  local testbench_port="0"
+  local testbench_port=""
+  local -r listening_at='Listening at: http://0.0.0.0:\([1-9][0-9]*\)'
   for attempt in $(seq 1 8); do
-    if grep -q 'Listening at: http://0.0.0.0:' testbench.log; then
-      testbench_port=$(
-          grep -m 1 'Listening at: http://0.0.0.0:' testbench.log | \
-          egrep -o 'http://0.0.0.0:[0-9]+' | sed 's/.*://')
-      break
-    fi
+    testbench_port=$(sed -n "s,^.*${listening_at}.*$,\1,p" testbench.log)
+    echo " DEBUG FOUND = ${testbench_port}" >&2
+    [[ -n "${testbench_port}" ]] && break
     sleep 1
   done
 
-  if [[ "${testbench_port}" = "0" ]]; then
+  if [[ -z "${testbench_port}" ]]; then
     echo "Cannot find listening port for testbench." >&2
     exit 1
   fi

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -87,7 +87,6 @@ start_testbench() {
   local -r listening_at='Listening at: http://0.0.0.0:\([1-9][0-9]*\)'
   for attempt in $(seq 1 8); do
     testbench_port=$(sed -n "s,^.*${listening_at}.*$,\1,p" testbench.log)
-    echo " DEBUG FOUND = ${testbench_port}" >&2
     [[ -n "${testbench_port}" ]] && break
     sleep 1
   done


### PR DESCRIPTION
Let the OS pick an unused port to run the storage testbench. We
want to prevent flakiness on CI systems where the tests are not
isolated to their own container or VM.

Part of the work for #1197.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2012)
<!-- Reviewable:end -->
