### PR TITLE
Enable HMAC Key integration tests in production.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2372,12 +2372,11 @@ class Client {
    *     information on Google Cloud Platform service accounts.
    */
   template <typename... Options>
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(std::string access_id,
-                                          Options&&... options) {
+  Status DeleteHmacKey(std::string access_id, Options&&... options) {
     auto const& project_id = raw_client_->client_options().project_id();
     internal::DeleteHmacKeyRequest request(project_id, std::move(access_id));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->DeleteHmacKey(request);
+    return raw_client_->DeleteHmacKey(request).status();
   }
 
   /**

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -150,26 +150,22 @@ TEST_F(ServiceAccountTest, DeleteHmacKey) {
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
-  Status actual = client.DeleteHmacKey(
-      "test-access-id-1", OverrideDefaultProject("test-project"));
+  Status actual = client.DeleteHmacKey("test-access-id-1",
+                                       OverrideDefaultProject("test-project"));
   ASSERT_STATUS_OK(actual);
 }
 
 TEST_F(ServiceAccountTest, DeleteHmacKeyTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
       mock, EXPECT_CALL(*mock, DeleteHmacKey(_)),
-      [](Client& client) {
-        return client.DeleteHmacKey("test-access-id");
-      },
+      [](Client& client) { return client.DeleteHmacKey("test-access-id"); },
       "DeleteHmacKey");
 }
 
 TEST_F(ServiceAccountTest, DeleteHmacKeyPermanentFailure) {
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
       *client, EXPECT_CALL(*mock, DeleteHmacKey(_)),
-      [](Client& client) {
-        return client.DeleteHmacKey("test-access-id");
-      },
+      [](Client& client) { return client.DeleteHmacKey("test-access-id"); },
       "DeleteHmacKey");
 }
 

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -140,42 +140,35 @@ TEST_F(ServiceAccountTest, CreateHmacKeyPermanentFailure) {
 }
 
 TEST_F(ServiceAccountTest, DeleteHmacKey) {
-  HmacKeyMetadata expected =
-      internal::HmacKeyMetadataParser::FromString(
-          R"""({"accessId": "test-access-id-1", "state": "DELETED"})""")
-          .value();
-
   EXPECT_CALL(*mock, DeleteHmacKey(_))
-      .WillOnce(Return(StatusOr<HmacKeyMetadata>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::DeleteHmacKeyRequest const& r) {
+      .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
+      .WillOnce(Invoke([](internal::DeleteHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
         EXPECT_EQ("test-access-id-1", r.access_id());
 
-        return make_status_or(expected);
+        return make_status_or(internal::EmptyResponse{});
       }));
   Client client{std::shared_ptr<internal::RawClient>(mock)};
 
-  StatusOr<HmacKeyMetadata> actual = client.DeleteHmacKey(
+  Status actual = client.DeleteHmacKey(
       "test-access-id-1", OverrideDefaultProject("test-project"));
   ASSERT_STATUS_OK(actual);
-  EXPECT_EQ(expected.access_id(), actual->access_id());
-  EXPECT_EQ(expected.state(), actual->state());
 }
 
 TEST_F(ServiceAccountTest, DeleteHmacKeyTooManyFailures) {
-  testing::TooManyFailuresStatusTest<HmacKeyMetadata>(
+  testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
       mock, EXPECT_CALL(*mock, DeleteHmacKey(_)),
       [](Client& client) {
-        return client.DeleteHmacKey("test-access-id").status();
+        return client.DeleteHmacKey("test-access-id");
       },
       "DeleteHmacKey");
 }
 
 TEST_F(ServiceAccountTest, DeleteHmacKeyPermanentFailure) {
-  testing::PermanentFailureStatusTest<HmacKeyMetadata>(
+  testing::PermanentFailureStatusTest<internal::EmptyResponse>(
       *client, EXPECT_CALL(*mock, DeleteHmacKey(_)),
       [](Client& client) {
-        return client.DeleteHmacKey("test-access-id").status();
+        return client.DeleteHmacKey("test-access-id");
       },
       "DeleteHmacKey");
 }

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -133,6 +133,8 @@ run_all_service_account_examples() {
           list-hmac-keys-with-service-account "${SERVICE_ACCOUNT}" | \
           sed -n 's;^access_id = \(.*\);\1;p'); do
     run_example ./storage_service_account_samples \
+        update-hmac-key "${access_id}" "INACTIVE"
+    run_example ./storage_service_account_samples \
         delete-hmac-key "${access_id}"
   done
 

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -104,12 +104,6 @@ run_all_service_account_examples() {
   run_example ./storage_service_account_samples get-service-account
   unset GOOGLE_CLOUD_PROJECT
 
-  if [[ -z "${CLOUD_STORAGE_TESTBENCH_ENDPOINT:-}" ]]; then
-    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
-        " HMAC key examples skipped because they are not enabled in production."
-    return
-  fi
-
   run_example ./storage_service_account_samples \
       create-hmac-key-for-project "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
 

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -208,17 +208,14 @@ void DeleteHmacKey(google::cloud::storage::Client client, int& argc,
   }
   //! [delete hmac key] [START storage_delete_hmac_key]
   namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string access_id) {
-    StatusOr<gcs::HmacKeyMetadata> hmac_key_details =
-        client.DeleteHmacKey(access_id);
+    google::cloud::Status status = client.DeleteHmacKey(access_id);
 
-    if (!hmac_key_details) {
-      throw std::runtime_error(hmac_key_details.status().message());
+    if (!status.ok()) {
+      throw std::runtime_error(status.message());
     }
     std::cout << "The key is deleted, though it may still appear"
-              << " in ListHmacKeys() results."
-              << "\nThe HMAC key metadata is: " << &hmac_key_details << "\n";
+              << " in ListHmacKeys() results.\n";
   }
   //! [delete hmac key] [END storage_delete_hmac_key]
   (std::move(client), argv[1]);

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1063,6 +1063,7 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
     return status;
   }
   builder.AddQueryParameter("serviceAccount", request.service_account());
+  builder.AddHeader("content-length: 0");
   return ParseFromHttpResponse<CreateHmacKeyResponse>(
       builder.BuildRequest().MakeRequest(std::string{}));
 }

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1062,7 +1062,7 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
   if (!status.ok()) {
     return status;
   }
-  builder.AddQueryParameter("serviceAccount", request.service_account());
+  builder.AddQueryParameter("serviceAccountEmail", request.service_account());
   builder.AddHeader("content-length: 0");
   return ParseFromHttpResponse<CreateHmacKeyResponse>(
       builder.BuildRequest().MakeRequest(std::string{}));

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1068,7 +1068,7 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 
-StatusOr<HmacKeyMetadata> CurlClient::DeleteHmacKey(
+StatusOr<EmptyResponse> CurlClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/projects/" +
                                  request.project_id() + "/hmacKeys/" +
@@ -1078,8 +1078,7 @@ StatusOr<HmacKeyMetadata> CurlClient::DeleteHmacKey(
   if (!status.ok()) {
     return status;
   }
-  return CheckedFromString<HmacKeyMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<HmacKeyMetadata> CurlClient::GetHmacKey(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -160,7 +160,7 @@ class CurlClient : public RawClient,
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
+  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
 

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -67,7 +67,7 @@ StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(
 
   CreateHmacKeyResponse result;
   result.kind = json.value("kind", "");
-  result.secret = json.value("secretKey", "");
+  result.secret = json.value("secret", "");
   if (json.count("metadata") != 0) {
     auto resource = HmacKeyMetadataParser::FromJson(json["metadata"]);
     if (!resource) {

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -322,7 +322,7 @@ StatusOr<CreateHmacKeyResponse> LoggingClient::CreateHmacKey(
   return MakeCall(*client_, &RawClient::CreateHmacKey, request, __func__);
 }
 
-StatusOr<HmacKeyMetadata> LoggingClient::DeleteHmacKey(
+StatusOr<EmptyResponse> LoggingClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteHmacKey, request, __func__);
 }

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -122,7 +122,7 @@ class LoggingClient : public RawClient {
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
+  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -151,7 +151,7 @@ class RawClient {
       ListHmacKeysRequest const&) = 0;
   virtual StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) = 0;
-  virtual StatusOr<HmacKeyMetadata> DeleteHmacKey(
+  virtual StatusOr<EmptyResponse> DeleteHmacKey(
       DeleteHmacKeyRequest const&) = 0;
   virtual StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) = 0;
   virtual StatusOr<HmacKeyMetadata> UpdateHmacKey(

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -530,7 +530,7 @@ StatusOr<CreateHmacKeyResponse> RetryClient::CreateHmacKey(
                   &RawClient::CreateHmacKey, request, __func__);
 }
 
-StatusOr<HmacKeyMetadata> RetryClient::DeleteHmacKey(
+StatusOr<EmptyResponse> RetryClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -136,7 +136,7 @@ class RetryClient : public RawClient {
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
+  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
 

--- a/google/cloud/storage/testbench/gcs_project.py
+++ b/google/cloud/storage/testbench/gcs_project.py
@@ -69,11 +69,11 @@ class ServiceAccount(object):
         key = self.keys.pop(key_id)
         if key is None:
             raise error_response.ErrorResponse(
-                'Cannot find key for key ' % key_id, status_code=404)
+                'Cannot find key for key %s' % key_id, status_code=404)
         resource = key.get('metadata')
         if resource is None:
             raise error_response.ErrorResponse(
-                'Missing resource for HMAC key ' % key_id, status_code=500)
+                'Missing resource for HMAC key %s' % key_id, status_code=500)
         resource['state'] = 'DELETED'
         return resource
 
@@ -82,11 +82,11 @@ class ServiceAccount(object):
         key = self.keys.get(key_id)
         if key is None:
             raise error_response.ErrorResponse(
-                'Cannot find key for key ' % key_id, status_code=404)
+                'Cannot find key for key %s' % key_id, status_code=404)
         metadata = key.get('metadata')
         if metadata is None:
             raise error_response.ErrorResponse(
-                'Missing resource for HMAC key ' % key_id, status_code=500)
+                'Missing resource for HMAC key %s' % key_id, status_code=500)
         return metadata
 
     def _check_etag(self, key_resource, etag, where):
@@ -103,11 +103,11 @@ class ServiceAccount(object):
         key = self.keys.get(key_id)
         if key is None:
             raise error_response.ErrorResponse(
-                'Cannot find key for key %s ' % key_id, status_code=404)
+                'Cannot find key for key %s' % key_id, status_code=404)
         metadata = key.get('metadata')
         if metadata is None:
             raise error_response.ErrorResponse(
-                'Missing metadata for HMAC key ' % key_id, status_code=500)
+                'Missing metadata for HMAC key %s' % key_id, status_code=500)
         self._check_etag(metadata, payload.get('etag'), 'payload')
         self._check_etag(
             metadata, flask.request.headers.get('if-match-etag'), 'header')
@@ -164,7 +164,7 @@ class GcsProject(object):
         sa = self.service_accounts.get(service_account)
         if sa is None:
             raise error_response.ErrorResponse(
-                'Cannot find service account for key=' % access_id, status_code=404)
+                'Cannot find service account for key=%s' % access_id, status_code=404)
         return sa.delete_key(key_id)
 
     def get_hmac_key(self, access_id):
@@ -173,7 +173,7 @@ class GcsProject(object):
         sa = self.service_accounts.get(service_account)
         if sa is None:
             raise error_response.ErrorResponse(
-                'Cannot find service account for key=' % access_id, status_code=404)
+                'Cannot find service account for key=%s' % access_id, status_code=404)
         return sa.get_key(key_id)
 
     def update_hmac_key(self, access_id, payload):
@@ -182,7 +182,7 @@ class GcsProject(object):
         sa = self.service_accounts.get(service_account)
         if sa is None:
             raise error_response.ErrorResponse(
-                'Cannot find service account for key=' % access_id, status_code=404)
+                'Cannot find service account for key=%s' % access_id, status_code=404)
         return sa.update_key(key_id, payload)
 
 
@@ -200,6 +200,11 @@ def get_project(project_id):
     # to create projects, nor do we want to create such functions. The point is
     # to test the GCS client library, not the IAM client library.
     return VALID_PROJECTS.setdefault(project_id, GcsProject(project_id))
+
+
+@projects.errorhandler(error_response.ErrorResponse)
+def handle_error(error):
+    return error.as_response()
 
 
 @projects.route('/<project_id>/serviceAccount')

--- a/google/cloud/storage/testbench/gcs_project.py
+++ b/google/cloud/storage/testbench/gcs_project.py
@@ -270,8 +270,8 @@ def hmac_keys_list(project_id):
 def hmac_keys_delete(project_id, access_id):
     """Implement the `HmacKeys: delete` API."""
     project = get_project(project_id)
-    return testbench_utils.filtered_response(
-        flask.request, project.delete_hmac_key(access_id))
+    project.delete_hmac_key(access_id)
+    return testbench_utils.filtered_response(flask.request, {})
 
 
 @projects.route('/<project_id>/hmacKeys/<access_id>')

--- a/google/cloud/storage/testbench/gcs_project.py
+++ b/google/cloud/storage/testbench/gcs_project.py
@@ -282,7 +282,7 @@ def hmac_keys_get(project_id, access_id):
         flask.request, project.get_hmac_key(access_id))
 
 
-@projects.route('/<project_id>/hmacKeys/<access_id>', methods=['POST'])
+@projects.route('/<project_id>/hmacKeys/<access_id>', methods=['PUT'])
 def hmac_keys_update(project_id, access_id):
     """Implement the `HmacKeys: delete` API."""
     project = get_project(project_id)

--- a/google/cloud/storage/testbench/gcs_project.py
+++ b/google/cloud/storage/testbench/gcs_project.py
@@ -66,7 +66,7 @@ class ServiceAccount(object):
 
     def delete_key(self, key_id):
         """Delete an existing HMAC key from the service account."""
-        key = self.keys.pop(key_id)
+        key = self.keys.get(key_id)
         if key is None:
             raise error_response.ErrorResponse(
                 'Cannot find key for key %s' % key_id, status_code=404)
@@ -74,7 +74,11 @@ class ServiceAccount(object):
         if resource is None:
             raise error_response.ErrorResponse(
                 'Missing resource for HMAC key %s' % key_id, status_code=500)
+        if resource.get('state') == 'ACTIVE':
+            raise error_response.ErrorResponse(
+                'Cannot delete ACTIVE key %s' % key_id, status_code=400)
         resource['state'] = 'DELETED'
+        self.keys.pop(key_id)
         return resource
 
     def get_key(self, key_id):

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -136,7 +136,7 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                  internal::ListHmacKeysRequest const&));
   MOCK_METHOD1(CreateHmacKey, StatusOr<internal::CreateHmacKeyResponse>(
                                   internal::CreateHmacKeyRequest const&));
-  MOCK_METHOD1(DeleteHmacKey, StatusOr<HmacKeyMetadata>(
+  MOCK_METHOD1(DeleteHmacKey, StatusOr<internal::EmptyResponse>(
                                   internal::DeleteHmacKeyRequest const&));
   MOCK_METHOD1(GetHmacKey,
                StatusOr<HmacKeyMetadata>(internal::GetHmacKeyRequest const&));

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -137,13 +137,13 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
   Client client(client_options->set_project_id(project_id));
 
   // Test failures in the HmacKey operations by using an invalid project id:
-  StatusOr<HmacKeyMetadata> create_status =
-      client.DeleteHmacKey("invalid-access-id", OverrideDefaultProject(""));
-  EXPECT_FALSE(create_status) << "value=" << *create_status;
+  auto create_status =
+      client.CreateHmacKey("invalid-service-account", OverrideDefaultProject(""));
+  EXPECT_FALSE(create_status) << "value=" << create_status->first;
 
-  StatusOr<HmacKeyMetadata> deleted_status =
+  Status deleted_status =
       client.DeleteHmacKey("invalid-access-id", OverrideDefaultProject(""));
-  EXPECT_FALSE(deleted_status) << "value=" << *deleted_status;
+  EXPECT_FALSE(deleted_status.ok());
 
   StatusOr<HmacKeyMetadata> get_status =
       client.GetHmacKey("invalid-access-id", OverrideDefaultProject(""));

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -119,6 +119,10 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   // Delete all HmacKeys for the test service account, it is just good practice
   // to cleanup after ourselves.
   for (auto const& id : post_delete_access_ids) {
+    StatusOr<HmacKeyMetadata> deactivate = client.UpdateHmacKey(
+      id, HmacKeyMetadata().set_state("INACTIVE"));
+    EXPECT_STATUS_OK(deactivate);
+
     StatusOr<HmacKeyMetadata> d = client.DeleteHmacKey(id);
     ASSERT_STATUS_OK(d);
   }

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -119,8 +119,8 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   // Delete all HmacKeys for the test service account, it is just good practice
   // to cleanup after ourselves.
   for (auto const& id : post_delete_access_ids) {
-    StatusOr<HmacKeyMetadata> deactivate = client.UpdateHmacKey(
-      id, HmacKeyMetadata().set_state("INACTIVE"));
+    StatusOr<HmacKeyMetadata> deactivate =
+        client.UpdateHmacKey(id, HmacKeyMetadata().set_state("INACTIVE"));
     EXPECT_STATUS_OK(deactivate);
 
     StatusOr<HmacKeyMetadata> d = client.DeleteHmacKey(id);
@@ -137,8 +137,8 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
   Client client(client_options->set_project_id(project_id));
 
   // Test failures in the HmacKey operations by using an invalid project id:
-  auto create_status =
-      client.CreateHmacKey("invalid-service-account", OverrideDefaultProject(""));
+  auto create_status = client.CreateHmacKey("invalid-service-account",
+                                            OverrideDefaultProject(""));
   EXPECT_FALSE(create_status) << "value=" << create_status->first;
 
   Status deleted_status =

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -30,11 +30,6 @@ using ::testing::HasSubstr;
 char const* flag_project_id;
 char const* flag_service_account;
 
-bool UsingTestbench() {
-  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
-      .has_value();
-}
-
 TEST(ServiceAccountIntegrationTest, Get) {
   std::string project_id = flag_project_id;
   StatusOr<Client> client = Client::CreateDefaultClient();
@@ -55,12 +50,6 @@ TEST(ServiceAccountIntegrationTest, Get) {
 }
 
 TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
-  if (!UsingTestbench()) {
-    // Temporarily disabled outside the testbench because the test does not
-    // cleanup after itself.
-    return;
-  }
-
   std::string project_id = flag_project_id;
   std::string service_account = flag_service_account;
   StatusOr<Client> client = Client::CreateDefaultClient();
@@ -74,12 +63,6 @@ TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
 }
 
 TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
-  if (!UsingTestbench()) {
-    // Temporarily disabled outside the testbench because the test does not
-    // cleanup after itself.
-    return;
-  }
-
   std::string project_id = flag_project_id;
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   std::string service_account = flag_service_account;
@@ -142,12 +125,6 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
 }
 
 TEST(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
-  if (!UsingTestbench()) {
-    // Temporarily disabled outside the testbench because the test does not
-    // cleanup after itself.
-    return;
-  }
-
   std::string project_id = flag_project_id;
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   std::string service_account = flag_service_account;

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -449,7 +449,7 @@ struct ServiceAccountFilter
     : public internal::WellKnownParameter<ServiceAccountFilter, std::string> {
   using WellKnownParameter<ServiceAccountFilter,
                            std::string>::WellKnownParameter;
-  static char const* well_known_parameter_name() { return "serviceAccount"; }
+  static char const* well_known_parameter_name() { return "serviceAccountEmail"; }
 };
 
 /**

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -449,7 +449,9 @@ struct ServiceAccountFilter
     : public internal::WellKnownParameter<ServiceAccountFilter, std::string> {
   using WellKnownParameter<ServiceAccountFilter,
                            std::string>::WellKnownParameter;
-  static char const* well_known_parameter_name() { return "serviceAccountEmail"; }
+  static char const* well_known_parameter_name() {
+    return "serviceAccountEmail";
+  }
 };
 
 /**


### PR DESCRIPTION
The HMAC Key support arrived (for whitelisted projects) to production,
so we can enable this for our integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2411)
<!-- Reviewable:end -->
