### PR TITLE
Update method doc after the change to StatusOr.

### DIFF
--- a/google/cloud/storage/oauth2/anonymous_credentials.h
+++ b/google/cloud/storage/oauth2/anonymous_credentials.h
@@ -25,7 +25,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
 /**
- * A Credentials subclass representing "anonymous" Google OAuth2.0 credentials.
+ * A `Credentials` type representing "anonymous" Google OAuth2.0 credentials.
  *
  * This is only useful in two cases: (a) in testing, where you want to access
  * a test bench without having to worry about authentication or SSL setup, and
@@ -40,7 +40,7 @@ class AnonymousCredentials : public Credentials {
   /**
    * While other Credentials subclasses return a string containing an
    * Authorization HTTP header from this method, this class always returns an
-   * empty string.
+   * empty string as its value.
    */
   StatusOr<std::string> AuthorizationHeader() override;
 };

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -28,7 +28,7 @@ namespace oauth2 {
 /**
  * Interface for OAuth 2.0 credentials used to access Google Cloud services.
  *
- * Instantiating a specific kind of Credentials should usually be done via the
+ * Instantiating a specific kind of `Credentials` should usually be done via the
  * convenience methods declared in google_credentials.h.
  *
  * @see https://cloud.google.com/docs/authentication/ for an overview of
@@ -39,13 +39,13 @@ class Credentials {
   virtual ~Credentials() = default;
 
   /**
-   * Returns a pair consisting of:
-   * - The status containing failure details if we were unable to obtain a
-   *   value for the Authorization header. For credentials that need to be
-   *   periodically refreshed, this might include failure details from a refresh
-   *   HTTP request. Otherwise an OK status is returned.
-   * - The value for the Authorization header in HTTP requests, or an empty
-   *   string if we were unable to obtain one.
+   * Attempts to obtain a value for the Authorization HTTP header.
+   *
+   * If unable to obtain a value for the Authorization header, which could
+   * happen for `Credentials` that need to be periodically refreshed, the
+   * underyling `Status` will indicate failure details from the refresh HTTP
+   * request. Otherwise, the returned value will contain the Authorization
+   * header to be used in HTTP requests.
    */
   virtual StatusOr<std::string> AuthorizationHeader() = 0;
 };


### PR DESCRIPTION
This still had notes about the std::pair that was (not being) returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2014)
<!-- Reviewable:end -->
