### PR TITLE
Create aliases for table schema view constants.

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_samples.cc
+++ b/google/cloud/bigtable/examples/bigtable_samples.cc
@@ -40,7 +40,7 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
 
   std::cout << "Listing tables:\n";
   auto tables =
-      admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+      admin.ListTables(google::cloud::bigtable::TableAdmin::NAME_ONLY);
 
   if (!tables) {
     throw std::runtime_error(tables.status().message());
@@ -51,7 +51,7 @@ void RunTableOperations(google::cloud::bigtable::TableAdmin admin,
 
   std::cout << "Get table:\n";
   auto table =
-      admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+      admin.GetTable(table_id, google::cloud::bigtable::TableAdmin::FULL);
   if (!table) {
     throw std::runtime_error(table.status().message());
   }
@@ -114,7 +114,7 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
 
   std::cout << "Listing tables:\n";
   auto tables =
-      admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+      admin.ListTables(google::cloud::bigtable::TableAdmin::VIEW_UNSPECIFIED);
 
   if (!tables) {
     throw std::runtime_error(tables.status().message());
@@ -125,7 +125,7 @@ void RunFullExample(google::cloud::bigtable::TableAdmin admin,
 
   std::cout << "Get table:\n";
   auto table =
-      admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+      admin.GetTable(table_id, google::cloud::bigtable::TableAdmin::FULL);
   if (!table) {
     throw std::runtime_error(table.status().message());
   }

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -80,8 +80,7 @@ void AsyncListTables(google::cloud::bigtable::TableAdmin admin,
   [](cbt::TableAdmin admin, cbt::CompletionQueue cq) {
     google::cloud::future<google::cloud::StatusOr<
         std::vector<google::bigtable::admin::v2::Table>>>
-        future = admin.AsyncListTables(
-            cq, google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+        future = admin.AsyncListTables(cq, cbt::TableAdmin::NAME_ONLY);
 
     auto final =
         future.then([](google::cloud::future<google::cloud::StatusOr<

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -78,8 +78,7 @@ void ListTables(google::cloud::bigtable::TableAdmin admin, int argc,
   //! [list tables] [START bigtable_list_tables]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin) {
-    auto tables =
-        admin.ListTables(google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED);
+    auto tables = admin.ListTables(cbt::TableAdmin::NAME_ONLY);
 
     if (!tables) {
       throw std::runtime_error(tables.status().message());
@@ -102,8 +101,7 @@ void GetTable(google::cloud::bigtable::TableAdmin admin, int argc,
   //! [get table] [START bigtable_get_table_metadata]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id) {
-    auto table =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+    auto table = admin.GetTable(table_id, cbt::TableAdmin::FULL);
     if (!table) {
       throw std::runtime_error(table.status().message());
     }
@@ -130,8 +128,7 @@ void CheckTableExists(google::cloud::bigtable::TableAdmin admin, int argc,
   //! [START bigtable_check_table_exists]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id) {
-    auto table =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::NAME_ONLY);
+    auto table = admin.GetTable(table_id, cbt::TableAdmin::NAME_ONLY);
     if (!table) {
       if (table.status().code() == google::cloud::StatusCode::kNotFound) {
         throw std::runtime_error("Table " + table_id + " does not exist");
@@ -155,8 +152,7 @@ void GetOrCreateTable(google::cloud::bigtable::TableAdmin admin, int argc,
   // [START bigtable_get_or_create_table]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id) {
-    auto table =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+    auto table = admin.GetTable(table_id, cbt::TableAdmin::FULL);
     if (!table &&
         table.status().code() == google::cloud::StatusCode::kNotFound) {
       // The table does not exist, try to create the table.
@@ -168,8 +164,7 @@ void GetOrCreateTable(google::cloud::bigtable::TableAdmin admin, int argc,
       }
       // The schema returned by a `CreateTable()` request does not include all
       // the metadata for a table, we need to explicitly request the rest:
-      table =
-          admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+      table = admin.GetTable(table_id, cbt::TableAdmin::FULL);
     }
     if (!table) {
       throw std::runtime_error(table.status().message());
@@ -398,8 +393,7 @@ void GetFamilyMetadata(google::cloud::bigtable::TableAdmin admin, int argc,
   // [START bigtable_get_family_metadata]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id, std::string family_name) {
-    auto schema =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+    auto schema = admin.GetTable(table_id, cbt::TableAdmin::FULL);
 
     if (!schema) {
       throw std::runtime_error(schema.status().message());
@@ -431,8 +425,7 @@ void GetOrCreateFamily(google::cloud::bigtable::TableAdmin admin, int argc,
   // [START bigtable_get_or_create_family]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id, std::string family_name) {
-    auto schema =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+    auto schema = admin.GetTable(table_id, cbt::TableAdmin::FULL);
 
     if (!schema) {
       throw std::runtime_error(schema.status().message());
@@ -504,8 +497,7 @@ void CheckFamilyExists(google::cloud::bigtable::TableAdmin admin, int argc,
   // [START bigtable_check_family_exists]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id, std::string family_name) {
-    auto schema =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+    auto schema = admin.GetTable(table_id, cbt::TableAdmin::FULL);
 
     if (!schema) {
       throw std::runtime_error(schema.status().message());
@@ -532,8 +524,7 @@ void ListColumnFamilies(google::cloud::bigtable::TableAdmin admin, int argc,
   // [START bigtable_list_column_families]
   namespace cbt = google::cloud::bigtable;
   [](cbt::TableAdmin admin, std::string table_id) {
-    auto schema =
-        admin.GetTable(table_id, google::bigtable::admin::v2::Table::FULL);
+    auto schema = admin.GetTable(table_id, cbt::TableAdmin::FULL);
 
     if (!schema) {
       throw std::runtime_error(schema.status().message());

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -32,6 +32,12 @@ static_assert(std::is_copy_constructible<bigtable::TableAdmin>::value,
 static_assert(std::is_copy_assignable<bigtable::TableAdmin>::value,
               "bigtable::TableAdmin must be assignable");
 
+constexpr TableAdmin::TableView TableAdmin::VIEW_UNSPECIFIED;
+constexpr TableAdmin::TableView TableAdmin::NAME_ONLY;
+constexpr TableAdmin::TableView TableAdmin::SCHEMA_VIEW;
+constexpr TableAdmin::TableView TableAdmin::REPLICATION_VIEW;
+constexpr TableAdmin::TableView TableAdmin::FULL;
+
 /// Shortcuts to avoid typing long names over and over.
 using ClientUtils = bigtable::internal::noex::UnaryClientUtils<AdminClient>;
 

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -162,6 +162,20 @@ class TableAdmin {
   TableAdmin(TableAdmin const& table_admin) = default;
   TableAdmin& operator=(TableAdmin const& table_admin) = default;
 
+  //@{
+  /// @name Convenience shorthands for the schema views.
+  using TableView = google::bigtable::admin::v2::Table::View;
+  constexpr static TableView VIEW_UNSPECIFIED =
+      google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED;
+  constexpr static TableView NAME_ONLY =
+      google::bigtable::admin::v2::Table::NAME_ONLY;
+  constexpr static TableView SCHEMA_VIEW =
+      google::bigtable::admin::v2::Table::SCHEMA_VIEW;
+  constexpr static TableView REPLICATION_VIEW =
+      google::bigtable::admin::v2::Table::REPLICATION_VIEW;
+  constexpr static TableView FULL = google::bigtable::admin::v2::Table::FULL;
+  //@}
+
   std::string const& project() const { return impl_.project(); }
   std::string const& instance_id() const { return impl_.instance_id(); }
   std::string const& instance_name() const { return impl_.instance_name(); }
@@ -288,9 +302,7 @@ class TableAdmin {
    * @snippet table_admin_snippets.cc get table
    */
   StatusOr<::google::bigtable::admin::v2::Table> GetTable(
-      std::string const& table_id,
-      ::google::bigtable::admin::v2::Table::View view =
-          ::google::bigtable::admin::v2::Table::SCHEMA_VIEW);
+      std::string const& table_id, TableView view = SCHEMA_VIEW);
 
   /**
    * Sends an asynchronous request to get information about an existing table.


### PR DESCRIPTION
Define aliases for the google.bigtable.admin.v2.Table.View constants.
We do this for other constants and it seems more consistent to have them
for these too.

In some of the examples we were using `VIEW_UNSPECIFIED`, but only
needed `NAME_ONLY`. Change the examples to use the more accurate
table view.

This fixes #2599.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2615)
<!-- Reviewable:end -->
