### PR TITLE
Fix exit status in examples runner.

### DIFF
--- a/ci/define-example-runner.sh
+++ b/ci/define-example-runner.sh
@@ -191,3 +191,28 @@ run_example_usage() {
   set -e
   /bin/rm -f "${log}"
 }
+
+################################################
+# Report the result of running many examples.
+# Globals:
+#   COLOR_*: colorize output messages, defined in colors.sh
+#   EXIT_STATUS: control the final exit status for the program.
+#   EMULATOR_LOG: the name of the emulator logfile.
+# Arguments:
+#   None
+# Returns:
+#   None
+################################################
+exit_example_runner() {
+  if [[ "${EXIT_STATUS}" == 0 ]]; then
+    echo
+    echo "${COLOR_GREEN}All the examples finished successfully.${COLOR_RESET}"
+    echo
+  else
+    echo
+    echo "${COLOR_RED}Some of the examples failed.${COLOR_RESET}"
+    echo
+  fi
+
+  exit "${EXIT_STATUS}"
+}

--- a/google/cloud/bigtable/examples/run_examples_emulator.sh
+++ b/google/cloud/bigtable/examples/run_examples_emulator.sh
@@ -41,4 +41,4 @@ run_all_table_admin_async_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_Z
 run_all_instance_admin_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_ZONE_ID}"
 run_all_instance_admin_async_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_ZONE_ID}"
 
-exit "${EXIT_STATUS}"
+exit_example_runner

--- a/google/cloud/bigtable/examples/run_examples_production.sh
+++ b/google/cloud/bigtable/examples/run_examples_production.sh
@@ -22,4 +22,4 @@ source "${BINDIR}/run_examples_utils.sh"
 # quotas for admin operations if we run the admin examples too.
 run_all_data_examples "${PROJECT_ID}" "${INSTANCE_ID}"
 
-exit "${EXIT_STATUS}"
+exit_example_runner

--- a/google/cloud/storage/examples/run_examples_production.sh
+++ b/google/cloud/storage/examples/run_examples_production.sh
@@ -19,3 +19,5 @@ set -eu
 source "$(dirname "$0")/run_examples_utils.sh"
 
 run_all_storage_examples
+
+exit_example_runner

--- a/google/cloud/storage/examples/run_examples_testbench.sh
+++ b/google/cloud/storage/examples/run_examples_testbench.sh
@@ -16,7 +16,7 @@
 
 set -eu
 
-if [ -z "${PROJECT_ROOT+x}" ]; then
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../../.."; pwd)"
 fi
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
@@ -42,3 +42,5 @@ run_example ./storage_bucket_samples create-bucket-for-project \
       "${DESTINATION_BUCKET_NAME}" "${PROJECT_ID}"
 
 run_all_storage_examples
+
+exit_example_runner


### PR DESCRIPTION
Sometimes we were failing to report the exit status, and even when we
did it was not obvious there was a problem, because it may have scrolled
up past the terminal size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2549)
<!-- Reviewable:end -->
