### PR TITLE
Support including nlohmann::json before our headers.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -335,7 +335,7 @@ if (BUILD_TESTING)
         internal/logging_client_test.cc
         internal/logging_resumable_upload_session_test.cc
         internal/metadata_parser_test.cc
-        internal/nljson_test.cc
+        internal/nljson_use_after_third_party_test.cc
         internal/nljson_use_third_party_test.cc
         internal/notification_requests_test.cc
         internal/object_acl_requests_test.cc

--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -32,13 +32,20 @@
  * @see https://github.com/nlohmann/json.git
  */
 
+// Remove the include guards because third-parties may have included their own
+// version of nlohmann::json. This is safe because google/cloud/storage always
+// includes the nlohmann::json through this header, so after the first time our
+// own include guards are enough.
+#undef NLOHMANN_JSON_HPP
+#undef NLOHMANN_JSON_FWD_HPP
+
 #define nlohmann google_cloud_storage_internal_nlohmann_3_4_0
 #include "google/cloud/storage/internal/nlohmann_json.hpp"
 
 // Remove the include guards so third-parties can include their own version of
-// nlohmann::jso. This is safe because google/cloud/storage always includes
+// nlohmann::json. This is safe because google/cloud/storage always includes
 // the nlohmann::json through this header, so after the first time our own
-// include guards are enough
+// include guards are enough.
 #undef NLOHMANN_JSON_HPP
 #undef NLOHMANN_JSON_FWD_HPP
 

--- a/google/cloud/storage/internal/nljson_use_after_third_party_test.cc
+++ b/google/cloud/storage/internal/nljson_use_after_third_party_test.cc
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Verify that we can #include the nljson.h header after a third-party has
+// included json.hpp directly. We want to support both users that include
+// nlohmann::json first (which is what this test file checks), and users that
+// include our headers first (which nljson_use_third_party_test.cc checks).
+// We simulate the nlohmann::json include by including nlohmann_json.hpp
+#include "google/cloud/storage/internal/nlohmann_json.hpp"
+// Create a separate include block to prevent clang-format from reordering.
+
 #include "google/cloud/storage/internal/nljson.h"
 #include <gtest/gtest.h>
 

--- a/google/cloud/storage/internal/nljson_use_third_party_test.cc
+++ b/google/cloud/storage/internal/nljson_use_third_party_test.cc
@@ -13,7 +13,15 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/nljson.h"
+
+// Verify that we can #include the nljson.h header before a third-party includes
+// json.hpp directly. We want to support both users that include nlohmann::json
+// first (which is what nljson_use_after_third_party_test.cc checks), and users
+// that include our headers first (which is what this program tests).
+// We simulate the nlohmann::json include by including nlohmann_json.hpp
 #include "google/cloud/storage/internal/nlohmann_json.hpp"
+// Create a separate include block to prevent clang-format from reordering.
+
 #include <gtest/gtest.h>
 
 /// @test Verify third-parties can include their own lohmann::json headers.

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -52,7 +52,7 @@ storage_client_unit_tests = [
     "internal/logging_client_test.cc",
     "internal/logging_resumable_upload_session_test.cc",
     "internal/metadata_parser_test.cc",
-    "internal/nljson_test.cc",
+    "internal/nljson_use_after_third_party_test.cc",
     "internal/nljson_use_third_party_test.cc",
     "internal/notification_requests_test.cc",
     "internal/object_acl_requests_test.cc",


### PR DESCRIPTION
In hindsight this was obvious. The customer may chose to include
nlohmann::json before our headers, and we need to support that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2324)
<!-- Reviewable:end -->
