### PR TITLE
Disable signals in libcurl.

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -119,7 +119,9 @@ void CurlDownloadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  // handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  handle_.SetOption(CURLOPT_DNS_CACHE_TIMEOUT, 5L);
+  handle_.SetOption(CURLOPT_CONNECTTIMEOUT_MS, 500L);
   if (!payload_.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -119,6 +119,7 @@ void CurlDownloadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
   if (!payload_.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -44,7 +44,9 @@ void CurlRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  // handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  handle_.SetOption(CURLOPT_DNS_CACHE_TIMEOUT, 5L);
+  handle_.SetOption(CURLOPT_CONNECTTIMEOUT_MS, 500L);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -44,6 +44,7 @@ void CurlRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -102,6 +102,7 @@ void CurlUploadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         this->response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -102,7 +102,9 @@ void CurlUploadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  // handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  handle_.SetOption(CURLOPT_DNS_CACHE_TIMEOUT, 5L);
+  handle_.SetOption(CURLOPT_CONNECTTIMEOUT_MS, 500L);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         this->response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(storage_client_integration_tests
     bucket_integration_test.cc
     curl_upload_request_integration_test.cc
     curl_download_request_integration_test.cc
+    curl_nosignal_integration_test.cc
     curl_request_integration_test.cc
     curl_resumable_streambuf_integration_test.cc
     curl_resumable_upload_session_integration_test.cc

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -18,7 +18,6 @@ set(storage_client_integration_tests
     bucket_integration_test.cc
     curl_upload_request_integration_test.cc
     curl_download_request_integration_test.cc
-    curl_nosignal_integration_test.cc
     curl_request_integration_test.cc
     curl_resumable_streambuf_integration_test.cc
     curl_resumable_upload_session_integration_test.cc
@@ -57,6 +56,15 @@ foreach (fname ${storage_client_integration_tests})
                                   nlohmann_json
                                   storage_common_options)
 endforeach ()
+
+add_executable(curl_nosignal_integration_test curl_nosignal_integration_test.cc)
+target_link_libraries(curl_nosignal_integration_test PRIVATE
+    storage_client
+    google_cloud_cpp_common
+    CURL::CURL
+    Threads::Threads
+    nlohmann_json
+    storage_common_options)
 
 include(CreateBazelConfig)
 export_list_to_bazel("storage_client_integration_tests.bzl"

--- a/google/cloud/storage/tests/curl_nosignal_integration_test.cc
+++ b/google/cloud/storage/tests/curl_nosignal_integration_test.cc
@@ -12,33 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/random.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/list_objects_reader.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
-#include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/init_google_mock.h"
-#include <gmock/gmock.h>
 #include <chrono>
-#include <future>
 #include <fstream>
+#include <future>
 
-namespace google {
-namespace cloud {
-namespace storage {
-inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::ElementsAreArray;
-using ::testing::HasSubstr;
 using ms = std::chrono::milliseconds;
 
-/// Store the options captured from the command-line arguments.
-std::string FLAG_bucket_name;
-std::chrono::seconds FLAG_idle_duration;
-
-class CurlNoSignalIntegrationTest
-    : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 void ConfigureWorkingResolver() {
   std::ofstream("/etc/resolv.conf") << R"""(
@@ -57,10 +41,11 @@ nameserver 71.114.67.58
 )""";
 }
 
-Status UploadFiles(std::string const& media,
-                   std::vector<std::string> const& names) {
-  auto bucket_name = FLAG_bucket_name;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+google::cloud::Status UploadFiles(std::string const& bucket_name,
+                                  std::string const& media,
+                                  std::vector<std::string> const& names) {
+  namespace gcs = google::cloud::storage;
+  auto client = gcs::Client::CreateDefaultClient();
   if (!client) {
     return client.status();
   }
@@ -68,29 +53,30 @@ Status UploadFiles(std::string const& media,
   for (auto const& object_name : names) {
     // Raise on error so the errors are reported to the thread that launched
     // this function.
-    auto meta = client->InsertObject(bucket_name, object_name, media,
-                                     IfGenerationMatch(0), Fields(""));
+    auto meta =
+        client->InsertObject(bucket_name, object_name, media,
+                             gcs::IfGenerationMatch(0), gcs::Fields(""));
     if (!meta) {
       std::cerr << "Error uploading " << object_name << std::endl;
     }
-    std::this_thread::sleep_for(ms(250));
-    // Ignore any errors...
-    //    if (!meta) {
-    //      return meta.status();
-    //    }
+    std::this_thread::sleep_for(ms(25));
   }
-  return Status();
+  return google::cloud::Status();
 }
 
-Status DownloadFiles(int iterations, std::vector<std::string> const& names) {
+google::cloud::Status DownloadFiles(int iterations,
+                                    std::string const& bucket_name,
+                                    std::vector<std::string> const& names) {
+  namespace gcs = google::cloud::storage;
+
   if (names.empty()) {
     // Nothing to do, should not happen, but checking explicitly so the code is
     // more readable.
-    return Status(StatusCode::kInvalidArgument, "empty object name list");
+    return google::cloud::Status(google::cloud::StatusCode::kInvalidArgument,
+                                 "empty object name list");
   }
 
-  auto bucket_name = FLAG_bucket_name;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  auto client = gcs::Client::CreateDefaultClient();
   if (!client) {
     return client.status();
   }
@@ -101,28 +87,26 @@ search corp.google.com prod.google.com prodz.google.com google.com nyc.corp.goog
 nameserver 71.114.67.58
 )""";
 
-  std::random_device rd;
-  std::mt19937_64 gen(rd());
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
   // Recall that both ends of `std::uniform_int_distribution` are inclusive.
   std::uniform_int_distribution<std::size_t> pick_name(0, names.size() - 1);
 
   for (int i = 0; i != iterations; ++i) {
-    auto object_name = names.at(pick_name(gen));
+    auto object_name = names.at(pick_name(generator));
     try {
       auto stream = client->ReadObject(bucket_name, object_name);
       std::string actual(std::istreambuf_iterator<char>{stream}, {});
-    } catch(std::exception const& ex) {
+    } catch (std::exception const& ex) {
       std::cerr << "Exception raised while downloading " << object_name
-      << ex.what() << std::endl;
+                << ex.what() << std::endl;
     }
     std::this_thread::sleep_for(ms(250));
   }
-  return Status();
+  return google::cloud::Status();
 }
 
-TEST_F(CurlNoSignalIntegrationTest, UploadDownloadThenIdle) {
-  auto bucket_name = FLAG_bucket_name;
-
+google::cloud::Status UploadDownloadThenIdle(
+    std::string const& bucket_name, std::chrono::seconds idle_duration) {
   int const thread_count = 16;
   int const objects_per_thread = 40;
   int const object_count = thread_count * objects_per_thread;
@@ -130,80 +114,100 @@ TEST_F(CurlNoSignalIntegrationTest, UploadDownloadThenIdle) {
   int const object_size = 4 * 1024 * 1024;
   int const line_size = 128;
 
-  std::vector<std::string> object_names;
-  std::generate_n(std::back_inserter(object_names), object_count,
-                  [this] { return MakeRandomObjectName(); });
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  std::string const letters =
+      "abcdefghijklmnopqrstuvwxyz"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "012456789";
 
-  std::string media = [this] {
-    std::ostringstream discard;
-    std::ostringstream capture;
-    WriteRandomLines(capture, discard, object_size / line_size, line_size);
-    return std::move(capture).str();
-  }();
+  std::vector<std::string> object_names;
+  std::generate_n(
+      std::back_inserter(object_names), object_count, [&generator, &letters] {
+        return "ob-" + google::cloud::internal::Sample(generator, 32, letters) +
+               ".txt";
+      });
+
+  std::string const media = [&generator, &letters](int total_bytes,
+                                                   int bytes_per_line) {
+    std::string media;
+    for (int i = 0; i != total_bytes / bytes_per_line; ++i) {
+      std::string line =
+          google::cloud::internal::Sample(generator, line_size - 1, letters);
+      line += '\n';
+      media += line;
+    }
+
+    return media;
+  }(object_size, line_size);
 
   ConfigureWorkingResolver();
 
-  std::vector<std::future<Status>> uploads;
+  std::vector<std::future<google::cloud::Status>> uploads;
   auto names_block_begin = object_names.begin();
   for (int i = 0; i != thread_count; ++i) {
     auto names_block_end = names_block_begin;
     std::advance(names_block_end, objects_per_thread);
     std::vector<std::string> names{names_block_begin, names_block_end};
-    uploads.emplace_back(
-        std::async(std::launch::async, UploadFiles, media, std::move(names)));
+    uploads.emplace_back(std::async(std::launch::async, UploadFiles,
+                                    bucket_name, media, std::move(names)));
     names_block_begin = names_block_end;
   }
-  EXPECT_EQ(names_block_begin, object_names.end());
 
   std::cout << "Waiting for uploads " << std::flush;
   for (auto&& fut : uploads) {
-    ASSERT_STATUS_OK(fut.get());
+    auto status = fut.get();
+    if (!status.ok()) {
+      std::cerr << "Failure in upload thread: " << status << "\n";
+    }
     std::cout << '.' << std::flush;
   }
   std::cout << " DONE\n" << std::flush;
 
   // Go idle for FLAG_idle_duration.
   ConfigureBrokenResolver();
-  std::this_thread::sleep_for(FLAG_idle_duration);
+  std::this_thread::sleep_for(idle_duration);
 
-  std::vector<std::future<Status>> downloads;
+  std::vector<std::future<google::cloud::Status>> downloads;
   for (int i = 0; i != thread_count; ++i) {
     downloads.emplace_back(std::async(std::launch::async, DownloadFiles,
-                                      download_iterations, object_names));
+                                      download_iterations, bucket_name,
+                                      object_names));
   }
 
   std::cout << "Waiting for downloads " << std::flush;
   for (auto&& fut : downloads) {
-    ASSERT_STATUS_OK(fut.get());
+    auto status = fut.get();
+    if (!status.ok()) {
+      std::cerr << "Failure in download thread: " << status << "\n";
+    }
     std::cout << '.' << std::flush;
   }
   std::cout << " DONE\n" << std::flush;
 
   // Go idle for FLAG_idle_duration.
   ConfigureWorkingResolver();
-  std::this_thread::sleep_for(FLAG_idle_duration);
+  std::this_thread::sleep_for(idle_duration);
 
-  StatusOr<Client> client = Client::CreateDefaultClient();
-  ASSERT_STATUS_OK(client);
+  auto client = google::cloud::storage::Client::CreateDefaultClient();
+  if (!client) {
+    return client.status();
+  }
 
   for (auto&& name : object_names) {
-    auto status = client->DeleteObject(FLAG_bucket_name, name);
-    EXPECT_STATUS_OK(status);
+    auto status = client->DeleteObject(bucket_name, name);
+    if (!status.ok()) {
+      std::cerr << "Error deleting " << name << " " << status << "\n";
+    }
   }
 
   // Go idle for FLAG_idle_duration.
-  std::this_thread::sleep_for(FLAG_idle_duration);
+  std::this_thread::sleep_for(idle_duration);
+  return google::cloud::Status();
 }
 
 }  // namespace
-}  // namespace STORAGE_CLIENT_NS
-}  // namespace storage
-}  // namespace cloud
-}  // namespace google
 
 int main(int argc, char* argv[]) {
-  google::cloud::testing_util::InitGoogleMock(argc, argv);
-
   // Make sure the arguments are valid.
   if (argc != 3) {
     std::string const cmd = argv[0];
@@ -213,9 +217,14 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  google::cloud::storage::FLAG_bucket_name = argv[1];
-  google::cloud::storage::FLAG_idle_duration =
-      std::chrono::seconds(std::stoi(argv[2]));
+  auto bucket_name = std::string(argv[1]);
+  auto idle_duration = std::chrono::seconds(std::stoi(argv[2]));
 
-  return RUN_ALL_TESTS();
+  auto status = UploadDownloadThenIdle(bucket_name, idle_duration);
+  if (!status.ok()) {
+    std::cerr << "Error running test: " << status << "\n";
+    return 1;
+  }
+
+  return 0;
 }

--- a/google/cloud/storage/tests/curl_nosignal_integration_test.cc
+++ b/google/cloud/storage/tests/curl_nosignal_integration_test.cc
@@ -39,7 +39,7 @@ class CurlNoSignalIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 Status UploadFiles(std::string const& media,
-                 std::vector<std::string> const& names) {
+                   std::vector<std::string> const& names) {
   auto bucket_name = FLAG_bucket_name;
   StatusOr<Client> client = Client::CreateDefaultClient();
   if (!client) {
@@ -49,9 +49,8 @@ Status UploadFiles(std::string const& media,
   for (auto const& object_name : names) {
     // Raise on error so the errors are reported to the thread that launched
     // this function.
-    auto meta = client
-                              ->InsertObject(bucket_name, object_name, media,
-                                             IfGenerationMatch(0), Fields(""));
+    auto meta = client->InsertObject(bucket_name, object_name, media,
+                                     IfGenerationMatch(0), Fields(""));
     if (!meta) {
       return meta.status();
     }

--- a/google/cloud/storage/tests/curl_nosignal_integration_test.cc
+++ b/google/cloud/storage/tests/curl_nosignal_integration_test.cc
@@ -1,0 +1,185 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/list_objects_reader.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <chrono>
+#include <future>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::storage::testing::TestPermanentFailure;
+using ::testing::ElementsAreArray;
+using ::testing::HasSubstr;
+
+/// Store the options captured from the command-line arguments.
+std::string FLAG_bucket_name;
+std::chrono::seconds FLAG_idle_duration;
+
+class CurlNoSignalIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+Status UploadFiles(std::string const& media,
+                 std::vector<std::string> const& names) {
+  auto bucket_name = FLAG_bucket_name;
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  if (!client) {
+    return client.status();
+  }
+
+  for (auto const& object_name : names) {
+    // Raise on error so the errors are reported to the thread that launched
+    // this function.
+    auto meta = client
+                              ->InsertObject(bucket_name, object_name, media,
+                                             IfGenerationMatch(0), Fields(""));
+    if (!meta) {
+      return meta.status();
+    }
+  }
+  return Status();
+}
+
+Status DownloadFiles(int iterations, std::vector<std::string> const& names) {
+  if (names.empty()) {
+    // Nothing to do, should not happen, but checking explicitly so the code is
+    // more readable.
+    return Status(StatusCode::kInvalidArgument, "empty object name list");
+  }
+
+  auto bucket_name = FLAG_bucket_name;
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  if (!client) {
+    return client.status();
+  }
+
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+  // Recall that both ends of `std::uniform_int_distribution` are inclusive.
+  std::uniform_int_distribution<std::size_t> pick_name(0, names.size() - 1);
+
+  for (int i = 0; i != iterations; ++i) {
+    auto object_name = names.at(pick_name(gen));
+    auto stream = client->ReadObject(bucket_name, object_name);
+    std::string actual(std::istreambuf_iterator<char>{stream}, {});
+    if (!stream.status().ok()) {
+      return stream.status();
+    }
+  }
+  return Status();
+}
+
+TEST_F(CurlNoSignalIntegrationTest, UploadDownloadThenIdle) {
+  auto bucket_name = FLAG_bucket_name;
+
+  int const thread_count = 16;
+  int const objects_per_thread = 40;
+  int const object_count = thread_count * objects_per_thread;
+  int const download_iterations = 2 * objects_per_thread;
+  int const object_size = 4 * 1024 * 1024;
+  int const line_size = 128;
+
+  std::vector<std::string> object_names;
+  std::generate_n(std::back_inserter(object_names), object_count,
+                  [this] { return MakeRandomObjectName(); });
+
+  std::string media = [this] {
+    std::ostringstream discard;
+    std::ostringstream capture;
+    WriteRandomLines(capture, discard, object_size / line_size, line_size);
+    return std::move(capture).str();
+  }();
+
+  std::vector<std::future<Status>> uploads;
+  auto names_block_begin = object_names.begin();
+  for (int i = 0; i != thread_count; ++i) {
+    auto names_block_end = names_block_begin;
+    std::advance(names_block_end, objects_per_thread);
+    std::vector<std::string> names{names_block_begin, names_block_end};
+    uploads.emplace_back(
+        std::async(std::launch::async, UploadFiles, media, std::move(names)));
+    names_block_begin = names_block_end;
+  }
+  EXPECT_EQ(names_block_begin, object_names.end());
+
+  std::cout << "Waiting for uploads " << std::flush;
+  for (auto&& fut : uploads) {
+    ASSERT_STATUS_OK(fut.get());
+    std::cout << '.' << std::flush;
+  }
+  std::cout << " DONE\n" << std::flush;
+
+  // Go idle for FLAG_idle_duration.
+  std::this_thread::sleep_for(FLAG_idle_duration);
+
+  std::vector<std::future<Status>> downloads;
+  for (int i = 0; i != thread_count; ++i) {
+    downloads.emplace_back(std::async(std::launch::async, DownloadFiles,
+                                      download_iterations, object_names));
+  }
+
+  std::cout << "Waiting for downloads " << std::flush;
+  for (auto&& fut : downloads) {
+    ASSERT_STATUS_OK(fut.get());
+    std::cout << '.' << std::flush;
+  }
+  std::cout << " DONE\n" << std::flush;
+
+  // Go idle for FLAG_idle_duration.
+  std::this_thread::sleep_for(FLAG_idle_duration);
+
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  for (auto&& name : object_names) {
+    auto status = client->DeleteObject(FLAG_bucket_name, name);
+    EXPECT_STATUS_OK(status);
+  }
+
+  // Go idle for FLAG_idle_duration.
+  std::this_thread::sleep_for(FLAG_idle_duration);
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 3) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <bucket-name> <idle-time>\n";
+    return 1;
+  }
+
+  google::cloud::storage::FLAG_bucket_name = argv[1];
+  google::cloud::storage::FLAG_idle_duration =
+      std::chrono::seconds(std::stoi(argv[2]));
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -20,7 +20,6 @@ storage_client_integration_tests = [
     "bucket_integration_test.cc",
     "curl_upload_request_integration_test.cc",
     "curl_download_request_integration_test.cc",
-    "curl_nosignal_integration_test.cc",
     "curl_request_integration_test.cc",
     "curl_resumable_streambuf_integration_test.cc",
     "curl_resumable_upload_session_integration_test.cc",

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -20,6 +20,7 @@ storage_client_integration_tests = [
     "bucket_integration_test.cc",
     "curl_upload_request_integration_test.cc",
     "curl_download_request_integration_test.cc",
+    "curl_nosignal_integration_test.cc",
     "curl_request_integration_test.cc",
     "curl_resumable_streambuf_integration_test.cc",
     "curl_resumable_upload_session_integration_test.cc",


### PR DESCRIPTION
TIL: libcurl uses signals to perform timeouts by default. This change
disables the signals for all the handles we create, per the
documentation on:

https://curl.haxx.se/libcurl/c/CURLOPT_NOSIGNAL.html

I will try to write a regression test later, though it might be hard
because it requires "waiting for a couple of minutes" to get the
signal.

In any case, given the documentation, and the fact that there is a bug
report (#2225) associated with this, I believe we should incorporate
these fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2226)
<!-- Reviewable:end -->
