### PR TITLE
Fix the admin tests and examples to run against production.

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -264,7 +264,7 @@ void CreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
                    int argc, char* argv[]) {
   if (argc != 4) {
     throw Usage{
-        "create-cluster: <project-id> <instance-id> <cluster-id> <zone>"};
+        "create-cluster <project-id> <instance-id> <cluster-id> <zone>"};
   }
   auto instance_id = ConsumeArg(argc, argv);
   auto cluster_id = ConsumeArg(argc, argv);
@@ -356,7 +356,7 @@ void ListAllClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
 void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
                    int argc, char* argv[]) {
   if (argc != 3) {
-    throw Usage{"update-cluster: <project-id> <instance-id> <cluster-id>"};
+    throw Usage{"update-cluster <project-id> <instance-id> <cluster-id>"};
   }
   auto instance_id = ConsumeArg(argc, argv);
   auto cluster_id = ConsumeArg(argc, argv);
@@ -372,7 +372,9 @@ void UpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
       throw std::runtime_error(cluster.status().message());
     }
 
-    // Modify the cluster.
+    // The state cannot be sent on updates, so clear it first.
+    cluster->clear_state();
+    // Set the desired cluster configuration.
     cluster->set_serve_nodes(4);
     auto modified_config = cbt::ClusterConfig(std::move(*cluster));
 

--- a/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples_instance_admin.cc
@@ -91,7 +91,7 @@ void RunInstanceOperations(std::string project_id, int argc, char* argv[]) {
 
     // production instance needs at least 3 nodes
     auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 3, google::cloud::bigtable::ClusterConfig::SSD);
+        zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
     google::cloud::bigtable::InstanceConfig config(
         google::cloud::bigtable::InstanceId(instance_id), display_name,
         {{cluster_id.get(), cluster_config}});
@@ -282,7 +282,7 @@ void CreateCluster(std::string project_id, int argc, char* argv[]) {
     // [START bigtable_create_cluster]
     std::cout << "Adding Cluster to Instance: " << instance_id.get() << "\n";
     auto cluster_config = google::cloud::bigtable::ClusterConfig(
-        zone, 3, google::cloud::bigtable::ClusterConfig::SSD);
+        zone, 3, google::cloud::bigtable::ClusterConfig::HDD);
     // Block until the operation completes.
     auto cluster =
         instance_admin.CreateCluster(cluster_config, instance_id, cluster_id)

--- a/google/cloud/bigtable/examples/run_admin_examples_production.sh
+++ b/google/cloud/bigtable/examples/run_admin_examples_production.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+readonly BINDIR="$(dirname "$0")"
+source "${BINDIR}/run_examples_utils.sh"
+source "${BINDIR}/../tools/run_emulator_utils.sh"
+source "${BINDIR}/../../../../ci/colors.sh"
+
+# Run all the admin examples tests against production. Only nightly builds
+# should run this script.
+#
+# The following environment variables must be defined before calling this
+# script:
+#
+# - PROJECT_ID: the id (typically the string form) of a valid GCP project.
+# - ZONE_A: the name of a valid GCP zone supporting Cloud Bigtable.
+# - ZONE_B: the name of a valid GCP zone supporting Cloud Bigtable, should be
+#   different from ZONE_A and should be in the same region.
+# - INSTANCE_ID: the ID of an existing Cloud Bigtable instance in ZONE_A.
+#
+
+echo "${COLOR_YELLOW}run_quickstart_example${COLOR_RESET}"
+run_quickstart_example "${PROJECT_ID}" "${INSTANCE_ID}"
+
+echo "${COLOR_YELLOW}run_hello_world_example${COLOR_RESET}"
+run_hello_world_example "${PROJECT_ID}" "${INSTANCE_ID}"
+
+echo "${COLOR_YELLOW}run_hello_app_profile_example${COLOR_RESET}"
+run_hello_app_profile_example "${PROJECT_ID}" "${INSTANCE_ID}"
+
+echo "${COLOR_YELLOW}run_all_table_admin_examples${COLOR_RESET}"
+run_all_table_admin_examples "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}"
+
+echo "${COLOR_YELLOW}run_all_table_admin_async_examples${COLOR_RESET}"
+run_all_table_admin_async_examples "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}"
+
+echo "${COLOR_YELLOW}run_all_instance_admin_examples${COLOR_RESET}"
+run_all_instance_admin_examples "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}"
+
+echo "${COLOR_YELLOW}run_all_instance_admin_async_examples${COLOR_RESET}"
+run_all_instance_admin_async_examples "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}"
+
+exit_example_runner

--- a/google/cloud/bigtable/examples/run_examples_emulator.sh
+++ b/google/cloud/bigtable/examples/run_examples_emulator.sh
@@ -25,20 +25,15 @@ echo
 echo "Running Bigtable Example programs"
 start_emulators
 
-# Use a (likely unique) project id for the emulator.
-readonly PROJECT_ID="project-${RANDOM}-${RANDOM}"
-readonly INSTANCE_ID="in-${RANDOM}-${RANDOM}"
-readonly ZONE_ID="fake-zone"
-readonly REPLICATION_ZONE_ID="fake-zone-2"
+# Setup the environment variables AS-IF running against production, but with
+# fake values.
+export PROJECT_ID="project-${RANDOM}-${RANDOM}"
+export INSTANCE_ID="in-${RANDOM}-${RANDOM}"
+export ZONE_A="fake-region1-a"
+export ZONE_B="fake-region1-b"
+export SERVICE_ACCOUNT="fake-sa@${PROJECT_ID}.iam.gserviceaccount.com"
 
-run_all_data_examples "${PROJECT_ID}" "${INSTANCE_ID}"
-run_all_data_async_examples "${PROJECT_ID}" "${INSTANCE_ID}"
-run_quickstart_example "${PROJECT_ID}" "${INSTANCE_ID}"
-run_hello_world_example "${PROJECT_ID}" "${INSTANCE_ID}"
-run_hello_app_profile_example "${PROJECT_ID}" "${INSTANCE_ID}"
-run_all_table_admin_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_ZONE_ID}"
-run_all_table_admin_async_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_ZONE_ID}"
-run_all_instance_admin_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_ZONE_ID}"
-run_all_instance_admin_async_examples "${PROJECT_ID}" "${ZONE_ID}" "${REPLICATION_ZONE_ID}"
+"${BINDIR}/run_examples_production.sh" || EXIT_STATUS=1
+"${BINDIR}/run_admin_examples_production.sh" || EXIT_STATUS=1
 
 exit_example_runner

--- a/google/cloud/bigtable/examples/run_examples_production.sh
+++ b/google/cloud/bigtable/examples/run_examples_production.sh
@@ -18,8 +18,13 @@ set -eu
 readonly BINDIR="$(dirname "$0")"
 source "${BINDIR}/run_examples_utils.sh"
 
-# Run only the data examples in production. The CI systems go over project
-# quotas for admin operations if we run the admin examples too.
+# In the presubmit and continuous integration builds we only run the data
+# examples against production. The CI systems go over project quotas for admin
+# operations if we run the admin examples too.
+echo "${COLOR_YELLOW}run_all_data_examples${COLOR_RESET}"
 run_all_data_examples "${PROJECT_ID}" "${INSTANCE_ID}"
+
+echo "${COLOR_YELLOW}run_all_data_async_examples${COLOR_RESET}"
+run_all_data_async_examples "${PROJECT_ID}" "${INSTANCE_ID}"
 
 exit_example_runner

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -222,7 +222,15 @@ void TableIntegrationTest::CreateCells(
     bulk.emplace_back(std::move(kv.second));
   }
   auto failures = table.BulkApply(std::move(bulk));
-  ASSERT_TRUE(failures.empty());
+  ASSERT_TRUE(failures.empty()) << "failures=" << [&failures]() {
+    std::ostringstream os;
+    char const* sep = "[";
+    for (auto const& f : failures) {
+      os << sep << "failure[" << f.original_index() << "]=" << f.status();
+      sep = ", ";
+    }
+    return os.str();
+  }();
 }
 
 std::vector<bigtable::Cell> TableIntegrationTest::GetCellsIgnoringTimestamp(

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -31,6 +31,9 @@ namespace {
 
 // Initialized in main() below.
 char const* flag_project_id;
+char const* flag_zone_a;
+char const* flag_zone_b;
+char const* flag_service_account;
 
 class InstanceAdminAsyncFutureIntegrationTest : public ::testing::Test {
  protected:
@@ -77,7 +80,7 @@ bool IsIdOrNamePresentInClusterList(
 }
 
 bigtable::InstanceConfig IntegrationTestConfig(
-    std::string const& id, std::string const& zone = "us-central1-f",
+    std::string const& id, std::string const& zone,
     bigtable::InstanceConfig::InstanceType instance_type =
         bigtable::InstanceConfig::DEVELOPMENT,
     int32_t serve_node = 0) {
@@ -127,8 +130,10 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
       << " generated at random.";
 
   // create instance
-  auto config = IntegrationTestConfig(instance_id);
+  auto config = IntegrationTestConfig(instance_id, flag_zone_a);
   auto instance = instance_admin_->AsyncCreateInstance(cq, config).get();
+  ASSERT_STATUS_OK(instance);
+
   auto async_instances_current = instance_admin_->AsyncListInstances(cq).get();
   ASSERT_STATUS_OK(async_instances_current);
   EXPECT_TRUE(
@@ -186,9 +191,10 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
   // create instance prerequisites for cluster operations
   bigtable::InstanceId instance_id(id);
   auto instance_config = IntegrationTestConfig(
-      id, "us-central1-f", bigtable::InstanceConfig::PRODUCTION, 3);
+      id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_details =
       instance_admin_->AsyncCreateInstance(cq, instance_config).get();
+  ASSERT_STATUS_OK(instance_details);
 
   // Make an asynchronous request, but immediately block because this is just a
   // test.
@@ -203,7 +209,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
   // create cluster
   bigtable::ClusterId cluster_id(cluster_id_str);
   auto cluster_config =
-      bigtable::ClusterConfig("us-central1-b", 3, bigtable::ClusterConfig::HDD);
+      bigtable::ClusterConfig(flag_zone_b, 3, bigtable::ClusterConfig::HDD);
   auto cluster =
       instance_admin_
           ->AsyncCreateCluster(cq, cluster_config, instance_id, cluster_id)
@@ -284,15 +290,22 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAllClustersTest) {
   std::thread pool([&cq] { cq.Run(); });
 
   auto instance_config1 = IntegrationTestConfig(
-      id1, "us-central1-c", bigtable::InstanceConfig::PRODUCTION, 3);
+      id1, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_config2 = IntegrationTestConfig(
-      id2, "us-central1-f", bigtable::InstanceConfig::PRODUCTION, 3);
-  auto instance1 = instance_admin_->AsyncCreateInstance(cq, instance_config1);
-  auto instance2 = instance_admin_->AsyncCreateInstance(cq, instance_config2);
-  // Wait for instance creation
+      id2, flag_zone_b, bigtable::InstanceConfig::PRODUCTION, 3);
+  auto instance1_future =
+      instance_admin_->AsyncCreateInstance(cq, instance_config1);
+  auto instance2_future =
+      instance_admin_->AsyncCreateInstance(cq, instance_config2);
 
-  auto instance1_name = instance1.get()->name();
-  auto instance2_name = instance2.get()->name();
+  // Wait for instance creation
+  auto instance1 = instance1_future.get();
+  auto instance2 = instance2_future.get();
+  ASSERT_STATUS_OK(instance1);
+  ASSERT_STATUS_OK(instance2);
+
+  auto instance1_name = instance1->name();
+  auto instance2_name = instance2->name();
   ASSERT_THAT(instance1_name, HasSubstr(id1));
   ASSERT_THAT(instance2_name, HasSubstr(id2));
 
@@ -311,8 +324,8 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAllClustersTest) {
   EXPECT_TRUE(
       IsIdOrNamePresentInClusterList(clusters_list->clusters, instance2_name));
 
-  ASSERT_STATUS_OK(instance_admin_->AsyncDeleteInstance(id1, cq).get());
-  ASSERT_STATUS_OK(instance_admin_->AsyncDeleteInstance(id2, cq).get());
+  EXPECT_STATUS_OK(instance_admin_->AsyncDeleteInstance(id1, cq).get());
+  EXPECT_STATUS_OK(instance_admin_->AsyncDeleteInstance(id2, cq).get());
 
   cq.Shutdown();
   pool.join();
@@ -327,10 +340,10 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   std::thread pool([&cq] { cq.Run(); });
 
   auto instance_config = IntegrationTestConfig(
-      instance_id, "us-central1-c", bigtable::InstanceConfig::PRODUCTION, 3);
+      instance_id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
   auto future = instance_admin_->AsyncCreateInstance(cq, instance_config);
   auto actual = future.get();
-  EXPECT_STATUS_OK(actual);
+  ASSERT_STATUS_OK(actual);
   // Wait for instance creation
   ASSERT_THAT(actual->name(), HasSubstr(instance_id));
 
@@ -428,14 +441,14 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
       instance_admin_
           ->AsyncDeleteAppProfile(cq, bigtable::InstanceId(instance_id),
                                   bigtable::AppProfileId(id2),
-                                  /*ignore_warnings=*/false)
+                                  /*ignore_warnings=*/true)
           .get());
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_EQ(0U, count_matching_profiles(id1, *current_profiles));
   EXPECT_EQ(0U, count_matching_profiles(id2, *current_profiles));
 
-  ASSERT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
+  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
 
   cq.Shutdown();
   pool.join();
@@ -452,18 +465,17 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, SetGetTestIamAPIsTest) {
   // create instance prerequisites for cluster operations
   bigtable::InstanceId instance_id(id);
   auto instance_config = IntegrationTestConfig(
-      id, "us-central1-f", bigtable::InstanceConfig::PRODUCTION, 3);
+      id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_details =
       instance_admin_->CreateInstance(instance_config).get();
+  ASSERT_STATUS_OK(instance_details);
 
-  std::string resource = id;
   auto iam_bindings = google::cloud::IamBindings(
-      "writer", {"abc@gmail.com", "xyz@gmail.com", "pqr@gmail.com"});
+      "roles/bigtable.reader",
+      {"serviceAccount:" + std::string(flag_service_account)});
 
   auto initial_policy =
-      instance_admin_
-          ->AsyncSetIamPolicy(cq, instance_id, iam_bindings, "test-tag")
-          .get();
+      instance_admin_->AsyncSetIamPolicy(cq, instance_id, iam_bindings).get();
   ASSERT_STATUS_OK(initial_policy);
 
   auto fetched_policy =
@@ -481,6 +493,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, SetGetTestIamAPIsTest) {
   ASSERT_STATUS_OK(permission_set);
 
   EXPECT_EQ(2U, permission_set->size());
+  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(id));
 
   cq.Shutdown();
   pool.join();
@@ -489,15 +502,19 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, SetGetTestIamAPIsTest) {
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
 
-  if (argc != 2) {
+  if (argc != 5) {
     std::string const cmd = argv[0];
     auto last_slash = std::string(cmd).find_last_of('/');
     // Show usage if number of arguments is invalid.
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1) << " <project_id>\n";
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1) << " <project_id>"
+              << " <zone-a> <zone-b> <service-account>\n";
     return 1;
   }
 
   flag_project_id = argv[1];
+  flag_zone_a = argv[2];
+  flag_zone_b = argv[3];
+  flag_service_account = argv[4];
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/run_admin_integration_tests_production.sh
+++ b/google/cloud/bigtable/tests/run_admin_integration_tests_production.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Run all the admin integration tests against production. Only nightly builds
+# should run this script.
+#
+# The following environment variables must be defined before calling this
+# script:
+#
+# - PROJECT_ID: the id (typically the string form) of a valid GCP project.
+# - ZONE_A: the name of a valid GCP zone supporting Cloud Bigtable.
+# - ZONE_B: the name of a valid GCP zone supporting Cloud Bigtable, should be
+#   different from ZONE_A and should be in the same region.
+# - INSTANCE_ID: the ID of an existing Cloud Bigtable instance in ZONE_A.
+# - SERVICE_ACCOUNT: a valid service account to test IAM operations.
+#
+
+echo
+echo "Running bigtable::InstanceAdmin integration test."
+./instance_admin_integration_test \
+    "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}" "${SERVICE_ACCOUNT}"
+
+echo
+echo "Running bigtable::InstanceAdmin async with futures integration test."
+./instance_admin_async_future_integration_test \
+    "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}" "${SERVICE_ACCOUNT}"
+
+echo
+echo "Running TableAdmin async integration test."
+./instance_admin_async_integration_test  \
+    "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}" "${SERVICE_ACCOUNT}"
+
+echo
+echo "Running bigtable::TableAdmin integration test."
+./admin_integration_test \
+    "${PROJECT_ID}" "${INSTANCE_ID}" "${ZONE_A}" "${ZONE_B}"
+
+echo
+echo "Running TableAdmin async with futures integration test."
+./admin_async_future_integration_test \
+    "${PROJECT_ID}" "${INSTANCE_ID}"  "${ZONE_A}" "${ZONE_B}"
+
+echo
+echo "Running TableAdmin async integration test."
+./admin_async_integration_test  \
+    "${PROJECT_ID}" "${INSTANCE_ID}"  "${ZONE_A}" "${ZONE_B}"

--- a/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
+++ b/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
@@ -26,49 +26,12 @@ start_emulators
 # Use a unique project name to allow multiple runs of the test with
 # an externally launched emulator.
 readonly NONCE="${RANDOM}-${RANDOM}"
-readonly PROJECT_ID="emulated-${NONCE}"
+export PROJECT_ID="emulated-${NONCE}"
+export INSTANCE_ID="it-${NONCE}"
+export ZONE_A="fake-region1-a"
+export ZONE_B="fake-region1-b"
+export SERVICE_ACCOUNT="fake-sa@${PROJECT_ID}.iam.gserviceaccount.com"
 
-echo
-echo "Running bigtable::InstanceAdmin integration test."
-./instance_admin_integration_test "${PROJECT_ID}";
-
-echo
-echo "Running bigtable::InstanceAdmin integration test."
-./instance_admin_async_integration_test "${PROJECT_ID}" "us-central1-f" "us-central1-b";
-
-echo
-echo "Running bigtable::InstanceAdmin async with futures integration test."
-./instance_admin_async_future_integration_test "${PROJECT_ID}";
-
-echo
-echo "Running bigtable::TableAdmin integration test."
-./admin_integration_test "${PROJECT_ID}" "admin-test" "fake-zone-1" "fake-zone-2"
-
-echo
-echo "Running bigtable::Table integration test."
-./data_integration_test "${PROJECT_ID}" "data-test"
-
-echo
-echo "Running bigtable::Filters integration tests."
-./filters_integration_test "${PROJECT_ID}" "filters-test"
-
-echo
-echo "Running Mutation (e.g. DeleteFromColumn, SetCell) integration tests."
-./mutations_integration_test "${PROJECT_ID}" "mutations-test"
-
-echo
-echo "Running TableAdmin async integration test."
-./admin_async_integration_test "${PROJECT_ID}" "admin-noex-async"
-
-echo
-echo "Running TableAdmin async with futures integration test."
-./admin_async_future_integration_test \
-  "${PROJECT_ID}" "admin-async-future" "fake-zone-1" "fake-zone-2"
-
-echo
-echo "Running Table::Async* integration test with futures."
-./data_async_future_integration_test "${PROJECT_ID}" "data-async-future"
-
-echo
-echo "Running Table::Async* integration test."
-./data_async_integration_test "${PROJECT_ID}" "data-noex-async"
+# We run the same tests we run in production, just with different settings.
+"${BINDIR}/run_integration_tests_production.sh"
+"${BINDIR}/run_admin_integration_tests_production.sh"


### PR DESCRIPTION
Introduce new scripts to run the admin integration tests and examples
against productions. There were a number of small problems in the
tests and examples that I had to fix to get the tests to pass.

These tests will be enabled in a future PR as part of a nightly build.
Part of the work for #2513.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2591)
<!-- Reviewable:end -->
