### PR TITLE
Use the bigtable_get_table_metadata region tag.

### DIFF
--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -99,7 +99,7 @@ void GetTable(google::cloud::bigtable::TableAdmin admin, int argc,
   }
   std::string const table_id = ConsumeArg(argc, argv);
 
-  //! [get table]
+  //! [get table] [START bigtable_get_table_metadata]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id) {
     auto table =
@@ -116,7 +116,7 @@ void GetTable(google::cloud::bigtable::TableAdmin admin, int argc,
       std::cout << "\t" << family_name << "\t\t" << gc_rule << "\n";
     }
   }
-  //! [get table]
+  //! [get table] [END bigtable_get_table_metadata]
   (std::move(admin), table_id);
 }
 


### PR DESCRIPTION
Seems like the code was already there, we just did not know what
region tag to use.

This fixes #2497.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2577)
<!-- Reviewable:end -->
