### PR TITLE
Fix noex build and improve build logs.

### DIFF
--- a/ci/install-retry.sh
+++ b/ci/install-retry.sh
@@ -36,8 +36,8 @@ min_wait=120
 # Do not exit on failures for this loop.
 set +e
 for i in 1 2 3; do
-  ${PROGRAM} "$@"
-  if [ $? -eq 0 ]; then
+  "${PROGRAM}" "$@"
+  if [[ $? -eq 0 ]]; then
     exit 0
   fi
   # Sleep for a few minutes before trying again.
@@ -46,3 +46,5 @@ for i in 1 2 3; do
   sleep ${period}s
   min_wait=$(( min_wait * 2 ))
 done
+
+exit 1

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -23,7 +23,6 @@ RUN apt update && \
         build-essential \
         ccache \
         clang \
-        clang-format-7 \
         cmake \
         curl \
         doxygen \


### PR DESCRIPTION
We cannot install `clang-format-7` on all versions of Ubuntu. We already install it on the
section of the Dockerfile for Ubuntu:18.04, so remove it from the generic section, and things
are happy.

I also changed the CI build scripts to actually print any errors while creating the docker images.
I could not figure out why the build was broken until I did that.

----

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2539)
<!-- Reviewable:end -->
