### PR TITLE
Update HMAC functions to catchup with protocol.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2342,7 +2342,7 @@ class Client {
     if (!result) {
       return result.status();
     }
-    return std::make_pair(std::move(result->resource),
+    return std::make_pair(std::move(result->metadata),
                           std::move(result->secret));
   }
 

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -120,7 +120,7 @@ TEST_F(ServiceAccountTest, CreateHmacKey) {
       client.CreateHmacKey("test-service-account",
                            OverrideDefaultProject("test-project"));
   ASSERT_STATUS_OK(actual);
-  EXPECT_EQ(expected.resource, actual->first);
+  EXPECT_EQ(expected.metadata, actual->first);
   EXPECT_EQ(expected.secret, actual->second);
 }
 

--- a/google/cloud/storage/hmac_key_metadata.cc
+++ b/google/cloud/storage/hmac_key_metadata.cc
@@ -26,7 +26,7 @@ std::ostream& operator<<(std::ostream& os, HmacKeyMetadata const& rhs) {
             << ", service_account_email=" << rhs.service_account_email()
             << ", state=" << rhs.state()
             << ", time_created=" << internal::FormatRfc3339(rhs.time_created())
-            << "}";
+            << ", updated=" << internal::FormatRfc3339(rhs.updated()) << "}";
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/hmac_key_metadata.h
+++ b/google/cloud/storage/hmac_key_metadata.h
@@ -73,6 +73,7 @@ class HmacKeyMetadata {
   std::chrono::system_clock::time_point time_created() const {
     return time_created_;
   }
+  std::chrono::system_clock::time_point updated() const { return updated_; }
 
   static std::string state_active() { return "ACTIVE"; }
   static std::string state_inactive() { return "INACTIVE"; }
@@ -91,17 +92,20 @@ class HmacKeyMetadata {
   std::string service_account_email_;
   std::string state_;
   std::chrono::system_clock::time_point time_created_;
+  std::chrono::system_clock::time_point updated_;
 };
 
 inline bool operator==(HmacKeyMetadata const& lhs, HmacKeyMetadata const& rhs) {
   auto lhs_time_created = lhs.time_created();
   auto rhs_time_created = rhs.time_created();
+  auto lhs_updated = lhs.updated();
+  auto rhs_updated = rhs.updated();
   return std::tie(lhs.id(), lhs.access_id(), lhs.etag(), lhs.kind(),
                   lhs.project_id(), lhs.service_account_email(), lhs.state(),
-                  lhs_time_created) ==
+                  lhs_time_created, lhs_updated) ==
          std::tie(rhs.id(), rhs.access_id(), rhs.etag(), rhs.kind(),
                   rhs.project_id(), rhs.service_account_email(), rhs.state(),
-                  rhs_time_created);
+                  rhs_time_created, rhs_updated);
 }
 
 inline bool operator!=(HmacKeyMetadata const& lhs, HmacKeyMetadata const& rhs) {

--- a/google/cloud/storage/hmac_key_metadata_test.cc
+++ b/google/cloud/storage/hmac_key_metadata_test.cc
@@ -30,11 +30,12 @@ HmacKeyMetadata CreateHmacKeyMetadataForTest() {
       "accessId": "test-access-id",
       "etag": "XYZ=",
       "id": "test-id-123",
-      "kind": "storage#hmacKey",
+      "kind": "storage#hmacKeyMetadata",
       "projectId": "test-project-id",
       "serviceAccountEmail": "test-service-account-email",
       "state": "ACTIVE",
-      "timeCreated": "2019-03-01T12:13:14Z"
+      "timeCreated": "2019-03-01T12:13:14Z",
+      "updated": "2019-03-02T12:13:14Z"
 })""";
   return internal::HmacKeyMetadataParser::FromString(text).value();
 }
@@ -46,12 +47,13 @@ TEST(HmacKeyMetadataTest, Parser) {
   EXPECT_EQ("test-access-id", hmac.access_id());
   EXPECT_EQ("XYZ=", hmac.etag());
   EXPECT_EQ("test-id-123", hmac.id());
-  EXPECT_EQ("storage#hmacKey", hmac.kind());
+  EXPECT_EQ("storage#hmacKeyMetadata", hmac.kind());
   EXPECT_EQ("test-project-id", hmac.project_id());
   EXPECT_EQ("test-service-account-email", hmac.service_account_email());
   EXPECT_EQ(HmacKeyMetadata::state_active(), hmac.state());
   EXPECT_EQ("2019-03-01T12:13:14Z",
             internal::FormatRfc3339(hmac.time_created()));
+  EXPECT_EQ("2019-03-02T12:13:14Z", internal::FormatRfc3339(hmac.updated()));
 
   EXPECT_EQ("ACTIVE", HmacKeyMetadata::state_active());
   EXPECT_EQ("INACTIVE", HmacKeyMetadata::state_inactive());
@@ -71,6 +73,7 @@ TEST(HmacKeyMetadataTest, IOStream) {
   EXPECT_THAT(actual, HasSubstr("test-service-account-email"));
   EXPECT_THAT(actual, HasSubstr("ACTIVE"));
   EXPECT_THAT(actual, HasSubstr("2019-03-01T12:13:14Z"));
+  EXPECT_THAT(actual, HasSubstr("2019-03-02T12:13:14Z"));
 }
 
 /// @test Verify we can change the state in a HmacKeyMetadata.

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -39,6 +39,9 @@ StatusOr<HmacKeyMetadata> HmacKeyMetadataParser::FromJson(
     result.time_created_ =
         internal::ParseRfc3339(json.value("timeCreated", ""));
   }
+  if (json.count("updated") != 0) {
+    result.updated_ = internal::ParseRfc3339(json.value("updated", ""));
+  }
   return result;
 }
 
@@ -66,18 +69,18 @@ StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(
   CreateHmacKeyResponse result;
   result.kind = json.value("kind", "");
   result.secret = json.value("secretKey", "");
-  if (json.count("resource") != 0) {
-    auto resource = HmacKeyMetadataParser::FromJson(json["resource"]);
+  if (json.count("metadata") != 0) {
+    auto resource = HmacKeyMetadataParser::FromJson(json["metadata"]);
     if (!resource) {
       return std::move(resource).status();
     }
-    result.resource = *std::move(resource);
+    result.metadata = *std::move(resource);
   }
   return result;
 }
 
 std::ostream& operator<<(std::ostream& os, CreateHmacKeyResponse const& r) {
-  return os << "CreateHmacKeyResponse={resource=" << r.resource
+  return os << "CreateHmacKeyResponse={metadata=" << r.metadata
             << ", secret=[censored]"
             << "}";
 }

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -91,7 +91,7 @@ struct CreateHmacKeyResponse {
       HttpResponse const& response);
 
   std::string kind;
-  HmacKeyMetadata resource;
+  HmacKeyMetadata metadata;
   std::string secret;
 };
 

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -57,18 +57,19 @@ TEST(HmacKeyRequestsTest, ParseCreateResponse) {
       "accessId": "test-access-id",
       "etag": "XYZ=",
       "id": "test-id-123",
-      "kind": "storage#hmacKey",
+      "kind": "storage#hmacKeyMetadata",
       "projectId": "test-project-id",
       "serviceAccountEmail": "test-service-account-email",
       "state": "ACTIVE",
-      "timeCreated": "2019-03-01T12:13:14Z"
+      "timeCreated": "2019-03-01T12:13:14Z",
+      "updated": "2019-03-02T12:13:14Z"
 })""";
   nl::json const json_object{
-      {"kind", "storage#hmacKeyCreate"},
+      {"kind", "storage#hmacKey"},
       // To generate the secret use:
       //   echo -n "test-secret" | openssl base64
       {"secretKey", "dGVzdC1zZWNyZXQ="},
-      {"resource", nl::json::parse(resource_text)},
+      {"metadata", nl::json::parse(resource_text)},
   };
 
   std::string const text = json_object.dump();
@@ -79,7 +80,7 @@ TEST(HmacKeyRequestsTest, ParseCreateResponse) {
   EXPECT_EQ("dGVzdC1zZWNyZXQ=", actual.secret);
   auto expected_resource =
       HmacKeyMetadataParser::FromString(resource_text).value();
-  EXPECT_THAT(expected_resource, actual.resource);
+  EXPECT_THAT(expected_resource, actual.metadata);
 }
 
 TEST(HmacKeyRequestsTest, ParseCreateResponseFailure) {
@@ -91,7 +92,7 @@ TEST(HmacKeyRequestsTest, ParseCreateResponseFailure) {
 }
 
 TEST(HmacKeyRequestsTest, ParseCreateResponseFailureInResource) {
-  std::string text = R"""({"resource": "invalid-resource" })""";
+  std::string text = R"""({"metadata": "invalid-metadata" })""";
 
   auto actual =
       CreateHmacKeyResponse::FromHttpResponse(HttpResponse{200, text, {}});
@@ -101,7 +102,7 @@ TEST(HmacKeyRequestsTest, ParseCreateResponseFailureInResource) {
 TEST(HmacKeyRequestsTest, CreateResponseIOStream) {
   std::string const text = R"""({
       "secret": "dGVzdC1zZWNyZXQ=",
-      "resource": {
+      "metadata": {
         "accessId": "test-access-id"
       }
 })""";
@@ -156,7 +157,7 @@ TEST(HmacKeysRequestsTest, ParseListResponse) {
       "timeCreated": "2019-03-02T12:13:14Z"
 })""";
   std::string text = R"""({
-      "kind": "storage#hmacKeys",
+      "kind": "storage#hmacKeysMetadata",
       "nextPageToken": "some-token-42",
       "items":
 )""";
@@ -190,7 +191,7 @@ TEST(HmacKeysRequestsTest, ParseListResponseFailureInItems) {
 
 TEST(HmacKeysRequestsTest, ListResponseOStream) {
   std::string text = R"""({
-      "kind": "storage#hmacKeys",
+      "kind": "storage#hmacKeysMetadata",
       "nextPageToken": "some-token-42",
       "items": [
         {"accessId": "test-access-id-1"},


### PR DESCRIPTION
The JSON protocol for HMAC keys is (as advertised) not stable. Changed
the implementation to catchup with the latest updates in the spec.

This fixes #2293.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2328)
<!-- Reviewable:end -->
