### PR TITLE
Cleanup the Doxygen documentation.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -51,6 +51,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/spanner/*"
     "*/google/cloud/storage/*"
     "*/google/cloud/*_test.cc")
+set(DOXYGEN_EXCLUDE_SYMBOL "internal")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -39,6 +39,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/bigtable/tests/*"
     "*/google/cloud/bigtable/tools/*"
     "*/google/cloud/bigtable/*_test.cc")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 
 include(GoogleCloudCppCommon)

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -24,6 +24,10 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+struct InstanceAdminTraits;
+}  // namespace internal
+
 /**
  * Configuration options for the Bigtable Client.
  *
@@ -288,9 +292,10 @@ class ClientOptions {
   static std::string UserAgentPrefix();
 
  private:
-  /// Return the current endpoint for instance admin RPCs.
-  friend struct InstanceAdminTraits;
+  friend struct internal::InstanceAdminTraits;
   friend struct ClientOptionsTestTraits;
+
+  /// Return the current endpoint for instance admin RPCs.
   std::string const& instance_admin_endpoint() const {
     return instance_admin_endpoint_;
   }

--- a/google/cloud/bigtable/cluster_list_responses.h
+++ b/google/cloud/bigtable/cluster_list_responses.h
@@ -29,8 +29,14 @@ struct ClusterList {
   /// The list of clusters received from Cloud Bigtable.
   std::vector<google::bigtable::admin::v2::Cluster> clusters;
 
-  /// The list of Google Cloud Platform locations where the request could not
-  /// get a response from.
+  /**
+   * The list of Google Cloud Platform locations where the request could not
+   * get a response from.
+   *
+   * During an outage Cloud Bigtable may be unable to access specific zones. In
+   * that case the service will return those locations for which no information
+   * could be retrieved in this parameter.
+   */
   std::vector<std::string> failed_locations;
 };
 

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -21,6 +21,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
 /**
  * Implement a simple DataClient.
  *
@@ -159,11 +160,12 @@ class DefaultDataClient : public DataClient {
 std::string const& DefaultDataClient::project_id() const { return project_; }
 
 std::string const& DefaultDataClient::instance_id() const { return instance_; }
+}  // namespace internal
 
 std::shared_ptr<DataClient> CreateDefaultDataClient(std::string project_id,
                                                     std::string instance_id,
                                                     ClientOptions options) {
-  return std::make_shared<DefaultDataClient>(
+  return std::make_shared<internal::DefaultDataClient>(
       std::move(project_id), std::move(instance_id), std::move(options));
 }
 

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -213,7 +213,6 @@ void ReadRow(google::cloud::bigtable::Table table, int argc, char* argv[]) {
       }
       std::cout << ">\n";
     }
-    std::cout << std::flush;
   }
   //! [read row] [END bigtable_read_error]
   (std::move(table));
@@ -247,7 +246,6 @@ void ReadRows(google::cloud::bigtable::Table table, int argc, char* argv[]) {
       auto const& cell = row->cells().at(0);
       std::cout << cell.row_key() << " = [" << cell.value() << "]\n";
     }
-    std::cout << std::flush;
   }
   //! [read rows] [END bigtable_read_range]
   (std::move(table));
@@ -282,7 +280,6 @@ void ReadRowsWithLimit(google::cloud::bigtable::Table table, int argc,
       auto const& cell = row->cells().at(0);
       std::cout << cell.row_key() << " = [" << cell.value() << "]\n";
     }
-    std::cout << std::flush;
   }
   //! [read rows with limit] [END bigtable_read_filter]
   (std::move(table));
@@ -356,7 +353,6 @@ void ReadKeysSet(google::cloud::bigtable::Table table, int argc, char* argv[]) {
                   << "\t\"" << cell.value() << '"' << "\n";
       }
     }
-    std::cout << std::flush;
   }
   // [END bigtable_read_keys_set]
   (std::move(table), std::move(row_keys));
@@ -392,7 +388,6 @@ void ReadRowSetPrefix(google::cloud::bigtable::Table table, int argc,
                   << "\t\"" << cell.value() << '"' << "\n";
       }
     }
-    std::cout << std::flush;
   }
   //! [read rowset prefix] [END bigtable_read_prefix]
   (std::move(table), prefix);
@@ -434,7 +429,6 @@ void ReadPrefixList(google::cloud::bigtable::Table table, int argc,
                   << "\t\"" << cell.value() << '"' << "\n";
       }
     }
-    std::cout << std::flush;
   }
   //! [read prefix list] [END bigtable_read_prefix_list]
   (std::move(table), prefix_list);
@@ -556,7 +550,6 @@ void SampleRows(google::cloud::bigtable::Table table, int argc, char* argv[]) {
       std::cout << "key=" << sample.row_key << " - " << sample.offset_bytes
                 << "\n";
     }
-    std::cout << std::flush;
   }
   //! [sample row keys] [END bigtable_table_sample_splits]
   (std::move(table));
@@ -588,7 +581,6 @@ void SampleRowsCollections(google::cloud::bigtable::Table table, int argc,
       std::cout << "key=" << sample.row_key << " - " << sample.offset_bytes
                 << "\n";
     }
-    std::cout << std::flush;
   }
   //! [sample row keys collections]
   (std::move(table));
@@ -617,7 +609,6 @@ void GetFamily(google::cloud::bigtable::Table table, int argc, char* argv[]) {
       std::cout << cell.family_name() << "\n";
       break;
     }
-    std::cout << std::flush;
   }
   //! [get family] [END bigtable_get_family] [END bigtable_family_ref]
   (std::move(table));

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -289,30 +289,31 @@ void AsyncCheckConsistency(google::cloud::bigtable::TableAdmin admin,
 
   //! [async check consistency]
   namespace cbt = google::cloud::bigtable;
+  using google::cloud::future;
+  using google::cloud::StatusOr;
   [](cbt::TableAdmin admin, cbt::CompletionQueue cq, std::string table_id_param,
      std::string consistency_token_param) {
     cbt::TableId table_id(table_id_param);
     cbt::ConsistencyToken consistency_token(consistency_token_param);
 
-    google::cloud::future<google::cloud::StatusOr<cbt::Consistency>> future =
-        admin.AsyncCheckConsistency(cq, table_id, consistency_token);
-
-    auto final = future.then([](google::cloud::future<
-                                 google::cloud::StatusOr<cbt::Consistency>>
-                                    f) {
-      auto consistency = f.get();
-      if (!consistency) {
-        throw std::runtime_error(consistency.status().message());
-      }
-      if (consistency.value() == cbt::Consistency::kConsistent) {
-        std::cout << "Table is consistent\n";
-      } else {
-        std::cout
-            << "Table is not yet consistent, Please Try again Later with the "
-               "same Token!";
-      }
-      std::cout << std::flush;
-    });
+    future<void> final =
+        admin.AsyncCheckConsistency(cq, table_id, consistency_token)
+            .then([consistency_token_param](
+                      future<StatusOr<cbt::Consistency>> f) {
+              auto consistency = f.get();
+              if (!consistency) {
+                throw std::runtime_error(consistency.status().message());
+              }
+              if (consistency.value() == cbt::Consistency::kConsistent) {
+                std::cout << "Table is consistent\n";
+              } else {
+                std::cout << "Table is not yet consistent, Please try again"
+                          << " later with the same token ("
+                          << consistency_token_param << ")";
+              }
+              std::cout << std::flush;
+            });
+    final.get();  // block until done to keep example simple.
   }
   //! [async check consistency]
   (std::move(admin), std::move(cq), argv[1], argv[2]);
@@ -341,6 +342,7 @@ void AsyncGenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
           }
           std::cout << "generated token is : " << token->get() << "\n";
         });
+    final.get();  // block to keep example simple.
   }
   //! [async generate consistency token]
   (std::move(admin), std::move(cq), argv[1]);

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -309,9 +309,8 @@ void AsyncCheckConsistency(google::cloud::bigtable::TableAdmin admin,
               } else {
                 std::cout << "Table is not yet consistent, Please try again"
                           << " later with the same token ("
-                          << consistency_token_param << ")";
+                          << consistency_token_param << ")\n";
               }
-              std::cout << std::flush;
             });
     final.get();  // block until done to keep example simple.
   }

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -672,9 +672,8 @@ void CheckConsistency(google::cloud::bigtable::TableAdmin admin, int argc,
     } else {
       std::cout
           << "Table is not yet consistent, Please try again later with the"
-          << " same token (" << consistency_token_param << ")";
+          << " same token (" << consistency_token_param << ")\n";
     }
-    std::cout << std::flush;
   }
   //! [check consistency]
   (std::move(admin), table_id_param, consistency_token_param);

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -628,13 +628,14 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
 
   //! [wait for consistency check]
   namespace cbt = google::cloud::bigtable;
+  using google::cloud::StatusOr;
   [](cbt::TableAdmin admin, std::string table_id_param) {
     cbt::TableId table_id(table_id_param);
     auto consistency_token(admin.GenerateConsistencyToken(table_id.get()));
     if (!consistency_token) {
       throw std::runtime_error(consistency_token.status().message());
     }
-    auto result =
+    StatusOr<bool> result =
         admin.WaitForConsistencyCheck(table_id, *consistency_token).get();
     if (result && *result) {
       std::cout << "Table is consistent\n";
@@ -670,8 +671,8 @@ void CheckConsistency(google::cloud::bigtable::TableAdmin admin, int argc,
       std::cout << "Table is consistent\n";
     } else {
       std::cout
-          << "Table is not yet consistent, Please Try again Later with the "
-             "same Token!";
+          << "Table is not yet consistent, Please try again later with the"
+          << " same token (" << consistency_token_param << ")";
     }
     std::cout << std::flush;
   }

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -38,13 +38,13 @@ inline namespace BIGTABLE_CLIENT_NS {
  * the [RE2](https://github.com/google/re2/wiki/Syntax) syntax.
  *
  * @note Special care need be used with the expression used. Some of the
- *   byte sequences matched (e.g. row keys, or values), can contain arbitrary
- *   bytes, the `\C` escape sequence must be used if a true wildcard is
- *   desired. The `.` character will not match the new line character `\n`,
- *   effectively `.` means `[^\n]` in RE2.  As new line characters may be
- *   present in a binary value, you may need to explicitly match it using "\\n"
- *   the double escape is necessary because RE2 needs to get the escape
- *   sequence.
+ *     filtered values (column names, row keys, cell values) are byte sequences,
+ *     and can contain arbitrary bytes, the `\C` escape sequence must be used
+ *     if a true wildcard is desired. The `.` character will not match the new
+ *     line character `\n`, because `.` means `[^\n]` in RE2.  As new line
+ *     characters may be present in a binary value, you may need to explicitly
+ *     match it using "\\n". The double escape is necessary because RE2 needs
+ *     to get the escape sequence.
  */
 class Filter {
  public:
@@ -106,6 +106,14 @@ class Filter {
    *     rejects filters with an invalid pattern with a
    *     `grpc::StatusCode::INVALID_ARGUMENT` status code.  This function makes
    *     no attempt to validate the pattern before sending it to the server.
+   *
+   * @note Special care need be used with the expression used. A column name
+   *     is a byte sequence, and can contain arbitrary bytes, the `\C` escape
+   *     sequence must be used if a true wildcard is desired. The `.` character
+   *     will not match the new line character `\n`, because `.` means `[^\n]`
+   *     in RE2.  As new line characters may be present in a binary value, you
+   *     may need to explicitly match it using "\\n". The double escape is
+   *     necessary because RE2 needs to get the escape sequence.
    */
   static Filter ColumnRegex(std::string pattern) {
     Filter tmp;
@@ -207,6 +215,14 @@ class Filter {
    *
    * @param pattern the regular expression.  It must be a valid RE2 pattern.
    *     More details at https://github.com/google/re2/wiki/Syntax
+   *
+   * @note Special care need be used with the expression used. A row key
+   *     is a byte sequence, and can contain arbitrary bytes, the `\C` escape
+   *     sequence must be used if a true wildcard is desired. The `.` character
+   *     will not match the new line character `\n`, because `.` means `[^\n]`
+   *     in RE2.  As new line characters may be present in a binary value, you
+   *     may need to explicitly match it using "\\n". The double escape is
+   *     necessary because RE2 needs to get the escape sequence.
    */
   static Filter RowKeysRegex(std::string pattern) {
     Filter tmp;
@@ -223,6 +239,14 @@ class Filter {
    *     `grpc::StatusCode::INVALID_ARGUMENT` status code. This function makes
    *     no attempt to validate the timestamp range before sending it to
    *     the server.
+   *
+   * @note Special care need be used with the expression used. A cell value
+   *     is a byte sequence, and can contain arbitrary bytes, the `\C` escape
+   *     sequence must be used if a true wildcard is desired. The `.` character
+   *     will not match the new line character `\n`, because `.` means `[^\n]`
+   *     in RE2.  As new line characters may be present in a binary value, you
+   *     may need to explicitly match it using "\\n". The double escape is
+   *     necessary because RE2 needs to get the escape sequence.
    */
   static Filter ValueRegex(std::string pattern) {
     Filter tmp;

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -686,10 +686,10 @@ class InstanceAdmin {
    * @par Idempotency
    * This operation is always treated as non-idempotent.
    *
-   * @par Example
+   * @par Multi-cluster Routing Example
    * @snippet bigtable_instance_admin_snippets.cc create app profile
    *
-   * @par Example
+   * @par Single Cluster Routing Example
    * @snippet bigtable_instance_admin_snippets.cc create app profile cluster
    */
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
@@ -765,13 +765,13 @@ class InstanceAdmin {
    * @par Idempotency
    * This operation is always treated as non-idempotent.
    *
-   * @par Example
+   * @par Change Description Example
    * @snippet bigtable_instance_admin_snippets.cc update app profile description
    *
-   * @par Example
+   * @par Change Routing to Any Cluster Example
    * @snippet bigtable_instance_admin_snippets.cc update app profile routing any
    *
-   * @par Example
+   * @par Change Routing to a Specific Cluster Example
    * @snippet bigtable_instance_admin_snippets.cc update app profile routing
    */
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -20,11 +20,14 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+/// Define what endpoint in ClientOptions is used for the InstanceAdminClient.
 struct InstanceAdminTraits {
-  static std::string const& Endpoint(bigtable::ClientOptions& options) {
+  static std::string const& Endpoint(ClientOptions& options) {
     return options.instance_admin_endpoint();
   }
 };
+}  // namespace internal
 
 namespace {
 /**
@@ -45,7 +48,7 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
   // Introduce an early `private:` section because this type is used to define
   // the public interface, it should not be part of the public interface.
   using Impl = internal::CommonClient<
-      InstanceAdminTraits,
+      internal::InstanceAdminTraits,
       ::google::bigtable::admin::v2::BigtableInstanceAdmin>;
 
  public:

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -98,9 +98,6 @@ class InstanceAdminClient {
   friend class internal::AsyncLongrunningOp;
   template <typename Client, typename Response>
   friend class internal::AsyncLongrunningOperation;
-  template <typename Client, typename Response, typename MemberFunctionType,
-            typename IdempotencyPolicy>
-  class AsyncRetryAndPollUnaryRpc;
   friend class internal::AsyncListClusters;
   friend class internal::AsyncListInstances;
   friend class internal::AsyncListAppProfiles;

--- a/google/cloud/bigtable/instance_list_responses.h
+++ b/google/cloud/bigtable/instance_list_responses.h
@@ -29,8 +29,14 @@ struct InstanceList {
   /// The list of instances received from Cloud Bigtable.
   std::vector<google::bigtable::admin::v2::Instance> instances;
 
-  /// The list of Google Cloud Platform locations where the request could not
-  /// get a response from.
+  /**
+   * The list of Google Cloud Platform locations where the request could not
+   * get a response from.
+   *
+   * During an outage Cloud Bigtable may be unable to access specific zones. In
+   * that case the service will return those locations for which no information
+   * could be retrieved in this parameter.
+   */
   std::vector<std::string> failed_locations;
 };
 

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -37,17 +37,17 @@ inline namespace BIGTABLE_CLIENT_NS {
  *
  * In order to maximize throughput when applying a lot of mutations to Cloud
  * Bigtable, one should pack the mutations in `BulkMutations`. This class helps
- * in doing so. Create a `MutationBatcher` and use its `AsyncApply` member
- * function to apply a large stream of mutations to the same `Table`. Objects
- * of this class will efficiently create batches of `SingleRowMutations` and
- * maintain multiple batches "in flight".
+ * in doing so. Create a `MutationBatcher` and use
+ * `MutationBatcher::AsyncApply()` to apply a large stream of mutations to the
+ * same `Table`. Objects of this class will efficiently create batches of
+ * `SingleRowMutations` and maintain multiple batches "in flight".
  *
  * This class also offers an easy-to-use flow control mechanism to avoid
  * unbounded growth in its internal buffers.
  *
- * Applications provide a `CompletionQueue` to (asynchronously) execute these
- * operations. The application is responsible of executing the `CompletionQueue`
- * event loop in one or more threads.
+ * Applications must provide a `CompletionQueue` to (asynchronously) execute
+ * these operations. The application is responsible of executing the
+ * `CompletionQueue` event loop in one or more threads.
  */
 class MutationBatcher {
  public:

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -88,11 +88,26 @@ class PollingPolicy {
   virtual std::chrono::milliseconds WaitPeriod() = 0;
 };
 
+/**
+ * Construct a polling policy from existing Retry and Backoff policies.
+ *
+ * A polling policy can be built by composing a retry and backoff policy. For
+ * example, to create a polling policy that "retries N times, waiting a fixed
+ * period between retries" you could compose the "try N times" retry policy with
+ * the "wait a fixed period between retries".
+ *
+ * This class makes it easier to create such composed polling policies.
+ *
+ * @tparam Retry the RPC retry strategy used to limit the number or the total
+ *     duration of the polling strategy.
+ * @tparam Backoff the RPC backoff strategy used to control how often the
+ *     library polls.
+ */
 template <typename Retry = LimitedTimeRetryPolicy,
           typename Backoff = ExponentialBackoffPolicy>
 class GenericPollingPolicy : public PollingPolicy {
  public:
-  GenericPollingPolicy(internal::RPCPolicyParameters defaults)
+  explicit GenericPollingPolicy(internal::RPCPolicyParameters defaults)
       : rpc_retry_policy_(Retry(defaults)),
         rpc_backoff_policy_(Backoff(defaults)) {}
   GenericPollingPolicy(Retry retry, Backoff backoff)

--- a/google/cloud/bigtable/row_key_sample.h
+++ b/google/cloud/bigtable/row_key_sample.h
@@ -25,7 +25,19 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /// A simple wrapper to represent the response from `Table::SampleRowKeys()`.
 struct RowKeySample {
+  /**
+   * A row key value strictly larger than all the rows included in this sample.
+   *
+   * Note that the service may return row keys that do not exist in the Cloud
+   * Bigtable table. This should be interpreted as "a split point for sharding
+   * a `Table::ReadRows()` call.  That is calling `Table::ReadRows()` to return
+   * all the rows in the range `[previous-sample-row-key, this-sample-row-key)`
+   * is expected to produce an efficient sharding of the `Table::ReadRows()`
+   * operation.
+   */
   std::string row_key;
+
+  /// An estimate of the table size for all the rows smaller than `row_key`.
   std::int64_t offset_bytes;
 };
 

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -27,6 +27,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
 /// An adapter to use `grpc::Status` with the `google::cloud::*Policies`.
 struct SafeGrpcRetry {
   static inline bool IsTransientFailure(google::cloud::StatusCode code) {
@@ -60,6 +61,7 @@ struct SafeGrpcRetry {
     return !IsOk(status) && !IsTransientFailure(status);
   }
 };
+}  // namespace internal
 
 /**
  * Define the interface for controlling how the Bigtable client
@@ -106,11 +108,11 @@ class RPCRetryPolicy {
   virtual bool OnFailure(grpc::Status const& status) = 0;
 
   static bool IsPermanentFailure(google::cloud::Status const& status) {
-    return SafeGrpcRetry::IsPermanentFailure(status);
+    return internal::SafeGrpcRetry::IsPermanentFailure(status);
   }
   // TODO(coryan) - remove ::grpc::Status version.
   static bool IsPermanentFailure(grpc::Status const& status) {
-    return SafeGrpcRetry::IsPermanentFailure(status);
+    return internal::SafeGrpcRetry::IsPermanentFailure(status);
   }
 };
 
@@ -134,7 +136,7 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
 
  private:
   using Impl = google::cloud::internal::LimitedErrorCountRetryPolicy<
-      google::cloud::Status, SafeGrpcRetry>;
+      google::cloud::Status, internal::SafeGrpcRetry>;
   Impl impl_;
 };
 
@@ -143,7 +145,7 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
  */
 class LimitedTimeRetryPolicy : public RPCRetryPolicy {
  public:
-  LimitedTimeRetryPolicy(internal::RPCPolicyParameters defaults);
+  explicit LimitedTimeRetryPolicy(internal::RPCPolicyParameters defaults);
   template <typename duration_t>
   explicit LimitedTimeRetryPolicy(duration_t maximum_duration)
       : impl_(maximum_duration) {}
@@ -157,7 +159,7 @@ class LimitedTimeRetryPolicy : public RPCRetryPolicy {
  private:
   using Impl =
       google::cloud::internal::LimitedTimeRetryPolicy<google::cloud::Status,
-                                                      SafeGrpcRetry>;
+                                                      internal::SafeGrpcRetry>;
   Impl impl_;
 };
 

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -23,11 +23,11 @@
   GOOGLE_CLOUD_CPP_VEVAL(BIGTABLE_CLIENT_VERSION_MAJOR, \
                          BIGTABLE_CLIENT_VERSION_MINOR)
 
+namespace google {
+namespace cloud {
 /**
  * Contains all the Cloud Bigtable C++ client APIs.
  */
-namespace google {
-namespace cloud {
 namespace bigtable {
 /**
  * The inlined, versioned namespace for the Cloud Bigtable C++ client APIs.

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -35,6 +35,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/storage/testing/*"
     "*/google/cloud/storage/tests/*"
     "*/google/cloud/storage/*_test.cc")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 
 include(GoogleCloudCppCommon)


### PR DESCRIPTION
I made a pass through the Doxygen documentation for Cloud Bigtable,
making the following changes:

- I documented the `google::cloud::bigtable` namespace (oops).
- I removed any symbol in the `internal` namespace from the generated
  documentation. Made the same change for the Cloud Storage and common
  libraries.
- I moved a few symbols into the `google::cloud::bigtable::internal`
  namespace, as they were not intended for general use.
- I removed a forward declaration for AsyncRetryAndPollUnaryRpc, a
  symbol that does not exist, but the forward declaration made it appear
  in the docs.
- I filled in some missing documentation, and fixed the formatting and
  wording for some Doxygen comments.
- I fixed some code samples that rendered poorly in the HTML output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2605)
<!-- Reviewable:end -->
