### PR TITLE
Add SigningAccount options to Sign*Request.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -349,6 +349,7 @@ if (BUILD_TESTING)
         internal/object_streambuf_test.cc
         internal/parse_rfc3339_test.cc
         internal/patch_builder_test.cc
+        internal/policy_document_request_test.cc
         internal/retry_client_test.cc
         internal/retry_resumable_upload_session_test.cc
         internal/service_account_requests_test.cc

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -54,6 +54,10 @@ std::string PolicyDocumentRequest::StringToSign() const {
   return std::move(j).dump();
 }
 
+std::ostream& operator<<(std::ostream& os, PolicyDocumentRequest const& r) {
+  return os << "PolicyDocumentRequest={" << r.StringToSign() << "}";
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_POLICY_DOCUMENT_REQUEST_H_
 
 #include "google/cloud/storage/policy_document.h"
+#include "google/cloud/storage/signed_url_options.h"
 
 namespace google {
 namespace cloud {
@@ -41,8 +42,29 @@ class PolicyDocumentRequest {
    */
   std::string StringToSign() const;
 
+  SigningAccount const& signing_account() const { return signing_account_; }
+  SigningAccountDelegates const& signing_account_delegates() const {
+    return signing_account_delegates_;
+  }
+
+  void SetOption(SigningAccount const& o) { signing_account_ = o; }
+
+  void SetOption(SigningAccountDelegates const& o) {
+    signing_account_delegates_ = o;
+  }
+
+  template <typename H, typename... T>
+  PolicyDocumentRequest& set_multiple_options(H&& h, T&&... tail) {
+    SetOption(std::forward<H>(h));
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+
+  PolicyDocumentRequest& set_multiple_options() { return *this; }
+
  private:
   PolicyDocument document_;
+  SigningAccount signing_account_;
+  SigningAccountDelegates signing_account_delegates_;
 };
 
 std::ostream& operator<<(std::ostream& os, PolicyDocumentRequest const& r);

--- a/google/cloud/storage/internal/policy_document_request_test.cc
+++ b/google/cloud/storage/internal/policy_document_request_test.cc
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/policy_document_request.h"
+#include "google/cloud/storage/internal/nljson.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+TEST(PolicyDocumentRequest, SigningAccount) {
+  PolicyDocumentRequest request;
+  EXPECT_FALSE(request.signing_account().has_value());
+  EXPECT_FALSE(request.signing_account_delegates().has_value());
+
+  request.set_multiple_options(
+      SigningAccount("another-account@example.com"),
+      SigningAccountDelegates({"test-delegate1", "test-delegate2"}));
+  ASSERT_TRUE(request.signing_account().has_value());
+  ASSERT_TRUE(request.signing_account_delegates().has_value());
+  EXPECT_EQ("another-account@example.com", request.signing_account().value());
+  EXPECT_THAT(request.signing_account_delegates().value(),
+              ::testing::ElementsAre("test-delegate1", "test-delegate2"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -48,6 +48,11 @@ class SignUrlRequestCommon {
     return query_parameters_;
   }
 
+  SigningAccount const& signing_account() const { return signing_account_; }
+  SigningAccountDelegates const& signing_account_delegates() const {
+    return signing_account_delegates_;
+  }
+
   void SetOption(SubResourceOption const& o) {
     if (!o.has_value()) {
       return;
@@ -64,6 +69,12 @@ class SignUrlRequestCommon {
     query_parameters_.insert(o.value());
   }
 
+  void SetOption(SigningAccount const& o) { signing_account_ = o; }
+
+  void SetOption(SigningAccountDelegates const& o) {
+    signing_account_delegates_ = o;
+  }
+
  private:
   std::string verb_;
   std::string bucket_name_;
@@ -71,6 +82,9 @@ class SignUrlRequestCommon {
   std::string sub_resource_;
   std::map<std::string, std::string> extension_headers_;
   std::multimap<std::string, std::string> query_parameters_;
+
+  SigningAccount signing_account_;
+  SigningAccountDelegates signing_account_delegates_;
 };
 
 /**
@@ -94,6 +108,12 @@ class V2SignUrlRequest {
   }
   std::string const& sub_resource() const {
     return common_request_.sub_resource();
+  }
+  SigningAccount const& signing_account() const {
+    return common_request_.signing_account();
+  }
+  SigningAccountDelegates const& signing_account_delegates() const {
+    return common_request_.signing_account_delegates();
   }
 
   std::chrono::seconds expiration_time_as_seconds() const {
@@ -146,6 +166,12 @@ class V2SignUrlRequest {
     common_request_.SetOption(o);
   }
 
+  void SetOption(SigningAccount const& o) { common_request_.SetOption(o); }
+
+  void SetOption(SigningAccountDelegates const& o) {
+    common_request_.SetOption(o);
+  }
+
   SignUrlRequestCommon common_request_;
   std::string md5_hash_value_;
   std::string content_type_;
@@ -176,6 +202,12 @@ class V4SignUrlRequest {
   }
   std::string const& sub_resource() const {
     return common_request_.sub_resource();
+  }
+  SigningAccount const& signing_account() const {
+    return common_request_.signing_account();
+  }
+  SigningAccountDelegates const& signing_account_delegates() const {
+    return common_request_.signing_account_delegates();
   }
 
   std::chrono::system_clock::time_point timestamp() const { return timestamp_; }
@@ -232,6 +264,12 @@ class V4SignUrlRequest {
   }
 
   void SetOption(AddQueryParameterOption const& o) {
+    common_request_.SetOption(o);
+  }
+
+  void SetOption(SigningAccount const& o) { common_request_.SetOption(o); }
+
+  void SetOption(SigningAccountDelegates const& o) {
     common_request_.SetOption(o);
   }
 

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -61,6 +61,7 @@ storage_client_unit_tests = [
     "internal/object_streambuf_test.cc",
     "internal/parse_rfc3339_test.cc",
     "internal/patch_builder_test.cc",
+    "internal/policy_document_request_test.cc",
     "internal/retry_client_test.cc",
     "internal/retry_resumable_upload_session_test.cc",
     "internal/service_account_requests_test.cc",


### PR DESCRIPTION
When singing a blob, either as part of a signed policy document or a
signed URL, we may want to use a different account (and it must be a
service account) than the account used for authentication. This is the
only way to use a authorized user account to access GCP, but sign the
URLs with a different service account. Or when using GCE authentication
we may want to use a different service account for the signed URLs.

Note that these options are currently unused, a future PR will connect
them to the rest of the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2447)
<!-- Reviewable:end -->
