### PR TITLE
Refactor BulkMutator state to a separate class.

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -30,21 +30,29 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
-/// Keep the state in the Table::BulkApply() member function.
-class BulkMutator {
+class BulkMutatorState {
  public:
-  BulkMutator(bigtable::AppProfileId const& app_profile_id,
-              bigtable::TableId const& table_name,
-              IdempotentMutationPolicy& idempotent_policy, BulkMutation mut);
+  BulkMutatorState(bigtable::AppProfileId const& app_profile_id,
+                   bigtable::TableId const& table_name,
+                   IdempotentMutationPolicy& idempotent_policy,
+                   BulkMutation mut);
 
-  /// Return true if there are pending mutations in the mutator
   bool HasPendingMutations() const {
     return pending_mutations_.entries_size() != 0;
   }
 
-  /// Synchronously send one batch request to the given stub.
-  grpc::Status MakeOneRequest(bigtable::DataClient& client,
-                              grpc::ClientContext& client_context);
+  /// Returns the Request parameter for the next MutateRows() RPC.
+  google::bigtable::v2::MutateRowsRequest const& BeforeStart();
+
+  /**
+   * Handle the result of a `Read()` operation on the MutateRows RPC.
+   *
+   * Returns the original index of any successful operations.
+   */
+  std::vector<int> OnRead(google::bigtable::v2::MutateRowsResponse& response);
+
+  /// Handle the result of a `Finish()` operation on the MutateRows() RPC.
+  void OnFinish(google::cloud::Status finish_status);
 
   /**
    * Return the permanently failed mutations.
@@ -52,41 +60,34 @@ class BulkMutator {
    * This will return all the mutations which we've learned are definite
    * failures since since the last call to this member function.
    *
-   * Whatever is returned, will not be returned by `ExtractFinalFailures`.
+   * Whatever is returned, will not be returned by `OnRetryDone()`.
    */
   std::vector<FailedMutation> ConsumeAccumulatedFailures();
 
-  /// Give up on any pending mutations, move them to the failures array.
-  std::vector<FailedMutation> ExtractFinalFailures();
+  /// Terminate the retry loop and return all the failures.
+  std::vector<FailedMutation> OnRetryDone() &&;
 
- protected:
-  /// Get ready for a new request.
-  void PrepareForRequest();
+ private:
+  /// The current request proto.
+  google::bigtable::v2::MutateRowsRequest mutations_;
 
   /**
-   * Process a single response.
+   * The status of the last MutateRows() RPC
    *
-   * @return Original indices of mutations which have succeeded.
+   * This is useful when the RPC terminates before the state of each mutation is
+   * known, the result of the RPC is applied to any mutation with an unknown
+   * result.
    */
-  std::vector<int> ProcessResponse(
-      google::bigtable::v2::MutateRowsResponse& response);
-
-  /// A request has finished and we have processed all the responses.
-  void FinishRequest();
-
   google::cloud::Status last_status_;
 
   /// Accumulate any permanent failures and the list of mutations we gave up on.
   std::vector<FailedMutation> failures_;
 
-  /// The current request proto.
-  google::bigtable::v2::MutateRowsRequest mutations_;
-
   /**
    * A small type to keep the annotations about pending mutations.
    *
    * As we process a MutateRows RPC we need to track the partial results for
-   * each mutation in the request.  This object groups them in a small POD-type.
+   * each mutation in the request. This class groups them in a small POD-type.
    */
   struct Annotations {
     /**
@@ -98,7 +99,7 @@ class BulkMutator {
      */
     int original_index;
     bool is_idempotent;
-    /// Set to false if the result is unknown.
+    /// Set to `false` if the result is unknown.
     bool has_mutation_result;
   };
 
@@ -112,6 +113,27 @@ class BulkMutator {
   std::vector<Annotations> pending_annotations_;
 };
 
+/// Keep the state in the Table::BulkApply() member function.
+class BulkMutator {
+ public:
+  BulkMutator(bigtable::AppProfileId const& app_profile_id,
+              bigtable::TableId const& table_name,
+              IdempotentMutationPolicy& idempotent_policy, BulkMutation mut);
+
+  /// Return true if there are pending mutations in the mutator
+  bool HasPendingMutations() const { return state_.HasPendingMutations(); }
+
+  /// Synchronously send one batch request to the given stub.
+  grpc::Status MakeOneRequest(bigtable::DataClient& client,
+                              grpc::ClientContext& client_context);
+
+  /// Give up on any pending mutations, move them to the failures array.
+  std::vector<FailedMutation> OnRetryDone() &&;
+
+ protected:
+  BulkMutatorState state_;
+};
+
 /**
  * Async-friendly version BulkMutator.
  *
@@ -120,7 +142,7 @@ class BulkMutator {
  * It extends the normal BulkMutator with logic to do its job asynchronously.
  * Conceptually it reimplements MakeOneRequest in an async way.
  */
-class AsyncBulkMutatorNoex : private BulkMutator {
+class AsyncBulkMutatorNoex {
  public:
   using MutationsSucceededFunctor =
       std::function<void(CompletionQueue&, std::vector<int>)>;
@@ -134,8 +156,7 @@ class AsyncBulkMutatorNoex : private BulkMutator {
                        bigtable::TableId const& table_name,
                        IdempotentMutationPolicy& idempotent_policy,
                        BulkMutation mut)
-      : BulkMutator(app_profile_id, table_name, idempotent_policy,
-                    std::move(mut)),
+      : state_(app_profile_id, table_name, idempotent_policy, std::move(mut)),
         client_(std::move(client)) {}
 
   AsyncBulkMutatorNoex(std::shared_ptr<bigtable::DataClient> client,
@@ -146,8 +167,7 @@ class AsyncBulkMutatorNoex : private BulkMutator {
                        MutationsFailedFunctor mutations_failed_callback,
                        AttemptFinishedFunctor attempt_finished_callback,
                        BulkMutation mut)
-      : BulkMutator(app_profile_id, table_name, idempotent_policy,
-                    std::move(mut)),
+      : state_(app_profile_id, table_name, idempotent_policy, std::move(mut)),
         client_(std::move(client)),
         mutations_succeeded_callback_(std::move(mutations_succeeded_callback)),
         mutations_failed_callback_(std::move(mutations_failed_callback)),
@@ -164,24 +184,24 @@ class AsyncBulkMutatorNoex : private BulkMutator {
   std::shared_ptr<AsyncOperation> Start(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
       Functor&& callback) {
-    PrepareForRequest();
+    auto const& mutations = state_.BeforeStart();
     return cq.MakeUnaryStreamRpc(
-        *client_, &DataClient::AsyncMutateRows, mutations_, std::move(context),
+        *client_, &DataClient::AsyncMutateRows, mutations, std::move(context),
         [this](CompletionQueue& cq, const grpc::ClientContext&,
                google::bigtable::v2::MutateRowsResponse& response) {
-          std::vector<int> succeeded_mutations = ProcessResponse(response);
+          std::vector<int> succeeded_mutations = state_.OnRead(response);
           if (mutations_succeeded_callback_) {
             mutations_succeeded_callback_(cq, std::move(succeeded_mutations));
           }
           if (mutations_failed_callback_) {
-            mutations_failed_callback_(cq, ConsumeAccumulatedFailures());
+            mutations_failed_callback_(cq, state_.ConsumeAccumulatedFailures());
           }
         },
         FinishedCallback<Functor>(*this, std::forward<Functor>(callback)));
   }
 
   std::vector<FailedMutation> AccumulatedResult() {
-    return ExtractFinalFailures();
+    return std::move(state_).OnRetryDone();
   }
 
  private:
@@ -196,9 +216,9 @@ class AsyncBulkMutatorNoex : private BulkMutator {
 
     void operator()(CompletionQueue& cq, grpc::ClientContext& context,
                     grpc::Status& status) {
-      parent_.FinishRequest();
+      parent_.state_.OnFinish(MakeStatusFromRpcError(status));
 
-      if (parent_.HasPendingMutations() && status.ok()) {
+      if (parent_.state_.HasPendingMutations() && status.ok()) {
         status = grpc::Status(grpc::StatusCode::UNAVAILABLE,
                               "Some mutations were not confirmed");
       }
@@ -217,6 +237,7 @@ class AsyncBulkMutatorNoex : private BulkMutator {
   };
 
  private:
+  BulkMutatorState state_;
   std::shared_ptr<bigtable::DataClient> client_;
   MutationsSucceededFunctor mutations_succeeded_callback_;
   MutationsFailedFunctor mutations_failed_callback_;

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -75,7 +75,7 @@ TEST(MultipleRowsMutatorTest, Simple) {
   grpc::ClientContext context;
   auto status = mutator.MakeOneRequest(client, context);
   EXPECT_TRUE(status.ok());
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   EXPECT_TRUE(failures.empty());
 }
 
@@ -133,7 +133,7 @@ TEST(MultipleRowsMutatorTest, BulkApply_AppProfileId) {
   grpc::ClientContext context;
   auto status = mutator.MakeOneRequest(client, context);
   EXPECT_TRUE(status.ok());
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   EXPECT_TRUE(failures.empty());
 }
 
@@ -204,7 +204,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
     auto status = mutator.MakeOneRequest(client, context);
     EXPECT_TRUE(status.ok());
   }
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   EXPECT_TRUE(failures.empty());
 }
 
@@ -267,7 +267,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
     auto status = mutator.MakeOneRequest(client, context);
     EXPECT_TRUE(status.ok());
   }
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   ASSERT_EQ(1UL, failures.size());
   EXPECT_EQ(1, failures[0].original_index());
   // EXPECT_EQ("bar", failures[0].mutation().row_key());
@@ -330,7 +330,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
     auto status = mutator.MakeOneRequest(client, context);
     EXPECT_TRUE(status.ok());
   }
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   EXPECT_TRUE(failures.empty());
 }
 
@@ -409,7 +409,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
     auto status = mutator.MakeOneRequest(client, context);
     EXPECT_TRUE(status.ok());
   }
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   ASSERT_EQ(3UL, failures.size());
   EXPECT_EQ(0, failures[0].original_index());
   // EXPECT_EQ("foo", failures[0].mutation().row_key());
@@ -469,7 +469,7 @@ TEST(MultipleRowsMutatorTest, UnconfirmedAreFailed) {
   auto status = mutator.MakeOneRequest(client, context);
   EXPECT_FALSE(status.ok());
 
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   ASSERT_EQ(1UL, failures.size());
   EXPECT_EQ(1, failures[0].original_index());
   // EXPECT_EQ("bar", failures[0].mutation().row_key());

--- a/google/cloud/bigtable/internal/table.cc
+++ b/google/cloud/bigtable/internal/table.cc
@@ -109,7 +109,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut,
     auto delay = backoff_policy->OnCompletion(status);
     std::this_thread::sleep_for(delay);
   }
-  auto failures = mutator.ExtractFinalFailures();
+  auto failures = std::move(mutator).OnRetryDone();
   if (!status.ok()) {
     return failures;
   }

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -132,9 +132,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut) {
     auto delay = backoff_policy->OnCompletion(status);
     std::this_thread::sleep_for(delay);
   }
-  auto failures = mutator.ExtractFinalFailures();
-
-  return failures;
+  return std::move(mutator).OnRetryDone();
 }
 
 struct AsyncBulkApplyCb {


### PR DESCRIPTION
I think it is easier to reuse this class for both asynchronous and
synchronous mutators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2538)
<!-- Reviewable:end -->
