### PR TITLE
Kokoro support to run ABI checks.

### DIFF
--- a/ci/check-abi.sh
+++ b/ci/check-abi.sh
@@ -44,7 +44,7 @@ for library in bigtable_client google_cloud_cpp_common storage_client; do
   reference_file="${PROJECT_ROOT}/ci/test-abi/${old_dump_file}.gz"
   abi-dumper "${libdir}/lib${library}.so" \
       -public-headers "${includedir}" \
-      -lver "${version}" \
+      -lver "current" \
       -o "${BUILD_OUTPUT}/${new_dump_file}"
 
   # We want to collect the data for as many libraries as possible, do not exit

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -73,6 +73,13 @@ elif [[ "${BUILD_NAME}" = "no-tests" ]]; then
   # is too high.
   export BUILD_TESTING=no
   export CMAKE_FLAGS=-DBUILD_TESTING=OFF
+elif [[ "${BUILD_NAME}" = "check-abi" ]]; then
+  export CHECK_ABI=yes
+  export TEST_INSTALL=yes
+  export CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes
+  export BUILD_TYPE=Debug
+  export DISTRO=ubuntu-install
+  export DISTRO_VERSION=18.04
 else
   echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."
   exit 1
@@ -120,6 +127,10 @@ echo "================================================================"
 
 echo "================================================================"
 "${PROJECT_ROOT}/ci/travis/dump-logs.sh"
+echo "================================================================"
+
+echo "================================================================"
+"${PROJECT_ROOT}/ci/travis/dump-reports.sh"
 echo "================================================================"
 
 exit ${exit_status}

--- a/ci/kokoro/docker/check-abi-presubmit.cfg
+++ b/ci/kokoro/docker/check-abi-presubmit.cfg
@@ -1,0 +1,29 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "check-abi"
+}
+
+action {
+  define_artifacts {
+    regex: "**/compat_report.html"
+    strip_prefix: "github/google-cloud-cpp/build-output/ubuntu-install-18.04-gcc-Debug-shared/compat_reports"
+  }
+}

--- a/ci/kokoro/docker/check-abi.cfg
+++ b/ci/kokoro/docker/check-abi.cfg
@@ -1,0 +1,29 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "check-abi"
+}
+
+action {
+  define_artifacts {
+    regex: "**/compat_report.html"
+    strip_prefix: "github/google-cloud-cpp/build-output/ubuntu-install-18.04-gcc-Debug-shared/compat_reports"
+  }
+}

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -180,7 +180,8 @@ if [ "${TEST_INSTALL:-}" = "yes" ]; then
 
   # Checking the ABI requires installation, so this is the first opportunity to
   # run the check.
-  (cd "${PROJECT_ROOT}" ; ./ci/check-abi.sh)
+  (cd "${PROJECT_ROOT}" ; ./ci/check-abi.sh ||
+   echo "${COLOR_RED}The ABI/API checks failed.${COLOR_RESET}")
 
   # Also verify that the install directory does not get unexpected files or
   # directories installed.


### PR DESCRIPTION
These changes will allow us to run the ABI checks in Kokoro. The script
will *not* fail on ABI failures, but the failure reports will be
available internally. I am planning to add scripts to update the
baseline in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2195)
<!-- Reviewable:end -->
