### PR TITLE
Do not raise exceptions in ReadObject().

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -340,6 +340,7 @@ if (BUILD_TESTING)
         internal/notification_requests_test.cc
         internal/object_acl_requests_test.cc
         internal/object_requests_test.cc
+        internal/object_streambuf_test.cc
         internal/parse_rfc3339_test.cc
         internal/patch_builder_test.cc
         internal/retry_client_test.cc

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -891,7 +891,7 @@ class Client {
                               Options&&... options) {
     internal::ReadObjectRangeRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ObjectReadStream(raw_client_->ReadObject(request).value());
+    return ReadObjectImpl(std::move(request));
   }
 
   /**
@@ -2744,6 +2744,9 @@ class Client {
         std::move(logging), std::forward<Policies>(policies)...);
     return retry;
   }
+
+  ObjectReadStream ReadObjectImpl(
+      internal::ReadObjectRangeRequest const& request);
 
   // The version of UploadFile() where UseResumableUploadSession is one of the
   // options. Note how this does not use InsertObjectMedia at all.

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -51,6 +51,33 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
 };
 
 /**
+ * A read stream in a permanent error status.
+ */
+class ObjectReadErrorStreambuf : public ObjectReadStreambuf {
+ public:
+  explicit ObjectReadErrorStreambuf(Status status)
+      : status_(std::move(status)) {}
+
+  void Close() override {}
+  bool IsOpen() const override { return false; }
+  Status const& status() const override { return status_; }
+  std::string const& received_hash() const override { return received_hash_; }
+  std::string const& computed_hash() const override { return computed_hash_; }
+  std::multimap<std::string, std::string> const& headers() const override {
+    return headers_;
+  }
+
+ protected:
+  int_type underflow() override { return traits_type::eof(); }
+
+ private:
+  Status status_;
+  std::string received_hash_;
+  std::string computed_hash_;
+  std::multimap<std::string, std::string> headers_;
+};
+
+/**
  * Defines a compilation barrier for libcurl.
  *
  * We do not want to expose the libcurl objects through `ObjectWriteStream`,

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -51,7 +51,7 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
 };
 
 /**
- * A read stream in a permanent error status.
+ * A read stream in a permanent error state.
  */
 class ObjectReadErrorStreambuf : public ObjectReadStreambuf {
  public:

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/object_streambuf.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+namespace {
+
+TEST(ObjectStreambufTest, ReadErrorStreambuf) {
+  Status expected(StatusCode::kUnknown, "test-message");
+  ObjectReadErrorStreambuf streambuf(expected);
+
+  EXPECT_EQ(expected, streambuf.status());
+
+  // Peek one character, should return the EOF value.
+  EXPECT_EQ(ObjectReadErrorStreambuf::traits_type::eof(), streambuf.sgetc());
+
+  EXPECT_FALSE(streambuf.IsOpen());
+
+  streambuf.Close();
+  EXPECT_FALSE(streambuf.IsOpen());
+
+  // These are mostly to increase code coverage, we want to find the important
+  // missing coverage, and adding 4 lines of tests saves us guessing later.
+  EXPECT_EQ("", streambuf.computed_hash());
+  EXPECT_EQ("", streambuf.received_hash());
+  EXPECT_TRUE(streambuf.headers().empty());
+
+  // The error status should still be set.
+  EXPECT_EQ(expected, streambuf.status());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -419,7 +419,7 @@ TEST_F(ObjectTest, ReadObjectTooManyFailures) {
 }
 
 TEST_F(ObjectTest, ReadObjectPermanentFailure) {
-  // We cannot use google::cloud::storage::testing::TooManyFailuresStatusTest,
+  // We cannot use google::cloud::storage::testing::PermanentFailureStatusTest,
   // because that assumes the type returned by the RawClient operation is
   // copyable.
   using ReturnType = std::unique_ptr<internal::ObjectReadStreambuf>;

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -57,6 +57,7 @@ storage_client_unit_tests = [
     "internal/notification_requests_test.cc",
     "internal/object_acl_requests_test.cc",
     "internal/object_requests_test.cc",
+    "internal/object_streambuf_test.cc",
     "internal/parse_rfc3339_test.cc",
     "internal/patch_builder_test.cc",
     "internal/retry_client_test.cc",


### PR DESCRIPTION
The plan was to return the status in the ReadObjectStream, that was not
working when there were errors (such as authentication problems)
preventing us from even creating a valid ReadObjectStreambuf. The
"solution" proposed here is to create a streambuf that is permanently
set to "this is an error stream, everything is terrible".

I am not sure this is the best fix, and welcome other ideas. It does not
solve all the known problems with error handling in `ReadObject()`, but
I think it is a pre-requisite to solve them. There is a separate bug to track
similar problems on `WriteObject` (#2374), and I think it should have a
similar solution.

This fixes #2373.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2375)
<!-- Reviewable:end -->
