### PR TITLE
Fix flaky integration test(s) for Bigtable.

### DIFF
--- a/google/cloud/bigtable/ci/run_integration_tests.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests.sh
@@ -32,7 +32,7 @@ set +e
 success=""
 readonly TIMEOUT_CMD="$(which timeout)"
 if [ -n "${TIMEOUT_CMD}" ]; then
-  timeout="${TIMEOUT_CMD} 20s"
+  timeout="${TIMEOUT_CMD} 300s"
 else
   timeout="env"
 fi

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -76,7 +76,7 @@ std::string TableTestEnvironment::CreateRandomId(std::string const& prefix,
 std::string TableTestEnvironment::RandomTableId() {
   // This value was discovered by trial and error, it is not documented in the
   // proto files.
-  constexpr int kMaxTableIdLength = 51;
+  constexpr int kMaxTableIdLength = 50;
   static std::string const prefix = "table-";
   return CreateRandomId(prefix, kMaxTableIdLength - prefix.length());
 }

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -74,13 +74,19 @@ std::string TableTestEnvironment::CreateRandomId(std::string const& prefix,
 }
 
 std::string TableTestEnvironment::RandomTableId() {
-  constexpr int RANDOM_CHARACTERS = 16;
-  return CreateRandomId("table-", RANDOM_CHARACTERS);
+  // This value was discovered by trial and error, it is not documented in the
+  // proto files.
+  constexpr int kMaxTableIdLength = 51;
+  static std::string const prefix = "table-";
+  return CreateRandomId(prefix, kMaxTableIdLength - prefix.length());
 }
 
 std::string TableTestEnvironment::RandomInstanceId() {
-  constexpr int RANDOM_CHARACTERS = 8;
-  return CreateRandomId("it-", RANDOM_CHARACTERS);
+  // This value was discovered by trial and error, it is not documented in the
+  // proto files.
+  constexpr int kMaxInstanceIdLenth = 33;
+  static std::string const prefix = "instance-";
+  return CreateRandomId(prefix, kMaxInstanceIdLenth - prefix.length());
 }
 
 void TableIntegrationTest::SetUp() {

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/internal/make_unique.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <google/protobuf/text_format.h>
 #include <algorithm>
 #include <cctype>
@@ -31,15 +32,42 @@ std::string TableTestEnvironment::cluster_id_;
 std::string TableTestEnvironment::zone_;
 std::string TableTestEnvironment::replication_zone_;
 google::cloud::internal::DefaultPRNG TableTestEnvironment::generator_;
+std::string TableTestEnvironment::table_id_;
 
 void TableTestEnvironment::SetUp() {
   generator_ = google::cloud::internal::MakeDefaultPRNG();
+
+  auto admin_client = bigtable::CreateDefaultAdminClient(
+      TableTestEnvironment::project_id(), ClientOptions());
+  auto table_admin =
+      bigtable::TableAdmin(admin_client, TableTestEnvironment::instance_id());
+
+  std::string const family1 = "family1";
+  std::string const family2 = "family2";
+  std::string const family3 = "family3";
+  std::string const family4 = "family4";
+  bigtable::TableConfig table_config =
+      bigtable::TableConfig({{family1, bigtable::GcRule::MaxNumVersions(10)},
+                             {family2, bigtable::GcRule::MaxNumVersions(10)},
+                             {family3, bigtable::GcRule::MaxNumVersions(10)},
+                             {family4, bigtable::GcRule::MaxNumVersions(10)}},
+                            {});
+
+  table_id_ = RandomTableId();
+  ASSERT_STATUS_OK(table_admin.CreateTable(table_id_, table_config));
 }
 
-void TableTestEnvironment::TearDown() {}
+void TableTestEnvironment::TearDown() {
+  auto admin_client = bigtable::CreateDefaultAdminClient(
+      TableTestEnvironment::project_id(), ClientOptions());
+  auto table_admin =
+      bigtable::TableAdmin(admin_client, TableTestEnvironment::instance_id());
+
+  ASSERT_STATUS_OK(table_admin.DeleteTable(table_id_));
+}
 
 std::string TableTestEnvironment::CreateRandomId(std::string const& prefix,
-                                                 std::size_t count) {
+                                                 int count) {
   return prefix +
          google::cloud::internal::Sample(
              generator_, count, "abcdefghijklmnopqrstuvwxyz0123456789");
@@ -66,17 +94,12 @@ void TableIntegrationTest::SetUp() {
   data_client_ = bigtable::CreateDefaultDataClient(
       TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
       ClientOptions());
+
+  ASSERT_STATUS_OK(table_admin_->DropAllRows(TableTestEnvironment::table_id()));
 }
 
-std::unique_ptr<bigtable::Table> TableIntegrationTest::CreateTable(
-    std::string const& table_name, bigtable::TableConfig& table_config) {
-  table_admin_->CreateTable(table_name, table_config);
-  return google::cloud::internal::make_unique<bigtable::Table>(data_client_,
-                                                               table_name);
-}
-
-Status TableIntegrationTest::DeleteTable(std::string const& table_name) {
-  return table_admin_->DeleteTable(table_name);
+bigtable::Table TableIntegrationTest::GetTable() {
+  return bigtable::Table(data_client_, TableTestEnvironment::table_id());
 }
 
 std::vector<bigtable::Cell> TableIntegrationTest::ReadRows(

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -30,6 +30,30 @@ std::string TableTestEnvironment::instance_id_;
 std::string TableTestEnvironment::cluster_id_;
 std::string TableTestEnvironment::zone_;
 std::string TableTestEnvironment::replication_zone_;
+google::cloud::internal::DefaultPRNG TableTestEnvironment::generator_;
+
+void TableTestEnvironment::SetUp() {
+  generator_ = google::cloud::internal::MakeDefaultPRNG();
+}
+
+void TableTestEnvironment::TearDown() {}
+
+std::string TableTestEnvironment::CreateRandomId(std::string const& prefix,
+                                                 std::size_t count) {
+  return prefix +
+         google::cloud::internal::Sample(
+             generator_, count, "abcdefghijklmnopqrstuvwxyz0123456789");
+}
+
+std::string TableTestEnvironment::RandomTableId() {
+  constexpr int RANDOM_CHARACTERS = 16;
+  return CreateRandomId("table-", RANDOM_CHARACTERS);
+}
+
+std::string TableTestEnvironment::RandomInstanceId() {
+  constexpr int RANDOM_CHARACTERS = 8;
+  return CreateRandomId("it-", RANDOM_CHARACTERS);
+}
 
 void TableIntegrationTest::SetUp() {
   admin_client_ = bigtable::CreateDefaultAdminClient(
@@ -140,11 +164,9 @@ void TableIntegrationTest::CheckEqualUnordered(
 }
 
 std::string TableIntegrationTest::RandomTableId() {
-  constexpr int RANDOM_CHARACTERS = 8;
-  return std::string("table-") + google::cloud::internal::Sample(
-                                     generator_, RANDOM_CHARACTERS,
-                                     "abcdefghijklmnopqrstuvwxyz0123456789");
+  return TableTestEnvironment::RandomTableId();
 }
+
 }  // namespace testing
 
 int CellCompare(bigtable::Cell const& lhs, bigtable::Cell const& rhs) {

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -69,14 +69,15 @@ class TableTestEnvironment : public ::testing::Environment {
    * instances of a test with minimal chance of interference, without having
    * to coordinate via some global state.
    */
-  static std::string CreateRandomId(std::string const& prefix,
-                                    std::size_t count);
+  static std::string CreateRandomId(std::string const& prefix, int count);
 
   /// Return a random table id.
   static std::string RandomTableId();
 
   /// Return a random instance id.
   static std::string RandomInstanceId();
+
+  static std::string const& table_id() { return table_id_; }
 
  private:
   static std::string project_id_;
@@ -86,6 +87,8 @@ class TableTestEnvironment : public ::testing::Environment {
   static std::string replication_zone_;
 
   static google::cloud::internal::DefaultPRNG generator_;
+
+  static std::string table_id_;
 };
 
 /**
@@ -96,12 +99,8 @@ class TableIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override;
 
-  /// Creates the table with @p table_config
-  std::unique_ptr<bigtable::Table> CreateTable(
-      std::string const& table_name, bigtable::TableConfig& table_config);
-
-  /// Deletes the table passed via arguments.
-  Status DeleteTable(std::string const& table_name);
+  /// Gets a Table object for the current test.
+  bigtable::Table GetTable();
 
   /// Return all the cells in @p table that pass @p filter.
   std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -51,11 +51,32 @@ class TableTestEnvironment : public ::testing::Environment {
     replication_zone_ = std::move(replication_zone);
   }
 
+  void SetUp() override;
+  void TearDown() override;
+
   static std::string const& project_id() { return project_id_; }
   static std::string const& instance_id() { return instance_id_; }
   static std::string const& cluster_id() { return cluster_id_; }
   static std::string const& zone() { return zone_; }
   static std::string const& replication_zone() { return replication_zone_; }
+
+  /**
+   * Generate a random string for instance, cluster, or table identifiers.
+   *
+   * Return a string starting with @p prefix and with @p count random symbols
+   * from the [a-z0-9] set. These strings are useful as identifiers for tables,
+   * clusters, or instances. Using a random table id allows us to run two
+   * instances of a test with minimal chance of interference, without having
+   * to coordinate via some global state.
+   */
+  static std::string CreateRandomId(std::string const& prefix,
+                                    std::size_t count);
+
+  /// Return a random table id.
+  static std::string RandomTableId();
+
+  /// Return a random instance id.
+  static std::string RandomInstanceId();
 
  private:
   static std::string project_id_;
@@ -63,6 +84,8 @@ class TableTestEnvironment : public ::testing::Environment {
   static std::string cluster_id_;
   static std::string zone_;
   static std::string replication_zone_;
+
+  static google::cloud::internal::DefaultPRNG generator_;
 };
 
 /**
@@ -124,9 +147,6 @@ class TableIntegrationTest : public ::testing::Test {
   std::string RandomTableId();
 
  protected:
-  google::cloud::internal::DefaultPRNG generator_ =
-      google::cloud::internal::MakeDefaultPRNG();
-
   std::shared_ptr<bigtable::AdminClient> admin_client_;
   std::unique_ptr<bigtable::TableAdmin> table_admin_;
   std::unique_ptr<bigtable::noex::TableAdmin> noex_table_admin_;

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -109,7 +109,6 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
 
   chain.get();
   SUCCEED();  // we expect that previous operations do not fail.
-  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   cq.Shutdown();
   pool.join();

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -301,9 +301,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
 TEST_F(AdminAsyncIntegrationTest, CheckConsistencyIntegrationTest) {
   using namespace google::cloud::testing_util::chrono_literals;
 
-  std::string id =
-      "it-" + google::cloud::internal::Sample(
-                  generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  std::string id = bigtable::testing::TableTestEnvironment::RandomInstanceId();
   std::string const random_table_id = RandomTableId();
 
   auto project_id = bigtable::testing::TableTestEnvironment::project_id();

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -230,7 +230,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
 
   promise_drop_row.get_future().get();
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 
@@ -290,7 +290,7 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
   promise_drop_row.get_future().get();
 
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));
 
   ASSERT_TRUE(actual_cells.empty());
   cq.Shutdown();

--- a/google/cloud/bigtable/tests/admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_integration_test.cc
@@ -170,32 +170,10 @@ TEST_F(AdminAsyncIntegrationTest, CreateListGetDeleteTableTest) {
 
 /// @test Verify that `noex::TableAdmin` AsyncDropRowsByPrefix works
 TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
-  std::string const table_id = RandomTableId();
-  std::string const column_family1 = "family1";
-  std::string const column_family2 = "family2";
-  std::string const column_family3 = "family3";
-
-  bigtable::TableConfig table_config = bigtable::TableConfig(
-      {{column_family1, bigtable::GcRule::MaxNumVersions(10)},
-       {column_family2, bigtable::GcRule::MaxNumVersions(10)},
-       {column_family3, bigtable::GcRule::MaxNumVersions(10)}},
-      {});
+  auto table = GetTable();
 
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
-
-  std::promise<btadmin::Table> promise_create_table;
-  noex_table_admin_->AsyncCreateTable(
-      cq,
-      [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
-                              grpc::Status const& status) {
-        promise_create_table.set_value(std::move(table));
-      },
-      table_id, table_config);
-
-  auto table_created = promise_create_table.get_future().get();
-
-  bigtable::Table table(data_client_, table_id);
 
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key1_prefix = "DropRowPrefix1";
@@ -204,17 +182,17 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
   std::string const row_key1_1 = row_key1_prefix + "_1-Key1";
   std::string const row_key2 = row_key2_prefix + "-Key2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
-      {row_key1_1, column_family2, "column_id3", 2000, "v-c-0-2"},
-      {row_key1_1, column_family2, "column_id3", 3000, "v-c-0-2"},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
+      {row_key1, "family1", "column_id1", 0, "v-c-0-0"},
+      {row_key1, "family1", "column_id1", 1000, "v-c-0-1"},
+      {row_key1, "family2", "column_id3", 2000, "v-c-0-2"},
+      {row_key1_1, "family2", "column_id3", 2000, "v-c-0-2"},
+      {row_key1_1, "family2", "column_id3", 3000, "v-c-0-2"},
+      {row_key2, "family2", "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, "family3", "column_id3", 3000, "v-c1-0-2"},
   };
   std::vector<bigtable::Cell> expected_cells{
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"}};
+      {row_key2, "family2", "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, "family3", "column_id3", 3000, "v-c1-0-2"}};
 
   // Create records
   CreateCells(table, created_cells);
@@ -226,11 +204,10 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
       [&promise_drop_row](CompletionQueue& cq, grpc::Status const& status) {
         promise_drop_row.set_value();
       },
-      table_id, row_key1_prefix);
+      bigtable::testing::TableTestEnvironment::table_id(), row_key1_prefix);
 
   promise_drop_row.get_future().get();
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));
 
   CheckEqualUnordered(expected_cells, actual_cells);
 
@@ -239,41 +216,20 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropRowsByPrefixTest) {
 }
 
 TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
-  std::string const table_id = RandomTableId();
-  std::string const column_family1 = "family1";
-  std::string const column_family2 = "family2";
-  std::string const column_family3 = "family3";
-  bigtable::TableConfig table_config = bigtable::TableConfig(
-      {{column_family1, bigtable::GcRule::MaxNumVersions(10)},
-       {column_family2, bigtable::GcRule::MaxNumVersions(10)},
-       {column_family3, bigtable::GcRule::MaxNumVersions(10)}},
-      {});
+  auto table = GetTable();
 
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
-
-  std::promise<btadmin::Table> promise_create_table;
-  noex_table_admin_->AsyncCreateTable(
-      cq,
-      [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
-                              grpc::Status const& status) {
-        promise_create_table.set_value(std::move(table));
-      },
-      table_id, table_config);
-
-  auto table_created = promise_create_table.get_future().get();
-
-  bigtable::Table table(data_client_, table_id);
 
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key1 = "DropRowKey1";
   std::string const row_key2 = "DropRowKey2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 0, "v-c-0-0"},
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-1"},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
+      {row_key1, "family1", "column_id1", 0, "v-c-0-0"},
+      {row_key1, "family1", "column_id1", 1000, "v-c-0-1"},
+      {row_key1, "family2", "column_id3", 2000, "v-c-0-2"},
+      {row_key2, "family2", "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, "family3", "column_id3", 3000, "v-c1-0-2"},
   };
 
   // Create records
@@ -286,11 +242,10 @@ TEST_F(AdminAsyncIntegrationTest, AsyncDropAllRowsTest) {
       [&promise_drop_row](CompletionQueue& cq, grpc::Status const& status) {
         promise_drop_row.set_value();
       },
-      table_id);
+      bigtable::testing::TableTestEnvironment::table_id());
   promise_drop_row.get_future().get();
 
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));
 
   ASSERT_TRUE(actual_cells.empty());
   cq.Shutdown();

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -246,9 +246,7 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableTest) {
 TEST_F(AdminIntegrationTest, CheckConsistencyIntegrationTest) {
   using namespace google::cloud::testing_util::chrono_literals;
 
-  std::string id =
-      "it-" + google::cloud::internal::Sample(
-                  generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  std::string id = bigtable::testing::TableTestEnvironment::RandomInstanceId();
   std::string const random_table_id = RandomTableId();
 
   auto project_id = bigtable::testing::TableTestEnvironment::project_id();

--- a/google/cloud/bigtable/tests/data_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_integration_test.cc
@@ -26,27 +26,22 @@ namespace {
 class DataAsyncIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
  protected:
-  std::string const family = "family";
-  std::string const family1 = "family1";
-  std::string const family2 = "family2";
-  std::string const family3 = "family3";
-  bigtable::TableConfig table_config =
-      bigtable::TableConfig({{family, bigtable::GcRule::MaxNumVersions(10)},
-                             {family1, bigtable::GcRule::MaxNumVersions(10)},
-                             {family2, bigtable::GcRule::MaxNumVersions(10)},
-                             {family3, bigtable::GcRule::MaxNumVersions(10)}},
-                            {});
+  noex::Table GetNoExTable() {
+    return noex::Table(data_client_,
+                       bigtable::testing::TableTestEnvironment::table_id());
+  }
 };
 
 using namespace google::cloud::testing_util::chrono_literals;
 
 TEST_F(DataAsyncIntegrationTest, TableApply) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
 
   std::string const row_key = "row-key-1";
-  std::vector<bigtable::Cell> created{{row_key, family, "c0", 1000, "v1000"},
-                                      {row_key, family, "c1", 2000, "v2000"}};
+  std::vector<bigtable::Cell> created{
+      {row_key, "family1", "c0", 1000, "v1000"},
+      {row_key, "family1", "c1", 2000, "v2000"}};
   SingleRowMutation mut(row_key);
   for (auto const& c : created) {
     mut.emplace_back(SetCell(
@@ -58,7 +53,6 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
 
-  noex::Table table(data_client_, table_id);
   std::promise<void> done;
   table.AsyncApply(
       cq,
@@ -75,31 +69,31 @@ TEST_F(DataAsyncIntegrationTest, TableApply) {
   done.get_future().get();
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<bigtable::Cell> expected{{row_key, family, "c0", 1000, "v1000"},
-                                       {row_key, family, "c1", 2000, "v2000"}};
+  std::vector<bigtable::Cell> expected{
+      {row_key, "family1", "c0", 1000, "v1000"},
+      {row_key, "family1", "c1", 2000, "v2000"}};
 
-  auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(sync_table, bigtable::Filter::PassAllFilter());
 
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataAsyncIntegrationTest, TableBulkApply) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
 
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::map<std::string, std::vector<bigtable::Cell>> created{
       {row_key1,
-       {{row_key1, family, "c0", 1000, "v1000"},
-        {row_key1, family, "c1", 2000, "v2000"}}},
+       {{row_key1, "family1", "c0", 1000, "v1000"},
+        {row_key1, "family1", "c1", 2000, "v2000"}}},
       {row_key2,
-       {{row_key2, family, "c0", 3000, "v1000"},
-        {row_key2, family, "c0", 4000, "v1000"}}}};
+       {{row_key2, "family1", "c0", 3000, "v1000"},
+        {row_key2, "family1", "c0", 4000, "v1000"}}}};
 
   BulkMutation mut;
   for (auto const& row_cells : created) {
@@ -118,7 +112,6 @@ TEST_F(DataAsyncIntegrationTest, TableBulkApply) {
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
 
-  noex::Table table(data_client_, table_id);
   std::promise<void> done;
   table.AsyncBulkApply(
       cq,
@@ -144,18 +137,17 @@ TEST_F(DataAsyncIntegrationTest, TableBulkApply) {
     }
   }
 
-  auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(sync_table, bigtable::Filter::PassAllFilter());
 
   // Cleanup the thread running the completion queue event loop.
   cq.Shutdown();
   pool.join();
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataAsyncIntegrationTest, SampleRowKeys) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
 
   // Create BATCH_SIZE * BATCH_COUNT rows.
   constexpr int BATCH_COUNT = 10;
@@ -174,17 +166,16 @@ TEST_F(DataAsyncIntegrationTest, SampleRowKeys) {
         std::string colid = "c" + std::to_string(col);
         std::string value = colid + "#" + os.str();
         mutation.emplace_back(
-            bigtable::SetCell(family, std::move(colid), std::move(value)));
+            bigtable::SetCell("family1", std::move(colid), std::move(value)));
       }
       bulk.emplace_back(std::move(mutation));
       ++rowid;
     }
-    sync_table->BulkApply(std::move(bulk));
+    sync_table.BulkApply(std::move(bulk));
   }
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
 
-  noex::Table table(data_client_, table_id);
   std::promise<std::vector<RowKeySample>> done;
   table.AsyncSampleRowKeys(
       cq, [&done](CompletionQueue& cq, std::vector<RowKeySample>& samples,
@@ -200,7 +191,6 @@ TEST_F(DataAsyncIntegrationTest, SampleRowKeys) {
 
   cq.Shutdown();
   pool.join();
-  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   // It is somewhat hard to verify that the values returned here are correct.
   // We cannot check the specific values, not even the format, of the row keys
@@ -220,13 +210,13 @@ TEST_F(DataAsyncIntegrationTest, SampleRowKeys) {
 }
 
 TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowPass) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
-  CreateCells(*sync_table, created);
+  std::vector<bigtable::Cell> created{{key, "family1", "c1", 0, "v1000"}};
+  CreateCells(sync_table, created);
   std::promise<void> done;
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
@@ -238,26 +228,25 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowPass) {
         EXPECT_TRUE(response);
       },
       key, bigtable::Filter::ValueRegex("v1000"),
-      {bigtable::SetCell(family, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(family, "c3", 0_ms, "v3000")});
+      {bigtable::SetCell("family1", "c2", 0_ms, "v2000")},
+      {bigtable::SetCell("family1", "c3", 0_ms, "v3000")});
   done.get_future().get();
   cq.Shutdown();
   pool.join();
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
-                                       {key, family, "c2", 0, "v2000"}};
-  auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  std::vector<bigtable::Cell> expected{{key, "family1", "c1", 0, "v1000"},
+                                       {key, "family1", "c2", 0, "v2000"}};
+  auto actual = ReadRows(sync_table, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowFail) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
-  CreateCells(*sync_table, created);
+  std::vector<bigtable::Cell> created{{key, "family1", "c1", 0, "v1000"}};
+  CreateCells(sync_table, created);
   CompletionQueue cq;
   std::promise<void> done;
   std::thread pool([&cq] { cq.Run(); });
@@ -269,22 +258,20 @@ TEST_F(DataAsyncIntegrationTest, TableCheckAndMutateRowFail) {
         EXPECT_FALSE(response);
       },
       key, bigtable::Filter::ValueRegex("not-there"),
-      {bigtable::SetCell(family, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(family, "c3", 0_ms, "v3000")});
+      {bigtable::SetCell("family1", "c2", 0_ms, "v2000")},
+      {bigtable::SetCell("family1", "c3", 0_ms, "v3000")});
   done.get_future().get();
   cq.Shutdown();
   pool.join();
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
-                                       {key, family, "c3", 0, "v3000"}};
-  auto actual = ReadRows(*sync_table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  std::vector<bigtable::Cell> expected{{key, "family1", "c1", 0, "v1000"},
+                                       {key, "family1", "c3", 0, "v3000"}};
+  auto actual = ReadRows(sync_table, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
 
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
@@ -293,17 +280,17 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
   std::string const add_suffix3 = "-newrecord";
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family1, "column-id1", 1000, "v1000"},
-      {row_key1, family2, "column-id2", 2000, "v2000"},
-      {row_key1, family3, "column-id1", 2000, "v3000"},
-      {row_key1, family1, "column-id3", 2000, "v5000"}};
+      {row_key1, "family1", "column-id1", 1000, "v1000"},
+      {row_key1, "family2", "column-id2", 2000, "v2000"},
+      {row_key1, "family3", "column-id1", 2000, "v3000"},
+      {row_key1, "family1", "column-id3", 2000, "v5000"}};
 
   std::vector<bigtable::Cell> expected{
-      {row_key1, family1, "column-id1", 1000, "v1000" + add_suffix1},
-      {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2},
-      {row_key1, family3, "column-id3", 2000, add_suffix3}};
+      {row_key1, "family1", "column-id1", 1000, "v1000" + add_suffix1},
+      {row_key1, "family2", "column-id2", 2000, "v2000" + add_suffix2},
+      {row_key1, "family3", "column-id3", 2000, add_suffix3}};
 
-  CreateCells(*sync_table, created);
+  CreateCells(sync_table, created);
 
   CompletionQueue cq;
   google::cloud::promise<Row> done;
@@ -316,11 +303,11 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
         EXPECT_TRUE(status.ok());
       },
       row_key1,
-      bigtable::ReadModifyWriteRule::AppendValue(family1, "column-id1",
+      bigtable::ReadModifyWriteRule::AppendValue("family1", "column-id1",
                                                  add_suffix1),
-      bigtable::ReadModifyWriteRule::AppendValue(family2, "column-id2",
+      bigtable::ReadModifyWriteRule::AppendValue("family2", "column-id2",
                                                  add_suffix2),
-      bigtable::ReadModifyWriteRule::AppendValue(family3, "column-id3",
+      bigtable::ReadModifyWriteRule::AppendValue("family3", "column-id3",
                                                  add_suffix3));
 
   auto result_row = done.get_future().get();
@@ -335,28 +322,27 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteAppendValueTest) {
   auto actual_cells_ignore_timestamp =
       GetCellsIgnoringTimestamp(result_row.cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_cells_ignore_timestamp,
                       actual_cells_ignore_timestamp);
 }
 
 TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowIncrementAmountTest) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const key = "row-key";
 
   // An initial; BigEndian int64 number with value 0.
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
-  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1}};
+  std::vector<bigtable::Cell> created{{key, "family1", "c1", 0, v1}};
 
   // The expected values as buffers containing BigEndian int64 numbers.
   std::string e1("\x00\x00\x00\x00\x00\x00\x00\x2A", 8);
   std::string e2("\x00\x00\x00\x00\x00\x00\x00\x07", 8);
-  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
-                                       {key, family1, "c2", 0, e2}};
+  std::vector<bigtable::Cell> expected{{key, "family1", "c1", 0, e1},
+                                       {key, "family1", "c2", 0, e2}};
 
-  CreateCells(*sync_table, created);
+  CreateCells(sync_table, created);
 
   CompletionQueue cq;
   google::cloud::promise<Row> done;
@@ -368,8 +354,8 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowIncrementAmountTest) {
         done.set_value(std::move(row));
         EXPECT_TRUE(status.ok());
       },
-      key, bigtable::ReadModifyWriteRule::IncrementAmount(family1, "c1", 42),
-      bigtable::ReadModifyWriteRule::IncrementAmount(family1, "c2", 7));
+      key, bigtable::ReadModifyWriteRule::IncrementAmount("family1", "c1", 42),
+      bigtable::ReadModifyWriteRule::IncrementAmount("family1", "c2", 7));
   auto row = done.get_future().get();
 
   cq.Shutdown();
@@ -379,37 +365,37 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowIncrementAmountTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row.cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
 TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowMultipleTest) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const key = "row-key";
 
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
-  std::vector<bigtable::Cell> created{{key, family1, "c1", 0, v1},
-                                      {key, family1, "c3", 0, "start;"},
-                                      {key, family2, "d1", 0, v1},
-                                      {key, family2, "d3", 0, "start;"}};
+  std::vector<bigtable::Cell> created{{key, "family1", "c1", 0, v1},
+                                      {key, "family1", "c3", 0, "start;"},
+                                      {key, "family2", "d1", 0, v1},
+                                      {key, "family2", "d3", 0, "start;"}};
 
   // The expected values as buffers containing BigEndian int64 numbers.
   std::string e1("\x00\x00\x00\x00\x00\x00\x00\x2A", 8);
   std::string e2("\x00\x00\x00\x00\x00\x00\x00\x07", 8);
   std::string e3("\x00\x00\x00\x00\x00\x00\x07\xD0", 8);
   std::string e4("\x00\x00\x00\x00\x00\x00\x0B\xB8", 8);
-  std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
-                                       {key, family1, "c2", 0, e2},
-                                       {key, family1, "c3", 0, "start;suffix"},
-                                       {key, family1, "c4", 0, "suffix"},
-                                       {key, family2, "d1", 0, e3},
-                                       {key, family2, "d2", 0, e4},
-                                       {key, family2, "d3", 0, "start;suffix"},
-                                       {key, family2, "d4", 0, "suffix"}};
+  std::vector<bigtable::Cell> expected{
+      {key, "family1", "c1", 0, e1},
+      {key, "family1", "c2", 0, e2},
+      {key, "family1", "c3", 0, "start;suffix"},
+      {key, "family1", "c4", 0, "suffix"},
+      {key, "family2", "d1", 0, e3},
+      {key, "family2", "d2", 0, e4},
+      {key, "family2", "d3", 0, "start;suffix"},
+      {key, "family2", "d4", 0, "suffix"}};
 
-  CreateCells(*sync_table, created);
+  CreateCells(sync_table, created);
 
   CompletionQueue cq;
   google::cloud::promise<Row> done;
@@ -422,14 +408,14 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowMultipleTest) {
         done.set_value(std::move(row));
         EXPECT_TRUE(status.ok());
       },
-      key, R::IncrementAmount(family1, "c1", 42),
-      R::IncrementAmount(family1, "c2", 7),
-      R::IncrementAmount(family2, "d1", 2000),
-      R::IncrementAmount(family2, "d2", 3000),
-      R::AppendValue(family1, "c3", "suffix"),
-      R::AppendValue(family1, "c4", "suffix"),
-      R::AppendValue(family2, "d3", "suffix"),
-      R::AppendValue(family2, "d4", "suffix"));
+      key, R::IncrementAmount("family1", "c1", 42),
+      R::IncrementAmount("family1", "c2", 7),
+      R::IncrementAmount("family2", "d1", 2000),
+      R::IncrementAmount("family2", "d2", 3000),
+      R::AppendValue("family1", "c3", "suffix"),
+      R::AppendValue("family1", "c4", "suffix"),
+      R::AppendValue("family2", "d3", "suffix"),
+      R::AppendValue("family2", "d4", "suffix"));
 
   auto row = done.get_future().get();
 
@@ -441,26 +427,25 @@ TEST_F(DataAsyncIntegrationTest, AsyncReadModifyWriteRowMultipleTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row.cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
 TEST_F(DataAsyncIntegrationTest, TableReadRowsAllRows) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3(1024, '3');    // a long key
   std::string const long_value(1024, 'v');  // a long value
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "data1"},
-      {row_key1, family, "c2", 1000, "data2"},
-      {row_key2, family, "c1", 1000, ""},
-      {row_key3, family, "c1", 1000, long_value}};
+      {row_key1, "family1", "c1", 1000, "data1"},
+      {row_key1, "family1", "c2", 1000, "data2"},
+      {row_key2, "family1", "c1", 1000, ""},
+      {row_key3, "family1", "c1", 1000, long_value}};
 
-  CreateCells(*sync_table, created);
+  CreateCells(sync_table, created);
 
   CompletionQueue cq;
   std::promise<void> done;
@@ -486,34 +471,36 @@ TEST_F(DataAsyncIntegrationTest, TableReadRowsAllRows) {
   cq.Shutdown();
   pool.join();
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(created, actual);
 }
 
 TEST_F(DataAsyncIntegrationTest, TableAsyncReadRow) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "v1000"},
-                                      {row_key2, family, "c2", 2000, "v2000"}};
-  std::vector<bigtable::Cell> expected{{row_key1, family, "c1", 1000, "v1000"}};
+  std::vector<bigtable::Cell> created{
+      {row_key1, "family1", "c1", 1000, "v1000"},
+      {row_key2, "family1", "c2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> expected{
+      {row_key1, "family1", "c1", 1000, "v1000"}};
 
-  CreateCells(*sync_table, created);
+  CreateCells(sync_table, created);
 
   CompletionQueue cq;
   google::cloud::promise<std::pair<bool, Row>> done;
   std::thread pool([&cq] { cq.Run(); });
 
-  table.AsyncReadRow(cq,
-                     [&done](CompletionQueue& cq, std::pair<bool, Row> response,
-                             grpc::Status const& status) {
-                       done.set_value(response);
-                       EXPECT_TRUE(status.ok());
-                     },
-                     "row-key-1", Filter::PassAllFilter());
+  table.AsyncReadRow(
+      cq,
+      [&done](CompletionQueue& cq, std::pair<bool, Row> response,
+              grpc::Status const& status) {
+        done.set_value(response);
+        EXPECT_TRUE(status.ok());
+      },
+      "row-key-1", Filter::PassAllFilter());
 
   auto response = done.get_future().get();
   std::vector<bigtable::Cell> actual;
@@ -522,39 +509,39 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRow) {
   cq.Shutdown();
   pool.join();
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
   EXPECT_TRUE(response.first);
 }
 
 TEST_F(DataAsyncIntegrationTest, TableAsyncReadRowForNoRow) {
-  std::string const table_id = RandomTableId();
-  auto sync_table = CreateTable(table_id, table_config);
-  noex::Table table(data_client_, table_id);
+  auto sync_table = GetTable();
+  auto table = GetNoExTable();
+
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{{row_key2, family, "c2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> created{
+      {row_key2, "family1", "c2", 2000, "v2000"}};
 
-  CreateCells(*sync_table, created);
+  CreateCells(sync_table, created);
 
   CompletionQueue cq;
   google::cloud::promise<std::pair<bool, Row>> done;
   std::thread pool([&cq] { cq.Run(); });
 
-  table.AsyncReadRow(cq,
-                     [&done](CompletionQueue& cq, std::pair<bool, Row> response,
-                             grpc::Status const& status) {
-                       done.set_value(response);
-                       EXPECT_TRUE(status.ok());
-                     },
-                     "row-key-1", Filter::PassAllFilter());
+  table.AsyncReadRow(
+      cq,
+      [&done](CompletionQueue& cq, std::pair<bool, Row> response,
+              grpc::Status const& status) {
+        done.set_value(response);
+        EXPECT_TRUE(status.ok());
+      },
+      "row-key-1", Filter::PassAllFilter());
 
   auto response = done.get_future().get();
 
   cq.Shutdown();
   pool.join();
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   EXPECT_FALSE(response.first);
   EXPECT_EQ(0, response.second.cells().size());
 }

--- a/google/cloud/bigtable/tests/data_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_integration_test.cc
@@ -493,14 +493,13 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRow) {
   google::cloud::promise<std::pair<bool, Row>> done;
   std::thread pool([&cq] { cq.Run(); });
 
-  table.AsyncReadRow(
-      cq,
-      [&done](CompletionQueue& cq, std::pair<bool, Row> response,
-              grpc::Status const& status) {
-        done.set_value(response);
-        EXPECT_TRUE(status.ok());
-      },
-      "row-key-1", Filter::PassAllFilter());
+  table.AsyncReadRow(cq,
+                     [&done](CompletionQueue& cq, std::pair<bool, Row> response,
+                             grpc::Status const& status) {
+                       done.set_value(response);
+                       EXPECT_TRUE(status.ok());
+                     },
+                     "row-key-1", Filter::PassAllFilter());
 
   auto response = done.get_future().get();
   std::vector<bigtable::Cell> actual;
@@ -528,14 +527,13 @@ TEST_F(DataAsyncIntegrationTest, TableAsyncReadRowForNoRow) {
   google::cloud::promise<std::pair<bool, Row>> done;
   std::thread pool([&cq] { cq.Run(); });
 
-  table.AsyncReadRow(
-      cq,
-      [&done](CompletionQueue& cq, std::pair<bool, Row> response,
-              grpc::Status const& status) {
-        done.set_value(response);
-        EXPECT_TRUE(status.ok());
-      },
-      "row-key-1", Filter::PassAllFilter());
+  table.AsyncReadRow(cq,
+                     [&done](CompletionQueue& cq, std::pair<bool, Row> response,
+                             grpc::Status const& status) {
+                       done.set_value(response);
+                       EXPECT_TRUE(status.ok());
+                     },
+                     "row-key-1", Filter::PassAllFilter());
 
   auto response = done.get_future().get();
 

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -110,8 +110,19 @@ void DataIntegrationTest::BulkApply(bigtable::Table& table,
 using namespace google::cloud::testing_util::chrono_literals;
 
 TEST_F(DataIntegrationTest, TableApply) {
+auto start = std::chrono::steady_clock::now();
+auto elapsed_ms = [&start] {
+  using ms = std::chrono::milliseconds;
+  auto now = std::chrono::steady_clock::now();
+  auto elapsed = now - start;
+  start = now;
+  return std::chrono::duration_cast<ms>(elapsed).count();
+};
+
   std::string const table_id = RandomTableId();
+  std::cerr << "Random: " << elapsed_ms() << std::endl;
   auto table = CreateTable(table_id, table_config);
+std::cerr << "Create: " << elapsed_ms() << std::endl;
 
   std::string const row_key = "row-key-1";
   std::vector<bigtable::Cell> created{{row_key, family, "c0", 1000, "v1000"},
@@ -121,8 +132,13 @@ TEST_F(DataIntegrationTest, TableApply) {
                                        {row_key, family, "c1", 2000, "v2000"}};
 
   auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
+std::cerr << "ReadRows: " << elapsed_ms() << std::endl;
   EXPECT_STATUS_OK(DeleteTable(table_id));
-  CheckEqualUnordered(expected, actual);
+std::cerr << "Delete: " << elapsed_ms() << std::endl;
+
+CheckEqualUnordered(expected, actual);
+std::cerr << "Check: " << elapsed_ms() << std::endl;
+
 }
 
 TEST_F(DataIntegrationTest, TableBulkApply) {

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -32,16 +32,11 @@ class DataIntegrationTest : public bigtable::testing::TableIntegrationTest {
   void BulkApply(bigtable::Table& table,
                  std::vector<bigtable::Cell> const& cells);
 
-  std::string const family = "family";
+  /// The column family used in this test.
   std::string const family1 = "family1";
   std::string const family2 = "family2";
   std::string const family3 = "family3";
-  bigtable::TableConfig table_config =
-      bigtable::TableConfig({{family, bigtable::GcRule::MaxNumVersions(10)},
-                             {family1, bigtable::GcRule::MaxNumVersions(10)},
-                             {family2, bigtable::GcRule::MaxNumVersions(10)},
-                             {family3, bigtable::GcRule::MaxNumVersions(10)}},
-                            {});
+  std::string const family4 = "family4";
 };
 
 bool UsingCloudBigtableEmulator() {
@@ -110,146 +105,119 @@ void DataIntegrationTest::BulkApply(bigtable::Table& table,
 using namespace google::cloud::testing_util::chrono_literals;
 
 TEST_F(DataIntegrationTest, TableApply) {
-auto start = std::chrono::steady_clock::now();
-auto elapsed_ms = [&start] {
-  using ms = std::chrono::milliseconds;
-  auto now = std::chrono::steady_clock::now();
-  auto elapsed = now - start;
-  start = now;
-  return std::chrono::duration_cast<ms>(elapsed).count();
-};
-
-  std::string const table_id = RandomTableId();
-  std::cerr << "Random: " << elapsed_ms() << std::endl;
-  auto table = CreateTable(table_id, table_config);
-std::cerr << "Create: " << elapsed_ms() << std::endl;
+  auto table = GetTable();
 
   std::string const row_key = "row-key-1";
-  std::vector<bigtable::Cell> created{{row_key, family, "c0", 1000, "v1000"},
-                                      {row_key, family, "c1", 2000, "v2000"}};
-  Apply(*table, row_key, created);
-  std::vector<bigtable::Cell> expected{{row_key, family, "c0", 1000, "v1000"},
-                                       {row_key, family, "c1", 2000, "v2000"}};
+  std::vector<bigtable::Cell> created{{row_key, family4, "c0", 1000, "v1000"},
+                                      {row_key, family4, "c1", 2000, "v2000"}};
+  Apply(table, row_key, created);
+  std::vector<bigtable::Cell> expected{{row_key, family4, "c0", 1000, "v1000"},
+                                       {row_key, family4, "c1", 2000, "v2000"}};
 
-  auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-std::cerr << "ReadRows: " << elapsed_ms() << std::endl;
-  EXPECT_STATUS_OK(DeleteTable(table_id));
-std::cerr << "Delete: " << elapsed_ms() << std::endl;
-
-CheckEqualUnordered(expected, actual);
-std::cerr << "Check: " << elapsed_ms() << std::endl;
-
+  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataIntegrationTest, TableBulkApply) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
 
   std::vector<bigtable::Cell> created{
-      {"row-key-1", family, "c0", 1000, "v1000"},
-      {"row-key-1", family, "c1", 2000, "v2000"},
-      {"row-key-2", family, "c0", 1000, "v1000"},
-      {"row-key-2", family, "c1", 2000, "v2000"},
-      {"row-key-3", family, "c0", 1000, "v1000"},
-      {"row-key-3", family, "c1", 2000, "v2000"},
-      {"row-key-4", family, "c0", 1000, "v1000"},
-      {"row-key-4", family, "c1", 2000, "v2000"}};
-  BulkApply(*table, created);
+      {"row-key-1", family4, "c0", 1000, "v1000"},
+      {"row-key-1", family4, "c1", 2000, "v2000"},
+      {"row-key-2", family4, "c0", 1000, "v1000"},
+      {"row-key-2", family4, "c1", 2000, "v2000"},
+      {"row-key-3", family4, "c0", 1000, "v1000"},
+      {"row-key-3", family4, "c1", 2000, "v2000"},
+      {"row-key-4", family4, "c0", 1000, "v1000"},
+      {"row-key-4", family4, "c1", 2000, "v2000"}};
+  BulkApply(table, created);
   std::vector<bigtable::Cell> expected{
-      {"row-key-1", family, "c0", 1000, "v1000"},
-      {"row-key-1", family, "c1", 2000, "v2000"},
-      {"row-key-2", family, "c0", 1000, "v1000"},
-      {"row-key-2", family, "c1", 2000, "v2000"},
-      {"row-key-3", family, "c0", 1000, "v1000"},
-      {"row-key-3", family, "c1", 2000, "v2000"},
-      {"row-key-4", family, "c0", 1000, "v1000"},
-      {"row-key-4", family, "c1", 2000, "v2000"}};
+      {"row-key-1", family4, "c0", 1000, "v1000"},
+      {"row-key-1", family4, "c1", 2000, "v2000"},
+      {"row-key-2", family4, "c0", 1000, "v1000"},
+      {"row-key-2", family4, "c1", 2000, "v2000"},
+      {"row-key-3", family4, "c0", 1000, "v1000"},
+      {"row-key-3", family4, "c1", 2000, "v2000"},
+      {"row-key-4", family4, "c0", 1000, "v1000"},
+      {"row-key-4", family4, "c1", 2000, "v2000"}};
 
-  auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataIntegrationTest, TableSingleRow) {
-  std::string const table_id = RandomTableId();
   std::string const row_key = "row-key-1";
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
 
   auto mutation = bigtable::SingleRowMutation(
-      row_key, bigtable::SetCell(family, "c1", 1_ms, "V1000"),
-      bigtable::SetCell(family, "c2", 2_ms, "V2000"),
-      bigtable::SetCell(family, "c3", 3_ms, "V3000"));
+      row_key, bigtable::SetCell(family4, "c1", 1_ms, "V1000"),
+      bigtable::SetCell(family4, "c2", 2_ms, "V2000"),
+      bigtable::SetCell(family4, "c3", 3_ms, "V3000"));
+  ASSERT_STATUS_OK(table.Apply(std::move(mutation)));
+  std::vector<bigtable::Cell> expected{{row_key, family4, "c1", 1000, "V1000"},
+                                       {row_key, family4, "c2", 2000, "V2000"},
+                                       {row_key, family4, "c3", 3000, "V3000"}};
 
-  ASSERT_STATUS_OK(table->Apply(std::move(mutation)));
-  std::vector<bigtable::Cell> expected{{row_key, family, "c1", 1000, "V1000"},
-                                       {row_key, family, "c2", 2000, "V2000"},
-                                       {row_key, family, "c3", 3000, "V3000"}};
-
-  auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataIntegrationTest, TableReadRowTest) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "v1000"},
-                                      {row_key2, family, "c2", 2000, "v2000"}};
-  std::vector<bigtable::Cell> expected{{row_key1, family, "c1", 1000, "v1000"}};
+  std::vector<bigtable::Cell> created{{row_key1, family4, "c1", 1000, "v1000"},
+                                      {row_key2, family4, "c2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> expected{
+      {row_key1, family4, "c1", 1000, "v1000"}};
 
-  CreateCells(*table, created);
-  auto row_cell = table->ReadRow(row_key1, bigtable::Filter::PassAllFilter());
+  CreateCells(table, created);
+  auto row_cell = table.ReadRow(row_key1, bigtable::Filter::PassAllFilter());
   std::vector<bigtable::Cell> actual;
   actual.emplace_back(row_cell.second.cells().at(0));
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataIntegrationTest, TableReadRowNotExistTest) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
-  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "v1000"}};
+  std::vector<bigtable::Cell> created{{row_key1, family4, "c1", 1000, "v1000"}};
 
-  CreateCells(*table, created);
-  auto row_cell = table->ReadRow(row_key2, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  CreateCells(table, created);
+  auto row_cell = table.ReadRow(row_key2, bigtable::Filter::PassAllFilter());
   EXPECT_FALSE(row_cell.first);
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3(1024, '3');    // a long key
   std::string const long_value(1024, 'v');  // a long value
 
   std::vector<bigtable::Cell> created{
-      {row_key1, family, "c1", 1000, "data1"},
-      {row_key1, family, "c2", 1000, "data2"},
-      {row_key2, family, "c1", 1000, ""},
-      {row_key3, family, "c1", 1000, long_value}};
+      {row_key1, family4, "c1", 1000, "data1"},
+      {row_key1, family4, "c2", 1000, "data2"},
+      {row_key2, family4, "c1", 1000, ""},
+      {row_key3, family4, "c1", 1000, long_value}};
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
 
   // Some equivalent ways to read the three rows
   auto read1 =
-      table->ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
-                      bigtable::Filter::PassAllFilter());
+      table.ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
+                     bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(created, MoveCellsFromReader(read1));
 
   auto read2 =
-      table->ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()), 3,
-                      bigtable::Filter::PassAllFilter());
+      table.ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()), 3,
+                     bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(created, MoveCellsFromReader(read2));
 
-  auto read3 = table->ReadRows(
+  auto read3 = table.ReadRows(
       bigtable::RowSet(bigtable::RowRange::InfiniteRange()),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(created, MoveCellsFromReader(read3));
@@ -257,80 +225,74 @@ TEST_F(DataIntegrationTest, TableReadRowsAllRows) {
   if (!UsingCloudBigtableEmulator()) {
     // TODO(#151) - remove workarounds for emulator bug(s).
     auto read4 =
-        table->ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
+        table.ReadRows(bigtable::RowSet(), bigtable::Filter::PassAllFilter());
     CheckEqualUnordered(created, MoveCellsFromReader(read4));
   }
-  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsPartialRows) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3 = "row-key-3";
 
-  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "data1"},
-                                      {row_key1, family, "c2", 1000, "data2"},
-                                      {row_key2, family, "c1", 1000, "data3"},
-                                      {row_key3, family, "c1", 1000, "data4"}};
+  std::vector<bigtable::Cell> created{{row_key1, family4, "c1", 1000, "data1"},
+                                      {row_key1, family4, "c2", 1000, "data2"},
+                                      {row_key2, family4, "c1", 1000, "data3"},
+                                      {row_key3, family4, "c1", 1000, "data4"}};
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
 
-  std::vector<bigtable::Cell> expected{{row_key1, family, "c1", 1000, "data1"},
-                                       {row_key1, family, "c2", 1000, "data2"},
-                                       {row_key2, family, "c1", 1000, "data3"}};
+  std::vector<bigtable::Cell> expected{
+      {row_key1, family4, "c1", 1000, "data1"},
+      {row_key1, family4, "c2", 1000, "data2"},
+      {row_key2, family4, "c1", 1000, "data3"}};
 
   // Some equivalent ways of reading just the first two rows
   auto read1 =
-      table->ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()), 2,
-                      bigtable::Filter::PassAllFilter());
+      table.ReadRows(bigtable::RowSet(bigtable::RowRange::InfiniteRange()), 2,
+                     bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read1));
 
   bigtable::RowSet rs2;
   rs2.Append(row_key1);
   rs2.Append(row_key2);
   auto read2 =
-      table->ReadRows(std::move(rs2), bigtable::Filter::PassAllFilter());
+      table.ReadRows(std::move(rs2), bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read2));
 
   bigtable::RowSet rs3(bigtable::RowRange::Closed(row_key1, row_key2));
   auto read3 =
-      table->ReadRows(std::move(rs3), bigtable::Filter::PassAllFilter());
+      table.ReadRows(std::move(rs3), bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
-
-  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsNoRows) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3 = "row-key-3";
 
-  std::vector<bigtable::Cell> created{{row_key1, family, "c1", 1000, "data1"},
-                                      {row_key3, family, "c1", 1000, "data2"}};
+  std::vector<bigtable::Cell> created{{row_key1, family4, "c1", 1000, "data1"},
+                                      {row_key3, family4, "c1", 1000, "data2"}};
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
 
   std::vector<bigtable::Cell> expected;  // empty
 
   // read nonexistent rows
-  auto read1 = table->ReadRows(bigtable::RowSet(row_key2),
-                               bigtable::Filter::PassAllFilter());
+  auto read1 = table.ReadRows(bigtable::RowSet(row_key2),
+                              bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read1));
 
   auto read2 =
-      table->ReadRows(bigtable::RowSet(bigtable::RowRange::Prefix(row_key2)),
-                      bigtable::Filter::PassAllFilter());
+      table.ReadRows(bigtable::RowSet(bigtable::RowRange::Prefix(row_key2)),
+                     bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read2));
 
-  auto read3 = table->ReadRows(bigtable::RowSet(bigtable::RowRange::Empty()),
-                               bigtable::Filter::PassAllFilter());
+  auto read3 = table.ReadRows(bigtable::RowSet(bigtable::RowRange::Empty()),
+                              bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, MoveCellsFromReader(read3));
-
-  EXPECT_STATUS_OK(DeleteTable(table_id));
 }
 
 TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
@@ -356,48 +318,43 @@ TEST_F(DataIntegrationTest, TableReadRowsWrongTable) {
 }
 
 TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
-  CreateCells(*table, created);
-  auto result = table->CheckAndMutateRow(
+  std::vector<bigtable::Cell> created{{key, family4, "c1", 0, "v1000"}};
+  CreateCells(table, created);
+  auto result = table.CheckAndMutateRow(
       key, bigtable::Filter::ValueRegex("v1000"),
-      {bigtable::SetCell(family, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(family, "c3", 0_ms, "v3000")});
+      {bigtable::SetCell(family4, "c2", 0_ms, "v2000")},
+      {bigtable::SetCell(family4, "c3", 0_ms, "v3000")});
   ASSERT_STATUS_OK(result);
   EXPECT_TRUE(*result);
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
-                                       {key, family, "c2", 0, "v2000"}};
-  auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  std::vector<bigtable::Cell> expected{{key, family4, "c1", 0, "v1000"},
+                                       {key, family4, "c2", 0, "v2000"}};
+  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataIntegrationTest, TableCheckAndMutateRowFail) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
-  CreateCells(*table, created);
-  auto result = table->CheckAndMutateRow(
+  std::vector<bigtable::Cell> created{{key, family4, "c1", 0, "v1000"}};
+  CreateCells(table, created);
+  auto result = table.CheckAndMutateRow(
       key, bigtable::Filter::ValueRegex("not-there"),
-      {bigtable::SetCell(family, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(family, "c3", 0_ms, "v3000")});
+      {bigtable::SetCell(family4, "c2", 0_ms, "v2000")},
+      {bigtable::SetCell(family4, "c3", 0_ms, "v3000")});
   ASSERT_STATUS_OK(result);
   EXPECT_FALSE(*result);
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
-                                       {key, family, "c3", 0, "v3000"}};
-  auto actual = ReadRows(*table, bigtable::Filter::PassAllFilter());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
+  std::vector<bigtable::Cell> expected{{key, family4, "c1", 0, "v1000"},
+                                       {key, family4, "c3", 0, "v3000"}};
+  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const add_suffix1 = "-suffix";
@@ -415,15 +372,15 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
       {row_key1, family2, "column-id2", 2000, "v2000" + add_suffix2},
       {row_key1, family3, "column-id3", 2000, add_suffix3}};
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
   auto result_row =
-      table->ReadModifyWriteRow(row_key1,
-                                bigtable::ReadModifyWriteRule::AppendValue(
-                                    family1, "column-id1", add_suffix1),
-                                bigtable::ReadModifyWriteRule::AppendValue(
-                                    family2, "column-id2", add_suffix2),
-                                bigtable::ReadModifyWriteRule::AppendValue(
-                                    family3, "column-id3", add_suffix3));
+      table.ReadModifyWriteRow(row_key1,
+                               bigtable::ReadModifyWriteRule::AppendValue(
+                                   family1, "column-id1", add_suffix1),
+                               bigtable::ReadModifyWriteRule::AppendValue(
+                                   family2, "column-id2", add_suffix2),
+                               bigtable::ReadModifyWriteRule::AppendValue(
+                                   family3, "column-id3", add_suffix3));
   ASSERT_STATUS_OK(result_row);
   // Returned cells contains timestamp in microseconds which is
   // not matching with the timestamp in expected cells, So creating
@@ -432,14 +389,12 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
   auto actual_cells_ignore_timestamp =
       GetCellsIgnoringTimestamp(result_row->cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_cells_ignore_timestamp,
                       actual_cells_ignore_timestamp);
 }
 
 TEST_F(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const key = "row-key";
 
   // An initial; BigEndian int64 number with value 0.
@@ -452,8 +407,8 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
   std::vector<bigtable::Cell> expected{{key, family1, "c1", 0, e1},
                                        {key, family1, "c2", 0, e2}};
 
-  CreateCells(*table, created);
-  auto row = table->ReadModifyWriteRow(
+  CreateCells(table, created);
+  auto row = table.ReadModifyWriteRow(
       key, bigtable::ReadModifyWriteRule::IncrementAmount(family1, "c1", 42),
       bigtable::ReadModifyWriteRule::IncrementAmount(family1, "c2", 7));
   ASSERT_STATUS_OK(row);
@@ -462,13 +417,11 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
 TEST_F(DataIntegrationTest, TableReadModifyWriteRowMultipleTest) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const key = "row-key";
 
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
@@ -491,30 +444,28 @@ TEST_F(DataIntegrationTest, TableReadModifyWriteRowMultipleTest) {
                                        {key, family2, "d3", 0, "start;suffix"},
                                        {key, family2, "d4", 0, "suffix"}};
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
   using R = bigtable::ReadModifyWriteRule;
   auto row =
-      table->ReadModifyWriteRow(key, R::IncrementAmount(family1, "c1", 42),
-                                R::IncrementAmount(family1, "c2", 7),
-                                R::IncrementAmount(family2, "d1", 2000),
-                                R::IncrementAmount(family2, "d2", 3000),
-                                R::AppendValue(family1, "c3", "suffix"),
-                                R::AppendValue(family1, "c4", "suffix"),
-                                R::AppendValue(family2, "d3", "suffix"),
-                                R::AppendValue(family2, "d4", "suffix"));
+      table.ReadModifyWriteRow(key, R::IncrementAmount(family1, "c1", 42),
+                               R::IncrementAmount(family1, "c2", 7),
+                               R::IncrementAmount(family2, "d1", 2000),
+                               R::IncrementAmount(family2, "d2", 3000),
+                               R::AppendValue(family1, "c3", "suffix"),
+                               R::AppendValue(family1, "c4", "suffix"),
+                               R::AppendValue(family2, "d3", "suffix"),
+                               R::AppendValue(family2, "d4", "suffix"));
   ASSERT_STATUS_OK(row);
   // Ignore the server set timestamp on the returned cells because it is not
   // predictable.
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
 TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   std::string const key = "row-key";
 
   std::vector<bigtable::Cell> created{
@@ -532,28 +483,26 @@ TEST_F(DataIntegrationTest, TableCellValueInt64Test) {
       {key, family2, "d2", 0, bigtable::bigendian64_t(9999998012)},
       {key, family2, "d3", 0, "start;suffix"}};
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
   using R = bigtable::ReadModifyWriteRule;
   auto row =
-      table->ReadModifyWriteRow(key, R::IncrementAmount(family1, "c1", -2),
-                                R::IncrementAmount(family1, "c2", 7),
-                                R::IncrementAmount(family2, "d1", 2000),
-                                R::IncrementAmount(family2, "d2", 9999993000),
-                                R::AppendValue(family1, "c3", "suffix"),
-                                R::AppendValue(family2, "d3", "suffix"));
+      table.ReadModifyWriteRow(key, R::IncrementAmount(family1, "c1", -2),
+                               R::IncrementAmount(family1, "c2", 7),
+                               R::IncrementAmount(family2, "d1", 2000),
+                               R::IncrementAmount(family2, "d2", 9999993000),
+                               R::AppendValue(family1, "c3", "suffix"),
+                               R::AppendValue(family2, "d3", "suffix"));
   ASSERT_STATUS_OK(row);
   // Ignore the server set timestamp on the returned cells because it is not
   // predictable.
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp = GetCellsIgnoringTimestamp(row->cells());
 
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
 TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
-  std::string const table_id = RandomTableId();
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
 
   // Create BATCH_SIZE * BATCH_COUNT rows.
   constexpr int BATCH_COUNT = 10;
@@ -577,11 +526,10 @@ TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
       bulk.emplace_back(std::move(mutation));
       ++rowid;
     }
-    table->BulkApply(std::move(bulk));
+    table.BulkApply(std::move(bulk));
   }
-  auto samples = table->SampleRows<std::vector>();
+  auto samples = table.SampleRows<std::vector>();
   ASSERT_STATUS_OK(samples);
-  EXPECT_STATUS_OK(DeleteTable(table_id));
 
   // It is somewhat hard to verify that the values returned here are correct.
   // We cannot check the specific values, not even the format, of the row keys
@@ -617,11 +565,7 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
     return std::chrono::duration_cast<ms>(elapsed).count();
   };
 
-  std::string const table_id = RandomTableId();
-  // TODO(#2015) - Capture elapsed time to troubleshoot flakiness.
-  SCOPED_TRACE("RandomTableId() " + std::to_string(elapsed_ms()) + "ms");
-
-  auto table = CreateTable(table_id, table_config);
+  auto table = GetTable();
   // TODO(#2015) - Capture elapsed time to troubleshoot flakiness.
   SCOPED_TRACE("CreateTable() " + std::to_string(elapsed_ms()) + "ms");
 
@@ -647,16 +591,17 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
 
   for (int i = 0; i < cell_count; i++) {
     auto col_qualifier = "c" + std::to_string(i);
-    created.push_back(bigtable::Cell(row_key, family, col_qualifier, 0, value));
+    created.push_back(
+        bigtable::Cell(row_key, family4, col_qualifier, 0, value));
     expected.push_back(
-        bigtable::Cell(row_key, family, col_qualifier, 0, value));
+        bigtable::Cell(row_key, family4, col_qualifier, 0, value));
   }
 
-  CreateCells(*table, created);
+  CreateCells(table, created);
   // TODO(#2015) - Capture elapsed time to troubleshoot flakiness.
   SCOPED_TRACE("CreateCells() " + std::to_string(elapsed_ms()) + "ms");
 
-  auto result = table->ReadRow(row_key, bigtable::Filter::PassAllFilter());
+  auto result = table.ReadRow(row_key, bigtable::Filter::PassAllFilter());
   EXPECT_TRUE(result.first);
   // TODO(#2015) - Capture elapsed time to troubleshoot flakiness.
   SCOPED_TRACE("ReadRow() " + std::to_string(elapsed_ms()) + "ms");
@@ -673,7 +618,6 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
   auto expected_ignore_timestamp = GetCellsIgnoringTimestamp(expected);
   auto actual_ignore_timestamp =
       GetCellsIgnoringTimestamp(result.second.cells());
-  EXPECT_STATUS_OK(DeleteTable(table_id));
   // TODO(#2015) - Capture elapsed time to troubleshoot flakiness.
   SCOPED_TRACE("DeleteTable() " + std::to_string(elapsed_ms()) + "ms");
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);

--- a/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
@@ -34,19 +34,6 @@ using namespace google::cloud::testing_util::chrono_literals;
 class SnapshotAsyncIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
  protected:
-  std::unique_ptr<TableAdmin> table_admin_;
-
-  void SetUp() {
-    TableIntegrationTest::SetUp();
-    std::shared_ptr<bigtable::AdminClient> admin_client =
-        CreateDefaultAdminClient(
-            bigtable::testing::TableTestEnvironment::project_id(),
-            ClientOptions());
-    table_admin_ = google::cloud::internal::make_unique<TableAdmin>(
-        admin_client, bigtable::testing::TableTestEnvironment::instance_id());
-  }
-
-  void TearDown() {}
   bool IsSnapshotPresent(
       std::vector<google::bigtable::admin::v2::Snapshot> const& snapshots,
       std::string const& snapshot_name) {
@@ -62,52 +49,33 @@ class SnapshotAsyncIntegrationTest
 /// @test Verify that `noex::TableAdmin` Async Snapshot CRUD operations work as
 /// expected.
 TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
-  google::cloud::bigtable::TableId table_id(RandomTableId());
+  auto table = GetTable();
+
   google::cloud::bigtable::ClusterId cluster_id(
       bigtable::testing::TableTestEnvironment::cluster_id());
+
+  google::cloud::bigtable::TableId table_id(
+      bigtable::testing::TableTestEnvironment::table_id());
   std::string snapshot_id_str = table_id.get() + "-snapshot";
   google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
 
-  // create table prerequisites for snapshot operations.
-  std::string const column_family1 = "family1";
-  std::string const column_family2 = "family2";
-  std::string const column_family3 = "family3";
-  bigtable::TableConfig table_config = bigtable::TableConfig(
-      {{column_family1, bigtable::GcRule::MaxNumVersions(10)},
-       {column_family2, bigtable::GcRule::MaxNumVersions(10)},
-       {column_family3, bigtable::GcRule::MaxNumVersions(10)}},
-      {});
-
   CompletionQueue cq;
   std::thread pool([&cq] { cq.Run(); });
-
-  std::promise<btadmin::Table> promise_create_table;
-  noex_table_admin_->AsyncCreateTable(
-      cq,
-      [&promise_create_table](CompletionQueue& cq, btadmin::Table& table,
-                              grpc::Status const& status) {
-        promise_create_table.set_value(std::move(table));
-      },
-      table_id.get(), table_config);
-
-  auto table_created = promise_create_table.get_future().get();
-
-  bigtable::Table table(data_client_, table_id.get());
 
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key1 = "row1";
   std::string const row_key2 = "row2";
   std::vector<bigtable::Cell> created_cells{
-      {row_key1, column_family1, "column_id1", 1000, "v-c-0-0"},
-      {row_key1, column_family1, "column_id2", 1000, "v-c-0-1"},
-      {row_key1, column_family2, "column_id3", 2000, "v-c-0-2"},
-      {row_key2, column_family2, "column_id2", 2000, "v-c0-0-0"},
-      {row_key2, column_family3, "column_id3", 3000, "v-c1-0-2"},
+      {row_key1, "family1", "column_id1", 1000, "v-c-0-0"},
+      {row_key1, "family1", "column_id2", 1000, "v-c-0-1"},
+      {row_key1, "family2", "column_id3", 2000, "v-c-0-2"},
+      {row_key2, "family2", "column_id2", 2000, "v-c0-0-0"},
+      {row_key2, "family3", "column_id3", 3000, "v-c1-0-2"},
   };
   // Create records
   CreateCells(table, created_cells);
 
-  // verify new snapshot id in list of snapshot
+  // Verify that the snapshot does not exist before create it.
   auto snapshots_before = table_admin_->ListSnapshots(cluster_id);
   ASSERT_STATUS_OK(snapshots_before);
   ASSERT_FALSE(IsSnapshotPresent(*snapshots_before, snapshot_id_str))
@@ -119,8 +87,11 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   auto snapshot =
       table_admin_->SnapshotTable(cluster_id, snapshot_id, table_id, 36000_s)
           .get();
+
+  // Verify that the newly created snapshot appears on the list.
   auto snapshots_current = table_admin_->ListSnapshots(cluster_id);
   ASSERT_STATUS_OK(snapshots_current);
+
   EXPECT_TRUE(IsSnapshotPresent(*snapshots_current, snapshot.name()));
 
   // get snapshot
@@ -151,9 +122,6 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   auto snapshots_after_delete = table_admin_->ListSnapshots(cluster_id);
   ASSERT_STATUS_OK(snapshots_after_delete);
   EXPECT_FALSE(IsSnapshotPresent(*snapshots_after_delete, snapshot.name()));
-
-  // delete table
-  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id.get()));
 
   cq.Shutdown();
   pool.join();

--- a/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/snapshot_async_integration_test.cc
@@ -153,7 +153,7 @@ TEST_F(SnapshotAsyncIntegrationTest, CreateListGetDeleteSnapshot) {
   EXPECT_FALSE(IsSnapshotPresent(*snapshots_after_delete, snapshot.name()));
 
   // delete table
-  EXPECT_STATUS_OK(DeleteTable(table_id.get()));
+  EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id.get()));
 
   cq.Shutdown();
   pool.join();


### PR DESCRIPTION
We used to create a separate table for each test case in the integration
tests. That makes the test case easier to reason about, but
creating a table is very slow in the production tests, and one can
easily hit the daily or peak quota for Bigtable:

https://cloud.google.com/bigtable/quotas#operation-quotas

In this PR we change the integration tests to share a common table. I
had to normalize the table schema: typically we had column families
named "family{1,2,3}" but sometimes it was "fam{0,1,2,3}". I also
changed the `SetUp()` function to drop all the rows in the table, so at
least the table is clean.

One good thing is that the `TearDown()` function automatically deletes the table,
so we do not need to delete it in each test.

Note that some of the instance admin and table admin tests still create
tables, but those are typically disabled when running against
production.

Apologies for the size of the PR.

This fixes #2015.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2057)
<!-- Reviewable:end -->
