### PR TITLE
Add synchronization to MutationBatcher::Batch.

### DIFF
--- a/google/cloud/bigtable/internal/mutation_batcher.h
+++ b/google/cloud/bigtable/internal/mutation_batcher.h
@@ -160,6 +160,8 @@ class MutationBatcher {
       int num_mutations;
       int request_size;
     };
+
+    std::mutex mu_;
     size_t num_mutations_;
     size_t requests_size_;
     BulkMutation requests_;


### PR DESCRIPTION
It will be touched from multiple callbacks without obtaining the
`MutationBatcher`'s lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2063)
<!-- Reviewable:end -->
