### PR TITLE
Break from stream loop early if we encounter an error

### DIFF
--- a/google/cloud/examples/gcs2cbt.cc
+++ b/google/cloud/examples/gcs2cbt.cc
@@ -178,12 +178,9 @@ int main(int argc, char* argv[]) try {
           std::cerr << "Apply failed: " << status;
         }
       };
-  while (!is.eof()) {
+  while (std::getline(is, line, '\n')) {
     ++lineno;
-    std::getline(is, line, '\n');
-    if (!is) {
-      break;
-    }
+
     if (line.empty()) {
       break;
     }
@@ -252,13 +249,9 @@ std::vector<std::string> ParseLine(long lineno, std::string const& line,
 
   // Extract the fields one at a time using a std::istringstream.
   std::istringstream tokens(line);
-  while (!tokens.eof()) {
-    std::string tk;
-    std::getline(tokens, tk, separator);
-    if (!tokens) {
-      break;
-    }
-    result.emplace_back(std::move(tk));
+  std::string tk;
+  while (std::getline(tokens, tk, separator)) {
+    result.emplace_back(tk);
   }
   return result;
 } catch (std::exception const& ex) {

--- a/google/cloud/examples/gcs2cbt.cc
+++ b/google/cloud/examples/gcs2cbt.cc
@@ -181,6 +181,9 @@ int main(int argc, char* argv[]) try {
   while (!is.eof()) {
     ++lineno;
     std::getline(is, line, '\n');
+    if (!is) {
+      break;
+    }
     if (line.empty()) {
       break;
     }
@@ -252,6 +255,9 @@ std::vector<std::string> ParseLine(long lineno, std::string const& line,
   while (!tokens.eof()) {
     std::string tk;
     std::getline(tokens, tk, separator);
+    if (!tokens) {
+      break;
+    }
     result.emplace_back(std::move(tk));
   }
   return result;

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -303,12 +303,8 @@ IterationResult ReadOnce(gcs::Client client, std::string const& bucket_name,
                                gcs::IfGenerationNotMatch(0));
   }
   std::size_t total_size = 0;
-  while (!stream.eof()) {
-    char buf[4096];
-    stream.read(buf, sizeof(buf));
-    if (!stream) {
-      break;
-    }
+  char buf[4096];
+  while (stream.read(buf, sizeof(buf))) {
     total_size += stream.gcount();
   }
   auto elapsed = std::chrono::steady_clock::now() - start;

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -306,6 +306,9 @@ IterationResult ReadOnce(gcs::Client client, std::string const& bucket_name,
   while (!stream.eof()) {
     char buf[4096];
     stream.read(buf, sizeof(buf));
+    if (!stream) {
+      break;
+    }
     total_size += stream.gcount();
   }
   auto elapsed = std::chrono::steady_clock::now() - start;

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -328,12 +328,8 @@ TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
   }
   std::size_t total_size = 0;
   constexpr auto report = kThroughputReportIntervalInChunks * kChunkSize;
-  while (!stream.eof()) {
-    char buf[4096];
-    stream.read(buf, sizeof(buf));
-    if (!stream) {
-      break;
-    }
+  char buf[4096];
+  while (stream.read(buf, sizeof(buf))) {
     if (stream.gcount() == 0) {
       continue;
     }

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -331,6 +331,9 @@ TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
   while (!stream.eof()) {
     char buf[4096];
     stream.read(buf, sizeof(buf));
+    if (!stream) {
+      break;
+    }
     if (stream.gcount() == 0) {
       continue;
     }

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -105,6 +105,9 @@ void ClientOptions::SetupFromEnvironment() {
     while (!is.eof()) {
       std::string token;
       std::getline(is, token, ',');
+      if (!is) {
+        break;
+      }
       enabled.emplace(std::move(token));
     }
     if (enabled.end() != enabled.find("http")) {

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -102,13 +102,9 @@ void ClientOptions::SetupFromEnvironment() {
   if (tracing.has_value()) {
     std::set<std::string> enabled;
     std::istringstream is{*tracing};
-    while (!is.eof()) {
-      std::string token;
-      std::getline(is, token, ',');
-      if (!is) {
-        break;
-      }
-      enabled.emplace(std::move(token));
+    std::string token;
+    while (std::getline(is, token, ',')) {
+      enabled.emplace(token);
     }
     if (enabled.end() != enabled.find("http")) {
       GCP_LOG(INFO) << "Enabling logging for http";

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -148,13 +148,9 @@ class CaptureSendHeaderBackend : public LogBackend {
   void Process(LogRecord const& lr) override {
     // Break the records in lines, because we will analyze the output per line.
     std::istringstream is(lr.message);
-    while (!is.eof()) {
-      std::string line;
-      std::getline(is, line);
-      if (!is) {
-        break;
-      }
-      log_lines.emplace_back(std::move(line));
+    std::string line;
+    while (std::getline(is, line)) {
+      log_lines.emplace_back(line);
     }
   }
 

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -151,6 +151,9 @@ class CaptureSendHeaderBackend : public LogBackend {
     while (!is.eof()) {
       std::string line;
       std::getline(is, line);
+      if (!is) {
+        break;
+      }
       log_lines.emplace_back(std::move(line));
     }
   }

--- a/google/cloud/testing_util/capture_log_lines_backend.cc
+++ b/google/cloud/testing_util/capture_log_lines_backend.cc
@@ -15,6 +15,9 @@ void CaptureLogLinesBackend::Process(LogRecord const& lr) {
   while (!is.eof()) {
     std::string line;
     std::getline(is, line);
+    if (!is) {
+      break;
+    }
     log_lines.emplace_back(std::move(line));
   }
 }

--- a/google/cloud/testing_util/capture_log_lines_backend.cc
+++ b/google/cloud/testing_util/capture_log_lines_backend.cc
@@ -12,13 +12,9 @@ namespace testing_util {
 void CaptureLogLinesBackend::Process(LogRecord const& lr) {
   // Break the records in lines, it is easier to analyze them as such.
   std::istringstream is(lr.message);
-  while (!is.eof()) {
-    std::string line;
-    std::getline(is, line);
-    if (!is) {
-      break;
-    }
-    log_lines.emplace_back(std::move(line));
+  std::string line;
+  while (std::getline(is, line)) {
+    log_lines.emplace_back(line);
   }
 }
 


### PR DESCRIPTION
Fixes #2144

Consider the following. Let's say we are looping over a stream and checking for `eof()`:

```c++
std::string message("hi there i am a message whoo hoo\nhi there i am a message whoo hoo\nhi there i am a message whoo hoo\nhi there i am a message whoo hoo\n");
std::vector<std::string> log_lines;
std::istringstream is(message);

while (!is.eof()) {
  std::string line;
  std::getline(is, line);
  log_lines.emplace_back(std::move(line));
}
```

This will output:

```
hi there i am a message whoo hoo|hi there i am a message whoo hoo|hi there i am a message whoo hoo|hi there i am a message whoo hoo||
```

Notice the extra blank entry at the end. It is incorrect to loop on `eof()` because if an error in the stream occurred, we will do an extra read on an invalid stream before the loop ends. One approach is to refactor the loops but this can result in [performance degradation](http://quick-bench.com/hY0cwQzDf7F3cFc-2IlA0JUDf9I). Instead, we just check the stream state inside the loop and break early.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2261)
<!-- Reviewable:end -->
