### PR TITLE
Silence MSVC warnings.

### DIFF
--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -45,7 +45,7 @@ std::string EncodeBigEndian(T value) {
   std::array<std::uint8_t, sizeof(n)> a;
   for (auto& c : a) {
     shift -= 8;
-    c = n >> shift;
+    c = static_cast<std::uint8_t>(n >> shift);
   }
   return {reinterpret_cast<char const*>(a.data()), a.size()};
 }


### PR DESCRIPTION
The warning is not applicable in this case, the standard guarantees that
the result here is exactly what we want. Use a static_cast to silence
the warning.

Oh, to see the warning go to line 655 in this log:

https://source.cloud.google.com/results/invocations/20d0b65d-4c5e-4f97-a6f3-3f7839fde1f5/targets/cloud-cpp%2Fgithub%2Fwindows%2Fcontinuous/log

PS: I would like to turn on warnings-as-errors for MSVC, but we are not quite there yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2110)
<!-- Reviewable:end -->
