### PR TITLE
Use new location for openSUSE:Leap Docker images.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,7 +128,7 @@ Platform proto files.
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install -y grpc-devel libcurl-devel pkg-config tar wget
+sudo zypper install -y grpc-devel gzip libcurl-devel pkg-config tar wget
 ```
 
 #### crc32c
@@ -176,8 +176,8 @@ Install the minimal development tools:
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel \
-        make tar wget
+sudo zypper install -y cmake gcc gcc-c++ git gzip libcurl-devel \
+        libopenssl-devel make tar wget
 ```
 
 #### crc32c

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel make
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel \
-        make tar wget
+sudo zypper install -y cmake gcc gcc-c++ git gzip libcurl-devel \
+        libopenssl-devel make tar wget
 ```
 
 ### Ubuntu (18.04 - Bionic Beaver)

--- a/ci/test-readme/Dockerfile.opensuse-leap
+++ b/ci/test-readme/Dockerfile.opensuse-leap
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=leap
-FROM opensuse:${DISTRO_VERSION}
+ARG DISTRO_VERSION=latest
+FROM opensuse/leap:${DISTRO_VERSION}
 
 ## [START INSTALL.md]
 
@@ -23,8 +23,8 @@ FROM opensuse:${DISTRO_VERSION}
 
 # ```bash
 RUN zypper refresh && \
-    zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel \
-        make tar wget
+    zypper install -y cmake gcc gcc-c++ git gzip libcurl-devel \
+        libopenssl-devel make tar wget
 # ```
 
 ## [END README.md]


### PR DESCRIPTION
Like openSUSE:Tumbleweed, Leap will be moving from here:

https://hub.docker.com/_/opensuse?tab=description

to here:

https://hub.docker.com/r/opensuse/leap

Change the source for the images before they remove the old ones. Also
some tweaks because apparently gzip is no longer implicitly installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2127)
<!-- Reviewable:end -->
