### PR TITLE
Prepare Credentials class to support SignBlob API.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -192,6 +192,7 @@ add_library(storage_client
             oauth2/compute_engine_credentials.h
             oauth2/credential_constants.h
             oauth2/credentials.h
+            oauth2/credentials.cc
             oauth2/google_application_default_credentials_file.h
             oauth2/google_application_default_credentials_file.cc
             oauth2/google_credentials.h

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2837,6 +2837,20 @@ class Client {
   Status DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
                           std::string const& file_name);
 
+  /// Determine the email used to sign a blob.
+  std::string SigningEmail(SigningAccount const& signing_account);
+
+  /// Represents the result of signing a blob, including the key used in the
+  /// signature.
+  struct SignBlobResponseRaw {
+    std::string key_id;
+    std::vector<std::uint8_t> signed_blob;
+  };
+
+  /// Sign a blob.
+  StatusOr<SignBlobResponseRaw> SignBlobImpl(
+      SigningAccount const& signing_account, std::string const& string_to_sign);
+
   StatusOr<std::string> SignUrlV2(internal::V2SignUrlRequest const& request);
   StatusOr<std::string> SignUrlV4(internal::V4SignUrlRequest request);
 

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -98,7 +98,7 @@ TEST(SignedUrlIntegrationTest, SignFailure) {
   auto actual =
       client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest());
   EXPECT_FALSE(actual.ok()) << "value=" << actual.value();
-  EXPECT_EQ(StatusCode::kInvalidArgument, actual.status().code());
+  EXPECT_EQ(StatusCode::kUnimplemented, actual.status().code());
 }
 
 }  // namespace

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -85,7 +85,7 @@ TEST(SignedUrlIntegrationTest, SignFailure) {
 
   auto actual = client.CreateV2SignedUrl("GET", "test-bucket", "test-object");
   EXPECT_FALSE(actual.ok()) << "value=" << actual.value();
-  EXPECT_EQ(StatusCode::kInvalidArgument, actual.status().code());
+  EXPECT_EQ(StatusCode::kUnimplemented, actual.status().code());
 }
 
 // This is a dummy service account JSON file that is inactive. It's fine for it

--- a/google/cloud/storage/oauth2/credentials.cc
+++ b/google/cloud/storage/oauth2/credentials.cc
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/oauth2/credentials.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace oauth2 {
+
+StatusOr<std::vector<std::uint8_t>> Credentials::SignBlob(
+    SigningAccount const&, std::string const&) const {
+  return Status(StatusCode::kUnimplemented,
+                "The current credentials cannot sign blobs locally");
+}
+
+}  // namespace oauth2
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/storage/signed_url_options.h"
 #include "google/cloud/storage/version.h"
 #include <chrono>
 
@@ -48,6 +49,24 @@ class Credentials {
    * header to be used in HTTP requests.
    */
   virtual StatusOr<std::string> AuthorizationHeader() = 0;
+
+  /**
+   * Try to sign @p string_to_sign using @p service_account.
+   *
+   * Some %Credentials types can locally sign a blob, most often just on behalf
+   * of an specific service account. This function returns an error if the
+   * credentials cannot sign the blob at all, or if the service account is a
+   * mismatch.
+   */
+  virtual StatusOr<std::vector<std::uint8_t>> SignBlob(
+      SigningAccount const& service_account,
+      std::string const& string_to_sign) const;
+
+  /// Return the account's email associated with these credentials, if any.
+  virtual std::string AccountEmail() const { return std::string{}; }
+
+  /// Return the account's key_id associated with these credentials, if any.
+  virtual std::string KeyId() const { return std::string{}; }
 };
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -372,8 +372,8 @@ x-goog-encryption-algorithm:AES256
 x-goog-meta-foo:bar,baz
 /bucket/objectname)""";
 
-  auto actual = credentials.SignString(blob);
-  ASSERT_STATUS_OK(actual.first);
+  auto actual = credentials.SignBlob(SigningAccount(), blob);
+  ASSERT_STATUS_OK(actual);
 
   // To generate the expected output I used:
   //   openssl dgst -sha256 -sign private.pem blob.txt | openssl base64 -A
@@ -388,7 +388,7 @@ x-goog-meta-foo:bar,baz
       "hRW9bSCCV8w1Ex+"
       "QxmB5z7P7zZn2pl7JAcL850emTo8f2tfv1xXWQGhACvIJeMdPmyjbc04Ye4M8Ljpkg3YhE6l"
       "4GwC2MnI8TkuoHe4Bj2MvA8mM8TVwIvpBs6Etsj6Jdaz4rg==";
-  EXPECT_EQ(expected_signed, actual.second);
+  EXPECT_EQ(expected_signed, internal::Base64Encode(*actual));
 }
 
 /// @test Verify that we can get the client id from a service account.
@@ -419,7 +419,7 @@ TEST_F(ServiceAccountCredentialsTest, ClientId) {
       *info);
 
   EXPECT_EQ("foo-email@foo-project.iam.gserviceaccount.com",
-            credentials.client_id());
+            credentials.AccountEmail());
 }
 
 }  // namespace

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -177,8 +177,8 @@ struct SigningAccount
  * `roles/iam.serviceAccountTokenCreator` on the target service account.
  */
 struct SigningAccountDelegates
-    : internal::ComplexOption<SigningAccountDelegates,
-                              std::vector<std::string>> {
+    : public internal::ComplexOption<SigningAccountDelegates,
+                                     std::vector<std::string>> {
   using ComplexOption<SigningAccountDelegates,
                       std::vector<std::string>>::ComplexOption;
   static char const* name() { return "signing-account-delegates"; }

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/complex_option.h"
 #include <chrono>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -156,6 +157,32 @@ struct SignedUrlDuration
   static char const* name() { return "x-goog-expires"; }
 };
 
+/**
+ * Specify the service account used to sign a blob.
+ *
+ * With this option the application can sign a URL or policy document using a
+ * different account than the account associated with the current credentials.
+ */
+struct SigningAccount
+    : public internal::ComplexOption<SigningAccount, std::string> {
+  using ComplexOption<SigningAccount, std::string>::ComplexOption;
+  static char const* name() { return "signing-account"; }
+};
+
+/**
+ * Specify the sequence of delegates used to sign a blob.
+ *
+ * With this option the application can sign a URL even if the account
+ * associated with the current credentials does not have direct
+ * `roles/iam.serviceAccountTokenCreator` on the target service account.
+ */
+struct SigningAccountDelegates
+    : internal::ComplexOption<SigningAccountDelegates,
+                              std::vector<std::string>> {
+  using ComplexOption<SigningAccountDelegates,
+                      std::vector<std::string>>::ComplexOption;
+  static char const* name() { return "signing-account-delegates"; }
+};
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -155,6 +155,7 @@ storage_client_srcs = [
     "notification_metadata.cc",
     "oauth2/anonymous_credentials.cc",
     "oauth2/authorized_user_credentials.cc",
+    "oauth2/credentials.cc",
     "oauth2/google_application_default_credentials_file.cc",
     "oauth2/google_credentials.cc",
     "oauth2/refreshing_credentials_wrapper.cc",


### PR DESCRIPTION
Instead of using RTTI to determine what Credential classes can be used
to sign documents use a virtual function. In a future PR we will first
try to sign blobs locally using the Credentials class, if that fails we
will use the SignBlob API.

Part of the work for #1595. Also fixes #1811.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2428)
<!-- Reviewable:end -->
