### PR TITLE
Refactor MSVC runtime configuration.

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -47,6 +47,9 @@ include(GNUInstallDirs)
 # Discover and add targets for the GTest::gtest and GTest::gmock libraries.
 include(IncludeGMock)
 
+# Pick the right MSVC runtime libraries.
+include(SelectMSVCRuntime)
+
 if (${CMAKE_VERSION} VERSION_LESS "3.9")
 
     # Old versions of CMake have really poor support for Doxygen generation.

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -63,30 +63,6 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
                 "Expected protobuf::libprotobuf target created by FindProtobuf")
     endif ()
 
-    if (VCPKG_TARGET_TRIPLET MATCHES "-static$" AND MSVC)
-        # Replace the runtime flags because all the dependencies are linked
-        # statically in this case.
-        message(STATUS " RELEASE=${CMAKE_CXX_FLAGS_RELEASE}")
-        message(STATUS " DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
-        foreach (flag_var
-                 CMAKE_CXX_FLAGS
-                 CMAKE_CXX_FLAGS_DEBUG
-                 CMAKE_CXX_FLAGS_RELEASE
-                 CMAKE_CXX_FLAGS_MINSIZEREL
-                 CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            if (${flag_var} MATCHES "/MD")
-                string(REGEX
-                       REPLACE "/MD"
-                               "/MT"
-                               ${flag_var}
-                               "${${flag_var}}")
-            endif ()
-        endforeach (flag_var)
-        message(STATUS " RELEASE=${CMAKE_CXX_FLAGS_RELEASE}")
-        message(STATUS " DEBUG=${CMAKE_CXX_FLAGS_DEBUG}")
-        message(STATUS " DEFAULT=${CMAKE_CXX_FLAGS}")
-    endif ()
-
     # The necessary compiler options and definitions are not defined by the
     # targets, we need to add them.
     if (WIN32)

--- a/cmake/SelectMSVCRuntime.cmake
+++ b/cmake/SelectMSVCRuntime.cmake
@@ -1,0 +1,46 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# When compiling against *-static vcpkg packages we need to use the static C++
+# runtime with MSVC. The default is to use the dynamic runtime, which does not
+# work in this case.  This seems to be the recommended way to change the
+# runtime:
+#
+# ~~~
+#  https://gitlab.kitware.com/cmake/community/wikis/FAQ#how-can-i-build-my-msvc-application-with-a-static-runtime
+# ~~~
+#
+# Note that currently we use VCPKG_TARGET_TRIPLET to determine if the static
+# runtime is needed. In the future we may need to use a more complex expression
+# to determine this, but this is a good start.
+#
+if (MSVC AND VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    foreach (flag_var
+             CMAKE_CXX_FLAGS
+             CMAKE_CXX_FLAGS_DEBUG
+             CMAKE_CXX_FLAGS_RELEASE
+             CMAKE_CXX_FLAGS_MINSIZEREL
+             CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+        if (${flag_var} MATCHES "/MD")
+            string(REGEX
+                   REPLACE "/MD"
+                           "/MT"
+                           ${flag_var}
+                           "${${flag_var}}")
+        endif ()
+    endforeach (flag_var)
+    unset(flag_var)
+endif ()


### PR DESCRIPTION
We had this in the gRPC config, but there is nothing gRPC specific about
it, and we will need it in a separate file for the `googleapis`
submodule removal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2268)
<!-- Reviewable:end -->
