### PR TITLE
Bypass creating real alarms in MockCompletionQueue

### DIFF
--- a/google/cloud/bigtable/completion_queue.cc
+++ b/google/cloud/bigtable/completion_queue.cc
@@ -68,6 +68,7 @@ class AsyncTimerFuture : public internal::AsyncGrpcOperation {
 
   promise<std::chrono::system_clock::time_point> promise_;
   std::chrono::system_clock::time_point deadline_;
+  /// Holds the underlying handle. It might be a nullptr in tests.
   std::unique_ptr<grpc::Alarm> alarm_;
 };
 


### PR DESCRIPTION
This fixes #2489.

Without this fix a timer could be deleted before it was fully handled by
`grpc::CompletionQueue`. Refer to #2489 for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2490)
<!-- Reviewable:end -->
