### PR TITLE
Retry the docker setup in the Kokoro builds.

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -100,10 +100,12 @@ echo "Creating Docker image with all the development tools $(date)."
 # flag. Later, we will want to print out the emulator(s) logs *only* if there
 # is an error, so disabling from this point on is the right choice.
 set +e
-"${PROJECT_ROOT}/ci/travis/install-linux.sh" \
-    >create-build-docker-image.log 2>&1 </dev/null
+mkdir -p "${BUILD_OUTPUT}"
+"${PROJECT_ROOT}/ci/install-retry.sh" \
+    "${PROJECT_ROOT}/ci/travis/install-linux.sh" \
+    >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null
 if [[ "$?" != 0 ]]; then
-  dump_log create-build-docker-image.log
+  dump_log "${BUILD_OUTPUT}/create-build-docker-image.log"
   exit 1
 fi
 echo "================================================================"


### PR DESCRIPTION
Sometimes the docker setup (preparing the Docker image for the build)
fails with transient errors. Instead of manually restarting the build,
let the robots try 3 times. The setup takes ~3 minutes so even the worst
case retry is not that terrible.

This fixes #2106.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2136)
<!-- Reviewable:end -->
