### PR TITLE
Simplify Makefile configuration.

### DIFF
--- a/ci/test-install/Makefile
+++ b/ci/test-install/Makefile
@@ -12,41 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A simple makefile to test the `install` target.
+# A simple Makefile to test the `install` target.
 #
 # This is not intended to be a demonstration of how to write good Makefiles,
 # nor is it a general solution on how to build Makefiles for google-cloud-cpp.
 # It is simply a minimal file to test the installed pkg-config support files.
 
-# This is hard-coded because it is intended for a test, applications typically
-# have their own configuration files.
+# The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
+# our tests, but applications would typically make them configurable parameters.
 CXX=g++
 CXXFLAGS=-std=c++11
 CXXLD=$(CXX)
 
-
 all: bigtable_install_test storage_install_test
 
-CBT_DEPS := bigtable_client google_cloud_cpp_common grpc++ grpc zlib openssl libcares protobuf
+# Configuration variables to compile and link against the Cloud Bigtable C++
+# client library.
+CBT_DEPS := bigtable_client
 CBT_CXXFLAGS   := $(shell pkg-config $(CBT_DEPS) --cflags)
 CBT_CXXLDFLAGS := $(shell pkg-config $(CBT_DEPS) --libs-only-L)
-# gRPC does not install a full complement of pkg-config files:
-#   https://github.com/grpc/grpc/issues/15166
-# so we need to "guess" that -lgpr and -laddress_sorting will be needed.
-CBT_LIBS := \
-    $(shell pkg-config $(CBT_DEPS) --libs-only-l) \
-    -lgpr -laddress_sorting \
-    $(shell pkg-config libcares --libs-only-l)
+CBT_LIBS       := $(shell pkg-config $(CBT_DEPS) --libs-only-l)
 
+# A target using the Cloud Bigtable C++ client library.
 bigtable_install_test: bigtable_install_test.cc
 	$(CXXLD) $(CXXFLAGS) $(CBT_CXXFLAGS) $(GCS_CXXLDFLAGS) -o $@ $^ $(CBT_LIBS)
 
 
-GCS_DEPS := storage_client google_cloud_cpp_common libcurl openssl
+# Configuration variables to compile and link against the Google Cloud Storage
+# C++ client library.
+GCS_DEPS := storage_client
 GCS_CXXFLAGS   := $(shell pkg-config $(GCS_DEPS) --cflags)
 GCS_CXXLDFLAGS := $(shell pkg-config $(GCS_DEPS) --libs-only-L)
-# CRC32C does not have pkg-config(1) files, so link it explicitly.
-GCS_LIBS := $(shell pkg-config $(GCS_DEPS) --libs-only-l) -lcrc32c
+GCS_LIBS       := $(shell pkg-config $(GCS_DEPS) --libs-only-l)
 
+# A target using the Google Cloud Storage C++ client library.
 storage_install_test: storage_install_test.cc
 	$(CXXLD) $(CXXFLAGS) $(GCS_CXXFLAGS) $(GCS_CXXLDFLAGS) -o $@ $^ $(GCS_LIBS)

--- a/cmake/external/googleapis/CMakeLists.txt
+++ b/cmake/external/googleapis/CMakeLists.txt
@@ -147,7 +147,7 @@ set(
 set(GOOGLE_CLOUD_CPP_PC_NAME "The Google APIS C++ Proto Library")
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Platforms.")
-set(GOOGLE_CLOUD_CPP_PC_REQUIRES "grpc++ grpc openssl protobuf")
+set(GOOGLE_CLOUD_CPP_PC_REQUIRES "grpc++ grpc openssl protobuf zlib libcares")
 set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogleapis_cpp_bigtable_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -467,7 +467,8 @@ if ("${GOOGLE_CLOUD_CPP_STORAGE_ENABLE_INSTALL}")
     set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Storage C++ Client Library")
     set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
         "Provides C++ APIs to access Google Cloud Storage.")
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lstorage_client")
+    set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common libcurl openssl")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lstorage_client -lcrc32c")
 
     # Create and install the pkg-config files.
     configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"


### PR DESCRIPTION
Generate better pkg-config configuration files for the Cloud Bigtable
and Google Cloud Storage C++ client libraries. While we do not use
pkg-config, nor do we use Make for that matter, we should expect that a
good number of our customers would:

https://www.jetbrains.com/research/devecosystem-2018/cpp/

Giving them easier to use pkg-config files seems like a good idea, at
relatively low effort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2333)
<!-- Reviewable:end -->
