### PR TITLE
Fixed small StatusOr::op bool, usage bug

### DIFF
--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -224,8 +224,9 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
     if (!consistency_token) {
       throw std::runtime_error(consistency_token.status().message());
     }
-    auto result = admin.WaitForConsistencyCheck(table_id, *consistency_token);
-    if (result.get()) {
+    auto result =
+        admin.WaitForConsistencyCheck(table_id, *consistency_token).get();
+    if (result && *result) {
       std::cout << "Table is consistent\n";
     } else {
       std::cout << "Table is not consistent\n";


### PR DESCRIPTION
`WaitForConsistency` returns a `future<StatusOr<bool>>`, so checking `.get()` is only checking that the future's `StatusOr` is OK, but it's not checking the boolean value of the `StatusOr`'s contained bool.

This may be an easy mistake to make with `StatusOr<bool>` in general. This is the only bug I saw in our codebase, but we might want to avoid `StatusOr<bool>` in general. I wonder if it's an antipattern. I'll file a separate issue where we can discuss that notion in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2389)
<!-- Reviewable:end -->
