### PR TITLE
Need 'ignore_warnings' to actually delete an AppProfile.

### DIFF
--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -628,7 +628,7 @@ void AsyncDeleteAppProfile(
     google::cloud::future<google::cloud::Status> future =
         instance_admin.AsyncDeleteAppProfile(cq, cbt::InstanceId(instance_id),
                                              cbt::AppProfileId(app_profile_id),
-                                             true);
+                                             /*ignore_warnings=*/true);
 
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -627,7 +627,8 @@ void AsyncDeleteAppProfile(
      std::string instance_id, std::string app_profile_id) {
     google::cloud::future<google::cloud::Status> future =
         instance_admin.AsyncDeleteAppProfile(cq, cbt::InstanceId(instance_id),
-                                             cbt::AppProfileId(app_profile_id));
+                                             cbt::AppProfileId(app_profile_id),
+                                             true);
 
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.

--- a/google/cloud/bigtable/internal/instance_admin.h
+++ b/google/cloud/bigtable/internal/instance_admin.h
@@ -914,11 +914,12 @@ class InstanceAdmin {
   std::shared_ptr<AsyncOperation> AsyncDeleteAppProfile(
       CompletionQueue& cq, Functor&& callback,
       bigtable::InstanceId const& instance_id,
-      bigtable::AppProfileId const& profile_id) {
+      bigtable::AppProfileId const& profile_id, bool ignore_warnings = true) {
     google::bigtable::admin::v2::DeleteAppProfileRequest request;
     // Setting profile name.
     request.set_name(InstanceName(instance_id.get()) + "/appProfiles/" +
                      profile_id.get());
+    request.set_ignore_warnings(ignore_warnings);
 
     static_assert(internal::ExtractMemberFunctionType<decltype(
                       &InstanceAdminClient::AsyncDeleteAppProfile)>::value,

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -416,7 +416,8 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   ASSERT_STATUS_OK(
       instance_admin_
           ->AsyncDeleteAppProfile(cq, bigtable::InstanceId(instance_id),
-                                  bigtable::AppProfileId(id1), true)
+                                  bigtable::AppProfileId(id1),
+                                  /*ignore_warnings=*/true)
           .get());
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
@@ -426,7 +427,8 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   ASSERT_STATUS_OK(
       instance_admin_
           ->AsyncDeleteAppProfile(cq, bigtable::InstanceId(instance_id),
-                                  bigtable::AppProfileId(id2), false)
+                                  bigtable::AppProfileId(id2),
+                                  /*ignore_warnings=*/false)
           .get());
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);

--- a/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
@@ -429,7 +429,7 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
                                 promise_delete_first_profile.set_value();
                               },
                               bigtable::InstanceId(instance_id),
-                              bigtable::AppProfileId(id1));
+                              bigtable::AppProfileId(id1), true);
 
   promise_delete_first_profile.get_future().get();
 
@@ -457,7 +457,7 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
                                 promise_delete_second_profile.set_value();
                               },
                               bigtable::InstanceId(instance_id),
-                              bigtable::AppProfileId(id2));
+                              bigtable::AppProfileId(id2), true);
 
   promise_delete_second_profile.get_future().get();
 

--- a/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
@@ -422,15 +422,15 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
 
   // delete first profile
   std::promise<void> promise_delete_first_profile;
-  admin.AsyncDeleteAppProfile(
-      cq,
-      [&promise_delete_first_profile](
-          google::cloud::bigtable::CompletionQueue& cq,
-          grpc::Status const& status) {
-        promise_delete_first_profile.set_value();
-      },
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id1),
-      /*ignore_warnings=*/true);
+  admin.AsyncDeleteAppProfile(cq,
+                              [&promise_delete_first_profile](
+                                  google::cloud::bigtable::CompletionQueue& cq,
+                                  grpc::Status const& status) {
+                                promise_delete_first_profile.set_value();
+                              },
+                              bigtable::InstanceId(instance_id),
+                              bigtable::AppProfileId(id1),
+                              /*ignore_warnings=*/true);
 
   promise_delete_first_profile.get_future().get();
 
@@ -451,15 +451,15 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
 
   // delete second profile
   std::promise<void> promise_delete_second_profile;
-  admin.AsyncDeleteAppProfile(
-      cq,
-      [&promise_delete_second_profile](
-          google::cloud::bigtable::CompletionQueue& cq,
-          grpc::Status const& status) {
-        promise_delete_second_profile.set_value();
-      },
-      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2),
-      /*ignore_warnings=*/true);
+  admin.AsyncDeleteAppProfile(cq,
+                              [&promise_delete_second_profile](
+                                  google::cloud::bigtable::CompletionQueue& cq,
+                                  grpc::Status const& status) {
+                                promise_delete_second_profile.set_value();
+                              },
+                              bigtable::InstanceId(instance_id),
+                              bigtable::AppProfileId(id2),
+                              /*ignore_warnings=*/true);
 
   promise_delete_second_profile.get_future().get();
 

--- a/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_integration_test.cc
@@ -422,14 +422,15 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
 
   // delete first profile
   std::promise<void> promise_delete_first_profile;
-  admin.AsyncDeleteAppProfile(cq,
-                              [&promise_delete_first_profile](
-                                  google::cloud::bigtable::CompletionQueue& cq,
-                                  grpc::Status const& status) {
-                                promise_delete_first_profile.set_value();
-                              },
-                              bigtable::InstanceId(instance_id),
-                              bigtable::AppProfileId(id1), true);
+  admin.AsyncDeleteAppProfile(
+      cq,
+      [&promise_delete_first_profile](
+          google::cloud::bigtable::CompletionQueue& cq,
+          grpc::Status const& status) {
+        promise_delete_first_profile.set_value();
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id1),
+      /*ignore_warnings=*/true);
 
   promise_delete_first_profile.get_future().get();
 
@@ -450,14 +451,15 @@ TEST_F(InstanceAdminAsyncIntegrationTest, AsyncCreateListDeleteAppProfile) {
 
   // delete second profile
   std::promise<void> promise_delete_second_profile;
-  admin.AsyncDeleteAppProfile(cq,
-                              [&promise_delete_second_profile](
-                                  google::cloud::bigtable::CompletionQueue& cq,
-                                  grpc::Status const& status) {
-                                promise_delete_second_profile.set_value();
-                              },
-                              bigtable::InstanceId(instance_id),
-                              bigtable::AppProfileId(id2), true);
+  admin.AsyncDeleteAppProfile(
+      cq,
+      [&promise_delete_second_profile](
+          google::cloud::bigtable::CompletionQueue& cq,
+          grpc::Status const& status) {
+        promise_delete_second_profile.set_value();
+      },
+      bigtable::InstanceId(instance_id), bigtable::AppProfileId(id2),
+      /*ignore_warnings=*/true);
 
   promise_delete_second_profile.get_future().get();
 


### PR DESCRIPTION
Without setting `ignore_warnings == true` deleting an AppProfile typically
fails during tests. There may be a case for making the default `true`, but
I think that is a different PR, right now I want these tests to actually
work when executed against production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2586)
<!-- Reviewable:end -->
