### PR TITLE
Eliminate BatchFinishedCallback.

### DIFF
--- a/google/cloud/bigtable/internal/mutation_batcher.cc
+++ b/google/cloud/bigtable/internal/mutation_batcher.cc
@@ -145,43 +145,30 @@ bool MutationBatcher::HasSpaceFor(PendingSingleRowMutation const& mut) const {
              options_.max_mutations_per_batch;
 }
 
-class BatchFinishedCallback {
- public:
-  BatchFinishedCallback(MutationBatcher& parent,
-                        std::unique_ptr<MutationBatcher::Batch> batch)
-      : parent_(parent), batch_(std::move(batch)) {}
-
-  void operator()(CompletionQueue& cq, std::vector<FailedMutation>& failed,
-                  grpc::Status&) {
-    // status is ignored - it's basically an logical AND on all mutations'
-    // statuses.
-    parent_.BatchFinished(cq, std::move(batch_), failed);
-  }
-
- private:
-  MutationBatcher& parent_;
-  std::unique_ptr<MutationBatcher::Batch> batch_;
-};
-
 void MutationBatcher::FlushIfPossible(CompletionQueue& cq) {
   if (cur_batch_->num_mutations() > 0 &&
       num_outstanding_batches_ < options_.max_batches) {
     oustanding_size_ += cur_batch_->requests_size();
     ++num_outstanding_batches_;
-    auto req = cur_batch_->TransferRequest();
-    table_.AsyncBulkApply(cq,
-                          BatchFinishedCallback(*this, std::move(cur_batch_)),
-                          std::move(req));
-    cur_batch_ = cloud::internal::make_unique<Batch>();
+    auto batch = cur_batch_;
+    table_.AsyncBulkApply(
+        cq, [this, batch](CompletionQueue& cq,
+                          std::vector<FailedMutation>& failed, grpc::Status&) {
+          // status is ignored - it's basically an logical AND on all mutations'
+          // statuses.
+          BatchFinished(cq, batch, failed);
+        },
+        cur_batch_->TransferRequest());
+    cur_batch_ = std::make_shared<Batch>();
   }
 }
 
 void MutationBatcher::BatchFinished(
-    CompletionQueue& cq, std::unique_ptr<MutationBatcher::Batch> batch,
+    CompletionQueue& cq, std::shared_ptr<MutationBatcher::Batch> batch,
     std::vector<FailedMutation> const& failed) {
   batch->FireCallbacks(cq, failed);
 
-  auto admission_callbacks = FlushOnBatchFinished(cq, std::move(batch));
+  auto admission_callbacks = FlushOnBatchFinished(cq, batch);
 
   // Inform the user that we've admitted these mutations and there might be some
   // space in the buffer finally.
@@ -192,7 +179,7 @@ void MutationBatcher::BatchFinished(
 }
 
 std::vector<AsyncApplyAdmissionCallback> MutationBatcher::FlushOnBatchFinished(
-    CompletionQueue& cq, std::unique_ptr<MutationBatcher::Batch> batch) {
+    CompletionQueue& cq, std::shared_ptr<MutationBatcher::Batch> batch) {
   std::unique_lock<std::mutex> lk(mu_);
   oustanding_size_ -= batch->requests_size();
   num_outstanding_batches_ -= 1;

--- a/google/cloud/bigtable/internal/mutation_batcher.h
+++ b/google/cloud/bigtable/internal/mutation_batcher.h
@@ -96,7 +96,7 @@ class MutationBatcher {
         options_(options),
         num_outstanding_batches_(),
         oustanding_size_(),
-        cur_batch_(cloud::internal::make_unique<Batch>()) {}
+        cur_batch_(std::make_shared<Batch>()) {}
 
   std::shared_ptr<AsyncOperation> AsyncApply(
       CompletionQueue& cq, AsyncApplyCompletionCallback&& completion_callback,
@@ -105,7 +105,6 @@ class MutationBatcher {
 
  private:
   class Batch;
-  friend class BatchFinishedCallback;
 
   /**
    * This structure represents a single mutation before it is admitted.
@@ -174,10 +173,10 @@ class MutationBatcher {
   }
 
   void FlushIfPossible(CompletionQueue& cq);
-  void BatchFinished(CompletionQueue& cq, std::unique_ptr<Batch> batch,
+  void BatchFinished(CompletionQueue& cq, std::shared_ptr<Batch> batch,
                      std::vector<FailedMutation> const& failed);
   std::vector<AsyncApplyAdmissionCallback> FlushOnBatchFinished(
-      CompletionQueue& cq, std::unique_ptr<MutationBatcher::Batch> batch);
+      CompletionQueue& cq, std::shared_ptr<MutationBatcher::Batch> batch);
 
   std::mutex mu_;
   noex::Table& table_;
@@ -186,7 +185,7 @@ class MutationBatcher {
   size_t num_outstanding_batches_;
   size_t oustanding_size_;
 
-  std::unique_ptr<Batch> cur_batch_;
+  std::shared_ptr<Batch> cur_batch_;
 
   // These are the mutations which have not been admission yet. If the user is
   // properly reacting to `admission_callback`s, there should be very few of

--- a/google/cloud/bigtable/internal/mutation_batcher.h
+++ b/google/cloud/bigtable/internal/mutation_batcher.h
@@ -173,10 +173,11 @@ class MutationBatcher {
   }
 
   void FlushIfPossible(CompletionQueue& cq);
-  void BatchFinished(CompletionQueue& cq, std::shared_ptr<Batch> batch,
+  void BatchFinished(CompletionQueue& cq, std::shared_ptr<Batch> const& batch,
                      std::vector<FailedMutation> const& failed);
   std::vector<AsyncApplyAdmissionCallback> FlushOnBatchFinished(
-      CompletionQueue& cq, std::shared_ptr<MutationBatcher::Batch> batch);
+      CompletionQueue& cq,
+      std::shared_ptr<MutationBatcher::Batch> const& batch);
 
   std::mutex mu_;
   noex::Table& table_;


### PR DESCRIPTION
`BatchFinishedCallback`'s purpose was to circumevent inability to pass a
`unique_ptr<>` to a lambda. In the future, we will need to reference
`Batch`es from multiple callbacks, so it has to be a held by a
`shared_ptr<>` anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2051)
<!-- Reviewable:end -->
