### PR TITLE
removed 'move' tests

### DIFF
--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -36,20 +36,6 @@ TEST(MutationsTest, SetCell) {
   EXPECT_EQ("v", server_set.op.set_cell().value());
   EXPECT_EQ(bigtable::ServerSetTimestamp(),
             server_set.op.set_cell().timestamp_micros());
-
-  std::string fam("fam2"), col("col2");
-  // We want to make sure the strings are efficiently moved.  The C++ library
-  // often implements the "small string optimization", where the memory
-  // allocation costs are traded off for extra copies.  Use a large string to
-  // work around that optimization and test the move behavior.
-  std::string val(1000000, 'a');
-  auto val_data = val.data();
-  auto moved = bigtable::SetCell(std::move(fam), std::move(col), 2345_ms,
-                                 std::move(val));
-  ASSERT_TRUE(moved.op.has_set_cell());
-  EXPECT_EQ("fam2", moved.op.set_cell().family_name());
-  EXPECT_EQ("col2", moved.op.set_cell().column_qualifier());
-  EXPECT_EQ(val_data, moved.op.set_cell().value().data());
 }
 
 TEST(MutationsTest, SetCellNumericValue) {


### PR DESCRIPTION
Testing move semantics is very difficult and usually requires depending on at least some unspecified behavior of the given type. For this reason, I think move tests are often omitted. In general, I'm happy to keep these tests if they give us more confidence in our code. However, in the two cases here, these move tests rely on the specific type of the protobuf fields being `std::string` and having a `.data()` member function. This causes problem for protocol buffers that use a field type that's not std::string. Therefore, I don't think these two particular move-tests are worth keeping... but if others feel differently, I could be convinced otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2031)
<!-- Reviewable:end -->
