### PR TITLE
WIP: migrate to gh-pages provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ matrix:
 
 script:
   - ci/travis/build-linux.sh
+  - ci/travis/upload-docs.sh
 
 # We do not need to recursively extract the submodules. This saves some time in
 # the builds, the default install step then performs a lighter weight module
@@ -97,7 +98,6 @@ install:
 
 after_success:
   - ci/travis/upload-codecov.sh
-  - ci/travis/upload-docs.sh
   - ci/travis/dump-logs.sh
 
 after_failure:
@@ -115,6 +115,20 @@ before_cache:
   # Do not save the Bazel installation, reinstall each time, it fails to install
   # if the installation is in the cache.
   - rm -fr ${HOME}/.cache/bazel/_bazel_${USER}/install
+
+# Note: deployment is always skipped for pull requests.
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GH_TOKEN
+  keep-history: true
+  email: "google-cloud-cpp-bot@users.noreply.github.com"
+  name: "Google Cloud C++ Project Robot"
+  local-dir: docs-output
+  on:
+      all_branches: true
+      # Only deploy for master and release branches.
+      condition: "${GENERATE_DOCS:-}" == "yes" || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ deploy:
   on:
       all_branches: true
       # Only deploy for master and release branches.
-      condition: $GENERATE_DOCS == "yes" || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
+      condition: $TRAVIS_COMMIT_MESSAGE =~ \[generate-docs\] || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ deploy:
   on:
       all_branches: true
       # Only deploy for master and release branches.
-      condition: "${GENERATE_DOCS:-}" == "yes" || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
+      condition: $GENERATE_DOCS == "yes" || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ deploy:
   on:
       all_branches: true
       # Only deploy for master and release branches.
-      condition: $TRAVIS_COMMIT_MESSAGE =~ \[generate-docs\] || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
+      condition: $TRAVIS_COMMIT_MESSAGE = "[generate-docs]" || $TRAVIS_BRANCH =~ ^master|v[0-9]\.*$
 
 notifications:
   email: false

--- a/ci/travis/upload-docs.sh
+++ b/ci/travis/upload-docs.sh
@@ -21,6 +21,16 @@ if [[ -z "${PROJECT_ROOT+x}" ]]; then
 fi
 source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
 
+if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+  echo "Skipping document generation as it is disabled for pull requests."
+  exit 0
+fi
+
+if [ "${GENERATE_DOCS:-}" != "yes" ]; then
+  echo "Skipping document generation as it is disabled for this build."
+  exit 0
+fi
+
 subdir=""
 case "${TRAVIS_BRANCH:-}" in
     master)
@@ -28,6 +38,10 @@ case "${TRAVIS_BRANCH:-}" in
       ;;
     v[0-9]\.*)
       subdir=$(echo "${TRAVIS_BRANCH:-}" | sed -r -e 's/^v//' -e 's/^([0-9]+).([0-9]+).x/\1.\2.0/')
+      ;;
+    *)
+      echo "Skipping document generation as it is only used in master and release branches."
+      exit 0
       ;;
 esac
 
@@ -58,7 +72,7 @@ if [ "${subdir}" != "latest" ]; then
   cp -r latest/img "${output}"
   cp -r latest/js "${output}"
 fi
-cp -r doc/landing/index.html "${output}"
+cp -r ../doc/landing/index.html "${output}"
 
 if git diff --quiet HEAD; then
   echo "Skipping documentation upload as there are no differences to upload."


### PR DESCRIPTION
Ref: #257 

This PR is a test to show what it would look like if we were theoretically to switch over to the gh-pages provider. The code isn't tested and probably doesn't work as-is. Some advantages:

- Not reinventing the wheel; also, having well-defined deployment semantics that are maintained upstream by Travis
- Easier to maintain/read by people unfamiliar with the codebase
- Easier to write documentation for

The general idea is that we build the documentation at the same stage as the program, then copy all artifacts to a directory, which is where Travis will deploy to `gh-pages` from. I also think that instead of downloading the assets from `gh-pages` it should either be kept in source tree or obtained elsewhere, but I'm fine with not changing it if that's too much of a hassle.

P.S.: Changing the commit message is currently not possible. There is a [PR](https://github.com/travis-ci/dpl/pull/824) open for that feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2116)
<!-- Reviewable:end -->
