### PR TITLE
 Enable all cores in Kokoro.

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -85,21 +85,17 @@ source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
 echo "================================================================"
-printenv
-echo "================================================================"
-
-echo "================================================================"
-echo "Updating submodules."
+echo "Updating submodules $(date)."
 cd "${PROJECT_ROOT}"
 git submodule update --init
 echo "================================================================"
 
 echo "================================================================"
 export NCPU=$(nproc)
-echo "Building with ${NCPU} cores."
+echo "Building with ${NCPU} cores $(date)."
 
 echo "================================================================"
-echo "Creating Docker image with all the development tools."
+echo "Creating Docker image with all the development tools $(date)."
 # We do not want to print the log unless there is an error, so disable the -e
 # flag. Later, we will want to print out the emulator(s) logs *only* if there
 # is an error, so disabling from this point on is the right choice.
@@ -113,10 +109,11 @@ fi
 echo "================================================================"
 
 echo "================================================================"
-echo "Running the full build."
+echo "Running the full build $(date)."
 export NEEDS_CCACHE=no
 "${PROJECT_ROOT}/ci/travis/build-linux.sh"
 exit_status=$?
+echo "Build finished with ${exit_status} exit status $(date)."
 echo "================================================================"
 
 echo "================================================================"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -31,13 +31,13 @@ elif [[ "${BUILD_NAME}" = "asan" ]]; then
   export CXX=clang++
   export CMAKE_FLAGS="-DSANITIZE_ADDRESS=yes"
 elif [[ "${BUILD_NAME}" = "centos-7" ]]; then
- # Compile under centos:7. This distro uses gcc-4.8.
- export DISTRO=centos
- export DISTRO_VERSION=7
+  # Compile under centos:7. This distro uses gcc-4.8.
+  export DISTRO=centos
+  export DISTRO_VERSION=7
 elif [[ "${BUILD_NAME}" = "noex" ]]; then
- # Compile with -fno-exceptions
- export DISTRO_VERSION=16.04
- export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no"
+  # Compile with -fno-exceptions
+  export DISTRO_VERSION=16.04
+  export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   # Compile with the UndefinedBehaviorSanitizer enabled.
   export BUILD_TYPE=Debug
@@ -93,6 +93,10 @@ echo "Updating submodules."
 cd "${PROJECT_ROOT}"
 git submodule update --init
 echo "================================================================"
+
+echo "================================================================"
+export NCPU=$(nproc)
+echo "Building with ${NCPU} cores."
 
 echo "================================================================"
 echo "Creating Docker image with all the development tools."

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -43,6 +43,10 @@ if [[ -z "${ccache_command}" ]]; then
   exit 1
 fi
 
+echo
+echo "${COLOR_YELLOW}Starting docker build $(date) with ${NCPU} cores${COLOR_RESET}"
+echo
+
 bootstrap_ccache="no"
 if [[ "${NEEDS_CCACHE:-}" = "no" ]]; then
   bootstrap_ccache="no"
@@ -152,6 +156,9 @@ if [ "${BUILD_TESTING:-}" != "no" ]; then
     echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
     (cd "${BUILD_OUTPUT}" && "${PROJECT_ROOT}/${subdir}/ci/run_integration_tests.sh")
   done
+  echo
+  echo "${COLOR_YELLOW}Completed unit and integration tests $(date)${COLOR_RESET}"
+  echo
 fi
 
 # Test the install rule and that the installation works.


### PR DESCRIPTION
I forgot that the build scripts are tuned for Travis, which only has 2
cores, while Kokoro VMs have 4.  Also fixed some indentation nits.

Unfortunately the change does not seem to improve build times that
much, but it is useful when running the builds locally, so I think we
should merge it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2115)
<!-- Reviewable:end -->
