### PR TITLE
Explicitly include grpcpp/resource_quota.h

### DIFF
--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/status.h"
 #include <grpcpp/grpcpp.h>
+#include <grpcpp/resource_quota.h>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
We are getting grpc::ResourceQuota by accident, we need to IWYU because
this will no longer be the case in the near future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2233)
<!-- Reviewable:end -->
