### PR TITLE
Fix nits in bigtable-quickstart.dox.

### DIFF
--- a/google/cloud/bigtable/doc/bigtable-quickstart.dox
+++ b/google/cloud/bigtable/doc/bigtable-quickstart.dox
@@ -6,13 +6,13 @@ library to read a row from an existing table.
 
 ## Running the example
 
-This example uses the
-[Cloud Bigtable C++ Client Library](https://googleapis.github.io/google-cloud-cpp)
+This example uses the [Cloud Bigtable C++ Client Library][reference-link]
 to communicate with Cloud Bigtable.
 
 To run the example program, follow the [instructions][github-examples] for the
 example on GitHub.
 
+[reference-link]: https://googleapis.github.io/google-cloud-cpp
 [github-examples]: https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud/bigtable/examples/
 
 ## The Code
@@ -20,5 +20,15 @@ example on GitHub.
 Here is the full example
 
 @snippet bigtable_quickstart.cc all code
+
+## Next Steps
+
+- @ref bigtable-hello-world "Hello World Example"
+
+- @ref bigtable-hello-instance-admin "Hello World for Instance Admin Example"
+
+- @ref bigtable-hello-table-admin "Hello World for Table Admin Example"
+
+- @ref bigtable-samples-data-client "Advanced Reading and Writing Examples"
 
 */


### PR DESCRIPTION
Made the `.dox` file more readable by using a link alias, and link the
other examples from this doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2647)
<!-- Reviewable:end -->
