### PR TITLE
Remove noexTable::CheckAndMutateRow() and ReadRows()

### DIFF
--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -56,6 +56,7 @@ inline std::string TableName(std::shared_ptr<DataClient> client,
 }
 
 class MutationBatcher;
+class Table;
 
 namespace internal {
 template <typename Request>
@@ -636,6 +637,7 @@ class Table {
  private:
   friend class NoexTableStreamingAsyncBulkApplyTest_SimpleTest_Test;
   friend class ::google::cloud::bigtable::MutationBatcher;
+  friend class ::google::cloud::bigtable::Table;
   /**
    * Make an asynchronous request to mutate a multiple rows and stream results.
    *


### PR DESCRIPTION

Part of the work for #2097 .
Second request in a series of pull requests to move functions from noex:;Table to Table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2221)
<!-- Reviewable:end -->
