### PR TITLE
Simplify kokoro windows build

### DIFF
--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -95,7 +95,7 @@ Get-Date -Format o
 $packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
               "protobuf:x64-windows-static", "c-ares:x64-windows-static",
               "grpc:x64-windows-static", "curl:x64-windows-static",
-              "crc32c:x64-windows-static")
+              "gtest:x64-windows-static", "crc32c:x64-windows-static")
 foreach ($pkg in $packages) {
     .\vcpkg.exe install $pkg
     if ($LastExitCode) {
@@ -103,19 +103,10 @@ foreach ($pkg in $packages) {
     }
 }
 
-# The dependencies are cached, we need to remove this old dependency. Otherwise
-# CMake files the old version of gtest+gmock instead of the external project.
-# This is clearly a defect in our hand-crafted caching, but without caching the
-# build takes about 1 hour to just build the dependencies.
-Write-Host "================================================================"
-Write-Host "================================================================"
-.\vcpkg.exe remove --recurse --purge "gtest:x64-windows-static"
-Remove-Item -Recurse -Path installed\x64-windows-static\include\gtest
-Remove-Item -Recurse -Path installed\x64-windows-static\include\gmock
-
 Write-Host "================================================================"
 Write-Host "================================================================"
 .\vcpkg.exe list
+# TODO(coryan) - remove this after testing in the CI system.
 Get-ChildItem -Recurse -Path installed\x64-windows-static\include\gtest -File
 Get-ChildItem -Recurse -Path installed\x64-windows-static\include\gmock -File
 Write-Host "================================================================"
@@ -129,10 +120,12 @@ if ($LastExitCode) {
     Write-Host "zip build cache failed with exit code $LastExitCode"
 }
 
-Write-Host "Upload cache zip file."
-Get-Date -Format o
-gsutil cp vcpkg-installed.zip gs://cloud-cpp-kokoro-results/build-artifacts/vcpkg-installed.zip
-if ($LastExitCode) {
-    # Ignore errors, caching failures should not break the build.
-    Write-Host "gsutil upload failed with exit code $LastExitCode"
-}
+# DEBUG DO NOT MERGE
+# Write-Host "Upload cache zip file."
+# Get-Date -Format o
+# gsutil cp vcpkg-installed.zip gs://cloud-cpp-kokoro-results/build-artifacts/vcpkg-installed.zip
+# if ($LastExitCode) {
+#     # Ignore errors, caching failures should not break the build.
+#     Write-Host "gsutil upload failed with exit code $LastExitCode"
+# }
+# DEBUG DO NOT MERGE

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -106,12 +106,9 @@ foreach ($pkg in $packages) {
 Write-Host "================================================================"
 Write-Host "================================================================"
 .\vcpkg.exe list
-# TODO(coryan) - remove this after testing in the CI system.
-Get-ChildItem -Recurse -Path installed\x64-windows-static\include\gtest -File
-Get-ChildItem -Recurse -Path installed\x64-windows-static\include\gmock -File
-Write-Host "================================================================"
-Write-Host "================================================================"
 
+Write-Host "================================================================"
+Write-Host "================================================================"
 Write-Host "Create cache zip file."
 Get-Date -Format o
 cmd /c 7z a vcpkg-installed.zip installed\
@@ -120,12 +117,12 @@ if ($LastExitCode) {
     Write-Host "zip build cache failed with exit code $LastExitCode"
 }
 
-# DEBUG DO NOT MERGE
-# Write-Host "Upload cache zip file."
-# Get-Date -Format o
-# gsutil cp vcpkg-installed.zip gs://cloud-cpp-kokoro-results/build-artifacts/vcpkg-installed.zip
-# if ($LastExitCode) {
-#     # Ignore errors, caching failures should not break the build.
-#     Write-Host "gsutil upload failed with exit code $LastExitCode"
-# }
-# DEBUG DO NOT MERGE
+Write-Host "================================================================"
+Write-Host "================================================================"
+Write-Host "Upload cache zip file."
+Get-Date -Format o
+gsutil cp vcpkg-installed.zip gs://cloud-cpp-kokoro-results/build-artifacts/vcpkg-installed.zip
+if ($LastExitCode) {
+    # Ignore errors, caching failures should not break the build.
+    Write-Host "gsutil upload failed with exit code $LastExitCode"
+}

--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -50,7 +50,6 @@ if ($LastExitCode) {
 
 # Setup the environment for vcpkg:
 $cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$PROVIDER"
-$cmake_flags += "-DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external"
 $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
 $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
 $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"


### PR DESCRIPTION
Now that vcpkg is upgraded to the same version of googletest we use for regular builds we can simplify the  build scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2103)
<!-- Reviewable:end -->
