### PR TITLE
Support running the admin tests and examples in a nightly build.

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -119,6 +119,17 @@ tar x -C "${HOME}" -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 "${HOME}/google-cloud-sdk/bin/gcloud" --quiet components install cbt
 export CBT="${HOME}/google-cloud-sdk/bin/cbt"
 
+if [[ "${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS}" = "yes" ]]; then
+  echo
+  echo "================================================================"
+  echo "Running Google Cloud Bigtable Integration Tests $(date)"
+  echo "================================================================"
+  (cd "$(bazel info bazel-bin)/google/cloud/bigtable/tests" && \
+     "${PROJECT_ROOT}/google/cloud/bigtable/tests/run_admin_integration_tests_production.sh")
+  (cd "$(bazel info bazel-bin)/google/cloud/bigtable/examples" && \
+     "${PROJECT_ROOT}/google/cloud/bigtable/examples/run_admin_examples_production.sh")
+fi
+
 echo
 echo "================================================================"
 echo "Running Google Cloud Bigtable Integration Tests $(date)"

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -119,7 +119,7 @@ tar x -C "${HOME}" -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 "${HOME}/google-cloud-sdk/bin/gcloud" --quiet components install cbt
 export CBT="${HOME}/google-cloud-sdk/bin/cbt"
 
-if [[ "${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS}" = "yes" ]]; then
+if [[ "${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS:-}" = "yes" ]]; then
   echo
   echo "================================================================"
   echo "Running Google Cloud Bigtable Integration Tests $(date)"

--- a/ci/kokoro/ubuntu/nightly.cfg
+++ b/ci/kokoro/ubuntu/nightly.cfg
@@ -1,0 +1,35 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/ubuntu/build.sh"
+timeout_mins: 120
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
+
+action {
+  define_artifacts {
+    regex: "**/test.xml"
+    regex: "**/*.log"
+    regex: "bazel_invocation_ids"
+  }
+}
+
+env_vars {
+  key: "ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS"
+  value: "yes"
+}


### PR DESCRIPTION
We cannot run the Cloud Bigtable admin tests and examples on every build,
because we run out of quota if we do. But we can run it once every day,
which at least would detect problems before we cut a release.

A separate CL will enable this build, but first stage the configuration changes.
This is part of the work for #2513.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2592)
<!-- Reviewable:end -->
