### PR TITLE
Implement make_ready_future().

### DIFF
--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -198,6 +198,16 @@ class promise final : private internal::promise_base<T> {
   using internal::promise_base<T>::set_exception;
 };
 
+/// Create a future<void> that is immediately ready.
+template <typename T>
+inline future<typename internal::make_ready_return<T>::type> make_ready_future(
+    T&& t) {
+  using V = typename internal::make_ready_return<T>::type;
+  promise<V> p;
+  p.set_value(std::forward<T>(t));
+  return p.get_future();
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -203,6 +203,8 @@ template <typename T>
 inline future<typename internal::make_ready_return<T>::type> make_ready_future(
     T&& t) {
   using V = typename internal::make_ready_return<T>::type;
+  // TODO(#1410) - Implement specializations of future<R&> and promise<R&>.
+  static_assert(!std::is_reference<V>::value, "future<R&> is not implemented");
   promise<V> p;
   p.set_value(std::forward<T>(t));
   return p.get_future();

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -550,7 +550,7 @@ TEST(FutureTestInt, conform_2_3_11_c) {
 }
 
 /// @test Verify conformance with section 2.10 of the Concurrency TS.
-TEST(FutureTestInt, conform_2_10_4_2_a) {
+TEST(FutureTestString, conform_2_10_4_2_a) {
   // When T is a simple value type we get back T.
   future<std::string> f = make_ready_future(std::string("42"));
   EXPECT_TRUE(f.valid());
@@ -559,7 +559,7 @@ TEST(FutureTestInt, conform_2_10_4_2_a) {
 }
 
 /// @test Verify conformance with section 2.10 of the Concurrency TS.
-TEST(FutureTestInt, conform_2_10_4_2_b) {
+TEST(FutureTestString, conform_2_10_4_2_b) {
   // When T is a reference we get std::decay<T>::type.
   std::string value("42");
   std::string& sref = value;
@@ -567,6 +567,23 @@ TEST(FutureTestInt, conform_2_10_4_2_b) {
   EXPECT_TRUE(f.valid());
   EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
   EXPECT_EQ("42", f.get());
+}
+
+//// @test Verify conformance with section 2.10 of the Concurrency TS.
+TEST(FutureTestString, conform_2_10_4_2_c) {
+#if 1
+  using V =
+      internal::make_ready_return<std::reference_wrapper<std::string>>::type;
+  static_assert(std::is_same<V, std::string&>::value, "Expected std::string&");
+#else
+  // TODO(#1410) - Implement future<R&> specialization.
+  // When T is a reference wrapper get R&.
+  std::string value("42");
+  future<std::string&> f = make_ready_future(std::ref(value));
+  EXPECT_TRUE(f.valid());
+  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  EXPECT_EQ("42", f.get());
+#endif  // 1
 }
 
 }  // namespace

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -549,6 +549,26 @@ TEST(FutureTestInt, conform_2_3_11_c) {
   ExpectFutureError([&] { f.is_ready(); }, std::future_errc::no_state);
 }
 
+/// @test Verify conformance with section 2.10 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_10_4_2_a) {
+  // When T is a simple value type we get back T.
+  future<std::string> f = make_ready_future(std::string("42"));
+  EXPECT_TRUE(f.valid());
+  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  EXPECT_EQ("42", f.get());
+}
+
+/// @test Verify conformance with section 2.10 of the Concurrency TS.
+TEST(FutureTestInt, conform_2_10_4_2_b) {
+  // When T is a reference we get std::decay<T>::type.
+  std::string value("42");
+  std::string& sref = value;
+  future<std::string> f = make_ready_future(sref);
+  EXPECT_TRUE(f.valid());
+  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  EXPECT_EQ("42", f.get());
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -184,6 +184,13 @@ class promise<void> final : private internal::promise_base<void> {
   using promise_base<void>::set_exception;
 };
 
+/// Create a future<void> that is immediately ready.
+inline future<void> make_ready_future() {
+  promise<void> p;
+  p.set_value();
+  return p.get_future();
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -549,6 +549,15 @@ TEST(FutureTestVoid, conform_2_3_11_c) {
   ExpectFutureError([&] { f.is_ready(); }, std::future_errc::no_state);
 }
 
+/// @test Verify conformance with section 2.10 of the Concurrency TS.
+TEST(FutureTestVoid, conform_2_10_4) {
+  future<void> f = make_ready_future();
+  EXPECT_TRUE(f.valid());
+  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  f.get();
+  SUCCEED();
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -202,6 +202,25 @@ struct then_helper {
   using state_t = future_shared_state<result_t>;
 };
 
+template <typename T, typename U>
+struct make_ready_helper {
+  using type = typename std::decay<T>::type;
+};
+
+template <typename T, typename X>
+struct make_ready_helper<T, std::reference_wrapper<X>> {
+  using type = X&;
+};
+
+/**
+ * Compute the return type of make_ready_future<T>.
+ */
+template <typename T>
+struct make_ready_return {
+  using type =
+      typename make_ready_helper<T, typename std::decay<T>::type>::type;
+};
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud


### PR DESCRIPTION
This is a convenience function to create futures that are immediately
ready. The current implementation is maybe suboptimal, but easy to
understand.

This fixes #2112.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2132)
<!-- Reviewable:end -->
