### PR TITLE
Makes optional's operator bool explicit.

### DIFF
--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -194,7 +194,7 @@ class optional {
                        : static_cast<T>(std::forward<U>(default_value));
   }
 
-  operator bool() const { return has_value_; }
+  explicit operator bool() const { return has_value_; }
   bool has_value() const { return has_value_; }
 
   void reset() {


### PR DESCRIPTION
Boolean conversion operators should (I think always) be marked as `explicit`. This prevents them from accidentally be used in the wrong context and producing an unintended conversion, while still allowing them to be used in all "boolean contexts" with ease. For example:

```cc
struct A {
  operator bool() const;
};
void F(A a) {
  int i = a;  // Oops: Allowed because operator bool is not explicit.
}
```
Whereas, an explicit operator bool allows the following:

```cc
struct B {
  explicit operator bool() const;
};
int F(B b) {
  int i = b;   // error: no viable conversion
  bool c = b;  // error: no implicit conversion to bool
  if (b) {     // OK: This is a "boolean context", so the conversion is allowed
  }
  return b ? 1 : 2;  // OK: again, a boolean context
}
```
The standard lists all the "boolean contexts", which I won't repeat here, but I think they're all obvious and what one would want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2119)
<!-- Reviewable:end -->
