### PR TITLE
We need Bazel 0.24.0 from now on [skip ci].

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ of these tools we test with are:
 | Tool       | Minimum Version |
 | ---------- | --------------- |
 | CMake      | 3.5 |
-| Bazel      | 0.20.0 |
+| Bazel      | 0.24.0 |
 
 #### Libraries
 


### PR DESCRIPTION
I forgot about this reference in the documentation this morning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2368)
<!-- Reviewable:end -->
