### PR TITLE
Implement ObjectMetadata::set_storage_class().

### DIFF
--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -205,6 +205,10 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::uint64_t size() const { return size_; }
 
   using CommonMetadata::storage_class;
+  ObjectMetadata& set_storage_class(std::string v) {
+    CommonMetadata::set_storage_class(std::move(v));
+    return *this;
+  }
 
   bool temporary_hold() const { return temporary_hold_; }
   ObjectMetadata& set_temporary_hold(bool v) {

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -442,6 +442,15 @@ TEST(ObjectMetadataTest, SetEventBasedHold) {
   EXPECT_NE(expected, copy);
 }
 
+/// @test Verify we can change the storageClass field.
+TEST(ObjectMetadataTest, SetStorageClass) {
+  auto expected = CreateObjectMetadataForTest();
+  auto copy = expected;
+  copy.set_content_type("NEARLINE");
+  EXPECT_EQ("NEARLINE", copy.content_type());
+  EXPECT_NE(expected, copy);
+}
+
 /// @test Verify we can delete metadata fields.
 TEST(ObjectMetadataTest, DeleteMetadata) {
   auto expected = CreateObjectMetadataForTest();

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -446,8 +446,8 @@ TEST(ObjectMetadataTest, SetEventBasedHold) {
 TEST(ObjectMetadataTest, SetStorageClass) {
   auto expected = CreateObjectMetadataForTest();
   auto copy = expected;
-  copy.set_content_type("NEARLINE");
-  EXPECT_EQ("NEARLINE", copy.content_type());
+  copy.set_storage_class("NEARLINE");
+  EXPECT_EQ("NEARLINE", copy.storage_class());
   EXPECT_NE(expected, copy);
 }
 

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -410,7 +410,6 @@ class GcsObject(object):
         }
         for key in metadata.keys():
             if key not in writeable_keys:
-                print("\n\nDEBUG DO NOT MERGE removing %s\n\n" % key)
                 metadata.pop(key, None)
         return metadata
 

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -406,10 +406,11 @@ class GcsObject(object):
         writeable_keys = {
             'acl', 'cacheControl', 'contentDisposition', 'contentEncoding',
             'contentLanguage', 'contentType', 'eventBasedHold', 'metadata',
-            'temporaryHold'
+            'temporaryHold', 'storageClass'
         }
         for key in metadata.keys():
             if key not in writeable_keys:
+                print("\n\nDEBUG DO NOT MERGE removing %s\n\n" % key)
                 metadata.pop(key, None)
         return metadata
 


### PR DESCRIPTION
The field is writeable, though not via Update or Patch operations.

This fixes #2322.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2334)
<!-- Reviewable:end -->
