### PR TITLE
Remove pkg config references from the documentation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,11 +129,7 @@ production use.
 ]===]")
 
 set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
-             PROPERTY STRINGS
-                      "external"
-                      "package"
-                      "vcpkg"
-                      "pkg-config")
+             PROPERTY STRINGS "external" "package")
 
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,15 +96,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-We can now compile and install `google-cloud-cpp`. Note that we use
-`pkg-config` to discover the options for gRPC and protobuf:
+We can now compile and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -119,7 +116,8 @@ Install the minimal development tools:
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install -y cmake gcc gcc-c++ git libcurl-devel libopenssl-devel make
+sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel make tar wget
 ```
 
 OpenSUSE:tumbleweed provides packages for gRPC, libcurl, and protobuf, and the
@@ -153,15 +151,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-We can now compile and install `google-cloud-cpp`. Note that we use
-`pkg-config` to discover the options for gRPC and protobuf:
+We can now compile and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -176,8 +171,8 @@ Install the minimal development tools:
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install -y cmake gcc gcc-c++ git gzip libcurl-devel \
-        libopenssl-devel make tar wget
+sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+        libcurl-devel libopenssl-devel make tar wget
 ```
 
 #### crc32c
@@ -271,15 +266,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-We can now compile and install `google-cloud-cpp`. Note that we use
-`pkg-config` to discover the options for gRPC and protobuf:
+We can now compile and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -356,14 +348,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-Finally we can install `google-cloud-cpp`. Note that we use `pkg-config` to
-discover the options for gRPC:
+Finally we can install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -464,14 +454,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-Finally we can install `google-cloud-cpp`. Note that we use `pkg-config` to
-discover the options for gRPC:
+Finally we can install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -617,20 +605,13 @@ sudo make install
 
 #### google-cloud-cpp
 
-We can now compile and install `google-cloud-cpp`. Note that we use
-`pkg-config` to discover the options for gRPC and protobuf:
+We can now compile and install `google-cloud-cpp`.
 
 ```bash
-echo
-pkg-config --modversion libcurl
-pkg-config --libs libcurl
-pkg-config --cflags libcurl
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DCMAKE_FIND_ROOT_PATH="/usr/local/curl;/usr/local/ssl" \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER=pkg-config \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -715,14 +696,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-Finally we can install `google-cloud-cpp`. Note that we use `pkg-config` to
-discover the options for gRPC:
+Finally we can install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/google-cloud-cpp/build-output
@@ -821,14 +800,12 @@ sudo ldconfig
 
 #### google-cloud-cpp
 
-Finally we can install `google-cloud-cpp`. Note that we use `pkg-config` to
-discover the options for gRPC:
+Finally we can install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/Downloads/google-cloud-cpp
 cmake -H. -Bbuild-output \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DGOOGLE_CLOUD_CPP_GRPC_PROVIDER=pkg-config \
     -DGOOGLE_CLOUD_CPP_GMOCK_PROVIDER=external
 cmake --build build-output -- -j $(nproc)
 cd $HOME/Downloads/google-cloud-cpp/build-output

--- a/cmake/IncludeCrc32c.cmake
+++ b/cmake/IncludeCrc32c.cmake
@@ -22,10 +22,7 @@ find_package(Threads REQUIRED)
 set(GOOGLE_CLOUD_CPP_CRC32C_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
     CACHE STRING "How to find the Crc32c library")
 set_property(CACHE GOOGLE_CLOUD_CPP_CRC32C_PROVIDER
-             PROPERTY STRINGS
-                      "external"
-                      "package"
-                      "pkg-config")
+             PROPERTY STRINGS "external" "package")
 
 if (TARGET Crc32c::crc32c)
     # Crc32c::crc32c is already defined, do not define it again.

--- a/cmake/IncludeCurl.cmake
+++ b/cmake/IncludeCurl.cmake
@@ -29,10 +29,7 @@ else()
         CACHE STRING "How to find the libcurl.")
 endif ()
 set_property(CACHE GOOGLE_CLOUD_CPP_CURL_PROVIDER
-             PROPERTY STRINGS
-                      "external"
-                      "package"
-                      "pkg-config")
+             PROPERTY STRINGS "external" "package")
 
 if ("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "external")
     include(external/curl)

--- a/cmake/IncludeGMock.cmake
+++ b/cmake/IncludeGMock.cmake
@@ -29,10 +29,7 @@ find_package(Threads REQUIRED)
 set(GOOGLE_CLOUD_CPP_GMOCK_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
     CACHE STRING "How to find the googlemock library")
 set_property(CACHE GOOGLE_CLOUD_CPP_GMOCK_PROVIDER
-             PROPERTY STRINGS
-                      "external"
-                      "package"
-                      "pkg-config")
+             PROPERTY STRINGS "external" "package")
 
 function (create_googletest_aliases)
     # FindGTest() is a standard CMake module. It, unfortunately, *only* creates
@@ -111,36 +108,4 @@ elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "package")
                                      "GTest::gmock;Threads::Threads"
                                      INTERFACE_INCLUDE_DIRECTORIES
                                      "${GMOCK_INCLUDE_DIRS}")
-
-elseif("${GOOGLE_CLOUD_CPP_GMOCK_PROVIDER}" STREQUAL "pkg-config")
-
-    # Use pkg-config to find the libraries.
-    find_package(PkgConfig REQUIRED)
-
-    # Load the helper function to convert pkg-config(1) output into target
-    # properties.
-    include(PkgConfigHelper)
-
-    pkg_check_modules(gtest_pc REQUIRED gtest)
-    add_library(GTest::gtest INTERFACE IMPORTED)
-    set_library_properties_from_pkg_config(GTest::gtest gtest_pc)
-    set_property(TARGET GTest::gtest
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES Threads::Threads)
-
-    pkg_check_modules(gmock_pc REQUIRED gmock)
-    add_library(GTest::gmock INTERFACE IMPORTED)
-    set_library_properties_from_pkg_config(GTest::gmock gmock_pc)
-    set_property(TARGET GTest::gmock
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          "GTest::test;Threads::Threads")
-
-    pkg_check_modules(gmock_main_pc REQUIRED gmock_main)
-    add_library(GTest::gmock_main INTERFACE IMPORTED)
-    set_library_properties_from_pkg_config(GTest::gmock_main gmock_pc)
-    set_property(TARGET GTest::gmock_main
-                 APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES
-                          "GTest::gmock;GTest::gtest;Threads::Threads")
 endif ()

--- a/cmake/IncludeGrpc.cmake
+++ b/cmake/IncludeGrpc.cmake
@@ -25,15 +25,10 @@ include(IncludeProtobuf)
 set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
     CACHE STRING "How to find the gRPC library")
 set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER
-             PROPERTY STRINGS
-                      "external"
-                      "package"
-                      "pkg-config")
+             PROPERTY STRINGS "external" "package")
 
 if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     include(external/grpc)
-elseif(("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
-       OR
-       ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "pkg-config"))
+elseif("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
     find_package(gRPC REQUIRED gRPC>=1.16)
 endif ()

--- a/cmake/IncludeProtobuf.cmake
+++ b/cmake/IncludeProtobuf.cmake
@@ -22,15 +22,10 @@ find_package(Threads REQUIRED)
 set(GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER ${GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER}
     CACHE STRING "How to find protobuf libraries and compiler")
 set_property(CACHE GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER
-             PROPERTY STRINGS
-                      "external"
-                      "package"
-                      "pkg-config")
+             PROPERTY STRINGS "external" "package")
 
 if ("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "external")
     include(external/protobuf)
-elseif(("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "package")
-       OR
-       ("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "pkg-config"))
+elseif("${GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER}" STREQUAL "package")
     find_package(ProtobufTargets REQUIRED protobuf>=3.5)
 endif ()

--- a/doc/managing-dependencies-in-cmake.md
+++ b/doc/managing-dependencies-in-cmake.md
@@ -1,4 +1,4 @@
-# Dependency Management for google-cloud-cpp
+# CMake Dependency Management for google-cloud-cpp
 
 `google-cloud-cpp` must have a minimal set of dependencies, every dependency is
 viewed as a blocker for adoption by our customers.  Only the following
@@ -17,6 +17,8 @@ libraries are allowed as dependencies:
   library to parse and generate JSON objects.
 * [OpenSSL](https://www.openssl.org/source/) is used by the storage library to
   perform some Base64 encoding and JWT signing.
+* [crc32c](https://github.com/google/crc32c) is used by the storage library to
+  generate CRC32C checksums.
 
 Some of these libraries have dependencies themselves:
 
@@ -34,19 +36,19 @@ included in CMake files.
 
 ## Overview
 
-We will support two different modes to compile the library with CMake:
+We support two different modes to compile the library with CMake:
 
 - Using [CMake external projects][cmake-doc-externalproject]
 - Using pre-installed dependencies.
 
 Bazel builds are basically external project builds.
 
-When compiline with external projects we will create
-[targets][cmake-doc-targets] that have the same names (and roles) as the
-installed for that dependency.
-For example, when protobuf is installed and discovered via `find_package()` the
-module for protobuf introduces a `protobuf::libprotobuf` target. We will
-construct our external projects to exhibit the same behavior.
+When compiline with external projects we create [targets][cmake-doc-targets]
+that have the same names (and roles) as the `Find<Package>` module creates when
+the dependency is installed. For example, when protobuf is installed and 
+discovered via `find_package()` the module for protobuf introduces a
+`protobuf::libprotobuf` target. We will construct our external projects to
+exhibit the same behavior.
 
 CMake supports this use case well as long as projects follow the following
 conventions:
@@ -55,51 +57,29 @@ conventions:
   example, `absl::base` and not `absl_base`.
 * Dependencies should use `target_include_directories()` and
   `target_compile_definitions()` to add compilation flags.
-* Dependencies should create a [package][cmake-doc-packages] config file as part
-  of their installation.
+* Dependencies should create a [CMake-config][cmake-doc-packages] config file as
+  part of their installation.
 
 ## Detailed Management for all Dependencies
 
-In this section we analyse the existing dependencies and how do we propose to
-manage them.
+Some of the dependencies require special treatment, these are noted below:
 
-### gRPC and Protobuf
+### gRPC
 
-gRPC can be compiled using CMake, plain GNU Make, Bazel, or vcpkg.  Depending
-how it is compiled it may offer an install target (GNU Make and CMake have
-them), and it may or may not have installed config files for `find_package()`.
+gRPC can be compiled using CMake, plain GNU Make, Bazel, or vcpkg. It may also
+be available as a binary package on some distributions. Depending on how it is
+compiled it may create CMake-config files to support `find_package()`, but
+in many distributions these are not installed. We support two modes to compile
+gRPC:
 
-We will support four different configurations for gRPC:
-
-1. [`vcpkg`](https://github.com/Microsoft/vcpkg) packages gRPC, and provides
-   targets (`gRPC::gprc++` and `gRPC::grpc`) for CMake.
-   When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `vcpkg` we will enable
-   these targets using `find_package()`.  We will also use `find_package()` to
-   find the `protobuf` library.  The package introduces a
-   `protobuf::libprotobuf` target.
-
-1. [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) when
-   compiled and installed with GNU Make gRPC installs `pkg-config` support
-   files. When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `pkg-config` we will
-   define `INTERFACE` libraries for `gRPC::grpc++` and `gRPC::grpc`each `absl::*`
-   library used in `google-cloud-cpp`.  These `INTERFACE` libraries will set
-   their target [properties][cmake-doc-target-properties] based on the
-   configuration flags discovered via `pkg-config`. We will also use
-   `pkg-config` to find `protobuf` in this case, and introduce
-   `protobuf::libprotobuf` as an `INTERFACE` target with its properties set
-   based on the `pkg-config` parameters. Note that on CMake-3.6 and higher the
-   `Protobuf` CMake module automatically introduces `protobuf::libprotobuf`. We
-   are targeting CMake-3.5, which does not offer this feature.
+1. `external`: When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `external`
+   (the default) we will compile gRPC as an external project and install it
+   in `<BUILD_DIR>/external`.
 
 1. `package`: When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `package` we
-    will use `find_package(... grpc)` to find the gRPC libraries. Note that gRPC
-    installs the necessary CMake support files when compiled with CMake, but not
-    when compiled and installed with GNU Make, so we cannot assume these support
-    files always exist.
-
-1. `external`: When `GOOGLE_CLOUD_CPP_GRPC_PROVIDER` is set to `module`
-   (the default) we will simply add the `third_party/grpc` subdirectory to
-   the CMake build.
+    will use `find_package(gRPC)` to find the gRPC libraries. We have
+    created a `FindgRPC` module that discovers how gRPC was installed, normally
+    using the CMake-config files, but can fallback on `pkg-config` if needed.
 
 #### Things that gRPC depends on
 
@@ -118,7 +98,7 @@ dependencies such as `libpthread`, `libc` and the C++ library (typically
 `libstdc++`). Of all these dependencies, only `protobuf`, `zlib`, and `pthread`
 need to be explicitly linked by the application.
 
-We already discussed how `protobuf` is discovered alongside `gRPC`.
+`protobuf` is covered in more detail below.
 
 `zlib` is often installed as a system library and has a relatively stable
 interface.  Unless it is used as a module we will use the native library via
@@ -128,24 +108,39 @@ interface.  Unless it is used as a module we will use the native library via
 `FindThreads` module creates a `Threads::Threads` target that works on all
 platforms.
 
+### Protobuf
+
+Protobuf can also be compiled using CMake, plain GNU Make, Bazel, or vcpkg. It
+may also be available as a binary package on some distributions. Depending on
+how it is compiled it may have installed CMake-config files. All CMake versions
+we support (>=3.5) provide a `FindProtobuf` module, but this module does not
+create the correct imported targets until CMake-3.9, and the protobuf compiler
+does not get an imported target until CMake-3.10.
+ 
+1. `external`: When `GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER` is set to `external`
+   (the default) we will compile gRPC as an external project and install it
+   in `<BUILD_DIR>/external`.
+
+1. `package`: When `GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER` is set to `package` we
+    will use `find_package(ProtobufTargets)` to find the Protobuf libraries.
+    `FindProtobufTargets` is a module that we wrote, it uses the CMake standard
+    `FindProtobuf` module to find the protobuf libraries, but always produces
+    the `protobuf::*` targets generated by CMake>=3.11.
+
 ### Googletest
 
 Googletest is not installed, nor should it be, and therefore it is only used
-as a submodule.
+as an external project.
 
-### Googleapis
+### Googleapis Protos
 
-The `third_party/googleapis` submodule contains the proto files for all Google
-APIs, most of which are not used by `google-cloud-cpp`.  While `googleapis`
-includes a `Makefile` for Unix-like platforms, this only creates the
-proto-generated files.  It does not compile the generated files, does not create
-any libraries, it is not portable to other platforms, and does not provide any
-mechanism to install artifacts.  For the time being we will use this dependency
-**only** as a submodule, and compile  a library with the minimal set of protos
-needed by `google-cloud-cpp`.
+The proto files and the generated libraries are always compiled as an external
+project. The build files are in `google-cloud-cpp/cmake/googleapis` and they
+generate both CMake-config files and pkg-config files to support CMake and Make
+users.
 
-Every time a new service is wrapper in `google-cloud-cpp` is updated this
-library will need to be updated too.
+To build with Bazel we have implemented a custom BUILD file in
+`bazel/googleapis.BUILD`.
 
 ## Implementation
 
@@ -153,72 +148,52 @@ library will need to be updated too.
 configuration option to control where to find all the dependencies. The macro
  can take the following values:
 
-
 * `external` implies that all the sources should be downloaded using the
-`ExternalProject` CMake module.
+  `ExternalProject` CMake module.
 * `package` implies that all the dependencies are already installed and can be
-found with `find_package()`.
-* `pkg-config` is used when the dependencies are already installed but cannot be
-found with `find_package()`, instead they can be found using the `pkg-config`
-tool.
+  found with `find_package()`.
 
-We will create a separate file in `cmake/Include<Dependency>.cmake` for each of
+We keep a separate file in `cmake/Include<Dependency>.cmake` for each of
 the dependencies. The file will typically be of this form:
 
 ```cmake
-set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER "module" CACHE STRING "How to find the gRPC library")
-set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER PROPERTY STRINGS "module" "package" "pkg-config")
+set(GOOGLE_CLOUD_CPP_GRPC_PROVIDER "external" CACHE STRING "How to find the gRPC library")
+set_property(CACHE GOOGLE_CLOUD_CPP_GRPC_PROVIDER PROPERTY STRINGS "module" "package")
 if ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "external")
     include(external/grpc)
-    # Define aliases if needed.
-    add_library(gRPC::grpc++ INTERFACE IMPORTED)
-    # ... some code ommitted ...
 elseif ("${GOOGLE_CLOUD_CPP_GRPC_PROVIDER}" STREQUAL "package")
-    find_package(GRPCPP REQUIRED >= 1.8)
-    find_package(GRPC REQUIRED)
-else ()
-    # Find the packages using `pkg-config`:
-    include(FindPkgConfig)
-    pkg_check_modules(gRPC++ REQUIRED IMPORTED_TARGET grpc++ >= 1.9.0)
-    add_library(gRPC::grpc++ INTERFACE IMPORTED)
-    # This custom macro sets all the properties based on pkg-config results.
-    set_library_properties_from_pkg_config(gRPC::grpc++ gRPC++)
+    find_package(gRPC REQUIRED >= 1.9.1)
 endif ()
 ```
 
 ## Testing
 
 The configurations must be tested as part of the CI builds. To ensure coverage
-we will:
+we:
 
-* Most builds will compile the dependencies from source, as external projects.
-  This is how the `google-cloud-cpp` developers use the system and we expect
-  that many of the users will too.
+* Most builds compile the dependencies as external projects. This is how the
+  `google-cloud-cpp` developers use the system and we expect that many of the
+   users will too.
 
-* One or more of the builds install all the dependencies and then use `package`.
+* On each supported Linux distribution we have a build that:
+  * Install all the dependencies.
+  * Compile the `google-cloud-cpp` libraries against those installed dependencies.
+  * Install `google-cloud-cpp` against those dependencies.
+  * Use both `make(1)` and `cmake(1)` to compile against the installed version
+    of `google-cloud-cpp`.
 
-* On Windows, we already use installed dependencies via `vcpkg`: compiling from
-  source can be (a) so slow that we go over the time allocated in the CI build,
-  and (b) the build may require patching the dependencies, as the `vcpkg` ports
-  do.
+* On Windows, we always compile using "installed" dependencies via `vcpkg`.
+  Compiling from source can be (a) so slow that we go over the time allocated in
+  the CI build, and (b) the build may require patching the dependencies, as the
+  `vcpkg` ports do.
+  
+* On MacOS, we are only building with Bazel at this time.
 
-* We will dedicate one CI build on Linux to compile against installed
-  dependencies using `pkg-config` files.
-
-## Alternatives Considered
-
-**Create support files for each dependency and always use `find_package`**: the
-author ([@coryan](https://github.com/coryan)) could not design a solution that
-works for modules, vcpkg, pkg-config, and system-wide `Find<dependency>.cmake`
-files.  It might be possible to do so and if found that would be a more elegant
-design than the if statements.
-
-## Estimated Effort
-
-N/A this document was written as the author explored how to solve the problem.
-There is a
-[branch](https://github.com/coryan/google-cloud-cpp/tree/test-install-target-v2)
-that implements all of this.
+* We also have two Bazel builds for Linux:
+  * A build to verify `google-cloud-cpp` can be used as a dependency of another
+    project.
+  * A build to compile the unit and integration tests of `google-cloud-cpp`,
+    though only the unit tests are executed.
 
 [cmake-doc-export]:    https://cmake.org/cmake/help/v3.5/command/export.html
 [cmake-doc-externalproject]: https://cmake.org/cmake/help/v3.5/module/ExternalProject.html

--- a/doc/managing-dependencies-in-cmake.md
+++ b/doc/managing-dependencies-in-cmake.md
@@ -43,7 +43,7 @@ We support two different modes to compile the library with CMake:
 
 Bazel builds are basically external project builds.
 
-When compiline with external projects we create [targets][cmake-doc-targets]
+When compiling with external projects we create [targets][cmake-doc-targets]
 that have the same names (and roles) as the `Find<Package>` module creates when
 the dependency is installed. For example, when protobuf is installed and 
 discovered via `find_package()` the module for protobuf introduces a
@@ -116,7 +116,7 @@ how it is compiled it may have installed CMake-config files. All CMake versions
 we support (>=3.5) provide a `FindProtobuf` module, but this module does not
 create the correct imported targets until CMake-3.9, and the protobuf compiler
 does not get an imported target until CMake-3.10.
- 
+
 1. `external`: When `GOOGLE_CLOUD_CPP_PROTOBUF_PROVIDER` is set to `external`
    (the default) we will compile gRPC as an external project and install it
    in `<BUILD_DIR>/external`.
@@ -186,7 +186,7 @@ we:
   Compiling from source can be (a) so slow that we go over the time allocated in
   the CI build, and (b) the build may require patching the dependencies, as the
   `vcpkg` ports do.
-  
+
 * On MacOS, we are only building with Bazel at this time.
 
 * We also have two Bazel builds for Linux:


### PR DESCRIPTION
Fix the documentation, where we still had a couple of places saying that
`pkg-config` was an optional mechanism to configure dependencies. We
have eliminated the need for this, and the code is cleaner. Also fix the
description of how we support dependencies via CMake.

This fixes #1610.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2327)
<!-- Reviewable:end -->
