### PR TITLE
Replace TEST_CASE with TEST_SUITE for tests.

### DIFF
--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -105,7 +105,21 @@ foreach ($pkg in $packages) {
 
 # The dependencies are cached, we need to remove this old dependency. Otherwise
 # CMake files the old version of gtest+gmock instead of the external project.
+# This is clearly a defect in our hand-crafted caching, but without caching the
+# build takes about 1 hour to just build the dependencies.
+Write-Host "================================================================"
+Write-Host "================================================================"
 .\vcpkg.exe remove --recurse --purge "gtest:x64-windows-static"
+Remove-Item -Recurse -Path installed\x64-windows-static\include\gtest
+Remove-Item -Recurse -Path installed\x64-windows-static\include\gmock
+
+Write-Host "================================================================"
+Write-Host "================================================================"
+.\vcpkg.exe list
+Get-ChildItem -Recurse -Path installed\x64-windows-static\include\gtest -File
+Get-ChildItem -Recurse -Path installed\x64-windows-static\include\gmock -File
+Write-Host "================================================================"
+Write-Host "================================================================"
 
 Write-Host "Create cache zip file."
 Get-Date -Format o

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -105,7 +105,7 @@ foreach ($pkg in $packages) {
 
 # The dependencies are cached, we need to remove this old dependency. Otherwise
 # CMake files the old version of gtest+gmock instead of the external project.
-.\vcpkg.exe remove --recurse "gtest:x64-windows-static"
+.\vcpkg.exe remove --recurse --purge "gtest:x64-windows-static"
 
 Write-Host "Create cache zip file."
 Get-Date -Format o

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -95,13 +95,17 @@ Get-Date -Format o
 $packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
               "protobuf:x64-windows-static", "c-ares:x64-windows-static",
               "grpc:x64-windows-static", "curl:x64-windows-static",
-              "gtest:x64-windows-static", "crc32c:x64-windows-static")
+              "crc32c:x64-windows-static")
 foreach ($pkg in $packages) {
     .\vcpkg.exe install $pkg
     if ($LastExitCode) {
         throw "vcpkg install $pkg failed with exit code $LastExitCode"
     }
 }
+
+# The dependencies are cached, we need to remove this old dependency. Otherwise
+# CMake files the old version of gtest+gmock instead of the external project.
+.\vcpkg.exe remove --recurse "gtest:x64-windows-static"
 
 Write-Host "Create cache zip file."
 Get-Date -Format o

--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -50,6 +50,7 @@ if ($LastExitCode) {
 
 # Setup the environment for vcpkg:
 $cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$PROVIDER"
+$cmake_flags += "-DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external"
 $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
 $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
 $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -224,7 +224,7 @@ if (BUILD_TESTING)
                                       GTest::gtest
                                       google_cloud_cpp_common_options)
         if (MSVC)
-            target_compile_options(${target} "/bigobj")
+            target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -223,6 +223,9 @@ if (BUILD_TESTING)
                                       GTest::gmock
                                       GTest::gtest
                                       google_cloud_cpp_common_options)
+        if (MSVC)
+            target_compile_options(${target} "/bigobj")
+        endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -402,7 +402,7 @@ if (BUILD_TESTING)
                                       protobuf::libprotobuf
                                       bigtable_common_options)
         if (MSVC)
-            target_compile_options(${target} "/bigobj")
+            target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -401,6 +401,9 @@ if (BUILD_TESTING)
                                       gRPC::grpc
                                       protobuf::libprotobuf
                                       bigtable_common_options)
+        if (MSVC)
+            target_compile_options(${target} "/bigobj")
+        endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -63,6 +63,9 @@ if (BUILD_TESTING)
                                       gRPC::grpc++
                                       gRPC::grpc
                                       protobuf::libprotobuf)
+        if (MSVC)
+            target_compile_options(${target} "/bigobj")
+        endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -64,7 +64,7 @@ if (BUILD_TESTING)
                                       gRPC::grpc
                                       protobuf::libprotobuf)
         if (MSVC)
-            target_compile_options(${target} "/bigobj")
+            target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()

--- a/google/cloud/bigtable/internal/async_check_consistency_test.cc
+++ b/google/cloud/bigtable/internal/async_check_consistency_test.cc
@@ -180,7 +180,7 @@ TEST_P(NoexAsyncCheckConsistencyRetryTest, OneRetry) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(OneRetry, NoexAsyncCheckConsistencyRetryTest,
+INSTANTIATE_TEST_SUITE_P(OneRetry, NoexAsyncCheckConsistencyRetryTest,
                         ::testing::Values(
                             // First RPC returns an OK status but indicates that
                             // replication has not yet caught up.
@@ -294,7 +294,7 @@ TEST_P(NoexAsyncCheckConsistencyEndToEnd, EndToEnd) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     EndToEnd, NoexAsyncCheckConsistencyEndToEnd,
     ::testing::Values(
         // Everything succeeds immediately.
@@ -478,7 +478,7 @@ TEST_P(NoexAsyncCheckConsistencyCancel, Cancellations) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CancelTest, NoexAsyncCheckConsistencyCancel,
     ::testing::Values(
         // Cancel during GenerateConsistencyTokenResponse

--- a/google/cloud/bigtable/internal/async_check_consistency_test.cc
+++ b/google/cloud/bigtable/internal/async_check_consistency_test.cc
@@ -181,12 +181,12 @@ TEST_P(NoexAsyncCheckConsistencyRetryTest, OneRetry) {
 }
 
 INSTANTIATE_TEST_SUITE_P(OneRetry, NoexAsyncCheckConsistencyRetryTest,
-                        ::testing::Values(
-                            // First RPC returns an OK status but indicates that
-                            // replication has not yet caught up.
-                            false,
-                            // First RPC fails.
-                            true));
+                         ::testing::Values(
+                             // First RPC returns an OK status but indicates
+                             // that replication has not yet caught up.
+                             false,
+                             // First RPC fails.
+                             true));
 
 class EndToEndConfig {
  public:

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -178,7 +178,7 @@ TEST_P(NoexAsyncLongrunningImmediatelyFinished, ImmeditalyFinished) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ImmediateFinished, NoexAsyncLongrunningImmediatelyFinished,
     ::testing::Values(
         // The long running operation was successful.
@@ -302,7 +302,7 @@ TEST_P(NoexAsyncLongrunningOpRetryTest, OneRetry) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     OneRetry, NoexAsyncLongrunningOpRetryTest,
     ::testing::Values(
         // First RPC returns an OK status but indicates

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -166,7 +166,7 @@ TEST_P(NoexTableAsyncPollOpImmediateFinishTest, ImmediateFinish) {
   EXPECT_TRUE(user_op_completed);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ImmediateFinish, NoexTableAsyncPollOpImmediateFinishTest,
     ::testing::Values(
         // Finished in first shot.
@@ -332,7 +332,7 @@ TEST_P(NoexTableAsyncPollOpOneRetryTest, OneRetry) {
   EXPECT_TRUE(user_op_completed);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     OneRetry, NoexTableAsyncPollOpOneRetryTest,
     ::testing::Values(
         // No error, not finished, then OK, finished == true,
@@ -512,7 +512,7 @@ TEST_P(NoexTableAsyncPollOpCancelInOpTest, CancelInOperation) {
   EXPECT_TRUE(user_op_completed);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CancelInOperation, NoexTableAsyncPollOpCancelInOpTest,
     ::testing::Values(
         // Simulate Cancel being called when an underlying operation is ongoing.
@@ -772,7 +772,7 @@ TEST_P(NoexTableAsyncPollOpCancelInTimerTest, TestCancelInTimer) {
   EXPECT_TRUE(user_op_completed);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CancelInTimer, NoexTableAsyncPollOpCancelInTimerTest,
     ::testing::Values(
         // Simulate Cancel being called when sleeping in a timer.

--- a/google/cloud/bigtable/internal/async_retry_op_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_op_test.cc
@@ -215,7 +215,7 @@ TEST_P(NoexTableAsyncRetryOpCancelInOpTest, CancelInOperation) {
   EXPECT_TRUE(user_op_completed);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CancelInOperation, NoexTableAsyncRetryOpCancelInOpTest,
     ::testing::Values(
         // Simulate Cancel being called when an underlying operation is ongoing.
@@ -405,7 +405,7 @@ TEST_P(NoexTableAsyncRetryOpCancelInTimerTest, TestCancelInTimer) {
   EXPECT_TRUE(user_op_completed);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CancelInTimer, NoexTableAsyncRetryOpCancelInTimerTest,
     ::testing::Values(
         // Simulate Cancel being called when sleeping in a timer.

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -193,7 +193,7 @@ TEST_P(AsyncRetryUnaryRpcAndPollResEndToEnd, EndToEnd) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     EndToEnd, AsyncRetryUnaryRpcAndPollResEndToEnd,
     ::testing::Values(
         // Everything succeeds immediately.
@@ -412,7 +412,7 @@ TEST_P(AsyncRetryUnaryRpcAndPollResCancel, Cancellations) {
   EXPECT_TRUE(cq_impl->empty());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CancelTest, AsyncRetryUnaryRpcAndPollResCancel,
     ::testing::Values(
         // Cancel during AsyncCreateCluster yields the request returning

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -105,6 +105,9 @@ if (BUILD_TESTING)
                                       GTest::gmock
                                       GTest::gtest
                                       firestore_common_options)
+        if (MSVC)
+            target_compile_options(${target} "/bigobj")
+        endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -106,7 +106,7 @@ if (BUILD_TESTING)
                                       GTest::gtest
                                       firestore_common_options)
         if (MSVC)
-            target_compile_options(${target} "/bigobj")
+            target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -378,6 +378,9 @@ if (BUILD_TESTING)
                                           CURL::CURL
                                           storage_common_options
                                           nlohmann_json)
+            if (MSVC)
+                target_compile_options(${target} "/bigobj")
+            endif ()
             add_test(NAME ${target} COMMAND ${target})
         endif ()
     endforeach ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -379,7 +379,7 @@ if (BUILD_TESTING)
                                           storage_common_options
                                           nlohmann_json)
             if (MSVC)
-                target_compile_options(${target} "/bigobj")
+            target_compile_options(${target} PRIVATE "/bigobj")
             endif ()
             add_test(NAME ${target} COMMAND ${target})
         endif ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -379,7 +379,7 @@ if (BUILD_TESTING)
                                           storage_common_options
                                           nlohmann_json)
             if (MSVC)
-            target_compile_options(${target} PRIVATE "/bigobj")
+                target_compile_options(${target} PRIVATE "/bigobj")
             endif ()
             add_test(NAME ${target} COMMAND ${target})
         endif ()

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -24,6 +24,10 @@
 #include <utility>
 #include <vector>
 
+#ifndef INSTANTIATE_TEST_SUITE_P
+#error "Wrong googletest TEST_SUITE_P not defined"
+#endif  // INSTANTIATE_TEST_SUITE_P
+
 namespace google {
 namespace cloud {
 namespace storage {

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -24,10 +24,6 @@
 #include <utility>
 #include <vector>
 
-#ifndef INSTANTIATE_TEST_SUITE_P
-#error "Wrong googletest TEST_SUITE_P not defined"
-#endif  // INSTANTIATE_TEST_SUITE_P
-
 namespace google {
 namespace cloud {
 namespace storage {

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -403,10 +403,10 @@ TEST_P(CurlClientTest, DeleteNotification) {
 }
 
 INSTANTIATE_TEST_SUITE_P(CredentialsFailure, CurlClientTest,
-                        ::testing::Values("credentials-failure"));
+                         ::testing::Values("credentials-failure"));
 
 INSTANTIATE_TEST_SUITE_P(LibCurlFailure, CurlClientTest,
-                        ::testing::Values("libcurl-failure"));
+                         ::testing::Values("libcurl-failure"));
 
 }  // namespace
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -402,10 +402,10 @@ TEST_P(CurlClientTest, DeleteNotification) {
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
-INSTANTIATE_TEST_CASE_P(CredentialsFailure, CurlClientTest,
+INSTANTIATE_TEST_SUITE_P(CredentialsFailure, CurlClientTest,
                         ::testing::Values("credentials-failure"));
 
-INSTANTIATE_TEST_CASE_P(LibCurlFailure, CurlClientTest,
+INSTANTIATE_TEST_SUITE_P(LibCurlFailure, CurlClientTest,
                         ::testing::Values("libcurl-failure"));
 
 }  // namespace


### PR DESCRIPTION
Newer versions of googletest prefer if we use `TEST_SUITE` over `TEST_CASE`.
In particular, when importing to google this makes the googletest folks happier.

Newer versions of googletest seem to make the test code larger or more complex,
at least MSVC requires the `/bigobj` option. We have workaround this limitation in
MSVC before by splitting tests, I think it is time to just pull the trigger and use it.

I also had to change the build scripts to cleanup previous versions of googletest cached
in `vcpkg`. Almost made me remove the hokey caching I put in place, but the build takes
about 2 hours without the hokey caching :disappointed:  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2075)
<!-- Reviewable:end -->
