### PR TITLE
Implement TableAdmin::AsyncDeleteTable().

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -255,6 +255,8 @@ function run_all_table_admin_async_examples {
       "${project_id}" "${INSTANCE}" "${TABLE}"
   run_example ./table_admin_async_snippets async-get-table \
       "${project_id}" "${INSTANCE}" "${TABLE}"
+ run_example ./table_admin_async_snippets async-delete-table \
+      "${project_id}" "${INSTANCE}" "${TABLE}"
 
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -109,6 +109,33 @@ void AsyncGetTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1]);
 }
 
+void AsyncDeleteTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+                      std::vector<std::string> argv) {
+  if (argv.size() != 2U) {
+    throw Usage{"async-delete-table: <project-id> <instance-id> <table-id>"};
+  }
+
+  //! [async delete table]
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id) {
+    google::cloud::future<google::cloud::Status> future =
+        admin.AsyncDeleteTable(cq, table_id);
+
+    auto final =
+        future.then([table_id](google::cloud::future<google::cloud::Status> f) {
+          auto status = f.get();
+          if (!status.ok()) {
+            throw std::runtime_error(status.message());
+          }
+          std::cout << "Successfully deleted table: " << table_id << "\n";
+        });
+
+    final.get();
+  }
+  //! [async delete table]
+  (std::move(admin), std::move(cq), argv[1]);
+}
+
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -119,6 +146,7 @@ int main(int argc, char* argv[]) try {
   std::map<std::string, CommandType> commands = {
       {"async-create-table", &AsyncCreateTable},
       {"async-get-table", &AsyncGetTable},
+      {"async-delete-table", &AsyncDeleteTable},
   };
 
   google::cloud::bigtable::CompletionQueue cq;

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -164,6 +164,32 @@ Status TableAdmin::DeleteTable(std::string const& table_id) {
   return internal::MakeStatusFromRpcError(status);
 }
 
+future<Status> TableAdmin::AsyncDeleteTable(CompletionQueue& cq,
+                                            std::string const& table_id) {
+  grpc::Status status;
+  btadmin::DeleteTableRequest request;
+  request.set_name(TableName(table_id));
+
+  MetadataUpdatePolicy metadata_update_policy(
+      instance_name(), MetadataParamTypes::NAME, table_id);
+
+  auto client = impl_.client_;
+  return internal::StartRetryAsyncUnaryRpc(
+             __func__, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
+             internal::ConstantIdempotencyPolicy(true),
+             clone_metadata_update_policy(),
+             [client](
+                 grpc::ClientContext* context,
+                 google::bigtable::admin::v2::DeleteTableRequest const& request,
+                 grpc::CompletionQueue* cq) {
+               return client->AsyncDeleteTable(context, request, cq);
+             },
+             std::move(request), cq)
+      .then([](future<StatusOr<google::protobuf::Empty>> r) {
+        return r.get().status();
+      });
+}
+
 StatusOr<btadmin::Table> TableAdmin::ModifyColumnFamilies(
     std::string const& table_id,
     std::vector<ColumnFamilyModification> modifications) {

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -225,6 +225,24 @@ class TableAdmin {
   Status DeleteTable(std::string const& table_id);
 
   /**
+   * Start a request to asynchronously delete a table.
+   *
+   * @param cq the completion queue that will execute the asynchronous calls,
+   *     the application must ensure that one or more threads are blocked on
+   *     `cq.Run()`.
+   * @param table_id the id of the table within the instance associated with
+   *     this object. The full name of the table is
+   *     `this->instance_name() + "/tables/" + table_id`
+   *
+   * @return status of the operation.
+   *
+   * @par Example
+   * @snippet table_admin_async_snippets.cc async delete table
+   */
+  future<Status> AsyncDeleteTable(CompletionQueue& cq,
+                                  std::string const& table_id);
+
+  /**
    * Modify the schema for an existing table.
    *
    * @param table_id the id of the table within the instance associated with

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -106,6 +106,12 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
             };
             EXPECT_EQ(1, count_matching_families(*get_result, "fam"));
             EXPECT_EQ(1, count_matching_families(*get_result, "foo"));
+
+            return table_admin_->AsyncDeleteTable(cq, table_id);
+          })
+          .then([&](future<Status> fut) {
+            Status delete_result = fut.get();
+            EXPECT_STATUS_OK(delete_result);
           });
 
   chain.get();


### PR DESCRIPTION
This implements `TableAdmin::AsyncDeleteTable()`, the integration test,
and an example. No unit test is needed because that would just duplicate
the existing unit tests for `internal::AsyncRetryUnaryRpc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2258)
<!-- Reviewable:end -->
