### PR TITLE
Increase timeouts in future<> tests.

### DIFF
--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -381,7 +381,7 @@ TEST(FutureTestInt, conform_30_6_6_15) {
 
   p.set_value(42);
   // now thread `t` can make progress.
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(20_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   waiter.get();
   t.join();
@@ -483,7 +483,7 @@ TEST(FutureTestInt, conform_30_6_6_20) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -502,7 +502,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
 
   std::thread t([&] {
     thread_started.set_value();
-    f.wait_for(100_ms);
+    f.wait_for(500_ms);
     f_wait_returned.set_value();
   });
 
@@ -511,7 +511,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -561,7 +561,7 @@ TEST(FutureTestInt, conform_30_6_6_24) {
 
   std::thread t([&] {
     thread_started.set_value();
-    f.wait_until(std::chrono::system_clock::now() + 100_ms);
+    f.wait_until(std::chrono::system_clock::now() + 500_ms);
     f_wait_returned.set_value();
   });
 
@@ -570,7 +570,7 @@ TEST(FutureTestInt, conform_30_6_6_24) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -388,7 +388,7 @@ TEST(FutureTestVoid, conform_30_6_6_15) {
 
   p.set_value();
   // now thread `t` can make progress.
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(20_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   waiter.get();
   t.join();
@@ -490,7 +490,7 @@ TEST(FutureTestVoid, conform_30_6_6_20) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value();
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -509,7 +509,7 @@ TEST(FutureTestVoid, conform_30_6_6_21) {
 
   std::thread t([&] {
     thread_started.set_value();
-    f.wait_for(100_ms);
+    f.wait_for(500_ms);
     f_wait_returned.set_value();
   });
 
@@ -518,7 +518,7 @@ TEST(FutureTestVoid, conform_30_6_6_21) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value();
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -569,7 +569,7 @@ TEST(FutureTestVoid, conform_30_6_6_24) {
 
   std::thread t([&] {
     thread_started.set_value();
-    f.wait_until(std::chrono::system_clock::now() + 100_ms);
+    f.wait_until(std::chrono::system_clock::now() + 500_ms);
     f_wait_returned.set_value();
   });
 
@@ -578,7 +578,7 @@ TEST(FutureTestVoid, conform_30_6_6_24) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value();
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(10_ms));
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }


### PR DESCRIPTION
Some of the tests verify that waiting for an event for X milliseconds
gets a response. The timeouts were typically 10ms or 50ms, but that is
too short for the CI systems (we got a failure with the 10ms timeout).

I increased all the actual waits to 500ms. I am not sure that is long
enough, but since I have only seen one failure due to timeouts with 10ms
it cannot be that terrible. Note that this will not slow down the tests,
this the the maximum time to wait, but if the scheduler and thread
communication works as usual the tests complete in less than 1ms.

Some calls to wait_for() or wait_until() are expecting a timeout or
are "waiting" for an event that already took place. In those cases I
left the values unchanged.

This fixes #2042.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2047)
<!-- Reviewable:end -->
