### PR TITLE
Add MutationBatcher::AsyncWaitForNoPendingRequests

### DIFF
--- a/google/cloud/bigtable/mutation_batcher.cc
+++ b/google/cloud/bigtable/mutation_batcher.cc
@@ -50,23 +50,35 @@ std::pair<future<void>, future<Status>> MutationBatcher::AsyncApply(
     pending.mut.Clear();
     pending.completion_promise.set_value(
         internal::MakeStatusFromRpcError(mutation_status));
+    // No need to consider no_more_pending_promises because this operation
+    // didn't lower the number of pending operations.
     pending.admission_promise.set_value();
     return res;
   }
+  ++num_requests_pending_;
 
   if (!CanAppendToBatch(pending)) {
     pending_mutations_.push(std::move(pending));
     return res;
   }
-  AdmissionPromise admission_promise_to_satisfy(
+  std::vector<AdmissionPromise> admission_promises_to_satisfy;
+  admission_promises_to_satisfy.emplace_back(
       std::move(pending.admission_promise));
   Admit(std::move(pending));
   FlushIfPossible(cq);
-
-  lk.unlock();
-
-  admission_promise_to_satisfy.set_value();
+  SatisfyPromises(std::move(admission_promises_to_satisfy), lk);
   return res;
+}
+
+future<void> MutationBatcher::AsyncWaitForNoPendingRequests() {
+  std::unique_lock<std::mutex> lk(mu_);
+  if (num_requests_pending_ == 0) {
+    promise<void> satisfied_promise;
+    satisfied_promise.set_value();
+    return satisfied_promise.get_future();
+  }
+  no_more_pending_promises_.emplace_back();
+  return no_more_pending_promises_.back().get_future();
 }
 
 MutationBatcher::PendingSingleRowMutation::PendingSingleRowMutation(
@@ -149,6 +161,7 @@ bool MutationBatcher::FlushIfPossible(CompletionQueue& cq) {
 void MutationBatcher::OnSuccessfulMutations(CompletionQueue& cq,
                                             MutationBatcher::Batch& batch,
                                             std::vector<int> indices) {
+  size_t const num_mutations = indices.size();
   size_t completed_size = 0;
 
   for (int idx : indices) {
@@ -161,12 +174,14 @@ void MutationBatcher::OnSuccessfulMutations(CompletionQueue& cq,
 
   std::unique_lock<std::mutex> lk(mu_);
   oustanding_size_ -= completed_size;
-  TryAdmit(cq, lk);  // unlocks the lock
+  num_requests_pending_ -= num_mutations;
+  SatisfyPromises(TryAdmit(cq), lk);  // unlocks the lock
 }
 
 void MutationBatcher::OnFailedMutations(CompletionQueue& cq,
                                         MutationBatcher::Batch& batch,
                                         std::vector<FailedMutation> failed) {
+  size_t const num_mutations = failed.size();
   size_t completed_size = 0;
 
   for (auto const& f : failed) {
@@ -184,7 +199,8 @@ void MutationBatcher::OnFailedMutations(CompletionQueue& cq,
 
   std::unique_lock<std::mutex> lk(mu_);
   oustanding_size_ -= completed_size;
-  TryAdmit(cq, lk);  // unlocks the lock
+  num_requests_pending_ -= num_mutations;
+  SatisfyPromises(TryAdmit(cq), lk);  // unlocks the lock
 }
 
 void MutationBatcher::OnBulkApplyAttemptFinished(
@@ -200,32 +216,24 @@ void MutationBatcher::OnBulkApplyAttemptFinished(
   std::unique_lock<std::mutex> lk(mu_);
   num_outstanding_batches_ -= 1;
   FlushIfPossible(cq);
-  TryAdmit(cq, lk);
+  SatisfyPromises(TryAdmit(cq), lk);  // unlocks the lock
 }
 
-void MutationBatcher::TryAdmit(CompletionQueue& cq,
-                               std::unique_lock<std::mutex>& lk) {
-  // Defer promises until we release the lock
-  std::vector<AdmissionPromise> admission_promises;
+std::vector<MutationBatcher::AdmissionPromise> MutationBatcher::TryAdmit(
+    CompletionQueue& cq) {
+  // Defer staisfying promises until we release the lock.
+  std::vector<AdmissionPromise> res;
 
   do {
     while (!pending_mutations_.empty() &&
            HasSpaceFor(pending_mutations_.front())) {
       auto& mut(pending_mutations_.front());
-      admission_promises.emplace_back(std::move(mut.admission_promise));
+      res.emplace_back(std::move(mut.admission_promise));
       Admit(std::move(mut));
       pending_mutations_.pop();
     }
   } while (FlushIfPossible(cq));
-
-  lk.unlock();
-
-  // Inform the user that we've admitted these mutations and there might be some
-  // space in the buffer finally.
-  for (auto& promise : admission_promises) {
-    grpc::Status status;
-    promise.set_value();
-  }
+  return res;
 }
 
 void MutationBatcher::Admit(PendingSingleRowMutation mut) {
@@ -235,6 +243,25 @@ void MutationBatcher::Admit(PendingSingleRowMutation mut) {
   cur_batch_->requests.emplace_back(std::move(mut.mut));
   cur_batch_->mutation_data.emplace(cur_batch_->last_idx++,
                                     Batch::MutationData(std::move(mut)));
+}
+
+void MutationBatcher::SatisfyPromises(
+    std::vector<AdmissionPromise> admission_promises,
+    std::unique_lock<std::mutex>& lk) {
+  std::vector<NoMorePendingPromise> no_more_pending_promises;
+  if (num_requests_pending_ == 0) {
+    no_more_pending_promises_.swap(no_more_pending_promises);
+  }
+  lk.unlock();
+
+  // Inform the user that we've admitted these mutations and there might be some
+  // space in the buffer finally.
+  for (auto& promise : admission_promises) {
+    promise.set_value();
+  }
+  for (auto& promise : no_more_pending_promises) {
+    promise.set_value();
+  }
 }
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -146,6 +146,7 @@ class MutationBatcher {
    */
   std::pair<future<void>, future<Status>> AsyncApply(CompletionQueue& cq,
                                                      SingleRowMutation mut);
+
   /**
    * Asynchronously wait until all submitted mutations complete.
    *

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -90,6 +90,7 @@ class MutationBatcher {
         options_(options),
         num_outstanding_batches_(),
         oustanding_size_(),
+        num_requests_pending_(),
         cur_batch_(std::make_shared<Batch>()) {}
 
   /**
@@ -137,17 +138,27 @@ class MutationBatcher {
    *   // MutationBatcher grow unbounded.
    *   admission_future.get();
    * }
-   * // wait for all mutations to complete
+   * // Wait for all mutations to complete
+   * batcher.AsyncWaitForNoPendingRequests().get();
    * cq.Shutdown();
    * cq_runner.join();
    * @endcode
    */
   std::pair<future<void>, future<Status>> AsyncApply(CompletionQueue& cq,
                                                      SingleRowMutation mut);
+  /**
+   * Asynchronously wait until all submitted mutations complete.
+   *
+   * @return a future which will be satisfied once all mutations submitted
+   *     before calling this function finish; if there are no such operations,
+   *     the returned future is already satisfied
+   */
+  future<void> AsyncWaitForNoPendingRequests();
 
  private:
   using CompletionPromise = promise<Status>;
   using AdmissionPromise = promise<void>;
+  using NoMorePendingPromise = promise<void>;
   struct Batch;
 
   /**
@@ -272,14 +283,23 @@ class MutationBatcher {
 
   /**
    * Try to move mutations waiting in `pending_mutations_` to the currently
-   * constructed batch. Unlocks `lk`.
+   * constructed batch.
+   *
+   * @return the admission promises of the newly admitted mutations.
    */
-  void TryAdmit(CompletionQueue& cq, std::unique_lock<std::mutex>& lk);
+  std::vector<MutationBatcher::AdmissionPromise> TryAdmit(CompletionQueue& cq);
 
   /**
    * Append mutation `mut` to the currently constructed batch.
    */
   void Admit(PendingSingleRowMutation mut);
+
+  /**
+   * Satisfies passed admission promises and potentially the promises of no more
+   * pending requests. Unlocks `lk`.
+   */
+  void SatisfyPromises(std::vector<AdmissionPromise>,
+                       std::unique_lock<std::mutex>& lk);
 
   std::mutex mu_;
   Table table_;
@@ -289,6 +309,8 @@ class MutationBatcher {
   size_t num_outstanding_batches_;
   /// Size of admitted but uncompleted mutations.
   size_t oustanding_size_;
+  // Number of uncompleted SingleRowMutations (including not admitted).
+  size_t num_requests_pending_;
 
   /// Currently contructed batch of mutations.
   std::shared_ptr<Batch> cur_batch_;
@@ -299,6 +321,7 @@ class MutationBatcher {
    * these (likely no more than one).
    */
   std::queue<PendingSingleRowMutation> pending_mutations_;
+  std::vector<NoMorePendingPromise> no_more_pending_promises_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS


### PR DESCRIPTION
This member function returns a future which will be satisfied once all
requests submitted to MutationBatcher will have completed. One can
obtain multiple such futures.

The intention is to relieve the user for the necessity to keep track of
submitted requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2109)
<!-- Reviewable:end -->
