### PR TITLE
Complete Linux distro documentation for `make install`.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -167,6 +167,124 @@ sudo cmake --build . --target install
 ```
 
 
+### OpenSUSE (Leap)
+
+Install the minimal development tools:
+
+```bash
+sudo zypper refresh && \
+sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel \
+        make tar wget
+```
+
+#### crc32c
+
+There is no OpenSUSE package for this library. To install it, use:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
+tar -xf 1.0.6.tar.gz
+cd $HOME/Downloads/crc32c-1.0.6
+cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      -H. -B.build/crc32c
+sudo cmake --build .build/crc32c --target install -- -j $(nproc)
+sudo ldconfig
+```
+
+#### Protobuf
+
+OpenSUSE Leap includes a package for protobuf-2.6, this is too old to support
+the Google Cloud Platform proto files, or to support gRPC for that matter.
+Manually install protobuf:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
+tar -xf v3.6.1.tar.gz
+cd $HOME/Downloads/protobuf-3.6.1/cmake
+cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -B.build
+sudo cmake --build .build --target install -- -j $(nproc)
+sudo ldconfig
+```
+
+#### c-ares
+
+Recent versions of gRPC require c-ares >= 1.11, while OpenSUSE Leap
+distributes c-ares-1.9. We need some additional development tools to compile
+this library:
+
+```bash
+sudo zypper refresh && \
+sudo zypper install -y automake libtool
+```
+
+Manually install a newer version:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
+tar -xf cares-1_14_0.tar.gz
+cd $HOME/Downloads/c-ares-cares-1_14_0
+./buildconf && ./configure && make -j $(nproc)
+sudo make install
+sudo ldconfig
+```
+
+#### gRPC
+
+The gRPC Makefile uses `which` to determine whether the compiler is available,
+install this command for the extremely rare case where it may be missing from
+your workstation or build server:
+
+```bash
+sudo zypper refresh && \
+sudo zypper install -y which
+```
+
+Then gRPC can be manually installed using:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
+tar -xf v1.17.2.tar.gz
+cd $HOME/Downloads/grpc-1.17.2
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+export PATH=/usr/local/bin:${PATH}
+make -j $(nproc)
+sudo make install
+sudo ldconfig
+```
+
+#### google-cloud-cpp
+
+We can now compile and install `google-cloud-cpp`. Note that we use
+`pkg-config` to discover the options for gRPC and protobuf:
+
+```bash
+cd $HOME/google-cloud-cpp
+cmake -H. -Bbuild-output \
+    -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
+    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
+    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
+    -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
+cmake --build build-output -- -j $(nproc)
+cd $HOME/google-cloud-cpp/build-output
+ctest --output-on-failure
+sudo cmake --build . --target install
+```
+
+
 ### Ubuntu (18.04 - Bionic Beaver)
 
 Install the minimal development tools:
@@ -330,6 +448,206 @@ sudo ldconfig
 
 Ubuntu-16.04 does not provide packages for the C++ gRPC bindings, install the
 library manually:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
+tar -xf v1.17.2.tar.gz
+cd $HOME/Downloads/grpc-1.17.2
+make -j $(nproc)
+sudo make install
+sudo ldconfig
+```
+
+#### google-cloud-cpp
+
+Finally we can install `google-cloud-cpp`. Note that we use `pkg-config` to
+discover the options for gRPC:
+
+```bash
+cd $HOME/google-cloud-cpp
+cmake -H. -Bbuild-output \
+    -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
+    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
+    -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
+cmake --build build-output -- -j $(nproc)
+cd $HOME/google-cloud-cpp/build-output
+ctest --output-on-failure
+sudo cmake --build . --target install
+```
+
+
+### Ubuntu (14.04 - Trusty Tahr)
+
+Install the minimal development tools:
+
+```bash
+sudo apt update && sudo apt install -y software-properties-common
+add-sudo apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt update && \
+sudo apt install -y cmake3 git gcc g++ make pkg-config tar wget zlib1g-dev
+```
+
+Ubuntu:14.04 ships with a very old version of OpenSSL, this version is not
+supported by gRPC. We need to compile and install OpenSSL-1.0.2 from source:
+
+```bash
+cd $HOME/Downloads
+wget -q https://www.openssl.org/source/openssl-1.0.2n.tar.gz
+tar xf openssl-1.0.2n.tar.gz
+cd $HOME/Downloads/openssl-1.0.2n
+./Configure --prefix=/usr/local --openssldir=/usr/local linux-x86_64
+make -j $(nproc)
+sudo make install
+```
+
+Because google-cloud-cpp uses both gRPC and curl, we need to compile libcurl
+against the same version of OpenSSL:
+
+```bash
+cd $HOME/Downloads
+wget -q https://curl.haxx.se/download/curl-7.61.0.tar.gz
+tar xf curl-7.61.0.tar.gz
+cd $HOME/Downloads/curl-7.61.0
+./configure
+make -j $(nproc)
+sudo make install
+```
+
+#### crc32c
+
+There is no Ubuntu Trusty package for this library. To install it, use:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
+tar -xf 1.0.6.tar.gz
+cd $HOME/Downloads/crc32c-1.0.6
+cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      -H. -B.build/crc32c
+sudo cmake --build .build/crc32c --target install -- -j $(nproc)
+```
+
+#### Protobuf
+
+While protobuf-2.5 is distributed with Ubuntu:trusty, the Google Cloud Plaform
+proto files require more recent versions (circa 3.4.x). To manually install a
+more recent version use:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
+tar -xf v3.6.1.tar.gz
+cd $HOME/Downloads/protobuf-3.6.1/cmake
+cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -B.build
+sudo cmake --build .build --target install -- -j $(nproc)
+```
+
+#### gRPC
+
+Ubuntu:trusty does not provide a package for gRPC. Manually install this
+library:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
+tar -xf v1.17.2.tar.gz
+cd $HOME/Downloads/grpc-1.17.2
+make
+sudo make install
+```
+
+#### google-cloud-cpp
+
+We can now compile and install `google-cloud-cpp`. Note that we use
+`pkg-config` to discover the options for gRPC and protobuf:
+
+```bash
+cd $HOME/google-cloud-cpp
+cmake -H. -Bbuild-output \
+    -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
+    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
+    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
+    -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
+cmake --build build-output -- -j $(nproc)
+cd $HOME/google-cloud-cpp/build-output
+ctest --output-on-failure
+sudo cmake --build . --target install
+```
+
+
+### Debian (Stretch)
+
+First install the development tools and libcurl.
+
+On Debian Stretch, libcurl links against openssl-1.0.2, and one must link
+against the same version or risk an inconsistent configuration of the library.
+This is specially important for multi-threaded applications, as openssl-1.0.2
+requires explicitly setting locking callbacks. Therefore, to use libcurl one
+must link against openssl-1.0.2. To do so, we must need to libssl1.0-dev. Note
+that this removes libssl-dev if you have it installed already, and would
+prevent you from compiling against openssl-1.1.0.
+
+```bash
+sudo apt update && \
+sudo apt install -y build-essential cmake git gcc g++ cmake \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
+        pkg-config tar wget zlib1g-dev
+```
+
+#### crc32c
+
+There is no Debian package for this library. To install it use:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
+tar -xf 1.0.6.tar.gz
+cd $HOME/Downloads/crc32c-1.0.6
+cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=yes \
+      -DCRC32C_BUILD_TESTS=OFF \
+      -DCRC32C_BUILD_BENCHMARKS=OFF \
+      -DCRC32C_USE_GLOG=OFF \
+      -H. -B.build/crc32c
+sudo cmake --build .build/crc32c --target install -- -j $(nproc)
+sudo ldconfig
+```
+
+#### Protobuf
+
+While protobuf-3.0 is distributed with Ubuntu, the Google Cloud Plaform proto
+files require more recent versions (circa 3.4.x). To manually install a more
+recent version use:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
+tar -xf v3.6.1.tar.gz
+cd $HOME/Downloads/protobuf-3.6.1/cmake
+cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -B.build
+sudo cmake --build .build --target install -- -j $(nproc)
+sudo ldconfig
+```
+
+#### gRPC
+
+Likewise, Ubuntu has packages for grpc-1.3.x, but this version is too old for
+the Google Cloud Platform APIs:
 
 ```bash
 cd $HOME/Downloads

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,8 +48,11 @@ these dependencies.
 
 - [Fedora 29](#fedora-29)
 - [openSUSE (Tumbleweed)](#opensuse-tumbleweed)
+- [openSUSE (Leap)](#opensuse-leap)
 - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804--bionic-beaver)
 - [Ubuntu (16.04 - Xenial Xerus)](#ubuntu-1604--xenial-xerus)
+- [Ubuntu (16.04 - Trusty Tahr)](#ubuntu-1404--trusty-tahr)
+- [Debian (Stretch)](#debian-stretch)
 - [CentOS 7](#centos-7)
 
 ### Fedora (29)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -596,9 +596,9 @@ On Debian Stretch, libcurl links against openssl-1.0.2, and one must link
 against the same version or risk an inconsistent configuration of the library.
 This is especially important for multi-threaded applications, as openssl-1.0.2
 requires explicitly setting locking callbacks. Therefore, to use libcurl one
-must link against openssl-1.0.2. To do so, we must need to install
-libssl1.0-dev. Note that this removes libssl-dev if you have it installed
-already, and would prevent you from compiling against openssl-1.1.0.
+must link against openssl-1.0.2. To do so, we need to install libssl1.0-dev.
+Note that this removes libssl-dev if you have it installed already, and would
+prevent you from compiling against openssl-1.1.0.
 
 ```bash
 sudo apt update && \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -202,9 +202,9 @@ sudo ldconfig
 
 #### Protobuf
 
-OpenSUSE Leap includes a package for protobuf-2.6, this is too old to support
-the Google Cloud Platform proto files, or to support gRPC for that matter.
-Manually install protobuf:
+OpenSUSE Leap includes a package for protobuf-2.6, but this is too old to
+support the Google Cloud Platform proto files, or to support gRPC for that
+matter. Manually install protobuf:
 
 ```bash
 cd $HOME/Downloads
@@ -245,8 +245,8 @@ sudo ldconfig
 
 #### gRPC
 
-The gRPC Makefile uses `which` to determine whether the compiler is available,
-install this command for the extremely rare case where it may be missing from
+The gRPC Makefile uses `which` to determine whether the compiler is available.
+Install this command for the extremely rare case where it may be missing from
 your workstation or build server:
 
 ```bash
@@ -486,7 +486,7 @@ Install the minimal development tools:
 
 ```bash
 sudo apt update && sudo apt install -y software-properties-common
-add-sudo apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt update && \
 sudo apt install -y cmake3 git gcc g++ make pkg-config tar wget zlib1g-dev
 ```
@@ -594,11 +594,11 @@ First install the development tools and libcurl.
 
 On Debian Stretch, libcurl links against openssl-1.0.2, and one must link
 against the same version or risk an inconsistent configuration of the library.
-This is specially important for multi-threaded applications, as openssl-1.0.2
+This is especially important for multi-threaded applications, as openssl-1.0.2
 requires explicitly setting locking callbacks. Therefore, to use libcurl one
-must link against openssl-1.0.2. To do so, we must need to libssl1.0-dev. Note
-that this removes libssl-dev if you have it installed already, and would
-prevent you from compiling against openssl-1.1.0.
+must link against openssl-1.0.2. To do so, we must need to install
+libssl1.0-dev. Note that this removes libssl-dev if you have it installed
+already, and would prevent you from compiling against openssl-1.1.0.
 
 ```bash
 sudo apt update && \

--- a/ci/test-readme/Dockerfile.debian
+++ b/ci/test-readme/Dockerfile.debian
@@ -29,9 +29,9 @@ MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 # against the same version or risk an inconsistent configuration of the library.
 # This is especially important for multi-threaded applications, as openssl-1.0.2
 # requires explicitly setting locking callbacks. Therefore, to use libcurl one
-# must link against openssl-1.0.2. To do so, we must need to install
-# libssl1.0-dev. Note that this removes libssl-dev if you have it installed
-# already, and would prevent you from compiling against openssl-1.1.0.
+# must link against openssl-1.0.2. To do so, we need to install libssl1.0-dev.
+# Note that this removes libssl-dev if you have it installed already, and would
+# prevent you from compiling against openssl-1.1.0.
 
 # ```bash
 RUN apt update && \

--- a/ci/test-readme/Dockerfile.debian
+++ b/ci/test-readme/Dockerfile.debian
@@ -27,11 +27,11 @@ MAINTAINER "Carlos O'Ryan <coryan@google.com>"
 
 # On Debian Stretch, libcurl links against openssl-1.0.2, and one must link
 # against the same version or risk an inconsistent configuration of the library.
-# This is specially important for multi-threaded applications, as openssl-1.0.2
+# This is especially important for multi-threaded applications, as openssl-1.0.2
 # requires explicitly setting locking callbacks. Therefore, to use libcurl one
-# must link against openssl-1.0.2. To do so, we must need to libssl1.0-dev. Note
-# that this removes libssl-dev if you have it installed already, and would
-# prevent you from compiling against openssl-1.1.0.
+# must link against openssl-1.0.2. To do so, we must need to install
+# libssl1.0-dev. Note that this removes libssl-dev if you have it installed
+# already, and would prevent you from compiling against openssl-1.1.0.
 
 # ```bash
 RUN apt update && \

--- a/ci/test-readme/Dockerfile.opensuse-leap
+++ b/ci/test-readme/Dockerfile.opensuse-leap
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,32 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=9
-FROM debian:${DISTRO_VERSION}
+ARG DISTRO_VERSION=leap
+FROM opensuse:${DISTRO_VERSION}
 MAINTAINER "Carlos O'Ryan <coryan@google.com>"
-
-# Please keep the formatting in these commands, it is optimized to cut & paste
-# into the README.md file.
 
 ## [START INSTALL.md]
 
-# First install the development tools and libcurl.
+# Install the minimal development tools:
 
 ## [START README.md]
 
-# On Debian Stretch, libcurl links against openssl-1.0.2, and one must link
-# against the same version or risk an inconsistent configuration of the library.
-# This is specially important for multi-threaded applications, as openssl-1.0.2
-# requires explicitly setting locking callbacks. Therefore, to use libcurl one
-# must link against openssl-1.0.2. To do so, we must need to libssl1.0-dev. Note
-# that this removes libssl-dev if you have it installed already, and would
-# prevent you from compiling against openssl-1.1.0.
-
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
-        pkg-config tar wget zlib1g-dev
+RUN zypper refresh && \
+    zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel \
+        make tar wget
 # ```
 
 ## [END README.md]
@@ -54,7 +42,7 @@ RUN (cd build-output && ctest --output-on-failure)
 
 # #### crc32c
 
-# There is no Debian package for this library. To install it use:
+# There is no OpenSUSE package for this library. To install it, use:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -74,9 +62,9 @@ RUN ldconfig
 
 # #### Protobuf
 
-# While protobuf-3.0 is distributed with Ubuntu, the Google Cloud Plaform proto
-# files require more recent versions (circa 3.4.x). To manually install a more
-# recent version use:
+# OpenSUSE Leap includes a package for protobuf-2.6, this is too old to support
+# the Google Cloud Platform proto files, or to support gRPC for that matter.
+# Manually install protobuf:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -92,16 +80,50 @@ RUN cmake --build .build --target install -- -j $(nproc)
 RUN ldconfig
 # ```
 
+# #### c-ares
+
+# Recent versions of gRPC require c-ares >= 1.11, while OpenSUSE Leap
+# distributes c-ares-1.9. We need some additional development tools to compile
+# this library:
+
+# ```bash
+RUN zypper refresh && \
+    zypper install -y automake libtool
+# ```
+
+# Manually install a newer version:
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
+RUN tar -xf cares-1_14_0.tar.gz
+WORKDIR /var/tmp/build/c-ares-cares-1_14_0
+RUN ./buildconf && ./configure && make -j $(nproc)
+RUN make install
+RUN ldconfig
+# ```
+
 # #### gRPC
 
-# Likewise, Ubuntu has packages for grpc-1.3.x, but this version is too old for
-# the Google Cloud Platform APIs:
+# The gRPC Makefile uses `which` to determine whether the compiler is available,
+# install this command for the extremely rare case where it may be missing from
+# your workstation or build server:
+
+# ```bash
+RUN zypper refresh && \
+    zypper install -y which
+# ```
+
+# Then gRPC can be manually installed using:
 
 # ```bash
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
 RUN tar -xf v1.17.2.tar.gz
 WORKDIR /var/tmp/build/grpc-1.17.2
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+ENV PATH=/usr/local/bin:${PATH}
 RUN make -j $(nproc)
 RUN make install
 RUN ldconfig
@@ -109,14 +131,15 @@ RUN ldconfig
 
 # #### google-cloud-cpp
 
-# Finally we can install `google-cloud-cpp`. Note that we use `pkg-config` to
-# discover the options for gRPC:
+# We can now compile and install `google-cloud-cpp`. Note that we use
+# `pkg-config` to discover the options for gRPC and protobuf:
 
 # ```bash
 WORKDIR /home/build/google-cloud-cpp
 COPY . /home/build/google-cloud-cpp
 RUN cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
+    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 RUN cmake --build build-output -- -j $(nproc)

--- a/ci/test-readme/Dockerfile.opensuse-leap
+++ b/ci/test-readme/Dockerfile.opensuse-leap
@@ -62,9 +62,9 @@ RUN ldconfig
 
 # #### Protobuf
 
-# OpenSUSE Leap includes a package for protobuf-2.6, this is too old to support
-# the Google Cloud Platform proto files, or to support gRPC for that matter.
-# Manually install protobuf:
+# OpenSUSE Leap includes a package for protobuf-2.6, but this is too old to
+# support the Google Cloud Platform proto files, or to support gRPC for that
+# matter. Manually install protobuf:
 
 # ```bash
 WORKDIR /var/tmp/build
@@ -105,8 +105,8 @@ RUN ldconfig
 
 # #### gRPC
 
-# The gRPC Makefile uses `which` to determine whether the compiler is available,
-# install this command for the extremely rare case where it may be missing from
+# The gRPC Makefile uses `which` to determine whether the compiler is available.
+# Install this command for the extremely rare case where it may be missing from
 # your workstation or build server:
 
 # ```bash

--- a/ci/test-readme/dockerfile2markdown.sh
+++ b/ci/test-readme/dockerfile2markdown.sh
@@ -24,15 +24,15 @@ sed \
     -e 's/^RUN //' \
     -e 's/^ENV /export /' \
     -e '/^COPY /d' \
-    -e 's/apt/sudo apt/g' \
+    -e 's/update-alternatives/sudo update-alternatives/g' \
+    -e 's/add-apt-repository/sudo add-apt-repository/g' \
+    -e 's/apt /sudo apt /g' \
     -e 's/dnf/sudo dnf/g' \
     -e 's/yum/sudo yum/g' \
     -e 's/zypper/sudo zypper/g' \
     -e 's/ldconfig/sudo ldconfig/g' \
     -e 's/^\(cmake.*--target install.*\)/sudo \1/g' \
     -e 's/^make install/sudo make install/' \
-    -e 's/update-alternatives/sudo update-alternatives/g' \
-    -e 's/add-apt-repository/sudo add-apt-repository/g' \
     -e 's;/home/build;$HOME;' \
     -e 's;/var/tmp/build;$HOME/Downloads;' \
     -e 's/^    sudo/sudo/' $* | \

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -69,8 +69,11 @@ these dependencies.
 
 - [Fedora 29](#fedora-29)
 - [openSUSE (Tumbleweed)](#opensuse-tumbleweed)
+- [openSUSE (Leap)](#opensuse-leap)
 - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804--bionic-beaver)
 - [Ubuntu (16.04 - Xenial Xerus)](#ubuntu-1604--xenial-xerus)
+- [Ubuntu (16.04 - Trusty Tahr)](#ubuntu-1404--trusty-tahr)
+- [Debian (Stretch)](#debian-stretch)
 - [CentOS 7](#centos-7)
 END_OF_PREAMBLE
 

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -83,12 +83,24 @@ echo "### OpenSUSE (Tumbleweed)"
 "${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.opensuse"
 
 echo
+echo "### OpenSUSE (Leap)"
+"${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.opensuse-leap"
+
+echo
 echo "### Ubuntu (18.04 - Bionic Beaver)"
 "${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.ubuntu"
 
 echo
 echo "### Ubuntu (16.04 - Xenial Xerus)"
 "${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.ubuntu-xenial"
+
+echo
+echo "### Ubuntu (14.04 - Trusty Tahr)"
+"${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.ubuntu-trusty"
+
+echo
+echo "### Debian (Stretch)"
+"${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.debian"
 
 echo
 echo "### CentOS (7)"


### PR DESCRIPTION
With this change our documentation on how to install google-cloud-cpp on
Linux matches list of distributions and versions on how to compile
google-cloud-cpp for development.

A future PR will update the README file to use the (tested) contents
from the Dockerfiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2019)
<!-- Reviewable:end -->
