### PR TITLE
 Update grpc and io_opencensus_cpp 

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -56,10 +56,10 @@ def google_cloud_cpp_deps():
             name = "com_github_grpc_grpc",
             strip_prefix = "grpc-1.19.0",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.19.0.tar.gz",
+                "https://github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz",
             ],
-            sha256 = "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73",
+            sha256 = "9a0ee9f59df481e2516deb59e3ccd1f973b023dab0e1be41cd30db56aea4b6cc",
         )
 
     # Load OpenCensus.

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -66,12 +66,12 @@ def google_cloud_cpp_deps():
     if "io_opencensus_cpp" not in native.existing_rules():
         http_archive(
             name = "io_opencensus_cpp",
-            strip_prefix = "opencensus-cpp-fdf0f308b1631bb4a942e32ba5d22536a6170274",
+            strip_prefix = "opencensus-cpp-03dff0352522983ffdee48cedbf87cbe37f1bb7f",
             urls = [
                 "https://github.com/census-instrumentation/opencensus-cpp/archive" +
-                "/fdf0f308b1631bb4a942e32ba5d22536a6170274.tar.gz",
+                "/03dff0352522983ffdee48cedbf87cbe37f1bb7f.tar.gz",
             ],
-            sha256 = "c3a0a760759420645699140f0f7124605177a12ce0b8a2379946973771473c5d",
+            sha256 = "8cbff4b73121d255c92aa91582af63f86b3c3e5da53fe5a0a55097b6abeb6157",
         )
 
     # We need libcurl for the Google Cloud Storage client.

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -54,24 +54,24 @@ def google_cloud_cpp_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.17.2",
+            strip_prefix = "grpc-1.19.0",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.17.2.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.17.2.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.19.0.tar.gz",
             ],
-            sha256 = "34ed95b727e7c6fcbf85e5eb422e962788e21707b712fdb4caf931553c2c6dbc",
+            sha256 = "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73",
         )
 
     # Load OpenCensus.
     if "io_opencensus_cpp" not in native.existing_rules():
         http_archive(
             name = "io_opencensus_cpp",
-            strip_prefix = "opencensus-cpp-893e0835a45d749221f049d0d167e157b67b6d9c",
+            strip_prefix = "opencensus-cpp-fdf0f308b1631bb4a942e32ba5d22536a6170274",
             urls = [
                 "https://github.com/census-instrumentation/opencensus-cpp/archive" +
-                "/893e0835a45d749221f049d0d167e157b67b6d9c.tar.gz",
+                "/fdf0f308b1631bb4a942e32ba5d22536a6170274.tar.gz",
             ],
-            sha256 = "8e2bddd3ea6d747a8c4255c73dcea1b9fcdf1560f3bb9ff96bcb20d4d207235e",
+            sha256 = "c3a0a760759420645699140f0f7124605177a12ce0b8a2379946973771473c5d",
         )
 
     # We need libcurl for the Google Cloud Storage client.

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -54,7 +54,7 @@ def google_cloud_cpp_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.19.0",
+            strip_prefix = "grpc-046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8",
             urls = [
                 "https://github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz",
                 "https://mirror.bazel.build/github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz",

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -26,7 +26,7 @@ elif [[ "$1" = "macos" ]] || [[ "$1" = "osx" ]]; then
   readonly PLATFORM="darwin-x86_64"
 fi
 
-readonly BAZEL_VERSION=0.22.0
+readonly BAZEL_VERSION=0.20.0
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -26,7 +26,7 @@ elif [[ "$1" = "macos" ]] || [[ "$1" = "osx" ]]; then
   readonly PLATFORM="darwin-x86_64"
 fi
 
-readonly BAZEL_VERSION=0.20.0
+readonly BAZEL_VERSION=0.22.0
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET gprc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz")
+        "https://github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73")
+        "9a0ee9f59df481e2516deb59e3ccd1f973b023dab0e1be41cd30db56aea4b6cc")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -22,8 +22,10 @@ include(external/protobuf)
 if (NOT TARGET gprc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
-    set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz")
+    set(
+        GOOGLE_CLOUD_CPP_GRPC_URL
+        "https://github.com/grpc/grpc/archive/046e3e4ab5cdb867bda7a5c40fd9b0ac84ad0ff8.tar.gz"
+        )
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
         "9a0ee9f59df481e2516deb59e3ccd1f973b023dab0e1be41cd30db56aea4b6cc")
 

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET gprc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.17.2.tar.gz")
+        "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "34ed95b727e7c6fcbf85e5eb422e962788e21707b712fdb4caf931553c2c6dbc")
+        "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
See https://github.com/grpc/grpc/issues/18080

Pinging @devjgm 

The problem as mentioned in the above issue is that abseil moved the location of a file. As a result, the version of io_opencensus_cpp we are using breaks. We need to update it too.

This PR doesn't update protobuf per https://github.com/googleapis/google-cloud-cpp/issues/2090 yet, because I'm not entirely sure if we need to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2131)
<!-- Reviewable:end -->
