### PR TITLE
Disable signals in libcurl.

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -119,6 +119,7 @@ void CurlDownloadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
   if (!payload_.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -44,6 +44,7 @@ void CurlRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -102,6 +102,7 @@ void CurlUploadRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         this->response_payload_.append(static_cast<char*>(ptr), size * nmemb);


### PR DESCRIPTION
TIL: libcurl uses signals to perform timeouts by default. This change
disables the signals for all the handles we create, per the
documentation on:

https://curl.haxx.se/libcurl/c/CURLOPT_NOSIGNAL.html

I will try to write a regression test later, though it might be hard
because it requires "waiting for a couple of minutes" to get the
signal.

In any case, given the documentation, and the fact that there is a bug
report (#2225) associated with this, I believe we should incorporate
these fixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2248)
<!-- Reviewable:end -->
