### PR TITLE
Disable debug output for googleapis_project.

### DIFF
--- a/cmake/FindProtobufTargets.cmake
+++ b/cmake/FindProtobufTargets.cmake
@@ -143,7 +143,7 @@ endif ()
 if (protobuf_DEBUG)
     message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "
                    "ProtobufTargets_FOUND = ${ProtobufTargets_FOUND}"
-                   "ProtobufTargets_VERSION = ${ProtobufTargets_VERSION}")
+                   " ProtobufTargets_VERSION = ${ProtobufTargets_VERSION}")
 endif ()
 
 # We also should try to find the protobuf C++ plugin for the protocol buffers

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -104,8 +104,6 @@ if (NOT TARGET googleapis_project)
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_SKIP_INSTALL_RPATH=ON
-                   -DgRPC_DEBUG=ON
-                   -Dprotobuf_DEBUG=ON
                    -DGOOGLE_CLOUD_CPP_USE_LIBCXX=${GOOGLE_CLOUD_CPP_USE_LIBCXX}
                    ${_googleapis_toolchain_flag}
                    ${_googleapis_triplet_flag}
@@ -115,9 +113,9 @@ if (NOT TARGET googleapis_project)
                       ${PARALLEL}
         BUILD_BYPRODUCTS ${googleapis_byproducts}
         LOG_DOWNLOAD ON
-        LOG_CONFIGURE OFF
-        LOG_BUILD OFF
-        LOG_INSTALL OFF)
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
 
     unset(_googleapis_toolchain_flag)
     unset(_googleapis_triplet_flag)


### PR DESCRIPTION
It was useful when bootstrapping the new googleapis dependency, now it
is just noise, I should have removed it when I merged the final version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2349)
<!-- Reviewable:end -->
