### PR TITLE
Fix inconsistently named function in RequestBuilder.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1345,7 +1345,7 @@ StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectXml(
   // UserIp cannot be set, checked by the caller.
 
   std::unique_ptr<internal::CurlWriteStreambuf> buf(
-      new internal::CurlWriteStreambuf(builder.BuildUpload(),
+      new internal::CurlWriteStreambuf(builder.BuildUploadRequest(),
                                        client_options().upload_buffer_size(),
                                        CreateHashValidator(request)));
   return std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf));
@@ -1373,7 +1373,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   // 3. Perform a streaming upload because computing the size upfront is more
   //    complicated than it is worth.
   std::unique_ptr<internal::CurlWriteStreambuf> buf(
-      new internal::CurlWriteStreambuf(builder.BuildUpload(),
+      new internal::CurlWriteStreambuf(builder.BuildUploadRequest(),
                                        client_options().upload_buffer_size(),
                                        CreateHashValidator(request)));
   ObjectWriteStream writer(std::move(buf));
@@ -1477,7 +1477,7 @@ StatusOr<std::unique_ptr<ObjectWriteStreambuf>> CurlClient::WriteObjectSimple(
   builder.AddQueryParameter("uploadType", "media");
   builder.AddQueryParameter("name", request.object_name());
   std::unique_ptr<internal::CurlWriteStreambuf> buf(
-      new internal::CurlWriteStreambuf(builder.BuildUpload(),
+      new internal::CurlWriteStreambuf(builder.BuildUploadRequest(),
                                        client_options().upload_buffer_size(),
                                        CreateHashValidator(request)));
   return std::unique_ptr<internal::ObjectWriteStreambuf>(std::move(buf));

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -48,7 +48,7 @@ CurlRequest CurlRequestBuilder::BuildRequest() {
   return request;
 }
 
-CurlUploadRequest CurlRequestBuilder::BuildUpload() {
+CurlUploadRequest CurlRequestBuilder::BuildUploadRequest() {
   ValidateBuilderState(__func__);
   CurlUploadRequest request(initial_buffer_size_);
   request.url_ = std::move(url_);

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -52,7 +52,7 @@ class CurlRequestBuilder {
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
    */
-  CurlUploadRequest BuildUpload();
+  CurlUploadRequest BuildUploadRequest();
 
   /**
    * Creates a non-blocking http request.

--- a/google/cloud/storage/tests/curl_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/curl_streambuf_integration_test.cc
@@ -41,7 +41,7 @@ TEST(CurlStreambufIntegrationTest, WriteManyBytes) {
   builder.SetMethod("POST");
   std::unique_ptr<internal::CurlWriteStreambuf> buf(
       new internal::CurlWriteStreambuf(
-          builder.BuildUpload(), 128 * 1024,
+          builder.BuildUploadRequest(), 128 * 1024,
           google::cloud::internal::make_unique<internal::NullHashValidator>()));
   ObjectWriteStream writer(std::move(buf));
 

--- a/google/cloud/storage/tests/curl_upload_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_upload_request_integration_test.cc
@@ -27,8 +27,8 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-
 namespace {
+
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
       .value_or("https://nghttp2.org/httpbin");
@@ -39,7 +39,7 @@ TEST(CurlUploadRequestTest, UploadPartial) {
                              storage::internal::GetDefaultCurlHandleFactory());
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.SetMethod("POST");
-  CurlUploadRequest upload = builder.BuildUpload();
+  CurlUploadRequest upload = builder.BuildUploadRequest();
 
   // A small function to generate random data.
   auto generator = google::cloud::internal::MakeDefaultPRNG();
@@ -108,7 +108,6 @@ TEST(CurlUploadRequestTest, UploadPartial) {
 }
 
 }  // namespace
-
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
The other two `RequestBuilder::Build*` functions are named after the
return type, `RequestBuilder::BuildUpload()` was different for no good
reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2381)
<!-- Reviewable:end -->
