### PR TITLE
Implement Client::CreateHmacKey.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2292,8 +2292,8 @@ class Client {
     if (!result) {
       return result.status();
     }
-    return std::make_pair(std::move(result.value().resource),
-                          std::move(result.value().secret));
+    return std::make_pair(std::move(result->resource),
+                          std::move(result->secret));
   }
 
   /**

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/storage/hmac_key_metadata.h"
 #include "google/cloud/storage/internal/logging_client.h"
 #include "google/cloud/storage/internal/retry_client.h"
 #include "google/cloud/storage/internal/signed_url_requests.h"
@@ -2251,6 +2252,81 @@ class Client {
     auto const& project_id = raw_client_->client_options().project_id();
     return GetServiceAccountForProject(project_id,
                                        std::forward<Options>(options)...);
+  }
+
+  /**
+   * Create a new HMAC key in a given project.
+   *
+   * @warning This GCS feature is not GA, it is subject to change without
+   *     notice.
+   *
+   * @param project_id the name of the project where you want to create the
+   *     service account.
+   * @param service_account the service account email where you want to create
+   *     the new HMAC key.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Only the standard options apply in this case.
+   *
+   * @return This operation returns the new HMAC key metadata *and* the HMAC key
+   *   secret (encoded as a base64 string). This is the only request that
+   *   returns the secret.
+   *
+   * @par Idempotency
+   * This operation is not idempotent. Retrying the operation will create a new
+   * key each time.
+   *
+   * @par Example
+   *
+   *
+   * @see https://cloud.google.com/iam/docs/service-accounts for general
+   *     information on Google Cloud Platform service accounts.
+   */
+  template <typename... Options>
+  StatusOr<std::pair<HmacKeyMetadata, std::string>> CreateHmacKeyForProject(
+      std::string project_id, std::string service_account,
+      Options&&... options) {
+    internal::CreateHmacKeyRequest request(std::move(project_id),
+                                           std::move(service_account));
+    request.set_multiple_options(std::forward<Options>(options)...);
+    auto result = raw_client_->CreateHmacKey(request);
+    if (!result) {
+      return result.status();
+    }
+    return std::make_pair(std::move(result.value().resource),
+                          std::move(result.value().secret));
+  }
+
+  /**
+   * Create a new HMAC key associated in the default project.
+   *
+   * @warning This GCS feature is not GA, it is subject to change without
+   *     notice.
+   *
+   * @param service_account the service account email where you want to create
+   *     the new HMAC key.
+   * @param options a list of optional query parameters and/or request headers.
+   *     Only the standard options apply in this case.
+   *
+   * @return This operation returns the new HMAC key metadata *and* the HMAC key
+   *   secret (encoded as a base64 string). This is the only request that
+   *   returns the secret.
+   *
+   * @par Idempotency
+   * This operation is not idempotent. Retrying the operation will create a new
+   * key each time.
+   *
+   * @par Example
+   *
+   *
+   * @see https://cloud.google.com/iam/docs/service-accounts for general
+   *     information on Google Cloud Platform service accounts.
+   */
+  template <typename... Options>
+  StatusOr<std::pair<HmacKeyMetadata, std::string>> CreateHmacKey(
+      std::string service_account, Options&&... options) {
+    auto const& project_id = raw_client_->client_options().project_id();
+    return CreateHmacKeyForProject(project_id, std::move(service_account),
+                                   std::forward<Options>(options)...);
   }
   //@}
 

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -197,6 +197,10 @@ bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
     internal::GetProjectServiceAccountRequest const&) const {
   return true;
 }
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::CreateHmacKeyRequest const&) const {
+  return true;
+}
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
     internal::ListNotificationsRequest const&) const {
@@ -454,6 +458,11 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::GetProjectServiceAccountRequest const&) const {
   return true;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::CreateHmacKeyRequest const&) const {
+  return false;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(

--- a/google/cloud/storage/idempotency_policy.h
+++ b/google/cloud/storage/idempotency_policy.h
@@ -157,6 +157,8 @@ class IdempotencyPolicy {
   //@{
   virtual bool IsIdempotent(
       internal::GetProjectServiceAccountRequest const& request) const = 0;
+  virtual bool IsIdempotent(
+      internal::CreateHmacKeyRequest const& request) const = 0;
   //@}
 
   //@{
@@ -279,6 +281,8 @@ class AlwaysRetryIdempotencyPolicy : public IdempotencyPolicy {
   //@{
   bool IsIdempotent(
       internal::GetProjectServiceAccountRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateHmacKeyRequest const& request) const override;
   //@}
 
   //@{
@@ -401,6 +405,8 @@ class StrictIdempotencyPolicy : public IdempotencyPolicy {
   //@{
   bool IsIdempotent(
       internal::GetProjectServiceAccountRequest const& request) const override;
+  bool IsIdempotent(
+      internal::CreateHmacKeyRequest const& request) const override;
   //@}
 
   //@{

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -529,6 +529,13 @@ TEST(StrictIdempotencyPolicyTest, GetProjectServiceAccount) {
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
 
+TEST(StrictIdempotencyPolicyTest, CreateHmacKey) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateHmacKeyRequest request("test-project-id",
+                                         "test-service-account");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
 TEST(StrictIdempotencyPolicyTest, ListNotification) {
   StrictIdempotencyPolicy policy;
   internal::ListNotificationsRequest request("test-bucket-name");

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -998,6 +998,20 @@ StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 
+StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
+    CreateHmacKeyRequest const& request) {
+  CurlRequestBuilder builder(
+      storage_endpoint_ + "/projects/" + request.project_id() + "/hmacKeys",
+      storage_factory_);
+  auto status = SetupBuilder(builder, request, "POST");
+  if (!status.ok()) {
+    return status;
+  }
+  builder.AddQueryParameter("serviceAccount", request.service_account());
+  return ParseFromHttpResponse<CreateHmacKeyResponse>(
+      builder.BuildRequest().MakeRequest(std::string{}));
+}
+
 StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
     ListNotificationsRequest const& request) {
   // Assume the bucket name is validated by the caller.

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -156,6 +156,8 @@ class CurlClient : public RawClient,
 
   StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) override;
+  StatusOr<CreateHmacKeyResponse> CreateHmacKey(
+      CreateHmacKeyRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -378,6 +378,12 @@ TEST_P(CurlClientTest, GetServiceAccount) {
   TestCorrectFailureStatus(status_or_foo.status());
 }
 
+TEST_P(CurlClientTest, CreateHmacKeyRequest) {
+  auto result = client_->CreateHmacKey(
+      CreateHmacKeyRequest("project_id", "service-account"));
+  TestCorrectFailureStatus(result.status());
+}
+
 TEST_P(CurlClientTest, ListNotifications) {
   auto status_or_foo =
       client_->ListNotifications(ListNotificationsRequest("bkt"));

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -318,6 +318,11 @@ StatusOr<ServiceAccount> LoggingClient::GetServiceAccount(
   return MakeCall(*client_, &RawClient::GetServiceAccount, request, __func__);
 }
 
+StatusOr<CreateHmacKeyResponse> LoggingClient::CreateHmacKey(
+    CreateHmacKeyRequest const& request) {
+  return MakeCall(*client_, &RawClient::CreateHmacKey, request, __func__);
+}
+
 StatusOr<ListNotificationsResponse> LoggingClient::ListNotifications(
     ListNotificationsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListNotifications, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -118,6 +118,8 @@ class LoggingClient : public RawClient {
 
   StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) override;
+  StatusOr<CreateHmacKeyResponse> CreateHmacKey(
+      CreateHmacKeyRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -23,6 +23,7 @@
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include "google/cloud/storage/internal/default_object_acl_requests.h"
 #include "google/cloud/storage/internal/empty_response.h"
+#include "google/cloud/storage/internal/hmac_key_requests.h"
 #include "google/cloud/storage/internal/notification_requests.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/internal/object_requests.h"
@@ -146,6 +147,8 @@ class RawClient {
   //@{
   virtual StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) = 0;
+  virtual StatusOr<CreateHmacKeyResponse> CreateHmacKey(
+      CreateHmacKeyRequest const&) = 0;
   //@}
 
   //@{

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -515,6 +515,15 @@ StatusOr<ServiceAccount> RetryClient::GetServiceAccount(
                   &RawClient::GetServiceAccount, request, __func__);
 }
 
+StatusOr<CreateHmacKeyResponse> RetryClient::CreateHmacKey(
+    CreateHmacKeyRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  auto is_idempotent = idempotency_policy_->IsIdempotent(request);
+  return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
+                  &RawClient::CreateHmacKey, request, __func__);
+}
+
 StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
     ListNotificationsRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -132,6 +132,8 @@ class RetryClient : public RawClient {
 
   StatusOr<ServiceAccount> GetServiceAccount(
       GetProjectServiceAccountRequest const&) override;
+  StatusOr<CreateHmacKeyResponse> CreateHmacKey(
+      CreateHmacKeyRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -132,6 +132,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   MOCK_METHOD1(GetServiceAccount,
                StatusOr<ServiceAccount>(
                    internal::GetProjectServiceAccountRequest const&));
+  MOCK_METHOD1(CreateHmacKey, StatusOr<internal::CreateHmacKeyResponse>(
+                                  internal::CreateHmacKeyRequest const&));
 
   MOCK_METHOD1(ListNotifications,
                StatusOr<internal::ListNotificationsResponse>(

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -23,6 +23,12 @@ set -eu
 #   tests should have read/write access to this bucket.
 # - STORAGE_REGION_ID: the name of of Google Cloud Storage region, ideally close
 #   to the VMs running the integration tests.
+# - SERVICE_ACCOUNT: a valid service account in ${PROJECT_ID}. It is used to
+#   test HMAC keys, new keys will be created in this account.
+# - TOPIC_NAME: a valid Cloud Pub/Sub topic name, configured to accept
+#   publications from the GCS service account in ${PROJECT_ID}. It is used to
+#   create Cloud Pub/Sub notifications, but no notifications are actually sent
+#   to it.
 
 echo
 echo "Running storage::internal::CurlResumableUploadSession integration tests."

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -24,7 +24,7 @@ set -eu
 # - STORAGE_REGION_ID: the name of of Google Cloud Storage region, ideally close
 #   to the VMs running the integration tests.
 # - SERVICE_ACCOUNT: a valid service account in ${PROJECT_ID}. It is used to
-#   test HMAC keys, new keys will be created in this account.
+#   test HMAC keys. New keys will be created in this account.
 # - TOPIC_NAME: a valid Cloud Pub/Sub topic name, configured to accept
 #   publications from the GCS service account in ${PROJECT_ID}. It is used to
 #   create Cloud Pub/Sub notifications, but no notifications are actually sent

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -72,4 +72,4 @@ echo "Running GCS Projects.serviceAccount integration tests."
 
 echo
 echo "Running GCS Projects.serviceAccount integration tests."
-./service_account_integration_test "${PROJECT_ID}"
+./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -28,6 +28,7 @@ export PROJECT_ID="fake-project-$(date +%s)"
 export BUCKET_NAME="fake-bucket-$(date +%s)"
 export TOPIC_NAME="projects/${PROJECT_ID}/topics/fake-topic-$(date +%s)"
 export LOCATION="fake-region1"
+readonly SERVICE_ACCOUNT="fake-service-account@example.com"
 
 echo
 echo "Running Storage integration tests against local servers."
@@ -91,7 +92,7 @@ echo "Running GCS multi-threaded integration test."
 
 echo
 echo "Running GCS Projects.serviceAccount integration tests."
-./service_account_integration_test "${PROJECT_ID}"
+./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
 
 # The tests were successful, so disable dumping of test bench log during
 # shutdown.

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
@@ -28,17 +29,27 @@ using ::testing::HasSubstr;
 /// Store the project and instance captured from the command-line arguments.
 class ServiceAccountTestEnvironment : public ::testing::Environment {
  public:
-  ServiceAccountTestEnvironment(std::string project) {
+  ServiceAccountTestEnvironment(std::string project,
+                                std::string service_account) {
     project_id_ = std::move(project);
+    service_account_ = std::move(service_account);
   }
 
   static std::string const& project_id() { return project_id_; }
+  static std::string const& service_account() { return service_account_; }
 
  private:
   static std::string project_id_;
+  static std::string service_account_;
 };
 
 std::string ServiceAccountTestEnvironment::project_id_;
+std::string ServiceAccountTestEnvironment::service_account_;
+
+bool UsingTestbench() {
+  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
+      .has_value();
+}
 
 TEST(ServiceAccountIntegrationTest, Get) {
   auto project_id = ServiceAccountTestEnvironment::project_id();
@@ -46,15 +57,56 @@ TEST(ServiceAccountIntegrationTest, Get) {
   ASSERT_STATUS_OK(client);
 
   StatusOr<ServiceAccount> a1 = client->GetServiceAccountForProject(project_id);
+  ASSERT_STATUS_OK(a1);
   EXPECT_FALSE(a1->email_address().empty());
 
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(client_options);
   Client client_with_default(client_options->set_project_id(project_id));
   StatusOr<ServiceAccount> a2 = client_with_default.GetServiceAccount();
+  ASSERT_STATUS_OK(a1);
   EXPECT_FALSE(a2->email_address().empty());
 
   EXPECT_EQ(*a1, *a2);
+}
+
+TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
+  if (!UsingTestbench()) {
+    // Temporarily disabled outside the testbench because the test does not
+    // cleanup after itself.
+    return;
+  }
+
+  auto project_id = ServiceAccountTestEnvironment::project_id();
+  auto service_account = ServiceAccountTestEnvironment::service_account();
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  StatusOr<std::pair<HmacKeyMetadata, std::string>> key =
+      client->CreateHmacKeyForProject(project_id, service_account);
+  ASSERT_STATUS_OK(key);
+
+  EXPECT_FALSE(key->second.empty());
+}
+
+TEST(ServiceAccountIntegrationTest, CreateHmacKey) {
+  if (!UsingTestbench()) {
+    // Temporarily disabled outside the testbench because the test does not
+    // cleanup after itself.
+    return;
+  }
+
+  auto project_id = ServiceAccountTestEnvironment::project_id();
+  auto client_options = ClientOptions::CreateDefaultClientOptions();
+  auto service_account = ServiceAccountTestEnvironment::service_account();
+  ASSERT_STATUS_OK(client_options);
+
+  Client client(client_options->set_project_id(project_id));
+  StatusOr<std::pair<HmacKeyMetadata, std::string>> key =
+      client.CreateHmacKey(service_account);
+  ASSERT_STATUS_OK(key);
+
+  EXPECT_FALSE(key->second.empty());
 }
 
 }  // namespace
@@ -67,16 +119,19 @@ int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
-  if (argc != 2) {
+  if (argc != 3) {
     std::string const cmd = argv[0];
     auto last_slash = std::string(argv[0]).find_last_of('/');
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1) << " <project>\n";
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project> <service-account>\n";
     return 1;
   }
 
   std::string const project_id = argv[1];
+  std::string const service_account = argv[2];
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::storage::ServiceAccountTestEnvironment(project_id));
+      new google::cloud::storage::ServiceAccountTestEnvironment(
+          project_id, service_account));
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -64,7 +64,7 @@ TEST(ServiceAccountIntegrationTest, Get) {
   ASSERT_STATUS_OK(client_options);
   Client client_with_default(client_options->set_project_id(project_id));
   StatusOr<ServiceAccount> a2 = client_with_default.GetServiceAccount();
-  ASSERT_STATUS_OK(a1);
+  ASSERT_STATUS_OK(a2);
   EXPECT_FALSE(a2->email_address().empty());
 
   EXPECT_EQ(*a1, *a2);


### PR DESCRIPTION
This PR adds the Client::CreateHmacKey function, it also adds the usual
unit and integration tests.  The integration test is disabled in
production because the feature is still under EAP. The examples will
come in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2167)
<!-- Reviewable:end -->
