### PR TITLE
A build for google-cloud-cpp as dependency.

### DIFF
--- a/ci/kokoro/bazel-dependency/linux/build.sh
+++ b/ci/kokoro/bazel-dependency/linux/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+echo "Building google-cloud-cpp as a dependency of another project $(date)."
+cd "$(dirname $0)/../../../.."
+readonly PROJECT_ROOT="${PWD}"
+
+echo "================================================================"
+echo "Update or Install Bazel $(date)."
+echo "================================================================"
+# We ping the version of Bazel because we do not want all our builds to break
+# when Kokoro updates Bazel. We rather upgrade our tooling when *we* decide it
+# is a good time to do so.
+"${PROJECT_ROOT}/ci/install-bazel.sh" linux
+
+export PATH=$HOME/bin:$PATH
+echo "which bazel: $(which bazel)"
+
+echo "================================================================"
+echo "Compile the project in ci/test-install $(date)."
+echo "================================================================"
+(cd ci/test-install ; bazel build \
+    --test_output=errors \
+    --verbose_failures=true \
+    --keep_going \
+    -- //...:all)

--- a/ci/kokoro/bazel-dependency/linux/continuous.cfg
+++ b/ci/kokoro/bazel-dependency/linux/continuous.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/bazel-dependency/linux/build.sh"
+timeout_mins: 120

--- a/ci/kokoro/bazel-dependency/linux/presubmit.cfg
+++ b/ci/kokoro/bazel-dependency/linux/presubmit.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/bazel-dependency/linux/build.sh"
+timeout_mins: 120


### PR DESCRIPTION
Some of our customers will use google-cloud-cpp as a Bazel dependency,
there is Starlark code that loads `google-cloud-cpp` and its
dependencies, and this code should be tested.

We currently have a build for this on Travis. This creates the
configuration files for Kokoro, the plan is to remove the Travis build
once the Kokoro build is working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2123)
<!-- Reviewable:end -->
