### PR TITLE
Support P12 files in GoogleDefaultCredentials().

### DIFF
--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -296,9 +296,9 @@ TEST_F(GoogleCredentialsTest, LoadInvalidCredentials) {
 
   auto creds = GoogleDefaultCredentials();
   ASSERT_FALSE(creds) << "status=" << creds.status();
+  EXPECT_EQ(StatusCode::kInvalidArgument, creds.status().code());
   EXPECT_THAT(creds.status().message(),
-              HasSubstr("Invalid contents in credentials file"));
-  EXPECT_THAT(creds.status().message(), HasSubstr(filename));
+              HasSubstr("credentials file " + filename));
 }
 
 TEST_F(GoogleCredentialsTest, MissingCredentialsViaEnvVar) {

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -100,3 +100,8 @@ echo "Running JSON keyfile integration test."
 
 echo "Running P12 keyfile integration test."
 ./key_file_integration_test "${BUCKET_NAME}" "${TEST_KEY_FILE_P12}" "${SIGNING_SERVICE_ACCOUNT}"
+
+echo
+echo "Running GCS Object APIs with P12 credentials."
+env "GOOGLE_APPLICATION_CREDENTIALS=${TEST_KEY_FILE_P12}" \
+    ./object_integration_test "${PROJECT_ID}" "${BUCKET_NAME}"


### PR DESCRIPTION
If we cannot load a file as a JSON file, assume it might be a P12 file
and try to load it as such.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2487)
<!-- Reviewable:end -->
