### PR TITLE
Fix race condition in async_read_stream_test.

### DIFF
--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -304,14 +304,24 @@ TEST_F(AsyncReadStreamTest, Return3) {
 
 /// @test Verify that the AsyncReadStream detect errors reported by the server.
 TEST_F(AsyncReadStreamTest, Return3ThenFail) {
+  // Very rarely (in the CI builds, with high load), all 3 responses and the
+  // error message are coalesced into a single message from the server, and then
+  // the OnRead() calls do not happen. We need to explicitly synchronize the
+  // client and server threads t
+  SimpleBarrier server_barrier;
   impl_.SetCallback(
-      [this](grpc::ServerContext*,
-             google::bigtable::v2::MutateRowsRequest const*,
-             grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
-                 writer) {
+      [this, &server_barrier](
+          grpc::ServerContext*, google::bigtable::v2::MutateRowsRequest const*,
+          grpc::ServerWriter<google::bigtable::v2::MutateRowsResponse>*
+              writer) {
         WriteOne(writer, 0);
         WriteOne(writer, 1);
-        WriteLast(writer, 2);
+        // Cannot use WritLast() because that blocks until the status is
+        // returned, and we want to pause in `server_barrier` to ensure all
+        // messages are received.
+        WriteOne(writer, 2);
+        // block until the client has received the responses.
+        server_barrier.Wait();
         return grpc::Status(grpc::StatusCode::INTERNAL, "bad luck");
       });
 
@@ -325,8 +335,11 @@ TEST_F(AsyncReadStreamTest, Return3ThenFail) {
         return stub_->PrepareAsyncMutateRows(context, request, cq);
       },
       request, std::move(context),
-      [&result](btproto::MutateRowsResponse r) {
+      [&result, &server_barrier](btproto::MutateRowsResponse r) {
         result.reads.emplace_back(std::move(r));
+        if (result.reads.size() == 3U) {
+          server_barrier.Lift();
+        }
         return make_ready_future(true);
       },
       [&result](Status s) {

--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -307,7 +307,7 @@ TEST_F(AsyncReadStreamTest, Return3ThenFail) {
   // Very rarely (in the CI builds, with high load), all 3 responses and the
   // error message are coalesced into a single message from the server, and then
   // the OnRead() calls do not happen. We need to explicitly synchronize the
-  // client and server threads t
+  // client and server threads.
   SimpleBarrier server_barrier;
   impl_.SetCallback(
       [this, &server_barrier](
@@ -316,11 +316,11 @@ TEST_F(AsyncReadStreamTest, Return3ThenFail) {
               writer) {
         WriteOne(writer, 0);
         WriteOne(writer, 1);
-        // Cannot use WritLast() because that blocks until the status is
+        // Cannot use WriteLast() because that blocks until the status is
         // returned, and we want to pause in `server_barrier` to ensure all
         // messages are received.
         WriteOne(writer, 2);
-        // block until the client has received the responses.
+        // Block until the client has received the responses.
         server_barrier.Wait();
         return grpc::Status(grpc::StatusCode::INTERNAL, "bad luck");
       });


### PR DESCRIPTION
The test for "read 3 messages and then an error" was a bit optimistic:
sometimes all three messages and the error are coalesced and then the
client just sees the error. Add some synchronization to make sure this
does not happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2548)
<!-- Reviewable:end -->
