### PR TITLE
Fix script to enforce formatting.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Reformatting all the files in a specific directory should be safe too, for
 example:
 
 ```console
-$ find google/cloud -name '*.h' -o -name '*.cc' -print0 \
+$ find google/cloud \( -name '*.h' -o -name '*.cc' \) -print0 \
     | xargs -0 clang-format -i
 ```
 

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -43,7 +43,7 @@ find . \( -path ./.git \
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly
 # different formatting output (sigh).
-find google/cloud -name '*.cc' -o -name '*.h' -print0 \
+find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 \
      | xargs -0 clang-format -i
 
 # Apply several transformations that cannot be enforced by clang-format:

--- a/google/cloud/bigtable/bigtable_version_test.cc
+++ b/google/cloud/bigtable/bigtable_version_test.cc
@@ -20,7 +20,6 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::StartsWith;

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -83,7 +83,8 @@ int main(int argc, char* argv[]) try {
   //! [write rows] [END writing_rows]
 
   //! [create filter] [START creating_a_filter]
-  auto filter = google::cloud::bigtable::Filter::ColumnRangeClosed("family", "c0", "c0");
+  auto filter =
+      google::cloud::bigtable::Filter::ColumnRangeClosed("family", "c0", "c0");
   //! [create filter] [END creating_a_filter]
 
   // Read a single row.

--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -215,4 +215,3 @@ int main(int argc, char* argv[]) try {
   return 1;
 }
 //! [all code]
-

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -231,7 +231,6 @@ void CheckConsistency(google::cloud::bigtable::TableAdmin admin, int argc,
   //! [check consistency]
   [](google::cloud::bigtable::TableAdmin admin, std::string table_id_param,
      std::string consistency_token_param) {
-
     google::cloud::bigtable::TableId table_id(table_id_param);
     google::cloud::bigtable::ConsistencyToken consistency_token(
         consistency_token_param);

--- a/google/cloud/bigtable/internal/async_future_from_callback_test.cc
+++ b/google/cloud/bigtable/internal/async_future_from_callback_test.cc
@@ -51,13 +51,12 @@ TEST(AsyncFutureFromCallbackGeneric, Failure) {
 
   ASSERT_TRUE(fut.is_ready());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { fut.get(); } catch (GRpcError const& ex) {
-        EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, ex.error_code());
-        EXPECT_THAT(ex.what(), HasSubstr("try again"));
-        throw;
-      },
-      GRpcError);
+  EXPECT_THROW(try { fut.get(); } catch (GRpcError const& ex) {
+    EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, ex.error_code());
+    EXPECT_THAT(ex.what(), HasSubstr("try again"));
+    throw;
+  },
+               GRpcError);
 #else
   EXPECT_DEATH_IF_SUPPORTED(fut.get(), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -90,13 +89,12 @@ TEST(AsyncFutureFromCallbackVoid, Failure) {
 
   ASSERT_TRUE(fut.is_ready());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { fut.get(); } catch (GRpcError const& ex) {
-        EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, ex.error_code());
-        EXPECT_THAT(ex.what(), HasSubstr("try again"));
-        throw;
-      },
-      GRpcError);
+  EXPECT_THROW(try { fut.get(); } catch (GRpcError const& ex) {
+    EXPECT_EQ(grpc::StatusCode::UNAVAILABLE, ex.error_code());
+    EXPECT_THAT(ex.what(), HasSubstr("try again"));
+    throw;
+  },
+               GRpcError);
 #else
   EXPECT_DEATH_IF_SUPPORTED(fut.get(), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/bigtable/internal/table_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/table_async_row_reader_test.cc
@@ -78,22 +78,22 @@ TEST_F(NoexTableAsyncReadRowsTest, Simple) {
   bool read_rows_op_called = false;
   bool done_op_called = false;
 
-  table_.AsyncReadRows(
-      cq,
-      [&read_rows_op_called](CompletionQueue& cq, Row row,
-                             grpc::Status& status) {
-        EXPECT_EQ("0001", row.row_key());
-        EXPECT_TRUE(status.ok());
-        read_rows_op_called = true;
-      },
-      [&done_op_called](CompletionQueue& cq, bool& response,
-                        grpc::Status const& status) {
-        EXPECT_TRUE(response);
-        EXPECT_TRUE(status.ok());
-        EXPECT_EQ("mocked-status", status.error_message());
-        done_op_called = true;
-      },
-      bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT, bt::Filter::PassAllFilter());
+  table_.AsyncReadRows(cq,
+                       [&read_rows_op_called](CompletionQueue& cq, Row row,
+                                              grpc::Status& status) {
+                         EXPECT_EQ("0001", row.row_key());
+                         EXPECT_TRUE(status.ok());
+                         read_rows_op_called = true;
+                       },
+                       [&done_op_called](CompletionQueue& cq, bool& response,
+                                         grpc::Status const& status) {
+                         EXPECT_TRUE(response);
+                         EXPECT_TRUE(status.ok());
+                         EXPECT_EQ("mocked-status", status.error_message());
+                         done_op_called = true;
+                       },
+                       bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT,
+                       bt::Filter::PassAllFilter());
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, true);
@@ -187,22 +187,22 @@ TEST_F(NoexTableAsyncReadRowsTest, ReadRowsWithRetry) {
   bool read_rows_op_called = false;
   bool done_op_called = false;
 
-  table_.AsyncReadRows(
-      cq,
-      [&read_rows_op_called](CompletionQueue& cq, Row row,
-                             grpc::Status& status) {
-        EXPECT_TRUE(status.ok());
-        read_rows_op_called = true;
-      },
-      [&done_op_called](CompletionQueue& cq, bool& response,
-                        grpc::Status const& status) {
-        EXPECT_TRUE(response);
-        EXPECT_TRUE(status.ok());
-        EXPECT_EQ("mocked-status", status.error_message());
-        done_op_called = true;
-      },
-      bt::RowSet(bt::RowRange::Range("0000", "0005")),
-      bt::RowReader::NO_ROWS_LIMIT, bt::Filter::PassAllFilter());
+  table_.AsyncReadRows(cq,
+                       [&read_rows_op_called](CompletionQueue& cq, Row row,
+                                              grpc::Status& status) {
+                         EXPECT_TRUE(status.ok());
+                         read_rows_op_called = true;
+                       },
+                       [&done_op_called](CompletionQueue& cq, bool& response,
+                                         grpc::Status const& status) {
+                         EXPECT_TRUE(response);
+                         EXPECT_TRUE(status.ok());
+                         EXPECT_EQ("mocked-status", status.error_message());
+                         done_op_called = true;
+                       },
+                       bt::RowSet(bt::RowRange::Range("0000", "0005")),
+                       bt::RowReader::NO_ROWS_LIMIT,
+                       bt::Filter::PassAllFilter());
 
   using bigtable::AsyncOperation;
   impl->SimulateCompletion(cq, true);

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -30,8 +30,7 @@ std::unique_ptr<RPCRetryPolicy> LimitedErrorCountRetryPolicy::clone() const {
       new LimitedErrorCountRetryPolicy(*this));
 }
 
-void LimitedErrorCountRetryPolicy::Setup(
-    grpc::ClientContext&) const {}
+void LimitedErrorCountRetryPolicy::Setup(grpc::ClientContext&) const {}
 
 bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
   return impl_.OnFailure(status);

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -27,7 +27,6 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-
 static_assert(std::is_copy_constructible<bigtable::TableAdmin>::value,
               "bigtable::TableAdmin must be constructible");
 static_assert(std::is_copy_assignable<bigtable::TableAdmin>::value,

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -54,6 +54,5 @@ TEST_F(TableCheckAndMutateRowTest, Failure) {
       "foo", bigtable::Filter::PassAllFilter(),
       {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
       {bigtable::SetCell("fam", "col", 0_ms, "it was false")}));
-
 }
-#endif // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -68,9 +68,8 @@ std::string FieldPath::ToApiRepr() const {
     if (part[0] != '_' && std::isalpha(part[0]) == 0) {
       return false;
     }
-    return std::all_of(part.begin(), part.end(), [](char c) {
-      return c == '_' || std::isalnum(c) != 0;
-    });
+    return std::all_of(part.begin(), part.end(),
+                       [](char c) { return c == '_' || std::isalnum(c) != 0; });
   };
   std::string s;
   if (valid_) {

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -28,9 +28,8 @@ using testing_util::ExpectFutureError;
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
 TEST(FutureTestInt, conform_30_6_5_3) {
   // TODO(coryan) - allocators are not supported for now.
-  static_assert(
-      !std::uses_allocator<promise<int>, std::allocator<int>>::value,
-      "promise<int> should use allocators if provided");
+  static_assert(!std::uses_allocator<promise<int>, std::allocator<int>>::value,
+                "promise<int> should use allocators if provided");
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
@@ -72,12 +71,11 @@ TEST(FutureTestInt, conform_30_6_5_7) {
   EXPECT_TRUE(f0.valid());
   ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { f0.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { f0.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       f0.get(),
@@ -176,12 +174,11 @@ TEST(FutureTestInt, conform_30_6_5_18) {
   p0.set_exception(std::make_exception_ptr(std::runtime_error("testing")));
   ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { f0.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_EQ(std::string("testing"), ex.what());
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { f0.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_EQ(std::string("testing"), ex.what());
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       f0.get(),
@@ -406,12 +403,11 @@ TEST(FutureTestInt, conform_30_6_6_17) {
   future<int> f = p.get_future();
   p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { f.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { f.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       f.get(),

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -74,12 +74,11 @@ TEST(FutureTestInt, ThenException) {
   EXPECT_TRUE(next.valid());
   EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
-  EXPECT_THROW(
-      try { next.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { next.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
   EXPECT_FALSE(next.valid());
 #else
   EXPECT_DEATH_IF_SUPPORTED(p.set_value(42), "test message");
@@ -158,12 +157,11 @@ TEST(FutureTestInt, conform_2_3_3_b) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(unwrapped.is_ready());
-  EXPECT_THROW(
-      try { unwrapped.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { unwrapped.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       p.set_exception(
@@ -189,12 +187,11 @@ TEST(FutureTestInt, conform_2_3_3_c) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p2.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(unwrapped.is_ready());
-  EXPECT_THROW(
-      try { unwrapped.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { unwrapped.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       p2.set_exception(
@@ -217,12 +214,11 @@ TEST(FutureTestInt, conform_2_3_3_d) {
   p.set_value(future<int>{});
   EXPECT_TRUE(unwrapped.is_ready());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { unwrapped.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { unwrapped.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       unwrapped.get(),
@@ -357,12 +353,11 @@ TEST(FutureTestInt, conform_2_3_8_e) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p.set_value(42);
   EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
-  EXPECT_THROW(
-      try { next.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test exception in functor"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { next.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test exception in functor"));
+    throw;
+  },
+               std::runtime_error);
   EXPECT_FALSE(next.valid());
 #else
   EXPECT_DEATH_IF_SUPPORTED(p.set_value(42), "test exception in functor");
@@ -466,12 +461,11 @@ TEST(FutureTestInt, conform_2_3_9_d) {
   p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(called);
   EXPECT_TRUE(r.is_ready());
-  EXPECT_THROW(
-      try { r.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { r.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   // With exceptions disabled the program terminates as soon as the exception is
   // set.
@@ -504,12 +498,11 @@ TEST(FutureTestInt, conform_2_3_9_e) {
   EXPECT_TRUE(r.is_ready());
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { r.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { r.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       r.get(),

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -35,9 +35,8 @@ static_assert(
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
 TEST(FutureTestVoid, conform_30_6_5_3) {
   // TODO(#1364) - allocators are not supported for now.
-  static_assert(
-      !std::uses_allocator<promise<void>, std::allocator<int>>::value,
-      "promise<void> should use allocators if provided");
+  static_assert(!std::uses_allocator<promise<void>, std::allocator<int>>::value,
+                "promise<void> should use allocators if provided");
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
@@ -79,12 +78,11 @@ TEST(FutureTestVoid, conform_30_6_5_7) {
   EXPECT_TRUE(f0.valid());
   ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { f0.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { f0.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       f0.get(),
@@ -183,12 +181,11 @@ TEST(FutureTestVoid, conform_30_6_5_18) {
   p0.set_exception(std::make_exception_ptr(std::runtime_error("testing")));
   ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { f0.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_EQ(std::string("testing"), ex.what());
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { f0.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_EQ(std::string("testing"), ex.what());
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       f0.get(),
@@ -413,12 +410,11 @@ TEST(FutureTestVoid, conform_30_6_6_17) {
   future<void> f = p.get_future();
   p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { f.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { f.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       f.get(),

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -68,12 +68,11 @@ TEST(FutureTestVoid, ThenException) {
   EXPECT_TRUE(next.valid());
   EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
-  EXPECT_THROW(
-      try { next.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { next.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
   EXPECT_FALSE(next.valid());
 #else
   EXPECT_DEATH_IF_SUPPORTED(p.set_value(), "test message");
@@ -152,12 +151,11 @@ TEST(FutureTestVoid, conform_2_3_3_b) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(unwrapped.is_ready());
-  EXPECT_THROW(
-      try { unwrapped.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { unwrapped.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       p.set_exception(
@@ -183,12 +181,11 @@ TEST(FutureTestVoid, conform_2_3_3_c) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p2.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(unwrapped.is_ready());
-  EXPECT_THROW(
-      try { unwrapped.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { unwrapped.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   std::string expected = "future_error\\[";
   expected += std::make_error_code(std::future_errc::promise_already_satisfied)
@@ -215,12 +212,11 @@ TEST(FutureTestVoid, conform_2_3_3_d) {
   EXPECT_TRUE(unwrapped.is_ready());
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { unwrapped.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { unwrapped.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       unwrapped.get(),
@@ -355,12 +351,11 @@ TEST(FutureTestVoid, conform_2_3_8_e) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p.set_value();
   EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
-  EXPECT_THROW(
-      try { next.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test exception in functor"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { next.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test exception in functor"));
+    throw;
+  },
+               std::runtime_error);
   EXPECT_FALSE(next.valid());
 #else
   EXPECT_DEATH_IF_SUPPORTED(p.set_value(), "test exception in functor");
@@ -465,12 +460,11 @@ TEST(FutureTestVoid, conform_2_3_9_d) {
   EXPECT_TRUE(called);
   EXPECT_TRUE(r.is_ready());
 
-  EXPECT_THROW(
-      try { r.get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { r.get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   // With exceptions disabled the program terminates as soon as the exception is
   // set.
@@ -502,12 +496,11 @@ TEST(FutureTestVoid, conform_2_3_9_e) {
   EXPECT_TRUE(called);
   EXPECT_TRUE(r.is_ready());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { r.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { r.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   // With exceptions disabled setting the value immediately terminates.
   EXPECT_DEATH_IF_SUPPORTED(

--- a/google/cloud/internal/filesystem_test.cc
+++ b/google/cloud/internal/filesystem_test.cc
@@ -253,14 +253,12 @@ TEST(FilesystemTest, StatusErrorDoesThrow) {
   std::ofstream(file_name).close();
   auto path = file_name + "/files/cannot/be/directories";
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { status(path); } catch (std::system_error const& ex) {
-        EXPECT_EQ(static_cast<int>(std::errc::not_a_directory),
-                  ex.code().value());
-        EXPECT_THAT(ex.what(), HasSubstr(path));
-        throw;
-      },
-      std::system_error);
+  EXPECT_THROW(try { status(path); } catch (std::system_error const& ex) {
+    EXPECT_EQ(static_cast<int>(std::errc::not_a_directory), ex.code().value());
+    EXPECT_THAT(ex.what(), HasSubstr(path));
+    throw;
+  },
+               std::system_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(status(path), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -305,14 +303,13 @@ TEST(FilesystemTest, FileSizeNotFound) {
 TEST(FilesystemTest, FileSizeNotFoundDoesThrow) {
   auto path = CreateRandomFileName();
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { file_size(path); } catch (std::system_error const& ex) {
-        EXPECT_EQ(static_cast<int>(std::errc::no_such_file_or_directory),
-                  ex.code().value());
-        EXPECT_THAT(ex.what(), HasSubstr(path));
-        throw;
-      },
-      std::system_error);
+  EXPECT_THROW(try { file_size(path); } catch (std::system_error const& ex) {
+    EXPECT_EQ(static_cast<int>(std::errc::no_such_file_or_directory),
+              ex.code().value());
+    EXPECT_THAT(ex.what(), HasSubstr(path));
+    throw;
+  },
+               std::system_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(file_size(path), "exceptions are disabled");
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -139,12 +139,11 @@ TEST(ContinuationVoidTest, SetExceptionCallsContinuation) {
       std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(called);
   EXPECT_TRUE(output->is_ready());
-  EXPECT_THROW(
-      try { output->get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { output->get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       input->set_exception(
@@ -227,12 +226,11 @@ TEST(FutureImplVoid, Abandon) {
   shared_state.abandon();
   EXPECT_TRUE(shared_state.is_ready());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { shared_state.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { shared_state.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       shared_state.get(),
@@ -373,12 +371,11 @@ TEST(FutureImplInt, Abandon) {
   shared_state.abandon();
   EXPECT_TRUE(shared_state.is_ready());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try { shared_state.get(); } catch (std::future_error const& ex) {
-        EXPECT_EQ(std::future_errc::broken_promise, ex.code());
-        throw;
-      },
-      std::future_error);
+  EXPECT_THROW(try { shared_state.get(); } catch (std::future_error const& ex) {
+    EXPECT_EQ(std::future_errc::broken_promise, ex.code());
+    throw;
+  },
+               std::future_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       shared_state.get(),
@@ -482,12 +479,11 @@ TEST(ContinuationIntTest, SetExceptionCallsContinuation) {
       std::make_exception_ptr(std::runtime_error("test message")));
   EXPECT_TRUE(called);
   EXPECT_TRUE(output->is_ready());
-  EXPECT_THROW(
-      try { output->get(); } catch (std::runtime_error const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("test message"));
-        throw;
-      },
-      std::runtime_error);
+  EXPECT_THROW(try { output->get(); } catch (std::runtime_error const& ex) {
+    EXPECT_THAT(ex.what(), HasSubstr("test message"));
+    throw;
+  },
+               std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(
       input->set_exception(

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -136,7 +136,6 @@ TEST(LogSinkTest, ClogMultiple) {
   EXPECT_EQ(0U, LogSink::Instance().BackendCount());
 }
 
-
 namespace {
 /// A class to count calls to IOStream operator.
 struct IOStreamCounter {

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/bucket_metadata.h"
-#include "google/cloud/status.h"
 #include "google/cloud/internal/ios_flags_saver.h"
-#include "google/cloud/storage/internal/format_rfc3339.h"
+#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/bucket_requests.h"
+#include "google/cloud/storage/internal/format_rfc3339.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
@@ -26,7 +26,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs) {
   auto join = [](char const* sep, std::vector<std::string> const& list) {
     if (list.empty()) {
@@ -448,7 +447,8 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetRetentionPolicy(
   // fields.
   impl_.AddSubPatch("retentionPolicy",
                     internal::PatchBuilder().SetIntField(
-                        "retentionPeriod", static_cast<std::uint64_t>(v.retention_period.count())));
+                        "retentionPeriod", static_cast<std::uint64_t>(
+                                               v.retention_period.count())));
   return *this;
 }
 

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -895,8 +895,10 @@ TEST(BucketMetadataPatchBuilder, ResetDefaultEventBasedHold) {
 
 TEST(BucketMetadataPatchBuilder, SetDefaultAcl) {
   BucketMetadataPatchBuilder builder;
-  builder.SetDefaultAcl({internal::ObjectAccessControlParser::FromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""").value()});
+  builder.SetDefaultAcl(
+      {internal::ObjectAccessControlParser::FromString(
+           R"""({"entity": "user-test-user", "role": "OWNER"})""")
+           .value()});
 
   auto actual = builder.BuildPatch();
   auto json = internal::nl::json::parse(actual);

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -353,9 +353,9 @@ void ReadObjectRange(google::cloud::storage::Client client, int& argc,
   //! [read object range] [START storage_download_byte_range]
   namespace gcs = google::cloud::storage;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
-      std::int64_t start, std::int64_t end) {
-    gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name,
-        gcs::ReadRange(start, end));
+     std::int64_t start, std::int64_t end) {
+    gcs::ObjectReadStream stream =
+        client.ReadObject(bucket_name, object_name, gcs::ReadRange(start, end));
 
     int count = 0;
     std::string line;
@@ -1463,7 +1463,7 @@ int main(int argc, char* argv[]) try {
   }
 
   using CommandType =
-      std::function<void(google::cloud::storage::Client, int&, char*[])>;
+      std::function<void(google::cloud::storage::Client, int&, char* [])>;
   std::map<std::string, CommandType> commands = {
       {"list-objects", &ListObjects},
       {"insert-object", &InsertObject},

--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -13,17 +13,16 @@
 // limitations under the License.
 
 #include "google/cloud/storage/hashing_options.h"
-#include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/internal/big_endian.h"
-#include <openssl/md5.h>
+#include "google/cloud/storage/internal/openssl_util.h"
 #include <crc32c/crc32c.h>
+#include <openssl/md5.h>
 #include <cstring>
 
 namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 std::string ComputeMD5Hash(std::string const& payload) {
   MD5_CTX md5;
   MD5_Init(&md5);
@@ -36,8 +35,7 @@ std::string ComputeMD5Hash(std::string const& payload) {
 
 std::string ComputeCrc32cChecksum(std::string const& payload) {
   auto checksum = crc32c::Extend(
-      0, reinterpret_cast<std::uint8_t const*>(payload.data()),
-      payload.size());
+      0, reinterpret_cast<std::uint8_t const*>(payload.data()), payload.size());
   std::uint32_t big_endian = google::cloud::internal::ToBigEndian(checksum);
   std::string hash;
   hash.resize(sizeof(big_endian));

--- a/google/cloud/storage/hashing_options_test.cc
+++ b/google/cloud/storage/hashing_options_test.cc
@@ -29,8 +29,8 @@ TEST(ComputeMD5HashTest, Empty) {
 }
 
 TEST(ComputeMD5HashTest, Simple) {
-  std::string actual = ComputeMD5Hash(
-      "The quick brown fox jumps over the lazy dog");
+  std::string actual =
+      ComputeMD5Hash("The quick brown fox jumps over the lazy dog");
   // I used this command to get the expected value:
   // /bin/echo -n "The quick brown fox jumps over the lazy dog" |
   //     openssl md5 -binary | openssl base64
@@ -45,8 +45,8 @@ TEST(ComputeCrc32cChecksumTest, Empty) {
 }
 
 TEST(ComputeCrc32cChecksumTest, Simple) {
-  std::string actual = ComputeCrc32cChecksum(
-      "The quick brown fox jumps over the lazy dog");
+  std::string actual =
+      ComputeCrc32cChecksum("The quick brown fox jumps over the lazy dog");
   // I used this command to get the expected value:
   // /bin/echo -n "The quick brown fox jumps over the lazy dog" > foo.txt &&
   // gsutil hash foo.txt

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -19,7 +19,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 std::unique_ptr<IdempotencyPolicy> AlwaysRetryIdempotencyPolicy::clone() const {
   return google::cloud::internal::make_unique<AlwaysRetryIdempotencyPolicy>(
       *this);

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -573,8 +573,8 @@ TEST(StrictIdempotencyPolicyTest, ResumableUploadIfGenerationMatch) {
 
 TEST(StrictIdempotencyPolicyTest, UploadChunk) {
   StrictIdempotencyPolicy policy;
-  internal::UploadChunkRequest request(
-      "https://test-url.example.com", 0, "test-payload", false);
+  internal::UploadChunkRequest request("https://test-url.example.com", 0,
+                                       "test-payload", false);
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
 

--- a/google/cloud/storage/internal/access_control_common.cc
+++ b/google/cloud/storage/internal/access_control_common.cc
@@ -21,7 +21,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 Status AccessControlCommon::ParseFromJson(AccessControlCommon& result,
-                                        nl::json const& json) {
+                                          nl::json const& json) {
   if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/bucket_requests.h"
-#include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/format_rfc3339.h"
+#include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include <sstream>
 
@@ -63,7 +63,8 @@ BucketPolicyOnly ParseBucketOnlyPolicy(internal::nl::json const& json) {
 
 }  // namespace
 
-StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(internal::nl::json const& json) {
+StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
+    internal::nl::json const& json) {
   if (!json.is_object()) {
     return Status(StatusCode::kInvalidArgument, __func__);
   }
@@ -100,7 +101,8 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(internal::nl::json const& 
   return result;
 }
 
-StatusOr<LifecycleRule> LifecycleRuleParser::FromString(std::string const& text) {
+StatusOr<LifecycleRule> LifecycleRuleParser::FromString(
+    std::string const& text) {
   auto json = internal::nl::json::parse(text, nullptr, false);
   return FromJson(json);
 }
@@ -281,7 +283,8 @@ std::string BucketMetadataToJsonString(BucketMetadata const& meta) {
 
   if (meta.has_encryption()) {
     json e;
-    SetIfNotEmpty(e, "defaultKmsKeyName", meta.encryption().default_kms_key_name);
+    SetIfNotEmpty(e, "defaultKmsKeyName",
+                  meta.encryption().default_kms_key_name);
     metadata_as_json["encryption"] = std::move(e);
   }
 
@@ -347,14 +350,16 @@ std::string BucketMetadataToJsonString(BucketMetadata const& meta) {
   SetIfNotEmpty(metadata_as_json, "name", meta.name());
 
   if (meta.has_retention_policy()) {
-    json r{{"retentionPeriod", meta.retention_policy().retention_period.count()}};
+    json r{
+        {"retentionPeriod", meta.retention_policy().retention_period.count()}};
     metadata_as_json["retentionPolicy"] = std::move(r);
   }
 
   SetIfNotEmpty(metadata_as_json, "storageClass", meta.storage_class());
 
   if (meta.versioning().has_value()) {
-    metadata_as_json["versioning"] = json{{"enabled", meta.versioning()->enabled}};
+    metadata_as_json["versioning"] =
+        json{{"enabled", meta.versioning()->enabled}};
   }
 
   if (meta.has_website()) {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -340,9 +340,10 @@ TEST(PatchBucketRequestTest, DiffSetDefaultAcl) {
 
 TEST(PatchBucketRequestTest, DiffResetDefaultAcl) {
   BucketMetadata original = CreateBucketMetadataForTest();
-  original.set_default_acl({internal::ObjectAccessControlParser::FromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""")
-      .value()});
+  original.set_default_acl(
+      {internal::ObjectAccessControlParser::FromString(
+           R"""({"entity": "user-test-user", "role": "OWNER"})""")
+           .value()});
   BucketMetadata updated = original;
   updated.set_default_acl({});
   PatchBucketRequest request("test-bucket", original, updated);
@@ -880,7 +881,8 @@ TEST(BucketRequestsTest, TestIamPermissionsResponse) {
       ]})""";
 
   auto actual = TestBucketIamPermissionsResponse::FromHttpResponse(
-      HttpResponse{200, text, {}}).value();
+                    HttpResponse{200, text, {}})
+                    .value();
   EXPECT_THAT(actual.permissions,
               ElementsAre("storage.buckets.get", "storage.buckets.setIamPolicy",
                           "storage.objects.update"));
@@ -905,7 +907,8 @@ TEST(BucketRequestsTest, TestIamPermissionsResponseEmpty) {
   std::string text = R"""({})""";
 
   auto actual = TestBucketIamPermissionsResponse::FromHttpResponse(
-      HttpResponse{200, text, {}}).value();
+                    HttpResponse{200, text, {}})
+                    .value();
   EXPECT_TRUE(actual.permissions.empty());
 }
 

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -222,7 +222,7 @@ Status CurlDownloadRequest::WaitForHandles(int& repeats) {
   return status;
 }
 
-Status CurlDownloadRequest::AsStatus(CURLMcode result, char const *where) {
+Status CurlDownloadRequest::AsStatus(CURLMcode result, char const* where) {
   if (result == CURLM_OK) {
     return Status();
   }

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -26,9 +26,8 @@ using google::cloud::storage::internal::BinaryDataAsDebugString;
 
 std::size_t const MAX_DATA_DEBUG_SIZE = 48;
 
-extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type,
-                                       char* data, std::size_t size,
-                                       void* userptr) {
+extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
+                                       std::size_t size, void* userptr) {
   auto debug_buffer = reinterpret_cast<std::string*>(userptr);
   switch (type) {
     case CURLINFO_TEXT:

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -20,17 +20,15 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-StatusOr<ResumableUploadResponse>
-CurlResumableUploadSession::UploadChunk(std::string const& buffer,
-                                        std::uint64_t upload_size) {
+StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
+    std::string const& buffer, std::uint64_t upload_size) {
   UploadChunkRequest request(session_id_, next_expected_, buffer, upload_size);
   auto result = client_->UploadChunk(request);
   Update(result);
   return result;
 }
 
-StatusOr<ResumableUploadResponse>
-CurlResumableUploadSession::ResetSession() {
+StatusOr<ResumableUploadResponse> CurlResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_);
   auto result = client_->QueryResumableUpload(request);
   Update(result);

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -202,8 +202,8 @@ Status CurlUploadRequest::WaitForHandles(int& repeats) {
   int numfds = 0;
   CURLMcode result =
       curl_multi_wait(multi_.get(), nullptr, 0, timeout_ms, &numfds);
-  GCP_LOG(DEBUG) << __func__ << "(): numfds=" << numfds
-                 << ", result=" << result << ", repeats=" << repeats;
+  GCP_LOG(DEBUG) << __func__ << "(): numfds=" << numfds << ", result=" << result
+                 << ", repeats=" << repeats;
   if (result != CURLM_OK) {
     return AsStatus(result, __func__);
   }

--- a/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
@@ -47,4 +47,3 @@ TEST(CurlWrappers, LockingDisabledTest) {
 //
 // Created by coryan on 11/26/18.
 //
-

--- a/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
@@ -36,4 +36,3 @@ TEST(CurlWrappers, LockingDisabledTest) {
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
-

--- a/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
@@ -36,4 +36,3 @@ TEST(CurlWrappers, LockingEnabledTest) {
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
-

--- a/google/cloud/storage/internal/generate_message_boundary_test.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_test.cc
@@ -22,8 +22,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using ::testing::Not;
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 TEST(GenerateMessageBoundaryTest, Simple) {
   auto generator = google::cloud::internal::MakeDefaultPRNG();
@@ -54,14 +54,15 @@ TEST(GenerateMessageBoundaryTest, RequiresGrowth) {
   int constexpr kMismatchedStringLength = 512;
 
   auto g1 = google::cloud::internal::MakeDefaultPRNG();
-  std::string message = google::cloud::internal::Sample(
-      g1, kMismatchedStringLength, chars);
+  std::string message =
+      google::cloud::internal::Sample(g1, kMismatchedStringLength, chars);
   // Copy the PRNG to obtain the same sequence of random numbers that
   // `generator` will create later.
   g1 = generator;
   message += google::cloud::internal::Sample(g1, kMatchedStringLength, chars);
   g1 = google::cloud::internal::MakeDefaultPRNG();
-  message += google::cloud::internal::Sample(g1, kMismatchedStringLength, chars);
+  message +=
+      google::cloud::internal::Sample(g1, kMismatchedStringLength, chars);
 
   auto string_generator = [&generator](int n) {
     return google::cloud::internal::Sample(generator, n, chars);
@@ -72,9 +73,9 @@ TEST(GenerateMessageBoundaryTest, RequiresGrowth) {
   // that forces the algorithm to find the initial string, and to grow it
   // several times before the kMatchedStringLength common characters are
   // exhausted.
-  auto boundary =
-      GenerateMessageBoundary(message, std::move(string_generator),
-          kMatchedStringLength / 2, kMatchedStringLength / 4);
+  auto boundary = GenerateMessageBoundary(message, std::move(string_generator),
+                                          kMatchedStringLength / 2,
+                                          kMatchedStringLength / 4);
   EXPECT_THAT(message, Not(HasSubstr(boundary)));
 
   // We expect that the string is longer than the common characters.

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -15,9 +15,9 @@
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/log.h"
+#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/object_metadata.h"
-#include "google/cloud/status.h"
 #include <crc32c/crc32c.h>
 
 namespace google {

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -36,16 +36,12 @@ TEST(HttpResponseTest, OStream) {
 }
 
 TEST(HttpResponseTest, AsStatus) {
-  EXPECT_EQ(StatusCode::kUnknown,
-            AsStatus(HttpResponse{-42, "weird"}).code());
+  EXPECT_EQ(StatusCode::kUnknown, AsStatus(HttpResponse{-42, "weird"}).code());
   EXPECT_EQ(StatusCode::kUnknown,
             AsStatus(HttpResponse{99, "still weird"}).code());
-  EXPECT_EQ(StatusCode::kOk,
-            AsStatus(HttpResponse{100, "Continue"}).code());
-  EXPECT_EQ(StatusCode::kOk,
-            AsStatus(HttpResponse{200, "success"}).code());
-  EXPECT_EQ(StatusCode::kOk,
-            AsStatus(HttpResponse{299, "success"}).code());
+  EXPECT_EQ(StatusCode::kOk, AsStatus(HttpResponse{100, "Continue"}).code());
+  EXPECT_EQ(StatusCode::kOk, AsStatus(HttpResponse{200, "success"}).code());
+  EXPECT_EQ(StatusCode::kOk, AsStatus(HttpResponse{299, "success"}).code());
   EXPECT_EQ(StatusCode::kUnknown,
             AsStatus(HttpResponse{300, "libcurl should handle this"}).code());
   EXPECT_EQ(StatusCode::kFailedPrecondition,
@@ -62,8 +58,7 @@ TEST(HttpResponseTest, AsStatus) {
             AsStatus(HttpResponse{405, "method not allowed"}).code());
   EXPECT_EQ(StatusCode::kAborted,
             AsStatus(HttpResponse{409, "conflict"}).code());
-  EXPECT_EQ(StatusCode::kNotFound,
-            AsStatus(HttpResponse{410, "gone"}).code());
+  EXPECT_EQ(StatusCode::kNotFound, AsStatus(HttpResponse{410, "gone"}).code());
   EXPECT_EQ(StatusCode::kInvalidArgument,
             AsStatus(HttpResponse{411, "length required"}).code());
   EXPECT_EQ(StatusCode::kFailedPrecondition,
@@ -84,8 +79,7 @@ TEST(HttpResponseTest, AsStatus) {
             AsStatus(HttpResponse{503, "service unavailable"}).code());
   EXPECT_EQ(StatusCode::kInternal,
             AsStatus(HttpResponse{599, "some 5XX error"}).code());
-  EXPECT_EQ(StatusCode::kUnknown,
-            AsStatus(HttpResponse{600, "bad"}).code());
+  EXPECT_EQ(StatusCode::kUnknown, AsStatus(HttpResponse{600, "bad"}).code());
 }
 }  // namespace
 }  // namespace internal

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/logging_client.h"
-#include "google/cloud/storage/internal/logging_resumable_upload_session.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/log.h"
+#include "google/cloud/storage/internal/logging_resumable_upload_session.h"
 #include "google/cloud/storage/internal/raw_client_wrapper_utils.h"
 
 namespace google {
@@ -155,14 +155,14 @@ StatusOr<ObjectMetadata> LoggingClient::GetObjectMetadata(
   return MakeCall(*client_, &RawClient::GetObjectMetadata, request, __func__);
 }
 
-StatusOr<std::unique_ptr<ObjectReadStreambuf>>
-LoggingClient::ReadObject(ReadObjectRangeRequest const& request) {
+StatusOr<std::unique_ptr<ObjectReadStreambuf>> LoggingClient::ReadObject(
+    ReadObjectRangeRequest const& request) {
   return MakeCallNoResponseLogging(*client_, &RawClient::ReadObject, request,
                                    __func__);
 }
 
-StatusOr<std::unique_ptr<ObjectWriteStreambuf>>
-LoggingClient::WriteObject(InsertObjectStreamingRequest const& request) {
+StatusOr<std::unique_ptr<ObjectWriteStreambuf>> LoggingClient::WriteObject(
+    InsertObjectStreamingRequest const& request) {
   return MakeCallNoResponseLogging(*client_, &RawClient::WriteObject, request,
                                    __func__);
 }
@@ -210,7 +210,7 @@ LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
 }
 
 StatusOr<std::unique_ptr<ResumableUploadSession>>
-LoggingClient::RestoreResumableSession(std::string const &request){
+LoggingClient::RestoreResumableSession(std::string const& request) {
   return MakeCallNoResponseLogging(
       *client_, &RawClient::RestoreResumableSession, request, __func__);
 }
@@ -275,8 +275,7 @@ StatusOr<ObjectAccessControl> LoggingClient::PatchObjectAcl(
   return MakeCall(*client_, &RawClient::PatchObjectAcl, request, __func__);
 }
 
-StatusOr<ListDefaultObjectAclResponse>
-LoggingClient::ListDefaultObjectAcl(
+StatusOr<ListDefaultObjectAclResponse> LoggingClient::ListDefaultObjectAcl(
     ListDefaultObjectAclRequest const& request) {
   return MakeCall(*client_, &RawClient::ListDefaultObjectAcl, request,
                   __func__);

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -120,7 +120,8 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
 
   auto mock = std::make_shared<testing::MockClient>();
   EXPECT_CALL(*mock, InsertObjectMedia(_))
-      .WillOnce(Return(internal::ObjectMetadataParser::FromString(text).value()));
+      .WillOnce(
+          Return(internal::ObjectMetadataParser::FromString(text).value()));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
@@ -146,9 +147,11 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
 
 TEST_F(LoggingClientTest, ListObjects) {
   std::vector<ObjectMetadata> items = {
-      internal::ObjectMetadataParser::FromString(R""({"name": "response-object-o1"})"")
+      internal::ObjectMetadataParser::FromString(
+          R""({"name": "response-object-o1"})"")
           .value(),
-      internal::ObjectMetadataParser::FromString(R""({"name": "response-object-o2"})"")
+      internal::ObjectMetadataParser::FromString(
+          R""({"name": "response-object-o2"})"")
           .value(),
   };
   auto mock = std::make_shared<testing::MockClient>();

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -21,9 +21,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-StatusOr<ResumableUploadResponse>
-LoggingResumableUploadSession::UploadChunk(std::string const& buffer,
-                                           std::uint64_t upload_size) {
+StatusOr<ResumableUploadResponse> LoggingResumableUploadSession::UploadChunk(
+    std::string const& buffer, std::uint64_t upload_size) {
   GCP_LOG(INFO) << __func__ << "() << upload_size=" << upload_size
                 << ", buffer.size=" << buffer.size();
   auto response = session_->UploadChunk(buffer, upload_size);

--- a/google/cloud/storage/internal/notification_requests_test.cc
+++ b/google/cloud/storage/internal/notification_requests_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/notification_requests.h"
-#include "google/cloud/storage/notification_payload_format.h"
 #include "google/cloud/storage/notification_event_type.h"
+#include "google/cloud/storage/notification_payload_format.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -45,7 +45,8 @@ TEST(NotificationRequestTest, Parse) {
       "payload_format": "JSON_API_V1",
       "selfLink": "https://www.googleapis.com/storage/v1/b/test-bucket/notificationConfigs/test-id-123",
       "topic": "test-topic"
-  })""").value();
+  })""")
+                    .value();
   EXPECT_EQ(2U, actual.custom_attributes().size());
   EXPECT_TRUE(actual.has_custom_attribute("test-ca-1"));
   EXPECT_EQ("value1", actual.custom_attribute("test-ca-1"));

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -391,7 +391,8 @@ TEST(ObjectRequestsTest, RewriteObjectResponse) {
 
   text += object1 + "\n}";
 
-  auto expected_resource = internal::ObjectMetadataParser::FromString(object1).value();
+  auto expected_resource =
+      internal::ObjectMetadataParser::FromString(object1).value();
 
   auto actual =
       RewriteObjectResponse::FromHttpResponse(HttpResponse{200, text, {}})
@@ -545,10 +546,12 @@ TEST(ObjectRequestsTest, ResumableUploadResponseNoRange) {
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseMissingBytesInRange) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(HttpResponse{
-      200,
-      "test-payload",
-      {{"location", "location-value"}, {"range", "units=0-2000"}}}).value();
+  auto actual = ResumableUploadResponse::FromHttpResponse(
+                    HttpResponse{200,
+                                 "test-payload",
+                                 {{"location", "location-value"},
+                                  {"range", "units=0-2000"}}})
+                    .value();
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("location-value", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -556,39 +559,48 @@ TEST(ObjectRequestsTest, ResumableUploadResponseMissingBytesInRange) {
 
 TEST(ObjectRequestsTest, ResumableUploadResponseMissingRangeEnd) {
   auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200, "test-payload", {{"range", "bytes=0-"}}}).value();
+                    HttpResponse{200, "test-payload", {{"range", "bytes=0-"}}})
+                    .value();
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseInvalidRangeEnd) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200, "test-payload", {{"range", "bytes=0-abcd"}}}).value();
+  auto actual =
+      ResumableUploadResponse::FromHttpResponse(
+          HttpResponse{200, "test-payload", {{"range", "bytes=0-abcd"}}})
+          .value();
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseInvalidRangeBegin) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200, "test-payload", {{"range", "bytes=abcd-2000"}}}).value();
+  auto actual =
+      ResumableUploadResponse::FromHttpResponse(
+          HttpResponse{200, "test-payload", {{"range", "bytes=abcd-2000"}}})
+          .value();
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseUnexpectedRangeBegin) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200, "test-payload", {{"range", "bytes=3000-2000"}}}).value();
+  auto actual =
+      ResumableUploadResponse::FromHttpResponse(
+          HttpResponse{200, "test-payload", {{"range", "bytes=3000-2000"}}})
+          .value();
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
 }
 
 TEST(ObjectRequestsTest, ResumableUploadResponseNegativeEnd) {
-  auto actual = ResumableUploadResponse::FromHttpResponse(
-      HttpResponse{200, "test-payload", {{"range", "bytes=0--7"}}}).value();
+  auto actual =
+      ResumableUploadResponse::FromHttpResponse(
+          HttpResponse{200, "test-payload", {{"range", "bytes=0--7"}}})
+          .value();
   EXPECT_EQ("test-payload", actual.payload);
   EXPECT_EQ("", actual.upload_session_url);
   EXPECT_EQ(0U, actual.last_committed_byte);
@@ -679,8 +691,8 @@ TEST(PatchObjectRequestTest, DiffSetAcl) {
   original.set_acl({});
   ObjectMetadata updated = original;
   updated.set_acl({internal::ObjectAccessControlParser::FromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""")
-      .value()});
+                       R"""({"entity": "user-test-user", "role": "OWNER"})""")
+                       .value()});
   PatchObjectRequest request("test-bucket", "test-object", original, updated);
 
   nl::json patch = nl::json::parse(request.payload());
@@ -693,8 +705,8 @@ TEST(PatchObjectRequestTest, DiffSetAcl) {
 TEST(PatchObjectRequestTest, DiffResetAcl) {
   ObjectMetadata original = CreateObjectMetadataForTest();
   original.set_acl({internal::ObjectAccessControlParser::FromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""")
-      .value()});
+                        R"""({"entity": "user-test-user", "role": "OWNER"})""")
+                        .value()});
   ObjectMetadata updated = original;
   updated.set_acl({});
   PatchObjectRequest request("test-bucket", "test-object", original, updated);

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -131,8 +131,7 @@ StatusOr<ListBucketsResponse> RetryClient::ListBuckets(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListBuckets, request,
-                  __func__);
+                  &RawClient::ListBuckets, request, __func__);
 }
 
 StatusOr<BucketMetadata> RetryClient::CreateBucket(
@@ -141,8 +140,7 @@ StatusOr<BucketMetadata> RetryClient::CreateBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateBucket, request,
-                  __func__);
+                  &RawClient::CreateBucket, request, __func__);
 }
 
 StatusOr<BucketMetadata> RetryClient::GetBucketMetadata(
@@ -151,8 +149,7 @@ StatusOr<BucketMetadata> RetryClient::GetBucketMetadata(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetBucketMetadata, request,
-                  __func__);
+                  &RawClient::GetBucketMetadata, request, __func__);
 }
 
 StatusOr<EmptyResponse> RetryClient::DeleteBucket(
@@ -161,8 +158,7 @@ StatusOr<EmptyResponse> RetryClient::DeleteBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteBucket, request,
-                  __func__);
+                  &RawClient::DeleteBucket, request, __func__);
 }
 
 StatusOr<BucketMetadata> RetryClient::UpdateBucket(
@@ -171,8 +167,7 @@ StatusOr<BucketMetadata> RetryClient::UpdateBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateBucket, request,
-                  __func__);
+                  &RawClient::UpdateBucket, request, __func__);
 }
 
 StatusOr<BucketMetadata> RetryClient::PatchBucket(
@@ -181,8 +176,7 @@ StatusOr<BucketMetadata> RetryClient::PatchBucket(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchBucket, request,
-                  __func__);
+                  &RawClient::PatchBucket, request, __func__);
 }
 
 StatusOr<IamPolicy> RetryClient::GetBucketIamPolicy(
@@ -191,8 +185,7 @@ StatusOr<IamPolicy> RetryClient::GetBucketIamPolicy(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetBucketIamPolicy, request,
-                  __func__);
+                  &RawClient::GetBucketIamPolicy, request, __func__);
 }
 
 StatusOr<IamPolicy> RetryClient::SetBucketIamPolicy(
@@ -201,8 +194,7 @@ StatusOr<IamPolicy> RetryClient::SetBucketIamPolicy(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::SetBucketIamPolicy, request,
-                  __func__);
+                  &RawClient::SetBucketIamPolicy, request, __func__);
 }
 
 StatusOr<TestBucketIamPermissionsResponse>
@@ -212,8 +204,7 @@ RetryClient::TestBucketIamPermissions(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::TestBucketIamPermissions, request,
-                   __func__);
+                  &RawClient::TestBucketIamPermissions, request, __func__);
 }
 
 StatusOr<BucketMetadata> RetryClient::LockBucketRetentionPolicy(
@@ -222,8 +213,7 @@ StatusOr<BucketMetadata> RetryClient::LockBucketRetentionPolicy(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::LockBucketRetentionPolicy, request,
-                   __func__);
+                  &RawClient::LockBucketRetentionPolicy, request, __func__);
 }
 
 StatusOr<ObjectMetadata> RetryClient::InsertObjectMedia(
@@ -232,8 +222,7 @@ StatusOr<ObjectMetadata> RetryClient::InsertObjectMedia(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::InsertObjectMedia, request,
-                  __func__);
+                  &RawClient::InsertObjectMedia, request, __func__);
 }
 
 StatusOr<ObjectMetadata> RetryClient::CopyObject(
@@ -242,8 +231,7 @@ StatusOr<ObjectMetadata> RetryClient::CopyObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CopyObject, request,
-                  __func__);
+                  &RawClient::CopyObject, request, __func__);
 }
 
 StatusOr<ObjectMetadata> RetryClient::GetObjectMetadata(
@@ -252,8 +240,7 @@ StatusOr<ObjectMetadata> RetryClient::GetObjectMetadata(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetObjectMetadata, request,
-                  __func__);
+                  &RawClient::GetObjectMetadata, request, __func__);
 }
 
 StatusOr<std::unique_ptr<ObjectReadStreambuf>> RetryClient::ReadObject(
@@ -262,19 +249,16 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> RetryClient::ReadObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ReadObject, request,
-                  __func__);
+                  &RawClient::ReadObject, request, __func__);
 }
 
-StatusOr<std::unique_ptr<ObjectWriteStreambuf>>
-RetryClient::WriteObject(
+StatusOr<std::unique_ptr<ObjectWriteStreambuf>> RetryClient::WriteObject(
     internal::InsertObjectStreamingRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::WriteObject, request,
-                  __func__);
+                  &RawClient::WriteObject, request, __func__);
 }
 
 StatusOr<ListObjectsResponse> RetryClient::ListObjects(
@@ -283,8 +267,7 @@ StatusOr<ListObjectsResponse> RetryClient::ListObjects(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListObjects, request,
-                  __func__);
+                  &RawClient::ListObjects, request, __func__);
 }
 
 StatusOr<EmptyResponse> RetryClient::DeleteObject(
@@ -293,8 +276,7 @@ StatusOr<EmptyResponse> RetryClient::DeleteObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteObject, request,
-                  __func__);
+                  &RawClient::DeleteObject, request, __func__);
 }
 
 StatusOr<ObjectMetadata> RetryClient::UpdateObject(
@@ -303,8 +285,7 @@ StatusOr<ObjectMetadata> RetryClient::UpdateObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateObject, request,
-                  __func__);
+                  &RawClient::UpdateObject, request, __func__);
 }
 
 StatusOr<ObjectMetadata> RetryClient::PatchObject(
@@ -313,8 +294,7 @@ StatusOr<ObjectMetadata> RetryClient::PatchObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchObject, request,
-                  __func__);
+                  &RawClient::PatchObject, request, __func__);
 }
 
 StatusOr<ObjectMetadata> RetryClient::ComposeObject(
@@ -323,8 +303,7 @@ StatusOr<ObjectMetadata> RetryClient::ComposeObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ComposeObject, request,
-                  __func__);
+                  &RawClient::ComposeObject, request, __func__);
 }
 
 StatusOr<RewriteObjectResponse> RetryClient::RewriteObject(
@@ -333,8 +312,7 @@ StatusOr<RewriteObjectResponse> RetryClient::RewriteObject(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::RewriteObject, request,
-                  __func__);
+                  &RawClient::RewriteObject, request, __func__);
 }
 
 StatusOr<std::unique_ptr<ResumableUploadSession>>
@@ -342,9 +320,9 @@ RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
-  auto result = MakeCall(*retry_policy, *backoff_policy, is_idempotent,
-                         *client_, &RawClient::CreateResumableSession, request,
-                         __func__);
+  auto result =
+      MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
+               &RawClient::CreateResumableSession, request, __func__);
   if (!result.ok()) {
     return result;
   }
@@ -361,8 +339,7 @@ RetryClient::RestoreResumableSession(std::string const& request) {
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = true;
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::RestoreResumableSession, request,
-                   __func__);
+                  &RawClient::RestoreResumableSession, request, __func__);
 }
 
 StatusOr<ListBucketAclResponse> RetryClient::ListBucketAcl(
@@ -371,8 +348,7 @@ StatusOr<ListBucketAclResponse> RetryClient::ListBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListBucketAcl, request,
-                  __func__);
+                  &RawClient::ListBucketAcl, request, __func__);
 }
 
 StatusOr<BucketAccessControl> RetryClient::GetBucketAcl(
@@ -381,8 +357,7 @@ StatusOr<BucketAccessControl> RetryClient::GetBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetBucketAcl, request,
-                  __func__);
+                  &RawClient::GetBucketAcl, request, __func__);
 }
 
 StatusOr<BucketAccessControl> RetryClient::CreateBucketAcl(
@@ -391,8 +366,7 @@ StatusOr<BucketAccessControl> RetryClient::CreateBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateBucketAcl, request,
-                  __func__);
+                  &RawClient::CreateBucketAcl, request, __func__);
 }
 
 StatusOr<EmptyResponse> RetryClient::DeleteBucketAcl(
@@ -401,8 +375,7 @@ StatusOr<EmptyResponse> RetryClient::DeleteBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteBucketAcl, request,
-                  __func__);
+                  &RawClient::DeleteBucketAcl, request, __func__);
 }
 
 StatusOr<ListObjectAclResponse> RetryClient::ListObjectAcl(
@@ -411,8 +384,7 @@ StatusOr<ListObjectAclResponse> RetryClient::ListObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListObjectAcl, request,
-                  __func__);
+                  &RawClient::ListObjectAcl, request, __func__);
 }
 
 StatusOr<BucketAccessControl> RetryClient::UpdateBucketAcl(
@@ -421,8 +393,7 @@ StatusOr<BucketAccessControl> RetryClient::UpdateBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateBucketAcl, request,
-                  __func__);
+                  &RawClient::UpdateBucketAcl, request, __func__);
 }
 
 StatusOr<BucketAccessControl> RetryClient::PatchBucketAcl(
@@ -431,8 +402,7 @@ StatusOr<BucketAccessControl> RetryClient::PatchBucketAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchBucketAcl, request,
-                  __func__);
+                  &RawClient::PatchBucketAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::CreateObjectAcl(
@@ -441,8 +411,7 @@ StatusOr<ObjectAccessControl> RetryClient::CreateObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateObjectAcl, request,
-                  __func__);
+                  &RawClient::CreateObjectAcl, request, __func__);
 }
 
 StatusOr<EmptyResponse> RetryClient::DeleteObjectAcl(
@@ -451,8 +420,7 @@ StatusOr<EmptyResponse> RetryClient::DeleteObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteObjectAcl, request,
-                  __func__);
+                  &RawClient::DeleteObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::GetObjectAcl(
@@ -461,8 +429,7 @@ StatusOr<ObjectAccessControl> RetryClient::GetObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetObjectAcl, request,
-                  __func__);
+                  &RawClient::GetObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::UpdateObjectAcl(
@@ -471,8 +438,7 @@ StatusOr<ObjectAccessControl> RetryClient::UpdateObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateObjectAcl, request,
-                  __func__);
+                  &RawClient::UpdateObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::PatchObjectAcl(
@@ -481,18 +447,16 @@ StatusOr<ObjectAccessControl> RetryClient::PatchObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchObjectAcl, request,
-                  __func__);
+                  &RawClient::PatchObjectAcl, request, __func__);
 }
 
-StatusOr<ListDefaultObjectAclResponse>
-RetryClient::ListDefaultObjectAcl(ListDefaultObjectAclRequest const& request) {
+StatusOr<ListDefaultObjectAclResponse> RetryClient::ListDefaultObjectAcl(
+    ListDefaultObjectAclRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListDefaultObjectAcl, request,
-                  __func__);
+                  &RawClient::ListDefaultObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
@@ -501,8 +465,7 @@ StatusOr<ObjectAccessControl> RetryClient::CreateDefaultObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateDefaultObjectAcl, request,
-                   __func__);
+                  &RawClient::CreateDefaultObjectAcl, request, __func__);
 }
 
 StatusOr<EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
@@ -511,8 +474,7 @@ StatusOr<EmptyResponse> RetryClient::DeleteDefaultObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteDefaultObjectAcl, request,
-                   __func__);
+                  &RawClient::DeleteDefaultObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
@@ -521,8 +483,7 @@ StatusOr<ObjectAccessControl> RetryClient::GetDefaultObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetDefaultObjectAcl, request,
-                  __func__);
+                  &RawClient::GetDefaultObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
@@ -531,8 +492,7 @@ StatusOr<ObjectAccessControl> RetryClient::UpdateDefaultObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::UpdateDefaultObjectAcl, request,
-                   __func__);
+                  &RawClient::UpdateDefaultObjectAcl, request, __func__);
 }
 
 StatusOr<ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
@@ -541,8 +501,7 @@ StatusOr<ObjectAccessControl> RetryClient::PatchDefaultObjectAcl(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::PatchDefaultObjectAcl, request,
-                   __func__);
+                  &RawClient::PatchDefaultObjectAcl, request, __func__);
 }
 
 StatusOr<ServiceAccount> RetryClient::GetServiceAccount(
@@ -551,8 +510,7 @@ StatusOr<ServiceAccount> RetryClient::GetServiceAccount(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetServiceAccount, request,
-                  __func__);
+                  &RawClient::GetServiceAccount, request, __func__);
 }
 
 StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
@@ -561,8 +519,7 @@ StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::ListNotifications, request,
-                  __func__);
+                  &RawClient::ListNotifications, request, __func__);
 }
 
 StatusOr<NotificationMetadata> RetryClient::CreateNotification(
@@ -571,8 +528,7 @@ StatusOr<NotificationMetadata> RetryClient::CreateNotification(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::CreateNotification, request,
-                  __func__);
+                  &RawClient::CreateNotification, request, __func__);
 }
 
 StatusOr<NotificationMetadata> RetryClient::GetNotification(
@@ -581,8 +537,7 @@ StatusOr<NotificationMetadata> RetryClient::GetNotification(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::GetNotification, request,
-                  __func__);
+                  &RawClient::GetNotification, request, __func__);
 }
 
 StatusOr<EmptyResponse> RetryClient::DeleteNotification(
@@ -591,8 +546,7 @@ StatusOr<EmptyResponse> RetryClient::DeleteNotification(
   auto backoff_policy = backoff_policy_->clone();
   auto is_idempotent = idempotency_policy_->IsIdempotent(request);
   return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
-                  &RawClient::DeleteNotification, request,
-                  __func__);
+                  &RawClient::DeleteNotification, request, __func__);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -82,8 +82,7 @@ TEST_F(RetryClientTest, TooManyTransientsHandling) {
 
   // Use a read-only operation because these are always idempotent.
   EXPECT_CALL(*mock, GetObjectMetadata(_))
-      .WillRepeatedly(
-          Return(StatusOr<ObjectMetadata>(TransientError())));
+      .WillRepeatedly(Return(StatusOr<ObjectMetadata>(TransientError())));
 
   StatusOr<ObjectMetadata> result = client.GetObjectMetadata(
       GetObjectMetadataRequest("test-bucket", "test-object"));

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -23,9 +23,9 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
 namespace {
-StatusOr<ResumableUploadResponse> ReturnError(
-    Status&& last_status, RetryPolicy const& retry_policy,
-    char const* error_message) {
+StatusOr<ResumableUploadResponse> ReturnError(Status&& last_status,
+                                              RetryPolicy const& retry_policy,
+                                              char const* error_message) {
   std::ostringstream os;
   if (retry_policy.IsExhausted()) {
     os << "Retry policy exhausted in " << error_message << ": " << last_status;
@@ -36,9 +36,8 @@ StatusOr<ResumableUploadResponse> ReturnError(
 }
 }  // namespace
 
-StatusOr<ResumableUploadResponse>
-RetryResumableUploadSession::UploadChunk(std::string const& buffer,
-                                         std::uint64_t upload_size) {
+StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadChunk(
+    std::string const& buffer, std::uint64_t upload_size) {
   Status last_status;
   while (!retry_policy_->IsExhausted()) {
     auto result = session_->UploadChunk(buffer, upload_size);
@@ -62,8 +61,7 @@ RetryResumableUploadSession::UploadChunk(std::string const& buffer,
   return Status(last_status.code(), os.str());
 }
 
-StatusOr<ResumableUploadResponse>
-RetryResumableUploadSession::ResetSession() {
+StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {
   Status last_status;
   while (!retry_policy_->IsExhausted()) {
     auto result = session_->ResetSession();

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -46,7 +46,7 @@ std::string SignUrlRequest::StringToSign() const {
   CurlHandle curl;
   os << '/' << bucket_name();
   if (!object_name().empty()) {
-    os << '/'  << curl.MakeEscapedString(object_name()).get();
+    os << '/' << curl.MakeEscapedString(object_name()).get();
   }
   char const* sep = "?";
   for (auto const& key_value : query_parameters_) {

--- a/google/cloud/storage/list_objects_reader.cc
+++ b/google/cloud/storage/list_objects_reader.cc
@@ -69,9 +69,7 @@ ListObjectsIterator& ListObjectsIterator::operator++() {
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
-ListObjectsReader::iterator ListObjectsReader::begin() {
-  return GetNext();
-}
+ListObjectsReader::iterator ListObjectsReader::begin() { return GetNext(); }
 
 ListObjectsIterator ListObjectsReader::GetNext() {
   static Status const past_the_end_error(
@@ -79,7 +77,8 @@ ListObjectsIterator ListObjectsReader::GetNext() {
       "Cannot iterating past the end of ListObjectReader");
   if (current_objects_.end() == current_) {
     if (on_last_page_) {
-      return ListObjectsIterator(nullptr, StatusOr<ObjectMetadata>(past_the_end_error));
+      return ListObjectsIterator(nullptr,
+                                 StatusOr<ObjectMetadata>(past_the_end_error));
     }
     request_.set_page_token(std::move(next_page_token_));
     auto response = client_->ListObjects(request_);

--- a/google/cloud/storage/oauth2/anonymous_credentials.cc
+++ b/google/cloud/storage/oauth2/anonymous_credentials.cc
@@ -20,8 +20,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
-StatusOr<std::string>
-AnonymousCredentials::AuthorizationHeader() {
+StatusOr<std::string> AnonymousCredentials::AuthorizationHeader() {
   return std::string{};
 }
 

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -22,7 +22,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
   return static_cast<internal::CommonMetadata<ObjectMetadata> const&>(lhs) ==
              rhs &&
@@ -35,7 +34,8 @@ bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
          lhs.content_type_ == rhs.content_type_ && lhs.crc32c_ == rhs.crc32c_ &&
          lhs.customer_encryption_ == rhs.customer_encryption_ &&
          lhs.event_based_hold_ == rhs.event_based_hold_ &&
-         lhs.generation_ == rhs.generation_ && lhs.kms_key_name_ == rhs.kms_key_name_ &&
+         lhs.generation_ == rhs.generation_ &&
+         lhs.kms_key_name_ == rhs.kms_key_name_ &&
          lhs.md5_hash_ == rhs.md5_hash_ && lhs.media_link_ == rhs.media_link_ &&
          lhs.metadata_ == rhs.metadata_ &&
          lhs.retention_expiration_time_ == rhs.retention_expiration_time_ &&

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_metadata.h"
-#include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
+#include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
 
@@ -330,7 +330,8 @@ TEST(ObjectMetadataTest, InsertMetadata) {
 TEST(ObjectMetadataPatchBuilder, SetAcl) {
   ObjectMetadataPatchBuilder builder;
   builder.SetAcl({internal::ObjectAccessControlParser::FromString(
-      R"""({"entity": "user-test-user", "role": "OWNER"})""").value()});
+                      R"""({"entity": "user-test-user", "role": "OWNER"})""")
+                      .value()});
 
   auto actual = builder.BuildPatch();
   auto actual_as_json = internal::nl::json::parse(actual);

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_rewriter.h"
-#include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/storage/internal/raw_client.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/service_account_test.cc
+++ b/google/cloud/storage/service_account_test.cc
@@ -26,7 +26,8 @@ ServiceAccount CreateServiceAccountForTest() {
   return ServiceAccount::ParseFromString(R"""({
       "email_address": "service-123@example.com",
       "kind": "storage#serviceAccount"
-})""").value();
+})""")
+      .value();
 }
 
 /// @test Verify that we parse JSON objects into ServiceAccount objects.

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -20,7 +20,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::StartsWith;


### PR DESCRIPTION
The script was only enforcing formatting in `.h` files. Fixed the script.
Also applied `clang-format` to the `.cc` files so the builds will work
from now on.

This fixes #1974.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2025)
<!-- Reviewable:end -->
