### PR TITLE
Cleanup the advanced read/write examples.

### DIFF
--- a/google/cloud/bigtable/doc/bigtable-samples-data-client.dox
+++ b/google/cloud/bigtable/doc/bigtable-samples-data-client.dox
@@ -10,13 +10,14 @@ This example is for advanced reading and writing opertions on bigtable data clie
 
 ## Run the example
 
-This example uses the
-[Cloud Bigtable C++ Client Library](https://googleapis.github.io/google-cloud-cpp)
+This example uses the [Cloud Bigtable C++ Client Library][reference-link]
 to communicate with Cloud Bigtable.
 
-To run the example program, follow the
-[instructions](https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud/bigtable/examples/)
-for the example on GitHub.
+To run the example program, follow the [instructions][github-examples] for the
+example on GitHub.
+
+[reference-link]: https://googleapis.github.io/google-cloud-cpp
+[github-examples]: https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud/bigtable/examples/
 
 ### Include the Necessary Headers
 
@@ -44,9 +45,4 @@ The example uses the following headers:
 
 @snippet data_snippets.cc check and mutate not present
 
-### Put it all together
-
-Here is the full example
-
-@snippet data_snippets.cc all code
 */


### PR DESCRIPTION
The example used to include all the code, which was not useful as this
is not an example you run end-to-end, but rather a series of code
snippets.

Also use link aliases to make the source `.dox` file more readable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2648)
<!-- Reviewable:end -->
