### PR TITLE
Map curl_easy_perform() errors to StatusCode.

### DIFF
--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -70,7 +70,7 @@ class CurlClientTest : public ::testing::Test,
       client_ =
           CurlClient::Create(ClientOptions(oauth2::CreateAnonymousCredentials())
                                  .set_endpoint("http://localhost:0"));
-      expected_status_code_ = StatusCode::kUnknown;
+      expected_status_code_ = StatusCode::kUnavailable;
       expected_status_substr_ = "CURL error";
     } else {
       FAIL() << "Invalid test parameter value: " << error_type


### PR DESCRIPTION
We were mapping all CURLE_* errors to kUnknown, we can do better for at
least some of the errors. This matters because kUnknown is not
retryable, but some of these errors are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2285)
<!-- Reviewable:end -->
