### PR TITLE
Use SFINAE to constrain applicability of the BulkMutation(M&&...) ctor

### DIFF
--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -416,13 +416,10 @@ class BulkMutation {
   }
 
   /// Create a muti-row mutation from a variadic list.
-  template <typename... M>
+  template <typename... M,
+            typename = typename std::enable_if<internal::conjunction<
+                std::is_convertible<M, SingleRowMutation>...>::value>::type>
   BulkMutation(M&&... m) : BulkMutation() {
-    static_assert(
-        internal::conjunction<
-            std::is_convertible<M, SingleRowMutation>...>::value,
-        "The arguments passed to BulkMutation(...) must be convertible"
-        " to SingleRowMutation");
     emplace_many(std::forward<M>(m)...);
   }
 


### PR DESCRIPTION
The unrestricted BulkMutation perfect-forwarding constructor was a
better match than the (generated) copy constructor for a non-const
lvalue, so its embedded static_assert requiring convertibility to a
SingleRowMutation meant that non-const BulkMutation lvalues could
not be copied (so they could not be used as pass-by-value function
arguments, for example).

So, make the "convertibility to a SingleRowMutation" requirement a
SFINAE constraint instead, meaning the perfect-forwarding constructor
will be disabled when it does not apply, and that allows the copy
constructor to be found instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2461)
<!-- Reviewable:end -->
