### PR TITLE
Add Client::CreateHmacKey examples.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2286,7 +2286,7 @@ class Client {
    * key each time.
    *
    * @par Example
-   *
+   * storage_service_account_samples.cc create hmac key project
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.
@@ -2326,7 +2326,7 @@ class Client {
    * key each time.
    *
    * @par Example
-   *
+   * storage_service_account_samples.cc create hmac key
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.

--- a/google/cloud/storage/examples/run_examples_testbench.sh
+++ b/google/cloud/storage/examples/run_examples_testbench.sh
@@ -33,6 +33,7 @@ readonly BUCKET_NAME="fake-bucket-$(date +%s)-${RANDOM}"
 readonly DESTINATION_BUCKET_NAME="destination-bucket-$(date +%s)-${RANDOM}"
 readonly TOPIC_NAME="fake-topic-$(date +%s)-${RANDOM}"
 readonly STORAGE_CMEK_KEY="projects/${PROJECT_ID}/locations/global/keyRings/fake-key-ring/cryptoKeys/fake-key"
+readonly SERVICE_ACCOUNT="fake-service-account@example.com"
 
 # Most of the examples assume a bucket already exists, create one for them.
 run_example ./storage_bucket_samples create-bucket-for-project \

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -99,6 +99,21 @@ run_all_service_account_examples() {
   export GOOGLE_CLOUD_PROJECT="${PROJECT_ID}"
   run_example ./storage_service_account_samples get-service-account
   unset GOOGLE_CLOUD_PROJECT
+
+  if [[ -z "${CLOUD_STORAGE_TESTBENCH_ENDPOINT:-}" ]]; then
+    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
+        " HMAC key examples skipped because they are not enabled in production."
+    return
+  fi
+
+  run_example ./storage_service_account_samples \
+      create-hmac-key-for-project "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
+
+  # Run the examples using the environment to get the project id:
+  export GOOGLE_CLOUD_PROJECT="${PROJECT_ID}"
+  run_example ./storage_service_account_samples \
+      create-hmac-key "${SERVICE_ACCOUNT}"
+  unset GOOGLE_CLOUD_PROJECT
 }
 
 ################################################


### PR DESCRIPTION
Add code snippets for `Client::CreateHmacKey()`, the region tags are
guesses, we can change them later if they turn out to be wrong. The
examples are disabled when running against production because the
feature is in EAP right now.

This fixes #2158.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2185)
<!-- Reviewable:end -->
