### PR TITLE
Moving `noex::InstanceAdmin` functions to `InstanceAdmin`

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -86,6 +86,14 @@ class InstanceAdmin {
     return impl_.InstanceName(instance_id);
   }
 
+  /// Return the fully qualified name of the given cluster_id in give
+  /// instance_id.
+  std::string ClusterName(bigtable::InstanceId const& instance_id,
+                          bigtable::ClusterId const& cluster_id) const {
+    return project_name() + "/instances/" + instance_id.get() + "/clusters/" +
+           cluster_id.get();
+  }
+
   /**
    * Create a new instance of Cloud Bigtable.
    *


### PR DESCRIPTION
This commit includes following functions
 - `ListInstances`
 - `GetInstance`
 - `DeleteInstance`
 - `ListClusters`
 - `DeleteCluster`
 - `GetCluster`

Please see #2099 for more insight.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2241)
<!-- Reviewable:end -->
