### PR TITLE
Make use of the streaming batch mutation API.

### DIFF
--- a/google/cloud/bigtable/internal/mutation_batcher.cc
+++ b/google/cloud/bigtable/internal/mutation_batcher.cc
@@ -158,7 +158,6 @@ void MutationBatcher::OnSuccessfulMutations(CompletionQueue& cq,
     // Release resources as early as possible.
     batch.mutation_data.erase(it);
   }
-  indices = std::vector<int>();
 
   std::unique_lock<std::mutex> lk(mu_);
   oustanding_size_ -= completed_size;
@@ -182,7 +181,9 @@ void MutationBatcher::OnFailedMutations(CompletionQueue& cq,
     // Release resources as early as possible.
     batch.mutation_data.erase(it);
   }
-  failed = std::vector<FailedMutation>();
+  // TODO(#2093): remove once `FailedMutations` are small.
+  failed.clear();
+  failed.shrink_to_fit();
 
   std::unique_lock<std::mutex> lk(mu_);
   oustanding_size_ -= completed_size;

--- a/google/cloud/bigtable/internal/mutation_batcher.cc
+++ b/google/cloud/bigtable/internal/mutation_batcher.cc
@@ -191,15 +191,14 @@ void MutationBatcher::OnFailedMutations(CompletionQueue& cq,
 
 void MutationBatcher::OnBulkApplyAttemptFinished(
     CompletionQueue& cq, MutationBatcher::Batch& batch) {
-  bool was_first_attempt = !batch.attempt_finished;
-  batch.attempt_finished = true;
-  // We consider a batch finished if the original request finished. If it is
-  // later retried, we don't count it against the limit. The reasoning is that
-  // it would usually be some long tail of mutations and it should not take up
-  // the resources for the incoming requests.
-  if (!was_first_attempt) {
+  if (batch.attempt_finished) {
+    // We consider a batch finished if the original request finished. If it is
+    // later retried, we don't count it against the limit. The reasoning is that
+    // it would usually be some long tail of mutations and it should not take up
+    // the resources for the incoming requests.
     return;
   }
+  batch.attempt_finished = true;
   std::unique_lock<std::mutex> lk(mu_);
   num_outstanding_batches_ -= 1;
   FlushIfPossible(cq);

--- a/google/cloud/bigtable/internal/mutation_batcher.h
+++ b/google/cloud/bigtable/internal/mutation_batcher.h
@@ -58,25 +58,25 @@ class MutationBatcher {
   struct Options {
     Options();
 
-    // A single RPC will not have more mutations than this.
+    /// A single RPC will not have more mutations than this.
     Options& SetMaxMutationsPerBatch(size_t max_mutations_per_batch_arg) {
       max_mutations_per_batch = max_mutations_per_batch_arg;
       return *this;
     }
 
-    // Sum of mutations' sizes in a single RPC will not be larger than this.
+    /// Sum of mutations' sizes in a single RPC will not be larger than this.
     Options& SetMaxSizePerBatch(size_t max_size_per_batch_arg) {
       max_size_per_batch = max_size_per_batch_arg;
       return *this;
     }
 
-    // There will be no more RPCs outstanding (except for retries) than this.
+    /// There will be no more RPCs outstanding (except for retries) than this.
     Options& SetMaxBatches(size_t max_batches_arg) {
       max_batches = max_batches_arg;
       return *this;
     }
 
-    // MutationBatcher will at most admit mutations of this total size.
+    /// MutationBatcher will at most admit mutations of this total size.
     Options& SetMaxOustandingSize(size_t max_oustanding_size_arg) {
       max_oustanding_size = max_oustanding_size_arg;
       return *this;
@@ -100,8 +100,6 @@ class MutationBatcher {
       AsyncApplyAdmissionCallback admission_callback, SingleRowMutation mut);
 
  private:
-  class Batch;
-
   /**
    * This structure represents a single mutation before it is admitted.
    */
@@ -134,29 +132,21 @@ class MutationBatcher {
    *
    * Objects of this class hold the accumulated mutations, their completion
    * callbacks and basic statistics.
+   *
+   * Objects of this class don't need separate synchronization.
+   * There are 2 important stages of these objects' lifecycle: when mutations
+   * are accumulated and when the batch is worked on by `AsyncBulkApply`. In the
+   * first stage, `MutationBatcher`'s synchronization ensures that its data is
+   * not accessed from multiple threads. In the second stage we rely on the fact
+   * that `AsyncBulkApply` invokes the callbacks serially. This in turn
+   * relies on the fact that `CompletionQueue` invokes callbacks from a
+   * streaming response in sequence and that `AsyncRetryOp` doesn't schedule
+   * another attempt before invoking callbacks for the previous one.
    */
-  class Batch {
-   public:
+  struct Batch {
     Batch()
-        : num_mutations_(),
-          requests_size_(),
-          last_idx_(),
-          attempt_finished_() {}
-    size_t requests_size() { return requests_size_; }
-    size_t num_mutations() { return num_mutations_; }
-    BulkMutation TransferRequest() { return std::move(requests_); }
+        : num_mutations(), requests_size(), last_idx(), attempt_finished() {}
 
-    void Add(PendingSingleRowMutation mut);
-    // Returns the size of the completed mutations.
-    size_t FireFailedCallbacks(CompletionQueue& cq,
-                               std::vector<FailedMutation> failed);
-    // Returns the size of the completed mutations.
-    size_t FireSuccessfulCallbacks(CompletionQueue& cq,
-                                   std::vector<int> indices);
-    // Returns if this was the first attempt on this batch.
-    bool AttemptFinished();
-
-   private:
     struct MutationData {
       MutationData(PendingSingleRowMutation pending)
           : callback(std::move(pending.completion_callback)),
@@ -168,26 +158,34 @@ class MutationBatcher {
     };
 
     std::mutex mu_;
-    size_t num_mutations_;
-    size_t requests_size_;
-    BulkMutation requests_;
-    int last_idx_;
-    // Whether at least one AsyncBulkApply finished.
-    bool attempt_finished_;
-    // The reason why it's not simple std::vector is that we want this structure
-    // to shrink as individual mutations complete, so that the user can have a
-    // bound on the amount of overhead per outstanding Apply.
-    std::unordered_map<int, MutationData> mutation_data_;
+    size_t num_mutations;
+    size_t requests_size;
+    BulkMutation requests;
+    int last_idx;
+    /// Whether at least one AsyncBulkApply finished.
+    bool attempt_finished;
+    /**
+     * The reason why it's not simple std::vector is that we want this
+     * structure to shrink as individual mutations complete, so that the user
+     * can have a bound on the amount of overhead per outstanding Apply.
+     */
+    std::unordered_map<int, MutationData> mutation_data;
   };
 
-  // Check if a mutation doesn't exceed allowed limits.
+  /// Check if a mutation doesn't exceed allowed limits.
   grpc::Status IsValid(PendingSingleRowMutation& mut) const;
-  // Check whether there is space for the passed mutation in the currently
-  // constructed batch.
+
+  /**
+   * Check whether there is space for the passed mutation in the currently
+   * constructed batch.
+   */
   bool HasSpaceFor(PendingSingleRowMutation const& mut) const;
-  // Check if one can append a mutation to the currently constructed batch. Even
-  // if there is space for the mutation, we shouldn't append mutations if some
-  // other are not admitted yet.
+
+  /**
+   * Check if one can append a mutation to the currently constructed batch.
+   * Even if there is space for the mutation, we shouldn't append mutations if
+   * some other are not admitted yet.
+   */
   bool CanAppendToBatch(PendingSingleRowMutation const& mut) const {
     // If some mutations are already subject to flow control, don't admit any
     // new, even if there's space for them. Otherwise we might starve big
@@ -195,41 +193,61 @@ class MutationBatcher {
     return pending_mutations_.empty() && HasSpaceFor(mut);
   }
 
-  // Send the currently constructed batch if there are not too many outstanding
-  // already. If there are no mutations in the batch, it's a noop.
+  /**
+   * Send the currently constructed batch if there are not too many outstanding
+   * already. If there are no mutations in the batch, it's a noop.
+   */
   bool FlushIfPossible(CompletionQueue& cq);
-  // Entry point for lower layers indicating that mutations with indices
-  // `indices` in batch `batch` have finished successfully.
-  void MutationsSucceeded(CompletionQueue& cq, MutationBatcher::Batch& batch,
-                          std::vector<int> indices);
-  // Entry point for lower layers indicating that mutations listed in `failed`
-  // in batch `batch` have failed permanently.
-  void MutationsFailed(CompletionQueue& cq, MutationBatcher::Batch& batch,
-                       std::vector<FailedMutation> failed);
-  // Entry point for lower layers indicating that an attempt to send the
-  // `batch` was made. This might be called multiple times in case of retries.
-  void BatchAttemptFinished(CompletionQueue& cq, MutationBatcher::Batch& batch);
-  // Try to move mutations waiting in `pending_mutations_` to the currently
-  // constructed batch. Unlocks `lk`.
+
+  /**
+   * Entry point for lower layers indicating that mutations with indices
+   * `indices` in batch `batch` have finished successfully.
+   */
+  void OnSuccessfulMutations(CompletionQueue& cq, MutationBatcher::Batch& batch,
+                             std::vector<int> indices);
+
+  /**
+   * Entry point for lower layers indicating that mutations listed in `failed`
+   * in batch `batch` have failed permanently.
+   */
+  void OnFailedMutations(CompletionQueue& cq, MutationBatcher::Batch& batch,
+                         std::vector<FailedMutation> failed);
+
+  /**
+   * Entry point for lower layers indicating that an attempt to send the
+   * `batch` was made. This might be called multiple times in case of retries.
+   */
+  void OnBulkApplyAttemptFinished(CompletionQueue& cq,
+                                  MutationBatcher::Batch& batch);
+
+  /**
+   * Try to move mutations waiting in `pending_mutations_` to the currently
+   * constructed batch. Unlocks `lk`.
+   */
   void TryAdmit(CompletionQueue& cq, std::unique_lock<std::mutex>& lk);
-  // Append mutation `mut` to the currently constructed batch.
+
+  /**
+   * Append mutation `mut` to the currently constructed batch.
+   */
   void Admit(PendingSingleRowMutation mut);
 
   std::mutex mu_;
   noex::Table& table_;
   Options options_;
 
-  // Num batches sent but not completed.
+  /// Num batches sent but not completed.
   size_t num_outstanding_batches_;
-  // Size of admitted but uncompleted mutations.
+  /// Size of admitted but uncompleted mutations.
   size_t oustanding_size_;
 
-  // Currently contructed batch of mutations.
+  /// Currently contructed batch of mutations.
   std::shared_ptr<Batch> cur_batch_;
 
-  // These are the mutations which have not been admission yet. If the user is
-  // properly reacting to `admission_callback`s, there should be very few of
-  // these (likely no more than one).
+  /**
+   * These are the mutations which have not been admitted yet. If the user is
+   * properly reacting to `admission_callback`s, there should be very few of
+   * these (likely no more than one).
+   */
   std::queue<PendingSingleRowMutation> pending_mutations_;
 };
 

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -124,6 +124,7 @@ class UnwrapReadModifyWriteRowResponse {
  private:
   Functor callback_;
 };
+class MutationBatcher;
 
 }  // namespace internal
 
@@ -635,6 +636,7 @@ class Table {
 
  private:
   friend class NoexTableStreamingAsyncBulkApplyTest_SimpleTest_Test;
+  friend class internal::MutationBatcher;
   /**
    * Make an asynchronous request to mutate a multiple rows and stream results.
    *


### PR DESCRIPTION
Per design, MutationBatcher should admit mutations as soon as other
mutations finish, not by the time the whole batch exhausts its retry
limit. This PR implements exactly this via:
- confirming mutations to the user as soon as we know they are done
- admitting more mutations in such an event
- releasing a slot for a next batch as soon as the first attempt
  retry finishes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2085)
<!-- Reviewable:end -->
