### PR TITLE
Refactor UsingTestbench() function.

### DIFF
--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 
 namespace google {
 namespace cloud {
@@ -59,6 +60,11 @@ std::string StorageIntegrationTest::MakeRandomBucketName() {
   return prefix + google::cloud::internal::Sample(
                       generator_, static_cast<int>(max_random_characters),
                       "abcdefghijklmnopqrstuvwxyz012456789");
+}
+
+bool StorageIntegrationTest::UsingTestbench() const {
+  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
+      .has_value();
 }
 
 void StorageIntegrationTest::WriteRandomLines(std::ostream& upload,

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -45,6 +45,8 @@ class StorageIntegrationTest : public ::testing::Test {
                         int line_count = kDefaultRandomLineCount,
                         int line_size = kDefaultLineSize);
 
+  bool UsingTestbench() const;
+
   google::cloud::internal::DefaultPRNG generator_ =
       google::cloud::internal::MakeDefaultPRNG();
 };

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -37,11 +36,6 @@ char const* flag_bucket_name;
 
 class ObjectChecksumIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
-
-bool UsingTestbench() {
-  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
-      .has_value();
-}
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32c) {
   StatusOr<Client> client = Client::CreateDefaultClient();

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
@@ -39,11 +38,6 @@ char const* flag_bucket_name;
 
 class ObjectHashIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
-
-bool UsingTestbench() {
-  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
-      .has_value();
-}
 
 /// @test Verify that MD5 hashes are computed by default.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/log.h"
@@ -51,11 +50,6 @@ class ObjectMediaIntegrationTest
  protected:
   ::google::cloud::testing_util::EnvironmentVariableRestore endpoint_;
 };
-
-bool UsingTestbench() {
-  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
-      .has_value();
-}
 
 TEST_F(ObjectMediaIntegrationTest, XmlDownloadFile) {
   StatusOr<Client> client = Client::CreateDefaultClient();

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -33,11 +32,6 @@ char const* flag_bucket_name;
 
 class ObjectResumableWriteIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
-
-bool UsingTestbench() {
-  return google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
-      .has_value();
-}
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentType) {
   StatusOr<Client> client = Client::CreateDefaultClient();


### PR DESCRIPTION
In some tests we need to know if we are running against the testbench,
for example, because the testbench implements special headers to control
its behavior, or because the testbench does not implement some
functionality (signed URLs is the one I can think of). We had multiple
versions of this function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2446)
<!-- Reviewable:end -->
