### PR TITLE
Support additional build types.

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -25,7 +25,7 @@ if [[ "${BUILD_NAME+x}" != "x" ]]; then
  echo "The BUILD_NAME is not defined or is empty. Fix the Kokoro .cfg file."
  exit 1
 elif [[ "${BUILD_NAME}" = "asan" ]]; then
-  # Compiule with the AddressSanitizer enabled.
+  # Compile with the AddressSanitizer enabled.
   export BUILD_TYPE=Debug
   export CC=clang
   export CXX=clang++

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -25,21 +25,54 @@ if [[ "${BUILD_NAME+x}" != "x" ]]; then
  echo "The BUILD_NAME is not defined or is empty. Fix the Kokoro .cfg file."
  exit 1
 elif [[ "${BUILD_NAME}" = "asan" ]]; then
+  # Compiule with the AddressSanitizer enabled.
   export BUILD_TYPE=Debug
   export CC=clang
   export CXX=clang++
   export CMAKE_FLAGS="-DSANITIZE_ADDRESS=yes"
 elif [[ "${BUILD_NAME}" = "centos-7" ]]; then
+ # Compile under centos:7. This distro uses gcc-4.8.
  export DISTRO=centos
  export DISTRO_VERSION=7
 elif [[ "${BUILD_NAME}" = "noex" ]]; then
+ # Compile with -fno-exceptions
  export DISTRO_VERSION=16.04
  export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
+  # Compile with the UndefinedBehaviorSanitizer enabled.
   export BUILD_TYPE=Debug
   export CC=clang
   export CXX=clang++
   export CMAKE_FLAGS="-DSANITIZE_UNDEFINED=yes"
+elif [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
+  # Compile with clang-tidy(1) turned on. The build treats clang-tidy warnings
+  # as errors.
+  export BUILD_TYPE=Debug
+  export CC=clang
+  export CXX=clang++
+  export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes"
+elif [[ "${BUILD_NAME}" = "libcxx" ]]; then
+  # Compile using libc++. This is easier to install on Fedora.
+  export CC=clang
+  export CXX=clang++
+  export CMAKE_FLAGS=-DBUILD_SHARED_LIBS=ON
+  export DISTRO=fedora
+  export DISTRO_VERSION=29
+  export USE_LIBCXX=yes
+elif [[ "${BUILD_NAME}" = "shared" ]]; then
+  # Compile with shared libraries. Needs to have the dependencies pre-installed.
+  export CMAKE_FLAGS=-DBUILD_SHARED_LIBS=ON
+  export TEST_INSTALL=yes
+  export BUILD_TYPE=Debug
+  export DISTRO=ubuntu-install
+  export CHECK_STYLE=yes
+  export GENERATE_DOCS=yes
+elif [[ "${BUILD_NAME}" = "no-tests" ]]; then
+  # Verify that the code can be compiled without unit tests. This is helpful for
+  # package maintainers, where the cost of running the tests for a fixed version
+  # is too high.
+  export BUILD_TESTING=no
+  export CMAKE_FLAGS=-DBUILD_TESTING=OFF
 else
   echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."
   exit 1


### PR DESCRIPTION
Add support for more additional build types currently in Travis. These builds
can be moved to Kokoro, but we need to merge these changes first, then
enable them in Kokoro, and then remove them from Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2033)
<!-- Reviewable:end -->
