### PR TITLE
Stops using grpc's DO_NOT_USE enum

### DIFF
--- a/google/cloud/bigtable/internal/grpc_error_delegate.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.cc
@@ -60,9 +60,9 @@ StatusCode MapStatusCode(grpc::StatusCode const& code) {
       return StatusCode::kUnavailable;
     case grpc::StatusCode::DATA_LOSS:
       return StatusCode::kDataLoss;
-    case grpc::StatusCode::DO_NOT_USE:
     default:
-      return StatusCode::kDoNotUse;
+      std::cerr << "Unexpected grpc::StatusCode: " << code << "\n";
+      return StatusCode::kUnknown;
   }
 }
 }  // namespace

--- a/google/cloud/bigtable/internal/grpc_error_delegate.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.cc
@@ -61,7 +61,6 @@ StatusCode MapStatusCode(grpc::StatusCode const& code) {
     case grpc::StatusCode::DATA_LOSS:
       return StatusCode::kDataLoss;
     default:
-      std::cerr << "Unexpected grpc::StatusCode: " << code << "\n";
       return StatusCode::kUnknown;
   }
 }

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -49,7 +49,6 @@ enum class StatusCode {
   kInternal = 13,
   kUnavailable = 14,
   kDataLoss = 15,
-  kDoNotUse = -1
 };
 
 std::string StatusCodeToString(StatusCode code);

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -47,8 +47,8 @@ TEST(Status, StatusCodeToString) {
   EXPECT_EQ("INTERNAL", StatusCodeToString(StatusCode::kInternal));
   EXPECT_EQ("UNAVAILABLE", StatusCodeToString(StatusCode::kUnavailable));
   EXPECT_EQ("DATA_LOSS", StatusCodeToString(StatusCode::kDataLoss));
-  EXPECT_EQ("UNEXPECTED_STATUS_CODE=-1",
-            StatusCodeToString(StatusCode::kDoNotUse));
+  EXPECT_EQ("UNEXPECTED_STATUS_CODE=42",
+            StatusCodeToString(static_cast<StatusCode>(42)));
 }
 
 }  // namespace


### PR DESCRIPTION
As the name implies, we shouldn't be using `grpc::StatusCode::DO_NOT_USE`. Additionally, I'm removing our own `kDoNotUse` status code. We don't need it. If unspecified, an enum class has an underlying type of `int`, so we can test stringifying any value within the range of `int`. In this case, I'm using `42` to make it clearish that I'm choosing an arbitrary value. Of course, if our legit status code values ever cover the value 42, this test will break, but that seems unlikely and the fix should be straightforward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2013)
<!-- Reviewable:end -->
