### PR TITLE
Allow third-parties to use nlohmann::json.

### DIFF
--- a/cmake/DownloadNlohmannJson.cmake
+++ b/cmake/DownloadNlohmannJson.cmake
@@ -28,3 +28,29 @@ message("JSON_SHA256 = ${JSON_SHA256}")
 message("DEST = ${DEST}")
 file(DOWNLOAD "${JSON_URL}" "${DEST}/json.hpp"
      EXPECTED_HASH SHA256=${JSON_SHA256})
+
+# Remove the definitions of `operator""_json()` and `operator""_json_pointer`. I
+# know it looks ugly to remove specific lines, but we know the contents of the
+# file exactly (there is a SHA256 hash of it above).
+file(READ "${DEST}/json.hpp" JSON_HPP_CONTENT)
+string(
+    REPLACE
+        [==[
+inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+{
+    return nlohmann::json::parse(s, s + n);
+}
+]==]
+        "" JSON_HPP_CONTENT "${JSON_HPP_CONTENT}")
+string(REPLACE
+        [==[
+inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+{
+    return nlohmann::json::json_pointer(std::string(s, n));
+}
+]==]
+        ""
+        JSON_HPP_CONTENT
+        "${JSON_HPP_CONTENT}")
+
+file(WRITE "${DEST}/json.hpp" "${JSON_HPP_CONTENT}")

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -42,7 +42,7 @@ genrule(
     name = "nlohmann_json_include_hierarchy",
     srcs = ["@com_github_nlohmann_json_single_header//file"],
     outs = ["google/cloud/storage/internal/nlohmann_json.hpp"],
-    cmd = "cp $< $@ && echo GENDIR=$(GENDIR) @=$(@) S=$<",
+    cmd = "sed '20213,20247d' $< >$@",
 )
 
 cc_library(

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -336,6 +336,7 @@ if (BUILD_TESTING)
         internal/logging_resumable_upload_session_test.cc
         internal/metadata_parser_test.cc
         internal/nljson_test.cc
+        internal/nljson_use_third_party_test.cc
         internal/notification_requests_test.cc
         internal/object_acl_requests_test.cc
         internal/object_requests_test.cc

--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -35,6 +35,13 @@
 #define nlohmann google_cloud_storage_internal_nlohmann_3_4_0
 #include "google/cloud/storage/internal/nlohmann_json.hpp"
 
+// Remove the include guards so third-parties can include their own version of
+// nlohmann::jso. This is safe because google/cloud/storage always includes
+// the nlohmann::json through this header, so after the first time our own
+// include guards are enough
+#undef NLOHMANN_JSON_HPP
+#undef NLOHMANN_JSON_FWD_HPP
+
 namespace nlohmann {
 //
 // Google Test uses PrintTo (with many overloads) to print the results of failed

--- a/google/cloud/storage/internal/nljson_use_third_party_test.cc
+++ b/google/cloud/storage/internal/nljson_use_third_party_test.cc
@@ -13,18 +13,19 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/internal/nlohmann_json.hpp"
 #include <gtest/gtest.h>
 
-/// @test Verify that we can compile against the nlohmann::json library.
-TEST(NlJsonTest, Simple) {
-  google::cloud::storage::internal::nl::json json = {
+/// @test Verify third-parties can include their own lohmann::json headers.
+TEST(NlJsonUseThirdPartTest, Simple) {
+  ::nlohmann::json object = {
       {"pi", 3.141},
       {"happy", true},
       {"nothing", nullptr},
       {"answer", {{"everything", 42}}},
       {"list", {1, 0, 2}},
       {"object", {{"currency", "USD"}, {"value", 42.99}}}};
-  EXPECT_NEAR(3.141, json["pi"], 0.001);
-  EXPECT_EQ("USD", json["object"]["currency"]);
-  EXPECT_EQ(1, json["list"][0]);
+  EXPECT_NEAR(3.141, object["pi"], 0.001);
+  EXPECT_EQ("USD", object["object"]["currency"]);
+  EXPECT_EQ(1, object["list"][0]);
 }

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -53,6 +53,7 @@ storage_client_unit_tests = [
     "internal/logging_resumable_upload_session_test.cc",
     "internal/metadata_parser_test.cc",
     "internal/nljson_test.cc",
+    "internal/nljson_use_third_party_test.cc",
     "internal/notification_requests_test.cc",
     "internal/object_acl_requests_test.cc",
     "internal/object_requests_test.cc",

--- a/google/cloud/storage/tests/storage_include_test.cc
+++ b/google/cloud/storage/tests/storage_include_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include <iostream>
 
@@ -32,6 +33,16 @@ int main() {
 #ifdef LIBCURL_VERSION
 #error "LIBCURL should not be included by storage public headers"
 #endif  // OPENSSL_VERSION_NUMBER
+
+  // When we include the storage headers we do not want to leave the include
+  // guards for nlohmann::json defined, that stops our users from including
+  // similar headers.
+#ifdef NLOHMANN_JSON_FWD_HPP
+#error "NLOHMANN_JSON_FWD_HPP should not be left defined."
+#endif  // NLOHMANN_JSON_FWD_HPP
+#ifdef NLOHMANN_JSON_HPP
+#error "NLOHMANN_JSON_HPP should not be left defined."
+#endif  // NLOHMANN_JSON_HPP
 
   std::cout << "PASSED: this is a compile-time test\n";
   return 0;


### PR DESCRIPTION
Using both nlohmann::json and google::cloud::storage together should be
possible, but some bugs were preventing customers from doing so. First,
we needed to `#undef` the include guards for nlohmann::json because
otherwise customers cannot include the header. We also needed to remove
literal operators nlohmann::json puts in the global namespace.

Eventually we should audit our public headers to not expose the
nlohmann::json types at all, but that is a more difficult fix.

This fixes #2314.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2315)
<!-- Reviewable:end -->
