### PR TITLE
fix error message for unable to open download file

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -167,7 +167,7 @@ Status Client::DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
     return Status(stream.status().code(), std::move(msg).str());
   };
   if (!stream.status().ok()) {
-    return report_error(__func__, "cannot open destination file");
+    return report_error(__func__, "cannot open download file");
   }
 
   // Open the destination file, and immediate raise an exception on failure.


### PR DESCRIPTION
Wrong error message had me chasing down the wrong path when my download wasn't working!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2192)
<!-- Reviewable:end -->
