### PR TITLE
Fix version integration test

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -724,13 +724,16 @@ run_temporary_hold_examples() {
 #   COLOR_*: colorize output messages, defined in colors.sh
 #   EXIT_STATUS: control the final exit status for the program.
 # Arguments:
-#   bucket_name: the name of the bucket to run the examples against.
+#   None
 # Returns:
 #   None
 ################################################
 run_object_versioning_examples() {
-  local bucket_name=$1
-  shift
+  # Create the bucket to avoid changing the configuration for "${BUCKET_NAME}"
+  local bucket_name="cloud-cpp-test-bucket-$(date +%s)-${RANDOM}-${RANDOM}"
+
+  run_example ./storage_bucket_samples create-bucket-for-project \
+      "${bucket_name}" "${PROJECT_ID}"
 
   local object_name="object-$(date +%s)-${RANDOM}.txt"
   local copied_object_name="object-$(date +%s)-${RANDOM}.txt"
@@ -755,6 +758,9 @@ run_object_versioning_examples() {
      "${bucket_name}" "${object_name}" "${live_generation}"
   run_example ./storage_bucket_samples disable-object-versioning \
      "${bucket_name}"
+
+  run_example ./storage_bucket_samples delete-bucket \
+      "${bucket_name}"
 }
 
 ################################################
@@ -1103,7 +1109,7 @@ run_all_storage_examples() {
   run_all_public_object_examples "${BUCKET_NAME}"
   run_event_based_hold_examples "${BUCKET_NAME}"
   run_temporary_hold_examples "${BUCKET_NAME}"
-  run_object_versioning_examples "${BUCKET_NAME}"
+  run_object_versioning_examples
   run_all_signed_url_v2_examples "${BUCKET_NAME}"
   run_all_signed_url_v4_examples "${BUCKET_NAME}"
   run_all_object_acl_examples "${BUCKET_NAME}"

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -753,11 +753,13 @@ run_object_versioning_examples() {
       "${bucket_name}" "${object_name}" \
       "${bucket_name}" "${copied_object_name}" "${archived_generation}"
   run_example ./storage_object_samples delete-versioned-object \
-     "${bucket_name}" "${object_name}" "${archived_generation}"
+      "${bucket_name}" "${object_name}" "${archived_generation}"
   run_example ./storage_object_samples delete-versioned-object \
-     "${bucket_name}" "${object_name}" "${live_generation}"
+      "${bucket_name}" "${object_name}" "${live_generation}"
   run_example ./storage_bucket_samples disable-object-versioning \
-     "${bucket_name}"
+      "${bucket_name}"
+  run_example ./storage_object_samples delete-object \
+      "${bucket_name}" "${copied_object_name}"
 
   run_example ./storage_bucket_samples delete-bucket \
       "${bucket_name}"

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -254,7 +254,7 @@ TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
   // This test requires the bucket to be configured with versioning. The buckets
   // used by the CI build are already configured with versioning enabled. The
   // bucket created in the testbench also has versioning. Regardless, set the
-  // bucket the desired state, that would produce a better error message if
+  // bucket to the desired state, which will produce a better error message if
   // there is a configuration problem.
   auto bucket_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(bucket_meta);

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -258,7 +258,8 @@ TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
   // there is a configuration problem.
   auto bucket_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(bucket_meta);
-  auto updated_meta = client->PatchBucket(bucket_name,
+  auto updated_meta = client->PatchBucket(
+      bucket_name,
       BucketMetadataPatchBuilder().SetVersioning(BucketVersioning{true}),
       IfMetagenerationMatch(bucket_meta->metageneration()));
   ASSERT_STATUS_OK(updated_meta);

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -253,13 +253,17 @@ TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
   auto bucket_name = ObjectTestEnvironment::bucket_name();
   // This test requires the bucket to be configured with versioning. The buckets
   // used by the CI build are already configured with versioning enabled. The
-  // bucket created in the testbench also has versioning. Regardless, check here
-  // first to produce a better error message if there is a configuration
-  // problem.
+  // bucket created in the testbench also has versioning. Regardless, set the
+  // bucket the desired state, that would produce a better error message if
+  // there is a configuration problem.
   auto bucket_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(bucket_meta);
-  ASSERT_TRUE(bucket_meta->versioning().has_value());
-  ASSERT_TRUE(bucket_meta->versioning().value().enabled);
+  auto updated_meta = client->PatchBucket(bucket_name,
+      BucketMetadataPatchBuilder().SetVersioning(BucketVersioning{true}),
+      IfMetagenerationMatch(bucket_meta->metageneration()));
+  ASSERT_STATUS_OK(updated_meta);
+  ASSERT_TRUE(updated_meta->versioning().has_value());
+  ASSERT_TRUE(updated_meta->versioning().value().enabled);
 
   auto create_object_with_3_versions = [&client, &bucket_name, this] {
     auto object_name = MakeRandomObjectName();


### PR DESCRIPTION
I did not notice one of the PRs was going to break the build. Note that
it did *not* break the build, the build passed once, but the second run
would be broken because the object versioning examples changed the state
of a global bucket.

The "Right Thing"[tm] would be to not use a global bucket. I plan to do
that in a future PR, but for now we need to get the builds restored
quickly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2213)
<!-- Reviewable:end -->
