### PR TITLE
cleanup!: Remove template parameter in SampleRows.

### DIFF
--- a/google/cloud/bigtable/examples/README.md
+++ b/google/cloud/bigtable/examples/README.md
@@ -190,7 +190,6 @@ Examples:
   data_snippets check-and-mutate my-project my-instance my-table
   data_snippets read-modify-write my-project my-instance my-table
   data_snippets sample-rows my-project my-instance my-table
-  data_snippets sample-rows-collections my-project my-instance my-table
 ```
 
 #### Run reading and writing samples

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -557,7 +557,7 @@ void SampleRows(google::cloud::bigtable::Table table, int argc, char* argv[]) {
   namespace cbt = google::cloud::bigtable;
   using google::cloud::StatusOr;
   [](cbt::Table table) {
-    StatusOr<std::vector<cbt::RowKeySample>> samples = table.SampleRows<>();
+    StatusOr<std::vector<cbt::RowKeySample>> samples = table.SampleRows();
     if (!samples) {
       throw std::runtime_error(samples.status().message());
     }
@@ -567,39 +567,6 @@ void SampleRows(google::cloud::bigtable::Table table, int argc, char* argv[]) {
     }
   }
   //! [sample row keys] [END bigtable_table_sample_splits]
-  (std::move(table));
-}
-
-void SampleRowsCollections(google::cloud::bigtable::Table table, int argc,
-                           char* argv[]) {
-  if (argc != 1) {
-    throw Usage{
-        "sample-rows-collections: <project-id> <instance-id> <table-id>"};
-  }
-
-  //! [sample row keys collections]
-  namespace cbt = google::cloud::bigtable;
-  using google::cloud::StatusOr;
-  [](cbt::Table table) {
-    StatusOr<std::list<cbt::RowKeySample>> list_samples =
-        table.SampleRows<std::list>();
-    if (!list_samples) {
-      throw std::runtime_error(list_samples.status().message());
-    }
-    for (auto const& sample : *list_samples) {
-      std::cout << "key=" << sample.row_key << " - " << sample.offset_bytes
-                << "\n";
-    }
-    auto deque_samples = table.SampleRows<std::deque>();
-    if (!deque_samples) {
-      throw std::runtime_error(deque_samples.status().message());
-    }
-    for (auto const& sample : *deque_samples) {
-      std::cout << "key=" << sample.row_key << " - " << sample.offset_bytes
-                << "\n";
-    }
-  }
-  //! [sample row keys collections]
   (std::move(table));
 }
 
@@ -1027,7 +994,6 @@ int main(int argc, char* argv[]) try {
       {"check-and-mutate-not-present", &CheckAndMutateNotPresent},
       {"read-modify-write", &ReadModifyWrite},
       {"sample-rows", &SampleRows},
-      {"sample-rows-collections", &SampleRowsCollections},
       {"get-family", &GetFamily},
       {"delete-all-cells", &DeleteAllCells},
       {"delete-family-cells", &DeleteFamilyCells},

--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -514,8 +514,6 @@ run_all_data_examples() {
       "mismatched-begin-end-pair"
   run_example ./data_snippets sample-rows \
       "${project_id}" "${instance_id}" "${TABLE}"
-  run_example ./data_snippets sample-rows-collections \
-      "${project_id}" "${instance_id}" "${TABLE}"
 
   run_example ./data_snippets mutate-insert-update-rows \
       "${project_id}" "${instance_id}" "${TABLE}" "check-and-mutate-row" \

--- a/google/cloud/bigtable/internal/table_test.cc
+++ b/google/cloud/bigtable/internal/table_test.cc
@@ -940,7 +940,7 @@ TEST_F(NoexTableTest, SampleRowsDefaultParameterTest) {
       .WillOnce(Invoke(reader.release()->MakeMockReturner()));
 
   grpc::Status status;
-  std::vector<bigtable::RowKeySample> result = table_.SampleRows<>(status);
+  std::vector<bigtable::RowKeySample> result = table_.SampleRows(status);
   EXPECT_TRUE(status.ok());
   auto it = result.begin();
   EXPECT_NE(it, result.end());
@@ -971,68 +971,8 @@ TEST_F(NoexTableTest, SampleRowKeys_AppProfileId) {
   bigtable::noex::Table table =
       bigtable::noex::Table(client_, app_profile_id, kTableId);
   grpc::Status status;
-  table.SampleRows<>(status);
+  table.SampleRows(status);
   EXPECT_TRUE(status.ok());
-}
-
-/// @test Verify that Table::SampleRows<T>() works for std::vector.
-TEST_F(NoexTableTest, SampleRowsSimpleVectorTest) {
-  using namespace ::testing;
-  namespace btproto = ::google::bigtable::v2;
-
-  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
-  EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
-        {
-          r->set_row_key("test1");
-          r->set_offset_bytes(11);
-        }
-        return true;
-      }))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
-  EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(reader.release()->MakeMockReturner()));
-
-  grpc::Status status;
-  std::vector<bigtable::RowKeySample> result =
-      table_.SampleRows<std::vector>(status);
-  EXPECT_TRUE(status.ok());
-  auto it = result.begin();
-  EXPECT_NE(it, result.end());
-  EXPECT_EQ(it->row_key, "test1");
-  EXPECT_EQ(it->offset_bytes, 11);
-  EXPECT_EQ(++it, result.end());
-}
-
-/// @test Verify that Table::SampleRows<T>() works for std::list.
-TEST_F(NoexTableTest, SampleRowsSimpleListTest) {
-  using namespace ::testing;
-  namespace btproto = ::google::bigtable::v2;
-
-  auto reader = google::cloud::internal::make_unique<MockSampleRowKeysReader>();
-  EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
-        {
-          r->set_row_key("test1");
-          r->set_offset_bytes(11);
-        }
-        return true;
-      }))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
-  EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(reader.release()->MakeMockReturner()));
-
-  grpc::Status status;
-  std::list<bigtable::RowKeySample> result =
-      table_.SampleRows<std::list>(status);
-  EXPECT_TRUE(status.ok());
-  auto it = result.begin();
-  EXPECT_NE(it, result.end());
-  EXPECT_EQ(it->row_key, "test1");
-  EXPECT_EQ(it->offset_bytes, 11);
-  EXPECT_EQ(++it, result.end());
 }
 
 TEST_F(NoexTableTest, SampleRowsSampleRowKeysRetryTest) {
@@ -1081,7 +1021,7 @@ TEST_F(NoexTableTest, SampleRowsSampleRowKeysRetryTest) {
       .WillOnce(Invoke(reader_retry.release()->MakeMockReturner()));
 
   grpc::Status status;
-  auto results = table_.SampleRows<std::vector>(status);
+  auto results = table_.SampleRows(status);
   EXPECT_TRUE(status.ok());
 
   auto it = results.begin();
@@ -1139,6 +1079,6 @@ TEST_F(NoexTableTest, SampleRowsTooManyFailures) {
       .WillOnce(Invoke(create_cancelled_stream))
       .WillOnce(Invoke(create_cancelled_stream));
   grpc::Status status;
-  custom_table.SampleRows<std::vector>(status);
+  custom_table.SampleRows(status);
   EXPECT_FALSE(status.ok());
 }

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -489,7 +489,6 @@ class Table {
   /**
    * Sample of the row keys in the table, including approximate data sizes.
    *
-   * @tparam Collection the type of collection where the samples are returned.
    * @returns Note that the sample may only include one element for small
    *     tables.  In addition, the sample may include row keys that do not exist
    *     on the table, and may include the empty row key to indicate
@@ -500,28 +499,8 @@ class Table {
    *
    * @par Examples
    * @snippet data_snippets.cc sample row keys
-   *
-   * In addition, application developers can specify other collection types, for
-   * example `std::list<>` or `std::deque<>`:
-   * @snippet data_snippets.cc sample row keys collections
    */
-  template <template <typename...> class Collection = std::vector>
-  StatusOr<Collection<bigtable::RowKeySample>> SampleRows() {
-    grpc::Status status;
-    Collection<bigtable::RowKeySample> result;
-
-    SampleRowsImpl(
-        [&result](bigtable::RowKeySample rs) {
-          result.emplace_back(std::move(rs));
-        },
-        [&result]() { result.clear(); }, status);
-
-    if (!status.ok()) {
-      return bigtable::internal::MakeStatusFromRpcError(status);
-    }
-
-    return result;
-  }
+  StatusOr<std::vector<bigtable::RowKeySample>> SampleRows();
 
   /**
    * Atomically read and modify the row in the server, returning the
@@ -616,19 +595,6 @@ class Table {
   future<StatusOr<Row>> AsyncReadModifyWriteRowImpl(
       CompletionQueue& cq,
       ::google::bigtable::v2::ReadModifyWriteRowRequest request);
-
-  /**
-   * Refactor implementation to `.cc` file.
-   *
-   * Provides a compilation barrier so that the application is not
-   * exposed to all the implementation details.
-   *
-   * @param inserter Function to insert the object to result.
-   * @param clearer Function to clear the result object if RPC fails.
-   */
-  void SampleRowsImpl(
-      std::function<void(bigtable::RowKeySample)> const& inserter,
-      std::function<void()> const& clearer, grpc::Status& status);
 
   void AddRules(google::bigtable::v2::ReadModifyWriteRowRequest& request) {
     // no-op for empty list

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -45,7 +45,7 @@ TEST_F(TableSampleRowKeysTest, DefaultParameterTest) {
       }))
       .WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
-  auto result = table_.SampleRows<>();
+  auto result = table_.SampleRows();
   ASSERT_STATUS_OK(result);
   auto it = result->begin();
   EXPECT_NE(it, result->end());
@@ -72,34 +72,7 @@ TEST_F(TableSampleRowKeysTest, SimpleVectorTest) {
       }))
       .WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
-  auto result = table_.SampleRows<std::vector>();
-  ASSERT_STATUS_OK(result);
-  auto it = result->begin();
-  EXPECT_NE(it, result->end());
-  EXPECT_EQ(it->row_key, "test1");
-  EXPECT_EQ(it->offset_bytes, 11);
-  EXPECT_EQ(++it, result->end());
-}
-
-/// @test Verify that Table::SampleRows<T>() works for std::list.
-TEST_F(TableSampleRowKeysTest, SimpleListTest) {
-  using namespace ::testing;
-  namespace btproto = ::google::bigtable::v2;
-
-  auto reader = new MockSampleRowKeysReader;
-  EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(reader->MakeMockReturner()));
-  EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
-        {
-          r->set_row_key("test1");
-          r->set_offset_bytes(11);
-        }
-        return true;
-      }))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
-  auto result = table_.SampleRows<std::list>();
+  auto result = table_.SampleRows();
   ASSERT_STATUS_OK(result);
   auto it = result->begin();
   EXPECT_NE(it, result->end());
@@ -151,7 +124,7 @@ TEST_F(TableSampleRowKeysTest, SampleRowKeysRetryTest) {
 
   EXPECT_CALL(*reader_retry, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  auto results = table_.SampleRows<std::vector>();
+  auto results = table_.SampleRows();
   ASSERT_STATUS_OK(results);
 
   auto it = results->begin();
@@ -209,6 +182,6 @@ TEST_F(TableSampleRowKeysTest, TooManyFailures) {
       .WillOnce(Invoke(create_cancelled_stream))
       .WillOnce(Invoke(create_cancelled_stream));
 
-  EXPECT_FALSE(custom_table.SampleRows<std::vector>());
+  EXPECT_FALSE(custom_table.SampleRows());
 }
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -537,7 +537,7 @@ TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
       return os.str();
     }();
   }
-  auto samples = table.SampleRows<std::vector>();
+  auto samples = table.SampleRows();
   ASSERT_STATUS_OK(samples);
 
   // It is somewhat hard to verify that the values returned here are correct.


### PR DESCRIPTION
BREAKING CHANGE: Removed the `Collection` template parameter from
`Table::SampleRows`, this allowed users to changed the returned
collection type, but that extra flexibility is not worth the complexity
for a rarely used API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2652)
<!-- Reviewable:end -->
