### PR TITLE
CMake: Use CURL::libcurl instead of CURL::CURL

### DIFF
--- a/cmake/IncludeCurl.cmake
+++ b/cmake/IncludeCurl.cmake
@@ -39,13 +39,13 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
     # stage/module/FindCURL.html for details).  Until then, define the target
     # ourselves if it is missing.
     find_package(CURL REQUIRED)
-    if (NOT TARGET CURL::CURL)
-        add_library(CURL::CURL UNKNOWN IMPORTED)
-        set_property(TARGET CURL::CURL
+    if (NOT TARGET CURL::libcurl)
+        add_library(CURL::libcurl UNKNOWN IMPORTED)
+        set_property(TARGET CURL::libcurl
                      APPEND
                      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                               "${CURL_INCLUDE_DIR}")
-        set_property(TARGET CURL::CURL
+        set_property(TARGET CURL::libcurl
                      APPEND
                      PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
     endif ()
@@ -56,7 +56,7 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
     if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
         find_package(OpenSSL REQUIRED)
         find_package(ZLIB REQUIRED)
-        set_property(TARGET CURL::CURL
+        set_property(TARGET CURL::libcurl
                      APPEND
                      PROPERTY INTERFACE_LINK_LIBRARIES
                               OpenSSL::SSL
@@ -64,7 +64,7 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
                               ZLIB::ZLIB)
         message(STATUS "CURL linkage will be static")
         if (WIN32)
-            set_property(TARGET CURL::CURL
+            set_property(TARGET CURL::libcurl
                          APPEND
                          PROPERTY INTERFACE_LINK_LIBRARIES
                                   crypt32
@@ -72,7 +72,7 @@ elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
                                   ws2_32)
         endif ()
         if (APPLE)
-            set_property(TARGET CURL::CURL
+            set_property(TARGET CURL::libcurl
                          APPEND
                          PROPERTY INTERFACE_LINK_LIBRARIES ldap)
         endif ()

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -88,10 +88,10 @@ if (NOT TARGET curl_project)
     endif ()
 
     include(ExternalProjectHelper)
-    add_library(CURL::CURL INTERFACE IMPORTED)
-    add_dependencies(CURL::CURL curl_project)
-    set_library_properties_for_external_project(CURL::CURL curl)
-    set_property(TARGET CURL::CURL
+    add_library(CURL::libcurl INTERFACE IMPORTED)
+    add_dependencies(CURL::libcurl curl_project)
+    set_library_properties_for_external_project(CURL::libcurl curl)
+    set_property(TARGET CURL::libcurl
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
                           c-ares::cares
@@ -99,7 +99,7 @@ if (NOT TARGET curl_project)
                           OpenSSL::Crypto
                           ZLIB::ZLIB)
     if (WIN32)
-        set_property(TARGET CURL::CURL
+        set_property(TARGET CURL::libcurl
                      APPEND
                      PROPERTY INTERFACE_LINK_LIBRARIES
                               crypt32
@@ -107,7 +107,7 @@ if (NOT TARGET curl_project)
                               ws2_32)
     endif ()
     if (APPLE)
-        set_property(TARGET CURL::CURL
+        set_property(TARGET CURL::libcurl
                      APPEND
                      PROPERTY INTERFACE_LINK_LIBRARIES ldap)
     endif ()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -226,7 +226,7 @@ target_link_libraries(storage_client
                       PUBLIC google_cloud_cpp_common
                              nlohmann_json
                              Crc32c::crc32c
-                             CURL::CURL
+                             CURL::libcurl
                              Threads::Threads
                              OpenSSL::SSL
                              OpenSSL::Crypto
@@ -396,7 +396,7 @@ if (BUILD_TESTING)
                                           GTest::gmock_main
                                           GTest::gmock
                                           GTest::gtest
-                                          CURL::CURL
+                                          CURL::libcurl
                                           storage_common_options
                                           nlohmann_json)
             if (MSVC)

--- a/google/cloud/storage/config.cmake.in
+++ b/google/cloud/storage/config.cmake.in
@@ -19,13 +19,13 @@ find_dependency(google_cloud_cpp_common)
 find_dependency(OpenSSL)
 find_dependency(ZLIB)
 
-# Some versions of FindCURL do not define CURL::CURL, so we define it ourselves.
-if (NOT TARGET CURL::CURL)
-    add_library(CURL::CURL UNKNOWN IMPORTED)
-    set_property(TARGET CURL::CURL
+# Some versions of FindCURL do not define CURL::libcurl, so we define it ourselves.
+if (NOT TARGET CURL::libcurl)
+    add_library(CURL::libcurl UNKNOWN IMPORTED)
+    set_property(TARGET CURL::libcurl
                  APPEND
                  PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
-    set_property(TARGET CURL::CURL
+    set_property(TARGET CURL::libcurl
                  APPEND
                  PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
 endif ()

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach (fname ${storage_client_integration_tests})
                                   GTest::gmock_main
                                   GTest::gmock
                                   GTest::gtest
-                                  CURL::CURL
+                                  CURL::libcurl
                                   Threads::Threads
                                   nlohmann_json
                                   storage_common_options)


### PR DESCRIPTION
This matches what libcurl exports and also what FindCURL defines as of CMake 3.12+.

See: https://cmake.org/cmake/help/v3.12/module/FindCURL.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2407)
<!-- Reviewable:end -->
