### PR TITLE
fix!: Inconsistent return type in AsyncCheckAndMutateRow.

### DIFF
--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -482,7 +482,7 @@ class Table {
    * @par Example
    * @snippet data_async_snippets.cc async check and mutate
    */
-  future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
+  future<StatusOr<bool>>
   AsyncCheckAndMutateRow(std::string row_key, Filter filter,
                          std::vector<Mutation> true_mutations,
                          std::vector<Mutation> false_mutations,

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -482,11 +482,9 @@ class Table {
    * @par Example
    * @snippet data_async_snippets.cc async check and mutate
    */
-  future<StatusOr<bool>>
-  AsyncCheckAndMutateRow(std::string row_key, Filter filter,
-                         std::vector<Mutation> true_mutations,
-                         std::vector<Mutation> false_mutations,
-                         CompletionQueue& cq);
+  future<StatusOr<bool>> AsyncCheckAndMutateRow(
+      std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
+      std::vector<Mutation> false_mutations, CompletionQueue& cq);
 
   /**
    * Sample of the row keys in the table, including approximate data sizes.


### PR DESCRIPTION
BREAKING CHANGE(bigtable.async): `Table::CheckAndMutateRow` returns
`StatusOr<bool>` to indicate which branch of the predicate was taken
in the atomic change. Meanwhile, `AsyncCheckAndMutateRow()` returned a
`future<StatusOr<proto-with-long-name>>`. Changed the async version to
return `future<StatusOr<bool>>`, note that the Async* functions are
still experimental and subject to change.

This fixes #2602.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2650)
<!-- Reviewable:end -->
