### PR TITLE
More fine-grained outstanding size bookkeeping.

### DIFF
--- a/google/cloud/bigtable/internal/mutation_batcher.h
+++ b/google/cloud/bigtable/internal/mutation_batcher.h
@@ -147,8 +147,8 @@ class MutationBatcher {
     BulkMutation TransferRequest() { return std::move(requests_); }
 
     void Add(PendingSingleRowMutation&& mut);
-    void FireCallbacks(CompletionQueue& cq,
-                       std::vector<FailedMutation> const& failed);
+    size_t FireCallbacks(CompletionQueue& cq,
+                         std::vector<FailedMutation> const& failed);
 
    private:
     struct MutationData {
@@ -183,8 +183,8 @@ class MutationBatcher {
   void BatchFinished(CompletionQueue& cq, std::shared_ptr<Batch> const& batch,
                      std::vector<FailedMutation> const& failed);
   std::vector<AsyncApplyAdmissionCallback> FlushOnBatchFinished(
-      CompletionQueue& cq,
-      std::shared_ptr<MutationBatcher::Batch> const& batch);
+      CompletionQueue& cq, size_t completed_size);
+  void Admit(PendingSingleRowMutation&& mut);
 
   std::mutex mu_;
   noex::Table& table_;


### PR DESCRIPTION
For now, this change is a noop, but it is needed for when we're going to
use the streaming version of `BulkMutator`. We want to update these
sizes on every finished mutation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2058)
<!-- Reviewable:end -->
