### PR TITLE
Refactor HmacKey requests.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -208,6 +208,7 @@ add_library(storage_client
             object_rewriter.cc
             object_stream.h
             object_stream.cc
+            override_default_project.h
             retry_policy.h
             service_account.h
             service_account.cc

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2270,12 +2270,11 @@ class Client {
    * @warning This GCS feature is not GA, it is subject to change without
    *     notice.
    *
-   * @param project_id the name of the project where you want to create the
-   *     service account.
    * @param service_account the service account email where you want to create
    *     the new HMAC key.
    * @param options a list of optional query parameters and/or request headers.
-   *     Only the standard options apply in this case.
+   *     In addition to the options common to all requests, this operation
+   *     accepts `OverrideDefaultProject`.
    *
    * @return This operation returns the new HMAC key metadata *and* the HMAC key
    *   secret (encoded as a base64 string). This is the only request that
@@ -2292,10 +2291,10 @@ class Client {
    *     information on Google Cloud Platform service accounts.
    */
   template <typename... Options>
-  StatusOr<std::pair<HmacKeyMetadata, std::string>> CreateHmacKeyForProject(
-      std::string project_id, std::string service_account,
-      Options&&... options) {
-    internal::CreateHmacKeyRequest request(std::move(project_id),
+  StatusOr<std::pair<HmacKeyMetadata, std::string>> CreateHmacKey(
+      std::string service_account, Options&&... options) {
+    auto const& project_id = raw_client_->client_options().project_id();
+    internal::CreateHmacKeyRequest request(project_id,
                                            std::move(service_account));
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->CreateHmacKey(request);
@@ -2304,39 +2303,6 @@ class Client {
     }
     return std::make_pair(std::move(result->resource),
                           std::move(result->secret));
-  }
-
-  /**
-   * Create a new HMAC key associated in the default project.
-   *
-   * @warning This GCS feature is not GA, it is subject to change without
-   *     notice.
-   *
-   * @param service_account the service account email where you want to create
-   *     the new HMAC key.
-   * @param options a list of optional query parameters and/or request headers.
-   *     Only the standard options apply in this case.
-   *
-   * @return This operation returns the new HMAC key metadata *and* the HMAC key
-   *   secret (encoded as a base64 string). This is the only request that
-   *   returns the secret.
-   *
-   * @par Idempotency
-   * This operation is not idempotent. Retrying the operation will create a new
-   * key each time.
-   *
-   * @par Example
-   * storage_service_account_samples.cc create hmac key
-   *
-   * @see https://cloud.google.com/iam/docs/service-accounts for general
-   *     information on Google Cloud Platform service accounts.
-   */
-  template <typename... Options>
-  StatusOr<std::pair<HmacKeyMetadata, std::string>> CreateHmacKey(
-      std::string service_account, Options&&... options) {
-    auto const& project_id = raw_client_->client_options().project_id();
-    return CreateHmacKeyForProject(project_id, std::move(service_account),
-                                   std::forward<Options>(options)...);
   }
   //@}
 

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -117,7 +117,8 @@ TEST_F(ServiceAccountTest, CreateHmacKey) {
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
   StatusOr<std::pair<HmacKeyMetadata, std::string>> actual =
-      client.CreateHmacKeyForProject("test-project", "test-service-account");
+      client.CreateHmacKey("test-service-account",
+                           OverrideDefaultProject("test-project"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected.resource, actual->first);
   EXPECT_EQ(expected.secret, actual->second);
@@ -127,9 +128,7 @@ TEST_F(ServiceAccountTest, CreateHmacKeyTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::CreateHmacKeyResponse>(
       mock, EXPECT_CALL(*mock, CreateHmacKey(_)),
       [](Client& client) {
-        return client
-            .CreateHmacKeyForProject("test-project", "test-service-account")
-            .status();
+        return client.CreateHmacKey("test-service-account").status();
       },
       "CreateHmacKey");
 }
@@ -138,9 +137,7 @@ TEST_F(ServiceAccountTest, CreateHmacKeyPermanentFailure) {
   testing::PermanentFailureStatusTest<internal::CreateHmacKeyResponse>(
       *client, EXPECT_CALL(*mock, CreateHmacKey(_)),
       [](Client& client) {
-        return client
-            .CreateHmacKeyForProject("test-project", "test-service-account")
-            .status();
+        return client.CreateHmacKey("test-service-account").status();
       },
       "CreateHmacKey");
 }

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -128,7 +128,8 @@ void CreateHmacKeyForProject(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string project_id,
      std::string service_account_email) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> hmac_key_details =
-        client.CreateHmacKeyForProject(project_id, service_account_email);
+        client.CreateHmacKey(service_account_email,
+                             gcs::OverrideDefaultProject(project_id));
 
     if (!hmac_key_details) {
       throw std::runtime_error(hmac_key_details.status().message());

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -49,8 +49,10 @@ StatusOr<HmacKeyMetadata> HmacKeyMetadataParser::FromString(
 }
 
 std::ostream& operator<<(std::ostream& os, CreateHmacKeyRequest const& r) {
-  return os << "CreateHmacKeyRequest={project_id=" << r.project_id()
-            << ", service_account=" << r.service_account() << "}";
+  os << "CreateHmacKeyRequest={project_id=" << r.project_id()
+     << ", service_account=" << r.service_account();
+  r.DumpOptions(os, ", ");
+  return os << "}";
 }
 
 StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/override_default_project.h"
 #include <iosfwd>
 
 namespace google {
@@ -33,18 +34,21 @@ struct HmacKeyMetadataParser {
 };
 
 /// Represents a request to create a call the `HmacKeys: insert` API.
-class CreateHmacKeyRequest : public GenericRequest<CreateHmacKeyRequest> {
+class CreateHmacKeyRequest
+    : public GenericRequest<CreateHmacKeyRequest, OverrideDefaultProject> {
  public:
   CreateHmacKeyRequest() = default;
   CreateHmacKeyRequest(std::string project_id, std::string service_account)
-      : project_id_(std::move(project_id)),
-        service_account_(std::move(service_account)) {}
+      : service_account_(std::move(service_account)) {
+    set_option(OverrideDefaultProject(std::move(project_id)));
+  }
 
-  std::string const& project_id() const { return project_id_; }
+  std::string project_id() const {
+    return GetOption<OverrideDefaultProject>().value();
+  }
   std::string const& service_account() const { return service_account_; }
 
  private:
-  std::string project_id_;
   std::string service_account_;
 };
 
@@ -65,12 +69,16 @@ std::ostream& operator<<(std::ostream& os, CreateHmacKeyResponse const& r);
 /// Represents a request to call the `HmacKeys: list` API.
 class ListHmacKeysRequest
     : public GenericRequest<ListHmacKeysRequest, Deleted, MaxResults,
-                            ServiceAccountFilter, UserProject> {
+                            OverrideDefaultProject, ServiceAccountFilter,
+                            UserProject> {
  public:
-  explicit ListHmacKeysRequest(std::string project_id)
-      : project_id_(std::move(project_id)) {}
+  explicit ListHmacKeysRequest(std::string project_id) {
+    set_option(OverrideDefaultProject(std::move(project_id)));
+  }
 
-  std::string const& project_id() const { return project_id_; }
+  std::string project_id() const {
+    return GetOption<OverrideDefaultProject>().value();
+  }
   std::string const& page_token() const { return page_token_; }
   ListHmacKeysRequest& set_page_token(std::string page_token) {
     page_token_ = std::move(page_token);
@@ -78,7 +86,6 @@ class ListHmacKeysRequest
   }
 
  private:
-  std::string project_id_;
   std::string page_token_;
 };
 

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -36,15 +36,19 @@ TEST(HmacKeyRequestsTest, ParseEmpty) {
 }
 
 TEST(HmacKeyRequestsTest, Create) {
-  CreateHmacKeyRequest request("test-project-id", "test-service-account");
-  EXPECT_EQ("test-project-id", request.project_id());
+  CreateHmacKeyRequest request("", "test-service-account");
+  EXPECT_EQ("", request.project_id());
   EXPECT_EQ("test-service-account", request.service_account());
+  request.set_multiple_options(OverrideDefaultProject("test-project-id"),
+                               UserIp("test-user-ip"));
+  EXPECT_EQ("test-project-id", request.project_id());
 
   std::ostringstream os;
   os << request;
   auto str = os.str();
   EXPECT_THAT(str, HasSubstr("CreateHmacKeyRequest"));
   EXPECT_THAT(str, HasSubstr("test-project-id"));
+  EXPECT_THAT(str, HasSubstr("test-user-ip"));
   EXPECT_THAT(str, HasSubstr("test-service-account"));
 }
 
@@ -116,14 +120,16 @@ TEST(HmacKeyRequestsTest, CreateResponseIOStream) {
 
 TEST(HmacKeysRequestsTest, List) {
   ListHmacKeysRequest request("test-project-id");
-  request.set_multiple_options(ServiceAccountFilter("test-service-account"),
-                               Deleted(true));
   EXPECT_EQ("test-project-id", request.project_id());
+  request.set_multiple_options(ServiceAccountFilter("test-service-account"),
+                               Deleted(true),
+                               OverrideDefaultProject("override-project-id"));
+  EXPECT_EQ("override-project-id", request.project_id());
 
   std::ostringstream os;
   os << request;
   std::string actual = os.str();
-  EXPECT_THAT(actual, HasSubstr("test-project-id"));
+  EXPECT_THAT(actual, HasSubstr("override-project-id"));
   EXPECT_THAT(actual, HasSubstr("serviceAccount=test-service-account"));
   EXPECT_THAT(actual, HasSubstr("deleted=true"));
 }

--- a/google/cloud/storage/override_default_project.h
+++ b/google/cloud/storage/override_default_project.h
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OVERRIDE_DEFAULT_PROJECT_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OVERRIDE_DEFAULT_PROJECT_H_
+
+#include "google/cloud/storage/internal/complex_option.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+/**
+ * Override the default project.
+ *
+ * In a small number of operations it is convenient to override the project id
+ * configured in a `storage::Client`. This option overrides the project id,
+ * without requiring additional overloads for each function.
+ */
+struct OverrideDefaultProject
+    : public internal::ComplexOption<OverrideDefaultProject, std::string> {
+  using ComplexOption<OverrideDefaultProject, std::string>::ComplexOption;
+  static char const* name() { return "override_default_project"; }
+};
+
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OVERRIDE_DEFAULT_PROJECT_H_

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -92,6 +92,7 @@ storage_client_hdrs = [
     "object_metadata.h",
     "object_rewriter.h",
     "object_stream.h",
+    "override_default_project.h",
     "retry_policy.h",
     "service_account.h",
     "signed_url_options.h",

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -82,8 +82,8 @@ TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
   StatusOr<Client> client = Client::CreateDefaultClient();
   ASSERT_STATUS_OK(client);
 
-  StatusOr<std::pair<HmacKeyMetadata, std::string>> key =
-      client->CreateHmacKeyForProject(project_id, service_account);
+  StatusOr<std::pair<HmacKeyMetadata, std::string>> key = client->CreateHmacKey(
+      service_account, OverrideDefaultProject(project_id));
   ASSERT_STATUS_OK(key);
 
   EXPECT_FALSE(key->second.empty());


### PR DESCRIPTION
First, I noticed that we could get rid of the `Client::*ForProject()` overloads if we
used an option to override the default project id.  That reduces the overall surface
and fits more naturally with all the other optional parameters.

Then I noticed that there was a lot of commonality across all the request types for
HmacKeys. We only have two such types so far, but we will get 5 of them, all with
a common `project_id()` field and (more interesting) with special handling for
`OverrideDefaultProject`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2199)
<!-- Reviewable:end -->
