### PR TITLE
Use exceptions to report "cannot happen" errors.

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -105,10 +105,15 @@ StatusOr<HttpResponse> CurlDownloadRequest::GetMore(std::string& buffer) {
   return HttpResponse{100, {}, {}};
 }
 
-Status CurlDownloadRequest::SetOptions() {
+void CurlDownloadRequest::SetOptions() {
   ResetOptions();
   auto error = curl_multi_add_handle(multi_.get(), handle_.handle_.get());
-  return AsStatus(error, __func__);
+  if (error != CURLM_OK) {
+    // This indicates that we are using the API incorrectly, the application
+    // can not recover from these problems, raising an exception is the
+    // "Right Thing"[tm] here.
+    google::cloud::internal::ThrowStatus(AsStatus(error, __func__));
+  }
 }
 
 void CurlDownloadRequest::ResetOptions() {

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -94,8 +94,8 @@ class CurlDownloadRequest {
 
  private:
   friend class CurlRequestBuilder;
-  /// Set the underlying CurlHandle options initially.
-  Status SetOptions();
+  /// Set the underlying CurlHandle options on a new CurlDownloadRequest.
+  void SetOptions();
 
   /// Reset the underlying CurlHandle options after a move operation.
   void ResetOptions();

--- a/google/cloud/storage/internal/curl_upload_request.cc
+++ b/google/cloud/storage/internal/curl_upload_request.cc
@@ -92,10 +92,15 @@ Status CurlUploadRequest::NextBuffer(std::string& next_buffer) {
   return status;
 }
 
-Status CurlUploadRequest::SetOptions() {
+void CurlUploadRequest::SetOptions() {
   ResetOptions();
   auto error = curl_multi_add_handle(multi_.get(), handle_.handle_.get());
-  return AsStatus(error, __func__);
+  if (error != CURLM_OK) {
+    // This indicates that we are using the API incorrectly, the application
+    // can not recover from these problems, raising an exception is the
+    // "Right Thing"[tm] here.
+    google::cloud::internal::ThrowStatus(AsStatus(error, __func__));
+  }
 }
 
 void CurlUploadRequest::ResetOptions() {

--- a/google/cloud/storage/internal/curl_upload_request.h
+++ b/google/cloud/storage/internal/curl_upload_request.h
@@ -96,8 +96,8 @@ class CurlUploadRequest {
 
  private:
   friend class CurlRequestBuilder;
-  /// Sets the underlying CurlHandle options initially.
-  Status SetOptions();
+  /// Set the underlying CurlHandle options on a new CurlUploadRequest.
+  void SetOptions();
 
   /// Resets the underlying CurlHandle options after a move operation.
   void ResetOptions();


### PR DESCRIPTION
A couple of functions were using `Status` to report an error that can
only happen if our code is using the libcurl APIs incorrectly. We use
exceptions for that in other places, we may want to change this, but at
least we should be consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2380)
<!-- Reviewable:end -->
