### PR TITLE
Enable OpenSSL when compiling libcurl as external.

### DIFF
--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -69,6 +69,7 @@ if (NOT TARGET curl_project)
                    # a version of libcurl with other protocols enabled they
                    # can select it using GOOGLE_CLOUD_CPP_CURL_PROVIDER=package.
                    -DHTTP_ONLY=ON
+                   -DCMAKE_ENABLE_OPENSSL=ON
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}


### PR DESCRIPTION
We disabled most protocols when compiling libcurl as an external project
because they often require additional libraries and managing that was
becoming difficult. But I got overenthusiastic and I removed OpenSSL
too. With local integration tests that is not a problem (we do not use
HTTPS in that case), but failed with production tests. *And* our
CI builds do not use external projects when running against production.

This fixes the immediate problem. A future PR will need to fix the
testing gap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2029)
<!-- Reviewable:end -->
