### PR TITLE
Do not construct an OK grpc::Status with an error message

### DIFF
--- a/google/cloud/bigtable/completion_queue_test.cc
+++ b/google/cloud/bigtable/completion_queue_test.cc
@@ -304,9 +304,8 @@ TEST(CompletionQueueTest, AsyncRpcSimpleStream) {
         r->add_entries()->set_index(2);
       }));
   EXPECT_CALL(*reader, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(client, AsyncMutateRows(_, _, _, _))
       .WillOnce(Invoke([&reader_deleter](grpc::ClientContext*,

--- a/google/cloud/bigtable/completion_queue_test.cc
+++ b/google/cloud/bigtable/completion_queue_test.cc
@@ -140,7 +140,7 @@ TEST(CompletionQueueTest, AyncRpcSimple) {
         // Initialize a value to make sure it is carried all the way back to
         // the caller.
         table->set_name("fake/table/name/response");
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(client, AsyncGetTable(_, _, _))
@@ -168,7 +168,6 @@ TEST(CompletionQueueTest, AyncRpcSimple) {
       [&completion_called](CompletionQueue& cq, btadmin::Table& response,
                            grpc::Status& status) {
         EXPECT_TRUE(status.ok());
-        EXPECT_EQ("mocked-status", status.error_message());
         EXPECT_EQ("fake/table/name/response", response.name());
         completion_called = true;
       });
@@ -306,7 +305,7 @@ TEST(CompletionQueueTest, AsyncRpcSimpleStream) {
       }));
   EXPECT_CALL(*reader, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(client, AsyncMutateRows(_, _, _, _))
@@ -337,7 +336,6 @@ TEST(CompletionQueueTest, AsyncRpcSimpleStream) {
       [&completion_called](CompletionQueue&, grpc::ClientContext&,
                            grpc::Status& result) {
         EXPECT_TRUE(result.ok());
-        EXPECT_EQ("mocked-status", result.error_message());
         completion_called = true;
       });
   // Initially stream is in CREATING state

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -90,8 +90,10 @@ TEST_P(AsyncRetryUnaryRpcAndPollResEndToEnd, EndToEnd) {
       .WillOnce(Invoke([config](longrunning::Operation* response,
                                 grpc::Status* status, void*) {
         response->set_name("create_cluster_op_1");
-        *status =
-            grpc::Status(config.create_clutester_error_code, "mocked-status");
+        *status = config.create_clutester_error_code != grpc::StatusCode::OK
+                      ? grpc::Status(config.create_clutester_error_code,
+                                     "mocked-status")
+                      : grpc::Status::OK;
       }));
   auto get_operation_reader =
       google::cloud::internal::make_unique<MockAsyncLongrunningOpReader>();
@@ -100,7 +102,10 @@ TEST_P(AsyncRetryUnaryRpcAndPollResEndToEnd, EndToEnd) {
         .WillOnce(Invoke([config](longrunning::Operation* response,
                                   grpc::Status* status, void*) {
           if (!config.polling_finished) {
-            *status = grpc::Status(config.polling_error_code, "mocked-status");
+            *status =
+                config.polling_error_code != grpc::StatusCode::OK
+                    ? grpc::Status(config.polling_error_code, "mocked-status")
+                    : grpc::Status::OK;
             return;
           }
           response->set_done(true);
@@ -310,8 +315,10 @@ TEST_P(AsyncRetryUnaryRpcAndPollResCancel, Cancellations) {
       .WillOnce(Invoke([config](longrunning::Operation* response,
                                 grpc::Status* status, void*) {
         response->set_name("create_cluster_op_1");
-        *status =
-            grpc::Status(config.create_clutester_error_code, "mocked-status");
+        *status = config.create_clutester_error_code != grpc::StatusCode::OK
+                      ? grpc::Status(config.create_clutester_error_code,
+                                     "mocked-status")
+                      : grpc::Status::OK;
       }));
   auto get_operation_reader =
       google::cloud::internal::make_unique<MockAsyncLongrunningOpReader>();
@@ -321,7 +328,10 @@ TEST_P(AsyncRetryUnaryRpcAndPollResCancel, Cancellations) {
                                   grpc::Status* status, void*) {
           response->set_done(true);
           if (config.polling_error_code != grpc::StatusCode::OK) {
-            *status = grpc::Status(config.polling_error_code, "mocked-status");
+            *status =
+                config.polling_error_code != grpc::StatusCode::OK
+                    ? grpc::Status(config.polling_error_code, "mocked-status")
+                    : grpc::Status::OK;
           } else {
             btproto::Cluster response_content;
             response_content.set_name("my_newly_created_cluster");

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -509,9 +509,8 @@ TEST(MultipleRowsMutatorTest, SimpleAsync) {
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
 
   EXPECT_CALL(*reader, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client, AsyncMutateRows(_, _, _, _))
       .WillOnce(Invoke([&reader_deleter](grpc::ClientContext*,

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -510,7 +510,7 @@ TEST(MultipleRowsMutatorTest, SimpleAsync) {
 
   EXPECT_CALL(*reader, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client, AsyncMutateRows(_, _, _, _))
@@ -534,7 +534,6 @@ TEST(MultipleRowsMutatorTest, SimpleAsync) {
   mutator.Start(cq, std::move(context),
                 [&](CompletionQueue&, grpc::Status& status) {
                   EXPECT_TRUE(status.ok());
-                  EXPECT_EQ("mocked-status", status.error_message());
                   mutator_finished = true;
                 });
   impl->SimulateCompletion(cq, true);

--- a/google/cloud/bigtable/internal/table_async_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_apply_test.cc
@@ -60,7 +60,7 @@ TEST_F(NoexTableAsyncApplyTest, SuccessAfterOneRetry) {
       .WillOnce(Invoke([&r2_called](btproto::MutateRowResponse* r,
                                     grpc::Status* status, void* tag) {
         r2_called = true;
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   // Because there is a transient failure, we expect two calls.
@@ -121,7 +121,6 @@ TEST_F(NoexTableAsyncApplyTest, SuccessAfterOneRetry) {
   EXPECT_TRUE(impl->empty());
 
   EXPECT_TRUE(capture_status.ok());
-  EXPECT_EQ("mocked-status", capture_status.error_message());
 }
 
 /// @test Verify that noes::Table::AsyncApply() fails on a permanent error.

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -74,7 +74,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
 
   EXPECT_CALL(*reader1, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   // reader2 will confirm only the first mutation (the only one); the mutation
@@ -96,7 +96,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
 
   EXPECT_CALL(*reader2, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
@@ -295,7 +295,7 @@ TEST_F(NoexTableAsyncBulkApplyTest, CancelledInTimer) {
 
   EXPECT_CALL(*reader1, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))

--- a/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/table_async_bulk_apply_test.cc
@@ -73,9 +73,8 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
 
   EXPECT_CALL(*reader1, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   // reader2 will confirm only the first mutation (the only one); the mutation
   // which used to be first should now be confirmed and the mutation which used
@@ -95,9 +94,8 @@ TEST_F(NoexTableAsyncBulkApplyTest, IdempotencyAndRetries) {
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
 
   EXPECT_CALL(*reader2, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
       .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,
@@ -294,9 +292,8 @@ TEST_F(NoexTableAsyncBulkApplyTest, CancelledInTimer) {
       .WillOnce(Invoke([](btproto::MutateRowsResponse* r, void*) {}));
 
   EXPECT_CALL(*reader1, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
       .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,

--- a/google/cloud/bigtable/internal/table_async_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/internal/table_async_check_and_mutate_row_test.cc
@@ -51,7 +51,7 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, Simple) {
       .WillOnce(Invoke([](btproto::CheckAndMutateRowResponse* response,
                           grpc::Status* status, void*) {
         response->set_predicate_matched(true);
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncCheckAndMutateRow(_, _, _))
@@ -86,7 +86,6 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, Simple) {
   EXPECT_TRUE(impl->empty());
 
   EXPECT_TRUE(capture_status.ok());
-  EXPECT_EQ("mocked-status", capture_status.error_message());
 }
 
 /// @test Verify that Table::CheckAndMutateRow() works on failure.
@@ -155,7 +154,7 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, RetryFailure) {
   EXPECT_CALL(*reader_2, Finish(_, _, _))
       .WillOnce(Invoke([](btproto::CheckAndMutateRowResponse* response,
                           grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncCheckAndMutateRow(_, _, _))
@@ -206,7 +205,6 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, RetryFailure) {
   EXPECT_TRUE(impl->empty());
 
   EXPECT_TRUE(capture_status.ok());
-  EXPECT_THAT(capture_status.error_message(), HasSubstr("mocked-status"));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/table_async_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/internal/table_async_check_and_mutate_row_test.cc
@@ -153,9 +153,8 @@ TEST_F(NoexTableAsyncCheckAndMutateRowTest, RetryFailure) {
       google::cloud::internal::make_unique<MockAsyncCheckAndMutateRowReader>();
   EXPECT_CALL(*reader_2, Finish(_, _, _))
       .WillOnce(Invoke([](btproto::CheckAndMutateRowResponse* response,
-                          grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+                          grpc::Status* status,
+                          void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncCheckAndMutateRow(_, _, _))
       .WillOnce(Invoke([&reader_1](grpc::ClientContext*,

--- a/google/cloud/bigtable/internal/table_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/table_async_row_reader_test.cc
@@ -59,9 +59,8 @@ TEST_F(NoexTableAsyncReadRowsTest, Simple) {
       .WillOnce(Invoke([](btproto::ReadRowsResponse* r, void*) {}));
 
   EXPECT_CALL(*reader1, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncReadRows(_, _, _, _))
       .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,
@@ -157,9 +156,8 @@ TEST_F(NoexTableAsyncReadRowsTest, ReadRowsWithRetry) {
       .WillOnce(Invoke([](btproto::ReadRowsResponse* r, void*) {}));
 
   EXPECT_CALL(*reader2, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncReadRows(_, _, _, _))
       .WillOnce(Invoke([&reader_deleter1](grpc::ClientContext*,

--- a/google/cloud/bigtable/internal/table_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/table_async_row_reader_test.cc
@@ -60,7 +60,7 @@ TEST_F(NoexTableAsyncReadRowsTest, Simple) {
 
   EXPECT_CALL(*reader1, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncReadRows(_, _, _, _))
@@ -89,7 +89,6 @@ TEST_F(NoexTableAsyncReadRowsTest, Simple) {
                                          grpc::Status const& status) {
                          EXPECT_TRUE(response);
                          EXPECT_TRUE(status.ok());
-                         EXPECT_EQ("mocked-status", status.error_message());
                          done_op_called = true;
                        },
                        bt::RowSet(), bt::RowReader::NO_ROWS_LIMIT,
@@ -159,7 +158,7 @@ TEST_F(NoexTableAsyncReadRowsTest, ReadRowsWithRetry) {
 
   EXPECT_CALL(*reader2, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncReadRows(_, _, _, _))
@@ -197,7 +196,6 @@ TEST_F(NoexTableAsyncReadRowsTest, ReadRowsWithRetry) {
                                          grpc::Status const& status) {
                          EXPECT_TRUE(response);
                          EXPECT_TRUE(status.ok());
-                         EXPECT_EQ("mocked-status", status.error_message());
                          done_op_called = true;
                        },
                        bt::RowSet(bt::RowRange::Range("0000", "0005")),

--- a/google/cloud/bigtable/internal/table_async_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/internal/table_async_sample_row_keys_test.cc
@@ -61,9 +61,8 @@ TEST_F(NoexTableAsyncSampleRowKeysTest, DefaultParameterTest) {
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r, void*) {}));
 
   EXPECT_CALL(*reader1, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncSampleRowKeys(_, _, _, _))
       .WillOnce(
@@ -150,9 +149,8 @@ TEST_F(NoexTableAsyncSampleRowKeysTest, RetryWorks) {
       .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r, void*) {}));
 
   EXPECT_CALL(*reader2, Finish(_, _))
-      .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status::OK;
-      }));
+      .WillOnce(Invoke(
+          [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
   EXPECT_CALL(*client_, AsyncSampleRowKeys(_, _, _, _))
       .WillOnce(

--- a/google/cloud/bigtable/internal/table_async_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/internal/table_async_sample_row_keys_test.cc
@@ -62,7 +62,7 @@ TEST_F(NoexTableAsyncSampleRowKeysTest, DefaultParameterTest) {
 
   EXPECT_CALL(*reader1, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncSampleRowKeys(_, _, _, _))
@@ -151,7 +151,7 @@ TEST_F(NoexTableAsyncSampleRowKeysTest, RetryWorks) {
 
   EXPECT_CALL(*reader2, Finish(_, _))
       .WillOnce(Invoke([](grpc::Status* status, void*) {
-        *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+        *status = grpc::Status::OK;
       }));
 
   EXPECT_CALL(*client_, AsyncSampleRowKeys(_, _, _, _))

--- a/google/cloud/bigtable/internal/table_test.cc
+++ b/google/cloud/bigtable/internal/table_test.cc
@@ -917,7 +917,6 @@ TEST_F(NoexTableTest, CheckAndMutateRowFailureRetry) {
       {bigtable::SetCell("fam", "col", 0_ms, "it was true")},
       {bigtable::SetCell("fam", "col", 0_ms, "it was false")}, status);
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(status.error_message(), HasSubstr("success"));
 }
 
 /// @test Verify that Table::SampleRows<T>() works for default parameter.

--- a/google/cloud/bigtable/internal/table_test.cc
+++ b/google/cloud/bigtable/internal/table_test.cc
@@ -908,7 +908,7 @@ TEST_F(NoexTableTest, CheckAndMutateRowFailureRetry) {
   EXPECT_CALL(*client_, CheckAndMutateRow(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
-      .WillOnce(Return(grpc::Status(grpc::StatusCode::OK, "success")));
+      .WillOnce(Return(grpc::Status::OK));
   grpc::Status status;
   bigtable::noex::Table table(client_, kTableId,
                               bigtable::AlwaysRetryMutationPolicy());

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -152,7 +152,7 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
 
       EXPECT_CALL(*reader, Finish(_, _))
           .WillOnce(Invoke([](grpc::Status* status, void*) {
-            *status = grpc::Status(grpc::StatusCode::OK, "mocked-status");
+            *status = grpc::Status::OK;
           }));
 
       EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -151,9 +151,8 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
       }
 
       EXPECT_CALL(*reader, Finish(_, _))
-          .WillOnce(Invoke([](grpc::Status* status, void*) {
-            *status = grpc::Status::OK;
-          }));
+          .WillOnce(Invoke(
+              [](grpc::Status* status, void*) { *status = grpc::Status::OK; }));
 
       EXPECT_CALL(*client_, AsyncMutateRows(_, _, _, _))
           .WillOnce(Invoke([reader, exchange](

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -62,7 +62,7 @@ TEST(LimitedTimeRetryPolicy, Simple) {
 /// @test A simple test for grpc::StatusCode::OK is not Permanent Error.
 TEST(LimitedTimeRetryPolicy, PermanentFailureCheck) {
   bigtable::LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
-  EXPECT_FALSE(tested.IsPermanentFailure(grpc::Status::OK))
+  EXPECT_FALSE(tested.IsPermanentFailure(grpc::Status::OK));
   EXPECT_FALSE(tested.IsPermanentFailure(CreateTransientError()));
   EXPECT_TRUE(tested.IsPermanentFailure(CreatePermanentError()));
 }

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -62,8 +62,7 @@ TEST(LimitedTimeRetryPolicy, Simple) {
 /// @test A simple test for grpc::StatusCode::OK is not Permanent Error.
 TEST(LimitedTimeRetryPolicy, PermanentFailureCheck) {
   bigtable::LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
-  EXPECT_FALSE(tested.IsPermanentFailure(
-      grpc::Status(grpc::StatusCode::OK, "No Error")));
+  EXPECT_FALSE(tested.IsPermanentFailure(grpc::Status::OK))
   EXPECT_FALSE(tested.IsPermanentFailure(CreateTransientError()));
   EXPECT_TRUE(tested.IsPermanentFailure(CreatePermanentError()));
 }


### PR DESCRIPTION
grpc::Status says, "It is an error to construct an OK status
with [a] non-empty error_message," so use grpc::Status::OK instead.
Similarly, don't ask for status.error_message() when status.ok().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2259)
<!-- Reviewable:end -->
