### PR TITLE
Prevent transient problems from breaking production test.

### DIFF
--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -528,9 +528,10 @@ TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
     auto failures = table.BulkApply(std::move(bulk));
     ASSERT_TRUE(failures.empty()) << "failures=" << [&failures]() {
       std::ostringstream os;
-      os << "[";
-      for (auto&& f : failures) {
-        os << "failed[" << f.original_index() << "]=" << f.status() << ", ";
+      char const* sep = "[";
+      for (auto const& f : failures) {
+        os << sep << "failed[" << f.original_index() << "]=" << f.status();
+        sep = ", ";
       }
       os << "]";
       return os.str();


### PR DESCRIPTION
One of the test runs against production failed in this test:

https://source.cloud.google.com/results/invocations/7e17585e-596f-40c3-b237-e4745b54dfc1

The log is not detailed enough to diagnose the problem, so first I
fixed that. My guess is that the test failed because the mutations
used to prepare data for the test are non-idempotent, so any transient
failure will stop the test. I fixed that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2578)
<!-- Reviewable:end -->
