### PR TITLE
Ignore additional build dirs in check-style

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -34,6 +34,8 @@ find . \( -path ./.git \
           -o -path ./third_party \
           -o -path './cmake-build-*' \
           -o -path ./build-output \
+          -o -path ./.build \
+          -o -path ./_build \
        \) -prune \
        -o \( -name 'CMakeLists.txt' \
              -o -name '*.cmake' \
@@ -73,6 +75,8 @@ find . \( -path ./.git \
           -o -path ./third_party \
           -o -path './cmake-build-*' \
           -o -path ./build-output \
+          -o -path ./.build \
+          -o -path ./_build \
        \) -prune \
      -o \( -name BUILD \
            -o -name '*.bzl' \


### PR DESCRIPTION
This has been bugging me for a while. We have these directories in `.gitignore`, so we should also ignore them in `check-style.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2386)
<!-- Reviewable:end -->
