### PR TITLE
Do not throw exceptions in WriteObject().

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -892,7 +892,7 @@ class Client {
                               Options&&... options) {
     internal::ReadObjectRangeRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ReadObjectImpl(std::move(request));
+    return ReadObjectImpl(request);
   }
 
   /**
@@ -958,7 +958,7 @@ class Client {
                                 Options&&... options) {
     internal::InsertObjectStreamingRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return ObjectWriteStream(raw_client_->WriteObject(request).value());
+    return WriteObjectImpl(request);
   }
 
   /**
@@ -2785,6 +2785,9 @@ class Client {
 
   ObjectReadStream ReadObjectImpl(
       internal::ReadObjectRangeRequest const& request);
+
+  ObjectWriteStream WriteObjectImpl(
+      internal::InsertObjectStreamingRequest const& request);
 
   // The version of UploadFile() where UseResumableUploadSession is one of the
   // options. Note how this does not use InsertObjectMedia at all.

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -195,11 +195,6 @@ TEST_P(CurlClientTest, InsertObjectMediaSimple) {
 }
 
 TEST_P(CurlClientTest, InsertObjectMediaMultipart) {
-  std::string const error_type = GetParam();
-  if (error_type != "credentials-failure") {
-    // TODO(#1735) - enable this test when ObjectWriteStream uses StatusOr.
-    return;
-  }
   auto actual = client_
                     ->InsertObjectMedia(
                         InsertObjectMediaRequest("bkt", "obj", "contents"))

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -81,15 +81,12 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentTypeFailure) {
   std::ostringstream expected;
 
   // Create the object, but only if it does not exist already.
-  TestPermanentFailure([&] {
-    auto os = client->WriteObject(
-        bucket_name, object_name, IfGenerationMatch(0),
-        WithObjectMetadata(ObjectMetadata().set_content_type("text/plain")));
-    os.exceptions(std::ios_base::failbit);
-    os << LoremIpsum();
-    os.Close();
-    ObjectMetadata meta = os.metadata().value();
-  });
+  auto os = client->WriteObject(
+      bucket_name, object_name, IfGenerationMatch(0),
+      WithObjectMetadata(ObjectMetadata().set_content_type("text/plain")));
+  EXPECT_TRUE(os.bad());
+  EXPECT_FALSE(os.metadata().status().ok())
+      << ", status=" << os.metadata().status();
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithUseResumable) {


### PR DESCRIPTION
We were still throwing an exception in WriteObject() for some types of
errors. This fixes that problem and adds integration tests to verify we
do not throw exceptions in other media operations (downloads, uploads,
etc.)

This fixes #2374.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2400)
<!-- Reviewable:end -->
