### PR TITLE
Fix name of openSUSE Tumbleweed image.

### DIFF
--- a/ci/test-readme/Dockerfile.opensuse
+++ b/ci/test-readme/Dockerfile.opensuse
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=tumbleweed
-FROM opensuse:${DISTRO_VERSION}
+ARG DISTRO_VERSION=latest
+FROM opensuse/tumbleweed:${DISTRO_VERSION}
 
 ## [START INSTALL.md]
 
@@ -44,7 +44,7 @@ RUN (cd build-output && ctest --output-on-failure)
 
 # ```bash
 RUN zypper refresh && \
-    zypper install -y grpc-devel libcurl-devel pkg-config tar wget
+    zypper install -y grpc-devel gzip libcurl-devel pkg-config tar wget
 # ```
 
 # #### crc32c


### PR DESCRIPTION
The images for openSUSE tumbleweed have migrated:

https://hub.docker.com/_/opensuse?tab=description

This should fix the latest Kokoro build breakage. Tested locally on my workstation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2125)
<!-- Reviewable:end -->
