### PR TITLE
Update documentation for top-level classes.

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -569,6 +569,48 @@ function run_all_data_async_examples {
   # some kind of Usage message.
   run_example_usage ./data_async_snippets
 }
+
+################################################
+# Run the Bigtable policy examples.
+# Globals:
+#   None
+# Arguments:
+#   project_id: the Google Cloud Storage project used in the test. Can be a
+#       fake project when testing against the emulator, as the emulator creates
+#       projects on demand. It must be a valid, existing instance when testing
+#       against production.
+#   instance_id: the Google Cloud Bigtable instance used in the test. Can be a
+#       fake instance when testing against the emulator, as the emulator creates
+#       instances on demand. It must be a valid, existing instance when testing
+#       against production.
+# Returns:
+#   None
+################################################
+run_all_policy_examples() {
+  local project_id=$1
+  local instance_id=$2
+  shift 2
+
+  EMULATOR_LOG="emulator.log"
+
+  # Use the same table in all the tests.
+  local -r TABLE="policy-ex-tbl-${RANDOM}-${RANDOM}"
+
+  run_example ./table_admin_snippets create-table \
+      "${project_id}" "${instance_id}" "${TABLE}"
+
+  run_example ./data_snippets apply-relaxed-idempotency \
+      "${project_id}" "${instance_id}" "${TABLE}" \
+      "apply-relaxed-idempotency"
+
+  run_example ./data_snippets apply-custom-retry \
+      "${project_id}" "${instance_id}" "${TABLE}" \
+      "apply-custom-retry"
+
+  run_example ./table_admin_snippets delete-table \
+      "${project_id}" "${instance_id}" "${TABLE}"
+}
+
 ################################################
 # Run the Bigtable quick start example.
 # Globals:

--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -15,7 +15,7 @@
 
 set -eu
 
-if [ -z "${PROJECT_ROOT+x}" ]; then
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../../.."; pwd)"
 fi
 source "${PROJECT_ROOT}/ci/define-example-runner.sh"
@@ -35,7 +35,7 @@ function exit_handler {
   local instance=$2
   shift 2
 
-  if [ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]; then
+  if [[ -n "${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST:-}" ]]; then
     kill_emulators
   else
     cleanup_instance "${project}" "${instance}"
@@ -479,6 +479,12 @@ run_all_data_examples() {
       "${project_id}" "${instance_id}" "${TABLE}"
   run_example ./data_snippets apply \
       "${project_id}" "${instance_id}" "${TABLE}"
+  run_example ./data_snippets apply-relaxed-idempotency \
+      "${project_id}" "${instance_id}" "${TABLE}" \
+      "apply-relaxed-idempotency"
+  run_example ./data_snippets apply-custom-retry \
+      "${project_id}" "${instance_id}" "${TABLE}" \
+      "apply-custom-retry"
   run_example ./data_snippets bulk-apply \
       "${project_id}" "${instance_id}" "${TABLE}"
 
@@ -549,6 +555,22 @@ run_all_data_examples() {
       "${project_id}" "${instance_id}" "${TABLE}"
 }
 
+################################################
+# Run the Bigtable examples for Async* operations on data.
+# Globals:
+#   None
+# Arguments:
+#   project_id: the Google Cloud Storage project used in the test. Can be a
+#       fake project when testing against the emulator, as the emulator creates
+#       projects on demand. It must be a valid, existing instance when testing
+#       against production.
+#   instance_id: the Google Cloud Bigtable instance used in the test. Can be a
+#       fake instance when testing against the emulator, as the emulator creates
+#       instances on demand. It must be a valid, existing instance when testing
+#       against production.
+# Returns:
+#   None
+################################################
 function run_all_data_async_examples {
   local project_id=$1
   local instance_id=$2
@@ -568,47 +590,6 @@ function run_all_data_async_examples {
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.
   run_example_usage ./data_async_snippets
-}
-
-################################################
-# Run the Bigtable policy examples.
-# Globals:
-#   None
-# Arguments:
-#   project_id: the Google Cloud Storage project used in the test. Can be a
-#       fake project when testing against the emulator, as the emulator creates
-#       projects on demand. It must be a valid, existing instance when testing
-#       against production.
-#   instance_id: the Google Cloud Bigtable instance used in the test. Can be a
-#       fake instance when testing against the emulator, as the emulator creates
-#       instances on demand. It must be a valid, existing instance when testing
-#       against production.
-# Returns:
-#   None
-################################################
-run_all_policy_examples() {
-  local project_id=$1
-  local instance_id=$2
-  shift 2
-
-  EMULATOR_LOG="emulator.log"
-
-  # Use the same table in all the tests.
-  local -r TABLE="policy-ex-tbl-${RANDOM}-${RANDOM}"
-
-  run_example ./table_admin_snippets create-table \
-      "${project_id}" "${instance_id}" "${TABLE}"
-
-  run_example ./data_snippets apply-relaxed-idempotency \
-      "${project_id}" "${instance_id}" "${TABLE}" \
-      "apply-relaxed-idempotency"
-
-  run_example ./data_snippets apply-custom-retry \
-      "${project_id}" "${instance_id}" "${TABLE}" \
-      "apply-custom-retry"
-
-  run_example ./table_admin_snippets delete-table \
-      "${project_id}" "${instance_id}" "${TABLE}"
 }
 
 ################################################
@@ -692,6 +673,7 @@ run_hello_world_example() {
   # some kind of Usage message.
   run_example_usage ./bigtable_hello_world
 }
+
 ################################################
 # Run the Bigtable hello app profile example.
 # Globals:

--- a/google/cloud/bigtable/internal/table.h
+++ b/google/cloud/bigtable/internal/table.h
@@ -156,6 +156,7 @@ class Table {
       : client_(std::move(client)),
         app_profile_id_(std::move(app_profile_id)),
         table_name_(bigtable::TableId(TableName(client_, table_id))),
+        table_id_(table_id),
         rpc_retry_policy_(
             bigtable::DefaultRPCRetryPolicy(internal::kBigtableLimits)),
         rpc_backoff_policy_(
@@ -183,6 +184,7 @@ class Table {
   }
 
   std::string const& table_name() const { return table_name_.get(); }
+  std::string const& table_id() const { return table_id_; }
   std::string const& app_profile_id() const { return app_profile_id_.get(); }
 
   //@{
@@ -738,6 +740,7 @@ class Table {
   std::shared_ptr<DataClient> client_;
   bigtable::AppProfileId app_profile_id_;
   bigtable::TableId table_name_;
+  std::string table_id_;
   std::shared_ptr<RPCRetryPolicy> rpc_retry_policy_;
   std::shared_ptr<RPCBackoffPolicy> rpc_backoff_policy_;
   MetadataUpdatePolicy metadata_update_policy_;


### PR DESCRIPTION
I updated the doxygen documentation for bigtable::Table,
bigtable::TableAdmin, and bigtable::InstanceAdmin. Fixed a lot of
nits, documented which operations are idempotent (and thus normally
retried), documented how to configure the policies in bigtable::Table,
their default values for all 3 classes. And also which operations are
thread safe on these classes.

Incidentally this fixes #801.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2596)
<!-- Reviewable:end -->
