### PR TITLE
Fix Object*Stream move constructor and assignment.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -360,6 +360,7 @@ if (BUILD_TESTING)
         oauth2/service_account_credentials_test.cc
         object_access_control_test.cc
         object_metadata_test.cc
+        object_stream_test.cc
         object_test.cc
         notification_metadata_test.cc
         retry_policy_test.cc

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/object_streambuf.h"
+#include "google/cloud/storage/object_metadata.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -20,7 +21,6 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-
 namespace {
 
 TEST(ObjectStreambufTest, ReadErrorStreambuf) {
@@ -45,6 +45,28 @@ TEST(ObjectStreambufTest, ReadErrorStreambuf) {
 
   // The error status should still be set.
   EXPECT_EQ(expected, streambuf.status());
+}
+
+TEST(ObjectStreambufTest, WriteErrorStreambuf) {
+  Status expected(StatusCode::kUnknown, "test-message");
+  ObjectWriteErrorStreambuf streambuf(expected);
+
+  EXPECT_TRUE(streambuf.IsOpen());
+
+  auto response = streambuf.Close();
+  EXPECT_EQ(expected, response.status());
+  EXPECT_FALSE(streambuf.IsOpen());
+
+  // These are mostly to increase code coverage, we want to find the important
+  // missing coverage, and adding 4 lines of tests saves us guessing later.
+  EXPECT_FALSE(streambuf.ValidateHash(ObjectMetadata()));
+  EXPECT_EQ("", streambuf.computed_hash());
+  EXPECT_EQ("", streambuf.received_hash());
+  EXPECT_EQ("", streambuf.resumable_session_id());
+
+  // The error status should still be set.
+  response = streambuf.Close();
+  EXPECT_EQ(expected, response.status());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -63,6 +63,7 @@ TEST(ObjectStreambufTest, WriteErrorStreambuf) {
   EXPECT_EQ("", streambuf.computed_hash());
   EXPECT_EQ("", streambuf.received_hash());
   EXPECT_EQ("", streambuf.resumable_session_id());
+  EXPECT_EQ(0, streambuf.next_expected_byte());
 
   // The error status should still be set.
   response = streambuf.Close();

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -60,7 +60,7 @@ class ObjectReadStream : public std::basic_istream<char> {
    * Creates a stream associated with the given `streambuf`.
    */
   explicit ObjectReadStream(std::unique_ptr<internal::ObjectReadStreambuf> buf)
-      : std::basic_istream<char>(), buf_(std::move(buf)) {
+      : std::basic_istream<char>(nullptr), buf_(std::move(buf)) {
     // Initialize the basic_ios<> class
     init(buf_.get());
     // Prime the iostream machinery with a peek().  This will trigger a call to
@@ -174,7 +174,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    */
   explicit ObjectWriteStream(
       std::unique_ptr<internal::ObjectWriteStreambuf> buf)
-      : std::basic_ostream<char>(), buf_(std::move(buf)) {
+      : std::basic_ostream<char>(nullptr), buf_(std::move(buf)) {
     // Initialize the basic_ios<> class
     init(buf_.get());
   }

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -71,16 +71,25 @@ class ObjectReadStream : public std::basic_istream<char> {
 
   ObjectReadStream(ObjectReadStream&& rhs) noexcept
       : ObjectReadStream(std::move(rhs.buf_)) {
-    // Move the basic_ios<> state and set rdbuf() without clearing the state
-    move(std::move(rhs));
-    set_rdbuf(buf_.get());
+    // We cannot use set_rdbuf() because older versions of libstdc++ do not
+    // implement this function. Unfortunately `move()` resets `rdbuf()`, and
+    // `rdbuf()` resets the state, so we have to manually copy the rest of
+    // the state.
+    setstate(rhs.rdstate());
+    copyfmt(rhs);
+    rhs.rdbuf(nullptr);
   }
 
   ObjectReadStream& operator=(ObjectReadStream&& rhs) noexcept {
     buf_ = std::move(rhs.buf_);
-    // Move the basic_ios<> state and set rdbuf() without clearing the state
-    move(std::move(rhs));
-    set_rdbuf(buf_.get());
+    // Use rdbuf() (instead of set_rdbuf()) because older versions of libstdc++
+    // do not implement this function. Unfortunately `rdbuf()` resets the state,
+    // and `move()` resets `rdbuf()`, so we have to manually copy the rest of
+    // the state.
+    rdbuf(buf_.get());
+    setstate(rhs.rdstate());
+    copyfmt(rhs);
+    rhs.rdbuf(nullptr);
     return *this;
   }
 
@@ -184,9 +193,13 @@ class ObjectWriteStream : public std::basic_ostream<char> {
     metadata_ = std::move(rhs.metadata_);
     headers_ = std::move(rhs.headers_);
     payload_ = std::move(rhs.payload_);
-    // Move the basic_ios<> state and set rdbuf() without clearing the state
-    move(std::move(rhs));
-    set_rdbuf(buf_.get());
+    // We cannot use set_rdbuf() because older versions of libstdc++ do not
+    // implement this function. Unfortunately `move()` resets `rdbuf()`, and
+    // `rdbuf()` resets the state, so we have to manually copy the rest of
+    // the state.
+    setstate(rhs.rdstate());
+    copyfmt(rhs);
+    rhs.rdbuf(nullptr);
   }
 
   ObjectWriteStream& operator=(ObjectWriteStream&& rhs) noexcept {
@@ -194,9 +207,14 @@ class ObjectWriteStream : public std::basic_ostream<char> {
     metadata_ = std::move(rhs.metadata_);
     headers_ = std::move(rhs.headers_);
     payload_ = std::move(rhs.payload_);
-    // Move the basic_ios<> state and set rdbuf() without clearing the state
-    move(std::move(rhs));
-    set_rdbuf(buf_.get());
+    // Use rdbuf() (instead of set_rdbuf()) because older versions of libstdc++
+    // do not implement this function. Unfortunately `rdbuf()` resets the state,
+    // and `move()` resets `rdbuf()`, so we have to manually copy the rest of
+    // the state.
+    rdbuf(buf_.get());
+    setstate(rhs.rdstate());
+    copyfmt(rhs);
+    rhs.rdbuf(nullptr);
     return *this;
   }
 

--- a/google/cloud/storage/object_stream_test.cc
+++ b/google/cloud/storage/object_stream_test.cc
@@ -1,0 +1,87 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/object_stream.h"
+#include "google/cloud/internal/make_unique.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+TEST(ObjectStream, ReadMoveConstructor) {
+  ObjectReadStream reader(
+      google::cloud::internal::make_unique<internal::ObjectReadErrorStreambuf>(
+          Status(StatusCode::kNotFound, "test-message")));
+  reader.setstate(std::ios::badbit | std::ios::eofbit);
+  EXPECT_TRUE(reader.bad());
+  EXPECT_TRUE(reader.eof());
+
+  ObjectReadStream copy(std::move(reader));
+  EXPECT_TRUE(copy.bad());
+  EXPECT_TRUE(copy.eof());
+  EXPECT_EQ(StatusCode::kNotFound, copy.status().code());
+}
+
+TEST(ObjectStream, ReadMoveAssignment) {
+  ObjectReadStream reader(
+      google::cloud::internal::make_unique<internal::ObjectReadErrorStreambuf>(
+          Status(StatusCode::kNotFound, "test-message")));
+  reader.setstate(std::ios::badbit | std::ios::eofbit);
+
+  ObjectReadStream copy;
+
+  copy = std::move(reader);
+  EXPECT_TRUE(copy.bad());
+  EXPECT_TRUE(copy.eof());
+  EXPECT_EQ(StatusCode::kNotFound, copy.status().code());
+}
+
+TEST(ObjectStream, WriteMoveConstructor) {
+  ObjectWriteStream writer(
+      google::cloud::internal::make_unique<internal::ObjectWriteErrorStreambuf>(
+          Status(StatusCode::kNotFound, "test-message")));
+  writer.setstate(std::ios::badbit | std::ios::eofbit);
+  writer.Close();
+  EXPECT_EQ(StatusCode::kNotFound, writer.metadata().status().code());
+
+  ObjectWriteStream copy(std::move(writer));
+  EXPECT_TRUE(copy.bad());
+  EXPECT_TRUE(copy.eof());
+  EXPECT_EQ(StatusCode::kNotFound, copy.metadata().status().code());
+}
+
+TEST(ObjectStream, WriteMoveAssignment) {
+  ObjectWriteStream writer(
+      google::cloud::internal::make_unique<internal::ObjectWriteErrorStreambuf>(
+          Status(StatusCode::kNotFound, "test-message")));
+  writer.setstate(std::ios::badbit | std::ios::eofbit);
+  writer.Close();
+  EXPECT_EQ(StatusCode::kNotFound, writer.metadata().status().code());
+
+  ObjectWriteStream copy;
+
+  copy = std::move(writer);
+  EXPECT_TRUE(copy.bad());
+  EXPECT_TRUE(copy.eof());
+  EXPECT_EQ(StatusCode::kNotFound, copy.metadata().status().code());
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/object_stream_test.cc
+++ b/google/cloud/storage/object_stream_test.cc
@@ -29,11 +29,15 @@ TEST(ObjectStream, ReadMoveConstructor) {
   reader.setstate(std::ios::badbit | std::ios::eofbit);
   EXPECT_TRUE(reader.bad());
   EXPECT_TRUE(reader.eof());
+  EXPECT_NE(nullptr, reader.rdbuf());
 
   ObjectReadStream copy(std::move(reader));
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_EQ(StatusCode::kNotFound, copy.status().code());
+
+  EXPECT_EQ(nullptr, reader.rdbuf());
+  EXPECT_NE(nullptr, copy.rdbuf());
 }
 
 TEST(ObjectStream, ReadMoveAssignment) {
@@ -41,6 +45,7 @@ TEST(ObjectStream, ReadMoveAssignment) {
       google::cloud::internal::make_unique<internal::ObjectReadErrorStreambuf>(
           Status(StatusCode::kNotFound, "test-message")));
   reader.setstate(std::ios::badbit | std::ios::eofbit);
+  EXPECT_NE(nullptr, reader.rdbuf());
 
   ObjectReadStream copy;
 
@@ -48,6 +53,9 @@ TEST(ObjectStream, ReadMoveAssignment) {
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_EQ(StatusCode::kNotFound, copy.status().code());
+
+  EXPECT_EQ(nullptr, reader.rdbuf());
+  EXPECT_NE(nullptr, copy.rdbuf());
 }
 
 TEST(ObjectStream, WriteMoveConstructor) {
@@ -57,11 +65,15 @@ TEST(ObjectStream, WriteMoveConstructor) {
   writer.setstate(std::ios::badbit | std::ios::eofbit);
   writer.Close();
   EXPECT_EQ(StatusCode::kNotFound, writer.metadata().status().code());
+  EXPECT_NE(nullptr, writer.rdbuf());
 
   ObjectWriteStream copy(std::move(writer));
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_EQ(StatusCode::kNotFound, copy.metadata().status().code());
+
+  EXPECT_EQ(nullptr, writer.rdbuf());
+  EXPECT_NE(nullptr, copy.rdbuf());
 }
 
 TEST(ObjectStream, WriteMoveAssignment) {
@@ -71,6 +83,7 @@ TEST(ObjectStream, WriteMoveAssignment) {
   writer.setstate(std::ios::badbit | std::ios::eofbit);
   writer.Close();
   EXPECT_EQ(StatusCode::kNotFound, writer.metadata().status().code());
+  EXPECT_NE(nullptr, writer.rdbuf());
 
   ObjectWriteStream copy;
 
@@ -78,6 +91,9 @@ TEST(ObjectStream, WriteMoveAssignment) {
   EXPECT_TRUE(copy.bad());
   EXPECT_TRUE(copy.eof());
   EXPECT_EQ(StatusCode::kNotFound, copy.metadata().status().code());
+
+  EXPECT_EQ(nullptr, writer.rdbuf());
+  EXPECT_NE(nullptr, copy.rdbuf());
 }
 
 }  // namespace

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -77,6 +77,7 @@ storage_client_unit_tests = [
     "oauth2/service_account_credentials_test.cc",
     "object_access_control_test.cc",
     "object_metadata_test.cc",
+    "object_stream_test.cc",
     "object_test.cc",
     "notification_metadata_test.cc",
     "retry_policy_test.cc",


### PR DESCRIPTION
We were not moving the state and formatting flags, evidently
`std::ios_base` has a `move()` function for this purpose.

Did a general pass making sure we are using the protected
functions of `std::ios_base<>` as intended.

To test `ObjectWriteStream` I had to create `ObjectWriteErrorStreambuf`,
this will be needed in a future PR cf. #2374.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2383)
<!-- Reviewable:end -->
