### PR TITLE
Add the "IncludeBlocks: Merge" clang-format option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,7 @@ BasedOnStyle: Google
 DerivePointerAlignment: false
 PointerAlignment: Left
 
+IncludeBlocks: Merge
 IncludeCategories:
 - Regex: '^\"google/cloud/'
   Priority: 1500

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -18,7 +18,6 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/status_or.h"
-
 #include <chrono>
 #include <vector>
 

--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/bigtable/cell.h"
 #include "google/cloud/testing_util/assert_ok.h"
-
 #include <gtest/gtest.h>
 
 namespace bigtable = google::cloud::bigtable;

--- a/google/cloud/bigtable/data_client_test.cc
+++ b/google/cloud/bigtable/data_client_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/data_client.h"
-
 #include <gmock/gmock.h>
 
 namespace bigtable = google::cloud::bigtable;

--- a/google/cloud/bigtable/row_set_test.cc
+++ b/google/cloud/bigtable/row_set_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/row_set.h"
-
 #include <gmock/gmock.h>
 
 namespace bigtable = google::cloud::bigtable;

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -22,7 +22,6 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include "google/cloud/testing_util/init_google_mock.h"
-
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
-
 #include <functional>
 #include <iostream>
 #include <map>

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
-
 #include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
@@ -23,7 +22,6 @@
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
-
 #include <fstream>
 #include <iterator>
 #include <memory>

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
-
 #include "google/cloud/storage/oauth2/credential_constants.h"
 
 namespace google {

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
-
 #include "google/cloud/storage/internal/openssl_util.h"
-
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
-
 #include <fstream>
 
 namespace google {

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -19,9 +19,7 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
-
 #include <gmock/gmock.h>
-
 #include <fstream>
 
 namespace google {


### PR DESCRIPTION
Specify that clang-format should merge include blocks, which is
how the majority of the code is already formatted.  Then fix the
10 current outliers.  This will allow for a smoother transition
to the new clang-format, where the default is to split include
blocks based on category priority.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2532)
<!-- Reviewable:end -->
