### PR TITLE
Implement get-bucket-class-and-location example.

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -48,6 +48,8 @@ run_all_bucket_examples() {
       "${bucket_name}" "STANDARD"
   run_example ./storage_bucket_samples patch-bucket-storage-class-with-builder \
       "${bucket_name}" "COLDLINE"
+  run_example ./storage_bucket_samples get-bucket-class-and-location \
+      "${bucket_name}"
   run_example ./storage_bucket_samples enable-bucket-policy-only \
       "${bucket_name}"
   run_example ./storage_bucket_samples disable-bucket-policy-only \

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
+
 #include <functional>
 #include <iostream>
 #include <map>
@@ -323,6 +324,33 @@ void PatchBucketStorageClassWithBuilder(google::cloud::storage::Client client,
   }
   //! [patch bucket storage class with builder]
   (std::move(client), bucket_name, storage_class);
+}
+
+void GetBucketClassAndLocation(google::cloud::storage::Client client, int& argc,
+                               char* argv[]) {
+  if (argc != 2) {
+    throw Usage{"get-bucket-class-and-location <bucket-name>"};
+  }
+  auto bucket_name = ConsumeArg(argc, argv);
+  // [START storage_get_bucket_class_and_location]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    StatusOr<gcs::BucketMetadata> bucket_metadata = client.GetBucketMetadata(
+        bucket_name, gcs::Fields("name,location,storageClass"));
+
+    if (!bucket_metadata) {
+      throw std::runtime_error(bucket_metadata.status().message());
+    }
+
+    std::cout << "Bucket " << bucket_metadata->name()
+              << " default storage class is "
+              << bucket_metadata->storage_class()
+              << ", and the default location is " << bucket_metadata->location()
+              << '\n';
+  }
+  // [END storage_get_bucket_class_and_location]
+  (std::move(client), bucket_name);
 }
 
 void AddBucketDefaultKmsKey(google::cloud::storage::Client client, int& argc,
@@ -1531,6 +1559,7 @@ int main(int argc, char* argv[]) try {
       {"patch-bucket-storage-class", &PatchBucketStorageClass},
       {"patch-bucket-storage-class-with-builder",
        &PatchBucketStorageClassWithBuilder},
+      {"get-bucket-class-and-location", &GetBucketClassAndLocation},
       {"add-bucket-default-kms-key", &AddBucketDefaultKmsKey},
       {"get-bucket-default-kms-key", &GetBucketDefaultKmsKey},
       {"remove-bucket-default-kms-key", &RemoveBucketDefaultKmsKey},

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -336,8 +336,8 @@ void GetBucketClassAndLocation(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> bucket_metadata = client.GetBucketMetadata(
-        bucket_name, gcs::Fields("name,location,storageClass"));
+    StatusOr<gcs::BucketMetadata> bucket_metadata =
+        client.GetBucketMetadata(bucket_name);
 
     if (!bucket_metadata) {
       throw std::runtime_error(bucket_metadata.status().message());
@@ -345,9 +345,8 @@ void GetBucketClassAndLocation(google::cloud::storage::Client client, int& argc,
 
     std::cout << "Bucket " << bucket_metadata->name()
               << " default storage class is "
-              << bucket_metadata->storage_class()
-              << ", and the default location is " << bucket_metadata->location()
-              << '\n';
+              << bucket_metadata->storage_class() << ", and the location is "
+              << bucket_metadata->location() << '\n';
   }
   // [END storage_get_bucket_class_and_location]
   (std::move(client), bucket_name);


### PR DESCRIPTION
This is one of the standard examples for GCS client libraries, it should
show how to get the storage class and location of a bucket.

This fixes #2414.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2426)
<!-- Reviewable:end -->
