### PR TITLE
Return an error when downloads fail to start.

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -565,6 +565,14 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
   std::unique_ptr<CurlReadStreambuf> buf(new CurlReadStreambuf(
       builder.BuildDownloadRequest(std::string{}),
       client_options().download_buffer_size(), CreateHashValidator(request)));
+  auto peek = buf->Peek();
+  if (!peek) {
+    buf->Close();
+    return Status(peek.status().code(),
+                  peek.status().message() +
+                      ", object_name=" + request.object_name() +
+                      ", bucket_name=" + request.bucket_name());
+  }
   return std::unique_ptr<ObjectReadStreambuf>(std::move(buf));
 }
 
@@ -1282,6 +1290,14 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObjectXml(
   std::unique_ptr<CurlReadStreambuf> buf(new CurlReadStreambuf(
       builder.BuildDownloadRequest(std::string{}),
       client_options().download_buffer_size(), CreateHashValidator(request)));
+  auto peek = buf->Peek();
+  if (!peek) {
+    buf->Close();
+    return Status(peek.status().code(),
+                  peek.status().message() +
+                      ", object_name=" + request.object_name() +
+                      ", bucket_name=" + request.bucket_name());
+  }
   return std::unique_ptr<ObjectReadStreambuf>(std::move(buf));
 }
 

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -223,14 +223,18 @@ TEST_P(CurlClientTest, GetObjectMetadata) {
   CheckStatus(actual);
 }
 
-TEST_P(CurlClientTest, ReadObject) {
-  std::string const error_type = GetParam();
-  if (error_type != "credentials-failure") {
-    // TODO(#1736) - enable this test when ObjectReadStream uses StatusOr.
-    return;
-  }
+TEST_P(CurlClientTest, ReadObjectXml) {
   auto actual =
       client_->ReadObject(ReadObjectRangeRequest("bkt", "obj")).status();
+  CheckStatus(actual);
+}
+
+TEST_P(CurlClientTest, ReadObjectJson) {
+  auto actual =
+      client_
+          ->ReadObject(ReadObjectRangeRequest("bkt", "obj")
+                           .set_multiple_options(IfGenerationNotMatch(0)))
+          .status();
   CheckStatus(actual);
 }
 

--- a/google/cloud/storage/internal/curl_streambuf.h
+++ b/google/cloud/storage/internal/curl_streambuf.h
@@ -38,6 +38,8 @@ class CurlReadStreambuf : public ObjectReadStreambuf {
 
   void Close() override;
   bool IsOpen() const override;
+  StatusOr<int_type> Peek();
+
   Status const& status() const override { return status_; }
   std::string const& received_hash() const override {
     return hash_validator_result_.received;

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -63,10 +63,6 @@ class ObjectReadStream : public std::basic_istream<char> {
       : std::basic_istream<char>(nullptr), buf_(std::move(buf)) {
     // Initialize the basic_ios<> class
     init(buf_.get());
-    // Prime the iostream machinery with a peek().  This will trigger a call to
-    // underflow(), and will detect if the download failed. Without it, the
-    // eof() bit is not initialized properly.
-    peek();
   }
 
   ObjectReadStream(ObjectReadStream&& rhs) noexcept

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -374,9 +374,7 @@ TEST_F(ObjectIntegrationTest, ReadNotFound) {
   EXPECT_FALSE(stream.IsOpen());
   EXPECT_EQ(StatusCode::kNotFound, stream.status().code())
       << "status=" << stream.status();
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_TRUE(stream.bad());
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWrite) {

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -707,10 +707,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureJSON) {
       client.ReadObject(bucket_name, object_name, IfGenerationNotMatch(0));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_TRUE(actual.empty());
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  // TODO(#2371) - this only works with exceptions for now.
   EXPECT_TRUE(stream.bad());
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_FALSE(stream.status().ok());
   EXPECT_EQ(StatusCode::kUnavailable, stream.status().code())
       << ", status=" << stream.status();
@@ -729,10 +726,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureXML) {
   auto stream = client.ReadObject(bucket_name, object_name);
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
   EXPECT_TRUE(actual.empty());
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  // TODO(#2371) - this only works with exceptions for now.
   EXPECT_TRUE(stream.bad());
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_FALSE(stream.status().ok());
   EXPECT_EQ(StatusCode::kUnavailable, stream.status().code())
       << ", status=" << stream.status();


### PR DESCRIPTION
Before returning a `ObjectReadStreambuf` from `CurlClient::ReadObject()`
verify that the stream has actually started to download. If it cannot,
then we want to signal this as a error (via the `StatusOr`) so the retry loop
can retry the download.

This fixes #2371.
