### PR TITLE
Reimplement AsyncPollOp via futures.

### DIFF
--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -243,6 +243,179 @@ class AsyncPollOp
                 std::move(operation))) {}
 };
 
+/// SFINAE extractor of `T` from `future<StatusOr<optional<T>>>`, false branch.
+template <typename Future>
+struct ResponseFromFutureStatusOrOptionalResponse : public std::false_type {};
+
+/// SFINAE extractor of `T` from `future<StatusOr<optional<T>>>`, true branch.
+template <typename R>
+struct ResponseFromFutureStatusOrOptionalResponse<future<StatusOr<optional<R>>>>
+    : public std::true_type {
+  using type = R;
+};
+
+/**
+ * Traits for operation which can be polled via `StartAsyncPollOp`.
+ *
+ * It should be invocable with
+ * `(CompletionQueue&, std::unique_ptr<ClientContext>)` and return a
+ * `future<StatusOr<optional<T>>>`. The semantics should be:
+ *       - on error return a non-ok status,
+ *       - on successfully checking that the polled operation is not finished,
+ *         return an empty option
+ *       - on finished poll return the polled value
+ */
+template <typename Operation>
+struct PollableOperationRequestTraits {
+  static_assert(::google::cloud::internal::is_invocable<
+                    Operation, CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>>::value,
+                "A pollable operation needs to be incovable with "
+                "(CompletionQueue&, std::unique_ptr<grpc::ClientContext>)");
+  /// The type of what `Operation` returns.
+  using ReturnType = typename google::cloud::internal::invoke_result_t<
+      Operation, CompletionQueue&, std::unique_ptr<grpc::ClientContext>>;
+  static_assert(
+      ResponseFromFutureStatusOrOptionalResponse<ReturnType>::value,
+      "A pollable operation should return future<StatusOr<optional<T>>>");
+  /// `T`, assuming that `Operation` returns `future<StatusOr<optional<T>>>`
+  using ResponseType =
+      typename ResponseFromFutureStatusOrOptionalResponse<ReturnType>::type;
+};
+
+template <typename Operation>
+future<
+    StatusOr<typename PollableOperationRequestTraits<Operation>::ResponseType>>
+StartAsyncPollOp(char const* location,
+                 std::unique_ptr<PollingPolicy> polling_policy,
+                 MetadataUpdatePolicy metadata_update_policy,
+                 CompletionQueue cq, Operation operation);
+
+// Implementation of StartAsyncPollOp. Refer to it for its purpose.
+template <typename Operation>
+class PollAsyncOpFuture
+    : public std::enable_shared_from_this<PollAsyncOpFuture<Operation>> {
+ private:
+  /// Convenience alias for the value we are polling.
+  using Response =
+      typename PollableOperationRequestTraits<Operation>::ResponseType;
+
+  // The constructor is private because we always want to wrap the object in
+  // a shared pointer. The lifetime is controlled by any pending operations in
+  // the CompletionQueue.
+  PollAsyncOpFuture(char const* location,
+                    std::unique_ptr<PollingPolicy> polling_policy,
+                    MetadataUpdatePolicy metadata_update_policy,
+                    CompletionQueue cq, Operation operation)
+      : location_(location),
+        polling_policy_(std::move(polling_policy)),
+        metadata_update_policy_(std::move(metadata_update_policy)),
+        cq_(std::move(cq)),
+        operation_(std::move(operation)) {}
+
+  /// The callback for a completed request, successful or not.
+  void OnCompletion(StatusOr<optional<Response>> result) {
+    if (result && *result) {
+      final_result_.set_value(**std::move(result));
+      return;
+    }
+    // TODO(#1475) remove this hack.
+    // PollingPolicy's interface doesn't allow it to make a decision on the
+    // delay depending on whether there was a success or a failure. This is
+    // because PollingPolicy never gets to know about a successful attempt. In
+    // order to work around it in this particular class we keep the invariant
+    // that a call to OnFailure() always preceeds a call to WaitPeriod(). That
+    // way the policy can react differently to successful requests.
+    bool const allowed_to_retry = polling_policy_->OnFailure(result.status());
+    if (!result && !allowed_to_retry) {
+      final_result_.set_value(
+          DetailedStatus(polling_policy_->IsPermanentError(result.status())
+                             ? "permanent error"
+                             : "too many transient errors",
+                         result.status()));
+      return;
+    }
+    if (polling_policy_->Exhausted()) {
+      final_result_.set_value(DetailedStatus("polling policy exhausted",
+                                             Status(StatusCode::kUnknown, "")));
+      return;
+    }
+    auto self = this->shared_from_this();
+    cq_.MakeRelativeTimer(polling_policy_->WaitPeriod())
+        .then([self](future<std::chrono::system_clock::time_point>) {
+          self->StartIteration();
+        });
+  }
+
+  /// The callback to start another iteration of the retry loop.
+  void StartIteration() {
+    auto context =
+        ::google::cloud::internal::make_unique<grpc::ClientContext>();
+    polling_policy_->Setup(*context);
+    metadata_update_policy_.Setup(*context);
+
+    auto self = this->shared_from_this();
+    operation_(cq_, std::move(context))
+        .then([self](future<StatusOr<optional<Response>>> fut) {
+          self->OnCompletion(fut.get());
+        });
+  }
+
+  /// Generate an error message
+  Status DetailedStatus(char const* context, Status const& status) {
+    std::string full_message = location_;
+    full_message += "(" + metadata_update_policy_.value() + ") ";
+    full_message += context;
+    full_message += ", last error=";
+    full_message += status.message();
+    return Status(status.code(), std::move(full_message));
+  }
+
+  char const* location_;
+  std::unique_ptr<PollingPolicy> polling_policy_;
+  MetadataUpdatePolicy metadata_update_policy_;
+  CompletionQueue cq_;
+  Operation operation_;
+  promise<StatusOr<Response>> final_result_;
+
+  friend future<StatusOr<
+      typename PollableOperationRequestTraits<Operation>::ResponseType>>
+  StartAsyncPollOp<Operation>(char const* location,
+                              std::unique_ptr<PollingPolicy> polling_policy,
+                              MetadataUpdatePolicy metadata_update_policy,
+                              CompletionQueue cq, Operation operation);
+};
+
+/**
+ * Start the asynchronous retry loop.
+ *
+ * @param location typically the name of the function that created this
+ *     asynchronous retry loop.
+ * @param polling_policy controls how often the server is queried
+ * @param metadata_update_policy controls how to update the metadata fields in
+ *     the request.
+ * @param cq the completion queue where the retry loop is executed.
+ * @param operation the operation to poll; refer to
+ *     `PollableOperationRequestTraits` for requirements.
+ * @return a future that becomes satisfied when (a) the service responds with an
+ *     indication that the poll is finished, or (b) one of the poll attempts
+ *     fails with a non-retryable error, or (d) the polling policy is expired.
+ */
+template <typename Operation>
+future<
+    StatusOr<typename PollableOperationRequestTraits<Operation>::ResponseType>>
+StartAsyncPollOp(char const* location,
+                 std::unique_ptr<PollingPolicy> polling_policy,
+                 MetadataUpdatePolicy metadata_update_policy,
+                 CompletionQueue cq, Operation operation) {
+  auto req = std::shared_ptr<PollAsyncOpFuture<Operation>>(
+      new PollAsyncOpFuture<Operation>(location, std::move(polling_policy),
+                                       std::move(metadata_update_policy),
+                                       std::move(cq), std::move(operation)));
+  req->StartIteration();
+  return req->final_result_.get_future();
+}
+
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_POLLING_POLICY_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_POLLING_POLICY_H_
 
+#include "google/cloud/bigtable/internal/grpc_error_delegate.h"
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
@@ -47,15 +48,34 @@ class PollingPolicy {
   /**
    * Return true if `status` represents a permanent error that cannot be
    * retried.
+   * TODO(dopiera): remove grpc::Status version.
    */
-  virtual bool IsPermanentError(grpc::Status const& status) = 0;
+  virtual bool IsPermanentError(grpc::Status const& status) {
+    return IsPermanentError(internal::MakeStatusFromRpcError(status));
+  }
+
+  /**
+   * Return true if `status` represents a permanent error that cannot be
+   * retried.
+   */
+  virtual bool IsPermanentError(google::cloud::Status const& status) = 0;
+
+  /**
+   * Handle an RPC failure.
+   * TODO(dopiera): remove grpc::Status version.
+   *
+   * @return true if the RPC operation should be retried.
+   */
+  virtual bool OnFailure(grpc::Status const& status) {
+    return OnFailure(internal::MakeStatusFromRpcError(status));
+  }
 
   /**
    * Handle an RPC failure.
    *
    * @return true if the RPC operation should be retried.
    */
-  virtual bool OnFailure(grpc::Status const& status) = 0;
+  virtual bool OnFailure(google::cloud::Status const& status) = 0;
 
   /**
    * Return true if we cannot try again.
@@ -88,15 +108,15 @@ class GenericPollingPolicy : public PollingPolicy {
     rpc_backoff_policy_.Setup(context);
   }
 
-  bool IsPermanentError(grpc::Status const& status) override {
+  bool IsPermanentError(google::cloud::Status const& status) override {
     return RPCRetryPolicy::IsPermanentFailure(status);
   }
 
-  bool OnFailure(grpc::Status const& status) override {
+  bool OnFailure(google::cloud::Status const& status) override {
     return rpc_retry_policy_.OnFailure(status);
   }
 
-  bool Exhausted() override { return !OnFailure(grpc::Status::OK); }
+  bool Exhausted() override { return !OnFailure(google::cloud::Status()); }
 
   std::chrono::milliseconds WaitPeriod() override {
     return rpc_backoff_policy_.OnCompletion(grpc::Status::OK);

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -48,7 +48,7 @@ class PollingPolicy {
   /**
    * Return true if `status` represents a permanent error that cannot be
    * retried.
-   * TODO(dopiera): remove grpc::Status version.
+   * TODO(#2344): remove grpc::Status version.
    */
   virtual bool IsPermanentError(grpc::Status const& status) {
     return IsPermanentError(internal::MakeStatusFromRpcError(status));
@@ -62,7 +62,7 @@ class PollingPolicy {
 
   /**
    * Handle an RPC failure.
-   * TODO(dopiera): remove grpc::Status version.
+   * TODO(#2344): remove grpc::Status version.
    *
    * @return true if the RPC operation should be retried.
    */


### PR DESCRIPTION
PollingPolicy had to also be adapted to allow for `google::cloud::Status`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2339)
<!-- Reviewable:end -->
