### PR TITLE
Adds spanner_tool for easy experimenting

### DIFF
--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -207,7 +207,7 @@ cc_grpc_library(
     srcs = ["google/spanner/v1/mutation.proto"],
     deps = [
         ":google_api_annotations",
-        ":google_spanner_v1_keys"
+        ":google_spanner_v1_keys",
     ],
     proto_only = False,
     well_known_protos = True,

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -183,3 +183,145 @@ cc_library(
     ],
     includes = ["."],
 )
+
+######################
+# BEGIN SPANNER PROTOS
+######################
+
+# WARNING:
+# These Spanner protos exist for prototyping only. Users should not rely on
+# these protos and bazel build targets existing in the future. We will
+# remove/rename these without notice.
+
+cc_grpc_library(
+    name = "google_spanner_v1_keys",
+    srcs = ["google/spanner/v1/keys.proto"],
+    deps = [":google_api_annotations"],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_grpc_library(
+    name = "google_spanner_v1_mutation",
+    srcs = ["google/spanner/v1/mutation.proto"],
+    deps = [
+        ":google_api_annotations",
+        ":google_spanner_v1_keys"
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_grpc_library(
+    name = "google_spanner_v1_query_plan",
+    srcs = ["google/spanner/v1/query_plan.proto"],
+    deps = [
+        ":google_api_annotations",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_grpc_library(
+    name = "google_spanner_v1_type",
+    srcs = ["google/spanner/v1/type.proto"],
+    deps = [
+        ":google_api_annotations",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_grpc_library(
+    name = "google_spanner_v1_transaction",
+    srcs = ["google/spanner/v1/transaction.proto"],
+    deps = [
+        ":google_api_annotations",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_grpc_library(
+    name = "google_spanner_v1_result_set",
+    srcs = ["google/spanner/v1/result_set.proto"],
+    deps = [
+        ":google_api_annotations",
+        ":google_spanner_v1_query_plan",
+        ":google_spanner_v1_transaction",
+        ":google_spanner_v1_type",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_grpc_library(
+    name = "google_spanner_v1_spanner",
+    srcs = ["google/spanner/v1/spanner.proto"],
+    deps = [
+        ":google_api_annotations",
+        ":google_spanner_v1_keys",
+        ":google_spanner_v1_mutation",
+        ":google_spanner_v1_result_set",
+        ":google_spanner_v1_transaction",
+        ":google_spanner_v1_type",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+# Instance Admin
+cc_grpc_library(
+    name = "google_spanner_admin_instance_v1_spanner_instance_admin",
+    srcs = ["google/spanner/admin/instance/v1/spanner_instance_admin.proto"],
+    deps = [
+        ":google_api_annotations",
+        ":google_longrunning_operations",
+        ":google_iam_v1_iam_policy",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+# Database Admin
+cc_grpc_library(
+    name = "google_spanner_admin_database_v1_spanner_database_admin",
+    srcs = ["google/spanner/admin/database/v1/spanner_database_admin.proto"],
+    deps = [
+        ":google_api_annotations",
+        ":google_longrunning_operations",
+        ":google_iam_v1_iam_policy",
+    ],
+    proto_only = False,
+    well_known_protos = True,
+    use_external = True,
+)
+
+cc_library(
+    name = "spanner_protos",
+    deps = [
+        ":google_spanner_v1_keys",
+        ":google_spanner_v1_mutation",
+        ":google_spanner_v1_query_plan",
+        ":google_spanner_v1_result_set",
+        ":google_spanner_v1_spanner",
+        ":google_spanner_v1_transaction",
+        ":google_spanner_v1_type",
+        ":google_spanner_admin_instance_v1_spanner_instance_admin",
+        ":google_spanner_admin_database_v1_spanner_database_admin",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+    includes = ["."],
+)
+
+####################
+# END SPANNER PROTOS
+####################

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -61,3 +61,12 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_unit_tests]
+
+cc_binary(
+    name = "spanner_tool",
+    srcs = [ "spanner_tool.cc" ],
+    deps = [
+        "//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_googleapis//:spanner_protos",
+    ]
+)

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -46,6 +46,7 @@ cc_library(
     hdrs = spanner_client_hdrs + ["version_info.h"],
     deps = [
         "//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_googleapis//:spanner_protos",
     ],
 )
 
@@ -66,7 +67,6 @@ cc_binary(
     name = "spanner_tool",
     srcs = [ "spanner_tool.cc" ],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_googleapis//:spanner_protos",
+        ":spanner_client",
     ]
 )

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -65,8 +65,8 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
 
 cc_binary(
     name = "spanner_tool",
-    srcs = [ "spanner_tool.cc" ],
+    srcs = ["spanner_tool.cc"],
     deps = [
         ":spanner_client",
-    ]
+    ],
 )

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -50,8 +50,8 @@ void ListDatabases(std::string const& project, std::string const& instance) {
 
 }  // namespace
 
-// This is a command-line tool to let folks easily experiment with Spanner usng
-// C++. This works with bazel using a command like:
+// This is a command-line tool to let folks easily experiment with Spanner
+// using C++. This works with bazel using a command like:
 //
 // $ bazel run google/cloud/spanner:spanner_tool -- jgm-cloud-cxx jgm-spanner-instance
 //

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -1,28 +1,46 @@
+#include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+#include <google/spanner/v1/spanner.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
 #include <iostream>
 #include <memory>
-#include <grpcpp/grpcpp.h>
-#include <google/spanner/v1/spanner.grpc.pb.h>
-#include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+#include <string>
 
-int main() {
+namespace {
+
+void ListDatabases(std::string const& project, std::string const& instance) {
   namespace spanner = google::spanner::admin::database::v1;
-  auto const cred = grpc::GoogleDefaultCredentials();
-  auto const channel = grpc::CreateChannel("spanner.googleapis.com", cred);
+
+  std::shared_ptr<grpc::ChannelCredentials> cred =
+      grpc::GoogleDefaultCredentials();
+  std::shared_ptr<grpc::Channel> channel =
+      grpc::CreateChannel("spanner.googleapis.com", std::move(cred));
   std::unique_ptr<spanner::DatabaseAdmin::Stub> stub(
-      spanner::DatabaseAdmin::NewStub(channel));
+      spanner::DatabaseAdmin::NewStub(std::move(channel)));
 
   spanner::ListDatabasesResponse response;
   spanner::ListDatabasesRequest request;
-  request.set_parent("projects/jgm-cloud-cxx/instances/jgm-spanner-instance");
+  request.set_parent("projects/" + project + "/instances/" + instance);
 
   grpc::ClientContext context;
-  auto status = stub->ListDatabases(&context, request, &response);
+  grpc::Status status = stub->ListDatabases(&context, request, &response);
 
   if (!status.ok()) {
     std::cerr << "FAILED: " << status.error_code() << ": "
               << status.error_message() << "\n";
+    return;
   }
 
   std::cout << "Response:\n";
   std::cout << response.DebugString() << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  if (argc != 3) {
+    std::cerr << "Usage: spanner_tool <project> <instance>\n";
+    return 1;
+  }
+
+  ListDatabases(argv[1], argv[2]);
 }

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <memory>
+#include <grpcpp/grpcpp.h>
+#include <google/spanner/v1/spanner.grpc.pb.h>
+#include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+
+int main() {
+  namespace spanner = google::spanner::admin::database::v1;
+  auto const cred = grpc::GoogleDefaultCredentials();
+  auto const channel = grpc::CreateChannel("spanner.googleapis.com", cred);
+  std::unique_ptr<spanner::DatabaseAdmin::Stub> stub(
+      spanner::DatabaseAdmin::NewStub(channel));
+
+  spanner::ListDatabasesResponse response;
+  spanner::ListDatabasesRequest request;
+  request.set_parent("projects/jgm-cloud-cxx/instances/jgm-spanner-instance");
+
+  grpc::ClientContext context;
+  auto status = stub->ListDatabases(&context, request, &response);
+
+  if (!status.ok()) {
+    std::cerr << "FAILED: " << status.error_code() << ": "
+              << status.error_message() << "\n";
+  }
+
+  std::cout << "Response:\n";
+  std::cout << response.DebugString() << "\n";
+}

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -53,12 +53,14 @@ void ListDatabases(std::string const& project, std::string const& instance) {
 // This is a command-line tool to let folks easily experiment with Spanner
 // using C++. This works with bazel using a command like:
 //
-// $ bazel run google/cloud/spanner:spanner_tool -- jgm-cloud-cxx jgm-spanner-instance
+// $ bazel run google/cloud/spanner:spanner_tool -- \
+//       jgm-cloud-cxx jgm-spanner-instance
 //
 // Currently, the above command will just invoke the "ListDatabases" RPC, which
 // makes it equivalent to the following command:
 //
-// $ gcloud spanner databases list --project jgm-cloud-cxx --instance jgm-spanner-instance 
+// $ gcloud spanner databases list \
+//       --project jgm-cloud-cxx --instance jgm-spanner-instance
 //
 // NOTE: The actual project and instance names will vary for other users; These
 // are just examples.

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <google/spanner/v1/spanner.grpc.pb.h>
 #include <grpcpp/grpcpp.h>
@@ -36,6 +50,18 @@ void ListDatabases(std::string const& project, std::string const& instance) {
 
 }  // namespace
 
+// This is a command-line tool to let folks easily experiment with Spanner usng
+// C++. This works with bazel using a command like:
+//
+// $ bazel run google/cloud/spanner:spanner_tool -- jgm-cloud-cxx jgm-spanner-instance
+//
+// Currently, the above command will just invoke the "ListDatabases" RPC, which
+// makes it equivalent to the following command:
+//
+// $ gcloud spanner databases list --project jgm-cloud-cxx --instance jgm-spanner-instance 
+//
+// NOTE: The actual project and instance names will vary for other users; These
+// are just examples.
 int main(int argc, char* argv[]) {
   if (argc != 3) {
     std::cerr << "Usage: spanner_tool <project> <instance>\n";


### PR DESCRIPTION
This PR adds a `spanner_tool` binary that we can use to easily experiment with the spanner API in C++. It currently only calls spanner's `ListDatabases` RPC, which is kinda like a hello-world program. It can be extended to support others.

It only works with bazel at this point because I don't really know how to make it work with cmake yet :-) But that can be done in a later PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2477)
<!-- Reviewable:end -->
