### PR TITLE
Enable hmac key integration tests

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -104,12 +104,6 @@ run_all_service_account_examples() {
   run_example ./storage_service_account_samples get-service-account
   unset GOOGLE_CLOUD_PROJECT
 
-  if [[ -z "${CLOUD_STORAGE_TESTBENCH_ENDPOINT:-}" ]]; then
-    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
-        " HMAC key examples skipped because they are not enabled in production."
-    return
-  fi
-
   run_example ./storage_service_account_samples \
       create-hmac-key-for-project "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
 

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -30,11 +30,6 @@ using ::testing::HasSubstr;
 char const* flag_project_id;
 char const* flag_service_account;
 
-bool UsingTestbench() {
-  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
-      .has_value();
-}
-
 TEST(ServiceAccountIntegrationTest, Get) {
   std::string project_id = flag_project_id;
   StatusOr<Client> client = Client::CreateDefaultClient();
@@ -55,12 +50,6 @@ TEST(ServiceAccountIntegrationTest, Get) {
 }
 
 TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
-  if (!UsingTestbench()) {
-    // Temporarily disabled outside the testbench because the test does not
-    // cleanup after itself.
-    return;
-  }
-
   std::string project_id = flag_project_id;
   std::string service_account = flag_service_account;
   StatusOr<Client> client = Client::CreateDefaultClient();
@@ -74,12 +63,6 @@ TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
 }
 
 TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
-  if (!UsingTestbench()) {
-    // Temporarily disabled outside the testbench because the test does not
-    // cleanup after itself.
-    return;
-  }
-
   std::string project_id = flag_project_id;
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   std::string service_account = flag_service_account;
@@ -144,12 +127,6 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
 }
 
 TEST(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
-  if (!UsingTestbench()) {
-    // Temporarily disabled outside the testbench because the test does not
-    // cleanup after itself.
-    return;
-  }
-
   std::string project_id = flag_project_id;
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   std::string service_account = flag_service_account;


### PR DESCRIPTION
The HMAC Key support arrived (for whitelisted projects) to production,
so we can enable this for our integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2423)
<!-- Reviewable:end -->
