### PR TITLE
Consistently warn about async-APIs status.

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -174,6 +174,10 @@ class InstanceAdmin {
   /**
    * Query (asynchronously) the list of instances in the project.
    *
+   * @warning This is an early version of the asynchronous APIs for Cloud
+   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
+   *     is not subject to any SLA or deprecation policy.
+   *
    * @note In some circumstances Cloud Bigtable may be unable to obtain the full
    *   list of instances, typically because some transient failure has made
    *   specific zones unavailable. In this cases the service returns a separate
@@ -272,6 +276,10 @@ class InstanceAdmin {
 
   /**
    * Query (asynchronously) the list of clusters in a project.
+   *
+   * @warning This is an early version of the asynchronous APIs for Cloud
+   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
+   *     is not subject to any SLA or deprecation policy.
    *
    * @note In some circumstances Cloud Bigtable may be unable to obtain the full
    *   list of clusters, typically because some transient failure has made

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -206,7 +206,11 @@ class Table {
   Status Apply(SingleRowMutation mut);
 
   /**
-   * Makes asycronous attempts to apply the mutation to a row.
+   * Makes asynchronous attempts to apply the mutation to a row.
+   *
+   * @warning This is an early version of the asynchronous APIs for Cloud
+   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
+   *     is not subject to any SLA or deprecation policy.
    *
    * @param mut the mutation. Note that this function takes ownership
    * (and then discards) the data in the mutation.  In general, a
@@ -237,7 +241,11 @@ class Table {
   std::vector<FailedMutation> BulkApply(BulkMutation mut);
 
   /**
-   * Makes asyncronous attempts to apply mutations to multiple rows.
+   * Makes asynchronous attempts to apply mutations to multiple rows.
+   *
+   * @warning This is an early version of the asynchronous APIs for Cloud
+   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
+   *     is not subject to any SLA or deprecation policy.
    *
    * @param mut the mutations, note that this function takes
    *     ownership (and then discards) the data in the mutation. In general, a

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -227,6 +227,10 @@ class TableAdmin {
   /**
    * Start a request to asynchronously delete a table.
    *
+   * @warning This is an early version of the asynchronous APIs for Cloud
+   *     Bigtable. These APIs might be changed in backward-incompatible ways. It
+   *     is not subject to any SLA or deprecation policy.
+   *
    * @param cq the completion queue that will execute the asynchronous calls,
    *     the application must ensure that one or more threads are blocked on
    *     `cq.Run()`.
@@ -429,10 +433,15 @@ class TableAdmin {
                           bigtable::SnapshotId const& snapshot_id,
                           std::string table_id);
 
-  //@}
-
   /**
    * List snapshots in the given instance.
+   *
+   * @warning This is a private alpha release of Cloud Bigtable snapshots. This
+   * feature is not currently available to most Cloud Bigtable customers. This
+   * feature might be changed in backward-incompatible ways and is not
+   * recommended for production use. It is not subject to any SLA or deprecation
+   * policy.
+   *
    * @param cluster_id the name of the cluster for which snapshots should be
    * listed.
    * @return vector containing the snapshots for the given cluster.
@@ -442,6 +451,7 @@ class TableAdmin {
    */
   StatusOr<std::vector<::google::bigtable::admin::v2::Snapshot>> ListSnapshots(
       bigtable::ClusterId const& cluster_id = bigtable::ClusterId("-"));
+  //@}
 
   /// Return the fully qualified name of a table in this object's instance.
   std::string TableName(std::string const& table_id) const {


### PR DESCRIPTION
The async APIs in Cloud Bigtable are not stable yet, we had not put the
warning in all the right places, fixed that, and a few typos too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2348)
<!-- Reviewable:end -->
