### PR TITLE
Fix openSUSE build.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -321,6 +321,7 @@ if (BUILD_TESTING)
         internal/bucket_requests_test.cc
         internal/compute_engine_util_test.cc
         internal/curl_client_test.cc
+        internal/curl_handle_test.cc
         internal/curl_resumable_upload_session_test.cc
         internal/curl_wrappers_locking_already_present_test.cc
         internal/curl_wrappers_locking_enabled_test.cc

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -166,6 +166,9 @@ class CurlHandle {
   /// Flushes any debug data using GCP_LOG().
   void FlushDebug(char const* where);
 
+  /// Convert a CURLE_* error code to a google::cloud::Status().
+  static Status AsStatus(CURLcode e, char const* where);
+
  private:
   explicit CurlHandle(CurlPtr ptr) : handle_(std::move(ptr)) {}
 
@@ -174,7 +177,6 @@ class CurlHandle {
   friend class CurlUploadRequest;
   friend class CurlRequestBuilder;
 
-  Status AsStatus(CURLcode e, char const* where);
   [[noreturn]] void ThrowSetOptionError(CURLcode e, CURLoption opt, long param);
   [[noreturn]] void ThrowSetOptionError(CURLcode e, CURLoption opt,
                                         char const* param);

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/curl_handle.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(CurlHandleTest, AsStatus) {
+  struct {
+    CURLcode curl;
+    StatusCode expected;
+  } expected_codes[]{
+      {CURLE_OK, StatusCode::kOk},
+      {CURLE_COULDNT_RESOLVE_HOST, StatusCode::kUnavailable},
+      {CURLE_COULDNT_RESOLVE_PROXY, StatusCode::kUnavailable},
+      {CURLE_COULDNT_CONNECT, StatusCode::kUnavailable},
+      {CURLE_REMOTE_ACCESS_DENIED, StatusCode::kPermissionDenied},
+      {CURLE_OPERATION_TIMEDOUT, StatusCode::kDeadlineExceeded},
+      {CURLE_RANGE_ERROR, StatusCode::kUnimplemented},
+      {CURLE_BAD_DOWNLOAD_RESUME, StatusCode::kInvalidArgument},
+      {CURLE_ABORTED_BY_CALLBACK, StatusCode::kAborted},
+      {CURLE_REMOTE_FILE_NOT_FOUND, StatusCode::kNotFound},
+      {CURLE_FAILED_INIT, StatusCode::kUnknown},
+      {CURLE_FTP_PORT_FAILED, StatusCode::kUnknown},
+      {CURLE_AGAIN, StatusCode::kUnknown},
+  };
+
+  for (auto const& codes : expected_codes) {
+    auto const expected = Status(codes.expected, "ignored");
+    auto const actual = CurlHandle::AsStatus(codes.curl, "in-test");
+    EXPECT_EQ(expected.code(), actual.code());
+    if (!actual.ok()) {
+      EXPECT_THAT(actual.message(), HasSubstr("in-test"));
+      EXPECT_THAT(actual.message(), HasSubstr(curl_easy_strerror(codes.curl)));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -38,6 +38,7 @@ storage_client_unit_tests = [
     "internal/bucket_requests_test.cc",
     "internal/compute_engine_util_test.cc",
     "internal/curl_client_test.cc",
+    "internal/curl_handle_test.cc",
     "internal/curl_resumable_upload_session_test.cc",
     "internal/curl_wrappers_locking_already_present_test.cc",
     "internal/curl_wrappers_locking_enabled_test.cc",


### PR DESCRIPTION
openSUSE's version of libcurl returns different error codes when
trying to connect to an invalid URL (we use http://localhost:0 in our
tests). Changed the curl_client_test to just check for "error" and not
care about the actual error code.

Also added a separate test for the CurlHandle::AsStatus() function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2306)
<!-- Reviewable:end -->
