### PR TITLE
Support move-only callables in future<T>.

### DIFF
--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -111,6 +111,70 @@ TEST(FutureTestInt, ThenUnwrap) {
   EXPECT_FALSE(next.valid());
 }
 
+TEST(FutureTestInt, ThenMoveOnlyCallable) {
+  class MoveOnlyCallable {
+   public:
+    explicit MoveOnlyCallable(bool& called) : called_(&called) {}
+
+    MoveOnlyCallable(MoveOnlyCallable&&) = default;
+    MoveOnlyCallable& operator=(MoveOnlyCallable&&) = default;
+
+    MoveOnlyCallable(MoveOnlyCallable const&) = delete;
+    MoveOnlyCallable& operator=(MoveOnlyCallable const&) = delete;
+
+    int operator()(future<int> f) {
+      *called_ = true;
+      return 2 * f.get();
+    }
+
+   private:
+    bool* called_;
+  };
+
+  promise<int> p;
+  future<int> fut = p.get_future();
+  EXPECT_TRUE(fut.valid());
+
+  bool called = false;
+  MoveOnlyCallable cb{called};
+  future<int> next = fut.then(std::move(cb));
+  EXPECT_FALSE(fut.valid());
+  EXPECT_TRUE(next.valid());
+  EXPECT_FALSE(called);
+
+  p.set_value(42);
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(next.valid());
+  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+
+  EXPECT_EQ(84, next.get());
+  EXPECT_FALSE(next.valid());
+}
+
+TEST(FutureTestInt, ThenByCopy) {
+  promise<int> p;
+  future<int> fut = p.get_future();
+  EXPECT_TRUE(fut.valid());
+
+  bool called = false;
+  auto callable = [&called](future<int> r) {
+    called = true;
+    return 2 * r.get();
+  };
+  future<int> next = fut.then(callable);
+  EXPECT_FALSE(fut.valid());
+  EXPECT_TRUE(next.valid());
+  EXPECT_FALSE(called);
+
+  p.set_value(42);
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(next.valid());
+  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+
+  EXPECT_EQ(84, next.get());
+  EXPECT_FALSE(next.valid());
+}
+
 // The following tests reference the technical specification:
 //   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0159r0.html
 // The test names match the section and paragraph from the TS.

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -112,15 +112,15 @@ TEST(FutureTestInt, ThenUnwrap) {
 }
 
 TEST(FutureTestInt, ThenMoveOnlyCallable) {
-  class MoveOnlyCallable {
+  class MoveOnlyDoubler {
    public:
-    explicit MoveOnlyCallable(bool& called) : called_(&called) {}
+    explicit MoveOnlyDoubler(bool& called) : called_(&called) {}
 
-    MoveOnlyCallable(MoveOnlyCallable&&) = default;
-    MoveOnlyCallable& operator=(MoveOnlyCallable&&) = default;
+    MoveOnlyDoubler(MoveOnlyDoubler&&) = default;
+    MoveOnlyDoubler& operator=(MoveOnlyDoubler&&) = default;
 
-    MoveOnlyCallable(MoveOnlyCallable const&) = delete;
-    MoveOnlyCallable& operator=(MoveOnlyCallable const&) = delete;
+    MoveOnlyDoubler(MoveOnlyDoubler const&) = delete;
+    MoveOnlyDoubler& operator=(MoveOnlyDoubler const&) = delete;
 
     int operator()(future<int> f) {
       *called_ = true;
@@ -136,7 +136,7 @@ TEST(FutureTestInt, ThenMoveOnlyCallable) {
   EXPECT_TRUE(fut.valid());
 
   bool called = false;
-  MoveOnlyCallable cb{called};
+  MoveOnlyDoubler cb{called};
   future<int> next = fut.then(std::move(cb));
   EXPECT_FALSE(fut.valid());
   EXPECT_TRUE(next.valid());
@@ -147,7 +147,7 @@ TEST(FutureTestInt, ThenMoveOnlyCallable) {
   EXPECT_TRUE(next.valid());
   EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
-  EXPECT_EQ(84, next.get());
+  EXPECT_EQ(2 * 42, next.get());
   EXPECT_FALSE(next.valid());
 }
 

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -157,11 +157,11 @@ TEST(FutureTestInt, ThenByCopy) {
   EXPECT_TRUE(fut.valid());
 
   bool called = false;
-  auto callable = [&called](future<int> r) {
+  auto doubler = [&called](future<int> r) {
     called = true;
     return 2 * r.get();
   };
-  future<int> next = fut.then(callable);
+  future<int> next = fut.then(doubler);
   EXPECT_FALSE(fut.valid());
   EXPECT_TRUE(next.valid());
   EXPECT_FALSE(called);
@@ -171,7 +171,7 @@ TEST(FutureTestInt, ThenByCopy) {
   EXPECT_TRUE(next.valid());
   EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
-  EXPECT_EQ(84, next.get());
+  EXPECT_EQ(2 * 42, next.get());
   EXPECT_FALSE(next.valid());
 }
 

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -63,14 +63,14 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   // instead of a lambda, as support for move+capture in lambdas is a C++14
   // feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(func) {}
+    explicit adapter(F&& func) : functor(std::move(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> functor_result_t {
       return functor(future<T>(std::move(state)));
     }
 
-    F functor;
+    typename std::decay<F>::type functor;
   };
 
   auto output_shared_state = local_state_type::make_continuation(
@@ -111,7 +111,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
       return functor(future<T>(std::move(state))).shared_state_;
     }
 
-    F functor;
+    typename std::decay<F>::type functor;
   };
 
   auto output_shared_state = local_state_type::make_continuation(
@@ -146,14 +146,14 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   // instead of a lambda, as support for move+capture in lambdas is a C++14
   // feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(func) {}
+    explicit adapter(F&& func) : functor(std::move(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> functor_result_t {
       return functor(future<void>(std::move(state)));
     }
 
-    F functor;
+    typename std::decay<F>::type functor;
   };
 
   auto output_shared_state = shared_state_type::make_continuation(
@@ -186,14 +186,14 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   // Because we need to support C++11, we use a local class instead of a lambda,
   // as support for move+capture in lambdas is a C++14 feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(func) {}
+    explicit adapter(F&& func) : functor(std::move(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> std::shared_ptr<internal::future_shared_state<result_t>> {
       return functor(future<void>(std::move(state))).shared_state_;
     }
 
-    F functor;
+    typename std::decay<F>::type functor;
   };
 
   auto output_shared_state = local_state_type::make_continuation(


### PR DESCRIPTION
I noticed this while trying to use `future<T>` in a larger change,
separating the change to its own bug seems to make sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2529)
<!-- Reviewable:end -->
