### PR TITLE
Search for port number only if the log file has been created.

### DIFF
--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -86,8 +86,10 @@ start_testbench() {
   local testbench_port=""
   local -r listening_at='Listening at: http://0.0.0.0:\([1-9][0-9]*\)'
   for attempt in $(seq 1 8); do
-    testbench_port=$(sed -n "s,^.*${listening_at}.*$,\1,p" testbench.log)
-    [[ -n "${testbench_port}" ]] && break
+    if [[ -r testbench.log ]]; then
+        testbench_port=$(sed -n "s,^.*${listening_at}.*$,\1,p" testbench.log)
+        [[ -n "${testbench_port}" ]] && break
+    fi
     sleep 1
   done
 


### PR DESCRIPTION
Because we start the testbench in the background, the log file may not
exist when we start waiting for the port number to be printed on it. We
need to test if it exists before running sed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2039)
<!-- Reviewable:end -->
