### PR TITLE
Fix std::size_t to int warnings.

### DIFF
--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -151,8 +151,6 @@ long RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
                   bigtable::AppProfileId app_profile_id,
                   std::string const& table_id,
                   std::chrono::seconds test_duration) {
-  long total_ops = 0;
-
   BenchmarkResult partial = {};
 
   auto data_client = benchmark.MakeDataClient();
@@ -176,8 +174,7 @@ long RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
   std::ostringstream msg;
   benchmark.PrintLatencyResult(msg, "long", "Partial::Op", partial);
   std::cout << msg.str() << std::flush;
-  total_ops = partial.operations.size();
-  return total_ops;
+  return static_cast<long>(partial.operations.size());
 }
 
 }  // anonymous namespace

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -77,18 +77,20 @@ std::string TableTestEnvironment::RandomTableId() {
   // This value was discovered by trial and error, it is not documented in the
   // proto files.
   constexpr int kMaxTableIdLength = 50;
-  static std::string const prefix = "table-";
-  return CreateRandomId(prefix,
-                        static_cast<int>(kMaxTableIdLength - prefix.length()));
+  static char const prefix[] = "table-";
+  static_assert(kMaxTableIdLength > sizeof(prefix), "prefix is too long");
+  constexpr int sample_count = kMaxTableIdLength - sizeof(prefix) + 1;
+  return CreateRandomId(prefix, sample_count);
 }
 
 std::string TableTestEnvironment::RandomInstanceId() {
   // This value was discovered by trial and error, it is not documented in the
   // proto files.
   constexpr int kMaxInstanceIdLenth = 33;
-  static std::string const prefix = "instance-";
-  return CreateRandomId(
-      prefix, static_cast<int>(kMaxInstanceIdLenth - prefix.length()));
+  static char const prefix[] = "instance-";
+  static_assert(kMaxInstanceIdLenth > sizeof(prefix), "prefix is too long");
+  constexpr int sample_count = kMaxInstanceIdLenth - sizeof(prefix) + 1;
+  return CreateRandomId(prefix, sample_count);
 }
 
 void TableIntegrationTest::SetUp() {

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -78,7 +78,8 @@ std::string TableTestEnvironment::RandomTableId() {
   // proto files.
   constexpr int kMaxTableIdLength = 50;
   static std::string const prefix = "table-";
-  return CreateRandomId(prefix, kMaxTableIdLength - prefix.length());
+  return CreateRandomId(prefix,
+                        static_cast<int>(kMaxTableIdLength - prefix.length()));
 }
 
 std::string TableTestEnvironment::RandomInstanceId() {
@@ -86,7 +87,8 @@ std::string TableTestEnvironment::RandomInstanceId() {
   // proto files.
   constexpr int kMaxInstanceIdLenth = 33;
   static std::string const prefix = "instance-";
-  return CreateRandomId(prefix, kMaxInstanceIdLenth - prefix.length());
+  return CreateRandomId(
+      prefix, static_cast<int>(kMaxInstanceIdLenth - prefix.length()));
 }
 
 void TableIntegrationTest::SetUp() {

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -86,10 +86,10 @@ std::string TableTestEnvironment::RandomTableId() {
 std::string TableTestEnvironment::RandomInstanceId() {
   // This value was discovered by trial and error, it is not documented in the
   // proto files.
-  constexpr int kMaxInstanceIdLenth = 33;
+  constexpr int kMaxInstanceIdLength = 33;
   static char const prefix[] = "instance-";
-  static_assert(kMaxInstanceIdLenth > sizeof(prefix), "prefix is too long");
-  constexpr int sample_count = kMaxInstanceIdLenth - sizeof(prefix) + 1;
+  static_assert(kMaxInstanceIdLength > sizeof(prefix), "prefix is too long");
+  constexpr int sample_count = kMaxInstanceIdLength - sizeof(prefix) + 1;
   return CreateRandomId(prefix, sample_count);
 }
 

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -519,7 +519,7 @@ TEST_F(ObjectMediaIntegrationTest, UploadFileResumableNonQuantum) {
                 "This test assumes the chunk quantum is a multiple of 256; it "
                 "needs fixing");
   auto desired_size = (5 * internal::UploadChunkRequest::kChunkSizeQuantum / 2);
-  WriteRandomLines(os, expected, desired_size / 128, 128);
+  WriteRandomLines(os, expected, static_cast<int>(desired_size / 128), 128);
   os.close();
 
   StatusOr<ObjectMetadata> meta = client.UploadFile(


### PR DESCRIPTION
These are easy because the values are small enough to fit into the
destination type, so a `static_cast<>` does the trick.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2341)
<!-- Reviewable:end -->
