### PR TITLE
Cleanup implementation oauth2::*Credentials.

### DIFF
--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
+
 #include "google/cloud/storage/oauth2/credential_constants.h"
 
 namespace google {
@@ -21,13 +22,14 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
-bool RefreshingCredentialsWrapper::IsExpired() {
+bool RefreshingCredentialsWrapper::IsExpired() const {
   auto now = std::chrono::system_clock::now();
-  return now > (expiration_time - GoogleOAuthAccessTokenExpirationSlack());
+  return now > (temporary_token.expiration_time -
+                GoogleOAuthAccessTokenExpirationSlack());
 }
 
-bool RefreshingCredentialsWrapper::IsValid() {
-  return !authorization_header.empty() && !IsExpired();
+bool RefreshingCredentialsWrapper::IsValid() const {
+  return !temporary_token.token.empty() && !IsExpired();
 }
 
 }  // namespace oauth2


### PR DESCRIPTION
I needed to implement ComputeEngineCredentials::AccountEmail, a virtual
function to determine the service account associated with a Credentials
object, if any.

In the process I started a small exercise in yak shaving. There is some
(rather trivial actually) code refactored from 3 oauth2::*Credentials
classes into oauth2::RefreshingCredentialsWrapper. There was a lot of
coupling in this code, and the const-correctness had (and probably still
does have) much to be desired.

I actually stopped myself before doing far more cleanup, because what I
need for the SignBlob support is fixed, and the code is better, if not
quite as good as it could be *yet*.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2448)
<!-- Reviewable:end -->
