### PR TITLE
Implement Client::DeleteHmacKey

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2339,6 +2339,37 @@ class Client {
                           std::move(result->secret));
   }
 
+  /**
+   * Delete a HMAC key in a given project.
+   *
+   * @warning This GCS feature is not GA, it is subject to change without
+   *     notice.
+   *
+   * @param access_id the HMAC key `access_id()` that you want to delete.  Each
+   *     HMAC key is assigned an `access_id()` attribute at creation time.
+   * @param options a list of optional query parameters and/or request headers.
+   *     In addition to the options common to all requests, this operation
+   *     accepts `OverrideDefaultProject`.
+   *
+   * @return This operation returns the new HMAC key metadata.
+   *
+   * @par Idempotency
+   * This operation is always idempotent. An access id identifies a single HMAC
+   * key, calling the operation multiple times can succeed only once.
+   *
+   * @par Example
+   *
+   * @see https://cloud.google.com/iam/docs/service-accounts for general
+   *     information on Google Cloud Platform service accounts.
+   */
+  template <typename... Options>
+  StatusOr<HmacKeyMetadata> DeleteHmacKey(std::string access_id,
+                                          Options&&... options) {
+    auto const& project_id = raw_client_->client_options().project_id();
+    internal::DeleteHmacKeyRequest request(project_id, std::move(access_id));
+    request.set_multiple_options(std::forward<Options>(options)...);
+    return raw_client_->DeleteHmacKey(request);
+  }
   //@}
 
   //@{

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2282,6 +2282,10 @@ class Client {
    * This is a read-only operation and is always idempotent.
    *
    * @par Example
+   * storage_service_account_samples.cc list hmac keys
+   *
+   * @par Example
+   * storage_service_account_samples.cc list hmac keys with service account
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.
@@ -2317,6 +2321,9 @@ class Client {
    * @par Idempotency
    * This operation is not idempotent. Retrying the operation will create a new
    * key each time.
+   *
+   * @par Example
+   * storage_service_account_samples.cc create hmac key
    *
    * @par Example
    * storage_service_account_samples.cc create hmac key project
@@ -2358,6 +2365,7 @@ class Client {
    * key, calling the operation multiple times can succeed only once.
    *
    * @par Example
+   * storage_service_account_samples.cc delete hmac key
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -117,6 +117,15 @@ run_all_service_account_examples() {
       list-hmac-keys
   run_example ./storage_service_account_samples \
       list-hmac-keys-with-service-account "${SERVICE_ACCOUNT}"
+  # Parse the output to delete all the keys created in this service account.
+  for access_id in $(
+      ./storage_service_account_samples \
+          list-hmac-keys-with-service-account "${SERVICE_ACCOUNT}" | \
+          sed -n 's;^access_id = \(.*\);\1;p'); do
+    run_example ./storage_service_account_samples \
+        delete-hmac-key "${access_id}"
+  done
+
   unset GOOGLE_CLOUD_PROJECT
 }
 

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -200,6 +200,29 @@ void CreateHmacKeyForProject(google::cloud::storage::Client client, int& argc,
   (std::move(client), argv[1], argv[2]);
 }
 
+void DeleteHmacKey(google::cloud::storage::Client client, int& argc,
+                   char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"delete-hmac-key <access-id>"};
+  }
+  //! [delete hmac key] [START storage_delete_hmac_key]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string access_id) {
+    StatusOr<gcs::HmacKeyMetadata> hmac_key_details =
+        client.DeleteHmacKey(access_id);
+
+    if (!hmac_key_details) {
+      throw std::runtime_error(hmac_key_details.status().message());
+    }
+    std::cout << "The key is deleted, though it may still appear"
+              << " in ListHmacKeys() results."
+              << "\nThe HMAC key metadata is: " << &hmac_key_details << "\n";
+  }
+  //! [delete hmac key] [END storage_delete_hmac_key]
+  (std::move(client), argv[1]);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -221,6 +244,7 @@ int main(int argc, char* argv[]) try {
       {"list-hmac-keys-with-service-account", &ListHmacKeysWithServiceAccount},
       {"create-hmac-key-for-project", &CreateHmacKeyForProject},
       {"create-hmac-key", &CreateHmacKey},
+      {"delete-hmac-key", &DeleteHmacKey},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/idempotency_policy.cc
+++ b/google/cloud/storage/idempotency_policy.cc
@@ -205,6 +205,10 @@ bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
     internal::CreateHmacKeyRequest const&) const {
   return true;
 }
+bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
+    internal::DeleteHmacKeyRequest const&) const {
+  return true;
+}
 
 bool AlwaysRetryIdempotencyPolicy::IsIdempotent(
     internal::ListNotificationsRequest const&) const {
@@ -472,6 +476,11 @@ bool StrictIdempotencyPolicy::IsIdempotent(
 bool StrictIdempotencyPolicy::IsIdempotent(
     internal::CreateHmacKeyRequest const&) const {
   return false;
+}
+
+bool StrictIdempotencyPolicy::IsIdempotent(
+    internal::DeleteHmacKeyRequest const&) const {
+  return true;
 }
 
 bool StrictIdempotencyPolicy::IsIdempotent(

--- a/google/cloud/storage/idempotency_policy.h
+++ b/google/cloud/storage/idempotency_policy.h
@@ -161,6 +161,8 @@ class IdempotencyPolicy {
       internal::ListHmacKeysRequest const& request) const = 0;
   virtual bool IsIdempotent(
       internal::CreateHmacKeyRequest const& request) const = 0;
+  virtual bool IsIdempotent(
+      internal::DeleteHmacKeyRequest const& request) const = 0;
   //@}
 
   //@{
@@ -287,6 +289,8 @@ class AlwaysRetryIdempotencyPolicy : public IdempotencyPolicy {
       internal::ListHmacKeysRequest const& request) const override;
   bool IsIdempotent(
       internal::CreateHmacKeyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteHmacKeyRequest const& request) const override;
   //@}
 
   //@{
@@ -413,6 +417,8 @@ class StrictIdempotencyPolicy : public IdempotencyPolicy {
       internal::ListHmacKeysRequest const& request) const override;
   bool IsIdempotent(
       internal::CreateHmacKeyRequest const& request) const override;
+  bool IsIdempotent(
+      internal::DeleteHmacKeyRequest const& request) const override;
   //@}
 
   //@{

--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -542,6 +542,13 @@ TEST(StrictIdempotencyPolicyTest, CreateHmacKey) {
   EXPECT_FALSE(policy.IsIdempotent(request));
 }
 
+TEST(StrictIdempotencyPolicyTest, DeleteHmacKey) {
+  StrictIdempotencyPolicy policy;
+  internal::CreateHmacKeyRequest request("test-project-id",
+                                         "test-service-account");
+  EXPECT_FALSE(policy.IsIdempotent(request));
+}
+
 TEST(StrictIdempotencyPolicyTest, ListNotification) {
   StrictIdempotencyPolicy policy;
   internal::ListNotificationsRequest request("test-bucket-name");

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1025,6 +1025,20 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 
+StatusOr<HmacKeyMetadata> CurlClient::DeleteHmacKey(
+    DeleteHmacKeyRequest const& request) {
+  CurlRequestBuilder builder(storage_endpoint_ + "/projects/" +
+                                 request.project_id() + "/hmacKeys/" +
+                                 request.access_id(),
+                             storage_factory_);
+  auto status = SetupBuilder(builder, request, "DELETE");
+  if (!status.ok()) {
+    return status;
+  }
+  return CheckedFromString<HmacKeyMetadataParser>(
+      builder.BuildRequest().MakeRequest(std::string{}));
+}
+
 StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
     ListNotificationsRequest const& request) {
   // Assume the bucket name is validated by the caller.

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -160,6 +160,7 @@ class CurlClient : public RawClient,
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
+  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -83,7 +83,7 @@ std::ostream& operator<<(std::ostream& os, CreateHmacKeyResponse const& r) {
 }
 
 std::ostream& operator<<(std::ostream& os, ListHmacKeysRequest const& r) {
-  os << "ListHmacKeysRequest={bucket_name=" << r.project_id();
+  os << "ListHmacKeysRequest={project_id=" << r.project_id();
   r.DumpOptions(os, ", ");
   return os << "}";
 }
@@ -118,6 +118,12 @@ std::ostream& operator<<(std::ostream& os, ListHmacKeysResponse const& r) {
   return os << "}}";
 }
 
+std::ostream& operator<<(std::ostream& os, DeleteHmacKeyRequest const& r) {
+  os << "DeleteHmacKeyRequest={project_id=" << r.project_id()
+     << ", access_id=" << r.access_id();
+  r.DumpOptions(os, ", ");
+  return os << "}";
+}
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -128,6 +128,22 @@ struct ListHmacKeysResponse {
 
 std::ostream& operator<<(std::ostream& os, ListHmacKeysResponse const& r);
 
+/// Represents a request to call the `HmacKeys: delete` API.
+class DeleteHmacKeyRequest
+    : public GenericHmacKeyRequest<DeleteHmacKeyRequest> {
+ public:
+  explicit DeleteHmacKeyRequest(std::string project_id, std::string access_id)
+  : GenericHmacKeyRequest(std::move(project_id)),
+  access_id_(std::move(access_id)) {}
+
+  std::string const& access_id() const { return access_id_; }
+
+ private:
+  std::string access_id_;
+};
+
+std::ostream& operator<<(std::ostream& os, DeleteHmacKeyRequest const& r);
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -133,8 +133,8 @@ class DeleteHmacKeyRequest
     : public GenericHmacKeyRequest<DeleteHmacKeyRequest> {
  public:
   explicit DeleteHmacKeyRequest(std::string project_id, std::string access_id)
-  : GenericHmacKeyRequest(std::move(project_id)),
-  access_id_(std::move(access_id)) {}
+      : GenericHmacKeyRequest(std::move(project_id)),
+        access_id_(std::move(access_id)) {}
 
   std::string const& access_id() const { return access_id_; }
 

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -209,6 +209,22 @@ TEST(HmacKeysRequestsTest, ListResponseOStream) {
   EXPECT_THAT(actual, HasSubstr("test-access-id-2"));
 }
 
+TEST(HmacKeysRequestsTest, Delete) {
+  DeleteHmacKeyRequest request("test-project-id", "test-access-id");
+  EXPECT_EQ("test-project-id", request.project_id());
+  EXPECT_EQ("test-access-id", request.access_id());
+  request.set_multiple_options(UserIp("test-user-ip"),
+                               OverrideDefaultProject("override-project-id"));
+  EXPECT_EQ("override-project-id", request.project_id());
+
+  std::ostringstream os;
+  os << request;
+  std::string actual = os.str();
+  EXPECT_THAT(actual, HasSubstr("override-project-id"));
+  EXPECT_THAT(actual, HasSubstr("test-access-id"));
+  EXPECT_THAT(actual, HasSubstr("test-user-ip"));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -328,6 +328,11 @@ StatusOr<CreateHmacKeyResponse> LoggingClient::CreateHmacKey(
   return MakeCall(*client_, &RawClient::CreateHmacKey, request, __func__);
 }
 
+StatusOr<HmacKeyMetadata> LoggingClient::DeleteHmacKey(
+    DeleteHmacKeyRequest const& request) {
+  return MakeCall(*client_, &RawClient::DeleteHmacKey, request, __func__);
+}
+
 StatusOr<ListNotificationsResponse> LoggingClient::ListNotifications(
     ListNotificationsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListNotifications, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -122,6 +122,7 @@ class LoggingClient : public RawClient {
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
+  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -151,6 +151,8 @@ class RawClient {
       ListHmacKeysRequest const&) = 0;
   virtual StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) = 0;
+  virtual StatusOr<HmacKeyMetadata> DeleteHmacKey(
+      DeleteHmacKeyRequest const&) = 0;
   //@}
 
   //@{

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -533,6 +533,15 @@ StatusOr<CreateHmacKeyResponse> RetryClient::CreateHmacKey(
                   &RawClient::CreateHmacKey, request, __func__);
 }
 
+StatusOr<HmacKeyMetadata> RetryClient::DeleteHmacKey(
+    DeleteHmacKeyRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  auto is_idempotent = idempotency_policy_->IsIdempotent(request);
+  return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
+                  &RawClient::DeleteHmacKey, request, __func__);
+}
+
 StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
     ListNotificationsRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -136,6 +136,7 @@ class RetryClient : public RawClient {
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
+  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -136,6 +136,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                  internal::ListHmacKeysRequest const&));
   MOCK_METHOD1(CreateHmacKey, StatusOr<internal::CreateHmacKeyResponse>(
                                   internal::CreateHmacKeyRequest const&));
+  MOCK_METHOD1(DeleteHmacKey, StatusOr<HmacKeyMetadata>(
+                                  internal::DeleteHmacKeyRequest const&));
 
   MOCK_METHOD1(ListNotifications,
                StatusOr<internal::ListNotificationsResponse>(

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -89,7 +89,7 @@ TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
   EXPECT_FALSE(key->second.empty());
 }
 
-TEST(ServiceAccountIntegrationTest, CreateHmacKey) {
+TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   if (!UsingTestbench()) {
     // Temporarily disabled outside the testbench because the test does not
     // cleanup after itself.
@@ -107,6 +107,11 @@ TEST(ServiceAccountIntegrationTest, CreateHmacKey) {
   ASSERT_STATUS_OK(key);
 
   EXPECT_FALSE(key->second.empty());
+
+  StatusOr<HmacKeyMetadata> deleted_key = client.DeleteHmacKey(
+      key->first.access_id(), OverrideDefaultProject(project_id));
+  ASSERT_STATUS_OK(deleted_key);
+  EXPECT_EQ(HmacKeyMetadata::state_deleted(), deleted_key->state());
 }
 
 TEST(ServiceAccountIntegrationTest, ListHmacKeys) {


### PR DESCRIPTION
This PR implements Client::DeleteHmacKey(), including the integration
tests, unit tests, and examples. It also consolidates the integration test
a bit, putting all the current (and future) CRUD operations for HMAC keys
in a single test.

Fixes #2162.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2207)
<!-- Reviewable:end -->
