### PR TITLE
Collect Windows minidumps.

### DIFF
--- a/ci/kokoro/windows/continuous.cfg
+++ b/ci/kokoro/windows/continuous.cfg
@@ -17,3 +17,9 @@ build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
 timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
+
+action {
+  define_artifacts {
+    regex: "**/win_minidumps/*.dmp"
+  }
+}

--- a/ci/kokoro/windows/presubmit.cfg
+++ b/ci/kokoro/windows/presubmit.cfg
@@ -20,3 +20,9 @@ gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.bat"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
+
+action {
+  define_artifacts {
+    regex: "**/win_minidumps/*.dmp"
+  }
+}


### PR DESCRIPTION
We just had a build fail:

https://source.cloud.google.com/results/invocations/dca9991e-1167-4b49-a4b0-7432d4a4dab6/targets/cloud-cpp%2Fgithub%2Fwindows%2Fcontinuous/log

It recommends that we add this change:

```
Be sure to add an artifacts regex to collect data from **/win_minidumps/*.dmp
```

I do not know exactly how these are usable, but while I research that,
let's get the ball rolling on collecting these minidumps so we can
figure out why we are crashing the system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2078)
<!-- Reviewable:end -->
