### PR TITLE
Dump detailed logs on build failures.

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -63,6 +63,9 @@ echo "================================================================"
 
 echo "================================================================"
 echo "Creating Docker image with all the development tools."
+# We do not want to print the log unless there is an error, so disable the -e
+# flag. Later, we will want to print out the emulator(s) logs *only* if there
+# is an error, so disabling from this point on is the right choice.
 set +e
 "${PROJECT_ROOT}/ci/travis/install-linux.sh" \
     >create-build-docker-image.log 2>&1 </dev/null
@@ -72,14 +75,15 @@ if [[ "$?" != 0 ]]; then
 fi
 echo "================================================================"
 
-set -e
 echo "================================================================"
 echo "Running the full build."
-
 export NEEDS_CCACHE=no
 "${PROJECT_ROOT}/ci/travis/build-linux.sh"
+exit_status=$?
 echo "================================================================"
 
 echo "================================================================"
 "${PROJECT_ROOT}/ci/travis/dump-logs.sh"
 echo "================================================================"
+
+exit ${exit_status}


### PR DESCRIPTION
When the build fails we want to print detailed logs of the emulator(s)
to be able to diagnose or reproduce the errors. This should help
troubleshoot bugs like #2005, which have proven hard to reproduce
locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2017)
<!-- Reviewable:end -->
