### PR TITLE
Enable presubmit for "test-install" builds.

### DIFF
--- a/ci/kokoro/install/centos-presubmit.cfg
+++ b/ci/kokoro/install/centos-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "centos"
+}

--- a/ci/kokoro/install/debian-presubmit.cfg
+++ b/ci/kokoro/install/debian-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "debian"
+}

--- a/ci/kokoro/install/fedora-presubmit.cfg
+++ b/ci/kokoro/install/fedora-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "fedora"
+}

--- a/ci/kokoro/install/opensuse-leap-presubmit.cfg
+++ b/ci/kokoro/install/opensuse-leap-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "opensuse-leap"
+}

--- a/ci/kokoro/install/opensuse-presubmit.cfg
+++ b/ci/kokoro/install/opensuse-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "opensuse"
+}

--- a/ci/kokoro/install/ubuntu-presubmit.cfg
+++ b/ci/kokoro/install/ubuntu-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu"
+}

--- a/ci/kokoro/install/ubuntu-trusty-presubmit.cfg
+++ b/ci/kokoro/install/ubuntu-trusty-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu-trusty"
+}

--- a/ci/kokoro/install/ubuntu-xenial-presubmit.cfg
+++ b/ci/kokoro/install/ubuntu-xenial-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/install/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "DISTRO"
+  value: "ubuntu-xenial"
+}


### PR DESCRIPTION
I thought we could away without these, but evidently not. A weird
platform specific bug just sneaked by (the openSUSE:Leap build is
broken), and I am about to submit changes to test the installed CMake
modules, and that is very tedious to test without these presubmits.

Note that merging these files will not active the builds, this is
just in preparation for a future change in the internal configuration
for Kokoro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2294)
<!-- Reviewable:end -->
