### PR TITLE
fix!: Return type for WaitForConsistencyCheck.

### DIFF
--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -647,14 +647,14 @@ void WaitForConsistencyCheck(google::cloud::bigtable::TableAdmin admin,
     if (!consistency_token) {
       throw std::runtime_error(consistency_token.status().message());
     }
-    std::future<StatusOr<bool>> consistent_future =
+    std::future<StatusOr<cbt::Consistency>> consistent_future =
         admin.WaitForConsistencyCheck(cbt::TableId(table_id),
                                       *consistency_token);
     auto is_consistent = consistent_future.get();
     if (!is_consistent) {
       throw std::runtime_error(is_consistent.status().message());
     }
-    if (*is_consistent) {
+    if (*is_consistent == cbt::Consistency::kConsistent) {
       std::cout << "Table is consistent with token " << consistency_token->get()
                 << "\n";
     } else {

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -441,7 +441,7 @@ future<StatusOr<Consistency>> TableAdmin::AsyncCheckConsistency(
         ;
       });
 }
-StatusOr<bool> TableAdmin::WaitForConsistencyCheckImpl(
+StatusOr<Consistency> TableAdmin::WaitForConsistencyCheckImpl(
     bigtable::TableId const& table_id,
     bigtable::ConsistencyToken const& consistency_token) {
   grpc::Status status;
@@ -461,7 +461,7 @@ StatusOr<bool> TableAdmin::WaitForConsistencyCheckImpl(
 
     if (status.ok()) {
       if (response.consistent()) {
-        return true;
+        return Consistency::kConsistent;
       }
     } else if (polling_policy->IsPermanentError(status)) {
       return bigtable::internal::MakeStatusFromRpcError(status);

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -585,7 +585,7 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc wait for consistency check
    */
-  std::future<StatusOr<bool>> WaitForConsistencyCheck(
+  std::future<StatusOr<Consistency>> WaitForConsistencyCheck(
       bigtable::TableId const& table_id,
       bigtable::ConsistencyToken const& consistency_token) {
     return std::async(std::launch::async,
@@ -646,7 +646,7 @@ class TableAdmin {
    * Implements the polling loop for `WaitForConsistencyCheck` on a
    * separate thread
    */
-  StatusOr<bool> WaitForConsistencyCheckImpl(
+  StatusOr<Consistency> WaitForConsistencyCheckImpl(
       bigtable::TableId const& table_id,
       bigtable::ConsistencyToken const& consistency_token);
 

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -681,9 +681,11 @@ TEST_F(TableAdminTest, AsyncCheckConsistencySimple) {
   bigtable::TableId table_id("the-async-table");
   bigtable::ConsistencyToken consistency_token("test-async-token");
   // After all the setup, make the actual call we want to test.
-  std::future<google::cloud::StatusOr<bool>> result =
+  std::future<google::cloud::StatusOr<bigtable::Consistency>> result =
       tested.WaitForConsistencyCheck(table_id, consistency_token);
-  EXPECT_STATUS_OK(result.get());
+  auto actual = result.get();
+  EXPECT_STATUS_OK(actual);
+  EXPECT_EQ(bigtable::Consistency::kConsistent, *actual);
 }
 
 /**
@@ -702,7 +704,7 @@ TEST_F(TableAdminTest, AsyncCheckConsistencyFailure) {
   bigtable::TableId table_id("other-async-table");
   bigtable::ConsistencyToken consistency_token("test-async-token");
 
-  std::future<google::cloud::StatusOr<bool>> result =
+  std::future<google::cloud::StatusOr<bigtable::Consistency>> result =
       tested.WaitForConsistencyCheck(table_id, consistency_token);
   EXPECT_FALSE(result.get());
 }

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -297,12 +297,12 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
   // Wait until all the mutations before the `consistency_token` have propagated
   // everywhere.
-  std::future<google::cloud::StatusOr<bool>> result =
+  std::future<google::cloud::StatusOr<bigtable::Consistency>> result =
       table_admin.WaitForConsistencyCheck(bigtable::TableId(random_table_id),
                                           *consistency_token);
   auto is_consistent = result.get();
   ASSERT_STATUS_OK(is_consistent);
-  EXPECT_TRUE(*is_consistent);
+  EXPECT_EQ(bigtable::Consistency::kConsistent, *is_consistent);
 
   // Cleanup the table and the instance.
   EXPECT_STATUS_OK(table_admin.DeleteTable(random_table_id));


### PR DESCRIPTION
BREAKING CHANGE: The return type for WaitForConsistencyCheck() was a
`future<StatusOr<bool>>` where most related functions return a
`bigtable::Consistency` enum.

Note the use of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/), folks had expressed an interest in using them to simplify the preparation of release notes.

This fixes #2562.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2649)
<!-- Reviewable:end -->
