### PR TITLE
Use the unparsed args in export_variables_to_bazel

### DIFF
--- a/cmake/CreateBazelConfig.cmake
+++ b/cmake/CreateBazelConfig.cmake
@@ -129,7 +129,7 @@ function (export_variables_to_bazel filename)
 """Automatically generated version numbers - DO NOT EDIT."""
 
 ]=])
-    foreach (item ${ARGN})
+    foreach (item ${_EXPORT_VARIABLES_TO_BAZEL_OPT_UNPARSED_ARGUMENTS})
         file(APPEND "${filename}" "${item} = \"${${item}}\"\n")
     endforeach ()
 endfunction ()


### PR DESCRIPTION
This allows properly passing arguments (i.e. YEAR) without them ending
up in the bazel file as (likely empty) variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2467)
<!-- Reviewable:end -->
