### PR TITLE
Better return type for Base64Decode.

### DIFF
--- a/google/cloud/storage/internal/openssl_util.cc
+++ b/google/cloud/storage/internal/openssl_util.cc
@@ -131,7 +131,7 @@ std::vector<std::uint8_t> Base64Decode(std::string const& str) {
   EVP_DecodedLength(&decoded_size, str.size());
   std::vector<std::uint8_t> result(decoded_size);
   EVP_DecodeBase64(result.data(), &decoded_size, result.size(),
-                   reinterpret_cast<std::uint8_t const*>(str.data()),
+                   reinterpret_cast<unsigned char const*>(str.data()),
                    str.size());
   result.resize(decoded_size);
   return result;

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -29,7 +29,7 @@ namespace internal {
 /**
  * Decodes a Base64-encoded string.
  */
-std::string Base64Decode(std::string const& str);
+std::vector<std::uint8_t> Base64Decode(std::string const& str);
 
 /**
  * Encodes a string using Base64.

--- a/google/cloud/storage/internal/sha256_hash.cc
+++ b/google/cloud/storage/internal/sha256_hash.cc
@@ -24,10 +24,16 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
 namespace {
-std::vector<std::uint8_t> Sha256Hash(void const* data, std::size_t size) {
+template <typename Byte,
+          typename std::enable_if<sizeof(Byte) == 1, int>::type = 0>
+std::vector<std::uint8_t> Sha256Hash(Byte const* data, std::size_t count) {
   SHA256_CTX sha256;
   SHA256_Init(&sha256);
-  SHA256_Update(&sha256, data, size);
+  static_assert(std::numeric_limits<unsigned char>::digits == 8,
+                "This function assumes that a 'char' uses a single byte,"
+                " because the argument to SHA256_Update() must be 'count bytes"
+                " at data'.");
+  SHA256_Update(&sha256, data, count);
 
   unsigned char hash[SHA256_DIGEST_LENGTH];
   SHA256_Final(hash, &sha256);

--- a/google/cloud/storage/internal/sha256_hash.cc
+++ b/google/cloud/storage/internal/sha256_hash.cc
@@ -23,10 +23,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::vector<std::uint8_t> Sha256Hash(std::string const& str) {
+namespace {
+std::vector<std::uint8_t> Sha256Hash(void const* data, std::size_t size) {
   SHA256_CTX sha256;
   SHA256_Init(&sha256);
-  SHA256_Update(&sha256, str.data(), str.size());
+  SHA256_Update(&sha256, data, size);
 
   unsigned char hash[SHA256_DIGEST_LENGTH];
   SHA256_Final(hash, &sha256);
@@ -35,6 +36,15 @@ std::vector<std::uint8_t> Sha256Hash(std::string const& str) {
   // by `SHA256_Final()` are 8-bit values, and (b) because if `std::uint8_t`
   // exists it must be large enough to fit an `unsigned char`.
   return {hash, hash + sizeof(hash)};
+}
+}  // namespace
+
+std::vector<std::uint8_t> Sha256Hash(std::string const& str) {
+  return Sha256Hash(str.data(), str.size());
+}
+
+std::vector<std::uint8_t> Sha256Hash(std::vector<std::uint8_t> const& bytes) {
+  return Sha256Hash(bytes.data(), bytes.size());
 }
 
 std::string HexEncode(std::vector<std::uint8_t> const& bytes) {

--- a/google/cloud/storage/internal/sha256_hash.h
+++ b/google/cloud/storage/internal/sha256_hash.h
@@ -29,6 +29,9 @@ namespace internal {
 /// Return the SHA256 hash (as raw bytes) of @p str.
 std::vector<std::uint8_t> Sha256Hash(std::string const& str);
 
+/// Return the SHA256 hash (as raw bytes) of @p bytes.
+std::vector<std::uint8_t> Sha256Hash(std::vector<std::uint8_t> const& bytes);
+
 /// Return @p bytes encoded as a lowercase hexadecimal string.
 std::string HexEncode(std::vector<std::uint8_t> const& bytes);
 


### PR DESCRIPTION
The sequence of bytes returned by `Base64Decode()` *might*
represent a string, but it can also be a binary blob. Return just
`std::vector<std::uint8_t>`, the caller can convert if they have
special knowledge allowing them to use a `std::string`.

In the process I discovered some duplication for Sha256, and
it was simpler to refactor to the common function instead of fixing
and then refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2154)
<!-- Reviewable:end -->
