### PR TITLE
Removed unneeded rvalue-reference arguments in bigtable/

### DIFF
--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -63,7 +63,7 @@ class InstanceConfig {
     return *this;
   }
 
-  InstanceConfig& emplace_label(std::string const& key, std::string&& value) {
+  InstanceConfig& emplace_label(std::string const& key, std::string value) {
     (*proto_.mutable_instance()->mutable_labels())[key] = std::move(value);
     return *this;
   }

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -89,7 +89,7 @@ class InstanceUpdateConfig {
   }
 
   InstanceUpdateConfig& emplace_label(std::string const& key,
-                                      std::string&& value) {
+                                      std::string value) {
     (*proto_.mutable_instance()->mutable_labels())[key] = std::move(value);
     AddPathIfNotPresent("labels");
     return *this;

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -72,17 +72,17 @@ class AsyncRetryBulkApply : public AsyncRetryOp<ConstantIdempotencyPolicy,
                       MetadataUpdatePolicy metadata_update_policy,
                       std::shared_ptr<bigtable::DataClient> client,
                       bigtable::AppProfileId const& app_profile_id,
-                      bigtable::TableId const& table_name, BulkMutation&& mut,
-                      Functor&& callback)
+                      bigtable::TableId const& table_name, BulkMutation mut,
+                      Functor callback)
       : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutator>(
             __func__, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
             // of the mutations it holds.
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
-            std::move(metadata_update_policy), std::forward<Functor>(callback),
+            std::move(metadata_update_policy), std::move(callback),
             AsyncBulkMutator(client, std::move(app_profile_id),
                              std::move(table_name), idempotent_policy,
-                             std::forward<BulkMutation>(mut))) {}
+                             std::move(mut))) {}
 
   AsyncRetryBulkApply(std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
                       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
@@ -90,23 +90,22 @@ class AsyncRetryBulkApply : public AsyncRetryOp<ConstantIdempotencyPolicy,
                       MetadataUpdatePolicy metadata_update_policy,
                       std::shared_ptr<bigtable::DataClient> client,
                       bigtable::AppProfileId const& app_profile_id,
-                      bigtable::TableId const& table_name, BulkMutation&& mut,
-                      MutationsSucceededFunctor&& mutations_succeeded_callback,
-                      MutationsFailedFunctor&& mutations_failed_callback,
-                      AttemptFinishedFunctor&& attempt_finished_callback,
-                      Functor&& callback)
+                      bigtable::TableId const& table_name, BulkMutation mut,
+                      MutationsSucceededFunctor mutations_succeeded_callback,
+                      MutationsFailedFunctor mutations_failed_callback,
+                      AttemptFinishedFunctor attempt_finished_callback,
+                      Functor callback)
       : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutator>(
             __func__, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
             // of the mutations it holds.
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
-            std::move(metadata_update_policy), std::forward<Functor>(callback),
-            AsyncBulkMutator(client, std::move(app_profile_id),
-                             std::move(table_name), idempotent_policy,
-                             std::move(mutations_succeeded_callback),
-                             std::move(mutations_failed_callback),
-                             std::move(attempt_finished_callback),
-                             std::forward<BulkMutation>(mut))) {}
+            std::move(metadata_update_policy), std::move(callback),
+            AsyncBulkMutator(
+                client, std::move(app_profile_id), std::move(table_name),
+                idempotent_policy, std::move(mutations_succeeded_callback),
+                std::move(mutations_failed_callback),
+                std::move(attempt_finished_callback), std::move(mut))) {}
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/async_future_from_callback.h
+++ b/google/cloud/bigtable/internal/async_future_from_callback.h
@@ -42,7 +42,7 @@ namespace internal {
 template <typename R>
 class AsyncFutureFromCallback {
  public:
-  explicit AsyncFutureFromCallback(promise<R>&& p, char const* w)
+  explicit AsyncFutureFromCallback(promise<R> p, char const* w)
       : promise_(std::move(p)), where_(w) {}
 
   void operator()(CompletionQueue& cq, R& result, grpc::Status& status) {
@@ -70,7 +70,7 @@ class AsyncFutureFromCallback {
 template <>
 class AsyncFutureFromCallback<void> {
  public:
-  explicit AsyncFutureFromCallback(promise<void>&& p, char const* w)
+  explicit AsyncFutureFromCallback(promise<void> p, char const* w)
       : promise_(std::move(p)), where_(w) {}
 
   void operator()(CompletionQueue& cq, google::protobuf::Empty& result,
@@ -94,7 +94,7 @@ class AsyncFutureFromCallback<void> {
  * and returns a new instance.
  */
 template <typename T>
-AsyncFutureFromCallback<T> MakeAsyncFutureFromCallback(promise<T>&& p,
+AsyncFutureFromCallback<T> MakeAsyncFutureFromCallback(promise<T> p,
                                                        const char* w) {
   return AsyncFutureFromCallback<T>(std::move(p), w);
 }

--- a/google/cloud/bigtable/internal/async_list_app_profiles.h
+++ b/google/cloud/bigtable/internal/async_list_app_profiles.h
@@ -127,11 +127,11 @@ class AsyncRetryListAppProfiles
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
       MetadataUpdatePolicy metadata_update_policy,
       std::shared_ptr<InstanceAdminClient> client, std::string instance_name,
-      Functor&& callback)
+      Functor callback)
       : AsyncRetryMultiPage<Functor, AsyncListAppProfiles>(
             error_message, std::move(rpc_retry_policy),
             std::move(rpc_backoff_policy), metadata_update_policy,
-            std::forward<Functor>(callback),
+            std::move(callback),
             AsyncListAppProfiles(std::move(client),
                                  std::move(instance_name))){};
 };

--- a/google/cloud/bigtable/internal/async_list_clusters.h
+++ b/google/cloud/bigtable/internal/async_list_clusters.h
@@ -135,11 +135,11 @@ class AsyncRetryListClusters
                          std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
                          MetadataUpdatePolicy metadata_update_policy,
                          std::shared_ptr<InstanceAdminClient> client,
-                         std::string instance_name, Functor&& callback)
+                         std::string instance_name, Functor callback)
       : AsyncRetryMultiPage<Functor, AsyncListClusters>(
             error_message, std::move(rpc_retry_policy),
             std::move(rpc_backoff_policy), metadata_update_policy,
-            std::forward<Functor>(callback),
+            std::move(callback),
             AsyncListClusters(std::move(client), std::move(instance_name))){};
 };
 

--- a/google/cloud/bigtable/internal/async_list_instances.h
+++ b/google/cloud/bigtable/internal/async_list_instances.h
@@ -139,7 +139,7 @@ class AsyncRetryListInstances
       : AsyncRetryMultiPage<Functor, AsyncListInstances>(
             error_message, std::move(rpc_retry_policy),
             std::move(rpc_backoff_policy), metadata_update_policy,
-            std::forward<Functor>(callback),
+            std::move(callback),
             AsyncListInstances(std::move(client), std::move(project_name))){};
 };
 

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -177,10 +177,10 @@ class AsyncPollLongrunningOp
                          MetadataUpdatePolicy metadata_update_policy,
                          std::shared_ptr<Client> client,
                          google::longrunning::Operation operation,
-                         Functor&& callback)
+                         Functor callback)
       : AsyncPollOp<Functor, AsyncLongrunningOp<Client, Response>>(
             error_message, std::move(polling_policy),
-            std::move(metadata_update_policy), std::forward<Functor>(callback),
+            std::move(metadata_update_policy), std::move(callback),
             AsyncLongrunningOp<Client, Response>(std::move(client),
                                                  std::move(operation))) {}
 };

--- a/google/cloud/bigtable/internal/async_loop_op.h
+++ b/google/cloud/bigtable/internal/async_loop_op.h
@@ -56,10 +56,10 @@ struct MeetsLoopOperationRequirements {
           decltype(
               &Operation::template Start<PrototypeLoopOperationStartCallback>),
           Operation&, CompletionQueue&,
-          PrototypeLoopOperationStartCallback&&>::value,
+          PrototypeLoopOperationStartCallback>::value,
       "Operation::Start<PrototypeLoopOperationStartCallback> has to be "
       "non-static and invocable with CompletionQueue&, "
-      "PrototypeLoopOperationStartCallback&&.");
+      "PrototypeLoopOperationStartCallback.");
   static_assert(
       google::cloud::internal::is_invocable<
           decltype(&Operation::Cancel), Operation&, CompletionQueue&>::value,
@@ -73,7 +73,7 @@ struct MeetsLoopOperationRequirements {
                                  decltype(&Operation::template Start<
                                           PrototypeLoopOperationStartCallback>),
                                  Operation&, CompletionQueue&,
-                                 PrototypeLoopOperationStartCallback&&>,
+                                 PrototypeLoopOperationStartCallback>,
                              std::shared_ptr<AsyncOperation>>::value,
                 "Operation::Start<>(...) has to return a "
                 "std::shared_ptr<AsyncOperation>");
@@ -131,7 +131,7 @@ template <typename Operation>
 class AsyncLoopOp : public std::enable_shared_from_this<AsyncLoopOp<Operation>>,
                     public AsyncOperation {
  public:
-  explicit AsyncLoopOp(Operation&& operation)
+  explicit AsyncLoopOp(Operation operation)
       : cancelled_(), operation_(std::move(operation)) {}
 
   void Cancel() override {

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -104,11 +104,11 @@ class PollableLoopAdapter {
   explicit PollableLoopAdapter(char const* error_message,
                                std::unique_ptr<PollingPolicy> polling_policy,
                                MetadataUpdatePolicy metadata_update_policy,
-                               UserFunctor&& callback, Operation&& operation)
+                               UserFunctor callback, Operation operation)
       : error_message_(error_message),
         polling_policy_(std::move(polling_policy)),
         metadata_update_policy_(std::move(metadata_update_policy)),
-        user_callback_(std::forward<UserFunctor>(callback)),
+        user_callback_(std::move(callback)),
         operation_(std::move(operation)) {}
 
   template <typename AttemptFunctor>
@@ -235,11 +235,11 @@ class AsyncPollOp
   explicit AsyncPollOp(char const* error_message,
                        std::unique_ptr<PollingPolicy> polling_policy,
                        MetadataUpdatePolicy metadata_update_policy,
-                       Functor&& callback, Operation&& operation)
+                       Functor callback, Operation operation)
       : AsyncLoopOp<PollableLoopAdapter<Functor, Operation>>(
             PollableLoopAdapter<Functor, Operation>(
                 error_message, std::move(polling_policy),
-                metadata_update_policy, std::forward<Functor>(callback),
+                metadata_update_policy, std::move(callback),
                 std::move(operation))) {}
 };
 

--- a/google/cloud/bigtable/internal/async_read_row_operation.h
+++ b/google/cloud/bigtable/internal/async_read_row_operation.h
@@ -79,13 +79,12 @@ class AsyncReadRowsOperation
       bigtable::TableId const& table_name, RowSet row_set,
       std::int64_t rows_limit, Filter filter, bool raise_on_error,
       std::unique_ptr<internal::ReadRowsParserFactory> parser_factory,
-      ReadRowCallback&& read_row_callback, DoneCallback&& done_callback)
+      ReadRowCallback read_row_callback, DoneCallback done_callback)
       : AsyncRetryOp<ConstantIdempotencyPolicy, DoneCallback,
                      AsyncRowReader<ReadRowCallback>>(
             __func__, std::move(rpc_retry_policy),
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
-            std::move(metadata_update_policy),
-            std::forward<DoneCallback>(done_callback),
+            std::move(metadata_update_policy), std::move(done_callback),
             AsyncRowReader<ReadRowCallback>(
                 client, std::move(app_profile_id), std::move(table_name),
                 std::move(row_set), rows_limit, std::move(filter),
@@ -117,7 +116,7 @@ template <typename Functor, typename std::enable_if<
                                 int>::type valid_callback_type = 0>
 class ReadRowCallbackAdapter {
  public:
-  explicit ReadRowCallbackAdapter(Functor&& callback,
+  explicit ReadRowCallbackAdapter(Functor callback,
                                   std::shared_ptr<std::vector<Row>> row)
       : callback_(std::move(callback)), rows_(std::move(row)) {}
 

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -61,14 +61,14 @@ class MultipageRetriableAdapter {
       char const* error_message,
       std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      MetadataUpdatePolicy metadata_update_policy, UserFunctor&& callback,
-      Operation&& operation)
+      MetadataUpdatePolicy metadata_update_policy, UserFunctor callback,
+      Operation operation)
       : error_message_(error_message),
         rpc_retry_policy_(std::move(rpc_retry_policy)),
         rpc_backoff_policy_(std::move(rpc_backoff_policy)),
         rpc_backoff_policy_prototype_(rpc_backoff_policy_->clone()),
         metadata_update_policy_(std::move(metadata_update_policy)),
-        user_callback_(std::forward<UserFunctor>(callback)),
+        user_callback_(std::move(callback)),
         operation_(std::move(operation)) {}
 
   template <typename AttemptFunctor>
@@ -193,13 +193,13 @@ class AsyncRetryMultiPage
                       std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
                       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
                       MetadataUpdatePolicy metadata_update_policy,
-                      Functor&& callback, Operation&& operation)
+                      Functor callback, Operation operation)
       : AsyncLoopOp<MultipageRetriableAdapter<Functor, Operation>>(
             MultipageRetriableAdapter<Functor, Operation>(
                 error_message, std::move(rpc_retry_policy),
                 std::move(rpc_backoff_policy),
-                std::move(metadata_update_policy),
-                std::forward<Functor>(callback), std::move(operation))) {}
+                std::move(metadata_update_policy), std::move(callback),
+                std::move(operation))) {}
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/async_retry_op.h
+++ b/google/cloud/bigtable/internal/async_retry_op.h
@@ -115,14 +115,14 @@ class RetriableLoopAdapter {
       std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
       IdempotencyPolicy idempotent_policy,
-      MetadataUpdatePolicy metadata_update_policy, UserFunctor&& callback,
-      Operation&& operation)
+      MetadataUpdatePolicy metadata_update_policy, UserFunctor callback,
+      Operation operation)
       : error_message_(error_message),
         rpc_retry_policy_(std::move(rpc_retry_policy)),
         rpc_backoff_policy_(std::move(rpc_backoff_policy)),
         idempotent_policy_(std::move(idempotent_policy)),
         metadata_update_policy_(std::move(metadata_update_policy)),
-        user_callback_(std::forward<UserFunctor>(callback)),
+        user_callback_(std::move(callback)),
         operation_(std::move(operation)) {}
 
   template <typename AttemptFunctor>
@@ -258,7 +258,7 @@ class AsyncRetryOp
             RetriableLoopAdapter<IdempotencyPolicy, Functor, Operation>(
                 error_message, std::move(rpc_retry_policy),
                 std::move(rpc_backoff_policy), std::move(idempotent_policy),
-                metadata_update_policy, std::forward<Functor>(callback),
+                metadata_update_policy, std::move(callback),
                 std::move(operation))) {}
 };
 

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -65,7 +65,7 @@ class AsyncUnaryRpc {
   using Response = typename Sig::ResponseType;
   //@}
   AsyncUnaryRpc(std::shared_ptr<Client> client,
-                MemberFunctionType Client::*call, Request&& request)
+                MemberFunctionType Client::*call, Request request)
       : client_(std::move(client)),
         call_(std::move(call)),
         request_(std::move(request)) {}
@@ -94,7 +94,7 @@ class AsyncUnaryRpc {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> Start(
-      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
       Functor&& callback) {
     return cq.MakeUnaryRpc(
         *client_, call_, request_, std::move(context),
@@ -137,12 +137,12 @@ class AsyncRetryUnaryRpc
       IdempotencyPolicy idempotent_policy,
       MetadataUpdatePolicy metadata_update_policy,
       std::shared_ptr<Client> client, MemberFunctionType Client::*call,
-      Request&& request, Functor&& callback)
+      Request request, Functor callback)
       : AsyncRetryOp<IdempotencyPolicy, Functor,
                      AsyncUnaryRpc<Client, MemberFunctionType>>(
             error_message, std::move(rpc_retry_policy),
             std::move(rpc_backoff_policy), std::move(idempotent_policy),
-            std::move(metadata_update_policy), std::forward<Functor>(callback),
+            std::move(metadata_update_policy), std::move(callback),
             AsyncUnaryRpc<Client, MemberFunctionType>(
                 std::move(client), std::move(call), std::move(request))) {}
 };
@@ -157,7 +157,7 @@ template <typename Functor,
               int>::type valid_callback_type = 0>
 class EmptyResponseAdaptor {
  public:
-  explicit EmptyResponseAdaptor(Functor&& callback)
+  explicit EmptyResponseAdaptor(Functor callback)
       : callback_(std::move(callback)) {}
 
   const void operator()(CompletionQueue& cq, google::protobuf::Empty& response,

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -62,7 +62,7 @@ class AsyncRowReader {
       bigtable::TableId const& table_name, RowSet row_set,
       std::int64_t rows_limit, Filter filter, bool raise_on_error,
       std::unique_ptr<internal::ReadRowsParserFactory> parser_factory,
-      ReadRowCallback&& read_row_callback)
+      ReadRowCallback read_row_callback)
       : client_(std::move(client)),
         app_profile_id_(std::move(app_profile_id)),
         table_name_(std::move(table_name)),
@@ -112,7 +112,7 @@ class AsyncRowReader {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> Start(
-      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
       Functor&& callback) {
     google::bigtable::v2::ReadRowsRequest request;
     request.set_app_profile_id(app_profile_id_.get());
@@ -152,7 +152,7 @@ class AsyncRowReader {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   struct FinishedCallback {
-    FinishedCallback(AsyncRowReader& parent, Functor&& callback)
+    FinishedCallback(AsyncRowReader& parent, Functor callback)
         : parent_(parent), callback_(std::move(callback)) {}
 
     void operator()(CompletionQueue& cq, grpc::ClientContext& context,

--- a/google/cloud/bigtable/internal/async_sample_row_keys.h
+++ b/google/cloud/bigtable/internal/async_sample_row_keys.h
@@ -73,7 +73,7 @@ class AsyncSampleRowKeys {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> Start(
-      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
       Functor&& callback) {
     return cq.MakeUnaryStreamRpc(
         *client_, &DataClient::AsyncSampleRowKeys, request_, std::move(context),
@@ -94,7 +94,7 @@ class AsyncSampleRowKeys {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   struct FinishedCallback {
-    FinishedCallback(AsyncSampleRowKeys& parent, Functor&& callback)
+    FinishedCallback(AsyncSampleRowKeys& parent, Functor callback)
         : parent_(parent), callback_(callback) {}
 
     void operator()(CompletionQueue& cq, grpc::ClientContext& context,
@@ -150,14 +150,13 @@ class AsyncRetrySampleRowKeys
                           MetadataUpdatePolicy metadata_update_policy,
                           std::shared_ptr<bigtable::DataClient> client,
                           bigtable::AppProfileId const& app_profile_id,
-                          bigtable::TableId const& table_name,
-                          Functor&& callback)
+                          bigtable::TableId const& table_name, Functor callback)
       : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncSampleRowKeys>(
             error_message, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
             // of the mutations it holds.
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
-            std::move(metadata_update_policy), std::forward<Functor>(callback),
+            std::move(metadata_update_policy), std::move(callback),
             AsyncSampleRowKeys(client, std::move(app_profile_id),
                                std::move(table_name))) {}
 };

--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -29,7 +29,7 @@ namespace btproto = google::bigtable::v2;
 BulkMutator::BulkMutator(bigtable::AppProfileId const& app_profile_id,
                          bigtable::TableId const& table_name,
                          IdempotentMutationPolicy& idempotent_policy,
-                         BulkMutation&& mut) {
+                         BulkMutation mut) {
   // Every time the client library calls MakeOneRequest(), the data in the
   // "pending_*" variables initializes the next request.  So in the constructor
   // we start by putting the data on the "pending_*" variables.

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -34,7 +34,7 @@ class BulkMutator {
  public:
   BulkMutator(bigtable::AppProfileId const& app_profile_id,
               bigtable::TableId const& table_name,
-              IdempotentMutationPolicy& idempotent_policy, BulkMutation&& mut);
+              IdempotentMutationPolicy& idempotent_policy, BulkMutation mut);
 
   /// Return true if there are pending mutations in the mutator
   bool HasPendingMutations() const {
@@ -130,7 +130,7 @@ class AsyncBulkMutator : private BulkMutator {
                    bigtable::AppProfileId const& app_profile_id,
                    bigtable::TableId const& table_name,
                    IdempotentMutationPolicy& idempotent_policy,
-                   BulkMutation&& mut)
+                   BulkMutation mut)
       : BulkMutator(app_profile_id, table_name, idempotent_policy,
                     std::move(mut)),
         client_(std::move(client)) {}
@@ -139,10 +139,10 @@ class AsyncBulkMutator : private BulkMutator {
                    bigtable::AppProfileId const& app_profile_id,
                    bigtable::TableId const& table_name,
                    IdempotentMutationPolicy& idempotent_policy,
-                   MutationsSucceededFunctor&& mutations_succeeded_callback,
-                   MutationsFailedFunctor&& mutations_failed_callback,
-                   AttemptFinishedFunctor&& attempt_finished_callback,
-                   BulkMutation&& mut)
+                   MutationsSucceededFunctor mutations_succeeded_callback,
+                   MutationsFailedFunctor mutations_failed_callback,
+                   AttemptFinishedFunctor attempt_finished_callback,
+                   BulkMutation mut)
       : BulkMutator(app_profile_id, table_name, idempotent_policy,
                     std::move(mut)),
         client_(std::move(client)),
@@ -159,7 +159,7 @@ class AsyncBulkMutator : private BulkMutator {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> Start(
-      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext>&& context,
+      CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
       Functor&& callback) {
     PrepareForRequest();
     return cq.MakeUnaryStreamRpc(
@@ -188,7 +188,7 @@ class AsyncBulkMutator : private BulkMutator {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   struct FinishedCallback {
-    FinishedCallback(AsyncBulkMutator& parent, Functor&& callback)
+    FinishedCallback(AsyncBulkMutator& parent, Functor callback)
         : parent_(parent), callback_(callback) {}
 
     void operator()(CompletionQueue& cq, grpc::ClientContext& context,

--- a/google/cloud/bigtable/internal/completion_queue_impl.h
+++ b/google/cloud/bigtable/internal/completion_queue_impl.h
@@ -89,7 +89,7 @@ template <
     typename std::enable_if<CheckTimerCallback<Functor>::value, int>::type = 0>
 class AsyncTimerFunctor : public AsyncGrpcOperation {
  public:
-  explicit AsyncTimerFunctor(Functor&& functor,
+  explicit AsyncTimerFunctor(Functor functor,
                              std::unique_ptr<grpc::Alarm> alarm)
       : functor_(std::move(functor)), alarm_(std::move(alarm)) {}
 
@@ -171,8 +171,8 @@ template <typename Request, typename Response, typename Functor,
               CheckUnaryRpcCallback<Functor, Response>::value, int>::type = 0>
 class AsyncUnaryRpcFunctor : public AsyncGrpcOperation {
  public:
-  explicit AsyncUnaryRpcFunctor(Functor&& functor)
-      : sync_(false), functor_(std::forward<Functor>(functor)) {}
+  explicit AsyncUnaryRpcFunctor(Functor functor)
+      : sync_(false), functor_(std::move(functor)) {}
 
   /// Make the RPC request and prepare the response callback.
   template <typename Client, typename MemberFunction>
@@ -240,12 +240,12 @@ template <typename Request, typename Response, typename DataFunctor,
                                   int>::type = 0>
 class AsyncUnaryStreamRpcFunctor : public AsyncGrpcOperation {
  public:
-  explicit AsyncUnaryStreamRpcFunctor(DataFunctor&& data_functor,
-                                      FinishedFunctor&& finished_functor)
+  explicit AsyncUnaryStreamRpcFunctor(DataFunctor data_functor,
+                                      FinishedFunctor finished_functor)
       : tag_(nullptr),
         state_(CREATING),
-        data_functor_(std::forward<DataFunctor>(data_functor)),
-        finished_functor_(std::forward<FinishedFunctor>(finished_functor)) {}
+        data_functor_(std::move(data_functor)),
+        finished_functor_(std::move(finished_functor)) {}
 
   /// Make the RPC request and prepare the response callback.
   template <typename Client, typename MemberFunction>

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -1025,7 +1025,7 @@ class InstanceAdmin {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   struct TransformResponseHelper {
-    TransformResponseHelper(Functor&& callback)
+    TransformResponseHelper(Functor callback)
         : application_callback_(std::move(callback)) {}
 
     void operator()(CompletionQueue& cq, google::iam::v1::Policy& response,

--- a/google/cloud/bigtable/internal/mutation_batcher.h
+++ b/google/cloud/bigtable/internal/mutation_batcher.h
@@ -96,9 +96,8 @@ class MutationBatcher {
         cur_batch_(std::make_shared<Batch>()) {}
 
   std::shared_ptr<AsyncOperation> AsyncApply(
-      CompletionQueue& cq, AsyncApplyCompletionCallback&& completion_callback,
-      AsyncApplyAdmissionCallback&& admission_callback,
-      SingleRowMutation&& mut);
+      CompletionQueue& cq, AsyncApplyCompletionCallback completion_callback,
+      AsyncApplyAdmissionCallback admission_callback, SingleRowMutation mut);
 
  private:
   class Batch;
@@ -107,9 +106,9 @@ class MutationBatcher {
    * This structure represents a single mutation before it is admitted.
    */
   struct PendingSingleRowMutation {
-    PendingSingleRowMutation(SingleRowMutation&& mut_arg,
-                             AsyncApplyCompletionCallback&& completion_callback,
-                             AsyncApplyAdmissionCallback&& admission_callback);
+    PendingSingleRowMutation(SingleRowMutation mut_arg,
+                             AsyncApplyCompletionCallback completion_callback,
+                             AsyncApplyAdmissionCallback admission_callback);
 
     SingleRowMutation mut;
     size_t num_mutations;
@@ -143,13 +142,13 @@ class MutationBatcher {
     size_t num_mutations() { return num_mutations_; }
     BulkMutation TransferRequest() { return std::move(requests_); }
 
-    void Add(PendingSingleRowMutation&& mut);
+    void Add(PendingSingleRowMutation mut);
     size_t FireCallbacks(CompletionQueue& cq,
                          std::vector<FailedMutation> const& failed);
 
    private:
     struct MutationData {
-      MutationData(PendingSingleRowMutation&& pending)
+      MutationData(PendingSingleRowMutation pending)
           : callback(std::move(pending.completion_callback)),
             num_mutations(pending.num_mutations),
             request_size(pending.request_size) {}
@@ -183,7 +182,7 @@ class MutationBatcher {
                      std::vector<FailedMutation> const& failed);
   void FlushOnBatchFinished(CompletionQueue& cq, size_t completed_size);
   void TryAdmit(CompletionQueue& cq, std::unique_lock<std::mutex>& lk);
-  void Admit(PendingSingleRowMutation&& mut);
+  void Admit(PendingSingleRowMutation mut);
 
   std::mutex mu_;
   noex::Table& table_;

--- a/google/cloud/bigtable/internal/strong_type.h
+++ b/google/cloud/bigtable/internal/strong_type.h
@@ -56,8 +56,7 @@ namespace internal {
 template <typename T, typename Parameter>
 class StrongType {
  public:
-  explicit StrongType(T const& value) : value_(value) {}
-  explicit StrongType(T&& value) : value_(std::move(value)) {}
+  explicit StrongType(T value) : value_(std::move(value)) {}
   T& get() { return value_; }
   T const& get() const { return value_; }
 

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -33,7 +33,7 @@ static_assert(std::is_copy_assignable<bigtable::noex::Table>::value,
 
 // Call the `google.bigtable.v2.Bigtable.MutateRow` RPC repeatedly until
 // successful, or until the policies in effect tell us to stop.
-std::vector<FailedMutation> Table::Apply(SingleRowMutation&& mut) {
+std::vector<FailedMutation> Table::Apply(SingleRowMutation mut) {
   // Copy the policies in effect for this operation.  Many policy classes change
   // their state as the operation makes progress (or fails to make progress), so
   // we need fresh instances.
@@ -87,7 +87,7 @@ std::vector<FailedMutation> Table::Apply(SingleRowMutation&& mut) {
 // successful, or until the policies in effect tell us to stop.  When the RPC
 // is partially successful, this function retries only the mutations that did
 // not succeed.
-std::vector<FailedMutation> Table::BulkApply(BulkMutation&& mut,
+std::vector<FailedMutation> Table::BulkApply(BulkMutation mut,
                                              grpc::Status& status) {
   // Copy the policies in effect for this operation.  Many policy classes change
   // their state as the operation makes progress (or fails to make progress), so
@@ -97,8 +97,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation&& mut,
   auto idemponent_policy = idempotent_mutation_policy_->clone();
 
   bigtable::internal::BulkMutator mutator(app_profile_id_, table_name_,
-                                          *idemponent_policy,
-                                          std::forward<BulkMutation>(mut));
+                                          *idemponent_policy, std::move(mut));
   while (mutator.HasPendingMutations()) {
     grpc::ClientContext client_context;
     backoff_policy->Setup(client_context);

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -48,7 +48,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 static_assert(std::is_copy_assignable<bigtable::Table>::value,
               "bigtable::Table must be CopyAssignable");
 
-Status Table::Apply(SingleRowMutation&& mut) {
+Status Table::Apply(SingleRowMutation mut) {
   std::vector<FailedMutation> failures = impl_.Apply(std::move(mut));
   if (!failures.empty()) {
     grpc::Status status = failures.front().status();
@@ -57,7 +57,7 @@ Status Table::Apply(SingleRowMutation&& mut) {
   return google::cloud::Status{};
 }
 
-future<void> Table::AsyncApply(SingleRowMutation&& mut, CompletionQueue& cq) {
+future<void> Table::AsyncApply(SingleRowMutation mut, CompletionQueue& cq) {
   promise<google::bigtable::v2::MutateRowResponse> p;
   future<google::bigtable::v2::MutateRowResponse> result = p.get_future();
 
@@ -73,7 +73,7 @@ future<void> Table::AsyncApply(SingleRowMutation&& mut, CompletionQueue& cq) {
   return final;
 }
 
-void Table::BulkApply(BulkMutation&& mut) {
+void Table::BulkApply(BulkMutation mut) {
   grpc::Status status;
   std::vector<FailedMutation> failures =
       impl_.BulkApply(std::move(mut), status);
@@ -82,7 +82,7 @@ void Table::BulkApply(BulkMutation&& mut) {
   }
 }
 
-future<void> Table::AsyncBulkApply(BulkMutation&& mut, CompletionQueue& cq) {
+future<void> Table::AsyncBulkApply(BulkMutation mut, CompletionQueue& cq) {
   promise<std::vector<FailedMutation>> pfm;
   future<std::vector<FailedMutation>> resultfm = pfm.get_future();
   impl_.AsyncBulkApply(

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -200,7 +200,7 @@ class Table {
    * @snippet data_snippets.cc apply
    */
 
-  Status Apply(SingleRowMutation&& mut);
+  Status Apply(SingleRowMutation mut);
 
   /**
    * Makes asycronous attempts to apply the mutation to a row.
@@ -217,7 +217,7 @@ class Table {
    * @snippet data_async_snippets.cc async-apply
    */
 
-  future<void> AsyncApply(SingleRowMutation&& mut, CompletionQueue& cq);
+  future<void> AsyncApply(SingleRowMutation mut, CompletionQueue& cq);
 
   /**
    * Attempts to apply mutations to multiple rows.
@@ -239,7 +239,7 @@ class Table {
    * @par Example
    * @snippet data_snippets.cc bulk apply
    */
-  void BulkApply(BulkMutation&& mut);
+  void BulkApply(BulkMutation mut);
 
   /**
    * Makes asyncronous attempts to apply mutations to multiple rows.
@@ -256,7 +256,7 @@ class Table {
    * @par Example
    * @snippet data_async_snippets.cc bulk async-bulk-apply
    */
-  future<void> AsyncBulkApply(BulkMutation&& mut, CompletionQueue& cq);
+  future<void> AsyncBulkApply(BulkMutation mut, CompletionQueue& cq);
 
   /**
    * Reads a set of rows from the table.


### PR DESCRIPTION
(IIRC, @coryan  at some point mentioned that during the exceptions -> StatusOr migration going on in bigtable/, we might want to do some other cleanups, such as changing rvalue reference function parameters to regular value parameters. Sadly, my search-fu is failing me and I'm unable to cite this. So I hope I didn't dream it. But if it's true, then I do agree with it.)

This PR removes all rvalue function arguments and replaces them with by-value arguments. Callers can (and should) still use `std::move` at the call site to avoid unnecessary copies. This PR also removes uses of `std::forward` when used used *without* a forwarding reference. In that case, it's equivalent to `std::move`, in which case, using `std::move` directly is clearer.

This PR should affect the number of moves vs copies in the code.

## Background

Rvalue reference arguments are different than forwarding references (sometimes called universal references). Forwarding references only apply to *function templates* and `std::forward` is only useful with a forwarding reference. For example:

```cc
template <typename T>
struct A {
  void F(T&&);  // rvalue reference, NOT a forwarding reference
};

void F(MyType&&);  // rvalue reference, NOT a forwarding reference

template <typename T>
void G(T&&);  // Forwarding reference (function template)

template <typename T>
struct B {
  template <typename U>
  void F(U&&);  // Forwarding reference (function template)
};
```

`std::forward` is only useful when used with a forwarding reference. In that case, it basically moves **and** casts the result to the value category of *function template's* original type. Therefore, if not used with a forwarding reference, a `std::forward` is roughly equivalent to `std::move`, so the latter would be clearer to use.

Related: https://isocpp.org/blog/2018/02/quick-q-whats-the-difference-between-stdmove-and-stdforward

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2089)
<!-- Reviewable:end -->
