### PR TITLE
Properly handle subresources in V2 signed URLs.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2275,16 +2275,23 @@ class Client {
    *     requests that only affect a bucket.
    * @param options a list of optional parameters for the signed URL, this
    *     include: `ExpirationTime`, `MD5HashValue`, `ContentType`,
-   *     `AddExtensionHeaderOption`, and `AddQueryParameterOption`. The
-   *     `AddExtensionHeader()` function provides a simpler way to create
-   *     extension headers. Note that you can provides multiple values of this
-   *     option. Likewise, the following helper functions can create properly
-   *     formatted query parameters: `WithAcl()`, `WithBilling()`,
-   *     `WithCompose()`, `WithCors()`, `WithEncryption()`,
-   *     `WithEncryptionConfig()`,`WithGeneration()`, `WithGenerationMarker()`,
-   *     `WithLifecycle()`, `WithLocation()`, `WithLogging()`, `WithMarker()`,
-   *     `WithResponseContentDisposition()`, `WithResponseContentType()`,
-   *     `WithStorageClass()`, `WithTagging()`, `WithUserProject()`.
+   *     `AddExtensionHeaderOption`, `AddQueryParameterOption`, and
+   *     `AddSubResourceOption`. Note that only the last `AddSubResourceOption`
+   *     option has any effect.
+   *
+   * @par Helper Functions
+   *
+   * The following functions create a `AddSubResourceOption` with less
+   * opportunities for typos in the sub-resource name: `WithAcl()`,
+   * `WithBilling()`, `WithCompose()`, `WithCors()`, `WithEncryption()`,
+   * `WithEncryptionConfig()`, `WithLifecycle()`, `WithLocation()`,
+   * `WithLogging()`, `WithStorageClass()`, and `WithTagging()`.
+   *
+   * Likewise, the following helper functions can create properly formatted
+   * `AddExtensionHeaderOption` objects: `WithGeneration()`,
+   * `WithGenerationMarker()`, `WithMarker()`,
+   * `WithResponseContentDisposition()`, `WithResponseContentType()`, and
+   * `WithUserProject()`.
    *
    * @return the signed URL.
    *

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -49,6 +49,10 @@ std::string SignUrlRequest::StringToSign() const {
     os << '/' << curl.MakeEscapedString(object_name()).get();
   }
   char const* sep = "?";
+  if (!sub_resource().empty()) {
+    os << sep << curl.MakeEscapedString(sub_resource()).get();
+    sep = "&";
+  }
   for (auto const& key_value : query_parameters_) {
     os << sep << key_value;
     sep = "&";

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -39,6 +39,7 @@ class SignUrlRequest {
   std::string const& verb() const { return verb_; }
   std::string const& bucket_name() const { return bucket_name_; }
   std::string const& object_name() const { return object_name_; }
+  std::string const& sub_resource() const { return sub_resource_; }
   std::chrono::seconds expiration_time_as_seconds() const {
     return std::chrono::duration_cast<std::chrono::seconds>(
         expiration_time_.time_since_epoch());
@@ -96,9 +97,17 @@ class SignUrlRequest {
     query_parameters_.push_back(o.value());
   }
 
+  void set_option(SubResourceOption const& o) {
+    if (!o.has_value()) {
+      return;
+    }
+    sub_resource_ = o.value();
+  }
+
   std::string verb_;
   std::string bucket_name_;
   std::string object_name_;
+  std::string sub_resource_;
   std::string md5_hash_value_;
   std::string content_type_;
   std::chrono::system_clock::time_point expiration_time_;

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -74,30 +74,6 @@ struct AddQueryParameterOption
   static std::string UrlEscape(std::string const& value);
 };
 
-inline AddQueryParameterOption WithAcl() {
-  return AddQueryParameterOption("acl");
-}
-
-inline AddQueryParameterOption WithBilling() {
-  return AddQueryParameterOption("billing");
-}
-
-inline AddQueryParameterOption WithCompose() {
-  return AddQueryParameterOption("compose");
-}
-
-inline AddQueryParameterOption WithCors() {
-  return AddQueryParameterOption("cors");
-}
-
-inline AddQueryParameterOption WithEncryption() {
-  return AddQueryParameterOption("encryption");
-}
-
-inline AddQueryParameterOption WithEncryptionConfig() {
-  return AddQueryParameterOption("encryptionConfig");
-}
-
 inline AddQueryParameterOption WithGeneration(std::uint64_t generation) {
   return AddQueryParameterOption(
       "generation=" +
@@ -110,16 +86,10 @@ inline AddQueryParameterOption WithGenerationMarker(std::uint64_t generation) {
       AddQueryParameterOption::UrlEscape(std::to_string(generation)));
 }
 
-inline AddQueryParameterOption WithLifecycle() {
-  return AddQueryParameterOption("lifecycle");
-}
-
-inline AddQueryParameterOption WithLocation() {
-  return AddQueryParameterOption("location");
-}
-
-inline AddQueryParameterOption WithLogging() {
-  return AddQueryParameterOption("logging");
+inline AddQueryParameterOption WithUserProject(
+    std::string const& user_project) {
+  return AddQueryParameterOption(
+      "userProject=" + AddQueryParameterOption::UrlEscape(user_project));
 }
 
 inline AddQueryParameterOption WithMarker(std::string const& marker) {
@@ -140,19 +110,46 @@ inline AddQueryParameterOption WithResponseContentType(
                                  AddQueryParameterOption::UrlEscape(type));
 }
 
-inline AddQueryParameterOption WithStorageClass() {
-  return AddQueryParameterOption("storageClass");
+/**
+ * Specify a sub-resource in a signed URL.
+ */
+struct SubResourceOption
+    : public internal::ComplexOption<SubResourceOption, std::string> {
+  using ComplexOption<SubResourceOption, std::string>::ComplexOption;
+  static char const* name() { return "query-parameter"; }
+};
+
+inline SubResourceOption WithAcl() { return SubResourceOption("acl"); }
+
+inline SubResourceOption WithBilling() { return SubResourceOption("billing"); }
+
+inline SubResourceOption WithCompose() { return SubResourceOption("compose"); }
+
+inline SubResourceOption WithCors() { return SubResourceOption("cors"); }
+
+inline SubResourceOption WithEncryption() {
+  return SubResourceOption("encryption");
 }
 
-inline AddQueryParameterOption WithTagging() {
-  return AddQueryParameterOption("tagging");
+inline SubResourceOption WithEncryptionConfig() {
+  return SubResourceOption("encryptionConfig");
 }
 
-inline AddQueryParameterOption WithUserProject(
-    std::string const& user_project) {
-  return AddQueryParameterOption(
-      "userProject=" + AddQueryParameterOption::UrlEscape(user_project));
+inline SubResourceOption WithLifecycle() {
+  return SubResourceOption("lifecycle");
 }
+
+inline SubResourceOption WithLocation() {
+  return SubResourceOption("location");
+}
+
+inline SubResourceOption WithLogging() { return SubResourceOption("logging"); }
+
+inline SubResourceOption WithStorageClass() {
+  return SubResourceOption("storageClass");
+}
+
+inline SubResourceOption WithTagging() { return SubResourceOption("tagging"); }
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
We should allow at most one subresource, and we should always put the
subresource first in the URL. This will be handy for V4 signed URLs too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2111)
<!-- Reviewable:end -->
