### PR TITLE
Use CMAKE_BINARY_DIR to make google-cloud-cpp work as a submodule.

### DIFF
--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -78,14 +78,14 @@ function (set_library_properties_for_external_project _target _lib)
         "z")
 
     if (${_lib} IN_LIST _libs_always_install_in_libdir)
-        set(_libpath "${PROJECT_BINARY_DIR}/external/lib/${_libfullname}")
+        set(_libpath "${CMAKE_BINARY_DIR}/external/lib/${_libfullname}")
     else()
         set(
             _libpath
-            "${PROJECT_BINARY_DIR}/external/${CMAKE_INSTALL_LIBDIR}/${_libfullname}"
+            "${CMAKE_BINARY_DIR}/external/${CMAKE_INSTALL_LIBDIR}/${_libfullname}"
             )
     endif ()
-    set(_includepath "${PROJECT_BINARY_DIR}/external/include")
+    set(_includepath "${CMAKE_BINARY_DIR}/external/include")
     message(STATUS "Configuring ${_target} with ${_libpath}")
     set_property(TARGET ${_target}
                  APPEND
@@ -104,7 +104,7 @@ function (set_executable_name_for_external_project _target _exe)
         TARGET ${_target}
         PROPERTY
             IMPORTED_LOCATION
-            "${PROJECT_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}"
+            "${CMAKE_BINARY_DIR}/external/bin/${_exe}${CMAKE_EXECUTABLE_SUFFIX}"
         )
 endfunction ()
 

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -53,8 +53,8 @@ if (NOT TARGET gprc_project)
         grpc_project
         DEPENDS c_ares_project protobuf_project ssl_project
         EXCLUDE_FROM_ALL ON
-        PREFIX "external/grpc"
-        INSTALL_DIR "external"
+        PREFIX "${CMAKE_BINARY_DIR}/external/grpc"
+        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
         URL ${GOOGLE_CLOUD_CPP_GRPC_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
         LIST_SEPARATOR |
@@ -131,5 +131,5 @@ if (NOT TARGET gprc_project)
     set_executable_name_for_external_project(gRPC::grpc_cpp_plugin
                                              grpc_cpp_plugin)
 
-    list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_BINARY_DIR}/external/include")
+    list(APPEND PROTOBUF_IMPORT_DIRS "${CMAKE_BINARY_DIR}/external/include")
 endif ()


### PR DESCRIPTION
Ref: #2395

This has two fixes:
- The `prefix` and `install_dir` for `grpc` was missing `${CMAKE_BINARY_DIR}`
- I change `PROJECT_BINARY_DIR` to `CMAKE_BINARY_DIR` to ensure that the files are built/installed and found in the right places when `google-cloud-cpp` is being used as a submodule

In a future PR, I will add an automated test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2455)
<!-- Reviewable:end -->
