### PR TITLE
Refactor parts of SignUrlRequest to base class.

### DIFF
--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -36,7 +36,7 @@ void SignUrlRequestCommon::SetOption(AddExtensionHeaderOption const& o) {
   if (!res.second) {
     // The element already exists, we need to append:
     res.first->second.push_back(',');
-    res.first->second.append(o.value().second);
+    res.first->second.append(kv.second);
   }
 }
 

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -52,7 +52,7 @@ std::string SignUrlRequest::StringToSign() const {
      << content_type_ << "\n"
      << expiration_time_as_seconds().count() << "\n";
 
-  for (auto const& kv : extension_headers_) {
+  for (auto const& kv : common_request_.extension_headers()) {
     os << kv.first << ":" << kv.second << "\n";
   }
 
@@ -66,7 +66,7 @@ std::string SignUrlRequest::StringToSign() const {
     os << sep << curl.MakeEscapedString(sub_resource()).get();
     sep = "&";
   }
-  for (auto const& kv : query_parameters_) {
+  for (auto const& kv : common_request_.query_parameters()) {
     os << sep << curl.MakeEscapedString(kv.first).get() << "="
        << curl.MakeEscapedString(kv.second).get();
     sep = "&";

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -136,9 +136,7 @@ class SignUrlRequest {
     expiration_time_ = o.value();
   }
 
-  void SetOption(SubResourceOption const& o) {
-    common_request_.SetOption(o);
-  }
+  void SetOption(SubResourceOption const& o) { common_request_.SetOption(o); }
 
   void SetOption(AddExtensionHeaderOption const& o) {
     common_request_.SetOption(o);

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -27,25 +27,69 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-/**
- * Requests the Google Cloud Storage service account for a project.
- */
-class SignUrlRequest {
+/// The common data for SignUrlRequests.
+class SignUrlRequestCommon {
  public:
-  SignUrlRequest() = default;
-  explicit SignUrlRequest(std::string verb, std::string bucket_name,
-                          std::string object_name);
+  SignUrlRequestCommon() = default;
+  SignUrlRequestCommon(std::string verb, std::string bucket_name,
+                       std::string object_name)
+      : verb_(std::move(verb)),
+        bucket_name_(std::move(bucket_name)),
+        object_name_(std::move(object_name)) {}
 
   std::string const& verb() const { return verb_; }
   std::string const& bucket_name() const { return bucket_name_; }
   std::string const& object_name() const { return object_name_; }
   std::string const& sub_resource() const { return sub_resource_; }
+
+ protected:
+  void SetOption(SubResourceOption const& o) {
+    if (!o.has_value()) {
+      return;
+    }
+    sub_resource_ = o.value();
+  }
+
+  void SetOption(AddExtensionHeaderOption const& o);
+
+  void SetOption(AddQueryParameterOption const& o) {
+    if (!o.has_value()) {
+      return;
+    }
+    query_parameters_.insert(o.value());
+  }
+
+  std::string verb_;
+  std::string bucket_name_;
+  std::string object_name_;
+  std::string sub_resource_;
+  std::map<std::string, std::string> extension_headers_;
+  std::multimap<std::string, std::string> query_parameters_;
+};
+
+/**
+ * Requests the Google Cloud Storage service account for a project.
+ */
+class SignUrlRequest : private SignUrlRequestCommon {
+ public:
+  SignUrlRequest() = default;
+  explicit SignUrlRequest(std::string verb, std::string bucket_name,
+                          std::string object_name)
+      : SignUrlRequestCommon(std::move(verb), std::move(bucket_name),
+                             std::move(object_name)),
+        expiration_time_(DefaultExpirationTime()) {}
+
+  using SignUrlRequestCommon::bucket_name;
+  using SignUrlRequestCommon::object_name;
+  using SignUrlRequestCommon::sub_resource;
+  using SignUrlRequestCommon::verb;
+
   std::chrono::seconds expiration_time_as_seconds() const {
     return std::chrono::duration_cast<std::chrono::seconds>(
         expiration_time_.time_since_epoch());
   }
 
-  /// Creates the blob to be signed.
+  /// Creates the string to be signed.
   std::string StringToSign() const;
 
   template <typename H, typename... T>
@@ -57,6 +101,8 @@ class SignUrlRequest {
   SignUrlRequest& set_multiple_options() { return *this; }
 
  private:
+  static std::chrono::system_clock::time_point DefaultExpirationTime();
+
   void SetOption(MD5HashValue const& o) {
     if (!o.has_value()) {
       return;
@@ -78,31 +124,11 @@ class SignUrlRequest {
     expiration_time_ = o.value();
   }
 
-  void SetOption(AddExtensionHeaderOption const& o);
+  using SignUrlRequestCommon::SetOption;
 
-  void SetOption(AddQueryParameterOption const& o) {
-    if (!o.has_value()) {
-      return;
-    }
-    query_parameters_.insert(o.value());
-  }
-
-  void SetOption(SubResourceOption const& o) {
-    if (!o.has_value()) {
-      return;
-    }
-    sub_resource_ = o.value();
-  }
-
-  std::string verb_;
-  std::string bucket_name_;
-  std::string object_name_;
-  std::string sub_resource_;
   std::string md5_hash_value_;
   std::string content_type_;
   std::chrono::system_clock::time_point expiration_time_;
-  std::map<std::string, std::string> extension_headers_;
-  std::multimap<std::string, std::string> query_parameters_;
 };
 
 std::ostream& operator<<(std::ostream& os, SignUrlRequest const& r);


### PR DESCRIPTION
This will be used to create a V4SignUrlRequest, which shares many, but
not all, the properties of a V2 signed url. I think renaming
SignUrlRequest to V2SignUrlRequest should happen in a future PR too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2121)
<!-- Reviewable:end -->
