### PR TITLE
Update gRPC in Dockerfiles and install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ platforms.
 
 | Library | Minimum version | Description |
 | ------- | --------------: | ----------- |
-| gRPC    | 1.19.1 | gRPC++ for Cloud Bigtable |
+| gRPC    | 1.16.x | gRPC++ for Cloud Bigtable |
 | libcurl | 7.47.0  | HTTP client library for the Google Cloud Storage client |
 | crc32c  | 1.0.6 | Hardware-accelerated CRC32C implementation |
 | OpenSSL | 1.0.2 | Crypto functions for Google Cloud Storage authentication |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,7 @@ platforms.
 
 | Library | Minimum version | Description |
 | ------- | --------------: | ----------- |
-| gRPC    | 1.17.x | gRPC++ for Cloud Bigtable |
+| gRPC    | 1.19.1 | gRPC++ for Cloud Bigtable |
 | libcurl | 7.47.0  | HTTP client library for the Google Cloud Storage client |
 | crc32c  | 1.0.6 | Hardware-accelerated CRC32C implementation |
 | OpenSSL | 1.0.2 | Crypto functions for Google Cloud Storage authentication |
@@ -258,9 +258,9 @@ Then gRPC can be manually installed using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-tar -xf v1.17.2.tar.gz
-cd $HOME/Downloads/grpc-1.17.2
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+tar -xf v1.19.1.tar.gz
+cd $HOME/Downloads/grpc-1.19.1
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 export PATH=/usr/local/bin:${PATH}
@@ -346,9 +346,9 @@ the Google Cloud Platform APIs:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-tar -xf v1.17.2.tar.gz
-cd $HOME/Downloads/grpc-1.17.2
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+tar -xf v1.19.1.tar.gz
+cd $HOME/Downloads/grpc-1.19.1
 make -j $(nproc)
 sudo make install
 sudo ldconfig
@@ -454,9 +454,9 @@ library manually:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-tar -xf v1.17.2.tar.gz
-cd $HOME/Downloads/grpc-1.17.2
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+tar -xf v1.19.1.tar.gz
+cd $HOME/Downloads/grpc-1.19.1
 make -j $(nproc)
 sudo make install
 sudo ldconfig
@@ -608,9 +608,9 @@ library:
 ```bash
 export PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig:/usr/local/curl/lib/pkgconfig
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-tar -xf v1.17.2.tar.gz
-cd $HOME/Downloads/grpc-1.17.2
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+tar -xf v1.19.1.tar.gz
+cd $HOME/Downloads/grpc-1.19.1
 make -j $(nproc)
 sudo make install
 ```
@@ -705,9 +705,9 @@ the Google Cloud Platform APIs:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-tar -xf v1.17.2.tar.gz
-cd $HOME/Downloads/grpc-1.17.2
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+tar -xf v1.19.1.tar.gz
+cd $HOME/Downloads/grpc-1.19.1
 make -j $(nproc)
 sudo make install
 sudo ldconfig
@@ -808,9 +808,9 @@ Can be manually installed using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-tar -xf v1.17.2.tar.gz
-cd $HOME/Downloads/grpc-1.17.2
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+tar -xf v1.19.1.tar.gz
+cd $HOME/Downloads/grpc-1.19.1
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 export PATH=/usr/local/bin:${PATH}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ versions of these dependencies:
 
 | Library | Minimum version |
 | ------- | --------------- |
-| gRPC    | v1.19.1 |
+| gRPC    | v1.16.x |
 | libcurl | 7.47.0  |
 
 #### Tests

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ versions of these dependencies:
 
 | Library | Minimum version |
 | ------- | --------------- |
-| gRPC    | v1.17.x |
+| gRPC    | v1.19.1 |
 | libcurl | 7.47.0  |
 
 #### Tests

--- a/ci/test-readme/Dockerfile.centos
+++ b/ci/test-readme/Dockerfile.centos
@@ -109,9 +109,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-RUN tar -xf v1.17.2.tar.gz
-WORKDIR /var/tmp/build/grpc-1.17.2
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.19.1
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 ENV PATH=/usr/local/bin:${PATH}

--- a/ci/test-readme/Dockerfile.debian
+++ b/ci/test-readme/Dockerfile.debian
@@ -98,9 +98,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-RUN tar -xf v1.17.2.tar.gz
-WORKDIR /var/tmp/build/grpc-1.17.2
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.19.1
 RUN make -j $(nproc)
 RUN make install
 RUN ldconfig

--- a/ci/test-readme/Dockerfile.opensuse-leap
+++ b/ci/test-readme/Dockerfile.opensuse-leap
@@ -117,9 +117,9 @@ RUN zypper refresh && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-RUN tar -xf v1.17.2.tar.gz
-WORKDIR /var/tmp/build/grpc-1.17.2
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.19.1
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 ENV PATH=/usr/local/bin:${PATH}

--- a/ci/test-readme/Dockerfile.ubuntu
+++ b/ci/test-readme/Dockerfile.ubuntu
@@ -90,9 +90,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-RUN tar -xf v1.17.2.tar.gz
-WORKDIR /var/tmp/build/grpc-1.17.2
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.19.1
 RUN make -j $(nproc)
 RUN make install
 RUN ldconfig

--- a/ci/test-readme/Dockerfile.ubuntu-trusty
+++ b/ci/test-readme/Dockerfile.ubuntu-trusty
@@ -161,9 +161,9 @@ RUN make install
 # ```bash
 ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig:/usr/local/curl/lib/pkgconfig
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-RUN tar -xf v1.17.2.tar.gz
-WORKDIR /var/tmp/build/grpc-1.17.2
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.19.1
 RUN make -j $(nproc)
 RUN make install
 # ```

--- a/ci/test-readme/Dockerfile.ubuntu-xenial
+++ b/ci/test-readme/Dockerfile.ubuntu-xenial
@@ -114,9 +114,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.17.2.tar.gz
-RUN tar -xf v1.17.2.tar.gz
-WORKDIR /var/tmp/build/grpc-1.17.2
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
+WORKDIR /var/tmp/build/grpc-1.19.1
 RUN make -j $(nproc)
 RUN make install
 RUN ldconfig

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -51,7 +51,7 @@ platforms.
 
 | Library | Minimum version | Description |
 | ------- | --------------: | ----------- |
-| gRPC    | 1.17.x | gRPC++ for Cloud Bigtable |
+| gRPC    | 1.19.1 | gRPC++ for Cloud Bigtable |
 | libcurl | 7.47.0  | HTTP client library for the Google Cloud Storage client |
 | crc32c  | 1.0.6 | Hardware-accelerated CRC32C implementation |
 | OpenSSL | 1.0.2 | Crypto functions for Google Cloud Storage authentication |

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -51,7 +51,7 @@ platforms.
 
 | Library | Minimum version | Description |
 | ------- | --------------: | ----------- |
-| gRPC    | 1.19.1 | gRPC++ for Cloud Bigtable |
+| gRPC    | 1.16.x | gRPC++ for Cloud Bigtable |
 | libcurl | 7.47.0  | HTTP client library for the Google Cloud Storage client |
 | crc32c  | 1.0.6 | Hardware-accelerated CRC32C implementation |
 | OpenSSL | 1.0.2 | Crypto functions for Google Cloud Storage authentication |

--- a/ci/travis/Dockerfile.ubuntu-install
+++ b/ci/travis/Dockerfile.ubuntu-install
@@ -140,10 +140,10 @@ RUN ldconfig
 # Install gRPC. Note that we use the system's zlib and ssl libraries.
 # For similar reasons to c-ares (see above), we need two install steps.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.16.1.tar.gz
-RUN tar -xf v1.16.1.tar.gz
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
+RUN tar -xf v1.19.1.tar.gz
 RUN ls -l
-WORKDIR /var/tmp/build/grpc-1.16.1
+WORKDIR /var/tmp/build/grpc-1.19.1
 RUN ls -l
 RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \


### PR DESCRIPTION
There were places where `1.17.x` was still being used. Note that it's important we say `1.19.1` and not just `1.19.x` because `1.19.1` contains a vital fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2238)
<!-- Reviewable:end -->
