### PR TITLE
Support g::c::Status in retry and backoff policies.

### DIFF
--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -102,6 +102,11 @@ class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
     return OnCompletionHook(s);
   }
 
+  std::chrono::milliseconds OnCompletion(
+      google::cloud::Status const& s) override {
+    return std::chrono::milliseconds(0);
+  }
+
   std::unique_ptr<RPCBackoffPolicy> clone() const override {
     return std::unique_ptr<RPCBackoffPolicy>();
   }
@@ -118,6 +123,11 @@ class SharedBackoffPolicyMock : public bigtable::RPCBackoffPolicy {
 
   std::chrono::milliseconds OnCompletion(grpc::Status const& s) override {
     return state_->OnCompletion(s);
+  }
+
+  std::chrono::milliseconds OnCompletion(
+      google::cloud::Status const& s) override {
+    return std::chrono::milliseconds(0);
   }
 
   std::unique_ptr<RPCBackoffPolicy> clone() const override {

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -117,6 +117,7 @@ class RetryPolicyMock : public bigtable::RPCRetryPolicy {
   bool OnFailure(grpc::Status const& status) override {
     return OnFailureHook(status);
   }
+  bool OnFailure(google::cloud::Status const& status) override { return true; }
 };
 
 class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
@@ -130,6 +131,10 @@ class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
                std::chrono::milliseconds(grpc::Status const& s));
   std::chrono::milliseconds OnCompletion(grpc::Status const& s) override {
     return OnCompletionHook(s);
+  }
+  std::chrono::milliseconds OnCompletion(
+      google::cloud::Status const& s) override {
+    return std::chrono::milliseconds(0);
   }
 };
 

--- a/google/cloud/bigtable/rpc_backoff_policy.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy.cc
@@ -36,6 +36,11 @@ std::unique_ptr<RPCBackoffPolicy> ExponentialBackoffPolicy::clone() const {
 void ExponentialBackoffPolicy::Setup(grpc::ClientContext&) const {}
 
 std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
+    google::cloud::Status const&) {
+  return impl_.OnCompletion();
+}
+
+std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion(
     grpc::Status const&) {
   return impl_.OnCompletion();
 }

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -64,7 +64,7 @@ class RPCBackoffPolicy {
    * Return the delay after an RPC operation has completed.
    *
    * @return true the delay before trying the operation again.
-   * @param s the status returned by the last RPC operation.
+   * @param status the status returned by the last RPC operation.
    */
   virtual std::chrono::milliseconds OnCompletion(
       google::cloud::Status const& status) = 0;

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -66,6 +66,9 @@ class RPCBackoffPolicy {
    * @return true the delay before trying the operation again.
    * @param s the status returned by the last RPC operation.
    */
+  virtual std::chrono::milliseconds OnCompletion(
+      google::cloud::Status const& status) = 0;
+  // TODO(coryan) - remove ::grpc::Status version.
   virtual std::chrono::milliseconds OnCompletion(grpc::Status const& s) = 0;
 };
 
@@ -85,6 +88,9 @@ class ExponentialBackoffPolicy : public RPCBackoffPolicy {
 
   std::unique_ptr<RPCBackoffPolicy> clone() const override;
   void Setup(grpc::ClientContext& context) const override;
+  std::chrono::milliseconds OnCompletion(
+      google::cloud::Status const& status) override;
+  // TODO(coryan) - remove ::grpc::Status version.
   std::chrono::milliseconds OnCompletion(grpc::Status const& status) override;
 
  private:

--- a/google/cloud/bigtable/rpc_retry_policy.cc
+++ b/google/cloud/bigtable/rpc_retry_policy.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/rpc_retry_policy.h"
+#include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 #include <sstream>
 
 namespace google {
@@ -32,8 +33,13 @@ std::unique_ptr<RPCRetryPolicy> LimitedErrorCountRetryPolicy::clone() const {
 
 void LimitedErrorCountRetryPolicy::Setup(grpc::ClientContext&) const {}
 
-bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
+bool LimitedErrorCountRetryPolicy::OnFailure(
+    google::cloud::Status const& status) {
   return impl_.OnFailure(status);
+}
+
+bool LimitedErrorCountRetryPolicy::OnFailure(grpc::Status const& status) {
+  return impl_.OnFailure(internal::MakeStatusFromRpcError(status));
 }
 
 LimitedTimeRetryPolicy::LimitedTimeRetryPolicy(
@@ -50,8 +56,12 @@ void LimitedTimeRetryPolicy::Setup(grpc::ClientContext& context) const {
   }
 }
 
-bool LimitedTimeRetryPolicy::OnFailure(grpc::Status const& status) {
+bool LimitedTimeRetryPolicy::OnFailure(google::cloud::Status const& status) {
   return impl_.OnFailure(status);
+}
+
+bool LimitedTimeRetryPolicy::OnFailure(grpc::Status const& status) {
+  return impl_.OnFailure(internal::MakeStatusFromRpcError(status));
 }
 
 }  // namespace BIGTABLE_CLIENT_NS


### PR DESCRIPTION
The `google::cloud:bigtable::RpcRetryPolicy` and
`google::cloud:bigtable::BackoffPolicy` classes expect errors
represented by `gprc::Status` objects. But now we are signaling errors
via `future<StatusOr<T>>` so they need to handle `google:cloud:Status`
too.

I expect we will remove the `grpc::Status` functions, but that is a big
change, and should be done (I think) separately.

This change is needed to implement the asynchronous retry loop based
solely on `future<StatusOr<T>>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2237)
<!-- Reviewable:end -->
