### PR TITLE
Avoid std::make_exception_ptr() in future_shared_state_base::abandon()

### DIFF
--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -171,9 +171,13 @@ class future_shared_state_base {
     if (is_ready_unlocked()) {
       return;
     }
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     set_exception(std::make_exception_ptr(
                       std::future_error(std::future_errc::broken_promise)),
                   lk);
+#else
+    set_exception(nullptr, lk);
+#endif
     cv_.notify_all();
   }
 


### PR DESCRIPTION
Some implementations of std::make_exception_ptr() use throw/catch, so
we should avoid it under !GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS.  This is
fine becase we never use future_shared_state_base::exception_ in that
case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2460)
<!-- Reviewable:end -->
