### PR TITLE
Support different RSA-SHA256 signature formats.

### DIFF
--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -136,7 +136,7 @@ std::string OpenSslUtils::Base64Encode(std::string const& str) {
 std::string OpenSslUtils::Base64Encode(std::vector<std::uint8_t> const& bytes) {
 #ifdef OPENSSL_IS_BORINGSSL
   std::size_t encoded_size;
-  EVP_EncodedLength(&encoded_size, str.size());
+  EVP_EncodedLength(&encoded_size, bytes.size());
   std::vector<std::uint8_t> result(encoded_size);
   std::size_t out_size =
       EVP_EncodeBlock(result.data(), bytes.data(), bytes.size());

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/storage/internal/sha256_hash.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
@@ -127,8 +128,15 @@ class ServiceAccountCredentials : public Credentials {
                       text, info_.private_key, JwtSigningAlgorithms::RS256)));
   }
 
+  std::pair<Status, std::string> SignStringHex(std::string const& text) const {
+    using ::google::cloud::storage::internal::OpenSslUtils;
+    return std::make_pair(
+        Status(), internal::HexEncode(OpenSslUtils::SignStringWithPem(
+                      text, info_.private_key, JwtSigningAlgorithms::RS256)));
+  }
+
   /// Return the client id of these credentials.
-  std::string client_id() const { return info_.client_email; }
+  std::string const& client_id() const { return info_.client_email; }
 
  private:
   /**


### PR DESCRIPTION
For V4 signed URLs we need to encode the signature using hex format,
while for V2 signed URLs we need to encode them using Base64. In this PR
we decouple the function to create the signature from the functions to
encode them.

I changed the return value of SignStringWithPem to signal that it is a
byte array. In a separate PR I am planning to cleanup all these
functions because they are handling byte arrays and strings kind of
loosely. That is a cleanup independent of the V4 signed URLs though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2129)
<!-- Reviewable:end -->
