### PR TITLE
Moving functions from noex::InstanceAdmin to InstanceAdmin

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -549,6 +549,20 @@ class InstanceAdmin {
       AppProfileUpdateConfig config);
 
  private:
+  static inline google::cloud::IamPolicy ProtoToWrapper(
+      google::iam::v1::Policy proto) {
+    google::cloud::IamPolicy result;
+    result.version = proto.version();
+    result.etag = std::move(*proto.mutable_etag());
+    for (auto& binding : *proto.mutable_bindings()) {
+      for (auto& member : *binding.mutable_members()) {
+        result.bindings.AddMember(binding.role(), std::move(member));
+      }
+    }
+
+    return result;
+  }
+
   noex::InstanceAdmin impl_;
 };
 


### PR DESCRIPTION
Following functions are added with this PR

`CreateAppProfile`
`GetAppProfile`
`UpdateAppProfile`
`ListAppProfiles`
`DeleteAppProfile`
`GetIamPolicy`
`SetIamPolicy`
`TestIamPermissions`

Please see #2099 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2251)
<!-- Reviewable:end -->
