### PR TITLE
Fix flake on request-pay examples.

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -101,11 +101,10 @@ run_all_requester_pays_examples() {
       "${bucket_name}" "${object_name}" "${PROJECT_ID}"
   run_example ./storage_bucket_samples read-object-requester-pays \
       "${bucket_name}" "${object_name}" "${PROJECT_ID}"
+  run_example ./storage_bucket_samples delete-object-requester-pays \
+      "${bucket_name}" "${object_name}" "${PROJECT_ID}"
   run_example ./storage_bucket_samples disable-requester-pays \
       "${bucket_name}" "${PROJECT_ID}"
-
-  run_example ./storage_object_samples delete-object \
-      "${bucket_name}" "${object_name}"
   run_example ./storage_bucket_samples delete-bucket "${bucket_name}"
 }
 
@@ -901,7 +900,12 @@ run_quickstart() {
 ################################################
 # Run all the examples.
 # Globals:
+#   PROJECT_ID: the id of a GCP project, do not use a project number.
 #   BUCKET_NAME: the name of the bucket to use in the examples.
+#   DESTINATION_BUCKET_NAME: a different bucket to test object rewrites
+#   TOPIC_NAME: a Cloud Pub/Sub topic configured to receive notifications
+#       from GCS.
+#   STORAGE_CMEK_KEY: a Cloud KMS key name.
 #   COLOR_*: colorize output messages, defined in colors.sh
 #   EXIT_STATUS: control the final exit status for the program.
 # Arguments:

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -657,6 +657,30 @@ void ReadObjectRequesterPays(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, object_name, billed_project);
 }
 
+void DeleteObjectRequesterPays(google::cloud::storage::Client client, int& argc,
+                               char* argv[]) {
+  if (argc != 4) {
+    throw Usage{
+        "delete-object-requester-pays <bucket-name> <object-name>"
+        " <billed-project>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  auto object_name = ConsumeArg(argc, argv);
+  auto billed_project = ConsumeArg(argc, argv);
+  //! [delete object requester pays]
+  namespace gcs = google::cloud::storage;
+  [](gcs::Client client, std::string bucket_name, std::string object_name,
+     std::string billed_project) {
+    google::cloud::Status status = client.DeleteObject(
+        bucket_name, object_name, gcs::UserProject(billed_project));
+    if (!status.ok()) {
+      throw std::runtime_error(status.message());
+    }
+  }
+  //! [read object requester pays]
+  (std::move(client), bucket_name, object_name, billed_project);
+}
+
 void GetServiceAccount(google::cloud::storage::Client client, int& argc,
                        char* argv[]) {
   if (argc != 1) {
@@ -1011,6 +1035,7 @@ int main(int argc, char* argv[]) try {
       {"disable-requester-pays", &DisableRequesterPays},
       {"write-object-requester-pays", &WriteObjectRequesterPays},
       {"read-object-requester-pays", &ReadObjectRequesterPays},
+      {"delete-object-requester-pays", &DeleteObjectRequesterPays},
       {"get-service-account", &GetServiceAccount},
       {"get-service-account-for-project", &GetServiceAccountForProject},
       {"get-default-event-based-hold", &GetDefaultEventBasedHold},


### PR DESCRIPTION
Changing the billing configuration of a bucket is an atomic operation,
but the propagation of this change to the objects in a bucket is not. We
need to delete the object using the requester-pays feature to avoid
races.

This fixes #2024.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2030)
<!-- Reviewable:end -->
