### PR TITLE
Only require googletest if it is needed.

### DIFF
--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -47,8 +47,12 @@ function (create_googletest_aliases)
     add_library(GTest::gtest_main ALIAS GTest_gtest_main)
 endfunction ()
 
+include(CTest)
 if (TARGET GTest::gmock)
     # GTest::gmock is already defined, do not define it again.
+elseif(NOT BUILD_TESTING)
+    # Tests are turned off via -DBUILD_TESTING, do not load the googletest or
+    # googlemock dependency.
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "external")
     include(external/googletest)
 elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "package")


### PR DESCRIPTION
When compiling with -DBUILD_TESTING=OFF the tests are disabled. This is
useful for package maintainers who build the same version over and over
and do not want to rebuild the tests every time, nor do they want the
dependency on a library (googletest) that is not needed at run-time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2035)
<!-- Reviewable:end -->
