### PR TITLE
Wrap streaming read RPC loop.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -134,6 +134,7 @@ add_library(bigtable_client
             internal/async_loop_op.h
             internal/async_op_traits.h
             internal/async_poll_op.h
+            internal/async_read_stream_impl.h
             internal/async_sample_row_keys.h
             internal/async_sample_row_keys.cc
             internal/async_read_row_operation.h
@@ -269,6 +270,7 @@ if (BUILD_TESTING)
         async_list_app_profiles_test.cc
         async_list_clusters_test.cc
         async_list_instances_test.cc
+        async_read_stream_test.cc
         bigtable_version_test.cc
         cell_test.cc
         client_options_test.cc

--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -611,7 +611,7 @@ TEST_F(AsyncReadStreamTest, CancelBeforeRead) {
   // way this actually unblocks is if the Cancel() succeeds.
   result.done.Wait();
   // There is no guarantee on how many messages will be received before the
-  // cancel succeeds, but we certainly expect fewer messages thant we sent.
+  // cancel succeeds, but we certainly expect fewer messages than we sent.
   EXPECT_LE(result.reads.size(), 3U);
   EXPECT_EQ(StatusCode::kCancelled, result.status.code());
 

--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -1,0 +1,723 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/completion_queue.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+
+#include <google/bigtable/v2/bigtable.grpc.pb.h>
+
+#include <gmock/gmock.h>
+
+#include <future>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+namespace btproto = google::bigtable::v2;
+using namespace google::cloud::testing_util::chrono_literals;
+
+/**
+ * Implement a single streaming read RPC to test the wrappers.
+ */
+class BulkApplyImpl final : public google::bigtable::v2::Bigtable::Service {
+ public:
+  BulkApplyImpl() = default;
+
+  grpc::Status MutateRows(
+      grpc::ServerContext* context,
+      google::bigtable::v2::MutateRowsRequest const* request,
+      grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>* writer)
+      override {
+    std::unique_lock<std::mutex> lk(mu_);
+    if (!callback_) {
+      return grpc::Status::OK;
+    }
+    Callback cb;
+    cb.swap(callback_);
+    lk.unlock();
+    return cb(context, request, writer);
+  }
+
+  using Callback = std::function<grpc::Status(
+      grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+      grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*)>;
+
+  void SetCallback(Callback callback) {
+    std::unique_lock<std::mutex> lk(mu_);
+    callback_ = std::move(callback);
+  }
+
+ private:
+  std::mutex mu_;
+  Callback callback_;
+};
+
+/**
+ * These test starts a server in a separate thread, and then executes against
+ * that server. We want to test the wrappers end-to-end, particularly with
+ * respect to error handling, and cancellation.
+ */
+class AsyncReadStreamTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int port;
+    std::string server_address("[::]:0");
+    builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
+                              &port);
+    builder_.RegisterService(&impl_);
+    server_ = builder_.BuildAndStart();
+    server_thread_ = std::thread([this]() { server_->Wait(); });
+
+    std::shared_ptr<grpc::Channel> channel =
+        grpc::CreateChannel("localhost:" + std::to_string(port),
+                            grpc::InsecureChannelCredentials());
+    stub_ = google::bigtable::v2::Bigtable::NewStub(channel);
+
+    cq_thread_ = std::thread([this] { cq_.Run(); });
+  }
+
+  void TearDown() override {
+    cq_.Shutdown();
+    if (cq_thread_.joinable()) {
+      cq_thread_.join();
+    }
+    WaitForServerShutdown();
+  }
+
+  void WaitForServerShutdown() {
+    server_->Shutdown();
+    if (server_thread_.joinable()) {
+      server_thread_.join();
+    }
+  }
+
+  void WriteOne(
+      grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>* writer,
+      int index) {
+    google::bigtable::v2::MutateRowsResponse response;
+    response.add_entries()->set_index(index);
+    writer->Write(response, grpc::WriteOptions().set_write_through());
+  }
+
+  void WriteLast(
+      grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>* writer,
+      int index) {
+    google::bigtable::v2::MutateRowsResponse response;
+    response.add_entries()->set_index(index);
+    writer->Write(response,
+                  grpc::WriteOptions().set_write_through().set_last_message());
+  }
+
+  BulkApplyImpl impl_;
+  grpc::ServerBuilder builder_;
+  std::unique_ptr<grpc::Server> server_;
+  std::thread server_thread_;
+  std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> stub_;
+
+  CompletionQueue cq_;
+  std::thread cq_thread_;
+};
+
+// A synchronization primitive to block a thread until it is allowed to
+// continue.
+class SimpleBarrier {
+ public:
+  SimpleBarrier() = default;
+
+  void Wait() { impl_.get_future().get(); }
+  void Lift() { impl_.set_value(); }
+
+ private:
+  promise<void> impl_;
+};
+
+struct HandlerResult {
+  std::vector<btproto::MutateRowsResponse> reads;
+  Status status;
+  SimpleBarrier done;
+};
+
+/// @test Verify that completion queues correctly validate asynchronous
+/// streaming read RPC callables.
+TEST_F(AsyncReadStreamTest, MetaFunctions) {
+  auto async_call = [this](grpc::ClientContext* context,
+                           btproto::MutateRowsRequest const& request,
+                           grpc::CompletionQueue* cq) {
+    return stub_->PrepareAsyncMutateRows(context, request, cq);
+  };
+  static_assert(
+      std::is_same<
+          btproto::MutateRowsResponse,
+          internal::AsyncStreamingReadResponseType<
+              decltype(async_call), btproto::MutateRowsRequest>::type>::value,
+      "Unexpected type for AsyncStreamingReadResponseType<>");
+}
+
+/// @test Verify that AsyncReadStream works event if the server does not exist.
+TEST_F(AsyncReadStreamTest, CannotConnect) {
+  std::shared_ptr<grpc::Channel> channel =
+      grpc::CreateChannel("localhost:0", grpc::InsecureChannelCredentials());
+  std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> stub =
+      google::bigtable::v2::Bigtable::NewStub(channel);
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  cq_.MakeStreamingReadRpc(
+      [&stub](grpc::ClientContext* context,
+              btproto::MutateRowsRequest const& request,
+              grpc::CompletionQueue* cq) {
+        return stub->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  EXPECT_TRUE(result.reads.empty());
+  EXPECT_EQ(StatusCode::kUnavailable, result.status.code());
+}
+
+/// @test Verify that the AsyncReadStream handles an empty stream.
+TEST_F(AsyncReadStreamTest, Empty) {
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  EXPECT_TRUE(result.reads.empty());
+  EXPECT_STATUS_OK(result.status);
+}
+
+/// @test Verify that the AsyncReadStream handles an error in a empty stream.
+TEST_F(AsyncReadStreamTest, FailImmediately) {
+  impl_.SetCallback(
+      [](grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+         grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*) {
+        return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
+      });
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  EXPECT_TRUE(result.reads.empty());
+  EXPECT_EQ(StatusCode::kPermissionDenied, result.status.code());
+}
+
+/// @test Verify that the AsyncReadStream handles a stream with 3 elements.
+TEST_F(AsyncReadStreamTest, Return3) {
+  impl_.SetCallback(
+      [this](grpc::ServerContext*,
+             google::bigtable::v2::MutateRowsRequest const*,
+             grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+                 writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        WriteLast(writer, 2);
+        return grpc::Status::OK;
+      });
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  EXPECT_STATUS_OK(result.status);
+  ASSERT_EQ(3U, result.reads.size());
+  for (int i = 0; i != 3; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+}
+
+/// @test Verify that the AsyncReadStream detect errors reported by the server.
+TEST_F(AsyncReadStreamTest, Return3ThenFail) {
+  impl_.SetCallback(
+      [this](grpc::ServerContext*,
+             google::bigtable::v2::MutateRowsRequest const*,
+             grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+                 writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        WriteLast(writer, 2);
+        return grpc::Status(grpc::StatusCode::INTERNAL, "bad luck");
+      });
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  ASSERT_EQ(3U, result.reads.size());
+  for (int i = 0; i != 3; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+  EXPECT_EQ(StatusCode::kInternal, result.status.code());
+}
+
+/// @test Verify that the AsyncReadStream wrappers work even if the server does
+/// not explicitly signal end-of-stream.
+TEST_F(AsyncReadStreamTest, Return3NoLast) {
+  impl_.SetCallback(
+      [this](grpc::ServerContext*,
+             google::bigtable::v2::MutateRowsRequest const*,
+             grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+                 writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        WriteOne(writer, 2);
+        return grpc::Status::OK;
+      });
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  ASSERT_EQ(3U, result.reads.size());
+  ASSERT_STATUS_OK(result.status);
+  for (int i = 0; i != 3; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+}
+
+/// @test Verify that the AsyncReadStream wrappers work even if the last Read()
+/// blocks for a bit.
+TEST_F(AsyncReadStreamTest, Return3LastIsBlocked) {
+  SimpleBarrier client_barrier;
+  SimpleBarrier server_barrier;
+  impl_.SetCallback(
+      [this, &client_barrier, &server_barrier](
+          grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+          grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+              writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        WriteOne(writer, 2);
+        client_barrier.Lift();
+        server_barrier.Wait();
+        return grpc::Status::OK;
+      });
+
+  HandlerResult result;
+  auto on_read = [&client_barrier, &server_barrier,
+                  &result](btproto::MutateRowsResponse r) {
+    result.reads.emplace_back(std::move(r));
+    if (result.reads.size() == 3U) {
+      client_barrier.Wait();
+      server_barrier.Lift();
+    }
+    return make_ready_future(true);
+  };
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context), on_read,
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  ASSERT_EQ(3U, result.reads.size());
+  ASSERT_STATUS_OK(result.status);
+  for (int i = 0; i != 3; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+}
+
+/// @test Verify that AsyncReadStream::Cancel() works in the middle of a Read().
+TEST_F(AsyncReadStreamTest, CancelWhileBlocked) {
+  SimpleBarrier client_barrier;
+  SimpleBarrier server_barrier;
+  impl_.SetCallback(
+      [this, &client_barrier, &server_barrier](
+          grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+          grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+              writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        client_barrier.Lift();
+        server_barrier.Wait();
+        WriteOne(writer, 2);
+        return grpc::Status::OK;
+      });
+
+  HandlerResult result;
+  auto on_read = [&client_barrier, &result](btproto::MutateRowsResponse r) {
+    result.reads.emplace_back(std::move(r));
+    if (result.reads.size() == 2U) {
+      client_barrier.Wait();
+      return make_ready_future(false);
+    }
+    return make_ready_future(true);
+  };
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context), on_read,
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  // The server remains blocked until the stream finishes, therefore, the only
+  // way this actually unblocks is if the Cancel() succeeds.
+  result.done.Wait();
+  ASSERT_EQ(2U, result.reads.size());
+  EXPECT_EQ(StatusCode::kCancelled, result.status.code());
+  for (int i = 0; i != 2; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+
+  // The barriers go out of scope when this function exits, but the server may
+  // still be using them, so wait for the server to shutdown before leaving the
+  // scope.
+  server_barrier.Lift();
+  WaitForServerShutdown();
+}
+
+/// @test Verify that AsyncReadStream works when one calls Cancel() more than
+/// once.
+TEST_F(AsyncReadStreamTest, DoubleCancel) {
+  SimpleBarrier server_sent_responses_barrier;
+  SimpleBarrier cancel_done_server_barrier;
+  impl_.SetCallback(
+      [this, &server_sent_responses_barrier, &cancel_done_server_barrier](
+          grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+          grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+              writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        server_sent_responses_barrier.Lift();
+        cancel_done_server_barrier.Wait();
+        WriteOne(writer, 2);
+        return grpc::Status::OK;
+      });
+
+  HandlerResult result;
+  SimpleBarrier read_received_barrier;
+  SimpleBarrier cancel_done_read_barrier;
+  auto on_read = [&read_received_barrier, &cancel_done_read_barrier,
+                  &result](btproto::MutateRowsResponse r) {
+    result.reads.emplace_back(std::move(r));
+    if (result.reads.size() == 2U) {
+      read_received_barrier.Lift();
+      cancel_done_read_barrier.Wait();
+    }
+    return make_ready_future(true);
+  };
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  auto op = cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context), on_read,
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  server_sent_responses_barrier.Wait();
+  read_received_barrier.Wait();
+  op->Cancel();
+  op->Cancel();
+  cancel_done_server_barrier.Lift();
+  cancel_done_read_barrier.Lift();
+
+  // The server remains blocked until the stream finishes, therefore, the only
+  // way this actually unblocks is if the Cancel() succeeds.
+  result.done.Wait();
+  ASSERT_EQ(2U, result.reads.size());
+  EXPECT_EQ(StatusCode::kCancelled, result.status.code());
+  for (int i = 0; i != 2; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+
+  // The barriers go out of scope when this function exits, but the server may
+  // still be using them, so wait for the server to shutdown before leaving the
+  // scope.
+  WaitForServerShutdown();
+}
+
+/// @test Verify that AsyncReadStream works when one Cancels() before reading.
+TEST_F(AsyncReadStreamTest, CancelBeforeRead) {
+  SimpleBarrier server_started_barrier;
+  SimpleBarrier cancel_done_server_barrier;
+  impl_.SetCallback(
+      [this, &server_started_barrier, &cancel_done_server_barrier](
+          grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+          grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+              writer) {
+        server_started_barrier.Lift();
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        WriteOne(writer, 2);
+        cancel_done_server_barrier.Wait();
+        return grpc::Status::OK;
+      });
+
+  HandlerResult result;
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  auto op = cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  server_started_barrier.Wait();
+  op->Cancel();
+
+  // The server remains blocked until the stream finishes, therefore, the only
+  // way this actually unblocks is if the Cancel() succeeds.
+  result.done.Wait();
+  // There is no guarantee on how many messages will be received before the
+  // cancel succeeds, so do not even try to check that.
+  EXPECT_EQ(StatusCode::kCancelled, result.status.code());
+
+  // The barriers go out of scope when this function exits, but the server may
+  // still be using them, so wait for the server to shutdown before leaving the
+  // scope.
+  cancel_done_server_barrier.Lift();
+  WaitForServerShutdown();
+}
+
+/// @test Verify that AsyncReadStream works event if Cancel() is misused.
+TEST_F(AsyncReadStreamTest, CancelAfterFinish) {
+  impl_.SetCallback(
+      [this](grpc::ServerContext*,
+             google::bigtable::v2::MutateRowsRequest const*,
+             grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+                 writer) {
+        WriteOne(writer, 0);
+        WriteOne(writer, 1);
+        WriteLast(writer, 2);
+        return grpc::Status::OK;
+      });
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  SimpleBarrier on_finish_stop_before_cancel;
+  SimpleBarrier on_finish_continue_after_cancel;
+  auto on_finish = [&result, &on_finish_stop_before_cancel,
+                    &on_finish_continue_after_cancel](Status s) {
+    result.status = std::move(s);
+    on_finish_stop_before_cancel.Lift();
+    on_finish_continue_after_cancel.Wait();
+    result.done.Lift();
+  };
+  auto op = cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        return make_ready_future(true);
+      },
+      on_finish);
+
+  // Call Cancel() while the on_finish() callback is running.
+  on_finish_stop_before_cancel.Wait();
+  op->Cancel();
+  on_finish_continue_after_cancel.Lift();
+
+  result.done.Wait();
+  EXPECT_STATUS_OK(result.status);
+  ASSERT_EQ(3U, result.reads.size());
+  for (int i = 0; i != 3; ++i) {
+    SCOPED_TRACE("Running iteration: " + std::to_string(i));
+    ASSERT_EQ(1, result.reads[0].entries_size());
+    EXPECT_EQ(0, result.reads[0].entries(0).index());
+  }
+}
+
+/// @test Verify that AsyncReadStream works event if Cancel() is misused.
+TEST_F(AsyncReadStreamTest, DiscardAfterReturningFalse) {
+  impl_.SetCallback(
+      [this](grpc::ServerContext*,
+             google::bigtable::v2::MutateRowsRequest const*,
+             grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+                 writer) {
+        for (int i = 0; i != 10; ++i) {
+          WriteOne(writer, i);
+        }
+        WriteLast(writer, 10);
+        return grpc::Status::OK;
+      });
+
+  btproto::MutateRowsRequest request;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  HandlerResult result;
+  auto op = cq_.MakeStreamingReadRpc(
+      [this](grpc::ClientContext* context,
+             btproto::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return stub_->PrepareAsyncMutateRows(context, request, cq);
+      },
+      request, std::move(context),
+      [&result](btproto::MutateRowsResponse r) {
+        result.reads.emplace_back(std::move(r));
+        // Cancel on *every* request, we do not expect additional calls after
+        // the first one.
+        return make_ready_future(false);
+      },
+      [&result](Status s) {
+        result.status = std::move(s);
+        result.done.Lift();
+      });
+
+  result.done.Wait();
+  ASSERT_EQ(StatusCode::kCancelled, result.status.code());
+  ASSERT_EQ(1U, result.reads.size());
+}
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/bigtable_client.bzl
+++ b/google/cloud/bigtable/bigtable_client.bzl
@@ -44,6 +44,7 @@ bigtable_client_hdrs = [
     "internal/async_loop_op.h",
     "internal/async_op_traits.h",
     "internal/async_poll_op.h",
+    "internal/async_read_stream_impl.h",
     "internal/async_sample_row_keys.h",
     "internal/async_read_row_operation.h",
     "internal/async_retry_multi_page.h",

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -22,6 +22,7 @@ bigtable_client_unit_tests = [
     "async_list_app_profiles_test.cc",
     "async_list_clusters_test.cc",
     "async_list_instances_test.cc",
+    "async_read_stream_test.cc",
     "bigtable_version_test.cc",
     "cell_test.cc",
     "client_options_test.cc",

--- a/google/cloud/bigtable/completion_queue.h
+++ b/google/cloud/bigtable/completion_queue.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_COMPLETION_QUEUE_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_COMPLETION_QUEUE_H_
 
+#include "google/cloud/bigtable/internal/async_read_stream_impl.h"
 #include "google/cloud/bigtable/internal/completion_queue_impl.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/future.h"
@@ -110,6 +111,50 @@ class CompletionQueue {
     void* tag = impl_->RegisterOperation(op);
     op->Start(async_call, std::move(context), request, &impl_->cq(), tag);
     return op->GetFuture();
+  }
+
+  /**
+   * Make an asynchronous streaming read RPC.
+   *
+   * Reading from the stream starts automatically, and the handler is notified
+   * of all interesting events in the stream. Note that then handler is called
+   * by any thread blocked on this object's Run() member function. However, only
+   * one callback in the handler is called at a time.
+   *
+   * @param async_call a callable to start the asynchronous RPC.
+   * @param request the contents of the request.
+   * @param context an initialized request context to make the call.
+   * @param on_read the callback to be invoked on each successful Read().
+   * @param on_finish the callback to be invoked when the stream is closed.
+   *
+   * @tparam AsyncCallType the type of @a async_call. It must be invocable with
+   *     parameters
+   *     `(grpc::ClientContext*, RequestType const&, grpc::CompletionQueue*)`.
+   *     Furthermore, it should return a type convertible to
+   *     `std::unique_ptr<grpc::ClientAsyncReaderInterface<Response>>>`.
+   *     These requirements are verified by
+   *     `internal::AsyncStreamingReadRpcUnwrap<>`, and this function is
+   *     excluded from overload resolution if the parameters do not meet these
+   *     requirements.
+   * @tparam Request the type of the request in the streaming RPC.
+   * @tparam Response the type of the response in the streaming RPC.
+   * @tparam OnReadHandler the type of the @p on_read callback.
+   * @tparam OnReadFinish the type of the @p on_read callback.
+   */
+  template <typename AsyncCallType, typename Request,
+            typename Response = typename internal::
+                AsyncStreamingReadResponseType<AsyncCallType, Request>::type,
+            typename OnReadHandler, typename OnFinishHandler>
+  std::shared_ptr<AsyncOperation> MakeStreamingReadRpc(
+      AsyncCallType&& async_call, Request const& request,
+      std::unique_ptr<grpc::ClientContext> context, OnReadHandler&& on_read,
+      OnFinishHandler&& on_finish) {
+    auto stream = internal::MakeAsyncReadStreamImpl<Response>(
+        std::forward<OnReadHandler>(on_read),
+        std::forward<OnFinishHandler>(on_finish));
+    stream->Start(std::forward<AsyncCallType>(async_call), request,
+                  std::move(context), impl_);
+    return stream;
   }
 
   //@{

--- a/google/cloud/bigtable/completion_queue.h
+++ b/google/cloud/bigtable/completion_queue.h
@@ -139,7 +139,7 @@ class CompletionQueue {
    * @tparam Request the type of the request in the streaming RPC.
    * @tparam Response the type of the response in the streaming RPC.
    * @tparam OnReadHandler the type of the @p on_read callback.
-   * @tparam OnReadFinish the type of the @p on_read callback.
+   * @tparam OnFinishHandler the type of the @p on_finish callback.
    */
   template <typename AsyncCallType, typename Request,
             typename Response = typename internal::

--- a/google/cloud/bigtable/internal/async_read_stream_impl.h
+++ b/google/cloud/bigtable/internal/async_read_stream_impl.h
@@ -1,0 +1,350 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_READ_STREAM_IMPL_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_READ_STREAM_IMPL_H_
+
+#include "google/cloud/bigtable/internal/completion_queue_impl.h"
+#include "google/cloud/bigtable/version.h"
+
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+/**
+ * A meta function to extract the `ResponseType` from an AsyncStreamingReadCall
+ * return type.
+ *
+ * This meta function extracts, if possible, the response type from an
+ * asynchronous streaming read RPC callable. These callables return a
+ * `std::unique_ptr<grpc::ClientAsyncReaderInterface<T>>` and we are
+ * interested in the `T` type.
+ *
+ * This is the generic version, implementing the "does not match the expected
+ * type" path.
+ */
+template <typename ResponseType>
+struct AsyncStreamingReadRpcUnwrap {};
+
+/**
+ * A meta function to extract the `ResponseType` from an AsyncStreamingReadCall
+ * return type.
+ *
+ * This meta function extracts, if possible, the response type from an
+ * asynchronous streaming read RPC callable. These callables return a
+ * `std::unique_ptr<grpc::ClientAsyncReaderInterface<T>>` and we are
+ * interested in the `T` type.
+ *
+ * This is the specialization implementing the "matched with the expected type"
+ * path.
+ */
+template <typename ResponseType>
+struct AsyncStreamingReadRpcUnwrap<
+    std::unique_ptr<grpc::ClientAsyncReaderInterface<ResponseType>>> {
+  using type = ResponseType;
+};
+
+/**
+ * A meta function to determine the `ResponseType` from an asynchronous\
+ * streaming read RPC callable.
+ *
+ * Asynchronous streaming read RPC calls have the form:
+ *
+ * @code
+ *   std::unique_ptr<grpc::ClientAsyncReaderInterface<ResponseType>>(
+ *      grpc::ClientContext*,
+ *      RequestType const&,
+ *      grpc::CompletionQueue*
+ *   );
+ * @endcode
+ *
+ * This meta-function extracts the `ResponseType` given the type of a callable
+ * and the `RequestType`.
+ */
+template <typename AsyncCallType, typename RequestType>
+using AsyncStreamingReadResponseType = AsyncStreamingReadRpcUnwrap<
+    typename google::cloud::internal::invoke_result_t<
+        AsyncCallType, grpc::ClientContext*, RequestType const&,
+        grpc::CompletionQueue*>>;
+
+/**
+ * Read responses from a asynchronous streaming read RPC and invoke callbacks.
+ *
+ * This class starts a streaming read RPC, reads all the responses, and invokes
+ * the user-provided callbacks for each successful Read() result and the final
+ * result for a Finish() request.
+ *
+ * Objects of this class need to live for as long as there are pending calls
+ * on it. We use `std::enable_shared_from_this<>` keep this object alive until
+ * the last callback finishes. This means the objects must always be owned by
+ * a `shared_ptr`. This is enforced by making the constructor private and the
+ * one factory function returns a `shared_ptr`.
+ *
+ * @tparam Response the type of the responses in the streaming read RPC.
+ * @tparam OnReadHandler the type of the user-provided callable to handle Read
+ *     responses.
+ * @tparam OnFinishHandler the type of the user-provided callback to handle
+ *     Finish responses.
+ */
+template <typename Response, typename OnReadHandler, typename OnFinishHandler>
+class AsyncReadStreamImpl
+    : public AsyncOperation,
+      public std::enable_shared_from_this<
+          AsyncReadStreamImpl<Response, OnReadHandler, OnFinishHandler>> {
+ public:
+  /**
+   * Create a new instance.
+   *
+   * @param on_read the handler for a successful `Read()` result. Failed
+   *   `Read()` operations automatically terminate the loop and call `Finish()`.
+   * @param on_finish the handler for a completed `Finish()` result.
+   */
+  static std::shared_ptr<AsyncReadStreamImpl> Create(
+      OnReadHandler&& on_read, OnFinishHandler&& on_finish) {
+    return std::shared_ptr<AsyncReadStreamImpl>(
+        new AsyncReadStreamImpl(std::forward<OnReadHandler>(on_read),
+                                std::forward<OnFinishHandler>(on_finish)));
+  }
+
+  /**
+   * Start the asynchronous streaming read request and its read loop.
+   *
+   * @param async_call the function that will make the asynchronous
+   *     streaming read RPC.  This is typically a wrapper around one of the
+   *     gRPC-generated `PrepareAsync*()` functions.
+   * @param request the request parameter for the streaming read RPC.
+   * @param context the client context to control the streaming read RPC.
+   * @param cq the completion queue that will execute the streaming read RPC. It
+   *     is the application's responsibility to keep a thread pool to execute
+   *     the completion queue loop.
+   *
+   * @tparam AsyncFunctionType the type for @p async_call.
+   * @tparam Request the type for @p request.
+   *
+   */
+  template <typename AsyncFunctionType, typename Request>
+  void Start(AsyncFunctionType&& async_call, Request const& request,
+             std::unique_ptr<grpc::ClientContext> context,
+             std::shared_ptr<CompletionQueueImpl> cq) {
+    // An adapter to call OnStart() via the completion queue.
+    class NotifyStart final : public AsyncGrpcOperation {
+     public:
+      explicit NotifyStart(std::shared_ptr<AsyncReadStreamImpl> c)
+          : control_(std::move(c)) {}
+
+     private:
+      void Cancel() override {}  // LCOV_EXCL_LINE
+      bool Notify(CompletionQueue&, bool ok) override {
+        control_->OnStart(ok);
+        return true;
+      }
+      std::shared_ptr<AsyncReadStreamImpl> control_;
+    };
+
+    context_ = std::move(context);
+    cq_ = std::move(cq);
+    reader_ = async_call(context_.get(), request, &cq_->cq());
+    auto self = this->shared_from_this();
+    auto callback = std::make_shared<NotifyStart>(self);
+    void* tag = cq_->RegisterOperation(std::move(callback));
+    reader_->StartCall(tag);
+  }
+
+  /// Cancel the current streaming read RPC.
+  void Cancel() override { context_->TryCancel(); }
+
+ private:
+  /// Handle a completed `Start()` request.
+  void OnStart(bool ok) {
+    if (!ok) {
+      Finish();
+      return;
+    }
+    Read();
+  }
+
+  /// Start a `Read()` request.
+  void Read() {
+    // An adapter to call `OnRead()` via the completion queue.
+    class NotifyRead final : public AsyncGrpcOperation {
+     public:
+      explicit NotifyRead(std::shared_ptr<AsyncReadStreamImpl> c)
+          : control_(std::move(c)) {}
+
+      Response response;
+
+     private:
+      void Cancel() override {}  // LCOV_EXCL_LINE
+      bool Notify(CompletionQueue&, bool ok) override {
+        control_->OnRead(ok, std::move(response));
+        return true;
+      }
+      std::shared_ptr<AsyncReadStreamImpl> control_;
+    };
+
+    auto self = this->shared_from_this();
+    auto callback = std::make_shared<NotifyRead>(self);
+    auto response = &callback->response;
+    void* tag = cq_->RegisterOperation(std::move(callback));
+    reader_->Read(response, tag);
+  }
+
+  /// Handle the result of a `Read()` call.
+  void OnRead(bool ok, Response response) {
+    if (!ok) {
+      Finish();
+      return;
+    }
+
+    auto continue_reading = on_read_(std::move(response));
+    auto self = this->shared_from_this();
+    continue_reading.then([self](future<bool> result) {
+      if (!result.get()) {
+        // Cancel the stream, this is what the user meant by returning `false`.
+        self->Cancel();
+        // Start discarding messages, gRPC requires that any pending messages
+        // are read before calling Finish(). So we need to read until the first
+        // message that returns ok==false.
+        self->Discard();
+        return;
+      }
+      self->Read();
+    });
+  }
+
+  /// Start a Finish() request on the underlying read stream.
+  void Finish() {
+    // An adapter to call `OnFinish()` via the completion queue.
+    class NotifyFinish final : public AsyncGrpcOperation {
+     public:
+      explicit NotifyFinish(std::shared_ptr<AsyncReadStreamImpl> c)
+          : control_(std::move(c)) {}
+
+      grpc::Status status;
+
+     private:
+      void Cancel() override {}  // LCOV_EXCL_LINE
+      bool Notify(CompletionQueue&, bool ok) override {
+        control_->OnFinish(ok, MakeStatusFromRpcError(status));
+        return true;
+      }
+      std::shared_ptr<AsyncReadStreamImpl> control_;
+    };
+
+    auto self = this->shared_from_this();
+    auto callback = std::make_shared<NotifyFinish>(self);
+    auto status = &callback->status;
+    void* tag = cq_->RegisterOperation(std::move(callback));
+    reader_->Finish(status, tag);
+  }
+
+  /// Handle the result of a Finish() request.
+  void OnFinish(bool, Status status) { on_finish_(std::move(status)); }
+
+  /**
+   * Discard all the messages until OnRead() receives a failure.
+   *
+   * gRPC requires that `Finish()` be called only once all received values have
+   * been discarded. When we cancel a request as a result of `OnRead()`
+   * returning false we need to ignore future messages before calling
+   * `Finish()`.
+   */
+  void Discard() {
+    // An adapter to call `OnDiscard()` via the completion queue.
+    class NotifyDiscard final : public AsyncGrpcOperation {
+     public:
+      explicit NotifyDiscard(std::shared_ptr<AsyncReadStreamImpl> c)
+          : control_(std::move(c)) {}
+
+      Response response;
+
+     private:
+      void Cancel() override {}  // LCOV_EXCL_LINE
+      bool Notify(CompletionQueue&, bool ok) override {
+        control_->OnDiscard(ok, std::move(response));
+        return true;
+      }
+      std::shared_ptr<AsyncReadStreamImpl> control_;
+    };
+
+    auto self = this->shared_from_this();
+    auto callback = std::make_shared<NotifyDiscard>(self);
+    auto response = &callback->response;
+    void* tag = cq_->RegisterOperation(std::move(callback));
+    reader_->Read(response, tag);
+  }
+
+  /// Handle the result of a Discard() call.
+  void OnDiscard(bool ok, Response r) {
+    if (!ok) {
+      Finish();
+      return;
+    }
+    Discard();
+  }
+
+ private:
+  explicit AsyncReadStreamImpl(OnReadHandler&& on_read,
+                               OnFinishHandler&& on_finish)
+      : on_read_(std::move(on_read)), on_finish_(std::move(on_finish)) {}
+
+  typename std::decay<OnReadHandler>::type on_read_;
+  typename std::decay<OnFinishHandler>::type on_finish_;
+  std::unique_ptr<grpc::ClientContext> context_;
+  std::shared_ptr<CompletionQueueImpl> cq_;
+  std::unique_ptr<grpc::ClientAsyncReaderInterface<Response>> reader_;
+};
+
+/**
+ * The analogous of `make_shared<>` for `AsyncReadStreamImpl<Response>`.
+ *
+ *
+ * @param on_read the handler for a successful `Read()` result. Failed
+ *   `Read()` operations automatically terminate the loop and call `Finish()`.
+ * @param on_finish the handler for a completed `Finish()` result.
+ *
+ * @tparam Response the type of the response.
+ * @tparam OnReadHandler the type of @p on_read.
+ * @tparam OnFinishHandler the type of @p on_finish.
+ */
+template <
+    typename Response, typename OnReadHandler, typename OnFinishHandler,
+    typename std::enable_if<
+        google::cloud::internal::is_invocable<OnReadHandler, Response>::value,
+        int>::type on_read_is_invocable_with_response = 0,
+    typename std::enable_if<
+        std::is_same<future<bool>, google::cloud::internal::invoke_result_t<
+                                       OnReadHandler, Response>>::value,
+        int>::type on_read_returns_future_bool = 0,
+    typename std::enable_if<
+        google::cloud::internal::is_invocable<OnFinishHandler, Status>::value,
+        int>::type on_finish_is_invocable_with_status = 0>
+inline std::shared_ptr<
+    AsyncReadStreamImpl<Response, OnReadHandler, OnFinishHandler>>
+MakeAsyncReadStreamImpl(OnReadHandler&& on_read, OnFinishHandler&& on_finish) {
+  return AsyncReadStreamImpl<Response, OnReadHandler, OnFinishHandler>::Create(
+      std::forward<OnReadHandler>(on_read),
+      std::forward<OnFinishHandler>(on_finish));
+}
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_READ_STREAM_IMPL_H_

--- a/google/cloud/bigtable/internal/async_read_stream_impl.h
+++ b/google/cloud/bigtable/internal/async_read_stream_impl.h
@@ -89,9 +89,9 @@ using AsyncStreamingReadResponseType = AsyncStreamingReadRpcUnwrap<
  * result for a Finish() request.
  *
  * Objects of this class need to live for as long as there are pending calls
- * on it. We use `std::enable_shared_from_this<>` keep this object alive until
- * the last callback finishes. This means the objects must always be owned by
- * a `shared_ptr`. This is enforced by making the constructor private and the
+ * on it. We use `std::enable_shared_from_this<>` to keep this object alive
+ * until the last callback finishes. This means the objects must always be owned
+ * by a `shared_ptr`. This is enforced by making the constructor private and the
  * one factory function returns a `shared_ptr`.
  *
  * @tparam Response the type of the responses in the streaming read RPC.
@@ -134,7 +134,6 @@ class AsyncReadStreamImpl
    *
    * @tparam AsyncFunctionType the type for @p async_call.
    * @tparam Request the type for @p request.
-   *
    */
   template <typename AsyncFunctionType, typename Request>
   void Start(AsyncFunctionType&& async_call, Request const& request,
@@ -158,8 +157,7 @@ class AsyncReadStreamImpl
     context_ = std::move(context);
     cq_ = std::move(cq);
     reader_ = async_call(context_.get(), request, &cq_->cq());
-    auto self = this->shared_from_this();
-    auto callback = std::make_shared<NotifyStart>(self);
+    auto callback = std::make_shared<NotifyStart>(this->shared_from_this());
     void* tag = cq_->RegisterOperation(std::move(callback));
     reader_->StartCall(tag);
   }
@@ -196,8 +194,7 @@ class AsyncReadStreamImpl
       std::shared_ptr<AsyncReadStreamImpl> control_;
     };
 
-    auto self = this->shared_from_this();
-    auto callback = std::make_shared<NotifyRead>(self);
+    auto callback = std::make_shared<NotifyRead>(this->shared_from_this());
     auto response = &callback->response;
     void* tag = cq_->RegisterOperation(std::move(callback));
     reader_->Read(response, tag);
@@ -245,8 +242,7 @@ class AsyncReadStreamImpl
       std::shared_ptr<AsyncReadStreamImpl> control_;
     };
 
-    auto self = this->shared_from_this();
-    auto callback = std::make_shared<NotifyFinish>(self);
+    auto callback = std::make_shared<NotifyFinish>(this->shared_from_this());
     auto status = &callback->status;
     void* tag = cq_->RegisterOperation(std::move(callback));
     reader_->Finish(status, tag);
@@ -281,8 +277,7 @@ class AsyncReadStreamImpl
       std::shared_ptr<AsyncReadStreamImpl> control_;
     };
 
-    auto self = this->shared_from_this();
-    auto callback = std::make_shared<NotifyDiscard>(self);
+    auto callback = std::make_shared<NotifyDiscard>(this->shared_from_this());
     auto response = &callback->response;
     void* tag = cq_->RegisterOperation(std::move(callback));
     reader_->Read(response, tag);
@@ -297,7 +292,6 @@ class AsyncReadStreamImpl
     Discard();
   }
 
- private:
   explicit AsyncReadStreamImpl(OnReadHandler&& on_read,
                                OnFinishHandler&& on_finish)
       : on_read_(std::move(on_read)), on_finish_(std::move(on_finish)) {}
@@ -311,7 +305,6 @@ class AsyncReadStreamImpl
 
 /**
  * The analogous of `make_shared<>` for `AsyncReadStreamImpl<Response>`.
- *
  *
  * @param on_read the handler for a successful `Read()` result. Failed
  *   `Read()` operations automatically terminate the loop and call `Finish()`.

--- a/google/cloud/bigtable/internal/async_read_stream_impl.h
+++ b/google/cloud/bigtable/internal/async_read_stream_impl.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/bigtable/internal/completion_queue_impl.h"
 #include "google/cloud/bigtable/version.h"
-
 #include <memory>
 
 namespace google {


### PR DESCRIPTION
This introduces a new way to implement the even loop for a streaming
read RPC. This version uses callables (as opposed to pointers to member
functions) to wrap the call that creates a asynchronous streaming read
RPC, I think those are more readable (and allegedly more efficient).

This version also uses the `PrepareAsync*()` generated functions, which
are less racy than `Async*()`. The latter immediately start the loop by
calling `Start()` on the streaming read RPC, which can create a race
because the most common action in response to a successful `Start()` is
to call `Read()` on the returned `ClientAsyncReader<>`, but said reader
may not have been returned yet.

I apologize for the large PR. Most of it is tests (the usual excuse), but the
main class is (I think) fairly monolithic.

This fixes #1387, it introduces several tests that successfully cancel a streaming
read RPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2533)
<!-- Reviewable:end -->
