### PR TITLE
Remove the Travis + Bazel build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ matrix:
     - # Compile on Travis' native environment with Bazel
       os: linux
       compiler: gcc
-      install: ci/install-retry.sh ci/install-bazel.sh linux
-      script: ci/travis/build-bazel.sh
-    - # Compile on Travis' native environment with Bazel
-      os: linux
-      compiler: gcc
       env:
         TEST_BAZEL_AS_DEPENDENCY=yes
       install: ci/install-retry.sh ci/install-bazel.sh linux


### PR DESCRIPTION
The Kokoro:Ubuntu build is also using Bazel, we do not need two separate
builds to check that Bazel works. Please check my math on this, compare
against `ci/kokoro/ubuntu/build.sh`.

I left the TEST_BAZEL_AS_DEPENDENCY=yes build on, because this is the
only build where we check that including `google-cloud-cpp` as a Bazel
dependency works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2071)
<!-- Reviewable:end -->
