### PR TITLE
Use standard name for grpc_cpp_plugin target.

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -146,11 +146,11 @@ function (GRPC_GENERATE_CPP_BASE SRCS HDRS MHDRS WITH_MOCK)
             COMMAND
                 $<TARGET_FILE:protobuf::protoc>
                 ARGS
-                --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
+                --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
                 --grpc_out=${GRPC_OUT_EXTRA}${CMAKE_CURRENT_BINARY_DIR}
                 --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path}
                                                       ${FIL}
-            DEPENDS ${FIL} protobuf::protoc grpc_cpp_plugin
+            DEPENDS ${FIL} protobuf::protoc gRPC::grpc_cpp_plugin
             COMMENT "Running gRPC++ protocol buffer compiler on ${FIL}"
             VERBATIM)
     endforeach ()

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -86,7 +86,9 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
-    add_executable(gRPC::grpc_cpp_plugin IMPORTED)
+    if (NOT TARGET gRPC::grpc_cpp_plugin)
+        add_executable(gRPC::grpc_cpp_plugin IMPORTED)
+    endif ()
     set_property(TARGET gRPC::grpc_cpp_plugin
                  PROPERTY IMPORTED_LOCATION ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE})
 

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -86,8 +86,8 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
-    add_executable(grpc_cpp_plugin IMPORTED)
-    set_property(TARGET grpc_cpp_plugin
+    add_executable(gRPC::grpc_cpp_plugin IMPORTED)
+    set_property(TARGET gRPC::grpc_cpp_plugin
                  PROPERTY IMPORTED_LOCATION ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE})
 
     if ("${Protobuf_IMPORT_DIRS}" STREQUAL "")
@@ -124,8 +124,8 @@ elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config")
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Release
             ${PROTOBUF_SRC_ROOT_FOLDER}/vsprojects/${_PROTOBUF_ARCH_DIR}Debug)
     mark_as_advanced(PROTOC_GRPCPP_PLUGIN_EXECUTABLE)
-    add_executable(grpc_cpp_plugin IMPORTED)
-    set_property(TARGET grpc_cpp_plugin
+    add_executable(gRPC::grpc_cpp_plugin IMPORTED)
+    set_property(TARGET gRPC::grpc_cpp_plugin
                  PROPERTY IMPORTED_LOCATION ${PROTOC_GRPCPP_PLUGIN_EXECUTABLE})
 
 endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -133,9 +133,10 @@ if (NOT TARGET gprc_project)
     add_dependencies(protoc protobuf_project)
     set_executable_name_for_external_project(protoc protoc)
 
-    add_executable(grpc_cpp_plugin IMPORTED)
-    add_dependencies(grpc_cpp_plugin grpc_project)
-    set_executable_name_for_external_project(grpc_cpp_plugin grpc_cpp_plugin)
+    add_executable(gRPC::grpc_cpp_plugin IMPORTED)
+    add_dependencies(gRPC::grpc_cpp_plugin grpc_project)
+    set_executable_name_for_external_project(gRPC::grpc_cpp_plugin
+                                             grpc_cpp_plugin)
 
     list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_BINARY_DIR}/external/include")
 endif ()


### PR DESCRIPTION
gRPC creates a gRPC::grpc_cpp_plugin target, so why create a target with
a different name for the same thing? Note that sometimes we need to
create the target ourselves, maybe because the gRPC library does not
have CMake-config files installed. But even then, we should just use the
standard name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2270)
<!-- Reviewable:end -->
