### PR TITLE
Removes unused import of chrono_literals

### DIFF
--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -18,24 +18,9 @@
 #include "google/cloud/bigtable/testing/mock_completion_queue.h"
 #include "google/cloud/bigtable/testing/mock_sample_row_keys_reader.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
-#include "google/cloud/testing_util/chrono_literals.h"
 #include <future>
 #include <thread>
 #include <typeinfo>
-
-namespace std {
-namespace chrono {
-
-void PrintTo(std::chrono::milliseconds const& ms, std::ostream* stream) {
-  *stream << ms.count() << "ms";
-}
-
-void PrintTo(std::chrono::seconds const& s, std::ostream* stream) {
-  *stream << s.count() << "s";
-}
-
-}  // namespace chrono
-}  // namespace std
 
 namespace google {
 namespace cloud {
@@ -45,7 +30,6 @@ namespace internal {
 
 namespace bt = ::google::cloud::bigtable;
 namespace btproto = google::bigtable::v2;
-using namespace google::cloud::testing_util::chrono_literals;
 using namespace ::testing;
 
 class RetryMultiPageTest


### PR DESCRIPTION
Removes header and using directive for chrono_literals since it was not used in this file. I also removed the `PrintTo` for std::chrono::milliseconds since this requires opening the `std::chrono` namespace, which we should try not to do. I don't think this PrintTo was needed/used anywhere either???

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2049)
<!-- Reviewable:end -->
