### PR TITLE
Updates bazel used in CI

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -19,7 +19,7 @@ set -eu
 readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-readonly BAZEL_VERSION="0.23.2"
+readonly BAZEL_VERSION="0.24.0"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"


### PR DESCRIPTION
Updating our CI to test with 0.24.0 (the latest) version of Bazel will allow us to migrate our genrules per https://github.com/bazelbuild/bazel/issues/6867

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2360)
<!-- Reviewable:end -->
