### PR TITLE
Workaround build problems on openSUSE:Leap.

### DIFF
--- a/ci/test-readme/Dockerfile.opensuse
+++ b/ci/test-readme/Dockerfile.opensuse
@@ -23,7 +23,8 @@ FROM opensuse/tumbleweed:${DISTRO_VERSION}
 
 # ```bash
 RUN zypper refresh && \
-    zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel make
+    zypper install  --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel make tar wget
 # ```
 
 ## [END README.md]

--- a/ci/test-readme/Dockerfile.opensuse
+++ b/ci/test-readme/Dockerfile.opensuse
@@ -23,7 +23,7 @@ FROM opensuse/tumbleweed:${DISTRO_VERSION}
 
 # ```bash
 RUN zypper refresh && \
-    zypper install  --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+    zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
         libcurl-devel libopenssl-devel make tar wget
 # ```
 

--- a/ci/test-readme/Dockerfile.opensuse-leap
+++ b/ci/test-readme/Dockerfile.opensuse-leap
@@ -23,8 +23,8 @@ FROM opensuse/leap:${DISTRO_VERSION}
 
 # ```bash
 RUN zypper refresh && \
-    zypper install -y cmake gcc gcc-c++ git gzip libcurl-devel \
-        libopenssl-devel make tar wget
+    zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel make tar wget
 # ```
 
 ## [END README.md]


### PR DESCRIPTION
This weekend openSUSE:Leap released the 1.1.0i version of the OpenSSL
runtime libraries, but they did *not* release the development libraries
at the same time. Effectively this means that installing the development
libraries requires a downgrade.

I just changed both openSUSE:Leap and openSUSE:Tumbleweed to always
allow a downgrade when installing the development tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2311)
<!-- Reviewable:end -->
