### PR TITLE
Fix flakiness caused by drop all rows quota

### DIFF
--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -110,9 +110,9 @@ void TableIntegrationTest::SetUp() {
       TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
       ClientOptions());
 
-  // We cannot use `DropAllRows()` to cleanup the table because the integration
-  // tests against production sometimes use all the "'DropRowRangeGroup' and
-  // limit 'USER-100s'" quota. Instead we delete the rows by using a
+  // In production, we cannot use `DropAllRows()` to cleanup the table because
+  // the integration tests sometimes use all the "'DropRowRangeGroup'" quota.
+  // Instead we delete the rows, when possible, using BulkApply().
   BulkMutation bulk;
   auto table = GetTable();
   // Bigtable does not support more than 100,000 mutations in a BulkMutation,

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -111,19 +111,19 @@ void TableIntegrationTest::SetUp() {
       ClientOptions());
 
   // In production, we cannot use `DropAllRows()` to cleanup the table because
-  // the integration tests sometimes use all the "'DropRowRangeGroup'" quota.
+  // the integration tests sometimes consume all the 'DropRowRangeGroup' quota.
   // Instead we delete the rows, when possible, using BulkApply().
   BulkMutation bulk;
   auto table = GetTable();
-  // Bigtable does not support more than 100,000 mutations in a BulkMutation,
-  // if we had that many rows then just fallback on DropAllRows(). Most tests
+  // Bigtable does not support more than 100,000 mutations in a BulkMutation.
+  // If we had that many rows then just fallback on DropAllRows(). Most tests
   // only have a small number of rows, so this is a good strategy to save
   // DropAllRows() quota, and should be fast in most cases.
   std::size_t const maximum_mutations = 100000;
 
   for (auto const& row :
        table.ReadRows(RowRange::InfiniteRange(), Filter::PassAllFilter())) {
-    if (not row) {
+    if (!row) {
       break;
     }
     bulk.emplace_back(
@@ -136,7 +136,7 @@ void TableIntegrationTest::SetUp() {
   // The version of the emulator distributed with the Cloud SDK does not handle
   // deleted rows correctly:
   //   https://github.com/googleapis/google-cloud-go/issues/1240
-  // this has been fixed at HEAD, but the changes have not made it to a version
+  // This has been fixed at HEAD, but the changes have not made it to a version
   // we can use yet. So just use DropAllRows() in that case.
   if (bulk.size() > maximum_mutations || UsingCloudBigtableEmulator()) {
     ASSERT_STATUS_OK(

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -79,6 +79,10 @@ class TableTestEnvironment : public ::testing::Environment {
 
   static std::string const& table_id() { return table_id_; }
 
+  static bool UsingCloudBigtableEmulator() {
+    return using_cloud_bigtable_emulator_;
+  }
+
  private:
   static std::string project_id_;
   static std::string instance_id_;
@@ -89,6 +93,8 @@ class TableTestEnvironment : public ::testing::Environment {
   static google::cloud::internal::DefaultPRNG generator_;
 
   static std::string table_id_;
+
+  static bool using_cloud_bigtable_emulator_;
 };
 
 /**
@@ -144,6 +150,11 @@ class TableIntegrationTest : public ::testing::Test {
    * the tests, we run each test with a randomly selected table name.
    */
   std::string RandomTableId();
+
+  /// Some tests cannot run on the emulator.
+  bool UsingCloudBigtableEmulator() const {
+    return TableTestEnvironment::UsingCloudBigtableEmulator();
+  }
 
  protected:
   std::shared_ptr<bigtable::AdminClient> admin_client_;

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/testing/table_integration_test.h"
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
@@ -54,9 +53,6 @@ class FilterIntegrationTest : public bigtable::testing::TableIntegrationTest {
    */
   void CreateComplexRows(bigtable::Table& table, std::string const& prefix);
 };
-
-/// Return true if connected to the Cloud Bigtable Emulator.
-bool UsingCloudBigtableEmulator();
 
 }  // namespace
 
@@ -577,7 +573,4 @@ void FilterIntegrationTest::CreateComplexRows(bigtable::Table& table,
   ASSERT_TRUE(failures.empty());
 }
 
-bool UsingCloudBigtableEmulator() {
-  return google::cloud::internal::GetEnv("BIGTABLE_EMULATOR_HOST").has_value();
-}
 }  // namespace

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/bigtable/grpc_error.h"
 #include "google/cloud/bigtable/testing/table_integration_test.h"
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/init_google_mock.h"
@@ -55,9 +54,6 @@ class MutationIntegrationTest : public bigtable::testing::TableIntegrationTest {
   }
 };
 
-bool UsingCloudBigtableEmulator() {
-  return google::cloud::internal::GetEnv("BIGTABLE_EMULATOR_HOST").has_value();
-}
 }  // namespace
 
 /**

--- a/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
+++ b/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
@@ -25,7 +25,7 @@ start_emulators
 # The project and instance do not matter for the Cloud Bigtable emulator.
 # Use a unique project name to allow multiple runs of the test with
 # an externally launched emulator.
-readonly NONCE="${RANDOM}-{RANDOM}"
+readonly NONCE="${RANDOM}-${RANDOM}"
 readonly PROJECT_ID="emulated-${NONCE}"
 
 echo


### PR DESCRIPTION
Before running each integration test we cleanup the test table, removing
all rows from it. We used `DropAllRows()` for this, but there is limited
quota for this operation and the builds are failing because we exceed
that quota. Use `BulkApply()` when the number of rows is relatively
small, which is most of the time, and fallback on DropAllRows()
otherwise.

This basic plan became a bit complicated because the version of the
emulator we can use has a bug in dealing with rows
deleted via `Apply()` or `BulkApply()`:

googleapis/google-cloud-go#1240

The bug is fixed, but that version has not made it to a usable SDK yet.
The bug does not affect rows deleted with `DropAllRows()`.

So to save `DropAllRows()` quota we will use `BulkApply()` when running
in production, and to workaround the bug use `DropAllRows()` when using
the emulator.

Since we need to know whether we are using the emulator in the
`TableIntegrationTest` fixture, refactor the function to check that.

This fixes #2272.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2355)
<!-- Reviewable:end -->
