### PR TITLE
Enable ShellCheck in check-style.sh

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -84,5 +84,21 @@ find . \( -path ./.git \
         \) -print0 \
      | xargs -0 buildifier -mode=fix
 
+# Apply shellcheck(1) to emit warnings for common scripting mistakes.
+find . \( -path ./.git \
+        -o -path ./third_party \
+        -o -path './cmake-build-*' \
+        -o -path ./build-output \
+        -o -path ./.build \
+        -o -path ./_build \
+        -o -path ./cmake-out \
+    \) -prune \
+    -o -iname '*.sh' -exec shellcheck \
+        --exclude=SC1090 \
+        --exclude=SC2034 \
+        --exclude=SC2153 \
+        --exclude=SC2181 \
+    '{}' \;
+
 # Report any differences created by running clang-format.
 git diff --ignore-submodules=all --color --exit-code .

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -39,6 +39,7 @@ RUN apt update && \
         make \
         pkg-config \
         python-pip \
+        shellcheck \
         tar \
         wget \
         zlib1g-dev

--- a/ci/travis/Dockerfile.ubuntu-install
+++ b/ci/travis/Dockerfile.ubuntu-install
@@ -39,6 +39,7 @@ RUN apt update && \
         make \
         pkg-config \
         python-pip \
+        shellcheck \
         tar \
         wget \
         zlib1g-dev


### PR DESCRIPTION
Part 1 of #2463

The warnings I excluded are either false positives or results in less readability if fixed. ShellCheck does not have an autofix feature (yet) so the build will not fail if warnings are present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2472)
<!-- Reviewable:end -->
