### PR TITLE
Implement internal::*Client::SignBlob().

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -72,6 +72,7 @@ StatusOr<ClientOptions> ClientOptions::CreateDefaultClientOptions() {
 ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials)
     : credentials_(std::move(credentials)),
       endpoint_("https://www.googleapis.com"),
+      iam_endpoint_("https://iamcredentials.googleapis.com/v1"),
       version_("v1"),
       enable_http_tracing_(false),
       enable_raw_client_tracing_(false),
@@ -84,6 +85,7 @@ ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials)
       google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
   if (emulator.has_value()) {
     endpoint_ = *emulator;
+    iam_endpoint_ = *emulator + "/iamapi";
   }
   SetupFromEnvironment();
 }

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -67,6 +67,12 @@ class ClientOptions {
     return *this;
   }
 
+  std::string const& iam_endpoint() const { return iam_endpoint_; }
+  ClientOptions& set_iam_endpoint(std::string endpoint) {
+    iam_endpoint_ = std::move(endpoint);
+    return *this;
+  }
+
   std::string const& version() const { return version_; }
   ClientOptions& set_version(std::string version) {
     version_ = std::move(version);
@@ -140,6 +146,7 @@ class ClientOptions {
  private:
   std::shared_ptr<oauth2::Credentials> credentials_;
   std::string endpoint_;
+  std::string iam_endpoint_;
   std::string version_;
   bool enable_http_tracing_;
   bool enable_raw_client_tracing_;

--- a/google/cloud/storage/idempotency_policy.h
+++ b/google/cloud/storage/idempotency_policy.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_IDEMPOTENCY_POLICY_H_
 
 #include "google/cloud/storage/internal/raw_client.h"
-#include "google/cloud/storage/internal/sign_blob_requests.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -163,6 +163,7 @@ class CurlClient : public RawClient,
   StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
+  StatusOr<SignBlobResponse> SignBlob(SignBlobRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;
@@ -220,6 +221,7 @@ class CurlClient : public RawClient,
   std::string upload_endpoint_;
   std::string xml_upload_endpoint_;
   std::string xml_download_endpoint_;
+  std::string iam_endpoint_;
 
   std::mutex mu_;
   CurlShare share_ /* GUARDED_BY(mu_) */;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -453,6 +453,14 @@ TEST_P(CurlClientTest, CreateHmacKeyRequest) {
   CheckStatus(actual);
 }
 
+TEST_P(CurlClientTest, SignBlob) {
+  auto actual =
+      client_
+          ->SignBlob(SignBlobRequest("test-service-account", "test-blob", {}))
+          .status();
+  CheckStatus(actual);
+}
+
 TEST_P(CurlClientTest, ListNotifications) {
   auto actual =
       client_->ListNotifications(ListNotificationsRequest("bkt")).status();

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -337,6 +337,11 @@ StatusOr<HmacKeyMetadata> LoggingClient::UpdateHmacKey(
   return MakeCall(*client_, &RawClient::UpdateHmacKey, request, __func__);
 }
 
+StatusOr<SignBlobResponse> LoggingClient::SignBlob(
+    SignBlobRequest const& request) {
+  return MakeCall(*client_, &RawClient::SignBlob, request, __func__);
+}
+
 StatusOr<ListNotificationsResponse> LoggingClient::ListNotifications(
     ListNotificationsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListNotifications, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -125,6 +125,7 @@ class LoggingClient : public RawClient {
   StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
+  StatusOr<SignBlobResponse> SignBlob(SignBlobRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -30,6 +30,7 @@
 #include "google/cloud/storage/internal/object_streambuf.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/internal/service_account_requests.h"
+#include "google/cloud/storage/internal/sign_blob_requests.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/service_account.h"
@@ -156,6 +157,7 @@ class RawClient {
   virtual StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) = 0;
   virtual StatusOr<HmacKeyMetadata> UpdateHmacKey(
       UpdateHmacKeyRequest const&) = 0;
+  virtual StatusOr<SignBlobResponse> SignBlob(SignBlobRequest const&) = 0;
   //@}
 
   //@{

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -557,6 +557,15 @@ StatusOr<HmacKeyMetadata> RetryClient::UpdateHmacKey(
                   &RawClient::UpdateHmacKey, request, __func__);
 }
 
+StatusOr<SignBlobResponse> RetryClient::SignBlob(
+    SignBlobRequest const& request) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  auto is_idempotent = idempotency_policy_->IsIdempotent(request);
+  return MakeCall(*retry_policy, *backoff_policy, is_idempotent, *client_,
+                  &RawClient::SignBlob, request, __func__);
+}
+
 StatusOr<ListNotificationsResponse> RetryClient::ListNotifications(
     ListNotificationsRequest const& request) {
   auto retry_policy = retry_policy_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -139,6 +139,7 @@ class RetryClient : public RawClient {
   StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
+  StatusOr<SignBlobResponse> SignBlob(SignBlobRequest const&) override;
 
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -51,6 +51,7 @@ TEST_F(ClientOptionsTest, Default) {
   EXPECT_TRUE(creds.get() == options.credentials().get());
   EXPECT_EQ("https://www.googleapis.com", options.endpoint());
   EXPECT_EQ("v1", options.version());
+  EXPECT_EQ("https://iamcredentials.googleapis.com/v1", options.iam_endpoint());
 }
 
 TEST_F(ClientOptionsTest, EnableRpc) {
@@ -84,6 +85,12 @@ TEST_F(ClientOptionsTest, SetEndpoint) {
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   options.set_endpoint("http://localhost:2345");
   EXPECT_EQ("http://localhost:2345", options.endpoint());
+}
+
+TEST_F(ClientOptionsTest, SetIamEndpoint) {
+  ClientOptions options(oauth2::CreateAnonymousCredentials());
+  options.set_iam_endpoint("http://localhost:0/v2");
+  EXPECT_EQ("http://localhost:0/v2", options.iam_endpoint());
 }
 
 TEST_F(ClientOptionsTest, SetCredentials) {

--- a/google/cloud/storage/testbench/gcs_iam.py
+++ b/google/cloud/storage/testbench/gcs_iam.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Simulate IAM operations."""
+
+import base64
+import error_response
+import flask
+import json
+
+
+IAM_HANDLER_PATH = '/iamapi'
+iam = flask.Flask(__name__)
+iam.debug = True
+
+
+@iam.route('/projects/-/serviceAccounts/<service_account>:signBlob',
+           methods=['POST'])
+def sign_blob(service_account):
+    """Implement the `projects.serviceAccounts.signBlob` API."""
+    payload = json.loads(flask.request.data)
+    if payload.get('payload') is None:
+        raise error_response.ErrorResponse(
+            'Missing payload in the payload', status_code=400)
+    try:
+        blob = base64.b64decode(payload.get('payload'))
+    except TypeError:
+        raise error_response.ErrorResponse(
+            'payload must be base64-encoded', status_code=400)
+    blob = 'signed: ' + blob
+    response = {
+        'keyId': 'fake-key-id-123',
+        'signedBlob': base64.b64encode(blob)
+    }
+    return json.dumps(response)
+
+
+def get_iam_app():
+    return IAM_HANDLER_PATH, iam

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -15,10 +15,10 @@
 """A test bench for the Google Cloud Storage C++ Client Library."""
 
 import argparse
-import base64
 import error_response
 import flask
 import gcs_bucket
+import gcs_iam
 import gcs_object
 import gcs_project
 import httpbin
@@ -750,6 +750,10 @@ def xmlapi_put_object(bucket_name, object_name):
 (PROJECTS_HANDLER_PATH, projects_app) = gcs_project.get_projects_app()
 
 
+# Define the WSGI application to handle IAM requests
+(IAM_HANDLER_PATH, iam_app) = gcs_iam.get_iam_app()
+
+
 application = wsgi.DispatcherMiddleware(
     root, {
         '/httpbin': httpbin.app,
@@ -757,6 +761,7 @@ application = wsgi.DispatcherMiddleware(
         UPLOAD_HANDLER_PATH: upload,
         XMLAPI_HANDLER_PATH: xmlapi,
         PROJECTS_HANDLER_PATH: projects_app,
+        IAM_HANDLER_PATH: iam_app,
     })
 
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -142,6 +142,8 @@ class MockClient : public google::cloud::storage::internal::RawClient {
                StatusOr<HmacKeyMetadata>(internal::GetHmacKeyRequest const&));
   MOCK_METHOD1(UpdateHmacKey, StatusOr<HmacKeyMetadata>(
                                   internal::UpdateHmacKeyRequest const&));
+  MOCK_METHOD1(SignBlob, StatusOr<internal::SignBlobResponse>(
+                             internal::SignBlobRequest const&));
 
   MOCK_METHOD1(ListNotifications,
                StatusOr<internal::ListNotificationsResponse>(

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(storage_client_integration_tests
     curl_request_integration_test.cc
     curl_resumable_streambuf_integration_test.cc
     curl_resumable_upload_session_integration_test.cc
+    curl_sign_blob_integration_test.cc
     object_checksum_integration_test.cc
     object_hash_integration_test.cc
     object_insert_integration_test.cc

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -1,0 +1,78 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+
+// Initialized in main() below.
+char const* flag_service_account;
+
+class CurlSignBlobIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+TEST_F(CurlSignBlobIntegrationTest, Simple) {
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+  std::string service_account = flag_service_account;
+
+  auto encoded = Base64Encode(LoremIpsum());
+
+  SignBlobRequest request(service_account, encoded, {});
+
+  StatusOr<SignBlobResponse> response = client->raw_client()->SignBlob(request);
+  ASSERT_STATUS_OK(response);
+
+  EXPECT_FALSE(response->key_id.empty());
+  EXPECT_FALSE(response->signed_blob.empty());
+
+  auto decoded = Base64Decode(response->signed_blob);
+  EXPECT_FALSE(decoded.empty());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 2) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <service-account>\n";
+    return 1;
+  }
+
+  google::cloud::storage::internal::flag_service_account = argv[1];
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -35,6 +35,10 @@ echo "Running storage::internal::CurlResumableUploadSession integration tests."
 ./curl_resumable_upload_session_integration_test "${BUCKET_NAME}"
 
 echo
+echo "Running CurlClient::SignBlob integration tests."
+./curl_sign_blob_integration_test "${SERVICE_ACCOUNT}"
+
+echo
 echo "Running GCS Bucket APIs integration tests."
 ./bucket_integration_test "${PROJECT_ID}" "${BUCKET_NAME}" "${TOPIC_NAME}"
 

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -51,6 +51,10 @@ echo "Running storage::internal::CurlResumableUploadSession integration tests."
 ./curl_resumable_upload_session_integration_test "${BUCKET_NAME}"
 
 echo
+echo "Running CurlClient::SignBlob integration tests."
+./curl_sign_blob_integration_test "${SERVICE_ACCOUNT}"
+
+echo
 echo "Running GCS Bucket APIs integration tests."
 ./bucket_integration_test "${PROJECT_ID}" "${BUCKET_NAME}" "${TOPIC_NAME}"
 

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -23,6 +23,7 @@ storage_client_integration_tests = [
     "curl_request_integration_test.cc",
     "curl_resumable_streambuf_integration_test.cc",
     "curl_resumable_upload_session_integration_test.cc",
+    "curl_sign_blob_integration_test.cc",
     "object_checksum_integration_test.cc",
     "object_hash_integration_test.cc",
     "object_insert_integration_test.cc",


### PR DESCRIPTION
We do not plan to expose directly to application developers, but with
this PR it is possible to use the IAM API to sign blobs:

https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/signBlob

the usual tests for retries and an integration test is part of the PR.

Part of the work for #1595.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2431)
<!-- Reviewable:end -->
