### PR TITLE
Output content-length-range parameters as numbers, not strings.

### DIFF
--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -75,20 +75,19 @@ TEST(SignedPolicyDocumentIntegrationTest, Sign) {
             internal::FormatRfc3339(actual->expiration));
 
   EXPECT_EQ(
-      "eyJjb25kaXRpb25zIjpbWyJzdGFydHMtd2l0aCIsIiRrZXkiLCIiXSx7ImFjbCI6ImJ1Y2tl"
-      "dC1vd25lci1yZWFkIn0seyJidWNrZXQiOiJ0cmF2ZWwtbWFwcyJ9LFsiZXEiLCIkQ29udGVu"
-      "dC1UeXBlIiwiaW1hZ2UvanBlZyJdLFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLCIwIiwiMTAw"
-      "MDAwMCJdXSwiZXhwaXJhdGlvbiI6IjIwMTAtMDYtMTZUMTE6MTE6MTFaIn0=",
+      "eyJjb25kaXRpb25zIjpbeyJhY2wiOiJidWNrZXQtb3duZXItcmVhZCJ9LHsiYnVja2V0Ijoi"
+      "dHJhdmVsLW1hcHMifSxbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwwLDEwMDAwMDBdXSwiZXhw"
+      "aXJhdGlvbiI6IjIwMTAtMDYtMTZUMTE6MTE6MTFaIn0=",
       actual->policy);
 
   EXPECT_EQ(
-      "NPjAK/xIruiwrsv56PcYcq4JTyBrfxRmpcp+oZZlPKPux4J/QUpxNh/"
-      "tWKJDzkWcDRhCfUqpBgkPZdf0pxr3IkYVgf9un1AR92GV020ZLGfoVUUnpuQyEouFp1dGAa1"
-      "FH+a89r8nz54sgLa/umCwhVQ6zX3D0qawym/"
-      "BK2Bu70DC2F1MKuVnmFwJNHbUq+ko69++"
-      "CT7QAh9WNyJ8AIuj3LQQFCZ5pRQaqyrRPSY82PUwDm0BXMtDpahc4vfDIiappjvli2G2YawD"
-      "KLMRsv/"
-      "86WtiuQdFYMZouiI3XEMKl0rOt7ohPVXEjfbeIM0FJGZ3t0+8ZQZ9RArakOtZFL9x9g==",
+      "kFWvHSh72uILi3XyvLe7dFzL4mzyHjEYHMwAo1UnfKTzfX7fcnuPa0jRWym8fAg5Q9dSnVrx"
+      "PWXKbIaxk1UmlQ992iMhwtgEFpGyc+znRXJBX/"
+      "CeDOj7i4t41RScLBzEcdPdGLm+"
+      "tyGM79SoBacJMmmw3gTZIrv4ASFp7we784tEpXBcAF1AcY4hKUfMX87cyqdH/"
+      "s+YKWuow7CJwpHJoC0QogkPpUCW2gt0tpZtRQZn5Beo9imFIvqG0Qkan/"
+      "nCxBpgTP3b9AzebOx1XQb6wi1QWWBjIFtPHyCOI7alpu8XNlN61jQNo/"
+      "MQcW2OKVKgjcQS6vnLm+MJiAo+sslUtg==",
       actual->signature);
 }
 

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -34,7 +34,8 @@ std::string PolicyDocumentRequest::StringToSign() const {
   for (auto const& kv : document.conditions) {
     std::vector<std::string> elements = kv.elements();
 
-    /** If the elements is of size 2, we've encountered an exact match in
+    /**
+     * If the elements is of size 2, we've encountered an exact match in
      * object form.  So we create a json object using the first element as the
      * key and the second element as the value.
      */
@@ -43,7 +44,10 @@ std::string PolicyDocumentRequest::StringToSign() const {
       object[elements.at(0)] = elements.at(1);
       j["conditions"].push_back(object);
     } else {
-      j["conditions"].push_back(elements);
+      if (elements.at(0) == "content-length-range") {
+        j["conditions"].push_back({elements.at(0), std::stol(elements.at(1)),
+                                   std::stol(elements.at(2))});
+      }
     }
   }
 


### PR DESCRIPTION
Previously it looked like:

```
["content-length-range", "0", "1000000"]
```

We want it to actually be like:

```
["content-length-range", 0, 1000000]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2438)
<!-- Reviewable:end -->
