### PR TITLE
Fix hmac key snippets

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2282,10 +2282,10 @@ class Client {
    * This is a read-only operation and is always idempotent.
    *
    * @par Example
-   * storage_service_account_samples.cc list hmac keys
+   * @snippet storage_service_account_samples.cc list hmac keys
    *
    * @par Example
-   * storage_service_account_samples.cc list hmac keys with service account
+   * @snippet storage_service_account_samples.cc list hmac keys with service account
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.
@@ -2323,10 +2323,10 @@ class Client {
    * key each time.
    *
    * @par Example
-   * storage_service_account_samples.cc create hmac key
+   * @snippet storage_service_account_samples.cc create hmac key
    *
    * @par Example
-   * storage_service_account_samples.cc create hmac key project
+   * @snippet storage_service_account_samples.cc create hmac key project
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.
@@ -2365,7 +2365,7 @@ class Client {
    * key, calling the operation multiple times can succeed only once.
    *
    * @par Example
-   * storage_service_account_samples.cc delete hmac key
+   * @snippet storage_service_account_samples.cc delete hmac key
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.
@@ -2397,7 +2397,7 @@ class Client {
    * This is a read-only operation and therefore it is always idempotent.
    *
    * @par Example
-   * storage_service_account_samples.cc get hmac key
+   * @snippet storage_service_account_samples.cc get hmac key
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.
@@ -2433,7 +2433,7 @@ class Client {
    * is set, or if the `IfMatchEtag` option is set.
    *
    * @par Example
-   * storage_service_account_samples.cc update hmac key
+   * @snippet storage_service_account_samples.cc update hmac key
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2285,7 +2285,7 @@ class Client {
    * @snippet storage_service_account_samples.cc list hmac keys
    *
    * @par Example
-   * @snippet storage_service_account_samples.cc list hmac keys with service account
+   * @snippet storage_service_account_samples.cc list hmac keys service account
    *
    * @see https://cloud.google.com/iam/docs/service-accounts for general
    *     information on Google Cloud Platform service accounts.

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -125,7 +125,7 @@ void ListHmacKeysWithServiceAccount(google::cloud::storage::Client client,
   if (argc != 2) {
     throw Usage{"list-hmac-keys-with-service-account <service-account>"};
   }
-  //! [list hmac keys with service account]
+  //! [list hmac keys service account]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string service_account) {
@@ -146,7 +146,7 @@ void ListHmacKeysWithServiceAccount(google::cloud::storage::Client client,
                 << " in default project\n";
     }
   }
-  //! [list hmac keys with service account]
+  //! [list hmac keys service account]
   (std::move(client), argv[1]);
 }
 

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -142,7 +142,8 @@ void ListHmacKeysWithServiceAccount(google::cloud::storage::Client client,
       ++count;
     }
     if (count == 0) {
-      std::cout << "No HMAC keys in default project\n";
+      std::cout << "No HMAC keys for service account " << service_account
+                << " in default project\n";
     }
   }
   //! [list hmac keys with service account]


### PR DESCRIPTION
I forgot the magic incantation to turn code snippets into actual
snippets.

### Before

https://googleapis.github.io/google-cloud-cpp/latest/storage/classgoogle_1_1cloud_1_1storage_1_1v0_1_1Client.html#a01bf6147775e115f1e25df1ba3f52ee7


### After

https://coryan.github.io/google-cloud-cpp/0.2227.0/storage/classgoogle_1_1cloud_1_1storage_1_1v0_1_1Client.html#a01bf6147775e115f1e25df1ba3f52ee7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2227)
<!-- Reviewable:end -->
