### PR TITLE
Fix Kokoro build for integration tests.

### DIFF
--- a/ci/kokoro/bazel-dependency/linux/build.sh
+++ b/ci/kokoro/bazel-dependency/linux/build.sh
@@ -28,13 +28,13 @@ echo "================================================================"
 # is a good time to do so.
 "${PROJECT_ROOT}/ci/install-bazel.sh" linux
 
-export PATH=$HOME/bin:$PATH
-echo "which bazel: $(which bazel)"
+readonly BAZEL_BIN="$HOME/bin/bazel"
+echo "Using Bazel in ${BAZEL_BIN}"
 
 echo "================================================================"
 echo "Compile the project in ci/test-install $(date)."
 echo "================================================================"
-(cd ci/test-install ; bazel build \
+(cd ci/test-install ; "${BAZEL_BIN}" build \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -35,8 +35,8 @@ function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
 
 "${PROJECT_ROOT}/ci/install-bazel.sh" macos
 
-export PATH=$HOME/bin:$PATH
-echo "which bazel: $(which bazel)"
+readonly BAZEL_BIN="$HOME/bin/bazel"
+echo "Using Bazel in ${BAZEL_BIN}"
 
 # We need this environment variable because on macOS gRPC crashes if it cannot
 # find the credentials, even if you do not use them. Some of the unit tests do
@@ -49,7 +49,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
 
 # The -DGRPC_BAZEL_BUILD is needed because gRPC does not compile on macOS unless
 # it is set.
-bazel test \
+"${BAZEL_BIN}" test \
     --copt=-DGRPC_BAZEL_BUILD \
     --action_env=GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
     --test_output=errors \
@@ -60,7 +60,7 @@ bazel test \
 echo
 echo "================================================================"
 echo "================================================================"
-bazel build \
+"${BAZEL_BIN}" build \
     --copt=-DGRPC_BAZEL_BUILD \
     --action_env=GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS}" \
     --test_output=errors \

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -32,8 +32,8 @@ echo "Update or Install Bazel $(date)."
 echo "================================================================"
 "${PROJECT_ROOT}/ci/install-bazel.sh" linux
 
-export PATH=$HOME/bin:$PATH
-echo "which bazel: $(which bazel)"
+readonly BAZEL_BIN="$HOME/bin/bazel"
+echo "Using Bazel in ${BAZEL_BIN}"
 
 cat >>kokoro-bazelrc <<_EOF_
 # Set flags for uploading to BES without Remote Build Execution.
@@ -66,7 +66,7 @@ echo ${INVOCATION_ID} >> "${KOKORO_ARTIFACTS_DIR}/bazel_invocation_ids"
 echo "================================================================"
 echo "Compiling and running unit tests $(date)"
 echo "================================================================"
-bazel test \
+"${BAZEL_BIN}" test \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \
@@ -84,7 +84,7 @@ echo "Compiling all the code, including integration tests $(date)"
 echo "================================================================"
 # Then build everything else (integration tests, examples, etc). So we can run
 # them next.
-bazel build \
+"${BAZEL_BIN}" build \
     --test_output=errors \
     --verbose_failures=true \
     --keep_going \


### PR DESCRIPTION
Pin the version of Bazel to the version that is known to work with our
dependencies. The newer version does not work with gRPC + protobuf until
a future release of gRPC.

I think letting Kokoro magically upgrade Bazel behind the scenes for us
was not a good idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2126)
<!-- Reviewable:end -->
