### PR TITLE
Increase timeouts for CompletionQueue tests.

### DIFF
--- a/google/cloud/bigtable/completion_queue_test.cc
+++ b/google/cloud/bigtable/completion_queue_test.cc
@@ -45,7 +45,7 @@ TEST(CompletionQueueTest, LifeCycle) {
       });
 
   auto f = promise.get_future();
-  auto status = f.wait_for(50_ms);
+  auto status = f.wait_for(500_ms);
   EXPECT_EQ(std::future_status::ready, status);
 
   cq.Shutdown();
@@ -67,7 +67,7 @@ TEST(CompletionQueueTest, CancelAlarm) {
   alarm->Cancel();
 
   auto f = promise.get_future();
-  auto status = f.wait_for(100_ms);
+  auto status = f.wait_for(500_ms);
   EXPECT_EQ(std::future_status::ready, status);
   EXPECT_TRUE(f.get().cancelled);
 


### PR DESCRIPTION
The CompletionQueue test failed once with a `wait_for(50_ms)` timing
out. Evidently the timeout is too short, so increase it to 500_ms.
Personally I dislike timeout values in unit tests, but this is a test to
verify that timers set via the gRPC completion queue work, so a generous
timeout is fine I think. Note that the test will typically complete much
faster than 500ms.

This fixes #2038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2045)
<!-- Reviewable:end -->
