### PR TITLE
 Clean up relational operators

### DIFF
--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/optional.h"
 #include <iterator>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -68,22 +69,29 @@ class RowReaderIterator {
   value_type const&& operator*() const&& { return std::move(row_); }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   value_type&& operator*() && { return std::move(row_); }
-  bool operator==(RowReaderIterator const& that) const {
-    // All non-end iterators are equal.
-    return owner_ == that.owner_;
-  }
-
-  bool operator!=(RowReaderIterator const& that) const {
-    return !(*this == that);
-  }
 
  private:
+  friend bool operator==(RowReaderIterator const& lhs,
+                         RowReaderIterator const& rhs);
+
   void Advance();
   /// nullptr indicates end()
   RowReader* owner_;
   /// Current value of the iterator.
   StatusOr<Row> row_;
 };
+
+inline bool operator==(RowReaderIterator const& lhs,
+                       RowReaderIterator const& rhs) {
+  // All non-end iterators are equal.
+  return lhs.owner_ == rhs.owner_;
+}
+
+inline bool operator!=(RowReaderIterator const& lhs,
+                       RowReaderIterator const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
 }  // namespace internal
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/metadata_update_policy.h
+++ b/google/cloud/bigtable/metadata_update_policy.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/version.h"
 #include <grpcpp/grpcpp.h>
 #include <memory>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -43,15 +44,22 @@ class MetadataParamTypes final {
   static MetadataParamTypes const RESOURCE;
   static MetadataParamTypes const TABLE_NAME;
 
-  bool operator==(MetadataParamTypes const& that) const {
-    return type_ == that.type_;
-  }
   std::string const& type() const { return type_; }
 
  private:
   std::string type_;
   MetadataParamTypes(std::string type) : type_(std::move(type)) {}
 };
+
+inline bool operator==(MetadataParamTypes const& lhs,
+                       MetadataParamTypes const& rhs) {
+  return lhs.type() == rhs.type();
+}
+
+inline bool operator!=(MetadataParamTypes const& lhs,
+                       MetadataParamTypes const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
 
 /// MetadataUpdatePolicy holds supported metadata and setup ClientContext
 class MetadataUpdatePolicy {

--- a/google/cloud/bigtable/row_range.cc
+++ b/google/cloud/bigtable/row_range.cc
@@ -186,38 +186,39 @@ std::pair<bool, RowRange> RowRange::Intersect(RowRange const& range) const {
   return std::make_pair(!is_empty, std::move(intersection));
 }
 
-bool RowRange::operator==(RowRange const& rhs) const {
-  if (row_range_.start_key_case() != rhs.row_range_.start_key_case()) {
+bool operator==(RowRange const& lhs, RowRange const& rhs) {
+  if (lhs.as_proto().start_key_case() != rhs.as_proto().start_key_case()) {
     return false;
   }
-  switch (row_range_.start_key_case()) {
+  switch (lhs.as_proto().start_key_case()) {
     case btproto::RowRange::START_KEY_NOT_SET:
       break;
     case btproto::RowRange::kStartKeyClosed:
-      if (row_range_.start_key_closed() != rhs.row_range_.start_key_closed()) {
+      if (lhs.as_proto().start_key_closed() !=
+          rhs.as_proto().start_key_closed()) {
         return false;
       }
       break;
     case btproto::RowRange::kStartKeyOpen:
-      if (row_range_.start_key_open() != rhs.row_range_.start_key_open()) {
+      if (lhs.as_proto().start_key_open() != rhs.as_proto().start_key_open()) {
         return false;
       }
       break;
   }
 
-  if (row_range_.end_key_case() != rhs.row_range_.end_key_case()) {
+  if (lhs.as_proto().end_key_case() != rhs.as_proto().end_key_case()) {
     return false;
   }
-  switch (row_range_.end_key_case()) {
+  switch (lhs.as_proto().end_key_case()) {
     case btproto::RowRange::END_KEY_NOT_SET:
       break;
     case btproto::RowRange::kEndKeyClosed:
-      if (row_range_.end_key_closed() != rhs.row_range_.end_key_closed()) {
+      if (lhs.as_proto().end_key_closed() != rhs.as_proto().end_key_closed()) {
         return false;
       }
       break;
     case btproto::RowRange::kEndKeyOpen:
-      if (row_range_.end_key_open() != rhs.row_range_.end_key_open()) {
+      if (lhs.as_proto().end_key_open() != rhs.as_proto().end_key_open()) {
         return false;
       }
       break;
@@ -227,26 +228,26 @@ bool RowRange::operator==(RowRange const& rhs) const {
 }
 
 std::ostream& operator<<(std::ostream& os, RowRange const& x) {
-  switch (x.row_range_.start_key_case()) {
+  switch (x.as_proto().start_key_case()) {
     case btproto::RowRange::START_KEY_NOT_SET:
       os << "['', ";
       break;
     case btproto::RowRange::kStartKeyClosed:
-      os << "['" << x.row_range_.start_key_closed() << "', ";
+      os << "['" << x.as_proto().start_key_closed() << "', ";
       break;
     case btproto::RowRange::kStartKeyOpen:
-      os << "('" << x.row_range_.start_key_open() << "', ";
+      os << "('" << x.as_proto().start_key_open() << "', ";
   }
 
-  switch (x.row_range_.end_key_case()) {
+  switch (x.as_proto().end_key_case()) {
     case btproto::RowRange::END_KEY_NOT_SET:
       os << "'')";
       break;
     case btproto::RowRange::kEndKeyClosed:
-      os << "'" << x.row_range_.end_key_closed() << "']";
+      os << "'" << x.as_proto().end_key_closed() << "']";
       break;
     case btproto::RowRange::kEndKeyOpen:
-      os << "'" << x.row_range_.end_key_open() << "')";
+      os << "'" << x.as_proto().end_key_open() << "')";
       break;
   }
   return os;

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/internal/prefix_range_end.h"
 #include <google/bigtable/v2/data.pb.h>
 #include <chrono>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -144,9 +145,6 @@ class RowRange {
    */
   std::pair<bool, RowRange> Intersect(RowRange const& range) const;
 
-  bool operator==(RowRange const& rhs) const;
-  bool operator!=(RowRange const& rhs) const { return !(*this == rhs); }
-
   /// Return the filter expression as a protobuf.
   ::google::bigtable::v2::RowRange const& as_proto() const& {
     return row_range_;
@@ -156,8 +154,6 @@ class RowRange {
   ::google::bigtable::v2::RowRange&& as_proto() && {
     return std::move(row_range_);
   }
-
-  friend std::ostream& operator<<(std::ostream& os, RowRange const& x);
 
  private:
   /// Private to avoid mistaken creation of uninitialized ranges.
@@ -172,6 +168,12 @@ class RowRange {
  private:
   ::google::bigtable::v2::RowRange row_range_;
 };
+
+bool operator==(RowRange const& lhs, RowRange const& rhs);
+
+inline bool operator!=(RowRange const& lhs, RowRange const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
 
 /// Print a human-readable representation of the range, mostly for testing.
 std::ostream& operator<<(std::ostream& os, RowRange const& x);

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -88,45 +88,29 @@ std::string FieldPath::ToApiRepr() const {
   return s;  // let the server catch the empty string error for invalid
 }
 
-bool FieldPath::operator==(FieldPath const& other) const {
-  return this->ToApiRepr() == other.ToApiRepr();
+bool operator==(FieldPath const& lhs, FieldPath const& rhs) {
+  return lhs.ToApiRepr() == rhs.ToApiRepr();
 }
 
-bool FieldPath::operator!=(const FieldPath& other) const {
-  return !((*this) == other);
-}
-
-bool FieldPath::operator<(FieldPath const& other) const {
-  auto const this_size = this->parts_.size();
-  auto const other_size = other.size();
-  auto const min_length = std::min(this_size, other_size);
+bool operator<(FieldPath const& lhs, FieldPath const& rhs) {
+  auto const lhs_size = lhs.parts_.size();
+  auto const rhs_size = rhs.parts_.size();
+  auto const min_length = std::min(lhs_size, rhs_size);
   for (auto i = 0u; i < min_length; i++) {
-    if (this->parts_[i] < other.parts_[i]) {
+    if (lhs.parts_[i] < rhs.parts_[i]) {
       return true;
     }
-    if (this->parts_[i] > other.parts_[i]) {
+    if (lhs.parts_[i] > rhs.parts_[i]) {
       return false;
     }
   }
-  if (this->parts_.size() < other.parts_.size()) {
+  if (lhs_size < rhs_size) {
     return true;
   }
-  if (this->parts_.size() > other.parts_.size()) {
+  if (lhs_size > rhs_size) {
     return false;
   }
   return false;
-}
-
-bool FieldPath::operator<=(FieldPath const& other) const {
-  return *this < other || *this == other;
-}
-
-bool FieldPath::operator>(FieldPath const& other) const {
-  return !(*this <= other);
-}
-
-bool FieldPath::operator>=(FieldPath const& other) const {
-  return !(*this < other);
 }
 
 std::ostream& operator<<(std::ostream& os, FieldPath const& field_path) {

--- a/google/cloud/firestore/field_path.h
+++ b/google/cloud/firestore/field_path.h
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -88,54 +89,7 @@ class FieldPath {
    */
   bool valid() const { return valid_; }
 
-  /**
-   * Compare the equality of this FieldPath with another FieldPath @p other.
-   *
-   * @param other The other const FieldPath to compare to.
-   * @return Whether this FieldPath is equal to another FieldPath
-   */
-  bool operator==(FieldPath const& other) const;
-
-  /**
-   * Compare the non-equality of this FieldPath with another FieldPath @p other.
-   *
-   * @param other The other const FieldPath to compare to.
-   * @return Whether this FieldPath is not equal to another FieldPath.
-   */
-  bool operator!=(FieldPath const& other) const;
-
-  /**
-   * Compare if this FieldPath is before another FieldPath @p other.
-   *
-   * @param other The other const FieldPath to compare to.
-   * @return Whether this FieldPath is before another FieldPath.
-   */
-  bool operator<(FieldPath const& other) const;
-
-  /**
-   * Compare if this FieldPath is before or equal to another FieldPath @p other.
-   *
-   * @param other The other const FieldPath to compare to.
-   * @return Whether this FieldPath is before or equal to another FieldPath.
-   */
-  bool operator<=(FieldPath const& other) const;
-
-  /**
-   * Compare if this FieldPath is after another FieldPath @p other.
-   *
-   * @param other The other const FieldPath to compare to.
-   * @return Whether this FieldPath is after another FieldPath.
-   */
-  bool operator>(FieldPath const& other) const;
-
-  /**
-   * Compare if this FieldPath is after or equal to another FieldPath @p other.
-   *
-   * @param other The other const FieldPath to compare to.
-   * @return Whether this FieldPath is after or equal to another FieldPath.
-   */
-  bool operator>=(FieldPath const& other) const;
-
+ private:
   /**
    * The representation of this FieldPath @p field_path for ostream @p os.
    *
@@ -146,7 +100,9 @@ class FieldPath {
   friend std::ostream& operator<<(std::ostream& os,
                                   const FieldPath& field_path);
 
- private:
+  // This is a friend because it accesses parts_ directly.
+  friend bool operator<(FieldPath const& lhs, FieldPath const& rhs);
+
   /**
    * Ensures @p string has no invalid characters.
    *
@@ -183,6 +139,26 @@ class FieldPath {
    */
   bool valid_;
 };
+
+bool operator==(FieldPath const& lhs, FieldPath const& rhs);
+bool operator<(FieldPath const& lhs, FieldPath const& rhs);
+
+inline bool operator!=(FieldPath const& lhs, FieldPath const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator<=(FieldPath const& lhs, FieldPath const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>(FieldPath const& lhs, FieldPath const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator>=(FieldPath const& lhs, FieldPath const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+
 }  // namespace firestore
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/iam_bindings.h
+++ b/google/cloud/iam_bindings.h
@@ -19,6 +19,7 @@
 #include "google/cloud/version.h"
 #include <map>
 #include <set>
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -150,33 +151,33 @@ class IamBindings {
   void RemoveMembers(std::string const& role,
                      std::set<std::string> const& members);
 
-  bool operator==(IamBindings const& rhs) const {
-    return bindings_ == rhs.bindings_;
-  }
-
-  bool operator<(IamBindings const& rhs) const {
-    return bindings_ < rhs.bindings_;
-  }
-
-  bool operator!=(IamBindings const& rhs) const {
-    return std::rel_ops::operator!=(*this, rhs);
-  }
-
-  bool operator>(IamBindings const& rhs) const {
-    return std::rel_ops::operator>(*this, rhs);
-  }
-
-  bool operator<=(IamBindings const& rhs) const {
-    return std::rel_ops::operator<=(*this, rhs);
-  }
-
-  bool operator>=(IamBindings const& rhs) const {
-    return std::rel_ops::operator>=(*this, rhs);
-  }
-
  private:
   std::map<std::string, std::set<std::string>> bindings_;
 };
+
+inline bool operator==(IamBindings const& lhs, IamBindings const& rhs) {
+  return lhs.bindings() == rhs.bindings();
+}
+
+inline bool operator<(IamBindings const& lhs, IamBindings const& rhs) {
+  return lhs.bindings() < rhs.bindings();
+}
+
+inline bool operator!=(IamBindings const& lhs, IamBindings const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(IamBindings const& lhs, IamBindings const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(IamBindings const& lhs, IamBindings const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(IamBindings const& lhs, IamBindings const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
 
 std::ostream& operator<<(std::ostream& os, IamBindings const& rhs);
 

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -123,17 +123,6 @@ class AccessControlCommon {
 
   std::string const& self_link() const { return self_link_; }
 
-  bool operator==(AccessControlCommon const& rhs) const {
-    // Start with id, bucket, etag because they should fail early, then
-    // alphabetical for readability.
-    return id_ == rhs.id_ && bucket_ == rhs.bucket_ && etag_ == rhs.etag_ &&
-           domain_ == rhs.domain_ && email_ == rhs.email_ &&
-           entity_ == rhs.entity_ && entity_id_ == rhs.entity_id_ &&
-           kind_ == rhs.kind_ && project_team_ == rhs.project_team_ &&
-           role_ == rhs.role_ && self_link_ == rhs.self_link_;
-  }
-  bool operator!=(AccessControlCommon const& rhs) { return !(*this == rhs); }
-
   static Status ParseFromJson(AccessControlCommon& result,
                               nl::json const& json);
 
@@ -150,6 +139,25 @@ class AccessControlCommon {
   std::string role_;
   std::string self_link_;
 };
+
+inline bool operator==(AccessControlCommon const& lhs,
+                       AccessControlCommon const& rhs) {
+  // Start with id, bucket, etag because they should fail early, then
+  // alphabetical for readability.
+  return lhs.id() == rhs.id() && lhs.bucket() == rhs.bucket() &&
+         lhs.etag() == rhs.etag() && lhs.domain() == rhs.domain() &&
+         lhs.email() == rhs.email() && lhs.entity() == rhs.entity() &&
+         lhs.entity_id() == rhs.entity_id() && lhs.kind() == rhs.kind() &&
+         lhs.has_project_team() == rhs.has_project_team() &&
+         (!lhs.has_project_team() ||
+          lhs.project_team() == rhs.project_team()) &&
+         lhs.role() == rhs.role() && lhs.self_link() == rhs.self_link();
+}
+
+inline bool operator!=(AccessControlCommon const& lhs,
+                       AccessControlCommon const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/internal/nljson.h"
 #include <chrono>
 #include <map>
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -123,19 +124,6 @@ class CommonMetadata {
   }
   std::chrono::system_clock::time_point updated() const { return updated_; }
 
-  bool operator==(CommonMetadata const& rhs) const {
-    // etag changes each time the metadata changes, so that is the best field
-    // to short-circuit this comparison.  The check the name, project number,
-    // and metadata generation, which have the next best chance to
-    // short-circuit.  The rest just put in alphabetical order.
-    return name_ == rhs.name_ && metageneration_ == rhs.metageneration_ &&
-           id_ == rhs.id_ && etag_ == rhs.etag_ && kind_ == rhs.kind_ &&
-           self_link_ == rhs.self_link_ &&
-           storage_class_ == rhs.storage_class_ &&
-           time_created_ == rhs.time_created_ && updated_ == rhs.updated_;
-  }
-  bool operator!=(CommonMetadata const& rhs) const { return !(*this == rhs); }
-
  private:
   // Keep the fields in alphabetical order.
   std::string etag_;
@@ -149,6 +137,29 @@ class CommonMetadata {
   std::chrono::system_clock::time_point time_created_;
   std::chrono::system_clock::time_point updated_;
 };
+
+template <typename T>
+inline bool operator==(CommonMetadata<T> const& lhs,
+                       CommonMetadata<T> const& rhs) {
+  // etag changes each time the metadata changes, so that is the best field
+  // to short-circuit this comparison.  The check the name, project number,
+  // and metadata generation, which have the next best chance to
+  // short-circuit.  The rest just put in alphabetical order.
+  return lhs.name() == rhs.name() &&
+         lhs.metageneration() == rhs.metageneration() && lhs.id() == rhs.id() &&
+         lhs.etag() == rhs.etag() && lhs.kind() == rhs.kind() &&
+         lhs.self_link() == rhs.self_link() &&
+         lhs.storage_class() == rhs.storage_class() &&
+         lhs.time_created() == rhs.time_created() &&
+         lhs.updated() == rhs.updated() && lhs.has_owner() == rhs.has_owner() &&
+         (!lhs.has_owner() || lhs.owner() == rhs.owner());
+}
+
+template <typename T>
+inline bool operator!=(CommonMetadata<T> const& lhs,
+                       CommonMetadata<T> const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/range_from_pagination.h
+++ b/google/cloud/storage/internal/range_from_pagination.h
@@ -64,8 +64,8 @@ class PaginationIterator {
  private:
   friend Range;
 
-  friend bool operator==(PaginationIterator<T, Range> const& lhs,
-                         PaginationIterator<T, Range> const& rhs) {
+  friend bool operator==(PaginationIterator const& lhs,
+                         PaginationIterator const& rhs) {
     // Iterators on different streams are always different.
     if (lhs.owner_ != rhs.owner_) {
       return false;
@@ -85,8 +85,8 @@ class PaginationIterator {
     return lhs.value_.ok() == rhs.value_.ok();
   }
 
-  friend bool operator!=(PaginationIterator<T, Range> const& lhs,
-                         PaginationIterator<T, Range> const& rhs) {
+  friend bool operator!=(PaginationIterator const& lhs,
+                         PaginationIterator const& rhs) {
     return std::rel_ops::operator!=(lhs, rhs);
   }
 

--- a/google/cloud/storage/internal/range_from_pagination.h
+++ b/google/cloud/storage/internal/range_from_pagination.h
@@ -18,6 +18,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/storage/version.h"
 #include <iterator>
+#include <utility>
 
 namespace google {
 namespace cloud {
@@ -60,8 +61,11 @@ class PaginationIterator {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_CONST_REF_REF
   value_type&& operator*() && { return std::move(value_); }
 
-  friend bool operator==(PaginationIterator const& lhs,
-                         PaginationIterator const& rhs) {
+ private:
+  friend Range;
+
+  friend bool operator==(PaginationIterator<T, Range> const& lhs,
+                         PaginationIterator<T, Range> const& rhs) {
     // Iterators on different streams are always different.
     if (lhs.owner_ != rhs.owner_) {
       return false;
@@ -81,17 +85,14 @@ class PaginationIterator {
     return lhs.value_.ok() == rhs.value_.ok();
   }
 
-  friend bool operator!=(PaginationIterator const& lhs,
-                         PaginationIterator const& rhs) {
-    return !(lhs == rhs);
+  friend bool operator!=(PaginationIterator<T, Range> const& lhs,
+                         PaginationIterator<T, Range> const& rhs) {
+    return std::rel_ops::operator!=(lhs, rhs);
   }
 
- private:
-  friend Range;
   explicit PaginationIterator(Range* owner, value_type value)
       : owner_(owner), value_(std::move(value)) {}
 
- private:
   Range* owner_;
   value_type value_;
 };

--- a/google/cloud/testing_util/testing_types.h
+++ b/google/cloud/testing_util/testing_types.h
@@ -27,6 +27,7 @@
  */
 
 #include "google/cloud/log.h"
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -39,18 +40,24 @@ class NoDefaultConstructor {
   NoDefaultConstructor() = delete;
   explicit NoDefaultConstructor(std::string x) : str_(std::move(x)) {}
 
-  bool operator==(NoDefaultConstructor const& rhs) const {
-    return str_ == rhs.str_;
-  }
-  bool operator!=(NoDefaultConstructor const& rhs) const {
-    return !(*this == rhs);
-  }
-
   std::string str() const { return str_; }
 
  private:
+  friend bool operator==(NoDefaultConstructor const& lhs,
+                         NoDefaultConstructor const& rhs);
+
   std::string str_;
 };
+
+inline bool operator==(NoDefaultConstructor const& lhs,
+                       NoDefaultConstructor const& rhs) {
+  return lhs.str_ == rhs.str_;
+}
+
+inline bool operator!=(NoDefaultConstructor const& lhs,
+                       NoDefaultConstructor const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
 
 /**
  * A class that counts calls to its constructors.


### PR DESCRIPTION
Clean up relational operators.  …
* Convert all member operators to free functions.
* Fix a bug in operator== for CommonMetadata (it wasn't checking owner)
* Standardize on using std::rel_ops
* Move 'friend' declarations to class private sections.
* changed operator<< for RowRange to not require friendship

In cases where I was able to implement the operators using the existing
public API I did so, otherwise I preferred making them friends over adding
to the API.

I left PaginationIterator operators defined inline in the class because
all the verbiage necessary (forward declaration, friend declaration,
then definition) to make them friends makes it less readable IMO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2419)
<!-- Reviewable:end -->
