### PR TITLE
Implement examples for Apply() and BulkApply().

### DIFF
--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -111,11 +111,7 @@ void BulkApply(google::cloud::bigtable::Table table, int argc, char* argv[]) {
       mutation.emplace_back(
           cbt::SetCell("fam", "col0", "value0-" + std::to_string(i)));
       mutation.emplace_back(
-          cbt::SetCell("fam", "col1", "value2-" + std::to_string(i)));
-      mutation.emplace_back(
-          cbt::SetCell("fam", "col2", "value3-" + std::to_string(i)));
-      mutation.emplace_back(
-          cbt::SetCell("fam", "col3", "value4-" + std::to_string(i)));
+          cbt::SetCell("fam", "col1", "value1-" + std::to_string(i)));
       bulk.emplace_back(std::move(mutation));
     }
     auto failures = table.BulkApply(std::move(bulk));
@@ -863,8 +859,7 @@ void RenameColumn(google::cloud::bigtable::Table table, int argc,
   (std::move(table), key, family, old_name, new_name);
 }
 
-void InsertTestData(google::cloud::bigtable::Table table, int argc,
-                    char* argv[]) {
+void InsertTestData(google::cloud::bigtable::Table table, int argc, char*[]) {
   if (argc != 1) {
     throw Usage{"insert-test-data <project-id> <instance-id> <table-id>"};
   }
@@ -890,11 +885,9 @@ void InsertTestData(google::cloud::bigtable::Table table, int argc,
     mutation.emplace_back(google::cloud::bigtable::SetCell(
         "fam", "col0", "value0-" + std::to_string(i)));
     mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "col1", "value2-" + std::to_string(i)));
+        "fam", "col1", "value1-" + std::to_string(i)));
     mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "col2", "value3-" + std::to_string(i)));
-    mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "col3", "value4-" + std::to_string(i)));
+        "fam", "col2", "value2-" + std::to_string(i)));
     bulk.emplace_back(std::move(mutation));
   }
   auto failures = table.BulkApply(std::move(bulk));

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -203,7 +203,6 @@ class Table {
    * @par Example
    * @snippet data_snippets.cc apply
    */
-
   Status Apply(SingleRowMutation mut);
 
   /**


### PR DESCRIPTION
These are the examples required by DPE. I chose to receive the arguments
for these examples, such as the key, column family names, column names,
etc., from the command-line. I think this lets the user experiment with
different values more easily.

This fixes #2503, fixes #2502, fixes #2501, and fixes #2500.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2547)
<!-- Reviewable:end -->
