### PR TITLE
Add Bucket Policy Only samples

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -48,6 +48,12 @@ run_all_bucket_examples() {
       "${bucket_name}" "STANDARD"
   run_example ./storage_bucket_samples patch-bucket-storage-class-with-builder \
       "${bucket_name}" "COLDLINE"
+  run_example ./storage_bucket_samples enable-bucket-policy-only \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples disable-bucket-policy-only \
+      "${bucket_name}"
+  run_example ./storage_bucket_samples get-bucket-policy-only \
+      "${bucket_name}"
   run_example ./storage_bucket_samples add-bucket-label \
       "${bucket_name}" "test-label" "test-label-value"
   run_example ./storage_bucket_samples get-bucket-labels \

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -452,20 +452,24 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> bucket_metadata = client.GetBucketMetadata(bucket_name);
+    StatusOr<gcs::BucketMetadata> bucket_metadata =
+        client.GetBucketMetadata(bucket_name);
 
     if (!bucket_metadata) {
       throw std::runtime_error(bucket_metadata.status().message());
     }
 
-    if (bucket_metadata->has_iam_configuration() && bucket_metadata->iam_configuration().bucket_policy_only.has_value()) {
-      gcs::BucketPolicyOnly bucket_policy_only = *bucket_metadata->iam_configuration().bucket_policy_only;
+    if (bucket_metadata->has_iam_configuration() &&
+        bucket_metadata->iam_configuration().bucket_policy_only.has_value()) {
+      gcs::BucketPolicyOnly bucket_policy_only =
+          *bucket_metadata->iam_configuration().bucket_policy_only;
 
-      std::cout << "Bucket Policy Only is enabled for " << bucket_metadata->name() << "\n";
+      std::cout << "Bucket Policy Only is enabled for "
+                << bucket_metadata->name() << "\n";
       std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";
     } else {
-      std::cout << "Bucket Policy Only is not enabled for " << bucket_metadata->name()
-                << "\n";
+      std::cout << "Bucket Policy Only is not enabled for "
+                << bucket_metadata->name() << "\n";
     }
   }
   // [END storage_get_bucket_policy_only]

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -459,7 +459,7 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
     }
 
     if (bucket_metadata->has_iam_configuration()) {
-      google::cloud::optional<gcs::BucketPolicyOnly> bucket_policy_only = bucket_metadata->iam_configuration().bucket_policy_only;
+      gcs::BucketPolicyOnly bucket_policy_only = *bucket_metadata->iam_configuration().bucket_policy_only;
 
       std::cout << "Bucket Policy Only is enabled for " << bucket_metadata->name() << "\n";
       std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -459,7 +459,7 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
     }
 
     if (bucket_metadata->has_iam_configuration()) {
-      gcs::BucketPolicyOnly bucket_policy_only = bucket_metadata->iam_configuration().bucket_policy_only;
+      google::cloud::optional<gcs::BucketPolicyOnly> bucket_policy_only = bucket_metadata->iam_configuration().bucket_policy_only;
 
       std::cout << "Bucket Policy Only is enabled for " << bucket_metadata->name() << "\n";
       std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -383,6 +383,96 @@ void RemoveBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name);
 }
 
+void EnableBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
+                            char *argv[]) {
+    if (argc != 2) {
+        throw Usage{"enable-bucket-policy-only <bucket-name>"};
+    }
+    auto bucket_name = ConsumeArg(argc, argv);
+    //! [enable bucket policy only]
+    // [START storage_enable_bucket_policy_only]
+    namespace gcs = google::cloud::storage;
+    using google::cloud::StatusOr;
+    [](gcs::Client client, std::string bucket_name) {
+        gcs::BucketIamConfiguration configuration;
+        configuration.bucket_policy_only = gcs::BucketPolicyOnly{true};
+        StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+                bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(std::move(configuration)));
+
+        if (!updated_metadata) {
+            throw std::runtime_error(updated_metadata.status().message());
+        }
+
+        std::cout << "Successfully enabled Bucket Policy Only on bucket "
+            << updated_metadata->name() << "\n";
+    }
+    // [END storage_enable_bucket_policy_only]
+    //! [enable bucket policy only]
+    (std::move(client), bucket_name);
+}
+
+void DisableBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
+                            char *argv[]) {
+    if (argc != 2) {
+        throw Usage{"disable-bucket-policy-only <bucket-name>"};
+    }
+    auto bucket_name = ConsumeArg(argc, argv);
+    //! [disable bucket policy only]
+    // [START storage_disable_bucket_policy_only]
+    namespace gcs = google::cloud::storage;
+    using google::cloud::StatusOr;
+    [](gcs::Client client, std::string bucket_name) {
+        gcs::BucketIamConfiguration configuration;
+        configuration.bucket_policy_only = gcs::BucketPolicyOnly{false};
+        StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+                bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(std::move(configuration)));
+
+        if (!updated_metadata) {
+            throw std::runtime_error(updated_metadata.status().message());
+        }
+
+        std::cout << "Successfully disabled Bucket Policy Only on bucket "
+            << updated_metadata->name() << "\n";
+    }
+    // [END storage_disable_bucket_policy_only]
+    //! [disable bucket policy only]
+    (std::move(client), bucket_name);
+}
+
+void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
+                            char *argv[]) {
+    if (argc != 2) {
+        throw Usage{"get-bucket-policy-only <bucket-name>"};
+    }
+    auto bucket_name = ConsumeArg(argc, argv);
+    //! [get bucket policy only]
+    // [START storage_get_bucket_policy_only]
+    namespace gcs = google::cloud::storage;
+    using google::cloud::StatusOr;
+    [](gcs::Client client, std::string bucket_name) {
+        StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+
+        if (!meta) {
+            throw std::runtime_error(meta.status().message());
+        }
+
+        if (meta->has_iam_configuration()) {
+            auto bucket_policy_only = meta->iam_configuration().bucket_policy_only;
+
+            std::cout << "Bucket Policy Only is enabled for "
+                << meta->name() << "\n";
+            std::cout << "Bucket will be locked on "
+                << bucket_policy_only << "\n";
+        } else {
+            std::cout << "Bucket Policy Only is not enabled for "
+                << meta->name() << "\n";
+        }
+    }
+    // [END storage_get_bucket_policy_only]
+    //! [get bucket policy only]
+    (std::move(client), bucket_name);
+}
+
 void AddBucketLabel(google::cloud::storage::Client client, int& argc,
                     char* argv[]) {
   if (argc != 4) {
@@ -1003,6 +1093,9 @@ int main(int argc, char* argv[]) try {
       {"add-bucket-default-kms-key", &AddBucketDefaultKmsKey},
       {"get-bucket-default-kms-key", &GetBucketDefaultKmsKey},
       {"remove-bucket-default-kms-key", &RemoveBucketDefaultKmsKey},
+      {"enable-bucket-policy-only", &EnableBucketPolicyOnly},
+      {"disable-bucket-policy-only", &DisableBucketPolicyOnly},
+      {"get-bucket-policy-only", &GetBucketPolicyOnly},
       {"add-bucket-label", &AddBucketLabel},
       {"get-bucket-labels", &GetBucketLabels},
       {"remove-bucket-label", &RemoveBucketLabel},

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -454,17 +454,17 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata = client.GetBucketMetadata(bucket_name);
 
-    if (!meta) {
-      throw std::runtime_error(meta.status().message());
+    if (!bucket_metadata) {
+      throw std::runtime_error(bucket_metadata.status().message());
     }
 
-    if (meta->has_iam_configuration()) {
-      gcs::BucketPolicyOnly bucket_policy_only = meta->iam_configuration().bucket_policy_only;
+    if (bucket_metadata->has_iam_configuration()) {
+      gcs::BucketPolicyOnly bucket_policy_only = bucket_metadata->iam_configuration().bucket_policy_only;
 
-      std::cout << "Bucket Policy Only is enabled for " << meta->name() << "\n";
+      std::cout << "Bucket Policy Only is enabled for " << bucket_metadata->name() << "\n";
       std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";
     } else {
-      std::cout << "Bucket Policy Only is not enabled for " << meta->name()
+      std::cout << "Bucket Policy Only is not enabled for " << bucket_metadata->name()
                 << "\n";
     }
   }

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -458,7 +458,7 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
       throw std::runtime_error(bucket_metadata.status().message());
     }
 
-    if (bucket_metadata->has_iam_configuration()) {
+    if (bucket_metadata->has_iam_configuration() && bucket_metadata->iam_configuration().bucket_policy_only.has_value()) {
       gcs::BucketPolicyOnly bucket_policy_only = *bucket_metadata->iam_configuration().bucket_policy_only;
 
       std::cout << "Bucket Policy Only is enabled for " << bucket_metadata->name() << "\n";

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -384,93 +384,93 @@ void RemoveBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
 }
 
 void EnableBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
-                            char *argv[]) {
-    if (argc != 2) {
-        throw Usage{"enable-bucket-policy-only <bucket-name>"};
-    }
-    auto bucket_name = ConsumeArg(argc, argv);
-    //! [enable bucket policy only]
-    // [START storage_enable_bucket_policy_only]
-    namespace gcs = google::cloud::storage;
-    using google::cloud::StatusOr;
-    [](gcs::Client client, std::string bucket_name) {
-        gcs::BucketIamConfiguration configuration;
-        configuration.bucket_policy_only = gcs::BucketPolicyOnly{true};
-        StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-                bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(std::move(configuration)));
+                            char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"enable-bucket-policy-only <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [enable bucket policy only]
+  // [START storage_enable_bucket_policy_only]
+  namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketIamConfiguration configuration;
+    configuration.bucket_policy_only = gcs::BucketPolicyOnly{true};
+    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
+                         std::move(configuration)));
 
-        if (!updated_metadata) {
-            throw std::runtime_error(updated_metadata.status().message());
-        }
-
-        std::cout << "Successfully enabled Bucket Policy Only on bucket "
-            << updated_metadata->name() << "\n";
+    if (!updated_metadata) {
+      throw std::runtime_error(updated_metadata.status().message());
     }
-    // [END storage_enable_bucket_policy_only]
-    //! [enable bucket policy only]
-    (std::move(client), bucket_name);
+
+    std::cout << "Successfully enabled Bucket Policy Only on bucket "
+              << updated_metadata->name() << "\n";
+  }
+  // [END storage_enable_bucket_policy_only]
+  //! [enable bucket policy only]
+  (std::move(client), bucket_name);
 }
 
 void DisableBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
-                            char *argv[]) {
-    if (argc != 2) {
-        throw Usage{"disable-bucket-policy-only <bucket-name>"};
-    }
-    auto bucket_name = ConsumeArg(argc, argv);
-    //! [disable bucket policy only]
-    // [START storage_disable_bucket_policy_only]
-    namespace gcs = google::cloud::storage;
-    using google::cloud::StatusOr;
-    [](gcs::Client client, std::string bucket_name) {
-        gcs::BucketIamConfiguration configuration;
-        configuration.bucket_policy_only = gcs::BucketPolicyOnly{false};
-        StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-                bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(std::move(configuration)));
+                             char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"disable-bucket-policy-only <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [disable bucket policy only]
+  // [START storage_disable_bucket_policy_only]
+  namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketIamConfiguration configuration;
+    configuration.bucket_policy_only = gcs::BucketPolicyOnly{false};
+    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
+                         std::move(configuration)));
 
-        if (!updated_metadata) {
-            throw std::runtime_error(updated_metadata.status().message());
-        }
-
-        std::cout << "Successfully disabled Bucket Policy Only on bucket "
-            << updated_metadata->name() << "\n";
+    if (!updated_metadata) {
+      throw std::runtime_error(updated_metadata.status().message());
     }
-    // [END storage_disable_bucket_policy_only]
-    //! [disable bucket policy only]
-    (std::move(client), bucket_name);
+
+    std::cout << "Successfully disabled Bucket Policy Only on bucket "
+              << updated_metadata->name() << "\n";
+  }
+  // [END storage_disable_bucket_policy_only]
+  //! [disable bucket policy only]
+  (std::move(client), bucket_name);
 }
 
 void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
-                            char *argv[]) {
-    if (argc != 2) {
-        throw Usage{"get-bucket-policy-only <bucket-name>"};
+                         char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"get-bucket-policy-only <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  //! [get bucket policy only]
+  // [START storage_get_bucket_policy_only]
+  namespace gcs = google::cloud::storage;
+  using google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+
+    if (!meta) {
+      throw std::runtime_error(meta.status().message());
     }
-    auto bucket_name = ConsumeArg(argc, argv);
-    //! [get bucket policy only]
-    // [START storage_get_bucket_policy_only]
-    namespace gcs = google::cloud::storage;
-    using google::cloud::StatusOr;
-    [](gcs::Client client, std::string bucket_name) {
-        StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
 
-        if (!meta) {
-            throw std::runtime_error(meta.status().message());
-        }
+    if (meta->has_iam_configuration()) {
+      auto bucket_policy_only = meta->iam_configuration().bucket_policy_only;
 
-        if (meta->has_iam_configuration()) {
-            auto bucket_policy_only = meta->iam_configuration().bucket_policy_only;
-
-            std::cout << "Bucket Policy Only is enabled for "
-                << meta->name() << "\n";
-            std::cout << "Bucket will be locked on "
-                << bucket_policy_only << "\n";
-        } else {
-            std::cout << "Bucket Policy Only is not enabled for "
-                << meta->name() << "\n";
-        }
+      std::cout << "Bucket Policy Only is enabled for " << meta->name() << "\n";
+      std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";
+    } else {
+      std::cout << "Bucket Policy Only is not enabled for " << meta->name()
+                << "\n";
     }
-    // [END storage_get_bucket_policy_only]
-    //! [get bucket policy only]
-    (std::move(client), bucket_name);
+  }
+  // [END storage_get_bucket_policy_only]
+  //! [get bucket policy only]
+  (std::move(client), bucket_name);
 }
 
 void AddBucketLabel(google::cloud::storage::Client client, int& argc,

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -452,14 +452,14 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
+    StatusOr<gcs::BucketMetadata> bucket_metadata = client.GetBucketMetadata(bucket_name);
 
     if (!meta) {
       throw std::runtime_error(meta.status().message());
     }
 
     if (meta->has_iam_configuration()) {
-      auto bucket_policy_only = meta->iam_configuration().bucket_policy_only;
+      gcs::BucketPolicyOnly bucket_policy_only = meta->iam_configuration().bucket_policy_only;
 
       std::cout << "Bucket Policy Only is enabled for " << meta->name() << "\n";
       std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";


### PR DESCRIPTION
Fixes #1973 

Adds some samples based on [the nodejs version](https://github.com/googleapis/nodejs-storage/blob/740bab9845e41cb561e6ae82d5264fa88657a3f9/samples/buckets.js) as linked by @frankyn. LMK if I'm missing anything or made any obvious mistakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2022)
<!-- Reviewable:end -->
