### PR TITLE
Support P12 key files.

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -95,6 +95,8 @@ echo "================================================================"
 echo "Download dependencies for integration tests $(date)."
 echo "================================================================"
 
+export TEST_KEY_FILE_JSON="${KOKORO_GFILE_DIR}/service-account.json"
+export TEST_KEY_FILE_P12="${KOKORO_GFILE_DIR}/service-account.p12"
 export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
 
 # Download the gRPC `roots.pem` file. Somewhere inside the bowels of Bazel, this

--- a/ci/kokoro/ubuntu/continuous.cfg
+++ b/ci/kokoro/ubuntu/continuous.cfg
@@ -17,6 +17,7 @@ build_file: "google-cloud-cpp/ci/kokoro/ubuntu/build.sh"
 timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 

--- a/ci/kokoro/ubuntu/presubmit.cfg
+++ b/ci/kokoro/ubuntu/presubmit.cfg
@@ -17,6 +17,7 @@ build_file: "google-cloud-cpp/ci/kokoro/ubuntu/build.sh"
 timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 

--- a/google/cloud/storage/doc/setup-test-resources.md
+++ b/google/cloud/storage/doc/setup-test-resources.md
@@ -10,22 +10,39 @@ TODO(#2420) - Complete this section.
 
 ## Create a Service Account to run the integration tests.
 
+First, create a new service account to execute the integration tests:
 
 ```console
 AGENT_ACCOUNT=...
 gcloud --project=${PROJECT_ID} iam service-accounts create ${AGENT_ACCOUNT}
+```
+
+Grant the new service account account full access to Google Cloud Storage:
+
+```
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member serviceAccount:${AGENT_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+  --role roles/storage.admin
+```
+
+Grant the new service account permissions to sign URLs, policy documents, and
+other blobs:
+
+```
 gcloud projects add-iam-policy-binding ${PROJECT_ID} \
   --member serviceAccount:${AGENT_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
   --role roles/iam.serviceAccountTokenCreator
 ```
 
+Download key files for the new service account:
+
 ```console
 gcloud --project=${PROJECT_ID} iam service-accounts keys create \
     /dev/shm/service-account.p12 --key-file-type=p12 \
-    --iam-account=${SERVICE_ACCOUNT}
+    --iam-account=${AGENT_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
 gcloud --project=${PROJECT_ID} iam service-accounts keys create \
     /dev/shm/service-account.json --key-file-type=json \
-    --iam-account=${SERVICE_ACCOUNT}  
+    --iam-account=${AGENT_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com
 ```
 
 ## Setting up a Bucket

--- a/google/cloud/storage/doc/setup-test-resources.md
+++ b/google/cloud/storage/doc/setup-test-resources.md
@@ -13,7 +13,7 @@ TODO(#2420) - Complete this section.
 First, create a new service account to execute the integration tests:
 
 ```console
-AGENT_ACCOUNT=...
+AGENT_ACCOUNT=... # e.g. integration-tests-robot
 gcloud --project=${PROJECT_ID} iam service-accounts create ${AGENT_ACCOUNT}
 ```
 

--- a/google/cloud/storage/doc/setup-test-resources.md
+++ b/google/cloud/storage/doc/setup-test-resources.md
@@ -8,6 +8,26 @@ an existing project in Google Cloud Platform.
 
 TODO(#2420) - Complete this section.
 
+## Create a Service Account to run the integration tests.
+
+
+```console
+AGENT_ACCOUNT=...
+gcloud --project=${PROJECT_ID} iam service-accounts create ${AGENT_ACCOUNT}
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member serviceAccount:${AGENT_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+  --role roles/iam.serviceAccountTokenCreator
+```
+
+```console
+gcloud --project=${PROJECT_ID} iam service-accounts keys create \
+    /dev/shm/service-account.p12 --key-file-type=p12 \
+    --iam-account=${SERVICE_ACCOUNT}
+gcloud --project=${PROJECT_ID} iam service-accounts keys create \
+    /dev/shm/service-account.json --key-file-type=json \
+    --iam-account=${SERVICE_ACCOUNT}  
+```
+
 ## Setting up a Bucket
 
 TODO(#2420) - Complete this section.

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -196,6 +196,28 @@ CreateServiceAccountCredentialsFromJsonFilePath(
 }
 
 StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromP12FilePath(std::string const& path) {
+  return CreateServiceAccountCredentialsFromP12FilePath(path, {}, {});
+}
+
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromP12FilePath(
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
+  auto info = ParseServiceAccountP12File(path);
+  if (!info) {
+    return StatusOr<std::shared_ptr<Credentials>>(info.status());
+  }
+  // These are supplied as extra parameters to this method, not in the P12
+  // file.
+  info->subject = std::move(subject);
+  info->scopes = std::move(scopes);
+  return StatusOr<std::shared_ptr<Credentials>>(
+      std::make_shared<ServiceAccountCredentials<>>(*info));
+}
+
+StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromJsonContents(std::string const& contents) {
   return CreateServiceAccountCredentialsFromJsonContents(contents, {}, {});
 }

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
+
 #include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
@@ -22,6 +23,7 @@
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+
 #include <fstream>
 #include <iterator>
 #include <memory>
@@ -169,6 +171,25 @@ CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents) {
   }
   return StatusOr<std::shared_ptr<Credentials>>(
       std::make_shared<AuthorizedUserCredentials<>>(*info));
+}
+
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromFilePath(std::string const& path) {
+  return CreateServiceAccountCredentialsFromFilePath(path, {}, {});
+}
+
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromFilePath(
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
+  auto credentials =
+      CreateServiceAccountCredentialsFromJsonFilePath(path, scopes, subject);
+  if (credentials) {
+    return credentials;
+  }
+  return CreateServiceAccountCredentialsFromP12FilePath(path, std::move(scopes),
+                                                        std::move(subject));
 }
 
 StatusOr<std::shared_ptr<Credentials>>

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -66,6 +66,52 @@ CreateAuthorizedUserCredentialsFromJsonFilePath(std::string const& path);
 StatusOr<std::shared_ptr<Credentials>>
 CreateAuthorizedUserCredentialsFromJsonContents(std::string const& contents);
 
+//@{
+/// @name Load service account key files.
+
+/**
+ * Creates a ServiceAccountCredentials from a file at the specified path.
+ *
+ * @note This function automatically detects if the file is a JSON or P12 (aka
+ * PFX aka PKCS#12) file and tries to load the file as a service account
+ * credential. We strongly recommend that applications use JSON files for
+ * service account key files.
+ *
+ * These credentials use the cloud-platform OAuth 2.0 scope, defined by
+ * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
+ * overloaded version of this function.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromFilePath(std::string const& path);
+
+/**
+ * Creates a ServiceAccountCredentials from a file at the specified path.
+ *
+ * @note This function automatically detects if the file is a JSON or P12 (aka
+ * PFX aka PKCS#12) file and tries to load the file as a service account
+ * credential. We strongly recommend that applications use JSON files for
+ * service account key files.
+ *
+ * @param path the path to the file containing service account JSON credentials.
+ * @param scopes the scopes to request during the authorization grant. If
+ *     omitted, the cloud-platform scope, defined by
+ *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
+ * @param subject for domain-wide delegation; the email address of the user for
+ *     which to request delegated access. If omitted, no "subject" attribute is
+ *     included in the authorization grant.
+ *
+ * @see https://developers.google.com/identity/protocols/googlescopes for a list
+ *     of OAuth 2.0 scopes used with Google APIs.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromFilePath(
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject);
+
 /**
  * Creates a ServiceAccountCredentials from a JSON file at the specified path.
  *
@@ -131,6 +177,7 @@ CreateServiceAccountCredentialsFromP12FilePath(
     std::string const& path,
     google::cloud::optional<std::set<std::string>> scopes,
     google::cloud::optional<std::string> subject);
+//@}
 
 /**
  * Creates a ServiceAccountCredentials from a JSON string.

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -100,6 +100,39 @@ CreateServiceAccountCredentialsFromJsonFilePath(
     google::cloud::optional<std::string> subject);
 
 /**
+ * Creates a ServiceAccountCredentials from a P12 file at the specified path.
+ *
+ * These credentials use the cloud-platform OAuth 2.0 scope, defined by
+ * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes, use the
+ * overloaded version of this function.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromP12FilePath(std::string const& path);
+
+/**
+ * Creates a ServiceAccountCredentials from a P12 file at the specified path.
+ *
+ * @param path the path to the file containing service account JSON credentials.
+ * @param scopes the scopes to request during the authorization grant. If
+ *     omitted, the cloud-platform scope, defined by
+ *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
+ * @param subject for domain-wide delegation; the email address of the user for
+ *     which to request delegated access. If omitted, no "subject" attribute is
+ *     included in the authorization grant.
+ *
+ * @see https://developers.google.com/identity/protocols/googlescopes for a list
+ *     of OAuth 2.0 scopes used with Google APIs.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromP12FilePath(
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject);
+
+/**
  * Creates a ServiceAccountCredentials from a JSON string.
  *
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -83,6 +83,9 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
 
   PKCS12* p12 = [](std::string const& source) {
     FILE* fp = std::fopen(source.c_str(), "rb");
+    if (fp == nullptr) {
+      return static_cast<PKCS12*>(nullptr);
+    }
     auto result = d2i_PKCS12_fp(fp, nullptr);
     fclose(fp);
     return result;

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -139,8 +139,8 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
   X509_NAME* name = X509_get_subject_name(cert.get());
 
   std::string service_account_id = [&name]() -> std::string {
-    std::unique_ptr<char, decltype(&std::free)> oneline(
-        X509_NAME_oneline(name, nullptr, 0), &std::free);
+    std::unique_ptr<char, decltype(&CRYPTO_free)> oneline(
+        X509_NAME_oneline(name, nullptr, 0), &CRYPTO_free);
     // We expect the name to be simply CN/ followed by a (small) number of
     // digits.
     if (strncmp("/CN=", oneline.get(), 4) != 0) {

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
-
 #include "google/cloud/storage/internal/openssl_util.h"
-
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
-
 #include <fstream>
 
 namespace google {

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -139,8 +139,9 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
   X509_NAME* name = X509_get_subject_name(cert.get());
 
   std::string service_account_id = [&name]() -> std::string {
-    std::unique_ptr<char, decltype(&CRYPTO_free)> oneline(
-        X509_NAME_oneline(name, nullptr, 0), &CRYPTO_free);
+    auto openssl_free = [](void* addr) { OPENSSL_free(addr); };
+    std::unique_ptr<char, decltype(openssl_free)> oneline(
+        X509_NAME_oneline(name, nullptr, 0), openssl_free);
     // We expect the name to be simply CN/ followed by a (small) number of
     // digits.
     if (strncmp("/CN=", oneline.get(), 4) != 0) {

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -52,6 +52,19 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
 
 /**
+ * Parses the contents of a P12 keyfile into a ServiceAccountCredentialsInfo.
+ *
+ * @warning We strongly recommend that applications use JSON keyfiles instead.
+ *
+ * @note Note that P12 keyfiles do not contain the `client_email` for the
+ * service account, the application must obtain this through some other means
+ * and provide them to the function.
+ */
+StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
+    std::string const& source,
+    std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
+
+/**
  * Wrapper class for Google OAuth 2.0 service account credentials.
  *
  * Takes a ServiceAccountCredentialsInfo and obtains access tokens from the

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/internal/random.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
@@ -20,7 +21,9 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
+#include <fstream>
 
 namespace google {
 namespace cloud {
@@ -80,6 +83,17 @@ class ServiceAccountCredentialsTest : public ::testing::Test {
         std::make_shared<MockHttpRequestBuilder::Impl>();
   }
   void TearDown() override { MockHttpRequestBuilder::mock.reset(); }
+
+  std::string CreateRandomFileName() {
+    // When running on the internal Google CI systems we cannot write to the
+    // local directory, GTest has a good temporary directory in that case.
+    return ::testing::TempDir() +
+           google::cloud::internal::Sample(
+               generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
+  }
+
+  google::cloud::internal::DefaultPRNG generator_ =
+      google::cloud::internal::MakeDefaultPRNG();
 };
 
 struct FakeClock : public std::chrono::system_clock {
@@ -420,6 +434,101 @@ TEST_F(ServiceAccountCredentialsTest, ClientId) {
 
   EXPECT_EQ("foo-email@foo-project.iam.gserviceaccount.com",
             credentials.AccountEmail());
+}
+
+// This is a base64-encoded p12 key-file. The service account was deleted
+// after creating the key-file, so the key was effectively invalidated, but
+// the format is correct, so we can use it to verify that p12 key-files can be
+// loaded.
+//
+// If you want to change the file (for whatever reason), these commands are
+// helpful:
+//    Generate a new key:
+//      gcloud iam service-accounts keys create /dev/shm/key.p12
+//          --key-file-type=p12 --iam-account=${SERVICE_ACCOUNT}
+//    Base64 encode the key (then cut&paste) here:
+//      openssl base64 -e < /dev/shm/key.p12
+//    Find the service account ID:
+//      openssl pkcs12 -in /dev/shm/key.p12
+//          -passin pass:notasecret  -nodes -info  | grep =CN
+//    Delete the service account ID:
+//      gcloud iam service-accounts delete --quiet ${SERVICE_ACCOUNT}
+char const kP12ServiceAccountId[] = "104849618361176160538";
+char const kP12KeyFileContents[] =
+    "MIIJqwIBAzCCCWQGCSqGSIb3DQEHAaCCCVUEgglRMIIJTTCCBXEGCSqGSIb3DQEH"
+    "AaCCBWIEggVeMIIFWjCCBVYGCyqGSIb3DQEMCgECoIIE+zCCBPcwKQYKKoZIhvcN"
+    "AQwBAzAbBBRJjl9WyBd6laey90H0EFphldIAhwIDAMNQBIIEyJUgdGTCCqkN2zxz"
+    "/Ta4wAYscwfiVWcaaEBzHKevPtTRQ9JaorKliNBPA4xEhC0fTcgioPQ60yc2ttnH"
+    "euD869RaaYo5PHNKFRidMkssbMsYVuiq0Q2pXaFn6AjG+It6+bFiE2e9o6d8COwb"
+    "COmWz2kbgKNJ3mpSvj+q8MB/r1YyRgz49Qq3hftmf1lMWybwrU08oSh6yMcfaAPh"
+    "wY6pyR+BfSMcuY13pnb6E2APTXaF2GJKoJmabWAhqYTBKvM9RLRs8HxKl6x3oFUk"
+    "57Cg/krA4cYB1mIEuomU0nypHUPJPX28gX6A+BUK0MtPKY3J3Ush5f3O01Qq6Mak"
+    "+i7TUP70JsXuVzBpy8YDVDmv3UA8/Qd11rDHyntvb9hsELkZHxVKoeIhT98/QHjg"
+    "2qhGO6fxoQhiuF7stktUwsWzJK25OMrvzJg3VV9dP8oHjhCxS/+RInbSVjCDS0Ow"
+    "ZOenXi0tkxuLMR6Q2Wy/uH21uD8+IMKjE8umtDNmCxvT4LEE14yRQkdiMlfDvFxp"
+    "c8YcR94VEUveP5Pr/B5LEPZf5XbG9YC1BotX3/Ti4Y0iE4xVZsMzvazB1MMiU4L+"
+    "pEB8CV+PNiGLB1ocbelZ8V5nTB6CZNB5E4kDC3owXkD9lz7GupZZqKkovw2F0jgT"
+    "sXGtO5lqmO/lE17eXbFRIAYSFXXQMbB7XRxZKsVWgk3J2iw3UvmJjmi0v/QD2XT1"
+    "YHQEqlk+qyOhzSN6kByNb7gnjjNqoWRv3rEap9Ivpx7PhfT/+f2b6LCpz4AuSR8y"
+    "e0DGr0O+Oc4jTHsKJi1jDBpgeir8zOevw98aTqmAfVrCHsnhwJ92KNmVDvEDe0By"
+    "8APjmzEUTUzx4XxU8dKTLbgjIpBaLxeGlN3525UPRD6ihLNwboYhcOgNSTKiwNXL"
+    "IoSQXhZt/RicMNw92PiZwKOefnn1fveNvG//B4t43WeXqpzpaTvjfmWhOEe6CouO"
+    "DdpRLqimTEoXGzV27Peo2Cp6FFmv5+qMBJ6FnXA9VF+jQqM58lLeqq+f5eEx9Ip3"
+    "GLpiu2F0BeRkoTOOK8eV769j2OG87SmfAgbs+9tmRifGK9mpPSv1dLXASOFOds9k"
+    "flawEARCxxdiFBv/smJDxDRzyUJPBLxw5zKRko9wJlQIl9/YglPVTAbClHBZhgRs"
+    "gbYoRwmKB9A60w6pCv6QmeMLjKeUgtbiTZkUBrjmQ4VzVFFg1V+ov7cAVCCtsDsI"
+    "9Le/wdUr5M+8WK5035HnTx/BNGOXuvw2jWoU8wSOn4YTbjsv448sZz2kblFcoZVY"
+    "cOp3mWhkizG7pdYcqMtjECqfCk+Qhj7LlaowfG+p8gmv9vqEimoDyaGuZwVXDhSt"
+    "txJlBhjIJomc29qLC5lWjqbRn9OF89xijm/8qyvm5zA/Fp8QHMRsiWftsPdGsR68"
+    "6qsgcXtlxxcQLURjcWbbDpaLi1+fiq/VIYqT+CjVTq9YTUyOTc+3f8MX2hgtC+c7"
+    "9CBSX7ftB4MGSfsZK4L9SW4k/CA/llFeDEmnEwwm0AMCTzLhCJqllXZhlqHZeixE"
+    "6/obqQNDWkC/kH4SdsmGG6S+i/uqf3A2OJFnTBhJzi8GnG4eNxmu8BZb6V/8OPNT"
+    "TWODEs9lfw6ZX/eCSTFIMCMGCSqGSIb3DQEJFDEWHhQAcAByAGkAdgBhAHQAZQBr"
+    "AGUAeTAhBgkqhkiG9w0BCRUxFAQSVGltZSAxNTU1MDc1ODE4NTA4MIID1AYJKoZI"
+    "hvcNAQcGoIIDxTCCA8ECAQAwggO6BgkqhkiG9w0BBwEwKQYKKoZIhvcNAQwBBjAb"
+    "BBQ+K8su6M1OCUUytxAnvcwMqvL6EgIDAMNQgIIDgMrjZUoN1PqivPJWz104ibfT"
+    "B+K6cpL/jzrEgt9gwbMmlJGQ/8unPZQ611zT2rUP2oDcjKsv4Ex3NT5IexZr0CQO"
+    "20eXZaHyobmvTS6uukhg6Ct1UZetghGQnpoiJp28vsZ5t4myRWNm0WKbMYNRMExF"
+    "wbJUVWWfz72DbUZd0jRz2dLtpip6aCfH5YgC4uKjPqjYSGBO/Lwqu0wK0Jtl/GmB"
+    "0RIbtlKmBj1Ut/wxexBIx2Yp3k3s8h1O1bDv9hWdRTFmf8c0oHDvO7kpUauULwUJ"
+    "PZpKzKEZcidifC1uZhmy/y+q1CKX8/ysEROJXqkiMtcCX7rsyC4NPU0cy3jEFN2v"
+    "VrZhgpAXxkn/Y7YSrt/5TVd+s3cGB6wMkGgUw4csw9Wq2Z2LwELSKcKzslvokUEe"
+    "XQoqtCVttcJG8ipEpDg1+/kZ7kokvrLKm0sEOc8Ym77W0Ta4wY/q+revS6xZimyC"
+    "+1MlbbJjAboiQUztfslPKwISD0j+gJnYOu89S8X6et2rLMMJ1gMV2aIfXFvfgIL6"
+    "gGP5/7p7+MMFU44V0niN7HpLMwJyM4HBoN1Pa+LfeJ37uggPv8v51y4e/5EYoRLw"
+    "5SmBv+vxfp1e5xJzbvs9SiBmAds/HGuiqcV4XISgrDSVVllaQUbyDSGLKqwd4xjl"
+    "sPjgaqGgwXiq0uEeIqzw5y+ywG4JFFF4ydN2hY1BAFa0Wrlop3mgwU5nn7D+0Yyc"
+    "cpdDf4KiePWrtRUgpZ6Mwu7yzLJBqVoNkuCAE57wlgQioutuqa/jcXJdYNgSBr2i"
+    "gvxhRjkLZ33/ZP6laGVmsbgF4sTgDXWgY2MMvEiJN8qYCuaIpYElXq1BCX0cY4bs"
+    "Rm9DN3Hr1GGsdTM++cqfIG867PQd7B+nMUSJ+VVh8aY+/eH9i30hbkIKqp5lfZ1l"
+    "0HEWwhYwXwQFftwVz9yZk9O3irM/qeAVVEw6DEfsCH1/OfctQQcZ0mqav34IzS8P"
+    "GA6qVXwQ6P7WjDNtzHTGyqEuxy6WFhXmVtpFmcjPDsNdfW07J1sE5LwaY32uo7tS"
+    "4xl4FU49NCZmKDUQgO/Mg74MhNvHq79UuWqYCNcz0iLxEXeZoZ1wU2oF7h/rkx4F"
+    "h2jszpNr2hhbsCDFGChM09RO5OBeloNdQbWcPX+im1wYU/PNBNzf6sJjzQ61WZ15"
+    "MEBRLRGzwEmh/syMX4jZMD4wITAJBgUrDgMCGgUABBRMwW+6BtBMmK0TpkdKUoLx"
+    "athJxwQUzb2wLrSCVOJ++SqKIlZsWF4mYz8CAwGGoA==";
+
+/// @test Verify that parsing a service account JSON string works.
+TEST_F(ServiceAccountCredentialsTest, ParseSimpleP12) {
+  auto p12_file = CreateRandomFileName();
+  std::ofstream os(p12_file, std::ios::binary);
+  auto bytes = internal::Base64Decode(kP12KeyFileContents);
+  for (unsigned char c : bytes) {
+    os << c;
+  }
+  os.close();
+
+  auto info = ParseServiceAccountP12File(p12_file);
+  ASSERT_STATUS_OK(info);
+
+  EXPECT_EQ(kP12ServiceAccountId, info->client_email);
+  EXPECT_FALSE(info->private_key.empty());
+  EXPECT_EQ(0, std::remove(p12_file.c_str()));
+
+  ServiceAccountCredentials<> credentials(*info);
+
+  auto signed_blob = credentials.SignBlob(SigningAccount(), "test-blob");
+  EXPECT_STATUS_OK(signed_blob);
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(storage_client_integration_tests
     curl_resumable_streambuf_integration_test.cc
     curl_resumable_upload_session_integration_test.cc
     curl_sign_blob_integration_test.cc
+    key_file_integration_test.cc
     object_checksum_integration_test.cc
     object_hash_integration_test.cc
     object_insert_integration_test.cc

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -35,7 +35,16 @@ char const* flag_key_file_name;
 char const* flag_service_account;
 
 class KeyFileIntegrationTest
-    : public google::cloud::storage::testing::StorageIntegrationTest {};
+    : public google::cloud::storage::testing::StorageIntegrationTest {
+ protected:
+  StatusOr<std::shared_ptr<oauth2::Credentials>> CredentialsFromFile(
+      std::string const& path) {
+    if (path.find(".p12") != std::string::npos) {
+      return oauth2::CreateServiceAccountCredentialsFromP12FilePath(path);
+    }
+    return oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
+  }
+};
 
 TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   if (UsingTestbench()) {
@@ -45,12 +54,7 @@ TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   std::string bucket_name = flag_bucket_name;
   std::string file_path = flag_key_file_name;
 
-  auto credentials = [](std::string const& path) {
-    if (path.find(".p12") != std::string::npos) {
-      return oauth2::CreateServiceAccountCredentialsFromP12FilePath(path);
-    }
-    return oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
-  }(flag_key_file_name);
+  auto credentials = CredentialsFromFile(flag_key_file_name);
   ASSERT_STATUS_OK(credentials);
 
   Client client(*credentials);
@@ -90,12 +94,7 @@ TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
   std::string file_path = flag_key_file_name;
   std::string service_account = flag_service_account;
 
-  auto credentials = [](std::string const& path) {
-    if (path.find(".p12") != std::string::npos) {
-      return oauth2::CreateServiceAccountCredentialsFromP12FilePath(path);
-    }
-    return oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
-  }(flag_key_file_name);
+  auto credentials = CredentialsFromFile(flag_key_file_name);
   ASSERT_STATUS_OK(credentials);
 
   Client client(*credentials);

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -1,0 +1,152 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/storage/internal/nljson.h"
+#include "google/cloud/storage/list_objects_reader.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <fstream>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+using ::testing::HasSubstr;
+
+// Initialized in main() below.
+char const* flag_bucket_name;
+char const* flag_key_file_name;
+char const* flag_service_account;
+
+class KeyFileIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
+  if (UsingTestbench()) {
+    // The testbench does not implement signed URLs.
+    return;
+  }
+  std::string bucket_name = flag_bucket_name;
+  std::string file_path = flag_key_file_name;
+
+  auto credentials = [](std::string const& path) {
+    if (path.find(".p12") != std::string::npos) {
+      return oauth2::CreateServiceAccountCredentialsFromP12FilePath(path);
+    }
+    return oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
+  }(flag_key_file_name);
+  ASSERT_STATUS_OK(credentials);
+
+  Client client(*credentials);
+
+  auto object_name = MakeRandomObjectName();
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  auto meta = client.InsertObject(bucket_name, object_name, expected,
+                                  IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+
+  StatusOr<std::string> signed_url =
+      client.CreateV4SignedUrl("GET", bucket_name, object_name);
+  ASSERT_STATUS_OK(signed_url);
+
+  // Verify the signed URL can be used to download the object.
+  internal::CurlRequestBuilder builder(
+      *signed_url, storage::internal::GetDefaultCurlHandleFactory());
+
+  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+
+  EXPECT_EQ(expected, response->payload);
+
+  auto deleted = client.DeleteObject(bucket_name, object_name);
+  ASSERT_STATUS_OK(deleted);
+}
+
+TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
+  if (UsingTestbench()) {
+    // The testbench does not implement signed URLs.
+    return;
+  }
+  std::string bucket_name = flag_bucket_name;
+  std::string file_path = flag_key_file_name;
+  std::string service_account = flag_service_account;
+
+  auto credentials = [](std::string const& path) {
+    if (path.find(".p12") != std::string::npos) {
+      return oauth2::CreateServiceAccountCredentialsFromP12FilePath(path);
+    }
+    return oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
+  }(flag_key_file_name);
+  ASSERT_STATUS_OK(credentials);
+
+  Client client(*credentials);
+
+  auto object_name = MakeRandomObjectName();
+  std::string expected = LoremIpsum();
+
+  // Create the object, but only if it does not exist already.
+  auto meta = client.InsertObject(bucket_name, object_name, expected,
+                                  IfGenerationMatch(0));
+  ASSERT_STATUS_OK(meta);
+
+  StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
+      "GET", bucket_name, object_name, SigningAccount(service_account));
+  ASSERT_STATUS_OK(signed_url);
+
+  // Verify the signed URL can be used to download the object.
+  internal::CurlRequestBuilder builder(
+      *signed_url, storage::internal::GetDefaultCurlHandleFactory());
+
+  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+
+  EXPECT_EQ(expected, response->payload);
+
+  auto deleted = client.DeleteObject(bucket_name, object_name);
+  ASSERT_STATUS_OK(deleted);
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 4) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <bucket-name> <key-file-name> <signing-service-account>\n";
+    return 1;
+  }
+
+  google::cloud::storage::flag_bucket_name = argv[1];
+  google::cloud::storage::flag_key_file_name = argv[2];
+  google::cloud::storage::flag_service_account = argv[3];
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -19,7 +19,9 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
+
 #include <gmock/gmock.h>
+
 #include <fstream>
 
 namespace google {
@@ -35,16 +37,7 @@ char const* flag_key_file_name;
 char const* flag_service_account;
 
 class KeyFileIntegrationTest
-    : public google::cloud::storage::testing::StorageIntegrationTest {
- protected:
-  StatusOr<std::shared_ptr<oauth2::Credentials>> CredentialsFromFile(
-      std::string const& path) {
-    if (path.find(".p12") != std::string::npos) {
-      return oauth2::CreateServiceAccountCredentialsFromP12FilePath(path);
-    }
-    return oauth2::CreateServiceAccountCredentialsFromJsonFilePath(path);
-  }
-};
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   if (UsingTestbench()) {
@@ -54,7 +47,8 @@ TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadDefaultAccount) {
   std::string bucket_name = flag_bucket_name;
   std::string file_path = flag_key_file_name;
 
-  auto credentials = CredentialsFromFile(flag_key_file_name);
+  auto credentials =
+      oauth2::CreateServiceAccountCredentialsFromFilePath(flag_key_file_name);
   ASSERT_STATUS_OK(credentials);
 
   Client client(*credentials);
@@ -94,7 +88,8 @@ TEST_F(KeyFileIntegrationTest, ObjectWriteSignAndReadExplicitAccount) {
   std::string file_path = flag_key_file_name;
   std::string service_account = flag_service_account;
 
-  auto credentials = CredentialsFromFile(flag_key_file_name);
+  auto credentials =
+      oauth2::CreateServiceAccountCredentialsFromFilePath(flag_key_file_name);
   ASSERT_STATUS_OK(credentials);
 
   Client client(*credentials);

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -94,3 +94,9 @@ echo "Running V4 Signed URL conformance tests."
 
 echo "Running Signed URL integration test."
 ./signed_url_integration_test "${BUCKET_NAME}" "${SIGNING_SERVICE_ACCOUNT}"
+
+echo "Running JSON keyfile integration test."
+./key_file_integration_test "${BUCKET_NAME}" "${TEST_KEY_FILE_JSON}" "${SIGNING_SERVICE_ACCOUNT}"
+
+echo "Running P12 keyfile integration test."
+./key_file_integration_test "${BUCKET_NAME}" "${TEST_KEY_FILE_P12}" "${SIGNING_SERVICE_ACCOUNT}"

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -23,6 +23,7 @@ storage_client_integration_tests = [
     "curl_resumable_streambuf_integration_test.cc",
     "curl_resumable_upload_session_integration_test.cc",
     "curl_sign_blob_integration_test.cc",
+    "key_file_integration_test.cc",
     "object_checksum_integration_test.cc",
     "object_hash_integration_test.cc",
     "object_insert_integration_test.cc",


### PR DESCRIPTION
Application developers can now use a P12 file to initialize the
credentials used to access GCS. This PR includes an integration test to
verify these credentials are usable for both accessing GCS as well as
signing URLs.

This fixes #1193.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2480)
<!-- Reviewable:end -->
