### PR TITLE
Fix linter warnings.

### DIFF
--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -53,8 +53,8 @@ std::once_flag ssl_locking_initialized;
 std::vector<std::mutex> ssl_locks;
 
 // A callback to lock and unlock the mutexes needed by the SSL library.
-extern "C" void ssl_locking_cb(int mode, int type, char const* file, int line) {
-  if (mode & CRYPTO_LOCK) {
+extern "C" void SslLockingCb(int mode, int type, char const*, int) {
+  if ((mode & CRYPTO_LOCK) != 0) {
     ssl_locks[type].lock();
   } else {
     ssl_locks[type].unlock();
@@ -129,7 +129,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   GCP_LOG(INFO) << "Installing SSL locking callbacks.";
   ssl_locks =
       std::vector<std::mutex>(static_cast<std::size_t>(CRYPTO_num_locks()));
-  CRYPTO_set_locking_callback(ssl_locking_cb);
+  CRYPTO_set_locking_callback(SslLockingCb);
 
   // The documentation also recommends calling CRYPTO_THREADID_set_callback() to
   // setup a function to return thread ids as integers (or pointers). Writing a


### PR DESCRIPTION
clang-tidy was complaining at the underscores and the implicit cast to bool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2134)
<!-- Reviewable:end -->
