### PR TITLE
Upgrade grpc to v1.19.1

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -54,12 +54,12 @@ def google_cloud_cpp_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.17.2",
+            strip_prefix = "grpc-1.19.0",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.17.2.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.17.2.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.19.0.tar.gz",
             ],
-            sha256 = "34ed95b727e7c6fcbf85e5eb422e962788e21707b712fdb4caf931553c2c6dbc",
+            sha256 = "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73",
         )
 
     # Load OpenCensus.

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -54,12 +54,12 @@ def google_cloud_cpp_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.19.0",
+            strip_prefix = "grpc-1.19.1",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.19.0.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.19.1.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.19.1.tar.gz",
             ],
-            sha256 = "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73",
+            sha256 = "f869c648090e8bddaa1260a271b1089caccbe735bf47ac9cd7d44d35a02fb129",
         )
 
     # Load OpenCensus.

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET gprc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz")
+        "https://github.com/grpc/grpc/archive/v1.19.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73")
+        "f869c648090e8bddaa1260a271b1089caccbe735bf47ac9cd7d44d35a02fb129")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET gprc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.17.2.tar.gz")
+        "https://github.com/grpc/grpc/archive/v1.19.0.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "34ed95b727e7c6fcbf85e5eb422e962788e21707b712fdb4caf931553c2c6dbc")
+        "1d54cd95ed276c42c276e0a3df8ab33ee41968b73af14023c03a19db48f82e73")
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")


### PR DESCRIPTION
Changes our grpc dep to [v1.19.1](https://github.com/grpc/grpc/releases/tag/v1.19.1), which fixes our builds using recent versions of bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2211)
<!-- Reviewable:end -->
