### PR TITLE
keep instance_admin_endpoint_ and admin_endpoint_ in sync

### DIFF
--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -81,6 +81,9 @@ class ClientOptions {
   std::string const& admin_endpoint() const { return admin_endpoint_; }
   ClientOptions& set_admin_endpoint(std::string endpoint) {
     admin_endpoint_ = std::move(endpoint);
+    // These two endpoints are generally equivalent, but they may differ in
+    // some tests.
+    instance_admin_endpoint_ = admin_endpoint_;
     return *this;
   }
 

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -133,6 +133,9 @@ TEST(ClientOptionsTest, EditAdminEndpoint) {
   client_options_object =
       client_options_object.set_admin_endpoint("customendpoint.com");
   EXPECT_EQ("customendpoint.com", client_options_object.admin_endpoint());
+  EXPECT_EQ(
+      "customendpoint.com",
+      ClientOptionsTestTraits::InstanceAdminEndpoint(client_options_object));
 }
 
 TEST(ClientOptionsTest, EditCredentials) {


### PR DESCRIPTION
These two fields should generally be kept in sync. They typically only differ in some unit testing scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2401)
<!-- Reviewable:end -->
