### PR TITLE
Coalesce the separated #include blocks

### DIFF
--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -15,15 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_COLUMN_FAMILY_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_COLUMN_FAMILY_H_
 
+#include "google/cloud/bigtable/internal/conjunction.h"
 #include "google/cloud/bigtable/version.h"
-
-#include <chrono>
-#include <memory>
-
 #include <google/bigtable/admin/v2/bigtable_table_admin.pb.h>
 #include <google/bigtable/admin/v2/table.pb.h>
-
-#include "google/cloud/bigtable/internal/conjunction.h"
+#include <chrono>
+#include <memory>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
This allows clang-format (6) to order the includes based on our
"IncludeCategories" priorities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2519)
<!-- Reviewable:end -->
