### PR TITLE
Removed unneeded enablers in storage/

### DIFF
--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -27,7 +27,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::internal::raw_client_wrapper_utils::
-    CheckSignature;
+    Signature;
 
 /**
  * Logs the input and results of each `RawClient` operation.
@@ -40,12 +40,10 @@ using ::google::cloud::storage::internal::raw_client_wrapper_utils::
  * @return the result from making the call;
  */
 template <typename MemberFunction>
-static typename std::enable_if<
-    CheckSignature<MemberFunction>::value,
-    typename CheckSignature<MemberFunction>::ReturnType>::type
-MakeCall(RawClient& client, MemberFunction function,
-         typename CheckSignature<MemberFunction>::RequestType const& request,
-         char const* context) {
+static typename Signature<MemberFunction>::ReturnType MakeCall(
+    RawClient& client, MemberFunction function,
+    typename Signature<MemberFunction>::RequestType const& request,
+    char const* context) {
   GCP_LOG(INFO) << context << "() << " << request;
   auto response = (client.*function)(request);
   if (response.ok()) {
@@ -70,13 +68,10 @@ MakeCall(RawClient& client, MemberFunction function,
  * @return the result from making the call;
  */
 template <typename MemberFunction>
-static typename std::enable_if<
-    CheckSignature<MemberFunction>::value,
-    typename CheckSignature<MemberFunction>::ReturnType>::type
-MakeCallNoResponseLogging(
+static typename Signature<MemberFunction>::ReturnType MakeCallNoResponseLogging(
     google::cloud::storage::internal::RawClient& client,
     MemberFunction function,
-    typename CheckSignature<MemberFunction>::RequestType const& request,
+    typename Signature<MemberFunction>::RequestType const& request,
     char const* context) {
   GCP_LOG(INFO) << context << "() << " << request;
   return (client.*function)(request);

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -26,8 +26,7 @@ namespace internal {
 
 namespace {
 
-using ::google::cloud::storage::internal::raw_client_wrapper_utils::
-    Signature;
+using ::google::cloud::storage::internal::raw_client_wrapper_utils::Signature;
 
 /**
  * Logs the input and results of each `RawClient` operation.

--- a/google/cloud/storage/internal/raw_client_wrapper_utils.h
+++ b/google/cloud/storage/internal/raw_client_wrapper_utils.h
@@ -33,26 +33,24 @@ namespace internal {
  * meta-functions defined here.
  */
 namespace raw_client_wrapper_utils {
+
 /**
- * Determines if @p F is a pointer to member function with the expected
- * signature for a `RawClient` member function.
+ * Metafunction to determine if @p F is a pointer to member function with the
+ * expected signature for a `RawClient` member function.
  *
  * This is the generic case, where the type does not match the expected
- * signature.  The class derives from `std::false_type`, so
- * `Signature<T>::%value` is `false`.
+ * signature and so member type aliases do not exist.
  *
  * @tparam F the type to check against the expected signature.
  */
-template <typename T>
+template <typename F>
 struct Signature {};
 
 /**
- * Determines if a type is a pointer to member function with the expected
- * signature.
+ * Partial specialization for the above `Signature` metafunction.
  *
- * This is the case where the type actually matches the expected signature.
- * This class derives from `std::true_type`, so `Signature<T>::%value` is
- * `true`.  The class also extracts the request and response types used in the
+ * This is the case where the type actually matches the expected signature. The
+ * class also extracts the request and response types used in the
  * implementation of `CallWithRetry()`.
  *
  * @tparam Request the RPC request type.
@@ -64,6 +62,7 @@ struct Signature<StatusOr<Response> (
   using RequestType = Request;
   using ReturnType = StatusOr<Response>;
 };
+
 }  // namespace raw_client_wrapper_utils
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/raw_client_wrapper_utils.h
+++ b/google/cloud/storage/internal/raw_client_wrapper_utils.h
@@ -34,34 +34,24 @@ namespace internal {
  */
 namespace raw_client_wrapper_utils {
 /**
- * Checks the expected signature for a `RawClient` member function.
- */
-template <typename Request, typename Response>
-using DesiredSignature = StatusOr<Response> (
-    google::cloud::storage::internal::RawClient::*)(Request const&);
-
-/**
- * Determines if @p T is a pointer to member function with the expected
+ * Determines if @p F is a pointer to member function with the expected
  * signature for a `RawClient` member function.
  *
  * This is the generic case, where the type does not match the expected
  * signature.  The class derives from `std::false_type`, so
- * `CheckSignature<T>::%value` is `false`.
+ * `Signature<T>::%value` is `false`.
  *
- * @tparam T the type to check against the expected signature.
+ * @tparam F the type to check against the expected signature.
  */
 template <typename T>
-struct CheckSignature : public std::false_type {
-  /// Must define ReturnType because it is used in std::enable_if<>.
-  using ReturnType = void;
-};
+struct Signature {};
 
 /**
  * Determines if a type is a pointer to member function with the expected
  * signature.
  *
  * This is the case where the type actually matches the expected signature.
- * This class derives from `std::true_type`, so `CheckSignature<T>::%value` is
+ * This class derives from `std::true_type`, so `Signature<T>::%value` is
  * `true`.  The class also extracts the request and response types used in the
  * implementation of `CallWithRetry()`.
  *
@@ -69,12 +59,10 @@ struct CheckSignature : public std::false_type {
  * @tparam Response the RPC response type.
  */
 template <typename Request, typename Response>
-struct CheckSignature<DesiredSignature<Request, Response>>
-    : public std::true_type {
-  using ResponseType = Response;
+struct Signature<StatusOr<Response> (
+    google::cloud::storage::internal::RawClient::*)(Request const&)> {
   using RequestType = Request;
-  using MemberFunctionType = DesiredSignature<Request, Response>;
-  using ReturnType = StatusOr<ResponseType>;
+  using ReturnType = StatusOr<Response>;
 };
 }  // namespace raw_client_wrapper_utils
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -46,8 +46,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::google::cloud::storage::internal::raw_client_wrapper_utils::
-    CheckSignature;
+using ::google::cloud::storage::internal::raw_client_wrapper_utils::Signature;
 
 /**
  * Calls a client operation with retries borrowing the RPC policies.
@@ -65,13 +64,11 @@ using ::google::cloud::storage::internal::raw_client_wrapper_utils::
  * @throw std::exception with a description of the last error.
  */
 template <typename MemberFunction>
-typename std::enable_if<
-    CheckSignature<MemberFunction>::value,
-    typename CheckSignature<MemberFunction>::ReturnType>::type
-MakeCall(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
-         bool is_idempotent, RawClient& client, MemberFunction function,
-         typename CheckSignature<MemberFunction>::RequestType const& request,
-         char const* error_message) {
+typename Signature<MemberFunction>::ReturnType MakeCall(
+    RetryPolicy& retry_policy, BackoffPolicy& backoff_policy,
+    bool is_idempotent, RawClient& client, MemberFunction function,
+    typename Signature<MemberFunction>::RequestType const& request,
+    char const* error_message) {
   Status last_status;
   auto error = [&last_status](std::string const& msg) {
     return Status(last_status.code(), msg);


### PR DESCRIPTION
Context #2236 

Again, I think this simplifies the metafunction, the call sites using the metafunction, and results is essentially equivalent error messages.

In this case, I left the doxygen comments on both the primary template and the partial specialization. I'm not sure this is better, but I'm happy to leave the existing comments now that I know how doxygen works a little more (thanks for letting me know).

Also notice that I removed the `ResponseType` member alias from `Signature`. It was never used. And if we do need to use that one day, I think we would probably want to do that by adding a `value_type` alias to `StatusOr<T>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2352)
<!-- Reviewable:end -->
