### PR TITLE
Remove bigtable::internal::ThrowRpcError()

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -70,7 +70,7 @@ void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   std::cout << "Waiting for instance creation to complete ";
   for (int i = 0; i != 100; ++i) {
     if (std::future_status::ready == future.wait_for(std::chrono::seconds(2))) {
-      std::cout << "DONE: " << future.get().name() << "\n";
+      std::cout << "DONE: " << future.get()->name() << "\n";
       return;
     }
     std::cout << '.' << std::flush;
@@ -103,7 +103,7 @@ void CreateDevInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   std::cout << "Waiting for instance creation to complete ";
   for (int i = 0; i != 100; ++i) {
     if (std::future_status::ready == future.wait_for(std::chrono::seconds(2))) {
-      std::cout << "DONE: " << future.get().name() << "\n";
+      std::cout << "DONE: " << future.get()->name() << "\n";
       return;
     }
     std::cout << '.' << std::flush;
@@ -131,7 +131,7 @@ void UpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   auto future =
       instance_admin.UpdateInstance(std::move(instance_update_config));
   std::string instance_detail;
-  google::protobuf::TextFormat::PrintToString(future.get(), &instance_detail);
+  google::protobuf::TextFormat::PrintToString(*future.get(), &instance_detail);
   std::cout << "GetInstance details : " << instance_detail << "\n";
 }
 //! [update instance]
@@ -287,7 +287,7 @@ void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
   auto modified_cluster = instance_admin.UpdateCluster(modified_config).get();
 
   std::string cluster_detail;
-  google::protobuf::TextFormat::PrintToString(modified_cluster,
+  google::protobuf::TextFormat::PrintToString(*modified_cluster,
                                               &cluster_detail);
   std::cout << "cluster details : " << cluster_detail << "\n";
 }
@@ -480,7 +480,7 @@ void UpdateAppProfileDescription(
           description));
   auto profile = profile_future.get();
   std::string detail;
-  google::protobuf::TextFormat::PrintToString(profile, &detail);
+  google::protobuf::TextFormat::PrintToString(*profile, &detail);
   std::cout << "Application Profile details=" << detail << "\n";
 }
 //! [update app profile description]
@@ -503,7 +503,7 @@ void UpdateAppProfileRoutingAny(
           .set_ignore_warnings(true));
   auto profile = profile_future.get();
   std::string detail;
-  google::protobuf::TextFormat::PrintToString(profile, &detail);
+  google::protobuf::TextFormat::PrintToString(*profile, &detail);
   std::cout << "Application Profile details=" << detail << "\n";
 }
 //! [update app profile routing any]
@@ -527,7 +527,7 @@ void UpdateAppProfileRoutingSingleCluster(
           .set_ignore_warnings(true));
   auto profile = profile_future.get();
   std::string detail;
-  google::protobuf::TextFormat::PrintToString(profile, &detail);
+  google::protobuf::TextFormat::PrintToString(*profile, &detail);
   std::cout << "Application Profile details=" << detail << "\n";
 }
 //! [update app profile routing]

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -138,8 +138,13 @@ void UpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
 
   auto future =
       instance_admin.UpdateInstance(std::move(instance_update_config));
+  auto updated_instance = future.get();
+  if (!updated_instance) {
+    throw std::runtime_error(updated_instance.status().message());
+  }
   std::string instance_detail;
-  google::protobuf::TextFormat::PrintToString(*future.get(), &instance_detail);
+  google::protobuf::TextFormat::PrintToString(*updated_instance,
+                                              &instance_detail);
   std::cout << "GetInstance details : " << instance_detail << "\n";
 }
 //! [update instance]
@@ -293,7 +298,9 @@ void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
       google::cloud::bigtable::ClusterConfig(std::move(*cluster));
 
   auto modified_cluster = instance_admin.UpdateCluster(modified_config).get();
-
+  if (!modified_cluster) {
+    throw std::runtime_error(modified_cluster.status().message());
+  }
   std::string cluster_detail;
   google::protobuf::TextFormat::PrintToString(*modified_cluster,
                                               &cluster_detail);

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -70,7 +70,11 @@ void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   std::cout << "Waiting for instance creation to complete ";
   for (int i = 0; i != 100; ++i) {
     if (std::future_status::ready == future.wait_for(std::chrono::seconds(2))) {
-      std::cout << "DONE: " << future.get()->name() << "\n";
+      auto instance = future.get();
+      if (!instance) {
+        throw std::runtime_error(instance.status().message());
+      }
+      std::cout << "DONE: " << instance->name() << "\n";
       return;
     }
     std::cout << '.' << std::flush;
@@ -103,7 +107,11 @@ void CreateDevInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   std::cout << "Waiting for instance creation to complete ";
   for (int i = 0; i != 100; ++i) {
     if (std::future_status::ready == future.wait_for(std::chrono::seconds(2))) {
-      std::cout << "DONE: " << future.get()->name() << "\n";
+      auto instance = future.get();
+      if (!instance) {
+        throw std::runtime_error(instance.status().message());
+      }
+      std::cout << "DONE: " << instance->name() << "\n";
       return;
     }
     std::cout << '.' << std::flush;

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -479,6 +479,9 @@ void UpdateAppProfileDescription(
       google::cloud::bigtable::AppProfileUpdateConfig().set_description(
           description));
   auto profile = profile_future.get();
+  if (!profile) {
+    throw std::runtime_error(profile.status().message());
+  }
   std::string detail;
   google::protobuf::TextFormat::PrintToString(*profile, &detail);
   std::cout << "Application Profile details=" << detail << "\n";
@@ -502,6 +505,9 @@ void UpdateAppProfileRoutingAny(
           .set_multi_cluster_use_any()
           .set_ignore_warnings(true));
   auto profile = profile_future.get();
+  if (!profile) {
+    throw std::runtime_error(profile.status().message());
+  }
   std::string detail;
   google::protobuf::TextFormat::PrintToString(*profile, &detail);
   std::cout << "Application Profile details=" << detail << "\n";
@@ -526,6 +532,9 @@ void UpdateAppProfileRoutingSingleCluster(
           .set_single_cluster_routing(cluster_id)
           .set_ignore_warnings(true));
   auto profile = profile_future.get();
+  if (!profile) {
+    throw std::runtime_error(profile.status().message());
+  }
   std::string detail;
   google::protobuf::TextFormat::PrintToString(*profile, &detail);
   std::cout << "Application Profile details=" << detail << "\n";

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -380,7 +380,7 @@ void CreateTableFromSnapshot(google::cloud::bigtable::TableAdmin admin,
     google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
     auto future =
         admin.CreateTableFromSnapshot(cluster_id, snapshot_id, table_id);
-    std::cout << "Table created :" << future.get().name() << "\n";
+    std::cout << "Table created :" << future.get()->name() << "\n";
   }
   //! [create table from snapshot]
   (std::move(admin), cluster_id_str, snapshot_id_str, table_id);

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -380,7 +380,11 @@ void CreateTableFromSnapshot(google::cloud::bigtable::TableAdmin admin,
     google::cloud::bigtable::SnapshotId snapshot_id(snapshot_id_str);
     auto future =
         admin.CreateTableFromSnapshot(cluster_id, snapshot_id, table_id);
-    std::cout << "Table created :" << future.get()->name() << "\n";
+    auto table = future.get();
+    if (!table) {
+      throw std::runtime_error(table.status().message());
+    }
+    std::cout << "Table created :" << table->name() << "\n";
   }
   //! [create table from snapshot]
   (std::move(admin), cluster_id_str, snapshot_id_str, table_id);

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -108,7 +108,7 @@ class InstanceAdmin {
    * @par Example
    * @snippet bigtable_samples_instance_admin.cc create instance
    */
-  std::future<google::bigtable::admin::v2::Instance> CreateInstance(
+  std::future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       InstanceConfig instance_config);
 
   /**
@@ -122,7 +122,7 @@ class InstanceAdmin {
    *  @par Example
    *  @snippet bigtable_samples_instance_admin.cc create cluster
    */
-  std::future<google::bigtable::admin::v2::Cluster> CreateCluster(
+  std::future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       ClusterConfig cluster_config, bigtable::InstanceId const& instance_id,
       bigtable::ClusterId const& cluster_id);
 
@@ -145,7 +145,7 @@ class InstanceAdmin {
    * @par Example
    * @snippet bigtable_samples_instance_admin.cc update instance
    */
-  std::future<google::bigtable::admin::v2::Instance> UpdateInstance(
+  std::future<StatusOr<google::bigtable::admin::v2::Instance>> UpdateInstance(
       InstanceUpdateConfig instance_update_config);
 
   /**
@@ -329,7 +329,7 @@ class InstanceAdmin {
    * @par Example
    * @snippet bigtable_samples_instance_admin.cc update cluster
    */
-  std::future<google::bigtable::admin::v2::Cluster> UpdateCluster(
+  std::future<StatusOr<google::bigtable::admin::v2::Cluster>> UpdateCluster(
       ClusterConfig cluster_config);
 
   /**
@@ -436,9 +436,10 @@ class InstanceAdmin {
    * @par Example
    * @snippet bigtable_samples_instance_admin.cc update app profile routing
    */
-  std::future<google::bigtable::admin::v2::AppProfile> UpdateAppProfile(
-      bigtable::InstanceId instance_id, bigtable::AppProfileId profile_id,
-      AppProfileUpdateConfig config);
+  std::future<StatusOr<google::bigtable::admin::v2::AppProfile>>
+  UpdateAppProfile(bigtable::InstanceId instance_id,
+                   bigtable::AppProfileId profile_id,
+                   AppProfileUpdateConfig config);
 
   /**
    * List the application profiles in an instance.
@@ -517,25 +518,25 @@ class InstanceAdmin {
 
  private:
   /// Implement CreateInstance() with a separate thread.
-  google::bigtable::admin::v2::Instance CreateInstanceImpl(
+  StatusOr<google::bigtable::admin::v2::Instance> CreateInstanceImpl(
       InstanceConfig instance_config);
 
   /// Implement CreateCluster() with a separate thread.
-  google::bigtable::admin::v2::Cluster CreateClusterImpl(
+  StatusOr<google::bigtable::admin::v2::Cluster> CreateClusterImpl(
       ClusterConfig const& cluster_config,
       bigtable::InstanceId const& instance_id,
       bigtable::ClusterId const& cluster_id);
 
   // Implement UpdateInstance() with a separate thread.
-  google::bigtable::admin::v2::Instance UpdateInstanceImpl(
+  StatusOr<google::bigtable::admin::v2::Instance> UpdateInstanceImpl(
       InstanceUpdateConfig instance_update_config);
 
   // Implement UpdateCluster() with a separate thread.
-  google::bigtable::admin::v2::Cluster UpdateClusterImpl(
+  StatusOr<google::bigtable::admin::v2::Cluster> UpdateClusterImpl(
       ClusterConfig cluster_config);
 
   /// Poll the result of UpdateAppProfile in a separate thread.
-  google::bigtable::admin::v2::AppProfile UpdateAppProfileImpl(
+  StatusOr<google::bigtable::admin::v2::AppProfile> UpdateAppProfileImpl(
       bigtable::InstanceId instance_id, bigtable::AppProfileId profile_id,
       AppProfileUpdateConfig config);
 

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -332,7 +332,7 @@ TEST_F(InstanceAdminTest, CreateInstance) {
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -377,7 +377,7 @@ TEST_F(InstanceAdminTest, CreateInstanceImmediatelyReady) {
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -435,7 +435,7 @@ TEST_F(InstanceAdminTest, CreateInstancePollRecoverableFailures) {
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -759,7 +759,7 @@ TEST_F(InstanceAdminTest, UpdateInstance) {
 
   auto future = tested.UpdateInstance(std::move(instance_update_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -809,7 +809,7 @@ TEST_F(InstanceAdminTest, UpdateInstanceImmediatelyReady) {
 
   auto future = tested.UpdateInstance(std::move(instance_update_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -873,7 +873,7 @@ TEST_F(InstanceAdminTest, UpdateInstancePollRecoverableFailures) {
 
   auto future = tested.UpdateInstance(std::move(instance_update_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1143,6 +1143,7 @@ TEST_F(InstanceAdminTest, CreateCluster) {
       bigtable::ClusterId("other-cluster"));
 
   auto actual = future.get();
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1187,7 +1188,7 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1250,7 +1251,7 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
       bigtable::InstanceId("test-instance"),
       bigtable::ClusterId("other-cluster"));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1317,7 +1318,7 @@ TEST_F(InstanceAdminTest, UpdateCluster) {
 
   auto future = tested.UpdateCluster(std::move(cluster_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1367,7 +1368,7 @@ TEST_F(InstanceAdminTest, UpdateClusterImmediatelyReady) {
 
   auto future = tested.UpdateCluster(std::move(cluster_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1431,7 +1432,7 @@ TEST_F(InstanceAdminTest, UpdateClusterPollRecoverableFailures) {
 
   auto future = tested.UpdateCluster(std::move(cluster_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1503,7 +1504,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfile) {
           .set_description("Test Profile")
           .set_multi_cluster_use_any());
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1554,7 +1555,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileImmediatelyReady) {
           .set_description("Test Profile")
           .set_multi_cluster_use_any());
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1612,7 +1613,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileRecoverableFailures) {
           .set_description("Test Profile")
           .set_multi_cluster_use_any());
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1721,7 +1722,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfilePollRecoverableFailures) {
 
   auto future = tested.UpdateCluster(std::move(cluster_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
@@ -1785,7 +1786,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileOperationFailure) {
 
   auto future = tested.UpdateCluster(std::move(cluster_config));
   auto actual = future.get();
-
+  EXPECT_STATUS_OK(actual);
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -336,7 +336,7 @@ TEST_F(InstanceAdminTest, CreateInstance) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::CreateInstance` works.
@@ -381,7 +381,7 @@ TEST_F(InstanceAdminTest, CreateInstanceImmediatelyReady) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected, *actual)) << delta;
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::CreateInstance`.
@@ -439,10 +439,9 @@ TEST_F(InstanceAdminTest, CreateInstancePollRecoverableFailures) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected, *actual)) << delta;
 }
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 /// @test Failures in `bigtable::InstanceAdmin::CreateInstance`.
 TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
   using namespace ::testing;
@@ -456,7 +455,7 @@ TEST_F(InstanceAdminTest, CreateInstanceRequestFailure) {
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
 
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::CreateInstance`.
@@ -480,7 +479,7 @@ TEST_F(InstanceAdminTest, CreateInstancePollUnrecoverableFailure) {
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Polling in `bigtable::InstanceAdmin::CreateInstance` returns failure.
@@ -527,7 +526,7 @@ TEST_F(InstanceAdminTest, CreateInstancePollReturnsFailure) {
   auto future = tested.CreateInstance(bigtable::InstanceConfig(
       bigtable::InstanceId("test-instance"), bigtable::DisplayName("foo bar"),
       {{"c1", {"a-zone", 3, bigtable::ClusterConfig::SSD}}}));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Failures in `bigtable::InstanceAdmin::UpdateInstance`.
@@ -542,7 +541,7 @@ TEST_F(InstanceAdminTest, UpdateInstanceRequestFailure) {
   btadmin::Instance instance;
   bigtable::InstanceUpdateConfig instance_update_config(std::move(instance));
   auto future = tested.UpdateInstance(std::move(instance_update_config));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::UpdateInstance`.
@@ -564,7 +563,7 @@ TEST_F(InstanceAdminTest, UpdateInstancePollUnrecoverableFailure) {
   btadmin::Instance instance;
   bigtable::InstanceUpdateConfig instance_update_config(std::move(instance));
   auto future = tested.UpdateInstance(std::move(instance_update_config));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Polling in `bigtable::InstanceAdmin::UpdateInstance` returns failure.
@@ -609,7 +608,7 @@ TEST_F(InstanceAdminTest, UpdateInstancePollReturnsFailure) {
   btadmin::Instance instance;
   bigtable::InstanceUpdateConfig instance_update_config(std::move(instance));
   auto future = tested.UpdateInstance(std::move(instance_update_config));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Failures in `bigtable::InstanceAdmin::UpdateCluster`.
@@ -624,7 +623,7 @@ TEST_F(InstanceAdminTest, UpdateClusterRequestFailure) {
   btadmin::Cluster cluster;
   bigtable::ClusterConfig cluster_config(std::move(cluster));
   auto future = tested.UpdateCluster(std::move(cluster_config));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::UpdateCluster`.
@@ -645,7 +644,7 @@ TEST_F(InstanceAdminTest, UpdateClusterPollUnrecoverableFailure) {
   btadmin::Cluster cluster;
   bigtable::ClusterConfig cluster_config(std::move(cluster));
   auto future = tested.UpdateCluster(std::move(cluster_config));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Polling in `bigtable::InstanceAdmin::UpdateCluster` returns failure.
@@ -689,9 +688,8 @@ TEST_F(InstanceAdminTest, UpdateClusterPollReturnsFailure) {
   btadmin::Cluster cluster;
   bigtable::ClusterConfig cluster_config(std::move(cluster));
   auto future = tested.UpdateCluster(std::move(cluster_config));
-  EXPECT_THROW(future.get(), bigtable::GRpcError);
+  EXPECT_FALSE(future.get());
 }
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateInstance` works.
 TEST_F(InstanceAdminTest, UpdateInstance) {
@@ -765,7 +763,7 @@ TEST_F(InstanceAdminTest, UpdateInstance) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateInstance` works.
@@ -815,7 +813,7 @@ TEST_F(InstanceAdminTest, UpdateInstanceImmediatelyReady) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::UpdateInstance`.
@@ -879,7 +877,7 @@ TEST_F(InstanceAdminTest, UpdateInstancePollRecoverableFailures) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify that DeleteInstance works in the positive case.
@@ -1148,7 +1146,7 @@ TEST_F(InstanceAdminTest, CreateCluster) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::CreateCluster` works.
@@ -1193,7 +1191,7 @@ TEST_F(InstanceAdminTest, CreateClusterImmediatelyReady) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected, *actual)) << delta;
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::CreateCluster`.
@@ -1256,7 +1254,7 @@ TEST_F(InstanceAdminTest, CreateClusterPollRecoverableFailures) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateCluster` works.
@@ -1323,7 +1321,7 @@ TEST_F(InstanceAdminTest, UpdateCluster) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateCluster` works.
@@ -1373,7 +1371,7 @@ TEST_F(InstanceAdminTest, UpdateClusterImmediatelyReady) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::UpdateCluster`.
@@ -1437,7 +1435,7 @@ TEST_F(InstanceAdminTest, UpdateClusterPollRecoverableFailures) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
@@ -1509,7 +1507,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfile) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
@@ -1560,7 +1558,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileImmediatelyReady) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
@@ -1618,10 +1616,9 @@ TEST_F(InstanceAdminTest, UpdateAppProfileRecoverableFailures) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
 TEST_F(InstanceAdminTest, UpdateAppProfileTooManyRecoverableFailures) {
   using ::testing::_;
@@ -1642,12 +1639,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileTooManyRecoverableFailures) {
           .set_description("Test Profile")
           .set_multi_cluster_use_any());
 
-  EXPECT_THROW(try { future.get(); } catch (std::runtime_error const& ex) {
-    EXPECT_THAT(ex.what(), HasSubstr("try-again"));
-    EXPECT_THAT(ex.what(), HasSubstr("UpdateAppProfile"));
-    throw;
-  },
-               std::runtime_error);
+  EXPECT_FALSE(future.get());
 }
 
 /// @test Verify that `bigtable::InstanceAdmin::UpdateAppProfile` works.
@@ -1669,14 +1661,8 @@ TEST_F(InstanceAdminTest, UpdateAppProfilePermanentFailure) {
           .set_description("Test Profile")
           .set_multi_cluster_use_any());
 
-  EXPECT_THROW(try { future.get(); } catch (std::runtime_error const& ex) {
-    EXPECT_THAT(ex.what(), HasSubstr("uh oh"));
-    EXPECT_THAT(ex.what(), HasSubstr("UpdateAppProfile"));
-    throw;
-  },
-               std::runtime_error);
+  EXPECT_FALSE(future.get());
 }
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 
 /// @test Failures while polling in `bigtable::InstanceAdmin::UpdateAppProfile`.
 TEST_F(InstanceAdminTest, UpdateAppProfilePollRecoverableFailures) {
@@ -1739,7 +1725,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfilePollRecoverableFailures) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Operation failures in `bigtable::InstanceAdmin::UpdateAppProfile`.
@@ -1803,7 +1789,7 @@ TEST_F(InstanceAdminTest, UpdateAppProfileOperationFailure) {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;
   differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected_copy, actual)) << delta;
+  EXPECT_TRUE(differencer.Compare(expected_copy, *actual)) << delta;
 }
 
 /// @test Verify positive scenario for InstanceAdmin::GetIamPolicy.

--- a/google/cloud/bigtable/internal/grpc_error_delegate.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.cc
@@ -73,21 +73,6 @@ google::cloud::Status MakeStatusFromRpcError(grpc::Status const& status) {
   return google::cloud::Status(code, status.error_message());
 }
 
-void ThrowRpcError(grpc::Status const& status, char const* msg) {
-#ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  throw bigtable::GRpcError(msg, status);
-#else
-  bigtable::GRpcError ex(msg, status);
-  std::cerr << "Aborting because exceptions are disabled: " << ex.what()
-            << "\n";
-  google::cloud::Terminate(ex.what());
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-}
-
-void ThrowRpcError(grpc::Status const& status, std::string const& msg) {
-  ThrowRpcError(status, msg.c_str());
-}
-
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/grpc_error_delegate.h
+++ b/google/cloud/bigtable/internal/grpc_error_delegate.h
@@ -29,22 +29,6 @@ namespace internal {
  */
 google::cloud::Status MakeStatusFromRpcError(grpc::Status const& status);
 
-//@{
-/**
- * @name Delete exception raising to hidden functions.
- *
- * The following functions raise the corresponding exception, unless the user
- * has disabled exception handling, in which case they print the error message
- * to std::cerr and call std::abort().
- *
- * We copied this technique from Abseil.  Unfortunately we cannot use it
- * directly because it is not a public interface for Abseil.
- */
-[[noreturn]] void ThrowRpcError(grpc::Status const& status, char const* msg);
-[[noreturn]] void ThrowRpcError(grpc::Status const& status,
-                                std::string const& msg);
-//@}
-
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/grpc_error_delegate_test.cc
+++ b/google/cloud/bigtable/internal/grpc_error_delegate_test.cc
@@ -18,11 +18,6 @@
 
 using namespace google::cloud::bigtable::internal;
 
-namespace {
-std::string const cmsg("testing with std::string const&");
-char const* msg = "testing with char const*";
-}  // anonymous namespace
-
 TEST(MakeStatusFromRpcError, AllCodes) {
   using google::cloud::StatusCode;
 
@@ -56,15 +51,4 @@ TEST(MakeStatusFromRpcError, AllCodes) {
     auto const actual = MakeStatusFromRpcError(original);
     EXPECT_EQ(expected, actual);
   }
-}
-
-TEST(ThrowDelegateTest, RpcError) {
-  grpc::Status status(grpc::StatusCode::UNAVAILABLE, "try-again");
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(ThrowRpcError(status, msg), google::cloud::bigtable::GRpcError);
-  EXPECT_THROW(ThrowRpcError(status, cmsg), google::cloud::bigtable::GRpcError);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(ThrowRpcError(status, msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(ThrowRpcError(status, cmsg), cmsg);
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -293,7 +293,7 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc wait for consistency check
    */
-  std::future<bool> WaitForConsistencyCheck(
+  std::future<StatusOr<bool>> WaitForConsistencyCheck(
       bigtable::TableId const& table_id,
       bigtable::ConsistencyToken const& consistency_token) {
     return std::async(std::launch::async,
@@ -406,9 +406,10 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc create table from snapshot
    */
-  std::future<google::bigtable::admin::v2::Table> CreateTableFromSnapshot(
-      bigtable::ClusterId const& cluster_id,
-      bigtable::SnapshotId const& snapshot_id, std::string table_id);
+  std::future<StatusOr<google::bigtable::admin::v2::Table>>
+  CreateTableFromSnapshot(bigtable::ClusterId const& cluster_id,
+                          bigtable::SnapshotId const& snapshot_id,
+                          std::string table_id);
 
   //@}
 
@@ -429,7 +430,7 @@ class TableAdmin {
    * Implements the polling loop for `WaitForConsistencyCheck` on a
    * separate thread
    */
-  bool WaitForConsistencyCheckImpl(
+  StatusOr<bool> WaitForConsistencyCheckImpl(
       bigtable::TableId const& table_id,
       bigtable::ConsistencyToken const& consistency_token);
 
@@ -443,7 +444,7 @@ class TableAdmin {
       bigtable::TableId const& table_id, std::chrono::seconds duration_ttl);
 
   /// Implement CreateTableFromSnapshot() with a separate thread.
-  google::bigtable::admin::v2::Table CreateTableFromSnapshotImpl(
+  StatusOr<google::bigtable::admin::v2::Table> CreateTableFromSnapshotImpl(
       bigtable::ClusterId const& cluster_id,
       bigtable::SnapshotId const& snapshot_id, std::string table_id);
 

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -152,7 +152,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
 
   // update instance
   google::cloud::StatusOr<btadmin::Instance> instance_copy;
-  instance_copy->CopyFrom(*instance);
+  instance_copy = *instance;
   bigtable::InstanceUpdateConfig instance_update_config(std::move(*instance));
   auto const updated_display_name = instance_id + " updated";
   instance_update_config.set_display_name(updated_display_name);
@@ -230,7 +230,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
 
   // Update cluster
   google::cloud::StatusOr<btadmin::Cluster> cluster_copy;
-  cluster_copy->CopyFrom(*cluster);
+  cluster_copy = *cluster;
   // update the storage type
   cluster->set_serve_nodes(4);
   cluster->clear_state();

--- a/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
@@ -300,7 +300,7 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
       instance_id, "us-central1-c", bigtable::InstanceConfig::PRODUCTION, 3);
   auto future = instance_admin_->CreateInstance(instance_config);
   // Wait for instance creation
-  ASSERT_THAT(future.get().name(), HasSubstr(instance_id));
+  ASSERT_THAT(future.get()->name(), HasSubstr(instance_id));
 
   bigtable::noex::InstanceAdmin admin(instance_admin_client_);
   google::cloud::bigtable::CompletionQueue cq;

--- a/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
@@ -299,8 +299,10 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
   auto instance_config = IntegrationTestConfig(
       instance_id, "us-central1-c", bigtable::InstanceConfig::PRODUCTION, 3);
   auto future = instance_admin_->CreateInstance(instance_config);
+  auto actual = future.get();
+  EXPECT_STATUS_OK(actual);
   // Wait for instance creation
-  ASSERT_THAT(future.get()->name(), HasSubstr(instance_id));
+  ASSERT_THAT(actual->name(), HasSubstr(instance_id));
 
   bigtable::noex::InstanceAdmin admin(instance_admin_client_);
   google::cloud::bigtable::CompletionQueue cq;

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -249,7 +249,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteInstanceTest) {
 
   // update instance
   google::cloud::StatusOr<btadmin::Instance> instance_copy;
-  instance_copy->CopyFrom(*instance);
+  instance_copy = *instance;
   bigtable::InstanceUpdateConfig instance_update_config(std::move(*instance));
   auto const updated_display_name = instance_id + " updated";
   instance_update_config.set_display_name(updated_display_name);
@@ -311,7 +311,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
 
   // Update cluster
   google::cloud::StatusOr<btadmin::Cluster> cluster_copy;
-  cluster_copy->CopyFrom(*cluster);
+  cluster_copy = *cluster;
   // update the storage type
   cluster->set_serve_nodes(4);
   cluster->clear_state();

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -132,8 +132,10 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   auto instance_config = IntegrationTestConfig(
       instance_id, "us-central1-c", bigtable::InstanceConfig::PRODUCTION, 3);
   auto future = instance_admin_->CreateInstance(instance_config);
+  auto actual = future.get();
+  EXPECT_STATUS_OK(actual);
   // Wait for instance creation
-  ASSERT_THAT(future.get()->name(), HasSubstr(instance_id));
+  ASSERT_THAT(actual->name(), HasSubstr(instance_id));
 
   std::string id1 =
       "profile-" + google::cloud::internal::Sample(

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <google/protobuf/text_format.h>
@@ -107,8 +108,8 @@ TEST_F(InstanceAdminIntegrationTest, ListAllClustersTest) {
   auto instance1 = instance_admin_->CreateInstance(instance_config1);
   auto instance2 = instance_admin_->CreateInstance(instance_config2);
   // Wait for instance creation
-  ASSERT_THAT(instance1.get().name(), HasSubstr(id1));
-  ASSERT_THAT(instance2.get().name(), HasSubstr(id2));
+  ASSERT_THAT(instance1.get()->name(), HasSubstr(id1));
+  ASSERT_THAT(instance2.get()->name(), HasSubstr(id2));
 
   auto clusters = instance_admin_->ListClusters();
   ASSERT_STATUS_OK(clusters);
@@ -132,7 +133,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
       instance_id, "us-central1-c", bigtable::InstanceConfig::PRODUCTION, 3);
   auto future = instance_admin_->CreateInstance(instance_config);
   // Wait for instance creation
-  ASSERT_THAT(future.get().name(), HasSubstr(instance_id));
+  ASSERT_THAT(future.get()->name(), HasSubstr(instance_id));
 
   std::string id1 =
       "profile-" + google::cloud::internal::Sample(
@@ -195,7 +196,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   auto detail_2_after_update = instance_admin_->GetAppProfile(
       bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2));
   ASSERT_STATUS_OK(detail_2_after_update);
-  EXPECT_EQ("new description", update_2.description());
+  EXPECT_EQ("new description", update_2->description());
   EXPECT_EQ("new description", detail_2_after_update->description());
 
   ASSERT_STATUS_OK(instance_admin_->DeleteAppProfile(
@@ -236,7 +237,8 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteInstanceTest) {
   auto instances_current = instance_admin_->ListInstances();
   ASSERT_STATUS_OK(instances_current);
   ASSERT_TRUE(instances_current->failed_locations.empty());
-  EXPECT_TRUE(IsInstancePresent(instances_current->instances, instance.name()));
+  EXPECT_TRUE(
+      IsInstancePresent(instances_current->instances, instance->name()));
 
   // Get instance
   auto instance_check = instance_admin_->GetInstance(instance_id);
@@ -246,9 +248,9 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteInstanceTest) {
   EXPECT_NE(npos, instance_check->name().find(instance_id));
 
   // update instance
-  btadmin::Instance instance_copy;
-  instance_copy.CopyFrom(instance);
-  bigtable::InstanceUpdateConfig instance_update_config(std::move(instance));
+  google::cloud::StatusOr<btadmin::Instance> instance_copy;
+  instance_copy->CopyFrom(*instance);
+  bigtable::InstanceUpdateConfig instance_update_config(std::move(*instance));
   auto const updated_display_name = instance_id + " updated";
   instance_update_config.set_display_name(updated_display_name);
   auto instance_after =
@@ -263,9 +265,9 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteInstanceTest) {
   ASSERT_STATUS_OK(instances_after_delete);
   ASSERT_TRUE(instances_after_delete->failed_locations.empty());
   EXPECT_TRUE(
-      IsInstancePresent(instances_current->instances, instance_copy.name()));
+      IsInstancePresent(instances_current->instances, instance_copy->name()));
   EXPECT_FALSE(
-      IsInstancePresent(instances_after_delete->instances, instance.name()));
+      IsInstancePresent(instances_after_delete->instances, instance->name()));
 }
 
 /// @test Verify that cluster CRUD operations work as expected.
@@ -297,8 +299,8 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
           .get();
   auto clusters_after = instance_admin_->ListClusters(id);
   ASSERT_STATUS_OK(clusters_after);
-  EXPECT_FALSE(IsClusterPresent(clusters_before->clusters, cluster.name()));
-  EXPECT_TRUE(IsClusterPresent(clusters_after->clusters, cluster.name()));
+  EXPECT_FALSE(IsClusterPresent(clusters_before->clusters, cluster->name()));
+  EXPECT_TRUE(IsClusterPresent(clusters_after->clusters, cluster->name()));
 
   // Get cluster
   auto cluster_check = instance_admin_->GetCluster(instance_id, cluster_id);
@@ -308,19 +310,19 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
   EXPECT_EQ(cluster_name_prefix + cluster_id.get(), cluster_check->name());
 
   // Update cluster
-  btadmin::Cluster cluster_copy;
-  cluster_copy.CopyFrom(cluster);
+  google::cloud::StatusOr<btadmin::Cluster> cluster_copy;
+  cluster_copy->CopyFrom(*cluster);
   // update the storage type
-  cluster.set_serve_nodes(4);
-  cluster.clear_state();
-  bigtable::ClusterConfig updated_cluster_config(std::move(cluster));
+  cluster->set_serve_nodes(4);
+  cluster->clear_state();
+  bigtable::ClusterConfig updated_cluster_config(std::move(*cluster));
   auto cluster_after_update =
       instance_admin_->UpdateCluster(std::move(updated_cluster_config)).get();
   auto check_cluster_after_update =
       instance_admin_->GetCluster(instance_id, cluster_id);
   ASSERT_STATUS_OK(check_cluster_after_update);
 
-  EXPECT_EQ(3, cluster_copy.serve_nodes());
+  EXPECT_EQ(3, cluster_copy->serve_nodes());
   EXPECT_EQ(4, check_cluster_after_update->serve_nodes());
 
   // Delete cluster
@@ -331,10 +333,10 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
   ASSERT_STATUS_OK(instance_admin_->DeleteInstance(id));
   EXPECT_TRUE(
       IsClusterPresent(clusters_after->clusters,
-                       instance_details.name() + "/clusters/" + id + "-cl2"));
+                       instance_details->name() + "/clusters/" + id + "-cl2"));
   EXPECT_FALSE(
       IsClusterPresent(clusters_after_delete->clusters,
-                       instance_details.name() + "/clusters/" + id + "-cl2"));
+                       instance_details->name() + "/clusters/" + id + "-cl2"));
 }
 
 /// @test Verify that IAM Policy APIs work as expected.


### PR DESCRIPTION
Fixes #2081 
Fixes #2061

This also fixes all functions that had `ThrowRpcError` per #2080 and #2079 but doesn't fix *every* function to return `StatusOr`, so won't close those automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2088)
<!-- Reviewable:end -->
