### PR TITLE
Consistently use namespace aliases in examples.

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -98,14 +98,12 @@ void CreateDevInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
   namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, std::string instance_id,
      std::string zone) {
-    google::cloud::bigtable::DisplayName display_name("Put description here");
+    cbt::DisplayName display_name("Put description here");
     std::string cluster_id = instance_id + "-c1";
-    auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 0, google::cloud::bigtable::ClusterConfig::HDD);
-    google::cloud::bigtable::InstanceConfig config(
-        google::cloud::bigtable::InstanceId(instance_id), display_name,
-        {{cluster_id, cluster_config}});
-    config.set_type(google::cloud::bigtable::InstanceConfig::DEVELOPMENT);
+    auto cluster_config = cbt::ClusterConfig(zone, 0, cbt::ClusterConfig::HDD);
+    cbt::InstanceConfig config(cbt::InstanceId(instance_id), display_name,
+                               {{cluster_id, cluster_config}});
+    config.set_type(cbt::InstanceConfig::DEVELOPMENT);
 
     auto future = instance_admin.CreateInstance(config);
     // Most applications would simply call future.get(), here we show how to
@@ -250,8 +248,7 @@ void CreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
   using google::cloud::StatusOr;
   [](cbt::InstanceAdmin instance_admin, std::string instance_id,
      std::string cluster_id, std::string zone) {
-    auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
+    auto cluster_config = cbt::ClusterConfig(zone, 3, cbt::ClusterConfig::HDD);
     auto future_cluster = instance_admin.CreateCluster(
         cluster_config, cbt::InstanceId(instance_id),
         cbt::ClusterId(cluster_id));
@@ -350,8 +347,7 @@ void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
 
     // Modify the cluster.
     cluster->set_serve_nodes(4);
-    auto modified_config =
-        google::cloud::bigtable::ClusterConfig(std::move(*cluster));
+    auto modified_config = cbt::ClusterConfig(std::move(*cluster));
 
     auto modified_cluster = instance_admin.UpdateCluster(modified_config).get();
     if (!modified_cluster) {
@@ -428,13 +424,11 @@ void RunInstanceOperations(
   namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, std::string instance_id,
      std::string cluster_id, std::string zone) {
-    google::cloud::bigtable::DisplayName display_name("Put description here");
-    auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
-    google::cloud::bigtable::InstanceConfig config(
-        google::cloud::bigtable::InstanceId(instance_id), display_name,
-        {{cluster_id, cluster_config}});
-    config.set_type(google::cloud::bigtable::InstanceConfig::PRODUCTION);
+    cbt::DisplayName display_name("Put description here");
+    auto cluster_config = cbt::ClusterConfig(zone, 3, cbt::ClusterConfig::HDD);
+    cbt::InstanceConfig config(cbt::InstanceId(instance_id), display_name,
+                               {{cluster_id, cluster_config}});
+    config.set_type(cbt::InstanceConfig::PRODUCTION);
 
     std::cout << "\nCreating a PRODUCTION Instance: ";
     auto future = instance_admin.CreateInstance(config).get();
@@ -507,7 +501,7 @@ void CreateAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
   namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, std::string instance_id,
      std::string profile_id) {
-    auto config = google::cloud::bigtable::AppProfileConfig::MultiClusterUseAny(
+    auto config = cbt::AppProfileConfig::MultiClusterUseAny(
         cbt::AppProfileId(profile_id));
     auto profile =
         instance_admin.CreateAppProfile(cbt::InstanceId(instance_id), config);
@@ -536,9 +530,8 @@ void CreateAppProfileCluster(
   namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, std::string instance_id,
      std::string profile_id, std::string cluster_id) {
-    auto config =
-        google::cloud::bigtable::AppProfileConfig::SingleClusterRouting(
-            cbt::AppProfileId(profile_id), cbt::ClusterId(cluster_id));
+    auto config = cbt::AppProfileConfig::SingleClusterRouting(
+        cbt::AppProfileId(profile_id), cbt::ClusterId(cluster_id));
     auto profile =
         instance_admin.CreateAppProfile(cbt::InstanceId(instance_id), config);
     if (!profile) {
@@ -594,8 +587,7 @@ void UpdateAppProfileDescription(
      std::string profile_id, std::string description) {
     auto profile_future = instance_admin.UpdateAppProfile(
         cbt::InstanceId(instance_id), cbt::AppProfileId(profile_id),
-        google::cloud::bigtable::AppProfileUpdateConfig().set_description(
-            description));
+        cbt::AppProfileUpdateConfig().set_description(description));
     auto profile = profile_future.get();
     if (!profile) {
       throw std::runtime_error(profile.status().message());
@@ -626,7 +618,7 @@ void UpdateAppProfileRoutingAny(
      std::string profile_id) {
     auto profile_future = instance_admin.UpdateAppProfile(
         cbt::InstanceId(instance_id), cbt::AppProfileId(profile_id),
-        google::cloud::bigtable::AppProfileUpdateConfig()
+        cbt::AppProfileUpdateConfig()
             .set_multi_cluster_use_any()
             .set_ignore_warnings(true));
     auto profile = profile_future.get();
@@ -660,7 +652,7 @@ void UpdateAppProfileRoutingSingleCluster(
      std::string profile_id, std::string cluster_id) {
     auto profile_future = instance_admin.UpdateAppProfile(
         cbt::InstanceId(instance_id), cbt::AppProfileId(profile_id),
-        google::cloud::bigtable::AppProfileUpdateConfig()
+        cbt::AppProfileUpdateConfig()
             .set_single_cluster_routing(cbt::ClusterId(cluster_id))
             .set_ignore_warnings(true));
     auto profile = profile_future.get();

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -21,7 +21,6 @@
 #include <google/protobuf/text_format.h>
 
 namespace {
-namespace cbt = google::cloud::bigtable;
 const std::string MAGIC_ROW_KEY = "key-000005";
 
 struct Usage {
@@ -38,57 +37,49 @@ void PrintUsage(std::string const& cmd, std::string const& msg) {
             << command_usage << "\n";
 }
 
-void AsyncApply(cbt::Table table, cbt::CompletionQueue cq,
+void AsyncApply(google::cloud::bigtable::Table table,
+                google::cloud::bigtable::CompletionQueue cq,
                 std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-apply: <project-id> <instance-id> <table-id>"};
   }
 
   //! [async-apply]
-  [&](cbt::Table table, cbt::CompletionQueue cq, std::string table_id) {
-    // Write several rows with some trivial data.
-    for (int i = 0; i != 20; ++i) {
-      // Note: This example uses sequential numeric IDs for simplicity, but
-      // this can result in poor performance in a production application.
-      // Since rows are stored in sorted order by key, sequential keys can
-      // result in poor distribution of operations across nodes.
-      //
-      // For more information about how to design a Bigtable schema for the
-      // best performance, see the documentation:
-      //
-      //     https://cloud.google.com/bigtable/docs/schema-design
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, cbt::CompletionQueue cq, std::string table_id) {
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch());
 
-      char buf[32];
-      snprintf(buf, sizeof(buf), "key-%06d", i);
-      google::cloud::bigtable::SingleRowMutation mutation(buf);
-      mutation.emplace_back(google::cloud::bigtable::SetCell(
-          "fam", "col0", "value0-" + std::to_string(i)));
-      mutation.emplace_back(google::cloud::bigtable::SetCell(
-          "fam", "col1", "value2-" + std::to_string(i)));
-      mutation.emplace_back(google::cloud::bigtable::SetCell(
-          "fam", "col2", "value3-" + std::to_string(i)));
-      mutation.emplace_back(google::cloud::bigtable::SetCell(
-          "fam", "col3", "value4-" + std::to_string(i)));
+    google::cloud::bigtable::SingleRowMutation mutation(
+        "test-key-for-async-apply");
+    mutation.emplace_back(
+        google::cloud::bigtable::SetCell("fam", "some-column", "some-value"));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "another-column", "another-value"));
+    mutation.emplace_back(google::cloud::bigtable::SetCell(
+        "fam", "even-more-columns", timestamp, "with-explicit-timestamp"));
 
-      google::cloud::future<google::cloud::Status> fut =
-          table.AsyncApply(std::move(mutation), cq);
-      google::cloud::Status status = fut.get();
-      if (!status.ok()) {
-        throw std::runtime_error(status.message());
-      }
+    google::cloud::future<google::cloud::Status> fut =
+        table.AsyncApply(std::move(mutation), cq);
+    google::cloud::Status status = fut.get();
+    if (!status.ok()) {
+      throw std::runtime_error(status.message());
     }
+    std::cout << "Successfully applied mutation\n";
   }
   //! [async-apply]
   (std::move(table), std::move(cq), argv[1]);
 }
 
-void AsyncBulkApply(cbt::Table table, cbt::CompletionQueue cq,
+void AsyncBulkApply(google::cloud::bigtable::Table table,
+                    google::cloud::bigtable::CompletionQueue cq,
                     std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-bulk-apply: <project-id> <instance-id> <table-id>"};
   }
 
   //! [bulk async-bulk-apply]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::Table table, cbt::CompletionQueue cq, std::string table_id) {
     // Write several rows in a single operation, each row has some trivial data.
     google::cloud::bigtable::BulkMutation bulk;
@@ -125,7 +116,8 @@ void AsyncBulkApply(cbt::Table table, cbt::CompletionQueue cq,
   (std::move(table), std::move(cq), argv[1]);
 }
 
-void AsyncCheckAndMutate(cbt::Table table, cbt::CompletionQueue cq,
+void AsyncCheckAndMutate(google::cloud::bigtable::Table table,
+                         google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{
@@ -133,6 +125,7 @@ void AsyncCheckAndMutate(cbt::Table table, cbt::CompletionQueue cq,
   }
 
   //! [async check and mutate]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::Table table, cbt::CompletionQueue cq, std::string table_id) {
     // Check if the latest value of the flip-flop column is "on".
     auto predicate = google::cloud::bigtable::Filter::Chain(
@@ -167,7 +160,8 @@ void AsyncCheckAndMutate(cbt::Table table, cbt::CompletionQueue cq,
   (std::move(table), std::move(cq), argv[1]);
 }
 
-void AsyncReadModifyWrite(cbt::Table table, cbt::CompletionQueue cq,
+void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
+                          google::cloud::bigtable::CompletionQueue cq,
                           std::vector<std::string> argv) {
   // TODO(#2404) - remove hard-coded key values
   if (argv.size() != 2U) {

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -167,16 +167,15 @@ void ReadRows(google::cloud::bigtable::Table table, int argc, char* argv[]) {
   }
 
   //! [read rows] [START bigtable_read_range]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     // Create the range of rows to read.
-    auto range =
-        google::cloud::bigtable::RowRange::Range("key-000010", "key-000020");
+    auto range = cbt::RowRange::Range("key-000010", "key-000020");
     // Filter the results, only include values from the "col0" column in the
     // "fam" column family, and only get the latest value.
-    auto filter = google::cloud::bigtable::Filter::Chain(
-        google::cloud::bigtable::Filter::ColumnRangeClosed("fam", "col0",
-                                                           "col0"),
-        google::cloud::bigtable::Filter::Latest(1));
+    auto filter = cbt::Filter::Chain(
+        cbt::Filter::ColumnRangeClosed("fam", "col0", "col0"),
+        cbt::Filter::Latest(1));
     // Read and print the rows.
     for (auto const& row : table.ReadRows(range, filter)) {
       if (!row) {
@@ -203,16 +202,15 @@ void ReadRowsWithLimit(google::cloud::bigtable::Table table, int argc,
   }
 
   //! [read rows with limit] [START bigtable_read_filter]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     // Create the range of rows to read.
-    auto range =
-        google::cloud::bigtable::RowRange::Range("key-000010", "key-000020");
+    auto range = cbt::RowRange::Range("key-000010", "key-000020");
     // Filter the results, only include values from the "col0" column in the
     // "fam" column family, and only get the latest value.
-    auto filter = google::cloud::bigtable::Filter::Chain(
-        google::cloud::bigtable::Filter::ColumnRangeClosed("fam", "col0",
-                                                           "col0"),
-        google::cloud::bigtable::Filter::Latest(1));
+    auto filter = cbt::Filter::Chain(
+        cbt::Filter::ColumnRangeClosed("fam", "col0", "col0"),
+        cbt::Filter::Latest(1));
     // Read and print the first 5 rows in the range.
     for (auto const& row : table.ReadRows(range, 5, filter)) {
       if (!row) {
@@ -240,7 +238,8 @@ void PopulateTableHierarchy(google::cloud::bigtable::Table table, int argc,
   }
 
   //! [populate table hierarchy]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     // Write several rows.
     int q = 0;
     for (int i = 0; i != 4; ++i) {
@@ -249,9 +248,9 @@ void PopulateTableHierarchy(google::cloud::bigtable::Table table, int argc,
           std::string row_key = "root/" + std::to_string(i) + "/";
           row_key += std::to_string(j) + "/";
           row_key += std::to_string(k);
-          google::cloud::bigtable::SingleRowMutation mutation(row_key);
-          mutation.emplace_back(google::cloud::bigtable::SetCell(
-              "fam", "col0", "value-" + std::to_string(q)));
+          cbt::SingleRowMutation mutation(row_key);
+          mutation.emplace_back(
+              cbt::SetCell("fam", "col0", "value-" + std::to_string(q)));
           ++q;
           google::cloud::Status status = table.Apply(std::move(mutation));
           if (!status.ok()) {
@@ -286,8 +285,7 @@ void ReadKeysSet(google::cloud::bigtable::Table table, int argc, char* argv[]) {
       row_set.Append(row_key);
     }
 
-    auto filter = google::cloud::bigtable::Filter::Latest(1);
-
+    auto filter = cbt::Filter::Latest(1);
     for (auto& row : table.ReadRows(std::move(row_set), filter)) {
       if (!row) {
         throw std::runtime_error(row.status().message());
@@ -316,15 +314,14 @@ void ReadRowSetPrefix(google::cloud::bigtable::Table table, int argc,
   std::string prefix = ConsumeArg(argc, argv);
 
   //! [read rowset prefix] [START bigtable_read_prefix]
-  [](google::cloud::bigtable::Table table, std::string prefix) {
-    namespace cbt = google::cloud::bigtable;
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, std::string prefix) {
     auto row_set = cbt::RowSet();
 
     auto range_prefix = cbt::RowRange::Prefix(prefix);
     row_set.Append(range_prefix);
 
-    auto filter = google::cloud::bigtable::Filter::Latest(1);
-
+    auto filter = cbt::Filter::Latest(1);
     for (auto& row : table.ReadRows(std::move(row_set), filter)) {
       if (!row) {
         throw std::runtime_error(row.status().message());
@@ -357,13 +354,12 @@ void ReadPrefixList(google::cloud::bigtable::Table table, int argc,
   }
 
   //! [read prefix list] [START bigtable_read_prefix_list]
-  [](google::cloud::bigtable::Table table,
-     std::vector<std::string> prefix_list) {
-    namespace cbt = google::cloud::bigtable;
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, std::vector<std::string> prefix_list) {
     auto row_set = cbt::RowSet();
-    auto filter = google::cloud::bigtable::Filter::Latest(1);
+    auto filter = cbt::Filter::Latest(1);
 
-    for (auto prefix : prefix_list) {
+    for (auto const& prefix : prefix_list) {
       auto row_range_prefix = cbt::RowRange::Prefix(prefix);
       row_set.Append(row_range_prefix);
     }
@@ -439,22 +435,21 @@ void CheckAndMutate(google::cloud::bigtable::Table table, int argc,
   }
 
   //! [check and mutate]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     // Check if the latest value of the flip-flop column is "on".
-    auto predicate = google::cloud::bigtable::Filter::Chain(
-        google::cloud::bigtable::Filter::ColumnRangeClosed("fam", "flip-flop",
-                                                           "flip-flop"),
-        google::cloud::bigtable::Filter::Latest(1),
-        google::cloud::bigtable::Filter::ValueRegex("on"));
+    auto predicate = cbt::Filter::Chain(
+        cbt::Filter::ColumnRangeClosed("fam", "flip-flop", "flip-flop"),
+        cbt::Filter::Latest(1), cbt::Filter::ValueRegex("on"));
     // If the predicate matches, change the latest value to "off", otherwise,
     // change the latest value to "on".  Modify the "flop-flip" column at the
     // same time.
-    auto mut = table.CheckAndMutateRow(
-        MAGIC_ROW_KEY, std::move(predicate),
-        {google::cloud::bigtable::SetCell("fam", "flip-flop", "off"),
-         google::cloud::bigtable::SetCell("fam", "flop-flip", "on")},
-        {google::cloud::bigtable::SetCell("fam", "flip-flop", "on"),
-         google::cloud::bigtable::SetCell("fam", "flop-flip", "off")});
+    auto mut =
+        table.CheckAndMutateRow(MAGIC_ROW_KEY, std::move(predicate),
+                                {cbt::SetCell("fam", "flip-flop", "off"),
+                                 cbt::SetCell("fam", "flop-flip", "on")},
+                                {cbt::SetCell("fam", "flip-flop", "on"),
+                                 cbt::SetCell("fam", "flop-flip", "off")});
 
     if (!mut) {
       throw std::runtime_error(mut.status().message());
@@ -471,13 +466,12 @@ void ReadModifyWrite(google::cloud::bigtable::Table table, int argc,
   }
 
   //! [read modify write]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     auto row = table.ReadModifyWriteRow(
         MAGIC_ROW_KEY,
-        google::cloud::bigtable::ReadModifyWriteRule::IncrementAmount(
-            "fam", "counter", 1),
-        google::cloud::bigtable::ReadModifyWriteRule::AppendValue("fam", "list",
-                                                                  ";element"));
+        cbt::ReadModifyWriteRule::IncrementAmount("fam", "counter", 1),
+        cbt::ReadModifyWriteRule::AppendValue("fam", "list", ";element"));
 
     if (!row) {
       throw std::runtime_error(row.status().message());
@@ -494,7 +488,8 @@ void SampleRows(google::cloud::bigtable::Table table, int argc, char* argv[]) {
   }
 
   //! [sample row keys] [START bigtable_table_sample_splits]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     auto samples = table.SampleRows<>();
     if (!samples) {
       throw std::runtime_error(samples.status().message());
@@ -517,7 +512,8 @@ void SampleRowsCollections(google::cloud::bigtable::Table table, int argc,
   }
 
   //! [sample row keys collections]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     auto list_samples = table.SampleRows<std::list>();
     if (!list_samples) {
       throw std::runtime_error(list_samples.status().message());
@@ -546,12 +542,13 @@ void GetFamily(google::cloud::bigtable::Table table, int argc, char* argv[]) {
   }
 
   //! [get family] [START bigtable_get_family] [START bigtable_family_ref]
-  [](google::cloud::bigtable::Table table) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table) {
     // Create the range of rows to read.
-    auto range = google::cloud::bigtable::RowRange::InfiniteRange();
+    auto range = cbt::RowRange::InfiniteRange();
 
     // Filter the results, only get the latest value
-    auto filter = google::cloud::bigtable::Filter::Latest(1);
+    auto filter = cbt::Filter::Latest(1);
 
     // Read and print the family name.
     for (auto const& row : table.ReadRows(range, filter)) {
@@ -577,9 +574,10 @@ void DeleteAllCells(google::cloud::bigtable::Table table, int argc,
   auto row_key = ConsumeArg(argc, argv);
 
   //! [delete all cells]
-  [](google::cloud::bigtable::Table table, std::string row_key) {
-    auto status = table.Apply(google::cloud::bigtable::SingleRowMutation(
-        row_key, google::cloud::bigtable::DeleteFromRow()));
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, std::string row_key) {
+    auto status =
+        table.Apply(cbt::SingleRowMutation(row_key, cbt::DeleteFromRow()));
 
     if (!status.ok()) {
       throw std::runtime_error(status.message());
@@ -600,11 +598,11 @@ void DeleteFamilyCells(google::cloud::bigtable::Table table, int argc,
   auto family_name = ConsumeArg(argc, argv);
 
   //! [delete family cells]
-  [](google::cloud::bigtable::Table table, std::string row_key,
-     std::string family_name) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, std::string row_key, std::string family_name) {
     // Delete all cells within a family.
-    auto status = table.Apply(google::cloud::bigtable::SingleRowMutation(
-        row_key, google::cloud::bigtable::DeleteFromFamily(family_name)));
+    auto status = table.Apply(
+        cbt::SingleRowMutation(row_key, cbt::DeleteFromFamily(family_name)));
 
     if (!status.ok()) {
       throw std::runtime_error(status.message());
@@ -626,12 +624,12 @@ void DeleteSelectiveFamilyCells(google::cloud::bigtable::Table table, int argc,
   auto column_name = ConsumeArg(argc, argv);
 
   //! [delete selective family cells]
-  [](google::cloud::bigtable::Table table, std::string row_key,
-     std::string family_name, std::string column_name) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, std::string row_key, std::string family_name,
+     std::string column_name) {
     // Delete selective cell within a family.
-    auto status = table.Apply(google::cloud::bigtable::SingleRowMutation(
-        row_key,
-        google::cloud::bigtable::DeleteFromColumn(family_name, column_name)));
+    auto status = table.Apply(cbt::SingleRowMutation(
+        row_key, cbt::DeleteFromColumn(family_name, column_name)));
 
     if (!status.ok()) {
       throw std::runtime_error(status.message());
@@ -649,9 +647,10 @@ void RowExists(google::cloud::bigtable::Table table, int argc, char* argv[]) {
   auto row_key = ConsumeArg(argc, argv);
 
   //! [row exists]
-  [](google::cloud::bigtable::Table table, std::string row_key) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::Table table, std::string row_key) {
     // Filter the results, turn any value into an empty string.
-    auto filter = google::cloud::bigtable::Filter::StripValueTransformer();
+    auto filter = cbt::Filter::StripValueTransformer();
 
     // Read a row, this returns a tuple (bool, row)
     auto status = table.ReadRow(row_key, std::move(filter));

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -69,13 +69,13 @@ void Apply(google::cloud::bigtable::Table table, int argc, char* argv[]) {
     auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch());
 
-    google::cloud::bigtable::SingleRowMutation mutation("test-key-for-apply");
+    cbt::SingleRowMutation mutation("test-key-for-apply");
     mutation.emplace_back(
         google::cloud::bigtable::SetCell("fam", "some-column", "some-value"));
-    mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "another-column", "another-value"));
-    mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "even-more-columns", timestamp, "with-explicit-timestamp"));
+    mutation.emplace_back(
+        cbt::SetCell("fam", "another-column", "another-value"));
+    mutation.emplace_back(cbt::SetCell("fam", "even-more-columns", timestamp,
+                                       "with-explicit-timestamp"));
     google::cloud::Status status = table.Apply(std::move(mutation));
     if (!status.ok()) {
       throw std::runtime_error(status.message());
@@ -130,9 +130,10 @@ void ReadRow(google::cloud::bigtable::Table table, int argc, char* argv[]) {
   }
 
   //! [read row] [START bigtable_read_error]
+  namespace cbt = google::cloud::bigtable;
   [](google::cloud::bigtable::Table table) {
     // Filter the results, only include the latest value on each cell.
-    auto filter = google::cloud::bigtable::Filter::Latest(1);
+    auto filter = cbt::Filter::Latest(1);
     // Read a row, this returns a tuple (bool, row)
     auto tuple = table.ReadRow(MAGIC_ROW_KEY, std::move(filter));
     if (!tuple) {
@@ -863,7 +864,8 @@ void InsertTestData(google::cloud::bigtable::Table table, int argc, char*[]) {
   // This is not a code sample in the normal sense, we do not display this code
   // in the documentation. We use it to populate data in the table used to run
   // the actual examples during the CI builds.
-  google::cloud::bigtable::BulkMutation bulk;
+  namespace cbt = google::cloud::bigtable;
+  cbt::BulkMutation bulk;
   for (int i = 0; i != 5000; ++i) {
     // Note: This example uses sequential numeric IDs for simplicity, but
     // this can result in poor performance in a production application.
@@ -876,13 +878,13 @@ void InsertTestData(google::cloud::bigtable::Table table, int argc, char*[]) {
     //     https://cloud.google.com/bigtable/docs/schema-design
     char buf[32];
     snprintf(buf, sizeof(buf), "key-%06d", i);
-    google::cloud::bigtable::SingleRowMutation mutation(buf);
-    mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "col0", "value0-" + std::to_string(i)));
-    mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "col1", "value1-" + std::to_string(i)));
-    mutation.emplace_back(google::cloud::bigtable::SetCell(
-        "fam", "col2", "value2-" + std::to_string(i)));
+    cbt::SingleRowMutation mutation(buf);
+    mutation.emplace_back(
+        cbt::SetCell("fam", "col0", "value0-" + std::to_string(i)));
+    mutation.emplace_back(
+        cbt::SetCell("fam", "col1", "value1-" + std::to_string(i)));
+    mutation.emplace_back(
+        cbt::SetCell("fam", "col2", "value2-" + std::to_string(i)));
     bulk.emplace_back(std::move(mutation));
   }
   auto failures = table.BulkApply(std::move(bulk));

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -320,8 +320,7 @@ void AsyncGetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
     google::cloud::future<StatusOr<google::cloud::IamPolicy>> future =
-        instance_admin.AsyncGetIamPolicy(
-            cq, google::cloud::bigtable::InstanceId(instance_id));
+        instance_admin.AsyncGetIamPolicy(cq, cbt::InstanceId(instance_id));
 
     auto final = future.then(
         [](google::cloud::future<StatusOr<google::cloud::IamPolicy>> f) {

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -21,8 +21,6 @@
 #include <google/protobuf/text_format.h>
 
 namespace {
-namespace cbt = google::cloud::bigtable;
-
 struct Usage {
   std::string msg;
 };
@@ -37,23 +35,22 @@ void PrintUsage(std::string const& cmd, std::string const& msg) {
             << command_usage << "\n";
 }
 
-void AsyncCreateInstance(cbt::InstanceAdmin instance_admin,
-                         cbt::CompletionQueue cq,
+void AsyncCreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                         google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{"async-create-instance: <project-id> <instance-id> <zone>"};
   }
   //! [async create instance]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id, std::string zone) {
-    google::cloud::bigtable::DisplayName display_name("Put description here");
+    cbt::DisplayName display_name("Put description here");
     std::string cluster_id = instance_id + "-c1";
-    auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
-    google::cloud::bigtable::InstanceConfig config(
-        google::cloud::bigtable::InstanceId(instance_id), display_name,
-        {{cluster_id, cluster_config}});
-    config.set_type(google::cloud::bigtable::InstanceConfig::PRODUCTION);
+    auto cluster_config = cbt::ClusterConfig(zone, 3, cbt::ClusterConfig::HDD);
+    cbt::InstanceConfig config(cbt::InstanceId(instance_id), display_name,
+                               {{cluster_id, cluster_config}});
+    config.set_type(cbt::InstanceConfig::PRODUCTION);
 
     auto future = instance_admin.AsyncCreateInstance(cq, config);
     // Most applications would simply call future.get(), here we show how to
@@ -77,21 +74,21 @@ void AsyncCreateInstance(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncCreateCluster(cbt::InstanceAdmin instance_admin,
-                        cbt::CompletionQueue cq,
+void AsyncCreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
+                        google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
   if (argv.size() != 4U) {
     throw Usage{
         "async-create-cluster <project-id> <instance-id> <cluster-id> <zone>"};
   }
   //! [async create cluster]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id, std::string cluster_id, std::string zone) {
-    auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
+    auto cluster_config = cbt::ClusterConfig(zone, 3, cbt::ClusterConfig::HDD);
     auto future = instance_admin.AsyncCreateCluster(
-        cq, cluster_config, google::cloud::bigtable::InstanceId(instance_id),
-        google::cloud::bigtable::ClusterId(cluster_id));
+        cq, cluster_config, cbt::InstanceId(instance_id),
+        cbt::ClusterId(cluster_id));
     // Most applications would simply call future.get(), here we show how to
     // perform additional work while the long running operation completes.
     std::cout << "Waiting for cluster creation to complete ";
@@ -113,9 +110,10 @@ void AsyncCreateCluster(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2], argv[3]);
 }
 
-void AsyncCreateAppProfile(cbt::InstanceAdmin instance_admin,
-                           cbt::CompletionQueue cq,
-                           std::vector<std::string> argv) {
+void AsyncCreateAppProfile(
+    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable::CompletionQueue cq,
+    std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{
         "async-create-app-profile <project-id> <instance-id> <profile-id>"};
@@ -155,13 +153,15 @@ void AsyncCreateAppProfile(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncGetInstance(cbt::InstanceAdmin instance_admin,
-                      cbt::CompletionQueue cq, std::vector<std::string> argv) {
+void AsyncGetInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                      google::cloud::bigtable::CompletionQueue cq,
+                      std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-get-instance: <project-id> <instance-id>"};
   }
 
   //! [async get instance]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
     google::cloud::future<
@@ -189,22 +189,21 @@ void AsyncGetInstance(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1]);
 }
 
-void AsyncListInstances(cbt::InstanceAdmin instance_admin,
-                        cbt::CompletionQueue cq,
+void AsyncListInstances(google::cloud::bigtable::InstanceAdmin instance_admin,
+                        google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
   if (argv.size() != 1U) {
     throw Usage{"async-list-instances: <project-id>"};
   }
 
   //! [async list instances]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq) {
-    google::cloud::future<
-        google::cloud::StatusOr<google::cloud::bigtable::v0::InstanceList>>
-        future = instance_admin.AsyncListInstances(cq);
+    google::cloud::future<google::cloud::StatusOr<cbt::InstanceList>> future =
+        instance_admin.AsyncListInstances(cq);
 
     auto final = future.then(
-        [](google::cloud::future<
-            google::cloud::StatusOr<google::cloud::bigtable::v0::InstanceList>>
+        [](google::cloud::future<google::cloud::StatusOr<cbt::InstanceList>>
                f) {
           auto instance_list = f.get();
           if (!instance_list) {
@@ -231,17 +230,19 @@ void AsyncListInstances(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq));
 }
 
-void AsyncGetCluster(cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
+void AsyncGetCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
+                     google::cloud::bigtable::CompletionQueue cq,
                      std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{"async-get-cluster: <project-id> <instance-id> <cluster-id>"};
   }
 
   //! [async get cluster]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id, std::string cluster_id) {
-    google::cloud::bigtable::InstanceId instance_id1(instance_id);
-    google::cloud::bigtable::ClusterId cluster_id1(cluster_id);
+    cbt::InstanceId instance_id1(instance_id);
+    cbt::ClusterId cluster_id1(cluster_id);
 
     google::cloud::future<
         google::cloud::StatusOr<google::bigtable::admin::v2::Cluster>>
@@ -268,8 +269,8 @@ void AsyncGetCluster(cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncGetAppProfile(cbt::InstanceAdmin instance_admin,
-                        cbt::CompletionQueue cq,
+void AsyncGetAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
+                        google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{
@@ -306,8 +307,9 @@ void AsyncGetAppProfile(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncGetIamPolicy(cbt::InstanceAdmin instance_admin,
-                       cbt::CompletionQueue cq, std::vector<std::string> argv) {
+void AsyncGetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
+                       google::cloud::bigtable::CompletionQueue cq,
+                       std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-get-iam-policy: <project-id> <instance-id>"};
   }
@@ -337,23 +339,22 @@ void AsyncGetIamPolicy(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1]);
 }
 
-void AsyncListClusters(cbt::InstanceAdmin instance_admin,
-                       cbt::CompletionQueue cq, std::vector<std::string> argv) {
+void AsyncListClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
+                       google::cloud::bigtable::CompletionQueue cq,
+                       std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-list-clusters: <project-id> <instance-id>"};
   }
 
   //! [async list clusters]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
-    google::cloud::future<
-        google::cloud::StatusOr<google::cloud::bigtable::v0::ClusterList>>
-        future = instance_admin.AsyncListClusters(cq, instance_id);
+    google::cloud::future<google::cloud::StatusOr<cbt::ClusterList>> future =
+        instance_admin.AsyncListClusters(cq, instance_id);
 
     auto final = future.then(
-        [](google::cloud::future<
-            google::cloud::StatusOr<google::cloud::bigtable::v0::ClusterList>>
-               f) {
+        [](google::cloud::future<google::cloud::StatusOr<cbt::ClusterList>> f) {
           auto cluster_list = f.get();
           if (!cluster_list) {
             throw std::runtime_error(cluster_list.status().message());
@@ -380,23 +381,21 @@ void AsyncListClusters(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1]);
 }
 
-void AsyncListAllClusters(cbt::InstanceAdmin instance_admin,
-                          cbt::CompletionQueue cq,
+void AsyncListAllClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
+                          google::cloud::bigtable::CompletionQueue cq,
                           std::vector<std::string> argv) {
   if (argv.size() != 1U) {
     throw Usage{"async-list-all-clusters: <project-id>"};
   }
 
   //! [async list all clusters]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq) {
-    google::cloud::future<
-        google::cloud::StatusOr<google::cloud::bigtable::v0::ClusterList>>
-        future = instance_admin.AsyncListClusters(cq);
+    google::cloud::future<google::cloud::StatusOr<cbt::ClusterList>> future =
+        instance_admin.AsyncListClusters(cq);
 
     auto final = future.then(
-        [](google::cloud::future<
-            google::cloud::StatusOr<google::cloud::bigtable::v0::ClusterList>>
-               f) {
+        [](google::cloud::future<google::cloud::StatusOr<cbt::ClusterList>> f) {
           auto cluster_list = f.get();
           if (!cluster_list) {
             throw std::runtime_error(cluster_list.status().message());
@@ -423,14 +422,15 @@ void AsyncListAllClusters(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq));
 }
 
-void AsyncListAppProfiles(cbt::InstanceAdmin instance_admin,
-                          cbt::CompletionQueue cq,
+void AsyncListAppProfiles(google::cloud::bigtable::InstanceAdmin instance_admin,
+                          google::cloud::bigtable::CompletionQueue cq,
                           std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-list-app-profiles: <project-id> <instance-id>"};
   }
 
   //! [async list app_profiles]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
     google::cloud::future<google::cloud::StatusOr<
@@ -458,14 +458,15 @@ void AsyncListAppProfiles(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1]);
 }
 
-void AsyncUpdateInstance(cbt::InstanceAdmin instance_admin,
-                         cbt::CompletionQueue cq,
+void AsyncUpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                         google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"update-instance: <project-id> <instance-id>"};
   }
 
   //! [async update instance]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
     auto future =
@@ -479,8 +480,8 @@ void AsyncUpdateInstance(cbt::InstanceAdmin instance_admin,
                 throw std::runtime_error(instance.status().message());
               }
               // Modify the instance and prepare the mask with modified field
-              google::cloud::bigtable::InstanceUpdateConfig
-                  instance_update_config(std::move(*instance));
+              cbt::InstanceUpdateConfig instance_update_config(
+                  std::move(*instance));
               instance_update_config.set_display_name("Modified Display Name");
 
               return instance_admin.AsyncUpdateInstance(cq,
@@ -510,21 +511,21 @@ void AsyncUpdateInstance(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1]);
 }
 
-void AsyncUpdateCluster(cbt::InstanceAdmin instance_admin,
-                        cbt::CompletionQueue cq,
+void AsyncUpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
+                        google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{"update-cluster: <project-id> <instance-id> <cluster-id>"};
   }
 
   //! [async update cluster]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id, std::string cluster_id) {
     auto future =
         instance_admin
-            .AsyncGetCluster(cq,
-                             google::cloud::bigtable::InstanceId(instance_id),
-                             google::cloud::bigtable::ClusterId(cluster_id))
+            .AsyncGetCluster(cq, cbt::InstanceId(instance_id),
+                             cbt::ClusterId(cluster_id))
             .then([instance_admin,
                    cq](google::cloud::future<google::cloud::StatusOr<
                            google::bigtable::admin::v2::Cluster>>
@@ -535,8 +536,7 @@ void AsyncUpdateCluster(cbt::InstanceAdmin instance_admin,
               }
               // Modify the cluster.
               cluster->set_serve_nodes(4);
-              auto modified_config =
-                  google::cloud::bigtable::ClusterConfig(std::move(*cluster));
+              auto modified_config = cbt::ClusterConfig(std::move(*cluster));
 
               return instance_admin.AsyncUpdateCluster(cq, modified_config);
             });
@@ -563,21 +563,21 @@ void AsyncUpdateCluster(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncUpdateAppProfile(cbt::InstanceAdmin instance_admin,
-                           cbt::CompletionQueue cq,
-                           std::vector<std::string> argv) {
+void AsyncUpdateAppProfile(
+    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable::CompletionQueue cq,
+    std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{"update-cluster: <project-id> <instance-id> <profile-id>"};
   }
 
   //! [async update app profile]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id, std::string profile_id) {
     auto future = instance_admin.AsyncUpdateAppProfile(
-        cq, google::cloud::bigtable::InstanceId(instance_id),
-        google::cloud::bigtable::AppProfileId(profile_id),
-        google::cloud::bigtable::AppProfileUpdateConfig().set_description(
-            "new description"));
+        cq, cbt::InstanceId(instance_id), cbt::AppProfileId(profile_id),
+        cbt::AppProfileUpdateConfig().set_description("new description"));
     // Most applications would simply call future.get(), here we show how to
     // perform additional work while the long running operation completes.
     std::cout << "Waiting for app profile update to complete ";
@@ -603,14 +603,15 @@ void AsyncUpdateAppProfile(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncDeleteInstance(cbt::InstanceAdmin instance_admin,
-                         cbt::CompletionQueue cq,
+void AsyncDeleteInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
+                         google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-delete-instance: <project-id> <instance-id> "};
   }
 
   //! [async-delete-instance] [START bigtable_async_delete_instance]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id) {
     google::cloud::future<google::cloud::Status> fut =
@@ -629,8 +630,8 @@ void AsyncDeleteInstance(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1]);
 }
 
-void AsyncDeleteCluster(cbt::InstanceAdmin instance_admin,
-                        cbt::CompletionQueue cq,
+void AsyncDeleteCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
+                        google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{
@@ -638,12 +639,12 @@ void AsyncDeleteCluster(cbt::InstanceAdmin instance_admin,
   }
 
   //! [async delete cluster]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string instance_id, std::string cluster_id) {
     google::cloud::future<google::cloud::Status> future =
-        instance_admin.AsyncDeleteCluster(
-            cq, google::cloud::bigtable::InstanceId(instance_id),
-            google::cloud::bigtable::ClusterId(cluster_id));
+        instance_admin.AsyncDeleteCluster(cq, cbt::InstanceId(instance_id),
+                                          cbt::ClusterId(cluster_id));
 
     // Most applications would simply call future.get(), here we show how to
     // perform additional work while the long running operation completes.
@@ -666,9 +667,10 @@ void AsyncDeleteCluster(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncDeleteAppProfile(cbt::InstanceAdmin instance_admin,
-                           cbt::CompletionQueue cq,
-                           std::vector<std::string> argv) {
+void AsyncDeleteAppProfile(
+    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable::CompletionQueue cq,
+    std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{
         "async-delete-app-profile: <project-id> <instance-id> "
@@ -704,9 +706,10 @@ void AsyncDeleteAppProfile(cbt::InstanceAdmin instance_admin,
   (std::move(instance_admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncTestIamPermissions(cbt::InstanceAdmin instance_admin,
-                             cbt::CompletionQueue cq,
-                             std::vector<std::string> argv) {
+void AsyncTestIamPermissions(
+    google::cloud::bigtable::InstanceAdmin instance_admin,
+    google::cloud::bigtable::CompletionQueue cq,
+    std::vector<std::string> argv) {
   if (argv.size() < 2U) {
     throw Usage{
         "async-test-iam-permissions: <project-id> <resource-id> "
@@ -714,6 +717,7 @@ void AsyncTestIamPermissions(cbt::InstanceAdmin instance_admin,
   }
 
   //! [async test iam permissions]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::InstanceAdmin instance_admin, cbt::CompletionQueue cq,
      std::string resource, std::vector<std::string>(permissions)) {
     auto future =

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -18,8 +18,6 @@
 #include <algorithm>
 
 namespace {
-namespace cbt = google::cloud::bigtable;
-
 struct Usage {
   std::string msg;
 };
@@ -34,7 +32,8 @@ void PrintUsage(std::string const& cmd, std::string const& msg) {
             << command_usage << "\n";
 }
 
-void AsyncCreateTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncCreateTable(google::cloud::bigtable::TableAdmin admin,
+                      google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-create-table: <project-id> <instance-id> <table-id>"};
@@ -47,10 +46,9 @@ void AsyncCreateTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
         google::cloud::StatusOr<google::bigtable::admin::v2::Table>>
         future = admin.AsyncCreateTable(
             cq, table_id,
-            google::cloud::bigtable::TableConfig(
-                {{"fam", google::cloud::bigtable::GcRule::MaxNumVersions(10)},
-                 {"foo", google::cloud::bigtable::GcRule::MaxAge(
-                             std::chrono::hours(72))}},
+            cbt::TableConfig(
+                {{"fam", cbt::GcRule::MaxNumVersions(10)},
+                 {"foo", cbt::GcRule::MaxAge(std::chrono::hours(72))}},
                 {}));
 
     auto final = future.then(
@@ -70,7 +68,8 @@ void AsyncCreateTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1]);
 }
 
-void AsyncListTables(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncListTables(google::cloud::bigtable::TableAdmin admin,
+                     google::cloud::bigtable::CompletionQueue cq,
                      std::vector<std::string> argv) {
   if (argv.size() != 1U) {
     throw Usage{"async-list-tables: <project-id> <instance-id>"};
@@ -103,7 +102,8 @@ void AsyncListTables(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq));
 }
 
-void AsyncGetTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncGetTable(google::cloud::bigtable::TableAdmin admin,
+                   google::cloud::bigtable::CompletionQueue cq,
                    std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-get-table: <project-id> <instance-id> <table-id>"};
@@ -142,7 +142,8 @@ void AsyncGetTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1]);
 }
 
-void AsyncDeleteTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncDeleteTable(google::cloud::bigtable::TableAdmin admin,
+                      google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-delete-table: <project-id> <instance-id> <table-id>"};
@@ -169,29 +170,29 @@ void AsyncDeleteTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1]);
 }
 
-void AsyncModifyTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncModifyTable(google::cloud::bigtable::TableAdmin admin,
+                      google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-modify-table: <project-id> <instance-id> <table-id>"};
   }
 
   //! [async modify table]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id) {
     google::cloud::future<
         google::cloud::StatusOr<google::bigtable::admin::v2::Table>>
         future = admin.AsyncModifyColumnFamilies(
             cq, table_id,
-            {google::cloud::bigtable::ColumnFamilyModification::Drop("foo"),
-             google::cloud::bigtable::ColumnFamilyModification::Update(
-                 "fam", google::cloud::bigtable::GcRule::Union(
-                            google::cloud::bigtable::GcRule::MaxNumVersions(5),
-                            google::cloud::bigtable::GcRule::MaxAge(
-                                std::chrono::hours(24 * 7)))),
-             google::cloud::bigtable::ColumnFamilyModification::Create(
-                 "bar", google::cloud::bigtable::GcRule::Intersection(
-                            google::cloud::bigtable::GcRule::MaxNumVersions(3),
-                            google::cloud::bigtable::GcRule::MaxAge(
-                                std::chrono::hours(72))))});
+            {cbt::ColumnFamilyModification::Drop("foo"),
+             cbt::ColumnFamilyModification::Update(
+                 "fam", cbt::GcRule::Union(
+                            cbt::GcRule::MaxNumVersions(5),
+                            cbt::GcRule::MaxAge(std::chrono::hours(24 * 7)))),
+             cbt::ColumnFamilyModification::Create(
+                 "bar", cbt::GcRule::Intersection(
+                            cbt::GcRule::MaxNumVersions(3),
+                            cbt::GcRule::MaxAge(std::chrono::hours(72))))});
 
     auto final = future.then(
         [](google::cloud::future<
@@ -218,7 +219,8 @@ void AsyncModifyTable(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1]);
 }
 
-void AsyncDropRowsByPrefix(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncDropRowsByPrefix(google::cloud::bigtable::TableAdmin admin,
+                           google::cloud::bigtable::CompletionQueue cq,
                            std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{
@@ -227,8 +229,9 @@ void AsyncDropRowsByPrefix(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   }
 
   //! [async drop rows by prefix]
-  [](google::cloud::bigtable::TableAdmin admin, cbt::CompletionQueue cq,
-     std::string table_id, std::string row_key) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id,
+     std::string row_key) {
     google::cloud::future<google::cloud::Status> future =
         admin.AsyncDropRowsByPrefix(cq, table_id, row_key);
     auto final =
@@ -247,15 +250,16 @@ void AsyncDropRowsByPrefix(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncDropAllRows(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncDropAllRows(google::cloud::bigtable::TableAdmin admin,
+                      google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{"async-drop-all-rows: <project-id> <instance-id> <table-id>"};
   }
 
   //! [async drop all rows]
-  [](google::cloud::bigtable::TableAdmin admin, cbt::CompletionQueue cq,
-     std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id) {
     google::cloud::future<google::cloud::Status> future =
         admin.AsyncDropAllRows(cq, table_id);
     auto final =
@@ -274,7 +278,8 @@ void AsyncDropAllRows(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1]);
 }
 
-void AsyncCheckConsistency(cbt::TableAdmin admin, cbt::CompletionQueue cq,
+void AsyncCheckConsistency(google::cloud::bigtable::TableAdmin admin,
+                           google::cloud::bigtable::CompletionQueue cq,
                            std::vector<std::string> argv) {
   if (argv.size() != 3U) {
     throw Usage{
@@ -283,11 +288,11 @@ void AsyncCheckConsistency(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   }
 
   //! [async check consistency]
+  namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id_param,
      std::string consistency_token_param) {
-    google::cloud::bigtable::TableId table_id(table_id_param);
-    google::cloud::bigtable::ConsistencyToken consistency_token(
-        consistency_token_param);
+    cbt::TableId table_id(table_id_param);
+    cbt::ConsistencyToken consistency_token(consistency_token_param);
 
     google::cloud::future<google::cloud::StatusOr<cbt::Consistency>> future =
         admin.AsyncCheckConsistency(cq, table_id, consistency_token);
@@ -299,8 +304,7 @@ void AsyncCheckConsistency(cbt::TableAdmin admin, cbt::CompletionQueue cq,
       if (!consistency) {
         throw std::runtime_error(consistency.status().message());
       }
-      if (consistency.value() ==
-          google::cloud::bigtable::Consistency::kConsistent) {
+      if (consistency.value() == cbt::Consistency::kConsistent) {
         std::cout << "Table is consistent\n";
       } else {
         std::cout
@@ -314,8 +318,8 @@ void AsyncCheckConsistency(cbt::TableAdmin admin, cbt::CompletionQueue cq,
   (std::move(admin), std::move(cq), argv[1], argv[2]);
 }
 
-void AsyncGenerateConsistencyToken(cbt::TableAdmin admin,
-                                   cbt::CompletionQueue cq,
+void AsyncGenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
+                                   google::cloud::bigtable::CompletionQueue cq,
                                    std::vector<std::string> argv) {
   if (argv.size() != 2U) {
     throw Usage{
@@ -324,14 +328,13 @@ void AsyncGenerateConsistencyToken(cbt::TableAdmin admin,
   }
 
   //! [async generate consistency token]
-  [](google::cloud::bigtable::TableAdmin admin, cbt::CompletionQueue cq,
-     std::string table_id) {
-    google::cloud::future<google::cloud::StatusOr<cbt::ConsistencyToken>>
-        future = admin.AsyncGenerateConsistencyToken(cq, table_id);
-    auto final =
-        future.then([table_id](google::cloud::future<
-                               google::cloud::StatusOr<cbt::ConsistencyToken>>
-                                   f) {
+  namespace cbt = google::cloud::bigtable;
+  using google::cloud::StatusOr;
+  [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id) {
+    google::cloud::future<StatusOr<cbt::ConsistencyToken>> future =
+        admin.AsyncGenerateConsistencyToken(cq, table_id);
+    auto final = future.then(
+        [table_id](google::cloud::future<StatusOr<cbt::ConsistencyToken>> f) {
           auto token = f.get();
           if (!token) {
             throw std::runtime_error(token.status().message());

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -24,7 +24,6 @@
 #include <sstream>
 
 namespace {
-
 struct Usage {
   std::string msg;
 };
@@ -58,14 +57,13 @@ void CreateTable(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [create table] [START bigtable_create_table]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     auto schema = admin.CreateTable(
         table_id,
-        google::cloud::bigtable::TableConfig(
-            {{"fam", google::cloud::bigtable::GcRule::MaxNumVersions(10)},
-             {"foo",
-              google::cloud::bigtable::GcRule::MaxAge(std::chrono::hours(72))}},
-            {}));
+        cbt::TableConfig({{"fam", cbt::GcRule::MaxNumVersions(10)},
+                          {"foo", cbt::GcRule::MaxAge(std::chrono::hours(72))}},
+                         {}));
   }
   //! [create table] [END bigtable_create_table]
   (std::move(admin), table_id);
@@ -78,7 +76,8 @@ void ListTables(google::cloud::bigtable::TableAdmin admin, int argc,
   }
 
   //! [list tables] [START bigtable_list_tables]
-  [](google::cloud::bigtable::TableAdmin admin) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin) {
     auto tables =
         admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
 
@@ -101,7 +100,8 @@ void GetTable(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [get table]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     auto table =
         admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
     if (!table) {
@@ -128,7 +128,8 @@ void DeleteTable(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [delete table]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     google::cloud::Status status = admin.DeleteTable(table_id);
     if (!status.ok()) {
       throw std::runtime_error(status.message());
@@ -146,20 +147,19 @@ void ModifyTable(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [modify table]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     auto schema = admin.ModifyColumnFamilies(
         table_id,
-        {google::cloud::bigtable::ColumnFamilyModification::Drop("foo"),
-         google::cloud::bigtable::ColumnFamilyModification::Update(
-             "fam", google::cloud::bigtable::GcRule::Union(
-                        google::cloud::bigtable::GcRule::MaxNumVersions(5),
-                        google::cloud::bigtable::GcRule::MaxAge(
-                            std::chrono::hours(24 * 7)))),
-         google::cloud::bigtable::ColumnFamilyModification::Create(
-             "bar", google::cloud::bigtable::GcRule::Intersection(
-                        google::cloud::bigtable::GcRule::MaxNumVersions(3),
-                        google::cloud::bigtable::GcRule::MaxAge(
-                            std::chrono::hours(72))))});
+        {cbt::ColumnFamilyModification::Drop("foo"),
+         cbt::ColumnFamilyModification::Update(
+             "fam", cbt::GcRule::Union(
+                        cbt::GcRule::MaxNumVersions(5),
+                        cbt::GcRule::MaxAge(std::chrono::hours(24 * 7)))),
+         cbt::ColumnFamilyModification::Create(
+             "bar", cbt::GcRule::Intersection(
+                        cbt::GcRule::MaxNumVersions(3),
+                        cbt::GcRule::MaxAge(std::chrono::hours(72))))});
 
     if (!schema) {
       throw std::runtime_error(schema.status().message());
@@ -452,7 +452,8 @@ void DropAllRows(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [drop all rows] [START bigtable_truncate_table]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     google::cloud::Status status = admin.DropAllRows(table_id);
     if (!status.ok()) {
       throw std::runtime_error(status.message());
@@ -470,7 +471,8 @@ void DropRowsByPrefix(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [drop rows by prefix] [START bigtable_delete_rows_prefix]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     google::cloud::Status status =
         admin.DropRowsByPrefix(table_id, "key-00004");
     if (!status.ok()) {
@@ -490,8 +492,9 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
   std::string const table_id_param = ConsumeArg(argc, argv);
 
   //! [wait for consistency check]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id_param) {
-    google::cloud::bigtable::TableId table_id(table_id_param);
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id_param) {
+    cbt::TableId table_id(table_id_param);
     auto consistency_token(admin.GenerateConsistencyToken(table_id.get()));
     if (!consistency_token) {
       throw std::runtime_error(consistency_token.status().message());
@@ -519,16 +522,16 @@ void CheckConsistency(google::cloud::bigtable::TableAdmin admin, int argc,
   std::string const consistency_token_param = ConsumeArg(argc, argv);
 
   //! [check consistency]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id_param,
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id_param,
      std::string consistency_token_param) {
-    google::cloud::bigtable::TableId table_id(table_id_param);
-    google::cloud::bigtable::ConsistencyToken consistency_token(
-        consistency_token_param);
+    cbt::TableId table_id(table_id_param);
+    cbt::ConsistencyToken consistency_token(consistency_token_param);
     auto result = admin.CheckConsistency(table_id, consistency_token);
     if (!result) {
       throw std::runtime_error(result.status().message());
     }
-    if (*result == google::cloud::bigtable::Consistency::kConsistent) {
+    if (*result == cbt::Consistency::kConsistent) {
       std::cout << "Table is consistent\n";
     } else {
       std::cout
@@ -550,7 +553,8 @@ void GenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
   std::string const table_id = ConsumeArg(argc, argv);
 
   //! [generate consistency token]
-  [](google::cloud::bigtable::TableAdmin admin, std::string table_id) {
+  namespace cbt = google::cloud::bigtable;
+  [](cbt::TableAdmin admin, std::string table_id) {
     auto token = admin.GenerateConsistencyToken(table_id);
     if (!token) {
       throw std::runtime_error(token.status().message());


### PR DESCRIPTION
Consistently use `namespace cbt = google::cloud::bigtable` in the examples.
That makes the code snippets less crufty and therefore more readable.

This fixes #2557, fixes #2558, fixes #2559, fixes #2560, and fixes #2561.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2575)
<!-- Reviewable:end -->
