### PR TITLE
Make `StartAsyncPollOp` accept future<Operation>.

### DIFF
--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -291,11 +291,21 @@ template <typename Client, typename Response>
 future<StatusOr<Response>> StartAsyncLongrunningOp(
     char const* location, std::unique_ptr<PollingPolicy> polling_policy,
     MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
-    CompletionQueue cq, google::longrunning::Operation operation) {
-  return StartAsyncPollOp(location, std::move(polling_policy),
-                          std::move(metadata_update_policy), std::move(cq),
-                          AsyncLongrunningOperation<Client, Response>(
-                              std::move(client), std::move(operation)))
+    CompletionQueue cq,
+    future<StatusOr<google::longrunning::Operation>> operation) {
+  return StartAsyncPollOp(
+             location, std::move(polling_policy),
+             std::move(metadata_update_policy), std::move(cq),
+             operation.then(
+                 [client](future<StatusOr<google::longrunning::Operation>> fut)
+                     -> StatusOr<AsyncLongrunningOperation<Client, Response>> {
+                   auto operation = fut.get();
+                   if (operation) {
+                     return AsyncLongrunningOperation<Client, Response>(
+                         std::move(client), *std::move(operation));
+                   }
+                   return operation.status();
+                 }))
       .then([](future<StatusOr<StatusOr<Response>>> fut) -> StatusOr<Response> {
         auto res = fut.get();
         if (!res) {

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -418,6 +418,22 @@ TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
   }
 }
 
+TEST(AsyncLongrunningOpFutureSimpleTest, NoOperation) {
+  bigtable::CompletionQueue cq;
+
+  auto fut = internal::StartAsyncLongrunningOp<
+      AdminClient, google::bigtable::v2::SampleRowKeysResponse>(
+      __func__, bigtable::DefaultPollingPolicy(internal::kBigtableLimits),
+      MetadataUpdatePolicy("instance_id", MetadataParamTypes::NAME, "table_id"),
+      std::make_shared<testing::MockAdminClient>(), cq,
+      make_ready_future<StatusOr<longrunning::Operation>>(
+          Status(StatusCode::kUnavailable, "")));
+
+  auto res = fut.get();
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kUnavailable, res.status().code());
+}
+
 INSTANTIATE_TEST_SUITE_P(EndToEnd, AsyncLongrunningOpFutureTest,
                          ::testing::Values(
                              // We succeeded to contact the service.

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -400,7 +400,7 @@ TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
   auto fut = internal::StartAsyncLongrunningOp<
       AdminClient, google::bigtable::v2::SampleRowKeysResponse>(
       __func__, polling_policy->clone(), metadata_update_policy, client, cq,
-      std::move(op_arg));
+      make_ready_future<StatusOr<longrunning::Operation>>(std::move(op_arg)));
 
   EXPECT_EQ(std::future_status::timeout, fut.wait_for(1_ms));
   EXPECT_EQ(1U, cq_impl->size());

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -786,6 +786,11 @@ INSTANTIATE_TEST_SUITE_P(
         // should still return CANCELLED to the user.
         false));
 
+template <typename F>
+StatusOr<F> MakeStatusOr(F f) {
+  return f;
+}
+
 class NoexTableAsyncPollOpImmediateFinishFutureTest
     : public bigtable::testing::internal::TableTestFixture {
  public:
@@ -806,10 +811,11 @@ class NoexTableAsyncPollOpImmediateFinishFutureTest
         bigtable::DefaultPollingPolicy(
             simulate_retries ? internal::kBigtableLimits : kNoRetries),
         std::move(metadata_update_policy_), cq_,
-        [this](CompletionQueue& cq,
-               std::unique_ptr<grpc::ClientContext> context) {
-          return attempt_promise_.get_future();
-        });
+        make_ready_future(
+            MakeStatusOr([this](CompletionQueue& cq,
+                                std::unique_ptr<grpc::ClientContext> context) {
+              return attempt_promise_.get_future();
+            })));
 
     EXPECT_EQ(std::future_status::timeout, user_future.wait_for(1_ms));
     return user_future;
@@ -872,11 +878,12 @@ class NoexTableAsyncPollOpOneRetryFutureTest
         user_future_(internal::StartAsyncPollOp(
             __func__, bigtable::DefaultPollingPolicy(internal::kBigtableLimits),
             std::move(metadata_update_policy_), cq_,
-            [this](CompletionQueue& cq,
-                   std::unique_ptr<grpc::ClientContext> context) {
-              attempt_promises_.emplace_back();
-              return attempt_promises_.back().get_future();
-            })) {
+            make_ready_future(MakeStatusOr(
+                [this](CompletionQueue& cq,
+                       std::unique_ptr<grpc::ClientContext> context) {
+                  attempt_promises_.emplace_back();
+                  return attempt_promises_.back().get_future();
+                })))) {
     EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
     EXPECT_EQ(1U, attempt_promises_.size());
   }


### PR DESCRIPTION
Per @coryan 's suggestion, `StartAsyncPollOp` is always used in then, se we
might make it friendlier to use in such a case.

This change allows calling `StartAsyncPollOp` before the operation is
ready, which allows us to not capture arguments required for its
creating in yet another entity - that was cumbersome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2384)
<!-- Reviewable:end -->
