### PR TITLE
Implement asynchronous retry loop for simple RPCs.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -335,6 +335,7 @@ if (BUILD_TESTING)
         internal/async_retry_multi_page_test.cc
         internal/async_retry_op_test.cc
         internal/async_retry_unary_rpc_and_poll_test.cc
+        internal/async_retry_unary_rpc_test.cc
         internal/bulk_mutator_test.cc
         internal/table_async_check_and_mutate_row_test.cc
         internal/instance_admin_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -44,6 +44,7 @@ bigtable_client_unit_tests = [
     "internal/async_retry_multi_page_test.cc",
     "internal/async_retry_op_test.cc",
     "internal/async_retry_unary_rpc_and_poll_test.cc",
+    "internal/async_retry_unary_rpc_test.cc",
     "internal/bulk_mutator_test.cc",
     "internal/table_async_check_and_mutate_row_test.cc",
     "internal/instance_admin_test.cc",

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -221,8 +221,8 @@ class RetryAsyncUnaryRpcFuture {
    * @param cq the completion queue where the retry loop is executed.
    * @return a future that becomes satisfied when (a) one of the retry attempts
    *     is successful, or (b) one of the retry attempts fails with a
-   *     retryable error, or (c) one of the retry attempts fails with a
-   *     non-retryable error, but the request is non-idempotent, or (d) the
+   *     non-retryable error, or (c) one of the retry attempts fails with a
+   *     retryable error, but the request is non-idempotent, or (d) the
    *     retry policy is expired.
    */
   static future<StatusOr<Response>> Start(
@@ -341,8 +341,8 @@ class RetryAsyncUnaryRpcFuture {
  *
  * @return a future that becomes satisfied when (a) one of the retry attempts
  *     is successful, or (b) one of the retry attempts fails with a
- *     retryable error, or (c) one of the retry attempts fails with a
- *     non-retryable error, but the request is non-idempotent, or (d) the
+ *     non-retryable error, or (c) one of the retry attempts fails with a
+ *     retryable error, but the request is non-idempotent, or (d) the
  *     retry policy is expired.
  */
 template <

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -343,8 +343,7 @@ future<StatusOr<ResponseType>> StartRetryAsyncUnaryRpc(
                                 std::move(rpc_backoff_policy),
                                 std::move(idempotent_policy),
                                 std::move(metadata_update_policy),
-                                std::move(async_call),
-                                std::move(request),
+                                std::move(async_call), std::move(request),
                                 std::move(cq));
 }
 

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc.h
@@ -170,6 +170,162 @@ class EmptyResponseAdaptor {
   Functor callback_;
 };
 
+/**
+ * Make an asynchronous unary RPC with retries.
+ *
+ * This class creates a future<> that becomes satisfied when an asynchronous
+ * operation either:
+ *
+ * - Succeeds.
+ * - Fails with a non-retryable error.
+ * - The retry policy expires.
+ *
+ * The class retries the operation, using a backoff policy to wait between
+ * retries. The class does not block, it uses the completion queue to wait.
+ *
+ * @tparam AsyncCallType the type of the callable used to start the asynchronous
+ *     operation. This is typically a lambda that wraps both the `Client` object
+ *     and the member function to invoke.
+ * @tparam RequestType the type of the request object.
+ * @tparam IdempotencyPolicy the type of the idempotency policy.
+ * @tparam Sig discover the signature and return type of `AsyncCallType`.
+ * @tparam ResponseType the discovered response type for `AsyncCallType`.
+ * @tparam validate_parameters validate the other template parameters.
+ */
+template <
+    typename AsyncCallType, typename RequestType, typename IdempotencyPolicy,
+    typename Sig = internal::AsyncCallResponseType<AsyncCallType, RequestType>,
+    typename ResponseType = typename Sig::type,
+    typename std::enable_if<Sig::value, int>::type validate_parameters = 0>
+class RetryAsyncUnaryRpcFuture {
+ public:
+  //@{
+  /// @name Convenience aliases for the RPC request response and callback types.
+  using Request = RequestType;
+  using Response = ResponseType;
+  //@}
+
+  /**
+   * Start the asynchronous retry loop.
+   *
+   * @param location typically the name of the function that created this
+   *     asynchronous retry loop.
+   * @param rpc_retry_policy controls the number of retries, and what errors are
+   *     considered retryable.
+   * @param rpc_backoff_policy determines the wait time between retries.
+   * @param idempotent_policy determines if a request is retryable.
+   * @param metadata_update_policy controls how to update the metadata fields in
+   *     the request.
+   * @param async_call the callable to start a new asynchronous operation.
+   * @param request the parameters of the request.
+   * @param cq the completion queue where the retry loop is executed.
+   * @return a future that becomes satisfied when (a) one of the retry attempts
+   *     is successful, or (b) one of the retry attempts fails with a
+   *     retryable error, or (c) one of the retry attempts fails with a
+   *     retryable error, but the request is non-idempotent, or (d) the retry
+   *     policy is expired.
+   */
+  static future<StatusOr<Response>> Start(
+      char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+      IdempotencyPolicy idempotent_policy,
+      MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
+      Request&& request, CompletionQueue cq) {
+    std::shared_ptr<RetryAsyncUnaryRpcFuture> self(new RetryAsyncUnaryRpcFuture(
+        location, std::move(rpc_retry_policy), std::move(rpc_backoff_policy),
+        std::move(idempotent_policy), std::move(metadata_update_policy),
+        async_call, std::forward<Request>(request)));
+    auto future = self->final_result_.get_future();
+    self->StartIteration(self, cq);
+    return future;
+  }
+
+ private:
+  // The constructor is private because we always want to wrap the object in
+  // a shared pointer. The lifetime is controlled by any pending operations in
+  // the CompletionQueue.
+  RetryAsyncUnaryRpcFuture(char const* location,
+                           std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+                           std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+                           IdempotencyPolicy idempotent_policy,
+                           MetadataUpdatePolicy metadata_update_policy,
+                           AsyncCallType async_call, Request&& request)
+      : location_(location),
+        rpc_retry_policy_(std::move(rpc_retry_policy)),
+        rpc_backoff_policy_(std::move(rpc_backoff_policy)),
+        idempotent_policy_(std::move(idempotent_policy)),
+        metadata_update_policy_(std::move(metadata_update_policy)),
+        async_call_(std::move(async_call)),
+        request_(std::move(request)) {}
+
+  /// The callback for a completed request, successful or not.
+  void OnCompletion(std::shared_ptr<RetryAsyncUnaryRpcFuture> self,
+                    CompletionQueue cq, StatusOr<Response> result) {
+    if (result) {
+      final_result_.set_value(std::move(result));
+      return;
+    }
+    if (!idempotent_policy_.is_idempotent()) {
+      Status detailed_status(
+          result.status().code(),
+          FullErrorMessage("non-idempotent operation failed", result.status()));
+      final_result_.set_value(std::move(detailed_status));
+      return;
+    }
+    if (!rpc_retry_policy_->OnFailure(result.status())) {
+      std::string full_message =
+          FullErrorMessage(RPCRetryPolicy::IsPermanentFailure(result.status())
+                               ? "permanent error"
+                               : "too many transient errors",
+                           result.status());
+      Status detailed_status(result.status().code(), full_message);
+      final_result_.set_value(std::move(detailed_status));
+      return;
+    }
+    cq.MakeRelativeTimer(rpc_backoff_policy_->OnCompletion(result.status()))
+        .then([self, cq](future<std::chrono::system_clock::time_point>) {
+          self->StartIteration(self, cq);
+        });
+  }
+
+  /// The callback to start another iteration of the retry loop.
+  void StartIteration(std::shared_ptr<RetryAsyncUnaryRpcFuture> self,
+                      CompletionQueue cq) {
+    auto context =
+        ::google::cloud::internal::make_unique<grpc::ClientContext>();
+    self->rpc_retry_policy_->Setup(*context);
+    self->rpc_backoff_policy_->Setup(*context);
+    self->metadata_update_policy_.Setup(*context);
+
+    cq.MakeUnaryRpc(async_call_, request_, std::move(context))
+        .then([self, cq](future<StatusOr<Response>> fut) {
+          self->OnCompletion(self, cq, fut.get());
+        });
+  }
+
+  /// Generate an error message
+  std::string FullErrorMessage(char const* where, Status const& status) {
+    std::string full_message = location_;
+    full_message += "(" + metadata_update_policy_.value() + ") ";
+    full_message += where;
+    full_message += ", last error=";
+    full_message += status.message();
+    return full_message;
+  }
+
+  char const* location_;
+  std::unique_ptr<RPCRetryPolicy> rpc_retry_policy_;
+  std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
+  IdempotencyPolicy idempotent_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
+
+  AsyncCallType async_call_;
+  Request request_;
+  Response response_;
+
+  promise<StatusOr<Response>> final_result_;
+};
+
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
@@ -61,7 +61,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
         // Initialize a value to make sure it is carried all the way back to
         // the caller.
         table->set_name("fake/table/name/response");
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(client, AsyncGetTable(_, _, _))

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/async_retry_unary_rpc.h"
+#include "google/cloud/bigtable/testing/mock_completion_queue.h"
+#include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+namespace {
+
+namespace btadmin = ::google::bigtable::admin::v2;
+using ::testing::_;
+using ::testing::Invoke;
+
+class MockClient {
+ public:
+  MOCK_METHOD3(
+      AsyncGetTable,
+      std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(
+          grpc::ClientContext*, btadmin::GetTableRequest const&,
+          grpc::CompletionQueue* cq));
+
+  MOCK_METHOD3(AsyncDeleteTable,
+               std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                   google::protobuf::Empty>>(grpc::ClientContext*,
+                                             btadmin::DeleteTableRequest const&,
+                                             grpc::CompletionQueue* cq));
+};
+
+TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
+  using namespace google::cloud::testing_util::chrono_literals;
+
+  MockClient client;
+
+  using ReaderType =
+      ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+          btadmin::Table>;
+  auto reader = google::cloud::internal::make_unique<ReaderType>();
+  EXPECT_CALL(*reader, Finish(_, _, _))
+      .WillOnce(Invoke([](btadmin::Table* table, grpc::Status* status, void*) {
+        // Initialize a value to make sure it is carried all the way back to
+        // the caller.
+        table->set_name("fake/table/name/response");
+        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+      }));
+
+  EXPECT_CALL(client, AsyncGetTable(_, _, _))
+      .WillOnce(Invoke([&reader](grpc::ClientContext*,
+                                 btadmin::GetTableRequest const& request,
+                                 grpc::CompletionQueue*) {
+        EXPECT_EQ("fake/table/name/request", request.name());
+        return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+            // This is safe, see comments in MockAsyncResponseReader.
+            btadmin::Table>>(reader.get());
+      }));
+
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  bigtable::CompletionQueue cq(impl);
+
+  // Do some basic initialization of the request to verify the values get
+  // carried to the mock.
+  btadmin::GetTableRequest request;
+  request.set_name("fake/table/name/request");
+
+  auto fut = StartRetryAsyncUnaryRpc(
+      __func__, LimitedErrorCountRetryPolicy(3).clone(),
+      ExponentialBackoffPolicy(10_us, 40_us).clone(),
+      ConstantIdempotencyPolicy(true),
+      MetadataUpdatePolicy("resource", MetadataParamTypes::RESOURCE),
+      [&client](grpc::ClientContext* context,
+                btadmin::GetTableRequest const& request,
+                grpc::CompletionQueue* cq) {
+        return client.AsyncGetTable(context, request, cq);
+      },
+      request, cq);
+
+  EXPECT_EQ(1U, impl->size());
+  impl->SimulateCompletion(cq, true);
+
+  EXPECT_TRUE(impl->empty());
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/testing/mock_completion_queue.h"
 #include "google/cloud/bigtable/testing/mock_mutate_rows_reader.h"
 #include "google/cloud/testing_util/chrono_literals.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <gmock/gmock.h>
 #include <thread>
@@ -98,6 +99,9 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
 
   EXPECT_TRUE(impl->empty());
   EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  auto result = fut.get();
+  ASSERT_STATUS_OK(result);
+  EXPECT_EQ("fake/table/name/response", result->name());
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_test.cc
@@ -180,28 +180,25 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
 
   EXPECT_CALL(client, AsyncGetTable(_, _, _))
       .WillOnce(Invoke([&r1](grpc::ClientContext*,
-                                   btadmin::GetTableRequest const& request,
-                                   grpc::CompletionQueue*) {
+                             btadmin::GetTableRequest const& request,
+                             grpc::CompletionQueue*) {
         EXPECT_EQ("fake/table/name/request", request.name());
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(
-            r1.get());
+            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(r1.get());
       }))
       .WillOnce(Invoke([&r2](grpc::ClientContext*,
                              btadmin::GetTableRequest const& request,
                              grpc::CompletionQueue*) {
         EXPECT_EQ("fake/table/name/request", request.name());
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(
-            r2.get());
+            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(r2.get());
       }))
       .WillOnce(Invoke([&r3](grpc::ClientContext*,
                              btadmin::GetTableRequest const& request,
                              grpc::CompletionQueue*) {
         EXPECT_EQ("fake/table/name/request", request.name());
         return std::unique_ptr<
-            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(
-            r3.get());
+            grpc::ClientAsyncResponseReaderInterface<btadmin::Table>>(r3.get());
       }));
 
   auto impl = std::make_shared<testing::MockCompletionQueue>();

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -87,7 +87,8 @@ future<StatusOr<google::bigtable::admin::v2::Table>> TableAdmin::AsyncGetTable(
                google::bigtable::admin::v2::GetTableRequest const& request,
                grpc::CompletionQueue* cq) {
         return client->AsyncGetTable(context, request, cq);
-      }, std::move(request), cq);
+      },
+      std::move(request), cq);
 }
 
 StatusOr<std::vector<btadmin::Table>> TableAdmin::ListTables(

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/bigtable/grpc_error.h"
 #include "google/cloud/bigtable/internal/async_future_from_callback.h"
+#include "google/cloud/bigtable/internal/async_retry_unary_rpc.h"
 #include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 #include "google/cloud/bigtable/internal/poll_longrunning_operation.h"
 #include "google/cloud/bigtable/internal/unary_client_utils.h"
@@ -73,14 +74,25 @@ TableAdmin::AsyncCreateTable(CompletionQueue& cq, std::string table_id,
 future<StatusOr<google::bigtable::admin::v2::Table>> TableAdmin::AsyncGetTable(
     CompletionQueue& cq, std::string const& table_id,
     btadmin::Table::View view) {
-  promise<StatusOr<google::bigtable::admin::v2::Table>> p;
-  auto result = p.get_future();
+  google::bigtable::admin::v2::GetTableRequest request{};
+  request.set_name(TableName(table_id));
+  request.set_view(view);
 
-  impl_.AsyncGetTable(
-      cq, internal::MakeAsyncFutureFromCallback(std::move(p), "AsyncGetTable"),
-      table_id, view);
+  auto client = impl_.client_;
+  auto async_call =
+      [client](grpc::ClientContext* context,
+               google::bigtable::admin::v2::GetTableRequest const& request,
+               grpc::CompletionQueue* cq) {
+        return client->AsyncGetTable(context, request, cq);
+      };
 
-  return result;
+  return internal::RetryAsyncUnaryRpcFuture<
+      decltype(async_call), google::bigtable::admin::v2::GetTableRequest,
+      internal::ConstantIdempotencyPolicy>::
+      Start(__func__, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
+            internal::ConstantIdempotencyPolicy(true),
+            clone_metadata_update_policy(), std::move(async_call),
+            std::move(request), cq);
 }
 
 StatusOr<std::vector<btadmin::Table>> TableAdmin::ListTables(

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -454,6 +454,22 @@ class TableAdmin {
       bigtable::SnapshotId const& snapshot_id, std::string table_id);
 
  private:
+  std::unique_ptr<RPCRetryPolicy> clone_rpc_retry_policy() {
+    return impl_.rpc_retry_policy_->clone();
+  }
+
+  std::unique_ptr<RPCBackoffPolicy> clone_rpc_backoff_policy() {
+    return impl_.rpc_backoff_policy_->clone();
+  }
+
+  MetadataUpdatePolicy clone_metadata_update_policy() {
+    return impl_.metadata_update_policy_;
+  }
+
+  std::unique_ptr<PollingPolicy> clone_polling_policy() {
+    return impl_.polling_policy_->clone();
+  }
+
   noex::TableAdmin impl_;
 };
 


### PR DESCRIPTION
This PR implements an asynchronous retry loop for simple (unary) RPCs.

The loop calls `CompletionQueue::MakeAsyncRpc`, on retryable failures it
sets a timer (based on the `RPCBackoffPolicy`) and tries again when the
timer expires.  If the `RPCRetryPolicy` is exhausted, or if the operation is
non-idempotent, or if the error is not retryable then the operation fails, and
the last error is reported back to the application (via an `future<StatusOr<T>>`).

In addition to implementing a unit test for the retry function, I modified
`TableAdmin::GetTable` to serve as a template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2252)
<!-- Reviewable:end -->
