### PR TITLE
moving GetTable, ListTables and DeleteTable from noex::TableAdmin to TableAdmin

### DIFF
--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -425,6 +425,11 @@ class TableAdmin {
   StatusOr<std::vector<::google::bigtable::admin::v2::Snapshot>> ListSnapshots(
       bigtable::ClusterId const& cluster_id = bigtable::ClusterId("-"));
 
+  /// Return the fully qualified name of a table in this object's instance.
+  std::string TableName(std::string const& table_id) const {
+    return instance_name() + "/tables/" + table_id;
+  }
+
  private:
   /**
    * Implements the polling loop for `WaitForConsistencyCheck` on a


### PR DESCRIPTION
Moving more functions from `noex::TableAdmin` to `TableAdmin`;
List of functions:
`TableAdmin::GetTable`
`TableAdmin::ListTables`
`TableAdmin::DeleteTable`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2205)
<!-- Reviewable:end -->
