### PR TITLE
Fix Kokoro + Windows build.

### DIFF
--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -29,6 +29,9 @@ $CONFIG = $env:CONFIG
 $PROVIDER = $env:PROVIDER
 $GENERATOR = "Ninja"
 
+Write-Host
+Get-Date -Format o
+Write-Host "Running git submodule update --init"
 git submodule update --init
 if ($LastExitCode) {
     throw "git submodule failed with exit code $LastExitCode"
@@ -40,13 +43,6 @@ $cmake_flags=@("-G$GENERATOR", "-DCMAKE_BUILD_TYPE=$CONFIG", "-H.", "-Bbuild-out
 # This script expects vcpkg to be installed in ..\vcpkg, discover the full
 # path to that directory:
 $dir = Split-Path (Get-Item -Path ".\" -Verbose).FullName
-
-# Run the vcpkg integration.
-$integrate = "$dir\vcpkg\vcpkg.exe integrate install"
-Invoke-Expression $integrate
-if ($LastExitCode) {
-    throw "vcpkg integrate failed with exit code $LastExitCode"
-}
 
 # Setup the environment for vcpkg:
 $cmake_flags += "-DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=$PROVIDER"

--- a/ci/kokoro/windows/install-dependencies.ps1
+++ b/ci/kokoro/windows/install-dependencies.ps1
@@ -14,9 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+Write-Host
+Write-Host "choco sources"
+Get-Date -Format o
+
 choco sources list
 
 # Ignore errors
+Write-Host
+Write-Host "choco install"
+Get-Date -Format o
 choco install --no-progress -y cmake
 
 # Ignore errors
@@ -24,3 +31,7 @@ choco install --no-progress -y cmake.portable
 
 # Ignore errors
 choco install --no-progress -y ninja
+
+Write-Host
+Write-Host "Post choco install"
+Get-Date -Format o


### PR DESCRIPTION
For some reason `vcpkg integrate` is freezing. We have not needed this
for a long time (when we switched to Ninja), so I just removed it.

I had to add some more debug logging to get here, which I think it is
generally useful, so I am leaving it in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2222)
<!-- Reviewable:end -->
