### PR TITLE
Limit all Kokoro builds to 120 minutes.

### DIFF
--- a/ci/kokoro/macos/continuous.cfg
+++ b/ci/kokoro/macos/continuous.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
-timeout_mins: 40
+timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"

--- a/ci/kokoro/macos/presubmit.cfg
+++ b/ci/kokoro/macos/presubmit.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
-timeout_mins: 40
+timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"

--- a/ci/kokoro/ubuntu/continuous.cfg
+++ b/ci/kokoro/ubuntu/continuous.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/ubuntu/build.sh"
-timeout_mins: 40
+timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"

--- a/ci/kokoro/ubuntu/presubmit.cfg
+++ b/ci/kokoro/ubuntu/presubmit.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/ubuntu/build.sh"
-timeout_mins: 40
+timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"


### PR DESCRIPTION
We had some builds at 40 minutes and others at 120 minutes. 40m is
too short, use the same value everywhere. We should set the default
in a single place, but it is not immediately obvious how to do that, so
just make the value consistent first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2041)
<!-- Reviewable:end -->
