### PR TITLE
Use SignBlob API if needed.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2593,8 +2593,8 @@ class Client {
    * which is a POST request to GCS.
    *
    * @param document the policy document.
-   * @param options a list of optional parameters, this include:
-   *      `SigningAccount`, and `SigningAccountDeletegates`.
+   * @param options a list of optional parameters, this includes:
+   *      `SigningAccount`, and `SigningAccountDelegates`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create signed policy document

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2471,6 +2471,7 @@ class Client {
    *     requests that only affect a bucket.
    * @param options a list of optional parameters for the signed URL, this
    *     include: `ExpirationTime`, `MD5HashValue`, `ContentType`,
+   *     `SigningAccount`, `SigningAccountDeletegates`,
    *     `AddExtensionHeaderOption`, `AddQueryParameterOption`, and
    *     `AddSubResourceOption`. Note that only the last `AddSubResourceOption`
    *     option has any effect.
@@ -2533,9 +2534,10 @@ class Client {
    *     requests that only affect a bucket.
    * @param options a list of optional parameters for the signed URL, this
    *     include: `SignedUrlTimestamp`, `SignedUrlDuration`, `MD5HashValue`,
-   *     `ContentType`, `AddExtensionHeaderOption`, `AddQueryParameterOption`,
-   *     and `AddSubResourceOption`. Note that only the last
-   *     `AddSubResourceOption` option has any effect.
+   *     `ContentType`, `SigningAccount`, `SigningAccountDeletegates`,
+   *     `AddExtensionHeaderOption`, `AddQueryParameterOption`, and
+   *     `AddSubResourceOption`. Note that only the last `AddSubResourceOption`
+   *     option has any effect.
    *
    * @par Helper Functions
    *
@@ -2591,12 +2593,8 @@ class Client {
    * which is a POST request to GCS.
    *
    * @param document the policy document.
-   *
-   * @par Helper Functions
-   *
-   * The following functions create a `PolicyDocumentCondition` with less
-   * opportunities for typos: `StartsWith()`, `ExactMatchObject()`,
-   * `ExactMatch()`, `ContentLengthRange()`.
+   * @param options a list of optional parameters, this include:
+   *      `SigningAccount`, and `SigningAccountDeletegates`.
    *
    * @par Example
    * @snippet storage_bucket_samples.cc create signed policy document
@@ -2608,9 +2606,11 @@ class Client {
    * @see https://cloud.google.com/storage/docs/xml-api/overview for a detailed
    *     description of the XML API.
    */
+  template <typename... Options>
   StatusOr<PolicyDocumentResult> CreateSignedPolicyDocument(
-      PolicyDocument document) {
-    internal::PolicyDocumentRequest request(document);
+      PolicyDocument document, Options&&... options) {
+    internal::PolicyDocumentRequest request(std::move(document));
+    request.set_multiple_options(std::forward<Options>(options)...);
     return SignPolicyDocument(request);
   }
 

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include "google/cloud/testing_util/init_google_mock.h"
+
 #include <gmock/gmock.h>
 
 namespace google {
@@ -60,7 +61,8 @@ class CreateSignedPolicyDocTest : public ::testing::Test {
     mock = std::make_shared<testing::MockClient>();
     EXPECT_CALL(*mock, client_options())
         .WillRepeatedly(ReturnRef(client_options));
-    client.reset(new Client{std::shared_ptr<internal::RawClient>(mock)});
+    client.reset(
+        new Client{std::static_pointer_cast<internal::RawClient>(mock)});
   }
   void TearDown() override {
     client.reset();

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -17,6 +17,8 @@
 #include "google/cloud/storage/internal/format_time_point.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/storage/testing/retry_tests.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include "google/cloud/testing_util/init_google_mock.h"
@@ -28,7 +30,13 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::canonical_errors::PermanentError;
+using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::testing::_;
 using ::testing::HasSubstr;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
 
 constexpr char kJsonKeyfileContents[] = R"""({
       "type": "service_account",
@@ -42,6 +50,28 @@ constexpr char kJsonKeyfileContents[] = R"""({
       "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/foo-email%40foo-project.iam.gserviceaccount.com"
 })""";
+
+/**
+ * Test the CreateV*SignUrl functions in storage::Client.
+ */
+class CreateSignedPolicyDocTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    mock = std::make_shared<testing::MockClient>();
+    EXPECT_CALL(*mock, client_options())
+        .WillRepeatedly(ReturnRef(client_options));
+    client.reset(new Client{std::shared_ptr<internal::RawClient>(mock)});
+  }
+  void TearDown() override {
+    client.reset();
+    mock.reset();
+  }
+
+  std::shared_ptr<testing::MockClient> mock;
+  std::unique_ptr<Client> client;
+  ClientOptions client_options =
+      ClientOptions(oauth2::CreateAnonymousCredentials());
+};
 
 PolicyDocument CreatePolicyDocumentForTest() {
   PolicyDocument result;
@@ -59,7 +89,7 @@ PolicyDocument CreatePolicyDocumentForTest() {
   return result;
 }
 
-TEST(SignedPolicyDocumentIntegrationTest, Sign) {
+TEST_F(CreateSignedPolicyDocTest, Sign) {
   auto creds = oauth2::CreateServiceAccountCredentialsFromJsonContents(
       kJsonKeyfileContents);
   ASSERT_STATUS_OK(creds);
@@ -91,13 +121,50 @@ TEST(SignedPolicyDocumentIntegrationTest, Sign) {
       actual->signature);
 }
 
-TEST(SignedUrlIntegrationTest, SignFailure) {
-  Client client(google::cloud::storage::oauth2::CreateAnonymousCredentials());
+/// @test Verify that CreateSignedPolicyDocument() uses the SignBlob API when
+/// needed.
+TEST_F(CreateSignedPolicyDocTest, SignRemote) {
+  // Use `echo -n test-signed-blob | openssl base64 -e` to create the magic
+  // string.
+  std::string expected_signed_blob = "dGVzdC1zaWduZWQtYmxvYg==";
+
+  EXPECT_CALL(*mock, SignBlob(_))
+      .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
+      .WillOnce(
+          Invoke([&expected_signed_blob](internal::SignBlobRequest const& r) {
+            return make_status_or(internal::SignBlobResponse{
+                "test-key-id", expected_signed_blob});
+          }));
+  Client client{std::shared_ptr<internal::RawClient>(mock)};
 
   auto actual =
       client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest());
-  EXPECT_FALSE(actual.ok()) << "value=" << actual.value();
-  EXPECT_EQ(StatusCode::kUnimplemented, actual.status().code());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_THAT(actual->signature, expected_signed_blob);
+}
+
+/// @test Verify that CreateSignedPolicyDocument() + SignBlob() respects retry
+/// policies.
+TEST_F(CreateSignedPolicyDocTest, V2SignTooManyFailures) {
+  testing::TooManyFailuresStatusTest<internal::SignBlobResponse>(
+      mock, EXPECT_CALL(*mock, SignBlob(_)),
+      [](Client& client) {
+        return client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest())
+            .status();
+      },
+      "SignBlob");
+}
+
+/// @test Verify that CreateSignedPolicyDocument() + SignBlob() respects retry
+/// policies.
+TEST_F(CreateSignedPolicyDocTest, V2SignPermanentFailure) {
+  testing::PermanentFailureStatusTest<internal::SignBlobResponse>(
+      *client, EXPECT_CALL(*mock, SignBlob(_)),
+      [](Client& client) {
+        return client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest())
+            .status();
+      },
+      "SignBlob");
 }
 
 }  // namespace

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -135,7 +135,7 @@ TEST_F(CreateSignedPolicyDocTest, SignRemote) {
             return make_status_or(internal::SignBlobResponse{
                 "test-key-id", expected_signed_blob});
           }));
-  Client client{std::shared_ptr<internal::RawClient>(mock)};
+  Client client{std::static_pointer_cast<internal::RawClient>(mock)};
 
   auto actual =
       client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest());


### PR DESCRIPTION
When the local Credentials cannot sign a blob, either because the
credentials type does not support this, or because the credentials do
not match the signing service account we need to fallback on the
SignBlob API.

This fixes #1595 (though there is some cleanup that I want to do after this).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2449)
<!-- Reviewable:end -->
