### PR TITLE
Support compiling spanner_tool with CMake.

### DIFF
--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -56,12 +56,13 @@ if (NOT TARGET googleapis_project)
 
     create_external_project_library_byproduct_list(
         googleapis_byproducts
-        "googleapis_cpp_longrunning_operations_protos"
         "googleapis_cpp_api_http_protos"
         "googleapis_cpp_api_annotations_protos"
         "googleapis_cpp_iam_v1_policy_protos"
         "googleapis_cpp_iam_v1_iam_policy_protos"
+        "googleapis_cpp_rpc_error_details_protos"
         "googleapis_cpp_rpc_status_protos"
+        "googleapis_cpp_longrunning_operations_protos"
         "googleapis_cpp_bigtable_protos"
         "googleapis_cpp_spanner_protos")
 
@@ -111,7 +112,6 @@ if (NOT TARGET googleapis_project)
                    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
-                   -DCMAKE_SKIP_INSTALL_RPATH=ON
                    -DGOOGLE_CLOUD_CPP_USE_LIBCXX=${GOOGLE_CLOUD_CPP_USE_LIBCXX}
                    ${_googleapis_toolchain_flag}
                    ${_googleapis_triplet_flag}
@@ -171,11 +171,17 @@ function (gooogleapis_project_create_all_libraries)
     set_property(TARGET googleapis-c++::iam_v1_iam_policy_protos
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
-                          googleapis-c++::iam_v1_policy_protos)
+                          googleapis-c++::iam_v1_policy_protos
+                          googleapis-c++::api_annotations_protos)
     set_property(TARGET googleapis-c++::rpc_status_protos
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
                           googleapis-c++::rpc_error_details_protos)
+    set_property(TARGET googleapis-c++::longrunning_operations_protos
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::rpc_status_protos
+                          googleapis-c++::api_annotations_protos)
 
     set_property(TARGET googleapis-c++::spanner_protos
                  APPEND

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -58,6 +58,7 @@ if (NOT TARGET googleapis_project)
         googleapis_byproducts
         "googleapis_cpp_api_http_protos"
         "googleapis_cpp_api_annotations_protos"
+        "googleapis_cpp_api_auth_protos"
         "googleapis_cpp_iam_v1_policy_protos"
         "googleapis_cpp_iam_v1_iam_policy_protos"
         "googleapis_cpp_rpc_error_details_protos"

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -164,6 +164,11 @@ function (gooogleapis_project_create_all_libraries)
     endforeach ()
 
     # We just magically "know" the dependencies between these libraries.
+    set_property(TARGET googleapis-c++::api_auth_protos
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::api_annotations_protos
+                          googleapis-c++::api_http_protos)
     set_property(TARGET googleapis-c++::api_annotations_protos
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
@@ -172,7 +177,8 @@ function (gooogleapis_project_create_all_libraries)
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
                           googleapis-c++::iam_v1_policy_protos
-                          googleapis-c++::api_annotations_protos)
+                          googleapis-c++::api_annotations_protos
+                          googleapis-c++::api_http_protos)
     set_property(TARGET googleapis-c++::rpc_status_protos
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
@@ -181,7 +187,8 @@ function (gooogleapis_project_create_all_libraries)
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
                           googleapis-c++::rpc_status_protos
-                          googleapis-c++::api_annotations_protos)
+                          googleapis-c++::api_annotations_protos
+                          googleapis-c++::api_http_protos)
 
     set_property(TARGET googleapis-c++::spanner_protos
                  APPEND
@@ -197,9 +204,9 @@ function (gooogleapis_project_create_all_libraries)
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES
                           googleapis-c++::longrunning_operations_protos
+                          googleapis-c++::api_auth_protos
                           googleapis-c++::api_annotations_protos
                           googleapis-c++::api_http_protos
-                          googleapis-c++::api_auth_protos
                           googleapis-c++::iam_v1_policy_protos
                           googleapis-c++::iam_v1_iam_policy_protos
                           googleapis-c++::rpc_status_protos)

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -121,10 +121,10 @@ if (NOT TARGET googleapis_project)
                       <BINARY_DIR>
                       ${PARALLEL}
         BUILD_BYPRODUCTS ${googleapis_byproducts}
-        LOG_DOWNLOAD OFF
-        LOG_CONFIGURE OFF
-        LOG_BUILD OFF
-        LOG_INSTALL OFF)
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
 
     unset(_googleapis_toolchain_flag)
     unset(_googleapis_triplet_flag)

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -55,7 +55,15 @@ if (NOT TARGET googleapis_project)
                    "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
 
     create_external_project_library_byproduct_list(
-        googleapis_byproducts "googleapis_cpp_bigtable_protos")
+        googleapis_byproducts
+        "googleapis_cpp_longrunning_operations_protos"
+        "googleapis_cpp_api_http_protos"
+        "googleapis_cpp_api_annotations_protos"
+        "googleapis_cpp_iam_v1_policy_protos"
+        "googleapis_cpp_iam_v1_iam_policy_protos"
+        "googleapis_cpp_rpc_status_protos"
+        "googleapis_cpp_bigtable_protos"
+        "googleapis_cpp_spanner_protos")
 
     set(_googleapis_toolchain_flag "")
     if (NOT "${CMAKE_TOOLCHAIN_FILE}" STREQUAL "")
@@ -112,10 +120,10 @@ if (NOT TARGET googleapis_project)
                       <BINARY_DIR>
                       ${PARALLEL}
         BUILD_BYPRODUCTS ${googleapis_byproducts}
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
-        LOG_BUILD ON
-        LOG_INSTALL ON)
+        LOG_DOWNLOAD OFF
+        LOG_CONFIGURE OFF
+        LOG_BUILD OFF
+        LOG_INSTALL OFF)
 
     unset(_googleapis_toolchain_flag)
     unset(_googleapis_triplet_flag)
@@ -129,13 +137,84 @@ if (NOT TARGET googleapis_project)
     endif ()
 endif ()
 
-if (NOT TARGET googleapis-c++::bigtable_protos)
-    add_library(googleapis-c++::bigtable_protos INTERFACE IMPORTED)
-    set_library_properties_for_external_project(googleapis-c++::bigtable_protos
-                                                googleapis_cpp_bigtable_protos)
-    add_dependencies(googleapis-c++::bigtable_protos googleapis_project)
+function (googleapis_project_create_lib lib)
+    set(scoped_name "googleapis-c++::${lib}_protos")
+    set(imported_name "googleapis_cpp_${lib}_protos")
+    if (NOT TARGET ${scoped_name})
+        add_library(${scoped_name} INTERFACE IMPORTED)
+        set_library_properties_for_external_project(${scoped_name}
+                                                    ${imported_name})
+        add_dependencies(${scoped_name} googleapis_project)
+    endif ()
+endfunction ()
+
+function (gooogleapis_project_create_all_libraries)
+    foreach (lib
+             api_http
+             api_annotations
+             api_auth
+             rpc_status
+             rpc_error_details
+             longrunning_operations
+             iam_v1_policy
+             iam_v1_iam_policy
+             bigtable
+             spanner)
+        googleapis_project_create_lib(${lib})
+    endforeach ()
+
+    # We just magically "know" the dependencies between these libraries.
+    set_property(TARGET googleapis-c++::api_annotations_protos
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::api_http_protos)
+    set_property(TARGET googleapis-c++::iam_v1_iam_policy_protos
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::iam_v1_policy_protos)
+    set_property(TARGET googleapis-c++::rpc_status_protos
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::rpc_error_details_protos)
+
+    set_property(TARGET googleapis-c++::spanner_protos
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::longrunning_operations_protos
+                          googleapis-c++::api_annotations_protos
+                          googleapis-c++::api_http_protos
+                          googleapis-c++::iam_v1_policy_protos
+                          googleapis-c++::iam_v1_iam_policy_protos
+                          googleapis-c++::rpc_status_protos)
+
     set_property(TARGET googleapis-c++::bigtable_protos
                  APPEND
-                 PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc++
-                          protobuf::libprotobuf)
-endif ()
+                 PROPERTY INTERFACE_LINK_LIBRARIES
+                          googleapis-c++::longrunning_operations_protos
+                          googleapis-c++::api_annotations_protos
+                          googleapis-c++::api_http_protos
+                          googleapis-c++::api_auth_protos
+                          googleapis-c++::iam_v1_policy_protos
+                          googleapis-c++::iam_v1_iam_policy_protos
+                          googleapis-c++::rpc_status_protos)
+
+    foreach (lib
+             api_http
+             api_annotations
+             api_auth
+             rpc_status
+             rpc_error_details
+             longrunning_operations
+             iam_v1_policy
+             iam_v1_iam_policy
+             bigtable
+             spanner)
+        set(scoped_name "googleapis-c++::${lib}_protos")
+        set_property(TARGET ${scoped_name}
+                     APPEND
+                     PROPERTY INTERFACE_LINK_LIBRARIES gRPC::grpc++
+                              protobuf::libprotobuf)
+    endforeach ()
+endfunction ()
+
+gooogleapis_project_create_all_libraries()

--- a/cmake/external/googleapis/CMakeLists.txt
+++ b/cmake/external/googleapis/CMakeLists.txt
@@ -389,7 +389,7 @@ add_library(googleapis-c++::spanner_protos ALIAS googleapis_cpp_spanner_protos)
 # GNUInstallDirs
 include(GNUInstallDirs)
 
-set(installed_libraries_list
+set(googleapis_cpp_installed_libraries_list
     googleapis_cpp_bigtable_protos
     googleapis_cpp_spanner_protos
     googleapis_cpp_longrunning_operations_protos
@@ -401,42 +401,33 @@ set(installed_libraries_list
     googleapis_cpp_rpc_error_details_protos
     googleapis_cpp_rpc_status_protos)
 
-message(STATUS "\n\n${installed_libraries_list}\n\n")
-
-install(TARGETS ${installed_libraries_list} googleapis_cpp_common_flags
+install(TARGETS ${googleapis_cpp_installed_libraries_list}
+                googleapis_cpp_common_flags
         EXPORT googleapis-targets
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Install proto generated files into include/google.
-foreach (header
-         ${BIGTABLE_PROTO_HDRS}
-         ${BIGTABLE_GRPCPP_HDRS}
-         ${LONGRUNNING_OPERATIONS_PROTO_HDRS}
-         ${LONGRUNNING_OPERATIONS_GRPC_HDRS}
-         ${API_HTTP_PROTO_HDRS}
-         ${API_HTTP_GRPC_HDRS}
-         ${API_ANNOTATIONS_PROTO_HDRS}
-         ${API_ANNOTATIONS_GRPC_HDRS}
-         ${API_AUTH_PROTO_HDRS}
-         ${API_AUTH_GRPC_HDRS}
-         ${IAM_V1_POLICY_PROTO_HDRS}
-         ${IAM_V1_POLICY_GRPCPP_HDRS}
-         ${IAM_V1_IAM_POLICY_PROTO_HDRS}
-         ${IAM_V1_IAM_POLICY_GRPCPP_HDRS}
-         ${RPC_ERROR_DETAILS_PROTO_HDRS}
-         ${RPC_ERROR_DETAILS_GRPCPP_HDRS}
-         ${RPC_STATUS_PROTO_HDRS}
-         ${RPC_STATUS_GRPCPP_HDRS}
-         ${SPANNER_PROTO_HDRS}
-         ${SPANNER_GRPCPP_HDRS})
-    string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
-                   ""
-                   relative
-                   "${header}")
-    get_filename_component(dir "${relative}" DIRECTORY)
-    install(FILES "${header}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${dir}")
+function (googleapis_cpp_install_headers target)
+    get_target_property(target_sources ${target} SOURCES)
+    foreach (header ${target_sources})
+        # Skip anything that is not a header file.
+        if (NOT "${header}" MATCHES "\\.h$")
+            continue()
+        endif ()
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
+                       ""
+                       relative
+                       "${header}")
+        get_filename_component(dir "${relative}" DIRECTORY)
+        install(FILES "${header}" DESTINATION
+                      "${CMAKE_INSTALL_INCLUDEDIR}/${dir}")
+    endforeach ()
+endfunction ()
+
+foreach (target ${googleapis_cpp_installed_libraries_list})
+    googleapis_cpp_install_headers("${target}")
 endforeach ()
 
 # Export the CMake targets to make it easy to create configuration files.
@@ -496,7 +487,7 @@ function (googleapis_cpp_install_pc target)
 endfunction ()
 
 # Create and install the pkg-config files.
-foreach (target ${installed_libraries_list})
+foreach (target ${googleapis_cpp_installed_libraries_list})
     googleapis_cpp_install_pc("${target}")
 endforeach ()
 

--- a/cmake/external/googleapis/CMakeLists.txt
+++ b/cmake/external/googleapis/CMakeLists.txt
@@ -389,17 +389,21 @@ add_library(googleapis-c++::spanner_protos ALIAS googleapis_cpp_spanner_protos)
 # GNUInstallDirs
 include(GNUInstallDirs)
 
-install(TARGETS googleapis_cpp_bigtable_protos
-                googleapis_cpp_spanner_protos
-                googleapis_cpp_longrunning_operations_protos
-                googleapis_cpp_api_http_protos
-                googleapis_cpp_api_annotations_protos
-                googleapis_cpp_api_auth_protos
-                googleapis_cpp_iam_v1_policy_protos
-                googleapis_cpp_iam_v1_iam_policy_protos
-                googleapis_cpp_rpc_error_details_protos
-                googleapis_cpp_rpc_status_protos
-                googleapis_cpp_common_flags
+set(installed_libraries_list
+    googleapis_cpp_bigtable_protos
+    googleapis_cpp_spanner_protos
+    googleapis_cpp_longrunning_operations_protos
+    googleapis_cpp_api_http_protos
+    googleapis_cpp_api_annotations_protos
+    googleapis_cpp_api_auth_protos
+    googleapis_cpp_iam_v1_policy_protos
+    googleapis_cpp_iam_v1_iam_policy_protos
+    googleapis_cpp_rpc_error_details_protos
+    googleapis_cpp_rpc_status_protos)
+
+message(STATUS "\n\n${installed_libraries_list}\n\n")
+
+install(TARGETS ${installed_libraries_list} googleapis_cpp_common_flags
         EXPORT googleapis-targets
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -449,13 +453,76 @@ set(
 set(
     GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}
     )
+
+# Use a function to create a scope for the variables.
+function (googleapis_cpp_install_pc target)
+    string(REPLACE "googleapis_cpp_"
+                   ""
+                   _short_name
+                   ${target})
+    string(REPLACE "_protos"
+                   ""
+                   _short_name
+                   ${_short_name})
+    set(GOOGLE_CLOUD_CPP_PC_NAME
+        "The Google APIS C++ ${_short_name} Proto Library")
+    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Compiled proto for C++.")
+    # Examine the target LINK_LIBRARIES property, use that to pull the
+    # dependencies between the googleapis-c++::* libraries.
+    set(_target_pc_requires)
+    get_target_property(_target_deps ${target} LINK_LIBRARIES)
+    foreach (dep ${_target_deps})
+        if ("${dep}" MATCHES "^googleapis-c\\+\\+::")
+            string(REPLACE "googleapis-c++::"
+                           "googleapis_cpp_"
+                           dep
+                           "${dep}")
+            list(APPEND _target_pc_requires " " "${dep}")
+        endif ()
+    endforeach ()
+    # These dependencies are required for all the googleapis-c++::* libraries.
+    list(APPEND _target_pc_requires
+                " grpc++"
+                " grpc"
+                " openssl"
+                " protobuf"
+                " zlib"
+                " libcares")
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${_target_pc_requires})
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-l${target}")
+    configure_file("${PROJECT_SOURCE_DIR}/config.pc.in" "${target}.pc" @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.pc" DESTINATION
+                  "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+endfunction ()
+
+# Create and install the pkg-config files.
+foreach (target ${installed_libraries_list})
+    googleapis_cpp_install_pc("${target}")
+endforeach ()
+
+# Create and install the googleapis pkg-config file for backwards compatibility.
 set(GOOGLE_CLOUD_CPP_PC_NAME "The Google APIS C++ Proto Library")
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Platforms.")
-set(GOOGLE_CLOUD_CPP_PC_REQUIRES "grpc++ grpc openssl protobuf zlib libcares")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogleapis_cpp_bigtable_protos")
-
-# Create and install the pkg-config files.
+# Note the use of spaces, `string(JOIN)` is not available in cmake-3.5, so we
+# need to add the separator ourselves.
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
+              "googleapis_cpp_bigtable_protos"
+              " googleapis_cpp_iam_v1_iam_policy_protos"
+              " googleapis_cpp_iam_v1_policy_protos"
+              " googleapis_cpp_longrunning_operations_protos"
+              " googleapis_cpp_api_auth_protos"
+              " googleapis_cpp_api_annotations_protos"
+              " googleapis_cpp_api_http_protos"
+              " googleapis_cpp_rpc_status_protos"
+              " googleapis_cpp_rpc_error_details_protos"
+              " grpc++"
+              " grpc"
+              " openssl"
+              " protobuf"
+              " zlib"
+              " libcares")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "")
 configure_file("${PROJECT_SOURCE_DIR}/config.pc.in" "googleapis.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/googleapis.pc" DESTINATION
               "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/cmake/external/googleapis/CMakeLists.txt
+++ b/cmake/external/googleapis/CMakeLists.txt
@@ -21,7 +21,7 @@ set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
 project(googleapis-cpp-protos CXX C)
 
 set(GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR 0)
-set(GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR 1)
+set(GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR 2)
 set(GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH 0)
 
 # Configure the compiler options, we will be using C++11 features.

--- a/cmake/external/googleapis/CMakeLists.txt
+++ b/cmake/external/googleapis/CMakeLists.txt
@@ -58,28 +58,251 @@ endif ()
 
 include(SelectMSVCRuntime)
 
-# TODO(#2283) - refactor common (non-bigtable) protos to a library
+protobuf_generate_cpp(API_HTTP_PROTO_SOURCES API_HTTP_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/api/http.proto)
+grpc_generate_cpp(API_HTTP_GRPCPP_SOURCES API_HTTP_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/api/http.proto)
+add_library(googleapis_cpp_api_http_protos
+            ${API_HTTP_PROTO_SOURCES}
+            ${API_HTTP_PROTO_HDRS}
+            ${API_HTTP_GRPCPP_SOURCES}
+            ${API_HTTP_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_api_http_protos
+                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_api_http_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_api_http_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(
+    googleapis-c++::api_http_protos ALIAS googleapis_cpp_api_http_protos)
+
+protobuf_generate_cpp(API_ANNOTATIONS_PROTO_SOURCES API_ANNOTATIONS_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/api/annotations.proto)
+grpc_generate_cpp(API_ANNOTATIONS_GRPCPP_SOURCES API_ANNOTATIONS_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/api/annotations.proto)
+add_library(googleapis_cpp_api_annotations_protos
+            ${API_ANNOTATIONS_PROTO_SOURCES}
+            ${API_ANNOTATIONS_PROTO_HDRS}
+            ${API_ANNOTATIONS_GRPCPP_SOURCES}
+            ${API_ANNOTATIONS_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_api_annotations_protos
+                      PUBLIC googleapis-c++::api_http_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_api_annotations_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_api_annotations_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::api_annotations_protos ALIAS
+            googleapis_cpp_api_annotations_protos)
+
+protobuf_generate_cpp(API_AUTH_PROTO_SOURCES API_AUTH_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/api/auth.proto)
+grpc_generate_cpp(API_AUTH_GRPCPP_SOURCES API_AUTH_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/api/auth.proto)
+add_library(googleapis_cpp_api_auth_protos
+            ${API_AUTH_PROTO_SOURCES}
+            ${API_AUTH_PROTO_HDRS}
+            ${API_AUTH_GRPCPP_SOURCES}
+            ${API_AUTH_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_api_auth_protos
+                      PUBLIC googleapis-c++::api_annotations_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_api_auth_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_api_auth_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(
+    googleapis-c++::api_auth_protos ALIAS googleapis_cpp_api_auth_protos)
+
+protobuf_generate_cpp(RPC_ERROR_DETAILS_PROTO_SOURCES
+                      RPC_ERROR_DETAILS_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/rpc/error_details.proto)
+grpc_generate_cpp(RPC_ERROR_DETAILS_GRPCPP_SOURCES RPC_ERROR_DETAILS_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/rpc/error_details.proto)
+add_library(googleapis_cpp_rpc_error_details_protos
+            ${RPC_ERROR_DETAILS_PROTO_SOURCES}
+            ${RPC_ERROR_DETAILS_PROTO_HDRS}
+            ${RPC_ERROR_DETAILS_GRPCPP_SOURCES}
+            ${RPC_ERROR_DETAILS_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_rpc_error_details_protos
+                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_rpc_error_details_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_rpc_error_details_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::rpc_error_details_protos ALIAS
+            googleapis_cpp_rpc_error_details_protos)
+
+protobuf_generate_cpp(RPC_STATUS_PROTO_SOURCES RPC_STATUS_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/rpc/status.proto)
+grpc_generate_cpp(RPC_STATUS_GRPCPP_SOURCES RPC_STATUS_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/rpc/status.proto)
+add_library(googleapis_cpp_rpc_status_protos
+            ${RPC_STATUS_PROTO_SOURCES}
+            ${RPC_STATUS_PROTO_HDRS}
+            ${RPC_STATUS_GRPCPP_SOURCES}
+            ${RPC_STATUS_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_rpc_status_protos
+                      PUBLIC googleapis-c++::rpc_error_details_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_rpc_status_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_rpc_status_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::rpc_status_protos ALIAS
+            googleapis_cpp_rpc_status_protos)
+
+protobuf_generate_cpp(IAM_V1_POLICY_PROTO_SOURCES IAM_V1_POLICY_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/iam/v1/policy.proto)
+grpc_generate_cpp(IAM_V1_POLICY_GRPCPP_SOURCES IAM_V1_POLICY_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/iam/v1/policy.proto)
+add_library(googleapis_cpp_iam_v1_policy_protos
+            ${IAM_V1_POLICY_PROTO_SOURCES}
+            ${IAM_V1_POLICY_PROTO_HDRS}
+            ${IAM_V1_POLICY_GRPCPP_SOURCES}
+            ${IAM_V1_POLICY_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_iam_v1_policy_protos
+                      PUBLIC googleapis-c++::api_annotations_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_iam_v1_policy_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_iam_v1_policy_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::iam_v1_policy_protos ALIAS
+            googleapis_cpp_iam_v1_policy_protos)
+
+protobuf_generate_cpp(IAM_V1_IAM_POLICY_PROTO_SOURCES
+                      IAM_V1_IAM_POLICY_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/iam/v1/iam_policy.proto)
+grpc_generate_cpp(IAM_V1_IAM_POLICY_GRPCPP_SOURCES IAM_V1_IAM_POLICY_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/iam/v1/iam_policy.proto)
+add_library(googleapis_cpp_iam_v1_iam_policy_protos
+            ${IAM_V1_IAM_POLICY_PROTO_SOURCES}
+            ${IAM_V1_IAM_POLICY_PROTO_HDRS}
+            ${IAM_V1_IAM_POLICY_GRPCPP_SOURCES}
+            ${IAM_V1_IAM_POLICY_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_iam_v1_iam_policy_protos
+                      PUBLIC googleapis-c++::api_annotations_protos
+                             googleapis-c++::iam_v1_policy_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_iam_v1_iam_policy_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_iam_v1_iam_policy_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::iam_v1_iam_policy_protos ALIAS
+            googleapis_cpp_iam_v1_iam_policy_protos)
+
+protobuf_generate_cpp(LONGRUNNING_OPERATIONS_PROTO_SOURCES
+                      LONGRUNNING_OPERATIONS_PROTO_HDRS
+                      ${PROJECT_SOURCE_DIR}/google/longrunning/operations.proto)
+grpc_generate_cpp(LONGRUNNING_OPERATIONS_GRPCPP_SOURCES
+                  LONGRUNNING_OPERATIONS_GRPCPP_HDRS
+                  ${PROJECT_SOURCE_DIR}/google/longrunning/operations.proto)
+add_library(googleapis_cpp_longrunning_operations_protos
+            ${LONGRUNNING_OPERATIONS_PROTO_SOURCES}
+            ${LONGRUNNING_OPERATIONS_PROTO_HDRS}
+            ${LONGRUNNING_OPERATIONS_GRPCPP_SOURCES}
+            ${LONGRUNNING_OPERATIONS_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_longrunning_operations_protos
+                      PUBLIC googleapis-c++::api_annotations_protos
+                             googleapis-c++::rpc_status_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_longrunning_operations_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_longrunning_operations_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::longrunning_operations_protos ALIAS
+            googleapis_cpp_longrunning_operations_protos)
+
 protobuf_generate_cpp(
-    PROTO_SOURCES
-    PROTO_HDRS
+    BIGTABLE_PROTO_SOURCES
+    BIGTABLE_PROTO_HDRS
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_instance_admin.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_table_admin.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/common.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/instance.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/table.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/v2/bigtable.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/v2/data.proto
-    ${PROJECT_SOURCE_DIR}/google/iam/v1/iam_policy.proto
-    ${PROJECT_SOURCE_DIR}/google/iam/v1/policy.proto
-    ${PROJECT_SOURCE_DIR}/google/longrunning/operations.proto
-    ${PROJECT_SOURCE_DIR}/google/rpc/status.proto
-    ${PROJECT_SOURCE_DIR}/google/rpc/error_details.proto
-    ${PROJECT_SOURCE_DIR}/google/api/annotations.proto
-    ${PROJECT_SOURCE_DIR}/google/api/auth.proto
-    ${PROJECT_SOURCE_DIR}/google/api/http.proto)
+    ${PROJECT_SOURCE_DIR}/google/bigtable/v2/data.proto)
 grpc_generate_cpp(
-    GRPCPP_SOURCES
-    GRPCPP_HDRS
+    BIGTABLE_GRPCPP_SOURCES
+    BIGTABLE_GRPCPP_HDRS
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_instance_admin.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_table_admin.proto
     ${PROJECT_SOURCE_DIR}/google/bigtable/v2/bigtable.proto
@@ -89,12 +312,19 @@ grpc_generate_cpp(
 # adding new services (e.g. Spanner) please create a new library and refactor
 # common protos
 add_library(googleapis_cpp_bigtable_protos
-            ${PROTO_SOURCES}
-            ${PROTO_HDRS}
-            ${GRPCPP_SOURCES}
-            ${GRPCPP_HDRS})
+            ${BIGTABLE_PROTO_SOURCES}
+            ${BIGTABLE_PROTO_HDRS}
+            ${BIGTABLE_GRPCPP_SOURCES}
+            ${BIGTABLE_GRPCPP_HDRS})
 target_link_libraries(googleapis_cpp_bigtable_protos
-                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
+                      PUBLIC googleapis-c++::api_annotations_protos
+                             googleapis-c++::api_auth_protos
+                             googleapis-c++::longrunning_operations_protos
+                             googleapis-c++::rpc_status_protos
+                             googleapis-c++::iam_v1_iam_policy_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
 target_include_directories(googleapis_cpp_bigtable_protos
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
@@ -110,18 +340,93 @@ set_target_properties(
 add_library(
     googleapis-c++::bigtable_protos ALIAS googleapis_cpp_bigtable_protos)
 
+protobuf_generate_cpp(
+    SPANNER_PROTO_SOURCES
+    SPANNER_PROTO_HDRS
+    ${PROJECT_SOURCE_DIR}/google/spanner/admin/database/v1/spanner_database_admin.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/admin/instance/v1/spanner_instance_admin.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/keys.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/mutation.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/query_plan.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/result_set.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/spanner.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/transaction.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/type.proto)
+grpc_generate_cpp(
+    SPANNER_GRPCPP_SOURCES
+    SPANNER_GRPCPP_HDRS
+    ${PROJECT_SOURCE_DIR}/google/spanner/admin/database/v1/spanner_database_admin.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/admin/instance/v1/spanner_instance_admin.proto
+    ${PROJECT_SOURCE_DIR}/google/spanner/v1/spanner.proto)
+add_library(googleapis_cpp_spanner_protos
+            ${SPANNER_PROTO_SOURCES}
+            ${SPANNER_PROTO_HDRS}
+            ${SPANNER_GRPCPP_SOURCES}
+            ${SPANNER_GRPCPP_HDRS})
+target_link_libraries(googleapis_cpp_spanner_protos
+                      PUBLIC googleapis-c++::api_annotations_protos
+                             googleapis-c++::longrunning_operations_protos
+                             googleapis-c++::rpc_status_protos
+                             googleapis-c++::iam_v1_iam_policy_protos
+                             gRPC::grpc++
+                             gRPC::grpc
+                             protobuf::libprotobuf
+                      PRIVATE googleapis_cpp_common_flags)
+target_include_directories(googleapis_cpp_spanner_protos
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>)
+set_target_properties(
+    googleapis_cpp_spanner_protos
+    PROPERTIES
+        VERSION
+        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
+        SOVERSION
+        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+add_library(googleapis-c++::spanner_protos ALIAS googleapis_cpp_spanner_protos)
+
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs
 include(GNUInstallDirs)
 
-install(TARGETS googleapis_cpp_bigtable_protos googleapis_cpp_common_flags
+install(TARGETS googleapis_cpp_bigtable_protos
+                googleapis_cpp_spanner_protos
+                googleapis_cpp_longrunning_operations_protos
+                googleapis_cpp_api_http_protos
+                googleapis_cpp_api_annotations_protos
+                googleapis_cpp_api_auth_protos
+                googleapis_cpp_iam_v1_policy_protos
+                googleapis_cpp_iam_v1_iam_policy_protos
+                googleapis_cpp_rpc_error_details_protos
+                googleapis_cpp_rpc_status_protos
+                googleapis_cpp_common_flags
         EXPORT googleapis-targets
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Install proto generated files into include/google.
-foreach (header ${PROTO_HDRS} ${GRPCPP_HDRS})
+foreach (header
+         ${BIGTABLE_PROTO_HDRS}
+         ${BIGTABLE_GRPCPP_HDRS}
+         ${LONGRUNNING_OPERATIONS_PROTO_HDRS}
+         ${LONGRUNNING_OPERATIONS_GRPC_HDRS}
+         ${API_HTTP_PROTO_HDRS}
+         ${API_HTTP_GRPC_HDRS}
+         ${API_ANNOTATIONS_PROTO_HDRS}
+         ${API_ANNOTATIONS_GRPC_HDRS}
+         ${API_AUTH_PROTO_HDRS}
+         ${API_AUTH_GRPC_HDRS}
+         ${IAM_V1_POLICY_PROTO_HDRS}
+         ${IAM_V1_POLICY_GRPCPP_HDRS}
+         ${IAM_V1_IAM_POLICY_PROTO_HDRS}
+         ${IAM_V1_IAM_POLICY_GRPCPP_HDRS}
+         ${RPC_ERROR_DETAILS_PROTO_HDRS}
+         ${RPC_ERROR_DETAILS_GRPCPP_HDRS}
+         ${RPC_STATUS_PROTO_HDRS}
+         ${RPC_STATUS_GRPCPP_HDRS}
+         ${SPANNER_PROTO_HDRS}
+         ${SPANNER_GRPCPP_HDRS})
     string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
                    ""
                    relative

--- a/cmake/external/googleapis/config.cmake.in
+++ b/cmake/external/googleapis/config.cmake.in
@@ -17,6 +17,20 @@ include("${CMAKE_CURRENT_LIST_DIR}/FindgRPC.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/googleapis-targets.cmake")
 
-add_library(googleapis-c++::bigtable_protos IMPORTED INTERFACE)
-set_target_properties(googleapis-c++::bigtable_protos PROPERTIES
-    INTERFACE_LINK_LIBRARIES googleapis_cpp_bigtable_protos)
+foreach (_target
+         api_http
+         api_annotations
+         api_auth
+         rpc_status
+         rpc_error_details
+         longrunning_operations
+         iam_v1_policy
+         iam_v1_iam_policy
+         bigtable
+         spanner)
+    set(scoped_name "googleapis-c++::${_target}_protos")
+    set(imported_name "googleapis_cpp_${_target}_protos")
+    add_library(${scoped_name} IMPORTED INTERFACE)
+    set_target_properties(${scoped_name} PROPERTIES
+            INTERFACE_LINK_LIBRARIES ${imported_name})
+endforeach ()

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -63,13 +63,16 @@ export_variables_to_bazel("spanner_client_version.bzl"
                           YEAR
                           ${SPANNER_CLIENT_COPYRIGHT_YEAR})
 
+include(external/googleapis)
+
 # the client library
 add_library(spanner_client
             ${CMAKE_CURRENT_BINARY_DIR}/version_info.h
             version.h
             version.cc)
 target_link_libraries(spanner_client
-                      PUBLIC google_cloud_cpp_common
+                      PUBLIC googleapis-c++::spanner_protos
+                             google_cloud_cpp_common
                       PRIVATE spanner_common_options)
 target_include_directories(spanner_client
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -85,6 +88,10 @@ set_target_properties(
         SOVERSION
         ${SPANNER_CLIENT_VERSION_MAJOR})
 add_library(spanner::client ALIAS spanner_client)
+
+add_executable(spanner_tool spanner_tool.cc)
+target_link_libraries(spanner_tool
+                      PRIVATE spanner_client googleapis-c++::spanner_protos)
 
 include(CreateBazelConfig)
 create_bazel_config(spanner_client YEAR ${SPANNER_CLIENT_COPYRIGHT_YEAR})

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -91,7 +91,8 @@ add_library(spanner::client ALIAS spanner_client)
 
 add_executable(spanner_tool spanner_tool.cc)
 target_link_libraries(spanner_tool
-                      PRIVATE spanner_client googleapis-c++::spanner_protos)
+                      PRIVATE spanner_client googleapis-c++::spanner_protos
+                              spanner_common_options)
 
 include(CreateBazelConfig)
 create_bazel_config(spanner_client YEAR ${SPANNER_CLIENT_COPYRIGHT_YEAR})

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -53,13 +53,13 @@ void ListDatabases(std::string const& project, std::string const& instance) {
 // This is a command-line tool to let folks easily experiment with Spanner
 // using C++. This works with bazel using a command like:
 //
-// $ bazel run google/cloud/spanner:spanner_tool -- \
+// $ bazel run google/cloud/spanner:spanner_tool --
 //       jgm-cloud-cxx jgm-spanner-instance
 //
 // Currently, the above command will just invoke the "ListDatabases" RPC, which
 // makes it equivalent to the following command:
 //
-// $ gcloud spanner databases list \
+// $ gcloud spanner databases list
 //       --project jgm-cloud-cxx --instance jgm-spanner-instance
 //
 // NOTE: The actual project and instance names will vary for other users; These


### PR DESCRIPTION
Compile the spanner protos in googleapis. I had to split the
bigtable_protos into a number of smaller libraries because there are
shared protos between bigtable and spanner.

This fixes #2451 and #2283.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2486)
<!-- Reviewable:end -->
