### PR TITLE
Multiple fixes to the HMAC implementation.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2372,12 +2372,11 @@ class Client {
    *     information on Google Cloud Platform service accounts.
    */
   template <typename... Options>
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(std::string access_id,
-                                          Options&&... options) {
+  Status DeleteHmacKey(std::string access_id, Options&&... options) {
     auto const& project_id = raw_client_->client_options().project_id();
     internal::DeleteHmacKeyRequest request(project_id, std::move(access_id));
     request.set_multiple_options(std::forward<Options>(options)...);
-    return raw_client_->DeleteHmacKey(request);
+    return raw_client_->DeleteHmacKey(request).status();
   }
 
   /**

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -143,6 +143,8 @@ run_all_service_account_examples() {
           list-hmac-keys-with-service-account "${SERVICE_ACCOUNT}" | \
           sed -n 's;^access_id = \(.*\);\1;p'); do
     run_example ./storage_service_account_samples \
+        update-hmac-key "${access_id}" "INACTIVE"
+    run_example ./storage_service_account_samples \
         delete-hmac-key "${access_id}"
   done
 

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -208,17 +208,14 @@ void DeleteHmacKey(google::cloud::storage::Client client, int& argc,
   }
   //! [delete hmac key] [START storage_delete_hmac_key]
   namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string access_id) {
-    StatusOr<gcs::HmacKeyMetadata> hmac_key_details =
-        client.DeleteHmacKey(access_id);
+    google::cloud::Status status = client.DeleteHmacKey(access_id);
 
-    if (!hmac_key_details) {
-      throw std::runtime_error(hmac_key_details.status().message());
+    if (!status.ok()) {
+      throw std::runtime_error(status.message());
     }
     std::cout << "The key is deleted, though it may still appear"
-              << " in ListHmacKeys() results."
-              << "\nThe HMAC key metadata is: " << &hmac_key_details << "\n";
+              << " in ListHmacKeys() results.\n";
   }
   //! [delete hmac key] [END storage_delete_hmac_key]
   (std::move(client), argv[1]);

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1062,12 +1062,13 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
   if (!status.ok()) {
     return status;
   }
-  builder.AddQueryParameter("serviceAccount", request.service_account());
+  builder.AddQueryParameter("serviceAccountEmail", request.service_account());
+  builder.AddHeader("content-length: 0");
   return ParseFromHttpResponse<CreateHmacKeyResponse>(
       builder.BuildRequest().MakeRequest(std::string{}));
 }
 
-StatusOr<HmacKeyMetadata> CurlClient::DeleteHmacKey(
+StatusOr<EmptyResponse> CurlClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/projects/" +
                                  request.project_id() + "/hmacKeys/" +
@@ -1077,8 +1078,7 @@ StatusOr<HmacKeyMetadata> CurlClient::DeleteHmacKey(
   if (!status.ok()) {
     return status;
   }
-  return CheckedFromString<HmacKeyMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
 }
 
 StatusOr<HmacKeyMetadata> CurlClient::GetHmacKey(
@@ -1101,7 +1101,7 @@ StatusOr<HmacKeyMetadata> CurlClient::UpdateHmacKey(
                                  request.project_id() + "/hmacKeys/" +
                                  request.access_id(),
                              storage_factory_);
-  auto status = SetupBuilder(builder, request, "POST");
+  auto status = SetupBuilder(builder, request, "PUT");
   if (!status.ok()) {
     return status;
   }

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -160,7 +160,7 @@ class CurlClient : public RawClient,
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
+  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
 

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -67,7 +67,7 @@ StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(
 
   CreateHmacKeyResponse result;
   result.kind = json.value("kind", "");
-  result.secret = json.value("secretKey", "");
+  result.secret = json.value("secret", "");
   if (json.count("metadata") != 0) {
     auto resource = HmacKeyMetadataParser::FromJson(json["metadata"]);
     if (!resource) {

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -68,7 +68,7 @@ TEST(HmacKeyRequestsTest, ParseCreateResponse) {
       {"kind", "storage#hmacKey"},
       // To generate the secret use:
       //   echo -n "test-secret" | openssl base64
-      {"secretKey", "dGVzdC1zZWNyZXQ="},
+      {"secret", "dGVzdC1zZWNyZXQ="},
       {"metadata", nl::json::parse(resource_text)},
   };
 
@@ -125,7 +125,7 @@ TEST(HmacKeysRequestsTest, List) {
   os << request;
   std::string actual = os.str();
   EXPECT_THAT(actual, HasSubstr("override-project-id"));
-  EXPECT_THAT(actual, HasSubstr("serviceAccount=test-service-account"));
+  EXPECT_THAT(actual, HasSubstr("serviceAccountEmail=test-service-account"));
   EXPECT_THAT(actual, HasSubstr("deleted=true"));
 }
 

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -322,7 +322,7 @@ StatusOr<CreateHmacKeyResponse> LoggingClient::CreateHmacKey(
   return MakeCall(*client_, &RawClient::CreateHmacKey, request, __func__);
 }
 
-StatusOr<HmacKeyMetadata> LoggingClient::DeleteHmacKey(
+StatusOr<EmptyResponse> LoggingClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteHmacKey, request, __func__);
 }

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -122,7 +122,7 @@ class LoggingClient : public RawClient {
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
+  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
 

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -151,7 +151,7 @@ class RawClient {
       ListHmacKeysRequest const&) = 0;
   virtual StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) = 0;
-  virtual StatusOr<HmacKeyMetadata> DeleteHmacKey(
+  virtual StatusOr<EmptyResponse> DeleteHmacKey(
       DeleteHmacKeyRequest const&) = 0;
   virtual StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) = 0;
   virtual StatusOr<HmacKeyMetadata> UpdateHmacKey(

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -530,7 +530,7 @@ StatusOr<CreateHmacKeyResponse> RetryClient::CreateHmacKey(
                   &RawClient::CreateHmacKey, request, __func__);
 }
 
-StatusOr<HmacKeyMetadata> RetryClient::DeleteHmacKey(
+StatusOr<EmptyResponse> RetryClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
   auto retry_policy = retry_policy_->clone();
   auto backoff_policy = backoff_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -136,7 +136,7 @@ class RetryClient : public RawClient {
       ListHmacKeysRequest const&) override;
   StatusOr<CreateHmacKeyResponse> CreateHmacKey(
       CreateHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
+  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -136,7 +136,7 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                                  internal::ListHmacKeysRequest const&));
   MOCK_METHOD1(CreateHmacKey, StatusOr<internal::CreateHmacKeyResponse>(
                                   internal::CreateHmacKeyRequest const&));
-  MOCK_METHOD1(DeleteHmacKey, StatusOr<HmacKeyMetadata>(
+  MOCK_METHOD1(DeleteHmacKey, StatusOr<internal::EmptyResponse>(
                                   internal::DeleteHmacKeyRequest const&));
   MOCK_METHOD1(GetHmacKey,
                StatusOr<HmacKeyMetadata>(internal::GetHmacKeyRequest const&));

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -449,7 +449,9 @@ struct ServiceAccountFilter
     : public internal::WellKnownParameter<ServiceAccountFilter, std::string> {
   using WellKnownParameter<ServiceAccountFilter,
                            std::string>::WellKnownParameter;
-  static char const* well_known_parameter_name() { return "serviceAccount"; }
+  static char const* well_known_parameter_name() {
+    return "serviceAccountEmail";
+  }
 };
 
 /**


### PR DESCRIPTION
The `serviceAccount` query parameter is now called
`serviceAccountEmail`.

The `secretKey` field when creating a HMAC key is now called simply
`secret`.

The testbench was not returning errors correctly, and some errors did
not include the necessary debugging information.

The UpdateHmacKey() request should use `PUT` not `POST`.

Only inactive HMAC keys can be deleted, so the testbench needs to check
this, and the unit + integration tests should deactivate a HMAC key
before trying to delete them.

DeleteHmacKey no longer returns the metadata for the deleted HMAC key,
it returns an empty response (which we represent by `Status`).

Set Content-Length in CreateHmacKey(). For somewhat silly reasons
`CurlRequestBuilder` does not automatically set the `Content-Length:`
header to 0 when the payload is empty: the same code path handles POST,
PUT, GET, and DELETE requests, and the header is only required for POST.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2422)
<!-- Reviewable:end -->
