### PR TITLE
Standardize on fully qualified using declarations

### DIFF
--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -25,8 +25,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::make_optional;
-using google::cloud::optional;
+
+using ::google::cloud::make_optional;
+using ::google::cloud::optional;
 using ::testing::HasSubstr;
 using ::testing::Not;
 

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -27,14 +27,14 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 
 /**
  * Test the functions in Storage::Client related to 'Buckets: *'.

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -26,14 +26,15 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using testing::canonical_errors::TransientError;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 
 /**
  * Test the functions in Storage::Client related to 'Buckets: *'.

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -26,12 +26,13 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the BucketAccessControls-related functions in storage::Client.

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -27,11 +27,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -26,12 +26,13 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the BucketAccessControls-related functions in storage::Client.

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -27,11 +27,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -28,13 +28,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the BucketAccessControls-related functions in storage::Client.

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -29,12 +29,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -25,12 +25,13 @@ namespace google {
 namespace cloud {
 namespace storage {
 namespace {
-using ::testing::_;
+
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the ObjectAccessControls-related functions in storage::Client.

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -26,11 +26,11 @@ namespace cloud {
 namespace storage {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -26,13 +26,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the functions in Storage::Client related to 'Objects: {copy,rewrite}'.

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -27,12 +27,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -26,13 +26,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using storage::oauth2::CreateAnonymousCredentials;
-using ::testing::_;
+
+using ::google::cloud::storage::oauth2::CreateAnonymousCredentials;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the Projects.serviceAccount-related functions in storage::Client.

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -28,11 +28,11 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::oauth2::CreateAnonymousCredentials;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -26,6 +26,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
 using ::testing::HasSubstr;
 
 constexpr char kJsonKeyfileContents[] = R"""({

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -25,9 +25,10 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::Return;
-using testing::canonical_errors::TransientError;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 
 class ObservableRetryPolicy : public LimitedErrorCountRetryPolicy {
  public:

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -26,9 +26,9 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::testing::Return;
-using ::testing::_;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
+using ::testing::Return;
 
 class ObservableRetryPolicy : public LimitedErrorCountRetryPolicy {
  public:

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -25,13 +25,13 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::PermanentError;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -24,13 +24,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using testing::canonical_errors::PermanentError;
-using testing::canonical_errors::TransientError;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -223,10 +223,10 @@ using the `.status()` member function (and trying to access the value produces
 undefined behavior).
 
 @code {.cpp}
-using namespace google::cloud;
-[](storage::Client client) {
-  StatusOr<storage::BucketMetadata> metadata = client.GetBucketMetadata(
-      "my-bucket");
+using gcs = google::cloud::storage;
+[](gcs::Client client) {
+  google::cloud::StatusOr<gcs::BucketMetadata> metadata =
+    client.GetBucketMetadata("my-bucket");
 
   if (!metadata) {
     std::cerr << "GetBucketMetadata: " << metadata.status() << "\n";
@@ -246,10 +246,10 @@ the `StatusOr<T>` object. This will return a `T` if the `StatusOr<T>` object
 contains a value, and will otherwise throw an exception.
 
 @code {.cpp}
-using namespace google::cloud;
-[](storage::Client client) {
-  storage::BucketMetadata metadata = client.GetBucketMetadata(
-        "my-bucket").value(); // throws on error
+using gcs = google::cloud::storage;
+[](gcs::Client client) {
+  gcs::BucketMetadata metadata = client.GetBucketMetadata(
+        "my-bucket").value();  // throws on error
   std::cout << "The metadata for bucket " << metadata.name()
             << " is " << metadata << "\n";
 }

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -52,7 +52,7 @@ void ListBucketAcl(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [list bucket acl] [START storage_print_bucket_acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<std::vector<gcs::BucketAccessControl>> items =
         client.ListBucketAcl(bucket_name);
@@ -80,7 +80,7 @@ void CreateBucketAcl(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [create bucket acl] [START storage_create_bucket_acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::BucketAccessControl> bucket_acl =
@@ -131,7 +131,7 @@ void GetBucketAcl(google::cloud::storage::Client client, int& argc,
   auto entity = ConsumeArg(argc, argv);
   //! [get bucket acl] [START storage_print_bucket_acl_for_user]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity) {
     StatusOr<gcs::BucketAccessControl> acl =
         client.GetBucketAcl(bucket_name, entity);
@@ -157,7 +157,7 @@ void UpdateBucketAcl(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [update bucket acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     gcs::BucketAccessControl desired_acl =
@@ -188,7 +188,7 @@ void PatchBucketAcl(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [patch bucket acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::BucketAccessControl> original_acl =
@@ -225,7 +225,7 @@ void PatchBucketAclNoRead(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [patch bucket acl no-read]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::BucketAccessControl> patched_acl = client.PatchBucketAcl(

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -52,7 +52,7 @@ void GetBucketIamPolicy(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [get bucket iam policy] [START storage_view_bucket_iam_members]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
@@ -78,7 +78,7 @@ void AddBucketIamMember(google::cloud::storage::Client client, int& argc,
   auto member = ConsumeArg(argc, argv);
   //! [add bucket iam member] [START storage_add_bucket_iam_member]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string role,
      std::string member) {
     StatusOr<google::cloud::IamPolicy> policy =
@@ -114,7 +114,7 @@ void RemoveBucketIamMember(google::cloud::storage::Client client, int& argc,
   auto member = ConsumeArg(argc, argv);
   //! [remove bucket iam member] [START storage_remove_bucket_iam_member]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string role,
      std::string member) {
     StatusOr<google::cloud::IamPolicy> policy =
@@ -153,7 +153,7 @@ void TestBucketIamPermissions(google::cloud::storage::Client client, int& argc,
   }
   //! [test bucket iam permissions]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name,
      std::vector<std::string> permissions) {
     StatusOr<std::vector<std::string>> actual_permissions =

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -51,7 +51,7 @@ void ListBuckets(google::cloud::storage::Client client, int& argc,
   }
   //! [list buckets] [START storage_list_buckets]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client) {
     int count = 0;
     gcs::ListBucketsReader bucket_list = client.ListBuckets();
@@ -107,7 +107,7 @@ void CreateBucket(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [create bucket] [START storage_create_bucket]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.CreateBucket(bucket_name, gcs::BucketMetadata());
@@ -132,7 +132,7 @@ void CreateBucketForProject(google::cloud::storage::Client client, int& argc,
   auto project_id = ConsumeArg(argc, argv);
   //! [create bucket for project]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string project_id) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.CreateBucketForProject(bucket_name, project_id,
@@ -158,7 +158,7 @@ void GetBucketMetadata(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [get bucket metadata] [START storage_get_bucket_metadata]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
@@ -204,7 +204,7 @@ void ChangeDefaultStorageClass(google::cloud::storage::Client client, int& argc,
   auto storage_class = ConsumeArg(argc, argv);
   //! [update bucket]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string storage_class) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
 
@@ -237,7 +237,7 @@ void PatchBucketStorageClass(google::cloud::storage::Client client, int& argc,
   auto storage_class = ConsumeArg(argc, argv);
   //! [patch bucket storage class] [START storage_change_default_storage_class]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string storage_class) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
@@ -274,7 +274,7 @@ void PatchBucketStorageClassWithBuilder(google::cloud::storage::Client client,
   auto storage_class = ConsumeArg(argc, argv);
   //! [patch bucket storage class with builder]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string storage_class) {
     StatusOr<gcs::BucketMetadata> patched = client.PatchBucket(
         bucket_name,
@@ -301,7 +301,7 @@ void AddBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   auto key_name = ConsumeArg(argc, argv);
   //! [add bucket kms key] [START storage_set_bucket_default_kms_key]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string key_name) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().SetEncryption(
@@ -336,7 +336,7 @@ void GetBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [get bucket default kms key] [START storage_get_bucket_default_kms_key]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
 
@@ -366,7 +366,7 @@ void RemoveBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
   //! [remove bucket default kms key]
   // [START storage_bucket_delete_default_kms_key]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetEncryption());
@@ -393,7 +393,7 @@ void AddBucketLabel(google::cloud::storage::Client client, int& argc,
   auto label_value = ConsumeArg(argc, argv);
   //! [add bucket label] [START storage_add_bucket_label]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string label_key,
      std::string label_value) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
@@ -424,7 +424,7 @@ void GetBucketLabels(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [get bucket labels] [START storage_get_bucket_labels]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name, gcs::Fields("labels"));
@@ -457,7 +457,7 @@ void RemoveBucketLabel(google::cloud::storage::Client client, int& argc,
   auto label_key = ConsumeArg(argc, argv);
   //! [remove bucket label] [START storage_remove_bucket_label]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string label_key) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetLabel(label_key));
@@ -490,7 +490,7 @@ void GetBilling(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [get billing] [START storage_get_requester_pays_status]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
@@ -529,7 +529,7 @@ void EnableRequesterPays(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [enable requester pays] [START storage_enable_requester_pays]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata = client.PatchBucket(
         bucket_name,
@@ -563,7 +563,7 @@ void DisableRequesterPays(google::cloud::storage::Client client, int& argc,
   auto project_id = ConsumeArg(argc, argv);
   //! [disable requester pays] [START storage_disable_requester_pays]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string project_id) {
     StatusOr<gcs::BucketMetadata> bucket_metadata = client.PatchBucket(
         bucket_name,
@@ -601,7 +601,7 @@ void WriteObjectRequesterPays(google::cloud::storage::Client client, int& argc,
   auto billed_project = ConsumeArg(argc, argv);
   //! [write object requester pays]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string billed_project) {
     std::string const text = "Lorem ipsum dolor sit amet";
@@ -664,7 +664,7 @@ void GetServiceAccount(google::cloud::storage::Client client, int& argc,
   }
   //! [get service account] [START storage_get_service_account]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client) {
     StatusOr<gcs::ServiceAccount> service_account_details =
         client.GetServiceAccount();
@@ -688,7 +688,7 @@ void GetServiceAccountForProject(google::cloud::storage::Client client,
   //! [get service account for project]
   // [START storage_get_service_account_for_project]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string project_id) {
     StatusOr<gcs::ServiceAccount> service_account_details =
         client.GetServiceAccountForProject(project_id);
@@ -714,7 +714,7 @@ void GetDefaultEventBasedHold(google::cloud::storage::Client client, int& argc,
   //! [get default event based hold]
   // [START storage_get_default_event_based_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
@@ -743,7 +743,7 @@ void EnableDefaultEventBasedHold(google::cloud::storage::Client client,
   //! [enable default event based hold]
   // [START storage_enable_default_event_based_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
@@ -781,7 +781,7 @@ void DisableDefaultEventBasedHold(google::cloud::storage::Client client,
   //! [disable default event based hold]
   // [START storage_disable_default_event_based_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
@@ -819,7 +819,7 @@ void GetRetentionPolicy(google::cloud::storage::Client client, int& argc,
   //! [get retention policy]
   // [START storage_get_retention_policy]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
@@ -853,7 +853,7 @@ void SetRetentionPolicy(google::cloud::storage::Client client, int& argc,
   //! [set retention policy]
   // [START storage_set_retention_policy]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::chrono::seconds period) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
@@ -895,7 +895,7 @@ void RemoveRetentionPolicy(google::cloud::storage::Client client, int& argc,
   //! [remove retention policy]
   // [START storage_remove_retention_policy]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
@@ -938,7 +938,7 @@ void LockRetentionPolicy(google::cloud::storage::Client client, int& argc,
   //! [lock retention policy]
   // [START storage_lock_retention_policy]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -52,7 +52,7 @@ void ListDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [list default object acl] [START storage_print_bucket_default_acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<std::vector<gcs::ObjectAccessControl>> items =
         client.ListDefaultObjectAcl(bucket_name);
@@ -80,7 +80,7 @@ void CreateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [create default object acl] [START storage_add_default_owner]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> default_object_acl =
@@ -133,7 +133,7 @@ void GetDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   auto entity = ConsumeArg(argc, argv);
   //! [get default object acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity) {
     StatusOr<gcs::ObjectAccessControl> acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
@@ -159,7 +159,7 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [update default object acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
@@ -196,7 +196,7 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client, int& argc,
   auto role = ConsumeArg(argc, argv);
   //! [patch default object acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
@@ -236,7 +236,7 @@ void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
   auto role = ConsumeArg(argc, argv);
   //! [patch default object acl no-read]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string entity,
      std::string role) {
     StatusOr<gcs::ObjectAccessControl> patched_acl =

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -52,7 +52,7 @@ void ListNotifications(google::cloud::storage::Client client, int& argc,
   auto bucket_name = ConsumeArg(argc, argv);
   //! [list notifications] [START storage_list_bucket_notifications]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
     StatusOr<std::vector<gcs::NotificationMetadata>> items =
         client.ListNotifications(bucket_name);
@@ -79,7 +79,7 @@ void CreateNotification(google::cloud::storage::Client client, int& argc,
   auto topic_name = ConsumeArg(argc, argv);
   //! [create notification] [START storage_create_bucket_notifications]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string topic_name) {
     StatusOr<gcs::NotificationMetadata> notification =
         client.CreateNotification(bucket_name, topic_name,
@@ -116,7 +116,7 @@ void GetNotification(google::cloud::storage::Client client, int& argc,
   auto notification_id = ConsumeArg(argc, argv);
   //! [get notification] [START storage_print_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string notification_id) {
     StatusOr<gcs::NotificationMetadata> notification =
         client.GetNotification(bucket_name, notification_id);

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -54,7 +54,7 @@ void ListObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto object_name = ConsumeArg(argc, argv);
   //! [list object acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<std::vector<gcs::ObjectAccessControl>> items =
         client.ListObjectAcl(bucket_name, object_name);
@@ -84,7 +84,7 @@ void CreateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [create object acl] [START storage_create_file_acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> object_acl =
@@ -136,7 +136,7 @@ void GetObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto entity = ConsumeArg(argc, argv);
   //! [get object acl] [START storage_print_file_acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity) {
     StatusOr<gcs::ObjectAccessControl> acl =
@@ -165,7 +165,7 @@ void UpdateObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [update object acl] [START storage_update_file_acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> current_acl =
@@ -202,7 +202,7 @@ void PatchObjectAcl(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [patch object acl]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
@@ -241,7 +241,7 @@ void PatchObjectAclNoRead(gcs::Client client, int& argc, char* argv[]) {
   auto role = ConsumeArg(argc, argv);
   //! [patch object acl no-read]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string entity, std::string role) {
     StatusOr<gcs::ObjectAccessControl> patched_acl = client.PatchObjectAcl(

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -80,7 +80,7 @@ void InsertObject(google::cloud::storage::Client client, int& argc,
   auto contents = ConsumeArg(argc, argv);
   //! [insert object]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string contents) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
@@ -110,7 +110,7 @@ void InsertObjectStrictIdempotency(google::cloud::storage::Client unused,
   auto contents = ConsumeArg(argc, argv);
   //! [insert object strict idempotency]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](std::string bucket_name, std::string object_name, std::string contents) {
     // Create a client that only retries idempotent operations, the default is
     // to retry all operations.
@@ -150,7 +150,7 @@ void InsertObjectModifiedRetry(google::cloud::storage::Client unused, int& argc,
   auto contents = ConsumeArg(argc, argv);
   //! [insert object modified retry]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](std::string bucket_name, std::string object_name, std::string contents) {
     // Create a client that only gives up on the third error. The default policy
     // is to retry for several minutes.
@@ -192,7 +192,7 @@ void InsertObjectMultipart(google::cloud::storage::Client client, int& argc,
   auto contents = ConsumeArg(argc, argv);
   //! [insert object multipart]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string content_type, std::string contents) {
     // Setting the object metadata (via the `gcs::WithObjectMadata` option)
@@ -230,7 +230,7 @@ void CopyObject(google::cloud::storage::Client client, int& argc,
   auto destination_object_name = ConsumeArg(argc, argv);
   //! [copy object] [START storage_copy_file]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name) {
@@ -268,7 +268,7 @@ void CopyEncryptedObject(google::cloud::storage::Client client, int& argc,
   auto key = ConsumeArg(argc, argv);
   //! [copy encrypted object]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name, std::string key_base64) {
@@ -300,7 +300,7 @@ void GetObjectMetadata(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [get object metadata] [START storage_get_metadata]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.GetObjectMetadata(bucket_name, object_name);
@@ -406,7 +406,7 @@ void WriteObject(google::cloud::storage::Client client, int& argc,
 
   //! [write object]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      long desired_line_count) {
     std::string const text = "Lorem ipsum dolor sit amet";
@@ -511,7 +511,7 @@ void ResumeResumableUpload(google::cloud::storage::Client client, int& argc,
 
   //! [resume resumable upload]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string session_id) {
     // Restore a resumable upload stream, the library automatically queries the
@@ -559,7 +559,7 @@ void UploadFile(google::cloud::storage::Client client, int& argc,
 
   //! [upload file] [START storage_upload_file]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string file_name, std::string bucket_name,
      std::string object_name) {
     // Note that the client library automatically computes a hash on the
@@ -592,7 +592,7 @@ void UploadFileResumable(google::cloud::storage::Client client, int& argc,
 
   //! [upload file resumable]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string file_name, std::string bucket_name,
      std::string object_name) {
     // Note that the client library automatically computes a hash on the
@@ -652,7 +652,7 @@ void UpdateObjectMetadata(google::cloud::storage::Client client, int& argc,
   auto value = ConsumeArg(argc, argv);
   //! [update object metadata] [START storage_set_metadata]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string key, std::string value) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
@@ -690,7 +690,7 @@ void PatchObjectDeleteMetadata(google::cloud::storage::Client client, int& argc,
   auto key = ConsumeArg(argc, argv);
   //! [patch object delete metadata]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string key) {
     StatusOr<gcs::ObjectMetadata> original =
@@ -728,7 +728,7 @@ void PatchObjectContentType(google::cloud::storage::Client client, int& argc,
   auto content_type = ConsumeArg(argc, argv);
   //! [patch object content type]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string content_type) {
     StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
@@ -755,7 +755,7 @@ void MakeObjectPublic(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [make object public] [START storage_make_public]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
@@ -856,7 +856,7 @@ void WriteEncryptedObject(google::cloud::storage::Client client, int& argc,
   auto base64_aes256_key = ConsumeArg(argc, argv);
   //! [insert encrypted object] [START storage_upload_encrypted_file]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string base64_aes256_key) {
     StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
@@ -915,7 +915,7 @@ void ComposeObject(google::cloud::storage::Client client, int& argc,
   }
   //! [compose object] [START storage_compose_file]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name,
      std::string destination_object_name,
      std::vector<gcs::ComposeSourceObject> compose_objects) {
@@ -952,7 +952,7 @@ void ComposeObjectFromEncryptedObjects(google::cloud::storage::Client client,
   }
   //! [compose object from encrypted objects]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name,
      std::string destination_object_name, std::string base64_aes256_key,
      std::vector<gcs::ComposeSourceObject> compose_objects) {
@@ -986,7 +986,7 @@ void WriteObjectWithKmsKey(google::cloud::storage::Client client, int& argc,
 
   //! [write object with kms key] [START storage_upload_with_kms_key]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string kms_key_name) {
     gcs::ObjectWriteStream stream = client.WriteObject(
@@ -1026,7 +1026,7 @@ void RewriteObject(google::cloud::storage::Client client, int& argc,
   auto destination_object_name = ConsumeArg(argc, argv);
   //! [rewrite object]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name) {
@@ -1060,7 +1060,7 @@ void RewriteObjectNonBlocking(google::cloud::storage::Client client, int& argc,
   auto destination_object_name = ConsumeArg(argc, argv);
   //! [rewrite object non blocking]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name) {
@@ -1106,7 +1106,7 @@ void RewriteObjectToken(google::cloud::storage::Client client, int& argc,
 
   //! [rewrite object token]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name) {
@@ -1147,7 +1147,7 @@ void RewriteObjectResume(google::cloud::storage::Client client, int& argc,
 
   //! [rewrite object resume]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string source_bucket_name,
      std::string source_object_name, std::string destination_bucket_name,
      std::string destination_object_name, std::string rewrite_token) {
@@ -1194,7 +1194,7 @@ void RotateEncryptionKey(google::cloud::storage::Client client, int& argc,
 
   //! [rotate encryption key] [START storage_rotate_encryption_key]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name,
      std::string old_key_base64, std::string new_key_base64) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
@@ -1227,7 +1227,7 @@ void RenameObject(google::cloud::storage::Client client, int& argc,
 
   //! [rename object] [START storage_move_file]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string old_object_name,
      std::string new_object_name) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
@@ -1261,7 +1261,7 @@ void SetObjectEventBasedHold(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [set event based hold] [START storage_set_event_based_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
@@ -1296,7 +1296,7 @@ void ReleaseObjectEventBasedHold(google::cloud::storage::Client client,
   auto object_name = ConsumeArg(argc, argv);
   //! [release event based hold] [START storage_release_event_based_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
@@ -1331,7 +1331,7 @@ void SetObjectTemporaryHold(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [set temporary hold] [START storage_set_temporary_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
@@ -1366,7 +1366,7 @@ void ReleaseObjectTemporaryHold(google::cloud::storage::Client client,
   auto object_name = ConsumeArg(argc, argv);
   //! [release temporary hold] [START storage_release_temporary_hold]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
@@ -1401,7 +1401,7 @@ void CreateGetSignedUrl(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [sign url] [START storage_generate_signed_url]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<std::string> signed_url = client.CreateV2SignedUrl(
         "GET", std::move(bucket_name), std::move(object_name),
@@ -1429,7 +1429,7 @@ void CreatePutSignedUrl(google::cloud::storage::Client client, int& argc,
   auto object_name = ConsumeArg(argc, argv);
   //! [create put signed url]
   namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
+  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     StatusOr<std::string> signed_url = client.CreateV2SignedUrl(
         "PUT", std::move(bucket_name), std::move(object_name),

--- a/google/cloud/storage/internal/bucket_acl_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests_test.cc
@@ -21,6 +21,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 TEST(BucketAclRequestTest, List) {

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -233,7 +233,7 @@ StatusOr<BucketMetadata> BucketMetadataParser::FromString(
 }
 
 std::string BucketMetadataToJsonString(BucketMetadata const& meta) {
-  using internal::nl::json;
+  using ::google::cloud::storage::internal::nl::json;
   json metadata_as_json;
   if (!meta.acl().empty()) {
     for (BucketAccessControl const& a : meta.acl()) {

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -23,6 +23,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Not;

--- a/google/cloud/storage/internal/compute_engine_util_test.cc
+++ b/google/cloud/storage/internal/compute_engine_util_test.cc
@@ -23,6 +23,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::google::cloud::internal::SetEnv;
 using ::google::cloud::internal::UnsetEnv;
 using ::google::cloud::testing_util::EnvironmentVariableRestore;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -30,6 +30,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::google::cloud::storage::oauth2::Credentials;
 using ::testing::HasSubstr;
 

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -22,7 +22,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using google::cloud::storage::internal::BinaryDataAsDebugString;
+
+using ::google::cloud::storage::internal::BinaryDataAsDebugString;
 
 std::size_t const MAX_DATA_DEBUG_SIZE = 48;
 

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -25,8 +25,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 class MockCurlClient : public CurlClient {
  public:

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -24,8 +24,9 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using ::testing::_;
+
 using ::testing::Invoke;
+using ::testing::_;
 
 class MockCurlClient : public CurlClient {
  public:

--- a/google/cloud/storage/internal/default_object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests_test.cc
@@ -23,6 +23,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 TEST(DefaultObjectAclRequestTest, List) {

--- a/google/cloud/storage/internal/format_rfc3339_test.cc
+++ b/google/cloud/storage/internal/format_rfc3339_test.cc
@@ -22,6 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 TEST(FormatRfc3339Test, NoFractional) {

--- a/google/cloud/storage/internal/generate_message_boundary_test.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_test.cc
@@ -22,6 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 using ::testing::Not;
 

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -25,6 +25,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 // These values were obtained using:

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -21,7 +21,9 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
+
 TEST(HttpResponseTest, OStream) {
   HttpResponse response{
       404, "some-payload", {{"header1", "value1"}, {"header2", "value2"}}};

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -25,7 +25,9 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
 namespace {
-using raw_client_wrapper_utils::CheckSignature;
+
+using ::google::cloud::storage::internal::raw_client_wrapper_utils::CheckSignature;
+
 /**
  * Logs the input and results of each `RawClient` operation.
  *

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -26,7 +26,8 @@ namespace internal {
 
 namespace {
 
-using ::google::cloud::storage::internal::raw_client_wrapper_utils::CheckSignature;
+using ::google::cloud::storage::internal::raw_client_wrapper_utils::
+    CheckSignature;
 
 /**
  * Logs the input and results of each `RawClient` operation.

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -24,11 +24,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
+
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::_;
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -26,10 +26,10 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
-using ::testing::_;
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -25,11 +25,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::google::cloud::testing_util::CaptureLogLinesBackend;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::_;
 
 class LoggingResumableUploadSessionTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -27,10 +27,10 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::CaptureLogLinesBackend;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
-using ::testing::_;
 
 class LoggingResumableUploadSessionTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/internal/notification_requests_test.cc
+++ b/google/cloud/storage/internal/notification_requests_test.cc
@@ -23,6 +23,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 /// @test Verify that we parse JSON objects into NotificationMetadata objects.

--- a/google/cloud/storage/internal/object_acl_requests_test.cc
+++ b/google/cloud/storage/internal/object_acl_requests_test.cc
@@ -22,6 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 /// @test Verify that we parse JSON objects into ObjectAccessControl objects.

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -104,7 +104,7 @@ StatusOr<ObjectMetadata> ObjectMetadataParser::FromString(
 }
 
 internal::nl::json ObjectMetadataJsonForUpdate(ObjectMetadata const& meta) {
-  using internal::nl::json;
+  using ::google::cloud::storage::internal::nl::json;
   json metadata_as_json;
   if (!meta.acl().empty()) {
     for (ObjectAccessControl const& a : meta.acl()) {
@@ -142,7 +142,7 @@ std::string ObjectMetadataJsonPayloadForUpdate(ObjectMetadata const& meta) {
 
 internal::nl::json ObjectMetadataJsonPayloadForCompose(
     ObjectMetadata const& meta) {
-  using internal::nl::json;
+  using ::google::cloud::storage::internal::nl::json;
   json metadata_as_json;
   if (!meta.acl().empty()) {
     for (ObjectAccessControl const& a : meta.acl()) {
@@ -345,7 +345,7 @@ ComposeObjectRequest::ComposeObjectRequest(
       source_objects_(std::move(source_objects)) {}
 
 std::string ComposeObjectRequest::JsonPayload() const {
-  using internal::nl::json;
+  using ::google::cloud::storage::internal::nl::json;
   json compose_object_payload_json;
   compose_object_payload_json["kind"] = "storage#composeRequest";
   json destination_metadata_payload;

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -22,6 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 TEST(ObjectRequestsTest, ParseFailure) {

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -71,7 +71,7 @@ struct OpenSslUtils {
   static std::string SignStringWithPem(
       std::string const& str, std::string const& pem_contents,
       storage::oauth2::JwtSigningAlgorithms alg) {
-    using storage::oauth2::JwtSigningAlgorithms;
+    using ::google::cloud::storage::oauth2::JwtSigningAlgorithms;
 
     // We check for failures several times, so we shorten this into a lambda
     // to avoid bloating the code with alloc/init checks.

--- a/google/cloud/storage/internal/parse_rfc3339_test.cc
+++ b/google/cloud/storage/internal/parse_rfc3339_test.cc
@@ -22,6 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::std::chrono::duration_cast;
 using ::std::chrono::milliseconds;
 using ::std::chrono::nanoseconds;

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -45,7 +45,9 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using raw_client_wrapper_utils::CheckSignature;
+
+using ::google::cloud::storage::internal::raw_client_wrapper_utils::
+    CheckSignature;
 
 /**
  * Calls a client operation with retries borrowing the RPC policies.

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -24,12 +24,13 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using ::testing::_;
+
+using ::google::cloud::testing_util::chrono_literals::operator""_us;
 using ::testing::HasSubstr;
 using ::testing::Return;
-using testing::canonical_errors::PermanentError;
-using testing::canonical_errors::TransientError;
-using namespace testing_util::chrono_literals;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 
 class RetryClientTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -26,11 +26,11 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::chrono_literals::operator""_us;
-using ::testing::HasSubstr;
-using ::testing::Return;
-using ::testing::_;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
+using ::testing::HasSubstr;
+using ::testing::Return;
 
 class RetryClientTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -25,7 +25,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator""_us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -30,10 +30,10 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::chrono_literals::operator""_ms;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
-using ::testing::_;
 
 class RetryResumableUploadSessionTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::google::cloud::testing_util::chrono_literals::operator""_ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -26,13 +26,14 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using ::testing::_;
+
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::google::cloud::testing_util::chrono_literals::operator""_ms;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
-using namespace testing_util::chrono_literals;
-using storage::testing::canonical_errors::PermanentError;
-using storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 
 class RetryResumableUploadSessionTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/internal/service_account_requests_test.cc
+++ b/google/cloud/storage/internal/service_account_requests_test.cc
@@ -21,6 +21,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 TEST(ServiceAccountRequests, Get) {

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -22,6 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 TEST(SignedUrlRequests, Sign) {

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -23,16 +23,15 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 using ::google::cloud::storage::internal::ListBucketsRequest;
 using ::google::cloud::storage::internal::ListBucketsResponse;
 using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::ContainerEq;
 using ::testing::Invoke;
 using ::testing::Return;
-using ::testing::_;
 
 namespace {
 BucketMetadata CreateElement(int index) {

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -23,6 +23,8 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace {
+
 using ::google::cloud::storage::internal::ListBucketsRequest;
 using ::google::cloud::storage::internal::ListBucketsResponse;
 using ::google::cloud::storage::testing::MockClient;
@@ -33,7 +35,6 @@ using ::testing::ContainerEq;
 using ::testing::Invoke;
 using ::testing::Return;
 
-namespace {
 BucketMetadata CreateElement(int index) {
   std::string id = "bucket-" + std::to_string(index);
   std::string name = id;

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -23,15 +23,17 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-using internal::ListBucketsRequest;
-using internal::ListBucketsResponse;
-using ::testing::_;
+
+using ::google::cloud::storage::internal::ListBucketsRequest;
+using ::google::cloud::storage::internal::ListBucketsResponse;
+using ::google::cloud::storage::testing::MockClient;
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::ContainerEq;
 using ::testing::Invoke;
-using testing::MockClient;
 using ::testing::Return;
-using testing::canonical_errors::PermanentError;
-using testing::canonical_errors::TransientError;
+using ::testing::_;
+
 namespace {
 BucketMetadata CreateElement(int index) {
   std::string id = "bucket-" + std::to_string(index);

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -30,11 +30,11 @@ using ::google::cloud::storage::internal::ListObjectsRequest;
 using ::google::cloud::storage::internal::ListObjectsResponse;
 using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::testing::_;
 using ::testing::ContainerEq;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
-using ::testing::_;
 
 ObjectMetadata CreateElement(int index) {
   std::string id = "object-" + std::to_string(index);

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -25,15 +25,16 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 namespace nl = internal::nl;
-using internal::ListObjectsRequest;
-using internal::ListObjectsResponse;
-using storage::testing::MockClient;
-using storage::testing::canonical_errors::PermanentError;
-using ::testing::_;
+
+using ::google::cloud::storage::internal::ListObjectsRequest;
+using ::google::cloud::storage::internal::ListObjectsResponse;
+using ::google::cloud::storage::testing::MockClient;
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::testing::ContainerEq;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::_;
 
 ObjectMetadata CreateElement(int index) {
   std::string id = "object-" + std::to_string(index);

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -24,7 +24,6 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-namespace nl = internal::nl;
 
 using ::google::cloud::storage::internal::ListObjectsRequest;
 using ::google::cloud::storage::internal::ListObjectsResponse;

--- a/google/cloud/storage/notification_metadata_test.cc
+++ b/google/cloud/storage/notification_metadata_test.cc
@@ -23,6 +23,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
 using ::testing::HasSubstr;
 
 NotificationMetadata CreateNotificationMetadataForTest() {

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -27,15 +27,16 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 namespace {
+
 using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
-using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
+using ::testing::_;
 
 class AuthorizedUserCredentialsTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -31,12 +31,12 @@ namespace {
 using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
+using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
-using ::testing::_;
 
 class AuthorizedUserCredentialsTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -28,17 +28,18 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 namespace {
+
 using ::google::cloud::storage::internal::GceMetadataHostname;
 using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
-using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::UnorderedElementsAre;
+using ::testing::_;
 
 class ComputeEngineCredentialsTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -33,13 +33,13 @@ using ::google::cloud::storage::internal::GceMetadataHostname;
 using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
+using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::UnorderedElementsAre;
-using ::testing::_;
 
 class ComputeEngineCredentialsTest : public ::testing::Test {
  protected:

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file_test.cc
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file_test.cc
@@ -23,6 +23,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 namespace {
+
 using ::google::cloud::internal::SetEnv;
 using ::google::cloud::internal::UnsetEnv;
 using ::google::cloud::testing_util::EnvironmentVariableRestore;

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -32,6 +32,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 namespace {
+
 using ::google::cloud::internal::SetEnv;
 using ::google::cloud::internal::UnsetEnv;
 using ::google::cloud::storage::internal::GceCheckOverrideEnvVar;

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -121,7 +121,7 @@ class ServiceAccountCredentials : public Credentials {
    *   credentials.
    */
   std::pair<Status, std::string> SignString(std::string const& text) const {
-    using storage::internal::OpenSslUtils;
+    using ::google::cloud::storage::internal::OpenSslUtils;
     return std::make_pair(
         Status(), OpenSslUtils::Base64Encode(OpenSslUtils::SignStringWithPem(
                       text, info_.private_key, JwtSigningAlgorithms::RS256)));
@@ -189,7 +189,7 @@ class ServiceAccountCredentials : public Credentials {
   std::string MakeJWTAssertion(storage::internal::nl::json const& header,
                                storage::internal::nl::json const& payload,
                                std::string const& pem_contents) {
-    using storage::internal::OpenSslUtils;
+    using ::google::cloud::storage::internal::OpenSslUtils;
     std::string encoded_header =
         OpenSslUtils::UrlsafeBase64Encode(header.dump());
     std::string encoded_payload =

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -32,12 +32,12 @@ namespace {
 using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
+using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
-using ::testing::_;
 
 constexpr char kAltScopeForTest[] =
     "https://www.googleapis.com/auth/devstorage.full_control";

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -28,15 +28,16 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 namespace {
+
 using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
-using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
+using ::testing::_;
 
 constexpr char kAltScopeForTest[] =
     "https://www.googleapis.com/auth/devstorage.full_control";

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -27,12 +27,12 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
-using ::testing::_;
-using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
 
 /**

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -26,13 +26,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::_;
+
 using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::_;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ms = std::chrono::milliseconds;
-using testing::canonical_errors::TransientError;
 
 /**
  * Test the functions in Storage::Client related to 'Objects: *'.

--- a/google/cloud/storage/service_account_test.cc
+++ b/google/cloud/storage/service_account_test.cc
@@ -20,6 +20,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
 using ::testing::HasSubstr;
 
 ServiceAccount CreateServiceAccountForTest() {

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -20,7 +20,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::StartsWith;

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -20,6 +20,8 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace {
+
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::StartsWith;
@@ -58,6 +60,7 @@ TEST(StorageVersionTest, HasBuildInfoInDevelopment) {
               HasSubstr("+" + google::cloud::internal::gitrev()));
 }
 
+}  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -20,6 +20,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::StartsWith;

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -54,7 +54,7 @@ void TooManyFailuresTest(
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<void(Client& client)> const& tested_operation,
     char const* api_name) {
-  using canonical_errors::TransientError;
+  using ::google::cloud::storage::testing::canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with a simple to test policy.
@@ -120,7 +120,7 @@ void NonIdempotentFailuresTest(
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<void(Client& client)> const& tested_operation,
     char const* api_name, bool has_will_repeatedly = false) {
-  using canonical_errors::TransientError;
+  using ::google::cloud::storage::testing::canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with the strict idempotency policy, but with a generous
@@ -187,7 +187,7 @@ void IdempotentFailuresTest(
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<void(Client& client)> const& tested_operation,
     char const* api_name, bool has_will_repeatedly = true) {
-  using canonical_errors::TransientError;
+  using ::google::cloud::storage::testing::canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with the strict idempotency policy, but with a generous
@@ -288,7 +288,7 @@ void PermanentFailureTest(Client& client,
                           ::testing::internal::TypedExpectation<F>& oncall,
                           std::function<void(Client& client)> tested_operation,
                           char const* api_name) {
-  using canonical_errors::PermanentError;
+  using ::google::cloud::storage::testing::canonical_errors::PermanentError;
   using ::testing::HasSubstr;
   using ::testing::Return;
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -343,7 +343,7 @@ void TooManyFailuresStatusTest(
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<Status(Client& client)> const& tested_operation,
     char const* api_name) {
-  using canonical_errors::TransientError;
+  using ::google::cloud::storage::testing::canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with a simple to test policy.
@@ -391,7 +391,7 @@ void NonIdempotentFailuresStatusTest(
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<Status(Client& client)> const& tested_operation,
     char const* api_name) {
-  using canonical_errors::TransientError;
+  using ::google::cloud::storage::testing::canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with the strict idempotency policy, but with a generous
@@ -439,7 +439,7 @@ void IdempotentFailuresStatusTest(
     ::testing::internal::TypedExpectation<F>& oncall,
     std::function<Status(Client& client)> const& tested_operation,
     char const* api_name) {
-  using canonical_errors::TransientError;
+  using ::google::cloud::storage::testing::canonical_errors::TransientError;
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with the strict idempotency policy, and with an
@@ -525,7 +525,7 @@ void PermanentFailureStatusTest(
     Client& client, ::testing::internal::TypedExpectation<F>& oncall,
     std::function<Status(Client& client)> tested_operation,
     char const* api_name) {
-  using canonical_errors::PermanentError;
+  using ::google::cloud::storage::testing::canonical_errors::PermanentError;
   using ::testing::HasSubstr;
   using ::testing::Return;
 

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -24,7 +24,8 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -25,6 +25,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+
 using ::testing::HasSubstr;
 
 namespace {

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -25,15 +25,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+namespace {
 
 using ::testing::HasSubstr;
 
-namespace {
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
       .value_or("https://nghttp2.org/httpbin");
 }
-}  // namespace
 
 TEST(CurlDownloadRequestTest, SimpleStream) {
   // httpbin can generate up to 100 lines, do not try to download more than
@@ -76,6 +75,7 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
   EXPECT_EQ(kDownloadedLines, count);
 }
 
+}  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -27,7 +27,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
-using testing::HasSubstr;
+
+using ::testing::HasSubstr;
 
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
@@ -368,8 +369,8 @@ TEST(CurlRequestTest, Logging) {
   auto mock_logger = std::make_shared<MockLogBackend>();
   google::cloud::LogSink::Instance().AddBackend(mock_logger);
 
-  using testing::_;
-  using testing::Invoke;
+  using ::testing::_;
+  using ::testing::Invoke;
 
   std::string log_messages;
   EXPECT_CALL(*mock_logger, ProcessWithOwnership(_))

--- a/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_streambuf_integration_test.cc
@@ -27,6 +27,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 class ResumableStreambufTestEnvironment : public ::testing::Environment {

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -24,6 +24,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
+
 using ::testing::HasSubstr;
 
 class ResumableUploadTestEnvironment : public ::testing::Environment {

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -26,6 +26,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
 using ::testing::HasSubstr;
 
 std::string HttpBinEndpoint() {

--- a/google/cloud/storage/tests/curl_upload_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_upload_request_integration_test.cc
@@ -22,8 +22,6 @@
 #include <cstdlib>
 #include <vector>
 
-using ::testing::HasSubstr;
-
 namespace google {
 namespace cloud {
 namespace storage {

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -26,8 +26,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::CountMatchingEntities;
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -28,8 +28,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::CountMatchingEntities;
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -26,8 +26,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::CountMatchingEntities;
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -27,8 +27,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::CountMatchingEntities;
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -31,8 +31,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::CountMatchingEntities;
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -24,7 +24,8 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -27,8 +27,9 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using google::cloud::storage::testing::CountMatchingEntities;
-using google::cloud::storage::testing::TestPermanentFailure;
+
+using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -22,6 +22,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
 using ::testing::HasSubstr;
 
 /// Store the project and instance captured from the command-line arguments.

--- a/google/cloud/storage/well_known_headers_test.cc
+++ b/google/cloud/storage/well_known_headers_test.cc
@@ -20,6 +20,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
 using ::testing::HasSubstr;
 
 /// @test Verify that CustomHeader works as expected.


### PR DESCRIPTION
This is a cleanup. It changes all using declarations within "google/cloud/storage" to be fully qualified. It also replaces the few uses of using *directives* with using declarations instead. See the Abseil Tips below for rationale for these changes.

I changed one `.dox` file, and I have not tested it yet, but I expect the travis builds will test this change.

Other minor stylistic changes:

* Using declarations are (almost) always placed within an anonymous namespace so as to not introduce new symbols into another namespace.
* Put a blank line after the opening of the anonymous namespace and before the first using declaration. This was done for two nit reasons: (1) the blank is symmetric w/ the blank line before the closing of the namespace at the bottom of the file, and (2) my standard vi configs made this formatting change automatically :-D Sorry.


Related:

* https://abseil.io/tips/119
* https://abseil.io/tips/153

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2028)
<!-- Reviewable:end -->
