### PR TITLE
Rename AsyncBulkApply support classes.

### DIFF
--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -31,7 +31,7 @@ namespace noex {
 class Table;
 }  // namespace noex
 namespace internal {
-class AsyncBulkMutator;
+class AsyncBulkMutatorNoex;
 class AsyncSampleRowKeys;
 class BulkMutator;
 template <typename ReadRowCallback,
@@ -91,7 +91,7 @@ class DataClient {
  protected:
   friend class Table;
   friend class noex::Table;
-  friend class internal::AsyncBulkMutator;
+  friend class internal::AsyncBulkMutatorNoex;
   friend class internal::AsyncSampleRowKeys;
   friend class internal::BulkMutator;
   friend class RowReader;

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -60,49 +60,51 @@ template <typename Functor,
                   Functor, CompletionQueue&, std::vector<FailedMutation>&,
                   grpc::Status&>::value,
               int>::type valid_callback_type = 0>
-class AsyncRetryBulkApply : public AsyncRetryOp<ConstantIdempotencyPolicy,
-                                                Functor, AsyncBulkMutator> {
+class AsyncRetryBulkApplyNoex
+    : public AsyncRetryOp<ConstantIdempotencyPolicy, Functor,
+                          AsyncBulkMutatorNoex> {
  public:
-  using MutationsSucceededFunctor = AsyncBulkMutator::MutationsSucceededFunctor;
-  using MutationsFailedFunctor = AsyncBulkMutator::MutationsFailedFunctor;
-  using AttemptFinishedFunctor = AsyncBulkMutator::AttemptFinishedFunctor;
+  using MutationsSucceededFunctor =
+      AsyncBulkMutatorNoex::MutationsSucceededFunctor;
+  using MutationsFailedFunctor = AsyncBulkMutatorNoex::MutationsFailedFunctor;
+  using AttemptFinishedFunctor = AsyncBulkMutatorNoex::AttemptFinishedFunctor;
 
-  AsyncRetryBulkApply(std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-                      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-                      IdempotentMutationPolicy& idempotent_policy,
-                      MetadataUpdatePolicy metadata_update_policy,
-                      std::shared_ptr<bigtable::DataClient> client,
-                      bigtable::AppProfileId const& app_profile_id,
-                      bigtable::TableId const& table_name, BulkMutation mut,
-                      Functor callback)
-      : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutator>(
+  AsyncRetryBulkApplyNoex(std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+                          std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+                          IdempotentMutationPolicy& idempotent_policy,
+                          MetadataUpdatePolicy metadata_update_policy,
+                          std::shared_ptr<bigtable::DataClient> client,
+                          bigtable::AppProfileId const& app_profile_id,
+                          bigtable::TableId const& table_name, BulkMutation mut,
+                          Functor callback)
+      : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutatorNoex>(
             __func__, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
             // of the mutations it holds.
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
             std::move(metadata_update_policy), std::move(callback),
-            AsyncBulkMutator(client, std::move(app_profile_id),
-                             std::move(table_name), idempotent_policy,
-                             std::move(mut))) {}
+            AsyncBulkMutatorNoex(client, std::move(app_profile_id),
+                                 std::move(table_name), idempotent_policy,
+                                 std::move(mut))) {}
 
-  AsyncRetryBulkApply(std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
-                      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-                      IdempotentMutationPolicy& idempotent_policy,
-                      MetadataUpdatePolicy metadata_update_policy,
-                      std::shared_ptr<bigtable::DataClient> client,
-                      bigtable::AppProfileId const& app_profile_id,
-                      bigtable::TableId const& table_name, BulkMutation mut,
-                      MutationsSucceededFunctor mutations_succeeded_callback,
-                      MutationsFailedFunctor mutations_failed_callback,
-                      AttemptFinishedFunctor attempt_finished_callback,
-                      Functor callback)
-      : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutator>(
+  AsyncRetryBulkApplyNoex(
+      std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
+      std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+      IdempotentMutationPolicy& idempotent_policy,
+      MetadataUpdatePolicy metadata_update_policy,
+      std::shared_ptr<bigtable::DataClient> client,
+      bigtable::AppProfileId const& app_profile_id,
+      bigtable::TableId const& table_name, BulkMutation mut,
+      MutationsSucceededFunctor mutations_succeeded_callback,
+      MutationsFailedFunctor mutations_failed_callback,
+      AttemptFinishedFunctor attempt_finished_callback, Functor callback)
+      : AsyncRetryOp<ConstantIdempotencyPolicy, Functor, AsyncBulkMutatorNoex>(
             __func__, std::move(rpc_retry_policy),
             // BulkMutator is idempotent because it keeps track of idempotency
             // of the mutations it holds.
             std::move(rpc_backoff_policy), ConstantIdempotencyPolicy(true),
             std::move(metadata_update_policy), std::move(callback),
-            AsyncBulkMutator(
+            AsyncBulkMutatorNoex(
                 client, std::move(app_profile_id), std::move(table_name),
                 idempotent_policy, std::move(mutations_succeeded_callback),
                 std::move(mutations_failed_callback),

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -120,7 +120,7 @@ class BulkMutator {
  * It extends the normal BulkMutator with logic to do its job asynchronously.
  * Conceptually it reimplements MakeOneRequest in an async way.
  */
-class AsyncBulkMutator : private BulkMutator {
+class AsyncBulkMutatorNoex : private BulkMutator {
  public:
   using MutationsSucceededFunctor =
       std::function<void(CompletionQueue&, std::vector<int>)>;
@@ -129,23 +129,23 @@ class AsyncBulkMutator : private BulkMutator {
   using AttemptFinishedFunctor =
       std::function<void(CompletionQueue&, grpc::Status&)>;
 
-  AsyncBulkMutator(std::shared_ptr<bigtable::DataClient> client,
-                   bigtable::AppProfileId const& app_profile_id,
-                   bigtable::TableId const& table_name,
-                   IdempotentMutationPolicy& idempotent_policy,
-                   BulkMutation mut)
+  AsyncBulkMutatorNoex(std::shared_ptr<bigtable::DataClient> client,
+                       bigtable::AppProfileId const& app_profile_id,
+                       bigtable::TableId const& table_name,
+                       IdempotentMutationPolicy& idempotent_policy,
+                       BulkMutation mut)
       : BulkMutator(app_profile_id, table_name, idempotent_policy,
                     std::move(mut)),
         client_(std::move(client)) {}
 
-  AsyncBulkMutator(std::shared_ptr<bigtable::DataClient> client,
-                   bigtable::AppProfileId const& app_profile_id,
-                   bigtable::TableId const& table_name,
-                   IdempotentMutationPolicy& idempotent_policy,
-                   MutationsSucceededFunctor mutations_succeeded_callback,
-                   MutationsFailedFunctor mutations_failed_callback,
-                   AttemptFinishedFunctor attempt_finished_callback,
-                   BulkMutation mut)
+  AsyncBulkMutatorNoex(std::shared_ptr<bigtable::DataClient> client,
+                       bigtable::AppProfileId const& app_profile_id,
+                       bigtable::TableId const& table_name,
+                       IdempotentMutationPolicy& idempotent_policy,
+                       MutationsSucceededFunctor mutations_succeeded_callback,
+                       MutationsFailedFunctor mutations_failed_callback,
+                       AttemptFinishedFunctor attempt_finished_callback,
+                       BulkMutation mut)
       : BulkMutator(app_profile_id, table_name, idempotent_policy,
                     std::move(mut)),
         client_(std::move(client)),
@@ -191,7 +191,7 @@ class AsyncBulkMutator : private BulkMutator {
                                                       grpc::Status&>::value,
                 int>::type valid_callback_type = 0>
   struct FinishedCallback {
-    FinishedCallback(AsyncBulkMutator& parent, Functor callback)
+    FinishedCallback(AsyncBulkMutatorNoex& parent, Functor callback)
         : parent_(parent), callback_(callback) {}
 
     void operator()(CompletionQueue& cq, grpc::ClientContext& context,
@@ -209,10 +209,10 @@ class AsyncBulkMutator : private BulkMutator {
       callback_(cq, status);
     }
 
-    // The user of AsyncBulkMutator has to make sure that it is not destructed
-    // before all callbacks return, so we have a guarantee that this reference
-    // is valid for as long as we don't call callback_.
-    AsyncBulkMutator& parent_;
+    // The user of AsyncBulkMutatorNoex has to make sure that it is not
+    // destructed before all callbacks return, so we have a guarantee that this
+    // reference is valid for as long as we don't call callback_.
+    AsyncBulkMutatorNoex& parent_;
     Functor callback_;
   };
 

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -523,9 +523,9 @@ TEST(MultipleRowsMutatorTest, SimpleAsync) {
       }));
 
   auto policy = bt::DefaultIdempotentMutationPolicy();
-  bt::internal::AsyncBulkMutator mutator(client, bigtable::AppProfileId(""),
-                                         bigtable::TableId("foo/bar/baz/table"),
-                                         *policy, std::move(mut));
+  bt::internal::AsyncBulkMutatorNoex mutator(
+      client, bigtable::AppProfileId(""),
+      bigtable::TableId("foo/bar/baz/table"), *policy, std::move(mut));
 
   auto impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
   using bigtable::CompletionQueue;
@@ -578,9 +578,9 @@ TEST(MultipleRowsMutatorTest, SimpleAsyncFailure) {
       }));
 
   auto policy = bt::DefaultIdempotentMutationPolicy();
-  bt::internal::AsyncBulkMutator mutator(client, bigtable::AppProfileId(""),
-                                         bigtable::TableId("foo/bar/baz/table"),
-                                         *policy, std::move(mut));
+  bt::internal::AsyncBulkMutatorNoex mutator(
+      client, bigtable::AppProfileId(""),
+      bigtable::TableId("foo/bar/baz/table"), *policy, std::move(mut));
 
   auto impl = std::make_shared<bigtable::testing::MockCompletionQueue>();
   using bigtable::CompletionQueue;

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -300,7 +300,7 @@ class Table {
                                                  Functor&& callback,
                                                  BulkMutation mut) {
     auto op =
-        std::make_shared<bigtable::internal::AsyncRetryBulkApply<Functor>>(
+        std::make_shared<bigtable::internal::AsyncRetryBulkApplyNoex<Functor>>(
             rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
             *idempotent_mutation_policy_, metadata_update_policy_, client_,
             app_profile_id_, table_name_, std::move(mut),
@@ -662,15 +662,15 @@ class Table {
                 int>::type valid_callback_type = 0>
   std::shared_ptr<AsyncOperation> StreamingAsyncBulkApply(
       CompletionQueue& cq,
-      typename internal::AsyncRetryBulkApply<Functor>::MutationsSucceededFunctor
-          mutations_succeeded_callback,
-      typename internal::AsyncRetryBulkApply<Functor>::MutationsFailedFunctor
-          mutations_failed_callback,
-      typename internal::AsyncRetryBulkApply<Functor>::AttemptFinishedFunctor
-          attempt_finished_callback,
+      typename internal::AsyncRetryBulkApplyNoex<
+          Functor>::MutationsSucceededFunctor mutations_succeeded_callback,
+      typename internal::AsyncRetryBulkApplyNoex<
+          Functor>::MutationsFailedFunctor mutations_failed_callback,
+      typename internal::AsyncRetryBulkApplyNoex<
+          Functor>::AttemptFinishedFunctor attempt_finished_callback,
       Functor&& callback, BulkMutation mut) {
     auto op =
-        std::make_shared<bigtable::internal::AsyncRetryBulkApply<Functor>>(
+        std::make_shared<bigtable::internal::AsyncRetryBulkApplyNoex<Functor>>(
             rpc_retry_policy_->clone(), rpc_backoff_policy_->clone(),
             *idempotent_mutation_policy_, metadata_update_policy_, client_,
             app_profile_id_, table_name_, std::move(mut),


### PR DESCRIPTION
The current classes will be deleted with all the `noex::` classes,
and I want to use their current names for the new
`Table::AsyncBulkApply()` implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2536)
<!-- Reviewable:end -->
