### PR TITLE
Changed to use the latest version of bazel

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -18,12 +18,12 @@ set -eu
 
 readonly PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
 # Ensures that the platform is one that we expect
-grep -P "linux|darwin" <<<"${PLATFORM}" > /dev/null
+test "${PLATFORM}" = "linux" -o "${PLATFORM}" = "darwin"
 
 # Gets the latest version number of bazel from the GitHub JSON API.
 readonly BAZEL_VERSION=$(
   curl -sL "https://api.github.com/repos/bazelbuild/bazel/releases/latest" \
-    | grep -P '"tag_name":' \
+    | grep '"tag_name":' \
     | cut -f4 -d\"
 )
 test -n "${BAZEL_VERSION}"

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -29,8 +29,8 @@ test -n "${BAZEL_VERSION}"
 
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
-wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
-wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
+curl -sLO "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
+curl -sLO "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
 
 # We want to protect against accidents (i.e., we don't want to download and
 # execute a 404 page), not malice, so downloading the checksum and the file

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -16,9 +16,8 @@
 
 set -eu
 
-readonly PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
-# Ensures that the platform is one that we expect
-test "${PLATFORM}" = "linux" -o "${PLATFORM}" = "darwin"
+readonly PLATFORM=$(printf "%s-%s\n" "$(uname -s)" "$(uname -m)" \
+  |  tr '[:upper:]' '[:lower:]')
 
 # Gets the latest version number of bazel from the GitHub JSON API.
 readonly BAZEL_VERSION=$(
@@ -29,7 +28,7 @@ readonly BAZEL_VERSION=$(
 test -n "${BAZEL_VERSION}"
 
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
-readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}-x86_64.sh"
+readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
 

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -16,21 +16,14 @@
 
 set -eu
 
-readonly PLATFORM=$(printf "%s-%s\n" "$(uname -s)" "$(uname -m)" \
+readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-# Gets the latest version number of bazel from the GitHub JSON API.
-readonly BAZEL_VERSION=$(
-  curl -sL "https://api.github.com/repos/bazelbuild/bazel/releases/latest" \
-    | grep '"tag_name":' \
-    | cut -f4 -d\"
-)
-test -n "${BAZEL_VERSION}"
-
+readonly BAZEL_VERSION="0.23.2"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
-curl -sLO "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
-curl -sLO "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
+wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
+wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
 
 # We want to protect against accidents (i.e., we don't want to download and
 # execute a 404 page), not malice, so downloading the checksum and the file

--- a/ci/kokoro/bazel-dependency/linux/build.sh
+++ b/ci/kokoro/bazel-dependency/linux/build.sh
@@ -26,7 +26,7 @@ echo "================================================================"
 # We ping the version of Bazel because we do not want all our builds to break
 # when Kokoro updates Bazel. We rather upgrade our tooling when *we* decide it
 # is a good time to do so.
-"${PROJECT_ROOT}/ci/install-bazel.sh" linux
+"${PROJECT_ROOT}/ci/install-bazel.sh"
 
 readonly BAZEL_BIN="$HOME/bin/bazel"
 echo "Using Bazel in ${BAZEL_BIN}"

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -33,7 +33,7 @@ echo
 # thing:
 function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
 
-"${PROJECT_ROOT}/ci/install-bazel.sh" macos
+"${PROJECT_ROOT}/ci/install-bazel.sh"
 
 readonly BAZEL_BIN="$HOME/bin/bazel"
 echo "Using Bazel in ${BAZEL_BIN}"

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -30,7 +30,7 @@ readonly PROJECT_ROOT="${PWD}"
 echo "================================================================"
 echo "Update or Install Bazel $(date)."
 echo "================================================================"
-"${PROJECT_ROOT}/ci/install-bazel.sh" linux
+"${PROJECT_ROOT}/ci/install-bazel.sh"
 
 readonly BAZEL_BIN="$HOME/bin/bazel"
 echo "Using Bazel in ${BAZEL_BIN}"


### PR DESCRIPTION
Updated the install-bazel.sh script to test using a newer version of bazel. Also changed the script to compute the `PLATFORM` value from `uname` rather than require the user to pass it as an argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2223)
<!-- Reviewable:end -->
