### PR TITLE
Format timestamps as needed by V4 signed URLs.

### DIFF
--- a/google/cloud/storage/internal/format_time_point.cc
+++ b/google/cloud/storage/internal/format_time_point.cc
@@ -27,29 +27,25 @@ std::string FormatFractional(std::chrono::nanoseconds ns) {
   }
 
   char buffer[16];
-  std::string result = ".";
   // If the fractional seconds can be just expressed as milliseconds, do that,
   // we do not want to print 1.123000000
   auto d = std::lldiv(ns.count(), 1000000LL);
   if (d.rem == 0) {
-    std::snprintf(buffer, sizeof(buffer), "%03lld", d.quot);
-    result += buffer;
-    return result;
+    std::snprintf(buffer, sizeof(buffer), ".%03lld", d.quot);
+    return buffer;
   }
   d = std::lldiv(ns.count(), 1000LL);
   if (d.rem == 0) {
-    std::snprintf(buffer, sizeof(buffer), "%06lld", d.quot);
-    result += buffer;
-    return result;
+    std::snprintf(buffer, sizeof(buffer), ".%06lld", d.quot);
+    return buffer;
   }
 
-  std::snprintf(buffer, sizeof(buffer), "%09lld",
+  std::snprintf(buffer, sizeof(buffer), ".%09lld",
                 static_cast<long long>(ns.count()));
-  result += buffer;
-  return result;
+  return buffer;
 }
 
-std::tm AsTm(std::chrono::system_clock::time_point tp) {
+std::tm AsUtcTm(std::chrono::system_clock::time_point tp) {
   std::time_t time = std::chrono::system_clock::to_time_t(tp);
   std::tm tm{};
   // The standard C++ function to convert time_t to a struct tm is not thread
@@ -70,9 +66,9 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
 std::string FormatRfc3339(std::chrono::system_clock::time_point tp) {
-  std::tm tm = AsTm(tp);
+  std::tm tm = AsUtcTm(tp);
   char buffer[256];
-  std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%T", &tm);
+  std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%S", &tm);
 
   std::string result(buffer);
   // Add the fractional seconds...
@@ -87,16 +83,14 @@ std::string FormatRfc3339(std::chrono::system_clock::time_point tp) {
 
 std::string FormatV4SignedUrlTimestamp(
     std::chrono::system_clock::time_point tp) {
-  std::tm tm = AsTm(tp);
+  std::tm tm = AsUtcTm(tp);
   char buffer[256];
-  std::strftime(buffer, sizeof(buffer), "%Y%m%dT%H%M%S", &tm);
-  std::string result(buffer);
-  result += "Z";
-  return result;
+  std::strftime(buffer, sizeof(buffer), "%Y%m%dT%H%M%SZ", &tm);
+  return buffer;
 }
 
 std::string FormatV4SignedUrlScope(std::chrono::system_clock::time_point tp) {
-  std::tm tm = AsTm(tp);
+  std::tm tm = AsUtcTm(tp);
   char buffer[256];
   std::strftime(buffer, sizeof(buffer), "%Y%m%d", &tm);
   return buffer;

--- a/google/cloud/storage/internal/format_time_point.h
+++ b/google/cloud/storage/internal/format_time_point.h
@@ -42,6 +42,13 @@ namespace internal {
  */
 std::string FormatRfc3339(std::chrono::system_clock::time_point tp);
 
+/// Format a time point as required by V4 signed urls.
+std::string FormatV4SignedUrlTimestamp(
+    std::chrono::system_clock::time_point tp);
+
+/// Format a time point to use in the scope of a V4 signed url.
+std::string FormatV4SignedUrlScope(std::chrono::system_clock::time_point tp);
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/format_time_point_test.cc
+++ b/google/cloud/storage/internal/format_time_point_test.cc
@@ -73,6 +73,18 @@ TEST(FormatRfc3339Test, FractionalNanos) {
   }
 }
 
+TEST(FormatV4SignedUrlTimestampTest, Base) {
+  auto timestamp = ParseRfc3339("2019-08-02T01:02:03Z");
+  std::string actual = FormatV4SignedUrlTimestamp(timestamp);
+  EXPECT_EQ("20190802T010203Z", actual);
+}
+
+TEST(FormatV4SignedUrlScopeTest, Base) {
+  auto timestamp = ParseRfc3339("2019-08-02T01:02:03Z");
+  std::string actual = FormatV4SignedUrlScope(timestamp);
+  EXPECT_EQ("20190802", actual);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
In V4 signed URLs we need to format timestamps as YYYYMMDDTHHMMSSZ, and
(in some places), ignore the sub-day components and just print YYYYMMDD.

This is part of the work for #1598.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2104)
<!-- Reviewable:end -->
