### PR TITLE
Refactor ObjectMetadata to JSON conversion functions.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -211,8 +211,10 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   builder.AddHeader("Content-Type: application/json; charset=UTF-8");
   std::string request_payload;
   if (request.template HasOption<WithObjectMetadata>()) {
-    request_payload = ObjectMetadataJsonPayloadForUpdate(
-        request.template GetOption<WithObjectMetadata>().value());
+    request_payload =
+        ObjectMetadataJsonForInsert(
+            request.template GetOption<WithObjectMetadata>().value())
+            .dump();
   }
   builder.AddHeader("Content-Length: " +
                     std::to_string(request_payload.size()));
@@ -510,8 +512,9 @@ StatusOr<ObjectMetadata> CurlClient::CopyObject(
   builder.AddHeader("Content-Type: application/json");
   std::string json_payload("{}");
   if (request.HasOption<WithObjectMetadata>()) {
-    json_payload = ObjectMetadataJsonPayloadForCopy(
-        request.GetOption<WithObjectMetadata>().value());
+    json_payload = ObjectMetadataJsonForCopy(
+                       request.GetOption<WithObjectMetadata>().value())
+                       .dump();
   }
   return CheckedFromString<ObjectMetadataParser>(
       builder.BuildRequest().MakeRequest(json_payload));
@@ -672,8 +675,9 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
   builder.AddHeader("Content-Type: application/json");
   std::string json_payload("{}");
   if (request.HasOption<WithObjectMetadata>()) {
-    json_payload = ObjectMetadataJsonPayloadForCopy(
-        request.GetOption<WithObjectMetadata>().value());
+    json_payload = ObjectMetadataJsonForRewrite(
+                       request.GetOption<WithObjectMetadata>().value())
+                       .dump();
   }
   auto response = builder.BuildRequest().MakeRequest(json_payload);
   if (!response.ok()) {
@@ -1377,7 +1381,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
 
   nl::json metadata = nl::json::object();
   if (request.HasOption<WithObjectMetadata>()) {
-    metadata = ObjectMetadataJsonForUpdate(
+    metadata = ObjectMetadataJsonForInsert(
         request.GetOption<WithObjectMetadata>().value());
   }
   if (request.HasOption<MD5HashValue>()) {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -33,11 +33,21 @@ struct ObjectMetadataParser {
   static StatusOr<ObjectMetadata> FromString(std::string const& payload);
 };
 
+//@{
+/**
+ * @name Create the correct JSON payload depending on the operation.
+ *
+ * Depending on the specific operation being performed the JSON object sent to
+ * the server needs to exclude different fields. We handle this by having
+ * different functions for each operation, though their implementations are
+ * shared.
+ */
+internal::nl::json ObjectMetadataJsonForCompose(ObjectMetadata const& meta);
+internal::nl::json ObjectMetadataJsonForCopy(ObjectMetadata const& meta);
+internal::nl::json ObjectMetadataJsonForInsert(ObjectMetadata const& meta);
+internal::nl::json ObjectMetadataJsonForRewrite(ObjectMetadata const& meta);
 internal::nl::json ObjectMetadataJsonForUpdate(ObjectMetadata const& meta);
-std::string ObjectMetadataJsonPayloadForUpdate(ObjectMetadata const& meta);
-internal::nl::json ObjectMetadataJsonPayloadForCompose(
-    ObjectMetadata const& meta);
-std::string ObjectMetadataJsonPayloadForCopy(ObjectMetadata const& meta);
+//@}
 
 /**
  * Represents a request to the `Objects: list` API.
@@ -240,7 +250,7 @@ class UpdateObjectRequest
 
   /// Returns the request as the JSON API payload.
   std::string json_payload() const {
-    return ObjectMetadataJsonPayloadForUpdate(metadata_);
+    return ObjectMetadataJsonForUpdate(metadata_).dump();
   }
 
   ObjectMetadata const& metadata() const { return metadata_; }

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -183,12 +183,159 @@ TEST(ObjectMetadataTest, IOStream) {
   EXPECT_THAT(actual, HasSubstr("temporary_hold=true"));
 }
 
-/// @test Verify we can convert a ObjectMetadata object to a JSON string.
-TEST(ObjectMetadataTest, UpdatePayload) {
+/// @test Verify that ObjectMetadataJsonForCompose works as expected.
+TEST(ObjectMetadataTest, JsonForComposeEmpty) {
+  internal::nl::json actual = ObjectMetadataJsonForCopy(ObjectMetadata());
+  internal::nl::json expected({});
+  EXPECT_EQ(expected, actual);
+}
+
+/// @test Verify the ObjectMetadataJsonForCompose() works as expected.
+TEST(ObjectMetadataTest, JsonForCompose) {
+  auto actual = ObjectMetadataJsonForCompose(CreateObjectMetadataForTest());
+
+  internal::nl::json expected = {
+      {"acl",
+       internal::nl::json{
+           {{"entity", "user-qux"}, {"role", "OWNER"}},
+           {{"entity", "user-quux"}, {"role", "READER"}},
+       }},
+      {"cacheControl", "no-cache"},
+      {"contentDisposition", "a-disposition"},
+      {"contentEncoding", "an-encoding"},
+      {"contentLanguage", "a-language"},
+      {"contentType", "application/octet-stream"},
+      {"eventBasedHold", true},
+      {"metadata",
+       internal::nl::json{
+           {"foo", "bar"},
+           {"baz", "qux"},
+       }},
+      {"name", "baz"},
+      {"storageClass", "STANDARD"},
+  };
+  EXPECT_EQ(expected, actual)
+      << "diff=" << internal::nl::json::diff(expected, actual);
+}
+
+/// @test Verify that ObjectMetadataJsonForCopy works as expected.
+TEST(ObjectMetadataTest, JsonForCopyEmpty) {
+  internal::nl::json actual = ObjectMetadataJsonForCopy(ObjectMetadata());
+  internal::nl::json expected({});
+  EXPECT_EQ(expected, actual);
+}
+
+/// @test Verify the ObjectMetadataJsonForCopy() works as expected.
+TEST(ObjectMetadataTest, JsonForCopy) {
+  auto actual = ObjectMetadataJsonForCopy(CreateObjectMetadataForTest());
+
+  internal::nl::json expected = {
+      {"acl",
+       internal::nl::json{
+           {{"entity", "user-qux"}, {"role", "OWNER"}},
+           {{"entity", "user-quux"}, {"role", "READER"}},
+       }},
+      {"cacheControl", "no-cache"},
+      {"contentDisposition", "a-disposition"},
+      {"contentEncoding", "an-encoding"},
+      {"contentLanguage", "a-language"},
+      {"contentType", "application/octet-stream"},
+      {"eventBasedHold", true},
+      {"metadata",
+       internal::nl::json{
+           {"foo", "bar"},
+           {"baz", "qux"},
+       }},
+      {"name", "baz"},
+      {"storageClass", "STANDARD"},
+  };
+  EXPECT_EQ(expected, actual)
+      << "diff=" << internal::nl::json::diff(expected, actual);
+}
+
+/// @test Verify that ObjectMetadataJsonForInsert works as expected.
+TEST(ObjectMetadataTest, JsonForInsertEmpty) {
+  internal::nl::json actual = ObjectMetadataJsonForInsert(ObjectMetadata());
+  internal::nl::json expected({});
+  EXPECT_EQ(expected, actual);
+}
+
+/// @test Verify the ObjectMetadataJsonForInsert() works as expected.
+TEST(ObjectMetadataTest, JsonForInsert) {
+  auto actual = ObjectMetadataJsonForInsert(CreateObjectMetadataForTest());
+
+  internal::nl::json expected = {
+      {"acl",
+       internal::nl::json{
+           {{"entity", "user-qux"}, {"role", "OWNER"}},
+           {{"entity", "user-quux"}, {"role", "READER"}},
+       }},
+      {"cacheControl", "no-cache"},
+      {"contentDisposition", "a-disposition"},
+      {"contentEncoding", "an-encoding"},
+      {"contentLanguage", "a-language"},
+      {"contentType", "application/octet-stream"},
+      {"crc32c", "deadbeef"},
+      {"eventBasedHold", true},
+      {"md5Hash", "deaderBeef="},
+      {"metadata",
+       internal::nl::json{
+           {"foo", "bar"},
+           {"baz", "qux"},
+       }},
+      {"name", "baz"},
+      {"storageClass", "STANDARD"},
+  };
+  EXPECT_EQ(expected, actual)
+      << "diff=" << internal::nl::json::diff(expected, actual);
+}
+
+/// @test Verify that ObjectMetadataJsonForRewrite works as expected.
+TEST(ObjectMetadataTest, JsonForRewriteEmpty) {
+  internal::nl::json actual = ObjectMetadataJsonForRewrite(ObjectMetadata());
+  internal::nl::json expected({});
+  EXPECT_EQ(expected, actual);
+}
+
+/// @test Verify the ObjectMetadataJsonForRewrite() works as expected.
+TEST(ObjectMetadataTest, JsonForRewrite) {
+  auto actual = ObjectMetadataJsonForRewrite(CreateObjectMetadataForTest());
+
+  internal::nl::json expected = {
+      {"acl",
+       internal::nl::json{
+           {{"entity", "user-qux"}, {"role", "OWNER"}},
+           {{"entity", "user-quux"}, {"role", "READER"}},
+       }},
+      {"cacheControl", "no-cache"},
+      {"contentDisposition", "a-disposition"},
+      {"contentEncoding", "an-encoding"},
+      {"contentLanguage", "a-language"},
+      {"contentType", "application/octet-stream"},
+      {"eventBasedHold", true},
+      {"metadata",
+       internal::nl::json{
+           {"foo", "bar"},
+           {"baz", "qux"},
+       }},
+      {"name", "baz"},
+      {"storageClass", "STANDARD"},
+  };
+  EXPECT_EQ(expected, actual)
+      << "diff=" << internal::nl::json::diff(expected, actual);
+}
+
+/// @test Verify that ObjectMetadataJsonForUpdate works as expected.
+TEST(ObjectMetadataTest, JsonForUpdateEmpty) {
+  internal::nl::json actual = ObjectMetadataJsonForUpdate(ObjectMetadata());
+  internal::nl::json expected({{"eventBasedHold", false}});
+  EXPECT_EQ(expected, actual);
+}
+
+/// @test Verify that ObjectMetadataJsonForUpdate works as expected.
+TEST(ObjectMetadataTest, JsonForUpdate) {
   auto tested = CreateObjectMetadataForTest();
-  auto actual_string = ObjectMetadataJsonPayloadForUpdate(tested);
-  // Verify that the produced string can be parsed as a JSON object.
-  internal::nl::json actual = internal::nl::json::parse(actual_string);
+  internal::nl::json actual = ObjectMetadataJsonForUpdate(tested);
 
   // Create a JSON object with only the writeable fields, because this is what
   // will be encoded in JsonPayloadForUpdate(). Before adding a new field,
@@ -211,7 +358,8 @@ TEST(ObjectMetadataTest, UpdatePayload) {
            {"baz", "qux"},
        }},
   };
-  EXPECT_EQ(expected, actual);
+  EXPECT_EQ(expected, actual)
+      << "diff=" << internal::nl::json::diff(expected, actual);
 }
 
 /// @test Verify we can make changes to one Acl in ObjectMetadata.

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -185,12 +185,12 @@ TEST(ObjectMetadataTest, IOStream) {
 
 /// @test Verify that ObjectMetadataJsonForCompose works as expected.
 TEST(ObjectMetadataTest, JsonForComposeEmpty) {
-  internal::nl::json actual = ObjectMetadataJsonForCopy(ObjectMetadata());
+  internal::nl::json actual = ObjectMetadataJsonForCompose(ObjectMetadata());
   internal::nl::json expected({});
   EXPECT_EQ(expected, actual);
 }
 
-/// @test Verify the ObjectMetadataJsonForCompose() works as expected.
+/// @test Verify that ObjectMetadataJsonForCompose() works as expected.
 TEST(ObjectMetadataTest, JsonForCompose) {
   auto actual = ObjectMetadataJsonForCompose(CreateObjectMetadataForTest());
 
@@ -225,7 +225,7 @@ TEST(ObjectMetadataTest, JsonForCopyEmpty) {
   EXPECT_EQ(expected, actual);
 }
 
-/// @test Verify the ObjectMetadataJsonForCopy() works as expected.
+/// @test Verify that ObjectMetadataJsonForCopy() works as expected.
 TEST(ObjectMetadataTest, JsonForCopy) {
   auto actual = ObjectMetadataJsonForCopy(CreateObjectMetadataForTest());
 
@@ -260,7 +260,7 @@ TEST(ObjectMetadataTest, JsonForInsertEmpty) {
   EXPECT_EQ(expected, actual);
 }
 
-/// @test Verify the ObjectMetadataJsonForInsert() works as expected.
+/// @test Verify that ObjectMetadataJsonForInsert() works as expected.
 TEST(ObjectMetadataTest, JsonForInsert) {
   auto actual = ObjectMetadataJsonForInsert(CreateObjectMetadataForTest());
 
@@ -297,7 +297,7 @@ TEST(ObjectMetadataTest, JsonForRewriteEmpty) {
   EXPECT_EQ(expected, actual);
 }
 
-/// @test Verify the ObjectMetadataJsonForRewrite() works as expected.
+/// @test Verify thhat ObjectMetadataJsonForRewrite() works as expected.
 TEST(ObjectMetadataTest, JsonForRewrite) {
   auto actual = ObjectMetadataJsonForRewrite(CreateObjectMetadataForTest());
 


### PR DESCRIPTION
I need to clean these up to properly support `set_storage_class()`. The
functions had different naming conventions, return types, and fairly
limited testing. Fixed all that so when we implement
`set_storage_class()` the values are inserted in the right calls.

This is part of the work for #2322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2330)
<!-- Reviewable:end -->
