### PR TITLE
Add bigtable::Cell constructors without labels argument

### DIFF
--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -53,34 +53,23 @@ class Cell {
   Cell(std::string row_key, std::string family_name,
        std::string column_qualifier, std::int64_t timestamp,
        bigendian64_t value, std::vector<std::string> labels)
-      : row_key_(std::move(row_key)),
-        family_name_(std::move(family_name)),
-        column_qualifier_(std::move(column_qualifier)),
-        timestamp_(timestamp),
-        value_(google::cloud::bigtable::internal::AsBigEndian64(value)),
-        labels_(std::move(labels)) {}
+      : Cell(std::move(row_key), std::move(family_name),
+             std::move(column_qualifier), timestamp,
+             internal::AsBigEndian64(value), std::move(labels)) {}
 
   /// Create a cell and fill it with data, but with empty labels.
   Cell(std::string row_key, std::string family_name,
        std::string column_qualifier, std::int64_t timestamp, std::string value)
-      : row_key_(std::move(row_key)),
-        family_name_(std::move(family_name)),
-        column_qualifier_(std::move(column_qualifier)),
-        timestamp_(timestamp),
-        value_(std::move(value)),
-        labels_{} {}
+      : Cell(std::move(row_key), std::move(family_name),
+             std::move(column_qualifier), timestamp, std::move(value), {}) {}
 
   /// Create a Cell and fill it with bigendian 64 bit value, but with empty
   /// labels.
   Cell(std::string row_key, std::string family_name,
        std::string column_qualifier, std::int64_t timestamp,
        bigendian64_t value)
-      : row_key_(std::move(row_key)),
-        family_name_(std::move(family_name)),
-        column_qualifier_(std::move(column_qualifier)),
-        timestamp_(timestamp),
-        value_(google::cloud::bigtable::internal::AsBigEndian64(value)),
-        labels_{} {}
+      : Cell(std::move(row_key), std::move(family_name),
+             std::move(column_qualifier), timestamp, std::move(value), {}) {}
 
   /// Return the row key this cell belongs to. The returned value is not valid
   /// after this object is deleted.

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -60,6 +60,28 @@ class Cell {
         value_(google::cloud::bigtable::internal::AsBigEndian64(value)),
         labels_(std::move(labels)) {}
 
+  /// Create a cell and fill it with data, but with empty labels.
+  Cell(std::string row_key, std::string family_name,
+       std::string column_qualifier, std::int64_t timestamp, std::string value)
+      : row_key_(std::move(row_key)),
+        family_name_(std::move(family_name)),
+        column_qualifier_(std::move(column_qualifier)),
+        timestamp_(timestamp),
+        value_(std::move(value)),
+        labels_{} {}
+
+  /// Create a Cell and fill it with bigendian 64 bit value, but with empty
+  /// labels.
+  Cell(std::string row_key, std::string family_name,
+       std::string column_qualifier, std::int64_t timestamp,
+       bigendian64_t value)
+      : row_key_(std::move(row_key)),
+        family_name_(std::move(family_name)),
+        column_qualifier_(std::move(column_qualifier)),
+        timestamp_(timestamp),
+        value_(google::cloud::bigtable::internal::AsBigEndian64(value)),
+        labels_{} {}
+
   /// Return the row key this cell belongs to. The returned value is not valid
   /// after this object is deleted.
   std::string const& row_key() const { return row_key_; }

--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -70,5 +70,5 @@ TEST(CellTest, SimpleNumericNegativeValue) {
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
   EXPECT_EQ(timestamp, cell.timestamp().count());
   EXPECT_EQ(value.get(), cell.value_as<bigtable::bigendian64_t>().get());
-  EXPECT_EQ(0U, cell.eabels().size());
+  EXPECT_EQ(0U, cell.labels().size());
 }

--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -27,10 +27,8 @@ TEST(CellTest, Simple) {
   std::string column_qualifier = "column";
   std::int64_t timestamp = 42;
   std::string value = "value";
-  std::vector<std::string> labels;
 
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value,
-                      labels);
+  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
@@ -48,9 +46,7 @@ TEST(CellTest, SimpleNumericValue) {
   std::string column_qualifier = "column";
   std::int64_t timestamp = 42;
   bigtable::bigendian64_t value(343321020);
-  std::vector<std::string> labels;
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value,
-                      labels);
+  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
@@ -68,13 +64,11 @@ TEST(CellTest, SimpleNumericNegativeValue) {
   std::string column_qualifier = "column";
   std::int64_t timestamp = 42;
   bigtable::bigendian64_t value(-343321020);
-  std::vector<std::string> labels;
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value,
-                      labels);
+  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
   EXPECT_EQ(timestamp, cell.timestamp().count());
   EXPECT_EQ(value.get(), cell.value_as<bigtable::bigendian64_t>().get());
-  EXPECT_EQ(0U, cell.labels().size());
+  EXPECT_EQ(0U, cell.eabels().size());
 }

--- a/google/cloud/bigtable/internal/encoder.h
+++ b/google/cloud/bigtable/internal/encoder.h
@@ -45,7 +45,7 @@ namespace internal {
  * Convert from Numeric Value to string of BigEndian bytes.
  * @code
  * bigtable::Cell new_cell("row_key", "column_family", "column_id3", 1000,
- *                         bigtable::bigendian64_t(5000), {});
+ *                         bigtable::bigendian64_t(5000));
  * @endcode
  *
  * Convert from string of BigEndian bytes to Numeric Value.

--- a/google/cloud/bigtable/row_test.cc
+++ b/google/cloud/bigtable/row_test.cc
@@ -20,7 +20,7 @@ namespace bigtable = google::cloud::bigtable;
 /// @test Verify Row instantiation and trivial accessors.
 TEST(RowTest, RowInstantiation) {
   std::string row_key = "row";
-  bigtable::Cell cell(row_key, "family", "column", 42, "value", {});
+  bigtable::Cell cell(row_key, "family", "column", 42, "value");
   bigtable::Row row(row_key, {cell});
 
   EXPECT_EQ(1U, row.cells().size());
@@ -30,7 +30,7 @@ TEST(RowTest, RowInstantiation) {
   EXPECT_EQ(0U, empty_row.cells().size());
   EXPECT_EQ(empty_row.cells().begin(), empty_row.cells().end());
 
-  bigtable::Cell cell2(row_key, "family", "column", 43, "val", {});
+  bigtable::Cell cell2(row_key, "family", "column", 43, "val");
   bigtable::Row two_cells_row(row_key, {cell, cell2});
   EXPECT_EQ(2U, two_cells_row.cells().size());
   EXPECT_EQ(std::next(two_cells_row.cells().begin())->value(), cell2.value());

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -204,17 +204,17 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
   std::string const row_key1_1 = row_key1_prefix + "_1-Key1";
   std::string const row_key2 = row_key2_prefix + "-Key2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key1_1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key1_1, column_family2, "column_id3", 3000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key1_1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key1_1, column_family2, "column_id3", 3000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}}};
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"}};
 
   // Create records
   CreateCells(table, created_cells);
@@ -269,11 +269,11 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
   std::string const row_key1 = "DropRowKey1";
   std::string const row_key2 = "DropRowKey2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records
@@ -358,11 +358,11 @@ TEST_F(AdminAsyncIntegrationTest, CheckConsistencyIntegrationTest) {
   std::string const row_key1 = "DropRowKey1";
   std::string const row_key2 = "DropRowKey2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0"},
+      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
 
   CreateCells(table, created_cells);

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -116,17 +116,17 @@ TEST_F(AdminIntegrationTest, DropRowsByPrefixTest) {
   std::string const row_key1_1 = row_key1_prefix + "_1-Key1";
   std::string const row_key2 = row_key2_prefix + "-Key2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key1_1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key1_1, column_family2, "column_id3", 3000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key1_1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key1_1, column_family2, "column_id3", 3000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}}};
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"}};
 
   // Create records
   CreateCells(*table, created_cells);
@@ -153,11 +153,11 @@ TEST_F(AdminIntegrationTest, DropAllRowsTest) {
   std::string const row_key1 = "DropRowKey1";
   std::string const row_key2 = "DropRowKey2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records
@@ -300,11 +300,11 @@ TEST_F(AdminIntegrationTest, CheckConsistencyIntegrationTest) {
   std::string const row_key1 = "DropRowKey1";
   std::string const row_key2 = "DropRowKey2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0"},
+      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
 
   CreateCells(table, created_cells);

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -38,9 +38,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   auto sync_table = CreateTable(table_id, table_config);
 
   std::string const row_key = "key-000010";
-  std::vector<bigtable::Cell> created{
-      {row_key, family, "cc1", 1000, "v1000", {}},
-      {row_key, family, "cc2", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> created{{row_key, family, "cc1", 1000, "v1000"},
+                                      {row_key, family, "cc2", 2000, "v2000"}};
   SingleRowMutation mut(row_key);
   for (auto const& c : created) {
     mut.emplace_back(SetCell(
@@ -61,9 +60,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   fut_void.get();
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<bigtable::Cell> expected{
-      {row_key, family, "cc1", 1000, "v1000", {}},
-      {row_key, family, "cc2", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> expected{{row_key, family, "cc1", 1000, "v1000"},
+                                       {row_key, family, "cc2", 2000, "v2000"}};
 
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
 
@@ -82,11 +80,11 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
   std::string const row_key2 = "key-000020";
   std::map<std::string, std::vector<bigtable::Cell>> created{
       {row_key1,
-       {{row_key1, family, "cc1", 1000, "vv10", {}},
-        {row_key1, family, "cc2", 2000, "vv20", {}}}},
+       {{row_key1, family, "cc1", 1000, "vv10"},
+        {row_key1, family, "cc2", 2000, "vv20"}}},
       {row_key2,
-       {{row_key2, family, "cc1", 3000, "vv30", {}},
-        {row_key2, family, "cc2", 4000, "vv40", {}}}}};
+       {{row_key2, family, "cc1", 3000, "vv30"},
+        {row_key2, family, "cc2", 4000, "vv40"}}}};
 
   BulkMutation mut;
   for (auto const& row_cells : created) {

--- a/google/cloud/bigtable/tests/data_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_integration_test.cc
@@ -45,9 +45,8 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
   auto sync_table = CreateTable(table_id, table_config);
 
   std::string const row_key = "row-key-1";
-  std::vector<bigtable::Cell> created{
-      {row_key, family, "c0", 1000, "v1000", {}},
-      {row_key, family, "c1", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> created{{row_key, family, "c0", 1000, "v1000"},
+                                      {row_key, family, "c1", 2000, "v2000"}};
   SingleRowMutation mut(row_key);
   for (auto const& c : created) {
     mut.emplace_back(SetCell(
@@ -76,9 +75,8 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
   done.get_future().get();
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<bigtable::Cell> expected{
-      {row_key, family, "c0", 1000, "v1000", {}},
-      {row_key, family, "c1", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> expected{{row_key, family, "c0", 1000, "v1000"},
+                                       {row_key, family, "c1", 2000, "v2000"}};
 
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
 
@@ -97,11 +95,11 @@ TEST_F(DataAsyncIntegrationTest, TableBulkApply) {
   std::string const row_key2 = "row-key-2";
   std::map<std::string, std::vector<bigtable::Cell>> created{
       {row_key1,
-       {{row_key1, family, "c0", 1000, "v1000", {}},
-        {row_key1, family, "c1", 2000, "v2000", {}}}},
+       {{row_key1, family, "c0", 1000, "v1000"},
+        {row_key1, family, "c1", 2000, "v2000"}}},
       {row_key2,
-       {{row_key2, family, "c0", 3000, "v1000", {}},
-        {row_key2, family, "c0", 4000, "v1000", {}}}}};
+       {{row_key2, family, "c0", 3000, "v1000"},
+        {row_key2, family, "c0", 4000, "v1000"}}}};
 
   BulkMutation mut;
   for (auto const& row_cells : created) {
@@ -227,7 +225,7 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowPass) {
   noex::Table table(data_client_, table_id);
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
   CreateCells(*sync_table, created);
   std::promise<void> done;
   CompletionQueue cq;
@@ -245,8 +243,8 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowPass) {
   done.get_future().get();
   cq.Shutdown();
   pool.join();
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
-                                       {key, family, "c2", 0, "v2000", {}}};
+  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
+                                       {key, family, "c2", 0, "v2000"}};
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
@@ -258,7 +256,7 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowFail) {
   noex::Table table(data_client_, table_id);
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
   CreateCells(*sync_table, created);
   CompletionQueue cq;
   std::promise<void> done;
@@ -276,8 +274,8 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowFail) {
   done.get_future().get();
   cq.Shutdown();
   pool.join();
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
-                                       {key, family, "c3", 0, "v3000", {}}};
+  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
+                                       {key, family, "c3", 0, "v3000"}};
   auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
@@ -295,15 +293,15 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
   std::string const add_suffix3 = "-newrecord";
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family1, "column-id1", 1000, "v1000", {}},
-      {row_key1, family2, "column-id2", 2000, "v2000", {}},
-      {row_key1, family3, "column-id1", 2000, "v3000", {}},
-      {row_key1, family1, "column-id3", 2000, "v5000", {}}};
+      {row_key1, family1, "column-id1", 1000, "v1000"},
+      {row_key1, family2, "column-id2", 2000, "v2000"},
+      {row_key1, family3, "column-id1", 2000, "v3000"},
+      {row_key1, family1, "column-id3", 2000, "v5000"}};
 
   std::vector<bigtable::Cell> expected{
-      {row_key1, family1, "column-id1", 1000, "v1000" + add_suffix1, {}},
-      {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2, {}},
-      {row_key1, family3, "column-id3", 2000, add_suffix3, {}}};
+      {row_key1, family1, "column-id1", 1000, "v1000" + add_suffix1},
+      {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2},
+      {row_key1, family3, "column-id3", 2000, add_suffix3}};
 
   CreateCells(*sync_table, created);
 
@@ -350,13 +348,13 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowIncrementAmountTest) {
 
   // An initial; BigEndian int64 number with value 0.
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
-  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1, {}}};
+  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1}};
 
   // The expected values as buffers containing BigEndian int64 numbers.
   std::string e1("\x00\x00\x00\x00\x00\x00\x00\x2A", 8);
   std::string e2("\x00\x00\x00\x00\x00\x00\x00\x07", 8);
-  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1, {}},
-                                       {key, family1, "c2", 0, e2, {}}};
+  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
+                                       {key, family1, "c2", 0, e2}};
 
   CreateCells(*sync_table, created);
 
@@ -392,25 +390,24 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowMultipleTest) {
   std::string const key = "row-key";
 
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
-  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1, {}},
-                                      {key, family1, "c3", 0, "start;", {}},
-                                      {key, family2, "d1", 0, v1, {}},
-                                      {key, family2, "d3", 0, "start;", {}}};
+  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1},
+                                      {key, family1, "c3", 0, "start;"},
+                                      {key, family2, "d1", 0, v1},
+                                      {key, family2, "d3", 0, "start;"}};
 
   // The expected values as buffers containing BigEndian int64 numbers.
   std::string e1("\x00\x00\x00\x00\x00\x00\x00\x2A", 8);
   std::string e2("\x00\x00\x00\x00\x00\x00\x00\x07", 8);
   std::string e3("\x00\x00\x00\x00\x00\x00\x07\xD0", 8);
   std::string e4("\x00\x00\x00\x00\x00\x00\x0B\xB8", 8);
-  std::vector<bigtable::Cell> expected{
-      {key, family1, "c1", 0, e1, {}},
-      {key, family1, "c2", 0, e2, {}},
-      {key, family1, "c3", 0, "start;suffix", {}},
-      {key, family1, "c4", 0, "suffix", {}},
-      {key, family2, "d1", 0, e3, {}},
-      {key, family2, "d2", 0, e4, {}},
-      {key, family2, "d3", 0, "start;suffix", {}},
-      {key, family2, "d4", 0, "suffix", {}}};
+  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
+                                       {key, family1, "c2", 0, e2},
+                                       {key, family1, "c3", 0, "start;suffix"},
+                                       {key, family1, "c4", 0, "suffix"},
+                                       {key, family2, "d1", 0, e3},
+                                       {key, family2, "d2", 0, e4},
+                                       {key, family2, "d3", 0, "start;suffix"},
+                                       {key, family2, "d4", 0, "suffix"}};
 
   CreateCells(*sync_table, created);
 
@@ -458,10 +455,10 @@ TEST_F(DataAsyncIntegrationTest, TableReadRowsAllRows) {
   std::string const long_value(1024, 'v');  // a long value
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "data1", {}},
-      {row_key1, family, "c2", 1000, "data2", {}},
-      {row_key2, family, "c1", 1000, "", {}},
-      {row_key3, family, "c1", 1000, long_value, {}}};
+      {row_key1, family, "c1", 1000, "data1"},
+      {row_key1, family, "c2", 1000, "data2"},
+      {row_key2, family, "c1", 1000, ""},
+      {row_key3, family, "c1", 1000, long_value}};
 
   CreateCells(*sync_table, created);
 
@@ -500,11 +497,9 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRow) {
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "v1000", {}},
-      {row_key2, family, "c2", 2000, "v2000", {}}};
-  std::vector<bigtable::Cell> expected{
-      {row_key1, family, "c1", 1000, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "v1000"},
+                                      {row_key2, family, "c2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> expected{{row_key1, family, "c1", 1000, "v1000"}};
 
   CreateCells(*sync_table, created);
 
@@ -538,8 +533,7 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRowForNoRow) {
   noex::Table table(data_client_, table_id);
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{
-      {row_key2, family, "c2", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> created{{row_key2, family, "c2", 2000, "v2000"}};
 
   CreateCells(*sync_table, created);
 

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -114,13 +114,11 @@ TEST_F(DataIntegrationTest, TableApply) {
   auto table = CreateTable(table_id, table_config);
 
   std::string const row_key = "row-key-1";
-  std::vector<bigtable::Cell> created{
-      {row_key, family, "c0", 1000, "v1000", {}},
-      {row_key, family, "c1", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> created{{row_key, family, "c0", 1000, "v1000"},
+                                      {row_key, family, "c1", 2000, "v2000"}};
   Apply(*table, row_key, created);
-  std::vector<bigtable::Cell> expected{
-      {row_key, family, "c0", 1000, "v1000", {}},
-      {row_key, family, "c1", 2000, "v2000", {}}};
+  std::vector<bigtable::Cell> expected{{row_key, family, "c0", 1000, "v1000"},
+                                       {row_key, family, "c1", 2000, "v2000"}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
@@ -132,24 +130,24 @@ TEST_F(DataIntegrationTest, TableBulkApply) {
   auto table = CreateTable(table_id, table_config);
 
   std::vector<bigtable::Cell> created{
-      {"row-key-1", family, "c0", 1000, "v1000", {}},
-      {"row-key-1", family, "c1", 2000, "v2000", {}},
-      {"row-key-2", family, "c0", 1000, "v1000", {}},
-      {"row-key-2", family, "c1", 2000, "v2000", {}},
-      {"row-key-3", family, "c0", 1000, "v1000", {}},
-      {"row-key-3", family, "c1", 2000, "v2000", {}},
-      {"row-key-4", family, "c0", 1000, "v1000", {}},
-      {"row-key-4", family, "c1", 2000, "v2000", {}}};
+      {"row-key-1", family, "c0", 1000, "v1000"},
+      {"row-key-1", family, "c1", 2000, "v2000"},
+      {"row-key-2", family, "c0", 1000, "v1000"},
+      {"row-key-2", family, "c1", 2000, "v2000"},
+      {"row-key-3", family, "c0", 1000, "v1000"},
+      {"row-key-3", family, "c1", 2000, "v2000"},
+      {"row-key-4", family, "c0", 1000, "v1000"},
+      {"row-key-4", family, "c1", 2000, "v2000"}};
   BulkApply(*table, created);
   std::vector<bigtable::Cell> expected{
-      {"row-key-1", family, "c0", 1000, "v1000", {}},
-      {"row-key-1", family, "c1", 2000, "v2000", {}},
-      {"row-key-2", family, "c0", 1000, "v1000", {}},
-      {"row-key-2", family, "c1", 2000, "v2000", {}},
-      {"row-key-3", family, "c0", 1000, "v1000", {}},
-      {"row-key-3", family, "c1", 2000, "v2000", {}},
-      {"row-key-4", family, "c0", 1000, "v1000", {}},
-      {"row-key-4", family, "c1", 2000, "v2000", {}}};
+      {"row-key-1", family, "c0", 1000, "v1000"},
+      {"row-key-1", family, "c1", 2000, "v2000"},
+      {"row-key-2", family, "c0", 1000, "v1000"},
+      {"row-key-2", family, "c1", 2000, "v2000"},
+      {"row-key-3", family, "c0", 1000, "v1000"},
+      {"row-key-3", family, "c1", 2000, "v2000"},
+      {"row-key-4", family, "c0", 1000, "v1000"},
+      {"row-key-4", family, "c1", 2000, "v2000"}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
@@ -165,12 +163,13 @@ TEST_F(DataIntegrationTest, TableSingleRow) {
       row_key, bigtable::SetCell(family, "c1", 1_ms, "V1000"),
       bigtable::SetCell(family, "c2", 2_ms, "V2000"),
       bigtable::SetCell(family, "c3", 3_ms, "V3000"));
+
   ASSERT_STATUS_OK(table->Apply(std::move(mutation)));
   std::vector<bigtable::Cell> expected{
-      {row_key, family, "c1", 1000, "V1000", {}},
-      {row_key, family, "c2", 2000, "V2000", {}},
-      {row_key, family, "c3", 3000, "V3000", {}}};
-
+      {row_key, family, "c1", 1000, "V1000"},
+      {row_key, family, "c2", 2000, "V2000"},
+      {row_key, family, "c3", 3000, "V3000"}};
+  
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
@@ -182,11 +181,9 @@ TEST_F(DataIntegrationTest, TableReadRowTest) {
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "v1000", {}},
-      {row_key2, family, "c2", 2000, "v2000", {}}};
-  std::vector<bigtable::Cell> expected{
-      {row_key1, family, "c1", 1000, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "v1000"},
+                                      {row_key2, family, "c2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> expected{{row_key1, family, "c1", 1000, "v1000"}};
 
   CreateCells(*table, created);
   auto row_cell = table->ReadRow(row_key1, bigtable::Filter::PassAllFilter());
@@ -202,8 +199,7 @@ TEST_F(DataIntegrationTest, TableReadRowNotExistTest) {
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "v1000"}};
 
   CreateCells(*table, created);
   auto row_cell = table->ReadRow(row_key2, bigtable::Filter::PassAllFilter());
@@ -220,10 +216,10 @@ TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
   std::string const long_value(1024, 'v');  // a long value
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "data1", {}},
-      {row_key1, family, "c2", 1000, "data2", {}},
-      {row_key2, family, "c1", 1000, "", {}},
-      {row_key3, family, "c1", 1000, long_value, {}}};
+      {row_key1, family, "c1", 1000, "data1"},
+      {row_key1, family, "c2", 1000, "data2"},
+      {row_key2, family, "c1", 1000, ""},
+      {row_key3, family, "c1", 1000, long_value}};
 
   CreateCells(*table, created);
 
@@ -259,18 +255,16 @@ TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
   std::string const row_key2 = "row-key-2";
   std::string const row_key3 = "row-key-3";
 
-  std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "data1", {}},
-      {row_key1, family, "c2", 1000, "data2", {}},
-      {row_key2, family, "c1", 1000, "data3", {}},
-      {row_key3, family, "c1", 1000, "data4", {}}};
+  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "data1"},
+                                      {row_key1, family, "c2", 1000, "data2"},
+                                      {row_key2, family, "c1", 1000, "data3"},
+                                      {row_key3, family, "c1", 1000, "data4"}};
 
   CreateCells(*table, created);
 
-  std::vector<bigtable::Cell> expected{
-      {row_key1, family, "c1", 1000, "data1", {}},
-      {row_key1, family, "c2", 1000, "data2", {}},
-      {row_key2, family, "c1", 1000, "data3", {}}};
+  std::vector<bigtable::Cell> expected{{row_key1, family, "c1", 1000, "data1"},
+                                       {row_key1, family, "c2", 1000, "data2"},
+                                       {row_key2, family, "c1", 1000, "data3"}};
 
   // Some equivalent ways of reading just the first two rows
   auto read1 =
@@ -300,9 +294,8 @@ TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
   std::string const row_key2 = "row-key-2";
   std::string const row_key3 = "row-key-3";
 
-  std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "data1", {}},
-      {row_key3, family, "c1", 1000, "data2", {}}};
+  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "data1"},
+                                      {row_key3, family, "c1", 1000, "data2"}};
 
   CreateCells(*table, created);
 
@@ -352,7 +345,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
   auto table = CreateTable(table_id, table_config);
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
   CreateCells(*table, created);
   auto result = table->CheckAndMutateRow(
       key, bigtable::Filter::ValueRegex("v1000"),
@@ -360,8 +353,8 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
       {bigtable::SetCell(family, "c3", 0_ms, "v3000")});
   ASSERT_STATUS_OK(result);
   EXPECT_TRUE(*result);
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
-                                       {key, family, "c2", 0, "v2000", {}}};
+  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
+                                       {key, family, "c2", 0, "v2000"}};
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
@@ -372,7 +365,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowFail) {
   auto table = CreateTable(table_id, table_config);
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000", {}}};
+  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
   CreateCells(*table, created);
   auto result = table->CheckAndMutateRow(
       key, bigtable::Filter::ValueRegex("not-there"),
@@ -380,8 +373,8 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowFail) {
       {bigtable::SetCell(family, "c3", 0_ms, "v3000")});
   ASSERT_STATUS_OK(result);
   EXPECT_FALSE(*result);
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000", {}},
-                                       {key, family, "c3", 0, "v3000", {}}};
+  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
+                                       {key, family, "c3", 0, "v3000"}};
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
@@ -397,15 +390,15 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
   std::string const add_suffix3 = "-newrecord";
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family1, "column-id1", 1000, "v1000", {}},
-      {row_key1, family2, "column-id2", 2000, "v2000", {}},
-      {row_key1, family3, "column-id1", 2000, "v3000", {}},
-      {row_key1, family1, "column-id3", 2000, "v5000", {}}};
+      {row_key1, family1, "column-id1", 1000, "v1000"},
+      {row_key1, family2, "column-id2", 2000, "v2000"},
+      {row_key1, family3, "column-id1", 2000, "v3000"},
+      {row_key1, family1, "column-id3", 2000, "v5000"}};
 
   std::vector<bigtable::Cell> expected{
-      {row_key1, family1, "column-id1", 1000, "v1000" + add_suffix1, {}},
-      {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2, {}},
-      {row_key1, family3, "column-id3", 2000, add_suffix3, {}}};
+      {row_key1, family1, "column-id1", 1000, "v1000" + add_suffix1},
+      {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2},
+      {row_key1, family3, "column-id3", 2000, add_suffix3}};
 
   CreateCells(*table, created);
   auto result_row =
@@ -436,13 +429,13 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
 
   // An initial; BigEndian int64 number with value 0.
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
-  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1, {}}};
+  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1}};
 
   // The expected values as buffers containing BigEndian int64 numbers.
   std::string e1("\x00\x00\x00\x00\x00\x00\x00\x2A", 8);
   std::string e2("\x00\x00\x00\x00\x00\x00\x00\x07", 8);
-  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1, {}},
-                                       {key, family1, "c2", 0, e2, {}}};
+  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
+                                       {key, family1, "c2", 0, e2}};
 
   CreateCells(*table, created);
   auto row = table->ReadModifyWriteRow(
@@ -464,25 +457,24 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowMultipleTest) {
   std::string const key = "row-key";
 
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
-  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1, {}},
-                                      {key, family1, "c3", 0, "start;", {}},
-                                      {key, family2, "d1", 0, v1, {}},
-                                      {key, family2, "d3", 0, "start;", {}}};
+  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1},
+                                      {key, family1, "c3", 0, "start;"},
+                                      {key, family2, "d1", 0, v1},
+                                      {key, family2, "d3", 0, "start;"}};
 
   // The expected values as buffers containing BigEndian int64 numbers.
   std::string e1("\x00\x00\x00\x00\x00\x00\x00\x2A", 8);
   std::string e2("\x00\x00\x00\x00\x00\x00\x00\x07", 8);
   std::string e3("\x00\x00\x00\x00\x00\x00\x07\xD0", 8);
   std::string e4("\x00\x00\x00\x00\x00\x00\x0B\xB8", 8);
-  std::vector<bigtable::Cell> expected{
-      {key, family1, "c1", 0, e1, {}},
-      {key, family1, "c2", 0, e2, {}},
-      {key, family1, "c3", 0, "start;suffix", {}},
-      {key, family1, "c4", 0, "suffix", {}},
-      {key, family2, "d1", 0, e3, {}},
-      {key, family2, "d2", 0, e4, {}},
-      {key, family2, "d3", 0, "start;suffix", {}},
-      {key, family2, "d4", 0, "suffix", {}}};
+  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
+                                       {key, family1, "c2", 0, e2},
+                                       {key, family1, "c3", 0, "start;suffix"},
+                                       {key, family1, "c4", 0, "suffix"},
+                                       {key, family2, "d1", 0, e3},
+                                       {key, family2, "d2", 0, e4},
+                                       {key, family2, "d3", 0, "start;suffix"},
+                                       {key, family2, "d4", 0, "suffix"}};
 
   CreateCells(*table, created);
   using R = bigtable::ReadModifyWriteRule;
@@ -511,19 +503,19 @@ TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
   std::string const key = "row-key";
 
   std::vector<bigtable::Cell> created{
-      {key, family1, "c1", 0, bigtable::bigendian64_t(42), {}},
-      {key, family1, "c3", 0, "start;", {}},
-      {key, family2, "d1", 0, bigtable::bigendian64_t(2), {}},
-      {key, family2, "d2", 0, bigtable::bigendian64_t(5012), {}},
-      {key, family2, "d3", 0, "start;", {}}};
+      {key, family1, "c1", 0, bigtable::bigendian64_t(42)},
+      {key, family1, "c3", 0, "start;"},
+      {key, family2, "d1", 0, bigtable::bigendian64_t(2)},
+      {key, family2, "d2", 0, bigtable::bigendian64_t(5012)},
+      {key, family2, "d3", 0, "start;"}};
 
   std::vector<bigtable::Cell> expected{
-      {key, family1, "c1", 0, bigtable::bigendian64_t(40), {}},
-      {key, family1, "c2", 0, bigtable::bigendian64_t(7), {}},
-      {key, family1, "c3", 0, "start;suffix", {}},
-      {key, family2, "d1", 0, bigtable::bigendian64_t(2002), {}},
-      {key, family2, "d2", 0, bigtable::bigendian64_t(9999998012), {}},
-      {key, family2, "d3", 0, "start;suffix", {}}};
+      {key, family1, "c1", 0, bigtable::bigendian64_t(40)},
+      {key, family1, "c2", 0, bigtable::bigendian64_t(7)},
+      {key, family1, "c3", 0, "start;suffix"},
+      {key, family2, "d1", 0, bigtable::bigendian64_t(2002)},
+      {key, family2, "d2", 0, bigtable::bigendian64_t(9999998012)},
+      {key, family2, "d3", 0, "start;suffix"}};
 
   CreateCells(*table, created);
   using R = bigtable::ReadModifyWriteRule;
@@ -613,10 +605,9 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
   std::string col_qualifier;
   for (int i = 0; i < 10; i++) {
     col_qualifier = "c" + std::to_string(i);
-    created.push_back(
-        bigtable::Cell(row_key, family, col_qualifier, 0, value, {}));
+    created.push_back(bigtable::Cell(row_key, family, col_qualifier, 0, value));
     expected.push_back(
-        bigtable::Cell(row_key, family, col_qualifier, 0, value, {}));
+        bigtable::Cell(row_key, family, col_qualifier, 0, value));
   }
 
   CreateCells(*table, created);

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -165,11 +165,10 @@ TEST_F(DataIntegrationTest, TableSingleRow) {
       bigtable::SetCell(family, "c3", 3_ms, "V3000"));
 
   ASSERT_STATUS_OK(table->Apply(std::move(mutation)));
-  std::vector<bigtable::Cell> expected{
-      {row_key, family, "c1", 1000, "V1000"},
-      {row_key, family, "c2", 2000, "V2000"},
-      {row_key, family, "c3", 3000, "V3000"}};
-  
+  std::vector<bigtable::Cell> expected{{row_key, family, "c1", 1000, "V1000"},
+                                       {row_key, family, "c2", 2000, "V2000"},
+                                       {row_key, family, "c3", 3000, "V3000"}};
+
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
   EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -94,12 +94,12 @@ TEST_F(FilterIntegrationTest, PassAll) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "pass-all-row-key";
   std::vector<bigtable::Cell> expected{
-      {row_key, "fam0", "c", 0, "v-c-0-0", {}},
-      {row_key, "fam0", "c", 1000, "v-c-0-1", {}},
-      {row_key, "fam0", "c", 2000, "v-c-0-2", {}},
-      {row_key, "fam1", "c0", 0, "v-c0-0-0", {}},
-      {row_key, "fam1", "c1", 1000, "v-c1-0-1", {}},
-      {row_key, "fam1", "c1", 2000, "v-c1-0-2", {}},
+      {row_key, "fam0", "c", 0, "v-c-0-0"},
+      {row_key, "fam0", "c", 1000, "v-c-0-1"},
+      {row_key, "fam0", "c", 2000, "v-c-0-2"},
+      {row_key, "fam1", "c0", 0, "v-c0-0-0"},
+      {row_key, "fam1", "c1", 1000, "v-c1-0-1"},
+      {row_key, "fam1", "c1", 2000, "v-c1-0-2"},
   };
   CreateCells(*table, expected);
 
@@ -113,12 +113,12 @@ TEST_F(FilterIntegrationTest, BlockAll) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "block-all-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key, "fam0", "c", 0, "v-c-0-0", {}},
-      {row_key, "fam0", "c", 1000, "v-c-0-1", {}},
-      {row_key, "fam0", "c", 2000, "v-c-0-2", {}},
-      {row_key, "fam1", "c0", 0, "v-c0-0-0", {}},
-      {row_key, "fam1", "c1", 1000, "v-c1-0-1", {}},
-      {row_key, "fam1", "c1", 2000, "v-c1-0-2", {}},
+      {row_key, "fam0", "c", 0, "v-c-0-0"},
+      {row_key, "fam0", "c", 1000, "v-c-0-1"},
+      {row_key, "fam0", "c", 2000, "v-c-0-2"},
+      {row_key, "fam1", "c0", 0, "v-c0-0-0"},
+      {row_key, "fam1", "c1", 1000, "v-c1-0-1"},
+      {row_key, "fam1", "c1", 2000, "v-c1-0-2"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{};
@@ -133,21 +133,21 @@ TEST_F(FilterIntegrationTest, Latest) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "latest-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key, "fam0", "c", 0, "v-c-0-0", {}},
-      {row_key, "fam0", "c", 1000, "v-c-0-1", {}},
-      {row_key, "fam0", "c", 2000, "v-c-0-2", {}},
-      {row_key, "fam1", "c0", 0, "v-c0-0-0", {}},
-      {row_key, "fam1", "c1", 1000, "v-c1-0-1", {}},
-      {row_key, "fam1", "c1", 2000, "v-c1-0-2", {}},
-      {row_key, "fam1", "c1", 3000, "v-c1-0-3", {}},
+      {row_key, "fam0", "c", 0, "v-c-0-0"},
+      {row_key, "fam0", "c", 1000, "v-c-0-1"},
+      {row_key, "fam0", "c", 2000, "v-c-0-2"},
+      {row_key, "fam1", "c0", 0, "v-c0-0-0"},
+      {row_key, "fam1", "c1", 1000, "v-c1-0-1"},
+      {row_key, "fam1", "c1", 2000, "v-c1-0-2"},
+      {row_key, "fam1", "c1", 3000, "v-c1-0-3"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {row_key, "fam0", "c", 1000, "v-c-0-1", {}},
-      {row_key, "fam0", "c", 2000, "v-c-0-2", {}},
-      {row_key, "fam1", "c0", 0, "v-c0-0-0", {}},
-      {row_key, "fam1", "c1", 2000, "v-c1-0-2", {}},
-      {row_key, "fam1", "c1", 3000, "v-c1-0-3", {}},
+      {row_key, "fam0", "c", 1000, "v-c-0-1"},
+      {row_key, "fam0", "c", 2000, "v-c-0-2"},
+      {row_key, "fam1", "c0", 0, "v-c0-0-0"},
+      {row_key, "fam1", "c1", 2000, "v-c1-0-2"},
+      {row_key, "fam1", "c1", 3000, "v-c1-0-3"},
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::Latest(2));
@@ -160,19 +160,16 @@ TEST_F(FilterIntegrationTest, FamilyRegex) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "family-regex-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key, "fam0", "c2", 0, "bar", {}},
-      {row_key, "fam0", "c", 0, "bar", {}},
-      {row_key, "fam1", "c", 0, "bar", {}},
-      {row_key, "fam2", "c", 0, "bar", {}},
-      {row_key, "fam2", "c2", 0, "bar", {}},
-      {row_key, "fam3", "c2", 0, "bar", {}},
+      {row_key, "fam0", "c2", 0, "bar"}, {row_key, "fam0", "c", 0, "bar"},
+      {row_key, "fam1", "c", 0, "bar"},  {row_key, "fam2", "c", 0, "bar"},
+      {row_key, "fam2", "c2", 0, "bar"}, {row_key, "fam3", "c2", 0, "bar"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {row_key, "fam0", "c2", 0, "bar", {}},
-      {row_key, "fam0", "c", 0, "bar", {}},
-      {row_key, "fam2", "c", 0, "bar", {}},
-      {row_key, "fam2", "c2", 0, "bar", {}},
+      {row_key, "fam0", "c2", 0, "bar"},
+      {row_key, "fam0", "c", 0, "bar"},
+      {row_key, "fam2", "c", 0, "bar"},
+      {row_key, "fam2", "c2", 0, "bar"},
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::FamilyRegex("fam[02]"));
@@ -185,19 +182,16 @@ TEST_F(FilterIntegrationTest, ColumnRegex) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "column-regex-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key, "fam0", "abc", 0, "bar", {}},
-      {row_key, "fam1", "bcd", 0, "bar", {}},
-      {row_key, "fam2", "abc", 0, "bar", {}},
-      {row_key, "fam3", "def", 0, "bar", {}},
-      {row_key, "fam0", "fgh", 0, "bar", {}},
-      {row_key, "fam1", "hij", 0, "bar", {}},
+      {row_key, "fam0", "abc", 0, "bar"}, {row_key, "fam1", "bcd", 0, "bar"},
+      {row_key, "fam2", "abc", 0, "bar"}, {row_key, "fam3", "def", 0, "bar"},
+      {row_key, "fam0", "fgh", 0, "bar"}, {row_key, "fam1", "hij", 0, "bar"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {row_key, "fam0", "abc", 0, "bar", {}},
-      {row_key, "fam2", "abc", 0, "bar", {}},
-      {row_key, "fam0", "fgh", 0, "bar", {}},
-      {row_key, "fam1", "hij", 0, "bar", {}},
+      {row_key, "fam0", "abc", 0, "bar"},
+      {row_key, "fam2", "abc", 0, "bar"},
+      {row_key, "fam0", "fgh", 0, "bar"},
+      {row_key, "fam1", "hij", 0, "bar"},
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::ColumnRegex("(abc|.*h.*)"));
@@ -210,18 +204,15 @@ TEST_F(FilterIntegrationTest, ColumnRange) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "column-range-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key, "fam0", "a00", 0, "bar", {}},
-      {row_key, "fam0", "b00", 0, "bar", {}},
-      {row_key, "fam0", "b01", 0, "bar", {}},
-      {row_key, "fam0", "b02", 0, "bar", {}},
-      {row_key, "fam1", "a00", 0, "bar", {}},
-      {row_key, "fam1", "b01", 0, "bar", {}},
-      {row_key, "fam1", "b00", 0, "bar", {}},
+      {row_key, "fam0", "a00", 0, "bar"}, {row_key, "fam0", "b00", 0, "bar"},
+      {row_key, "fam0", "b01", 0, "bar"}, {row_key, "fam0", "b02", 0, "bar"},
+      {row_key, "fam1", "a00", 0, "bar"}, {row_key, "fam1", "b01", 0, "bar"},
+      {row_key, "fam1", "b00", 0, "bar"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {row_key, "fam0", "b00", 0, "bar", {}},
-      {row_key, "fam0", "b01", 0, "bar", {}},
+      {row_key, "fam0", "b00", 0, "bar"},
+      {row_key, "fam0", "b01", 0, "bar"},
   };
 
   auto actual =
@@ -235,18 +226,18 @@ TEST_F(FilterIntegrationTest, TimestampRange) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "timestamp-range-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key, "fam0", "c0", 1000, "v1000", {}},
-      {row_key, "fam1", "c1", 2000, "v2000", {}},
-      {row_key, "fam2", "c2", 3000, "v3000", {}},
-      {row_key, "fam0", "c3", 4000, "v4000", {}},
-      {row_key, "fam1", "c4", 4000, "v5000", {}},
-      {row_key, "fam2", "c5", 6000, "v6000", {}},
+      {row_key, "fam0", "c0", 1000, "v1000"},
+      {row_key, "fam1", "c1", 2000, "v2000"},
+      {row_key, "fam2", "c2", 3000, "v3000"},
+      {row_key, "fam0", "c3", 4000, "v4000"},
+      {row_key, "fam1", "c4", 4000, "v5000"},
+      {row_key, "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {row_key, "fam2", "c2", 3000, "v3000", {}},
-      {row_key, "fam0", "c3", 4000, "v4000", {}},
-      {row_key, "fam1", "c4", 4000, "v5000", {}},
+      {row_key, "fam2", "c2", 3000, "v3000"},
+      {row_key, "fam0", "c3", 4000, "v4000"},
+      {row_key, "fam1", "c4", 4000, "v5000"},
   };
 
   auto actual = ReadRows(
@@ -261,16 +252,16 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
   auto table = CreateTable(table_id, table_config);
   std::string const row_key = "row-key-regex-row-key";
   std::vector<bigtable::Cell> created{
-      {row_key + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {row_key + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {row_key + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {row_key + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {row_key + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {row_key + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {row_key + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {row_key + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {row_key + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {row_key + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {row_key + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {row_key + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {row_key + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
+      {row_key + "/bcd0", "fam1", "c1", 2000, "v2000"},
   };
 
   auto actual =
@@ -284,17 +275,17 @@ TEST_F(FilterIntegrationTest, ValueRegex) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "value-regex-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::ValueRegex("v[34][0-9].*"));
@@ -307,19 +298,19 @@ TEST_F(FilterIntegrationTest, ValueRange) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "value-range-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
   };
 
   auto actual =
@@ -441,21 +432,21 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "strip-value-transformer-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {prefix + "/abc0", "fam0", "c0", 1000, "", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, ""},
+      {prefix + "/bcd0", "fam1", "c1", 2000, ""},
+      {prefix + "/abc1", "fam2", "c2", 3000, ""},
+      {prefix + "/fgh0", "fam0", "c3", 4000, ""},
+      {prefix + "/hij0", "fam1", "c4", 4000, ""},
+      {prefix + "/hij1", "fam2", "c5", 6000, ""},
   };
 
   auto actual = ReadRows(*table, bigtable::Filter::StripValueTransformer());
@@ -473,12 +464,12 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "apply-label-transformer-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
@@ -501,20 +492,20 @@ TEST_F(FilterIntegrationTest, Condition) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "condition-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, ""},
+      {prefix + "/abc1", "fam2", "c2", 3000, ""},
+      {prefix + "/fgh0", "fam0", "c3", 4000, ""},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
   };
 
   using F = bigtable::Filter;
@@ -531,16 +522,16 @@ TEST_F(FilterIntegrationTest, Chain) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "chain-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
+      {prefix + "/fgh0", "fam0", "c3", 4000, ""},
   };
 
   using F = bigtable::Filter;
@@ -557,20 +548,20 @@ TEST_F(FilterIntegrationTest, Interleave) {
   auto table = CreateTable(table_id, table_config);
   std::string const prefix = "interleave-prefix";
   std::vector<bigtable::Cell> created{
-      {prefix + "/abc0", "fam0", "c0", 1000, "v1000", {}},
-      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "v3000", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "v5000", {}},
-      {prefix + "/hij1", "fam2", "c5", 6000, "v6000", {}},
+      {prefix + "/abc0", "fam0", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "fam1", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "fam2", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "fam2", "c5", 6000, "v6000"},
   };
   CreateCells(*table, created);
   std::vector<bigtable::Cell> expected{
-      {prefix + "/bcd0", "fam1", "c1", 2000, "", {}},
-      {prefix + "/abc1", "fam2", "c2", 3000, "", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "", {}},
-      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000", {}},
-      {prefix + "/hij0", "fam1", "c4", 4000, "", {}},
+      {prefix + "/bcd0", "fam1", "c1", 2000, ""},
+      {prefix + "/abc1", "fam2", "c2", 3000, ""},
+      {prefix + "/fgh0", "fam0", "c3", 4000, ""},
+      {prefix + "/fgh0", "fam0", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "fam1", "c4", 4000, ""},
   };
 
   using F = bigtable::Filter;

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -75,12 +75,12 @@ TEST_F(MutationIntegrationTest, SetCellTest) {
   // Create a vector of cells which will be inserted into bigtable
   std::string const row_key = "SetCellRowKey";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id1", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 0, "v-c0-0-0", {}},
-      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1", {}},
-      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key, column_family1, "column_id1", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 0, "v-c0-0-0"},
+      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1"},
+      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2"},
   };
 
   CreateCells(*table, created_cells);
@@ -100,7 +100,7 @@ TEST_F(MutationIntegrationTest, SetCellNumericValueTest) {
   // Create a vector of cells which will be inserted into bigtable
   std::string const row_key = "SetCellNumRowKey";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
       {row_key,
        column_family1,
        "column_id1",
@@ -113,14 +113,14 @@ TEST_F(MutationIntegrationTest, SetCellNumericValueTest) {
        2000,
        bigtable::bigendian64_t(3000),
        {}},
-      {row_key, column_family2, "column_id2", 0, "v-c0-0-0", {}},
+      {row_key, column_family2, "column_id2", 0, "v-c0-0-0"},
       {row_key,
        column_family2,
        "column_id3",
        1000,
        bigtable::bigendian64_t(5000),
        {}},
-      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2", {}},
+      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2"},
   };
 
   CreateCells(*table, created_cells);
@@ -138,7 +138,7 @@ TEST_F(MutationIntegrationTest, SetCellNumericValueTest) {
 TEST_F(MutationIntegrationTest, SetCellNumericValueExceptionTest) {
   std::string const table_id = RandomTableId();
   bigtable::Cell new_cell("row-key", "column_family", "column_id", 1000,
-                          "string-value", {});
+                          "string-value");
   EXPECT_THROW(new_cell.value_as<bigtable::bigendian64_t>().get(),
                std::range_error);
 }
@@ -154,21 +154,21 @@ TEST_F(MutationIntegrationTest, SetCellIgnoreTimestampTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key = "SetCellRowKey";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 0, "v-c0-0-0", {}},
-      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1", {}},
-      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key, column_family1, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 0, "v-c0-0-0"},
+      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1"},
+      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2"},
   };
   std::int64_t server_timestamp = -1;
   std::vector<bigtable::Cell> expected_cells{
-      {row_key, column_family1, "column_id1", server_timestamp, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id2", server_timestamp, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id3", server_timestamp, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", server_timestamp, "v-c0-0-0", {}},
-      {row_key, column_family2, "column_id3", server_timestamp, "v-c1-0-1", {}},
-      {row_key, column_family3, "column_id1", server_timestamp, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", server_timestamp, "v-c-0-0"},
+      {row_key, column_family1, "column_id2", server_timestamp, "v-c-0-1"},
+      {row_key, column_family1, "column_id3", server_timestamp, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", server_timestamp, "v-c0-0-0"},
+      {row_key, column_family2, "column_id3", server_timestamp, "v-c1-0-1"},
+      {row_key, column_family3, "column_id1", server_timestamp, "v-c1-0-2"},
   };
 
   CreateCellsIgnoringTimestamp(*table, created_cells);
@@ -193,26 +193,26 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForTimestampRangeTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key = "DeleteColumn-Key";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family2, "column_id2", 1000, "v-c0-0-1", {}},
-      {row_key, column_family2, "column_id2", 3000, "v-c0-0-2", {}},
-      {row_key, column_family2, "column_id2", 4000, "v-c0-0-3", {}},
-      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c1-0-2", {}},
-      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key, column_family1, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family2, "column_id2", 1000, "v-c0-0-1"},
+      {row_key, column_family2, "column_id2", 3000, "v-c0-0-2"},
+      {row_key, column_family2, "column_id2", 4000, "v-c0-0-3"},
+      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1"},
+      {row_key, column_family2, "column_id2", 2000, "v-c1-0-2"},
+      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2"},
   };
 
   std::vector<bigtable::Cell> expected_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 1000, "v-c0-0-1", {}},
-      {row_key, column_family2, "column_id2", 4000, "v-c0-0-3", {}},
-      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1", {}},
-      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key, column_family1, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 1000, "v-c0-0-1"},
+      {row_key, column_family2, "column_id2", 4000, "v-c0-0-3"},
+      {row_key, column_family2, "column_id3", 1000, "v-c1-0-1"},
+      {row_key, column_family3, "column_id1", 2000, "v-c1-0-2"},
   };
 
   // Create records
@@ -243,15 +243,15 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForReversedTimestampRangeTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const key = "row";
   std::vector<bigtable::Cell> created_cells{
-      {key, column_family1, "c1", 1000, "v1", {}},
-      {key, column_family1, "c2", 1000, "v2", {}},
-      {key, column_family1, "c3", 2000, "v3", {}},
-      {key, column_family2, "c2", 1000, "v4", {}},
-      {key, column_family2, "c2", 3000, "v5", {}},
-      {key, column_family2, "c2", 4000, "v6", {}},
-      {key, column_family2, "c3", 1000, "v7", {}},
-      {key, column_family2, "c2", 2000, "v8", {}},
-      {key, column_family3, "c1", 2000, "v9", {}},
+      {key, column_family1, "c1", 1000, "v1"},
+      {key, column_family1, "c2", 1000, "v2"},
+      {key, column_family1, "c3", 2000, "v3"},
+      {key, column_family2, "c2", 1000, "v4"},
+      {key, column_family2, "c2", 3000, "v5"},
+      {key, column_family2, "c2", 4000, "v6"},
+      {key, column_family2, "c3", 1000, "v7"},
+      {key, column_family2, "c2", 2000, "v8"},
+      {key, column_family3, "c1", 2000, "v9"},
   };
 
   CreateCells(*table, created_cells);
@@ -281,9 +281,9 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForEmptyTimestampRangeTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const key = "row";
   std::vector<bigtable::Cell> created_cells{
-      {key, column_family1, "c3", 2000, "v3", {}},
-      {key, column_family2, "c2", 2000, "v2", {}},
-      {key, column_family3, "c1", 2000, "v1", {}},
+      {key, column_family1, "c3", 2000, "v3"},
+      {key, column_family2, "c2", 2000, "v2"},
+      {key, column_family3, "c1", 2000, "v1"},
   };
 
   CreateCells(*table, created_cells);
@@ -307,16 +307,16 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnForAllTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key = "DeleteColumnForAll-Key";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id3", 1000, "v-c-0-1", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id3", 1000, "v-c-0-1"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
   };
 
   // Create records
@@ -342,18 +342,18 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnStartingFromTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key = "DeleteColumnStartingFrom-Key";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id1", 2000, "v-c-0-1", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key, column_family1, "column_id1", 2000, "v-c-0-1"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records
@@ -380,18 +380,18 @@ TEST_F(MutationIntegrationTest, DeleteFromColumnEndingAtTest) {
   // Create a vector of cell which will be inserted into bigtable cloud
   std::string const row_key = "DeleteColumnEndingAt-Key";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key, column_family1, "column_id1", 2000, "v-c-0-1", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key, column_family1, "column_id1", 2000, "v-c-0-1"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key, column_family1, "column_id1", 2000, "v-c-0-1", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 2000, "v-c-0-1"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records
@@ -419,15 +419,15 @@ TEST_F(MutationIntegrationTest, DeleteFromFamilyTest) {
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key = "DeleteFamily-Key";
   std::vector<bigtable::Cell> created_cells{
-      {row_key, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key, column_family1, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
+      {row_key, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key, column_family2, "column_id2", 2000, "v-c0-0-0"},
   };
 
   // Create records
@@ -453,15 +453,15 @@ TEST_F(MutationIntegrationTest, DeleteFromRowTest) {
   std::string const row_key1 = "DeleteRowKey1";
   std::string const row_key2 = "DeleteRowKey2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records

--- a/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
@@ -98,11 +98,11 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   std::string const row_key1 = "row1";
   std::string const row_key2 = "row2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0"},
+      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
   // Create records
   CreateCells(table, created_cells);

--- a/google/cloud/bigtable/tests/snapshot_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_integration_test.cc
@@ -80,11 +80,11 @@ TEST_F(SnapshotIntegrationTest, SnapshotOperationsTableTest) {
   std::string const row_key1 = "row1";
   std::string const row_key2 = "row2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0"},
+      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records
@@ -128,11 +128,11 @@ TEST_F(SnapshotIntegrationTest, CreateListGetDeleteSnapshot) {
   std::string const row_key1 = "row1";
   std::string const row_key2 = "row2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0", {}},
-      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1", {}},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2", {}},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0", {}},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2", {}},
+      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0"},
+      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1"},
+      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
+      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
   };
   // Create records
   CreateCells(*table, created_cells);


### PR DESCRIPTION
Fixes #1111

Per the Google style guide I added new overloads instead of default arguments (happy to change this if need be). Pinging @devjgm so he can use his command-line fu to make sure I didn't miss any instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2053)
<!-- Reviewable:end -->
