### PR TITLE
Pass NCPU to external projects.

### DIFF
--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -125,7 +125,7 @@ fi
 # scan-build disabled we compile everything, to test the build as most
 # developers will experience it.
 echo "${COLOR_YELLOW}Started build at: $(date)${COLOR_RESET}"
-${CMAKE_COMMAND} --build "${BUILD_OUTPUT}" -- -j ${NCPU}
+env GOOGLE_CLOUD_CPP_NCPU=${NCPU} ${CMAKE_COMMAND} --build "${BUILD_OUTPUT}" -- -j ${NCPU}
 echo "${COLOR_YELLOW}Finished build at: $(date)${COLOR_RESET}"
 
 # If ccache is enabled we want to zero out the statistics because otherwise

--- a/ci/travis/build-docker.sh
+++ b/ci/travis/build-docker.sh
@@ -125,7 +125,7 @@ fi
 # scan-build disabled we compile everything, to test the build as most
 # developers will experience it.
 echo "${COLOR_YELLOW}Started build at: $(date)${COLOR_RESET}"
-env GOOGLE_CLOUD_CPP_NCPU=${NCPU} ${CMAKE_COMMAND} --build "${BUILD_OUTPUT}" -- -j ${NCPU}
+${CMAKE_COMMAND} --build "${BUILD_OUTPUT}" -- -j ${NCPU}
 echo "${COLOR_YELLOW}Finished build at: $(date)${COLOR_RESET}"
 
 # If ccache is enabled we want to zero out the statistics because otherwise

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -134,3 +134,22 @@ function (create_external_project_library_byproduct_list var_name)
 
     set(${var_name} ${_decorated_byproduct_names} PARENT_SCOPE)
 endfunction ()
+
+function (set_external_project_build_parallel_level var_name)
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(${var_name}
+                "--"
+                "-j"
+                "$ENV{GOOGLE_CLOUD_CPP_NCPU}"
+                PARENT_SCOPE)
+        else()
+            include(ProcessorCount)
+            processorcount(NCPU)
+            set(${var_name} "--" "-j" "${NCPU}" PARENT_SCOPE)
+        endif ()
+    else()
+        set(${var_name} "" PARENT_SCOPE)
+    endif ()
+endfunction ()

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -138,12 +138,8 @@ endfunction ()
 function (set_external_project_build_parallel_level var_name)
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(${var_name}
-                "--"
-                "-j"
-                "$ENV{GOOGLE_CLOUD_CPP_NCPU}"
-                PARENT_SCOPE)
+        if (DEFINED ENV{NCPU})
+            set(${var_name} "--" "-j" "$ENV{NCPU}" PARENT_SCOPE)
         else()
             include(ProcessorCount)
             processorcount(NCPU)

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -26,9 +26,9 @@ if (NOT TARGET c_ares_project)
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -24,14 +24,7 @@ if (NOT TARGET c_ares_project)
     set(GOOGLE_CLOUD_CPP_C_ARES_SHA256
         "62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     create_external_project_library_byproduct_list(c_ares_byproducts
                                                    ALWAYS_SHARED "cares")

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -24,9 +24,9 @@ if (NOT TARGET crc32c_project)
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -22,14 +22,7 @@ if (NOT TARGET crc32c_project)
     set(GOOGLE_CLOUD_CPP_CRC32C_SHA256
         "6b3b1d861bb8307658b2407bc7a4c59e566855ef5368a60b35c893551e4788e9")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     create_external_project_library_byproduct_list(crc32c_byproducts "crc32c")
 

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -26,14 +26,7 @@ if (NOT TARGET curl_project)
     set(GOOGLE_CLOUD_CPP_CURL_SHA256
         "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     # When passing a semi-colon delimited list to ExternalProject_Add, we need
     # to escape the semi-colon. Quoting does not work and escaping the semi-

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -26,10 +26,11 @@ if (NOT TARGET curl_project)
     set(GOOGLE_CLOUD_CPP_CURL_SHA256
         "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -26,14 +26,7 @@ if (NOT TARGET googletest_project)
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
         "8d9aa381a6885fe480b7d0ce8ef747a0b8c6ee92f99d74ab07e3503434007cb0")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     create_external_project_library_byproduct_list(googletest_byproducts
                                                    "gtest"

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -26,10 +26,11 @@ if (NOT TARGET googletest_project)
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
         "8d9aa381a6885fe480b7d0ce8ef747a0b8c6ee92f99d74ab07e3503434007cb0")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -27,14 +27,7 @@ if (NOT TARGET gprc_project)
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
         "f869c648090e8bddaa1260a271b1089caccbe735bf47ac9cd7d44d35a02fb129")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     # When passing a semi-colon delimited list to ExternalProject_Add, we need
     # to escape the semi-colon. Quoting does not work and escaping the semi-

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -29,9 +29,9 @@ if (NOT TARGET gprc_project)
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -26,14 +26,7 @@ if (NOT TARGET protobuf_project)
     set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
         "3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     # When passing a semi-colon delimited list to ExternalProject_Add, we need
     # to escape the semi-colon. Quoting does not work and escaping the semi-

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -28,9 +28,9 @@ if (NOT TARGET protobuf_project)
 
     if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
         OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -22,14 +22,7 @@ if (NOT TARGET zlib_project)
     set(GOOGLE_CLOUD_CPP_ZLIB_SHA256
         "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
-            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
-        endif ()
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
     create_external_project_library_byproduct_list(zlib_byproducts "z")
 

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -22,10 +22,11 @@ if (NOT TARGET zlib_project)
     set(GOOGLE_CLOUD_CPP_ZLIB_SHA256
         "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
+        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+        if (DEFINED ENV{GOOGLE_CLOUD_CPP_NCPU})
+            set(PARALLEL "--" "-j" "$ENV{GOOGLE_CLOUD_CPP_NCPU}")
+        endif ()
     else()
         set(PARALLEL "")
     endif ()


### PR DESCRIPTION
Fixes #2262 

Ideally we would use [`CMAKE_BUILD_PARALLEL_LEVEL`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html), but that isn't available until CMake 3.12. Since we can't pass `-j ${NCPU}` to external projects an ad-hoc approach is to use an environment variable. Since CMake takes environment variables from the calling process, we can't just do `export GOOGLE_CLOUD_CPP_NCPU`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2273)
<!-- Reviewable:end -->
