### PR TITLE
Save some space in the Travis log.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,14 +76,15 @@ install:
   # The git default is to recurse, override it because we do not need to and
   # that saves time.
   - git submodule update --init
-  - ci/install-retry.sh ci/travis/install-linux.sh
+  - ci/install-retry.sh ci/travis/install-linux.sh >build-output/install-linux.log 2>&1
 
 after_success:
   - ci/travis/upload-codecov.sh
   - ci/travis/upload-docs.sh
-  - ci/travis/dump-logs.sh
+  - ci/travis/dump-reports.sh
 
 after_failure:
+  - ci/travis/dump-reports.sh
   - ci/travis/dump-logs.sh
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ install:
   # The git default is to recurse, override it because we do not need to and
   # that saves time.
   - git submodule update --init
-  - ci/install-retry.sh ci/travis/install-linux.sh >build-output/install-linux.log 2>&1
+  - travis_wait 20 /bin/sh -c "ci/install-retry.sh ci/travis/install-linux.sh >build-output/install-linux.log 2>&1"
 
 after_success:
   - ci/travis/upload-codecov.sh

--- a/ci/travis/dump-logs.sh
+++ b/ci/travis/dump-logs.sh
@@ -22,34 +22,11 @@ fi
 source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
 source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 
+# Dump the image installation log.
+echo
+dump_log "build-output/install-linux.log"
+
 # Dump the emulator log file. Tests run in the google/cloud/bigtable/tests directory.
 echo
 dump_log "${BUILD_OUTPUT}/google/cloud/bigtable/tests/emulator.log"
 dump_log "${BUILD_OUTPUT}/google/cloud/bigtable/tests/instance-admin-emulator.log"
-
-# Find any analysis reports, currently ABI checks and Clang static analysis are
-# the two things that produce them. Note that the Clang static analysis reports
-# are copied into the scan-build-output directory by the build-docker.sh script.
-readonly ABI_CHECK_REPORTS="$(find "${BUILD_OUTPUT}" -name 'compat_report.html')"
-readonly SCAN_BUILD_REPORTS="$(find scan-build-output/ -name '*.html' 2>/dev/null)"
-
-if [ -z "${ABI_CHECK_REPORTS}" ] && [ -z "${SCAN_BUILD_REPORTS}" ]; then
-  echo "No analysis reports found, exit scripts with success."
-  exit 0
-fi
-
-# If w3m is installed there is nothing to do.
-if which w3m >/dev/null 2>&1; then
-  echo "Found w3m already installed."
-else
-  # Try to install a HTML renderer, if this fails the script will exit.
-  # Note that this runs on the Travis VM, under Ubuntu, so the command
-  # to install things is well-known:
-  sudo apt install -y w3m
-fi
-
-for report in ${ABI_CHECK_REPORTS} ${SCAN_BUILD_REPORTS}; do
-  echo
-  echo "================ ${report} ================"
-  w3m -dump "${report}"
-done

--- a/ci/travis/dump-reports.sh
+++ b/ci/travis/dump-reports.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
+
+# Find any analysis reports, currently ABI checks and Clang static analysis are
+# the two things that produce them. Note that the Clang static analysis reports
+# are copied into the scan-build-output directory by the build-docker.sh script.
+readonly ABI_CHECK_REPORTS="$(find "${BUILD_OUTPUT}" -name 'compat_report.html')"
+readonly SCAN_BUILD_REPORTS="$(find scan-build-output/ -name '*.html' 2>/dev/null)"
+
+if [ -z "${ABI_CHECK_REPORTS}" ] && [ -z "${SCAN_BUILD_REPORTS}" ]; then
+  echo "No analysis reports found, exit scripts with success."
+  exit 0
+fi
+
+# If w3m is installed there is nothing to do.
+if which w3m >/dev/null 2>&1; then
+  echo "Found w3m already installed."
+else
+  # Try to install a HTML renderer, if this fails the script will exit.
+  # Note that this runs on the Travis VM, under Ubuntu, so the command
+  # to install things is well-known:
+  sudo apt install -y w3m
+fi
+
+for report in ${ABI_CHECK_REPORTS} ${SCAN_BUILD_REPORTS}; do
+  echo
+  echo "================ ${report} ================"
+  w3m -dump "${report}"
+done


### PR DESCRIPTION
The pretty Travis log is limited to 10,000 lines (you can get more, but
only in "raw" form). I think we should reserve those lines for the stuff
we care about, so I am pruning a bit:

- dump-logs.sh will only run on failures, because that is when we need
  to see the logs.
- I moved some of the report pretty printing to a separate file so we
  still saw those reports on success and failures.
- The Docker image creation is only interesting if it fails, so save the
  log to a file and print it (only on failures) in dump-logs.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2165)
<!-- Reviewable:end -->
