### PR TITLE
New integration tests for SignUrl.

### DIFF
--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -910,45 +910,6 @@ run_all_signed_url_v2_examples() {
       "${bucket_name}" "${object_name}"
   run_example ./storage_object_samples create-get-signed-url-v2 \
       "${bucket_name}" "${object_name}"
-
-  local magic_string="${RANDOM}-some-data-to-serve-as-object-media"
-
-  set +e
-  echo    "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  local put_url
-  put_url=$(./storage_object_samples create-put-signed-url-v2 \
-      "${bucket_name}" "${object_name}" | head -1 | \
-      sed "s/The signed url is: //")
-  curl --silent -X PUT -H 'Content-Type: application/octet-stream' \
-      "${put_url}" -d "${magic_string}"
-  if [[ $? = 0 ]]; then
-    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  else
-    echo   "${COLOR_RED}[   FAILED ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  fi
-  set -e
-
-  set +e
-  echo    "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
-        " using GET signed URL"
-  local get_url
-  get_url=$(./storage_object_samples create-get-signed-url-v2 \
-      "${bucket_name}" "${object_name}" | head -1 | \
-      sed "s/The signed url is: //")
-  if curl --silent "${get_url}" | grep -q "${magic_string}"; then
-    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  else
-    echo   "${COLOR_RED}[   FAILED ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  fi
-  set -e
-
-  run_example ./storage_object_samples delete-object \
-      "${bucket_name}" "${object_name}"
 }
 
 ################################################
@@ -976,45 +937,6 @@ run_all_signed_url_v4_examples() {
   run_example ./storage_object_samples create-put-signed-url-v4 \
       "${bucket_name}" "${object_name}"
   run_example ./storage_object_samples create-get-signed-url-v4 \
-      "${bucket_name}" "${object_name}"
-
-  local magic_string="${RANDOM}-some-data-to-serve-as-object-media"
-
-  set +e
-  echo    "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  local put_url
-  put_url=$(./storage_object_samples create-put-signed-url-v4 \
-      "${bucket_name}" "${object_name}" | head -1 | \
-      sed "s/The signed url is: //")
-  curl --silent -X PUT -H 'Content-Type: application/octet-stream' \
-      "${put_url}" -d "${magic_string}"
-  if [[ $? = 0 ]]; then
-    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  else
-    echo   "${COLOR_RED}[   FAILED ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  fi
-  set -e
-
-  set +e
-  echo    "${COLOR_GREEN}[ RUN      ]${COLOR_RESET}" \
-        " using GET signed URL"
-  local get_url
-  get_url=$(./storage_object_samples create-get-signed-url-v4 \
-      "${bucket_name}" "${object_name}" | head -1 | \
-      sed "s/The signed url is: //")
-  if curl --silent "${get_url}" | grep -q "${magic_string}"; then
-    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  else
-    echo   "${COLOR_RED}[   FAILED ]${COLOR_RESET}" \
-        " using PUT signed URL"
-  fi
-  set -e
-
-  run_example ./storage_object_samples delete-object \
       "${bucket_name}" "${object_name}"
 }
 

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(storage_client_integration_tests
     object_rewrite_integration_test.cc
     service_account_integration_test.cc
     signed_url_conformance_test.cc
+    signed_url_integration_test.cc
     storage_include_test.cc
     thread_integration_test.cc)
 

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -81,5 +81,12 @@ echo "Running GCS Projects.serviceAccount integration tests."
 ./thread_integration_test "${PROJECT_ID}" "${STORAGE_REGION_ID}"
 
 echo
+echo "Running GCS Projects.serviceAccount integration tests."
+./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
+
+echo
 echo "Running V4 Signed URL conformance tests."
 ./signed_url_conformance_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"
+
+echo "Running Signed URL integration test."
+./signed_url_integration_test "${BUCKET_NAME}" "${SERVICE_ACCOUNT}"

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -23,8 +23,12 @@ set -eu
 #   tests should have read/write access to this bucket.
 # - STORAGE_REGION_ID: the name of of Google Cloud Storage region, ideally close
 #   to the VMs running the integration tests.
-# - SERVICE_ACCOUNT: a valid service account in ${PROJECT_ID}. It is used to
-#   test HMAC keys. New keys will be created in this account.
+# - HMAC_SERVICE_ACCOUNT: a valid service account in ${PROJECT_ID}. It is used
+#   to test HMAC keys. New keys will be created in this account.
+# - SIGNING_SERVICE_ACCOUNT: a valid service account in ${PROJECT_ID}. It is
+#   used to sign URLs and policy documents. The account must have enough
+#   privileges to sign blobs (roles/iam.serviceAccountTokenCreator) and enough
+#   privileges to create and access objects in ${BUCKET_NAME}.
 # - TOPIC_NAME: a valid Cloud Pub/Sub topic name, configured to accept
 #   publications from the GCS service account in ${PROJECT_ID}. It is used to
 #   create Cloud Pub/Sub notifications, but no notifications are actually sent
@@ -42,7 +46,7 @@ echo "Running storage::internal::CurlResumableUploadSession integration tests."
 
 echo
 echo "Running CurlClient::SignBlob integration tests."
-./curl_sign_blob_integration_test "${SERVICE_ACCOUNT}"
+./curl_sign_blob_integration_test "${SIGNING_SERVICE_ACCOUNT}"
 
 echo
 echo "Running GCS Bucket APIs integration tests."
@@ -82,11 +86,11 @@ echo "Running GCS Projects.serviceAccount integration tests."
 
 echo
 echo "Running GCS Projects.serviceAccount integration tests."
-./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
+./service_account_integration_test "${PROJECT_ID}" "${HMAC_SERVICE_ACCOUNT}"
 
 echo
 echo "Running V4 Signed URL conformance tests."
 ./signed_url_conformance_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"
 
 echo "Running Signed URL integration test."
-./signed_url_integration_test "${BUCKET_NAME}" "${SERVICE_ACCOUNT}"
+./signed_url_integration_test "${BUCKET_NAME}" "${SIGNING_SERVICE_ACCOUNT}"

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -98,6 +98,9 @@ echo
 echo "Running V4 Signed URL conformance tests."
 ./signed_url_conformance_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"
 
+echo "Running Signed URL integration test."
+./signed_url_integration_test "${BUCKET_NAME}" "${SERVICE_ACCOUNT}"
+
 # The tests were successful, so disable dumping of test bench log during
 # shutdown.
 TESTBENCH_DUMP_LOG=no

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -28,7 +28,8 @@ export PROJECT_ID="fake-project-${RANDOM}-${RANDOM}"
 export BUCKET_NAME="fake-bucket-${RANDOM}-${RANDOM}"
 export TOPIC_NAME="projects/${PROJECT_ID}/topics/fake-topic-${RANDOM}-${RANDOM}"
 export LOCATION="fake-region1"
-readonly SERVICE_ACCOUNT="fake-service-account@example.com"
+readonly HMAC_SERVICE_ACCOUNT="fake-service-account@example.com"
+readonly SIGNING_SERVICE_ACCOUNT="fake-service-account@example.com"
 
 
 readonly TEST_ACCOUNT_FILE="${PROJECT_ROOT}/google/cloud/storage/tests/UrlSignerV4TestAccount.json"
@@ -52,7 +53,7 @@ echo "Running storage::internal::CurlResumableUploadSession integration tests."
 
 echo
 echo "Running CurlClient::SignBlob integration tests."
-./curl_sign_blob_integration_test "${SERVICE_ACCOUNT}"
+./curl_sign_blob_integration_test "${SIGNING_SERVICE_ACCOUNT}"
 
 echo
 echo "Running GCS Bucket APIs integration tests."
@@ -92,14 +93,14 @@ echo "Running GCS multi-threaded integration test."
 
 echo
 echo "Running GCS Projects.serviceAccount integration tests."
-./service_account_integration_test "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
+./service_account_integration_test "${PROJECT_ID}" "${HMAC_SERVICE_ACCOUNT}"
 
 echo
 echo "Running V4 Signed URL conformance tests."
 ./signed_url_conformance_test "${TEST_ACCOUNT_FILE}" "${TEST_DATA_FILE}"
 
 echo "Running Signed URL integration test."
-./signed_url_integration_test "${BUCKET_NAME}" "${SERVICE_ACCOUNT}"
+./signed_url_integration_test "${BUCKET_NAME}" "${SIGNING_SERVICE_ACCOUNT}"
 
 # The tests were successful, so disable dumping of test bench log during
 # shutdown.

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -1,0 +1,211 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/list_objects_reader.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <fstream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+using ::testing::HasSubstr;
+
+// Initialized in main() below.
+char const* flag_bucket_name;
+char const* flag_service_account;
+
+class SignedUrlIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
+  if (UsingTestbench()) {
+    // The testbench does not implement signed URLs.
+    return;
+  }
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  std::string service_account = flag_service_account;
+
+  auto object_name = MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  auto meta = client->InsertObject(bucket_name, object_name, expected,
+                                   IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+
+  StatusOr<std::string> signed_url = client->CreateV2SignedUrl(
+      "GET", bucket_name, object_name, SigningAccount(service_account));
+  ASSERT_STATUS_OK(signed_url);
+
+  // Verify the signed URL can be used to download the object.
+  internal::CurlRequestBuilder builder(
+      *signed_url, storage::internal::GetDefaultCurlHandleFactory());
+
+  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+
+  EXPECT_EQ(expected, response->payload);
+
+  auto deleted = client->DeleteObject(bucket_name, object_name);
+  ASSERT_STATUS_OK(deleted);
+}
+
+TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
+  if (UsingTestbench()) {
+    // The testbench does not implement signed URLs.
+    return;
+  }
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  std::string service_account = flag_service_account;
+
+  auto object_name = MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  StatusOr<std::string> signed_url = client->CreateV2SignedUrl(
+      "PUT", bucket_name, object_name, SigningAccount(service_account),
+      ContentType("application/octet-stream"));
+  ASSERT_STATUS_OK(signed_url);
+
+  // Verify the signed URL can be used to download the object.
+  internal::CurlRequestBuilder builder(
+      *signed_url, storage::internal::GetDefaultCurlHandleFactory());
+  builder.SetMethod("PUT");
+  builder.AddHeader("content-type: application/octet-stream");
+
+  auto response = builder.BuildRequest().MakeRequest(expected);
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+
+  auto stream = client->ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  auto deleted = client->DeleteObject(bucket_name, object_name);
+  ASSERT_STATUS_OK(deleted);
+}
+
+TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
+  if (UsingTestbench()) {
+    // The testbench does not implement signed URLs.
+    return;
+  }
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  std::string service_account = flag_service_account;
+
+  auto object_name = MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  auto meta = client->InsertObject(bucket_name, object_name, expected,
+                                   IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+
+  StatusOr<std::string> signed_url = client->CreateV4SignedUrl(
+      "GET", bucket_name, object_name, SigningAccount(service_account));
+  ASSERT_STATUS_OK(signed_url);
+
+  // Verify the signed URL can be used to download the object.
+  internal::CurlRequestBuilder builder(
+      *signed_url, storage::internal::GetDefaultCurlHandleFactory());
+
+  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+
+  EXPECT_EQ(expected, response->payload);
+
+  auto deleted = client->DeleteObject(bucket_name, object_name);
+  ASSERT_STATUS_OK(deleted);
+}
+
+TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
+  if (UsingTestbench()) {
+    // The testbench does not implement signed URLs.
+    return;
+  }
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  std::string service_account = flag_service_account;
+
+  auto object_name = MakeRandomObjectName();
+
+  std::string expected = LoremIpsum();
+
+  StatusOr<std::string> signed_url = client->CreateV4SignedUrl(
+      "PUT", bucket_name, object_name, SigningAccount(service_account));
+  ASSERT_STATUS_OK(signed_url);
+
+  // Verify the signed URL can be used to download the object.
+  internal::CurlRequestBuilder builder(
+      *signed_url, storage::internal::GetDefaultCurlHandleFactory());
+  builder.SetMethod("PUT");
+
+  auto response = builder.BuildRequest().MakeRequest(expected);
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+
+  auto stream = client->ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  auto deleted = client->DeleteObject(bucket_name, object_name);
+  ASSERT_STATUS_OK(deleted);
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 3) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <bucket-name> <service-account-name>\n";
+    return 1;
+  }
+
+  google::cloud::storage::flag_bucket_name = argv[1];
+  google::cloud::storage::flag_service_account = argv[2];
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -32,6 +32,7 @@ storage_client_integration_tests = [
     "object_rewrite_integration_test.cc",
     "service_account_integration_test.cc",
     "signed_url_conformance_test.cc",
+    "signed_url_integration_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
 ]


### PR DESCRIPTION
Wrote the integration tests for Create*SignedUrl() as C++ integration
tests, using the internal CurlRequest class to verify the generated URL
is usable. That let me simplify the driver script for the examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2456)
<!-- Reviewable:end -->
