### PR TITLE
Simplify the bigtable_hello_*_admin examples.

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -708,7 +708,7 @@ run_hello_instance_admin_example() {
   local -r RANDOM_INSTANCE_ID="it-${RANDOM}-${RANDOM}"
   local -r RANDOM_CLUSTER_ID="${RANDOM_INSTANCE_ID}-c1"
 
-  run_example ./bigtable_hello_instance_admin "run" \
+  run_example ./bigtable_hello_instance_admin \
       "${project_id}" "${RANDOM_INSTANCE_ID}" "${RANDOM_CLUSTER_ID}" \
       "${zone_id}"
 
@@ -738,21 +738,14 @@ run_hello_table_admin_example() {
   local instance_id=$2
   shift 2
 
-  # TODO(#2626) - remove "run-full-example" it is just a duplicate of "run".
-  # Use a different table for the full example test, if we use the same table
-  # as the other tests this can fail with timeouts.
-  local -r FULL_TABLE="data-ex-full-${RANDOM}-${RANDOM}"
-  run_example ./bigtable_hello_table_admin run-full-example \
-      "${project_id}" "${instance_id}" "${FULL_TABLE}"
-
   # Use the same table in all the tests.
   local -r TABLE="hello-table-admin-${RANDOM}"
-  run_example ./bigtable_hello_table_admin run \
+  run_example ./bigtable_hello_table_admin \
       "${project_id}" "${instance_id}" "${TABLE}"
 
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.
-  run_example_usage ./bigtable_hello_world
+  run_example_usage ./bigtable_hello_table_admin
 }
 
 ################################################


### PR DESCRIPTION
Remove redundant code, and move the (single) function in the example to
the body of `main()`. Also use explicit return types, the normal
aliases, and general cleanups.

I think this fixes #2626.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2633)
<!-- Reviewable:end -->
