### PR TITLE
Refactor V4 signed URL conformance test.

### DIFF
--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 set(storage_client_integration_tests
     bucket_integration_test.cc
-    client_sign_url_integration_test.cc
     curl_download_request_integration_test.cc
     curl_request_integration_test.cc
     curl_resumable_streambuf_integration_test.cc
@@ -30,6 +29,7 @@ set(storage_client_integration_tests
     object_resumable_write_integration_test.cc
     object_rewrite_integration_test.cc
     service_account_integration_test.cc
+    signed_url_conformance_test.cc
     storage_include_test.cc
     thread_integration_test.cc)
 

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -30,6 +30,12 @@ set -eu
 #   create Cloud Pub/Sub notifications, but no notifications are actually sent
 #   to it.
 
+if [ -z "${PROJECT_ROOT+x}" ]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname $0)/../../../.."; pwd)"
+fi
+readonly TEST_ACCOUNT_FILE="${PROJECT_ROOT}/google/cloud/storage/tests/UrlSignerV4TestAccount.json"
+readonly TEST_DATA_FILE="${PROJECT_ROOT}/google/cloud/storage/tests/UrlSignerV4TestData.json"
+
 echo
 echo "Running storage::internal::CurlResumableUploadSession integration tests."
 ./curl_resumable_upload_session_integration_test "${BUCKET_NAME}"

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -75,5 +75,5 @@ echo "Running GCS Projects.serviceAccount integration tests."
 ./thread_integration_test "${PROJECT_ID}" "${STORAGE_REGION_ID}"
 
 echo
-echo "Running GCS Projects.serviceAccount integration tests."
-./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
+echo "Running V4 Signed URL conformance tests."
+./signed_url_conformance_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -95,8 +95,8 @@ echo "Running GCS Projects.serviceAccount integration tests."
 ./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
 
 echo
-echo "Running storage::internal::ClientSignUrl integration test."
-./client_sign_url_integration_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"
+echo "Running V4 Signed URL conformance tests."
+./signed_url_conformance_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"
 
 # The tests were successful, so disable dumping of test bench log during
 # shutdown.

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -18,7 +18,6 @@
 
 storage_client_integration_tests = [
     "bucket_integration_test.cc",
-    "client_sign_url_integration_test.cc",
     "curl_download_request_integration_test.cc",
     "curl_request_integration_test.cc",
     "curl_resumable_streambuf_integration_test.cc",
@@ -32,6 +31,7 @@ storage_client_integration_tests = [
     "object_resumable_write_integration_test.cc",
     "object_rewrite_integration_test.cc",
     "service_account_integration_test.cc",
+    "signed_url_conformance_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
 ]


### PR DESCRIPTION
Move the test to a new file, with a more descriptive name, and fixed a
few nits in the test. I am making room for an actual integration test
for signed URLs and mixing both kinds of tests in one file was getting
confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2452)
<!-- Reviewable:end -->
