### PR TITLE
moved tests into namespace to avoid using directive

### DIFF
--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -15,7 +15,11 @@
 #include "google/cloud/log.h"
 #include <gmock/gmock.h>
 
-using namespace google::cloud;
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
 using namespace ::testing;
 
 TEST(LogSeverityTest, Streaming) {
@@ -219,3 +223,8 @@ TEST(LogSinkTest, DisabledLogsMakeNoCalls) {
   // With no backends, we expect no calls to the expressions in the log line.
   EXPECT_EQ(0, counter);
 }
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is one step toward minimizing our use of using *directives* (though using *declarations* are fine). These are subtle and can cause strange build breaks from seemingly unrelated code changes. Avoiding using directives will make this code more robust in more environments[1]. See https://abseil.io/tips/153 for a bit more background about Google's advice on using directives.

[1]: For example, the current test would break if built in an environment that also defined a symbol like `::LogSink` or `::Severity`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2023)
<!-- Reviewable:end -->
