### PR TITLE
Gives google::cloud::optional value conversion c'tors matching std::optional

### DIFF
--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -62,7 +62,7 @@ class optional {
       new (reinterpret_cast<T*>(&buffer_)) T(*rhs);
     }
   }
-  optional(optional&& rhs) noexcept : has_value_(rhs.has_value_) {
+  optional(optional&& rhs) : has_value_(rhs.has_value_) {
     if (has_value_) {
       new (reinterpret_cast<T*>(&buffer_)) T(std::move(*rhs));
     }
@@ -71,14 +71,14 @@ class optional {
             typename std::enable_if<std::is_constructible<T, U&&>::value &&
                                         AllowImplicit<T, U>::value,
                                     int>::type = 0>
-  optional(U&& x) noexcept : has_value_(true) {
+  optional(U&& x) : has_value_(true) {
     new (reinterpret_cast<T*>(&buffer_)) T(std::move(x));
   }
   template <typename U = T,
             typename std::enable_if<std::is_constructible<T, U&&>::value &&
                                         !AllowImplicit<T, U>::value,
                                     int>::type = 0>
-  explicit optional(U&& x) noexcept : has_value_(true) {
+  explicit optional(U&& x) : has_value_(true) {
     new (reinterpret_cast<T*>(&buffer_)) T(std::move(x));
   }
   ~optional() { reset(); }

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -328,6 +328,53 @@ TEST(OptionalTest, WithNoDefaultConstructor) {
   EXPECT_TRUE(actual.has_value());
   EXPECT_EQ(actual->str(), "foo");
 }
+
+struct ExplicitlyConvertible {
+  explicit operator std::string() const { return "explicit-conversion"; }
+};
+
+struct ImplicitlyConvertible {
+  operator std::string() const { return "implicit-conversion"; }
+};
+
+TEST(OptionalTest, ValueConstructorWithImplicitConversion) {
+  optional<int> i = 123.5;
+  EXPECT_EQ(*i, 123);
+  optional<std::string> x = "hi";
+  EXPECT_EQ(*x, "hi");
+  optional<std::string> implicit_conversion = ImplicitlyConvertible{};
+  EXPECT_EQ(*implicit_conversion, "implicit-conversion");
+  // We may want to make a full no-compile test for the following case, but
+  // those are kinda a PITA.
+  optional<std::string> explicit_conversion(ExplicitlyConvertible{});
+  EXPECT_EQ(*explicit_conversion, "explicit-conversion");
+}
+
+TEST(OptionalTest, ValueAssignmentWithImplicitConversion) {
+  optional<std::string> x;
+  x = "hi";
+  EXPECT_EQ(*x, "hi");
+}
+
+optional<std::string> FunctionReturningOptStringValue() {
+  return "it-worked";  // If this compiles, it works.
+}
+
+TEST(OptionalTest, OptionalReturnWithValue) {
+  optional<std::string> x = FunctionReturningOptStringValue();
+  EXPECT_EQ(*x, "it-worked");
+}
+
+optional<std::string> FunctionReturningOptWithoutValue() {
+  return {};  // If this compiles, it works.
+}
+
+TEST(OptionalTest, OptionalReturnWithoutValue) {
+  optional<std::string> x = FunctionReturningOptWithoutValue();
+  EXPECT_FALSE(x);
+  EXPECT_FALSE(x.has_value());
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -26,8 +26,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::make_optional;
-using ::google::cloud::optional;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
@@ -171,15 +169,11 @@ TEST(BucketMetadataTest, Parse) {
   EXPECT_EQ("acl-id-1", actual.acl().at(1).id());
   EXPECT_TRUE(actual.billing().requester_pays);
   EXPECT_EQ(2U, actual.cors().size());
-  auto expected_cors_0 = CorsEntry{make_optional<std::int64_t>(3600),
-                                   {"GET", "HEAD"},
-                                   {"cross-origin-example.com"},
-                                   {}};
+  auto expected_cors_0 =
+      CorsEntry{3600, {"GET", "HEAD"}, {"cross-origin-example.com"}, {}};
   EXPECT_EQ(expected_cors_0, actual.cors().at(0));
-  auto expected_cors_1 = CorsEntry{optional<std::int64_t>(),
-                                   {"GET", "HEAD"},
-                                   {"another-example.com"},
-                                   {"Content-Type"}};
+  auto expected_cors_1 =
+      CorsEntry{{}, {"GET", "HEAD"}, {"another-example.com"}, {"Content-Type"}};
   EXPECT_EQ(expected_cors_1, actual.cors().at(1));
   EXPECT_TRUE(actual.default_event_based_hold());
   EXPECT_EQ(1U, actual.default_acl().size());
@@ -764,7 +758,7 @@ TEST(BucketMetadataTest, SetVersioning) {
   EXPECT_TRUE(expected.versioning().has_value());
   EXPECT_TRUE(expected.versioning()->enabled);
   auto copy = expected;
-  copy.set_versioning(optional<BucketVersioning>(BucketVersioning{false}));
+  copy.set_versioning(BucketVersioning{false});
   EXPECT_TRUE(copy.versioning().has_value());
   EXPECT_FALSE(copy.versioning()->enabled);
   EXPECT_NE(copy, expected);
@@ -843,8 +837,7 @@ TEST(BucketMetadataPatchBuilder, SetCors) {
   BucketMetadataPatchBuilder builder;
   std::vector<CorsEntry> v;
   v.emplace_back(CorsEntry{{}, {"method1", "method2"}, {}, {"header1"}});
-  v.emplace_back(CorsEntry{
-      google::cloud::optional<std::int64_t>(86400), {}, {"origin1"}, {}});
+  v.emplace_back(CorsEntry{86400, {}, {"origin1"}, {}});
   builder.SetCors(v);
 
   auto actual = builder.BuildPatch();

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -173,9 +173,7 @@ CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
 
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonFilePath(std::string const& path) {
-  return CreateServiceAccountCredentialsFromJsonFilePath(
-      path, google::cloud::optional<std::set<std::string>>(),
-      google::cloud::optional<std::string>());
+  return CreateServiceAccountCredentialsFromJsonFilePath(path, {}, {});
 }
 
 StatusOr<std::shared_ptr<Credentials>>
@@ -199,9 +197,7 @@ CreateServiceAccountCredentialsFromJsonFilePath(
 
 StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
-  return CreateServiceAccountCredentialsFromJsonContents(
-      contents, google::cloud::optional<std::set<std::string>>(),
-      google::cloud::optional<std::string>());
+  return CreateServiceAccountCredentialsFromJsonContents(contents, {}, {});
 }
 
 StatusOr<std::shared_ptr<Credentials>>

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/internal/setenv.h"
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
@@ -218,10 +217,8 @@ TEST_F(GoogleCredentialsTest,
 
   // Test that the service account credentials are loaded from a file.
   auto creds = CreateServiceAccountCredentialsFromJsonFilePath(
-      filename,
-      google::cloud::optional<std::set<std::string>>(
-          {"https://www.googleapis.com/auth/devstorage.full_control"}),
-      google::cloud::optional<std::string>("user@foo.bar"));
+      filename, {{"https://www.googleapis.com/auth/devstorage.full_control"}},
+      "user@foo.bar");
   ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
@@ -232,9 +229,8 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromContents) {
   // representing JSON contents.
   auto creds = CreateServiceAccountCredentialsFromJsonContents(
       SERVICE_ACCOUNT_CRED_CONTENTS,
-      google::cloud::optional<std::set<std::string>>(
-          {"https://www.googleapis.com/auth/devstorage.full_control"}),
-      google::cloud::optional<std::string>("user@foo.bar"));
+      {{"https://www.googleapis.com/auth/devstorage.full_control"}},
+      "user@foo.bar");
   ASSERT_STATUS_OK(creds);
   auto* ptr = creds->get();
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -188,8 +188,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   }
 
   // cors()
-  desired_state.mutable_cors().push_back(
-      CorsEntry{google::cloud::optional<std::int64_t>(86400), {"GET"}, {}, {}});
+  desired_state.mutable_cors().push_back(CorsEntry{86400, {"GET"}, {}, {}});
 
   // default_acl()
   desired_state.mutable_default_acl().push_back(


### PR DESCRIPTION
These constructors make optional easier to use at call sites because it lets the caller construct an `optional<T>` implicitly from any type that is implicitly convertible to T. For example, before this PR the following example would not compile, but with this PR it works as expected:

```cc
optional<std::string> msg = "hello world";  // Converts a char array to a std::string
```

I also updated most call sites to rely on the new converting constructors, which results in making less verbosity at the call site and, I think, clearer code (fwiw, this is how calls will look using `std::optional`). This issue came up when I suggested calling syntax like this to @houglum in #1987 and he informed me that my suggested syntax didn't compile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2087)
<!-- Reviewable:end -->
