### PR TITLE
Changes Clear() member to explicitly clear fields rather than rely on move-from

### DIFF
--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -277,8 +277,8 @@ class SingleRowMutation {
 
   /// Remove the contents of the mutation.
   void Clear() {
-    google::bigtable::v2::MutateRowsRequest::Entry entry;
-    MoveTo(&entry);
+    row_key_.clear();
+    ops_.Clear();
   }
 
  private:


### PR DESCRIPTION
Moving from an object is not guaranteed to leave the moved-from object in any particular state. So to ensure these fields are cleared after a call to `Clear()`, we need to explicitly clear them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2016)
<!-- Reviewable:end -->
