### PR TITLE
Disable some MSVC warnings because Protobuf.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -55,6 +55,16 @@ endif ()
 # users to add more common options without having to touch the code.
 add_library(bigtable_common_options INTERFACE)
 google_cloud_cpp_add_common_options(bigtable_common_options)
+if (MSVC)
+    #
+    # We turn off 4996 because some protobuf types derive from std::iterator,
+    # turn off the warnings about this being deprecated in C++17.
+    #
+    # We turn off 4244 because protobuf headers convert from `int64` to
+    # `RepeatedPtrField< T>::size_type`, which is really `int` and that may
+    # cause loss of data. But we only run on 64-bit platforms.
+    target_compile_options(bigtable_common_options INTERFACE /wd4996 /wd4244)
+endif ()
 
 # Configure the location of proto files, particulary the googleapis protos.
 list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis"

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -56,13 +56,14 @@ endif ()
 add_library(bigtable_common_options INTERFACE)
 google_cloud_cpp_add_common_options(bigtable_common_options)
 if (MSVC)
-    #
     # We turn off 4996 because some protobuf types derive from std::iterator,
     # turn off the warnings about this being deprecated in C++17.
     #
-    # We turn off 4244 because protobuf headers convert from `int64` to
+    # We turn off 4244 because protobuf headers convert from `std::size_t` to
     # `RepeatedPtrField< T>::size_type`, which is really `int` and that may
-    # cause loss of data. But we only run on 64-bit platforms.
+    # cause loss of data. There is nothing we can do to fix protobuf, so just
+    # silence the warning for now. The code in protobuf seems safe because a
+    # repeated field cannot hold more than `MAX_INT` elements.
     target_compile_options(bigtable_common_options INTERFACE /wd4996 /wd4244)
 endif ()
 


### PR DESCRIPTION
Protobuf headers generate too many warnings on MSVC. Specifically, they
use `std::iterator<>` which will be deprecated in C++17, but MSVC warns
about it now, and they convert from `int64` to `int` without a cast,
which MSVC also dislikes.

Oh, and we are getting these warnings now because in the changes to improve
the installation process I removed a bunch of code to turn off warnings. Good thing
too because only 2 out of like 10 was relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2337)
<!-- Reviewable:end -->
