### PR TITLE
Moves enablers to LHS of assignment to prevent callers specifying.

### DIFF
--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -418,8 +418,9 @@ class BulkMutation {
 
   /// Create a muti-row mutation from a variadic list.
   template <typename... M,
-            typename = typename std::enable_if<internal::conjunction<
-                std::is_convertible<M, SingleRowMutation>...>::value>::type>
+            typename std::enable_if<internal::conjunction<std::is_convertible<
+                                        M, SingleRowMutation>...>::value,
+                                    int>::type = 0>
   BulkMutation(M&&... m) : BulkMutation() {
     emplace_many(std::forward<M>(m)...);
   }

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -106,7 +106,7 @@ struct invoke_impl<MT B::*> {
    * @return the result of `(t.*f)(a...)`.
    */
   template <class T, class... Args,
-            class = typename std::enable_if<std::is_function<MT>::value>::type>
+            typename std::enable_if<std::is_function<MT>::value, int>::type = 0>
   static auto call(MT B::*f, T&& t, Args&&... a)
       -> decltype((std::forward<T>(t).*f)(std::forward<Args>(a)...));
 };


### PR DESCRIPTION
It's preferable to use SFINAE on the left-hand side of the assignment so
that it's declaring the type of a non-type template parameter rather
than on the right-hand side where it's instead setting the default type
for a regular (type) template parameter. This way is preferred because
it prevents callers from overriding the SFINAE by explicitly specifying
the template parameter, which callers could do if the enabler were only
setting the default.

For more explanation of why this form is preferred, here's an example in godbolt: https://godbolt.org/z/YG6io0

```cc
#include <type_traits>

template <typename T,
          typename = typename std::enable_if<std::is_integral<T>::value>::type>
void RequireInt1(T);

template <typename T,
          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
void RequireInt2(T);

int Test() {
  float x;

  // Oops: Caller can "override" RequireInt1's enabler by explicitly specifying
  // a type for the second paramter, which will cause our enabler to be skipped,
  // thus a caller can call RequireInt1() and pass it a float.
  RequireInt1<decltype(x), void>(x);

  // There's no way for the caller to override or cause our enabler to be
  // skipped because it's defining the type of the template parameter, not the
  // default value for the template parameter. Note the use of 'int' in the
  // enabler is arbitrary yet idiomatic. Similarly, the use of `= 0` as the
  // default value is also arbitrary and idiomatic.
  
  // RequireInt2<decltype(x), void>(x);  // Doesn't compile!
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2493)
<!-- Reviewable:end -->
