### PR TITLE
Avoid SIGPIPE signals when connections break.

### DIFF
--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -141,6 +141,12 @@ class ClientOptions {
     return *this;
   }
 
+  bool enable_libcurl_nosignal() const { return enable_libcurl_nosignal_; }
+  ClientOptions& set_enable_libcurl_nosignal(bool v) {
+    enable_libcurl_nosignal_ = v;
+    return *this;
+  }
+
  private:
   void SetupFromEnvironment();
 
@@ -158,6 +164,7 @@ class ClientOptions {
   std::string user_agent_prefix_;
   std::size_t maximum_simple_upload_size_;
   bool enable_ssl_locking_callbacks_ = true;
+  bool enable_libcurl_nosignal_ = false;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -262,7 +262,8 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   }
   builder.AddHeader("Content-Length: " +
                     std::to_string(request_payload.size()));
-  auto http_response = builder.BuildRequest().MakeRequest(request_payload);
+  auto http_response =
+      builder.BuildRequest(client_options()).MakeRequest(request_payload);
   if (!http_response.ok()) {
     return std::move(http_response).status();
   }
@@ -330,7 +331,8 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.payload().size()));
-  auto response = builder.BuildRequest().MakeRequest(request.payload());
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(request.payload());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -350,7 +352,8 @@ StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
   builder.AddHeader("Content-Range: bytes */*");
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.AddHeader("Content-Length: 0");
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -369,7 +372,7 @@ StatusOr<ListBucketsResponse> CurlClient::ListBuckets(
   }
   builder.AddQueryParameter("project", request.project_id());
   return ParseFromHttpResponse<ListBucketsResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<BucketMetadata> CurlClient::CreateBucket(
@@ -383,7 +386,8 @@ StatusOr<BucketMetadata> CurlClient::CreateBucket(
   builder.AddQueryParameter("project", request.project_id());
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      builder.BuildRequest(client_options())
+          .MakeRequest(request.json_payload()));
 }
 
 StatusOr<BucketMetadata> CurlClient::GetBucketMetadata(
@@ -396,7 +400,7 @@ StatusOr<BucketMetadata> CurlClient::GetBucketMetadata(
     return status;
   }
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteBucket(
@@ -408,7 +412,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucket(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<BucketMetadata> CurlClient::UpdateBucket(
@@ -422,7 +427,8 @@ StatusOr<BucketMetadata> CurlClient::UpdateBucket(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      builder.BuildRequest(client_options())
+          .MakeRequest(request.json_payload()));
 }
 
 StatusOr<BucketMetadata> CurlClient::PatchBucket(
@@ -436,7 +442,7 @@ StatusOr<BucketMetadata> CurlClient::PatchBucket(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      builder.BuildRequest(client_options()).MakeRequest(request.payload()));
 }
 
 StatusOr<IamPolicy> CurlClient::GetBucketIamPolicy(
@@ -448,7 +454,8 @@ StatusOr<IamPolicy> CurlClient::GetBucketIamPolicy(
   if (!status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -468,7 +475,8 @@ StatusOr<IamPolicy> CurlClient::SetBucketIamPolicy(
     return status;
   }
   builder.AddHeader("Content-Type: application/json");
-  auto response = builder.BuildRequest().MakeRequest(request.json_payload());
+  auto response = builder.BuildRequest(client_options())
+                      .MakeRequest(request.json_payload());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -490,7 +498,8 @@ StatusOr<TestBucketIamPermissionsResponse> CurlClient::TestBucketIamPermissions(
   for (auto const& perm : request.permissions()) {
     builder.AddQueryParameter("permissions", perm);
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -513,7 +522,7 @@ StatusOr<BucketMetadata> CurlClient::LockBucketRetentionPolicy(
   builder.AddHeader("content-length: 0");
   builder.AddOption(IfMetagenerationMatch(request.metageneration()));
   return CheckedFromString<BucketMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMedia(
@@ -563,7 +572,7 @@ StatusOr<ObjectMetadata> CurlClient::CopyObject(
                        .dump();
   }
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(json_payload));
+      builder.BuildRequest(client_options()).MakeRequest(json_payload));
 }
 
 StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
@@ -576,7 +585,7 @@ StatusOr<ObjectMetadata> CurlClient::GetObjectMetadata(
     return status;
   }
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
@@ -609,7 +618,7 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
   }
 
   std::unique_ptr<CurlReadStreambuf> buf(new CurlReadStreambuf(
-      builder.BuildDownloadRequest(std::string{}),
+      builder.BuildDownloadRequest(client_options()),
       client_options().download_buffer_size(), CreateHashValidator(request)));
   auto peek = buf->Peek();
   if (!peek) {
@@ -639,7 +648,7 @@ StatusOr<ListObjectsResponse> CurlClient::ListObjects(
   }
   builder.AddQueryParameter("pageToken", request.page_token());
   return ParseFromHttpResponse<ListObjectsResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObject(
@@ -652,7 +661,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteObject(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectMetadata> CurlClient::UpdateObject(
@@ -666,7 +676,8 @@ StatusOr<ObjectMetadata> CurlClient::UpdateObject(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      builder.BuildRequest(client_options())
+          .MakeRequest(request.json_payload()));
 }
 
 StatusOr<ObjectMetadata> CurlClient::PatchObject(
@@ -680,7 +691,7 @@ StatusOr<ObjectMetadata> CurlClient::PatchObject(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      builder.BuildRequest(client_options()).MakeRequest(request.payload()));
 }
 
 StatusOr<ObjectMetadata> CurlClient::ComposeObject(
@@ -695,7 +706,8 @@ StatusOr<ObjectMetadata> CurlClient::ComposeObject(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.JsonPayload()));
+      builder.BuildRequest(client_options())
+          .MakeRequest(request.JsonPayload()));
 }
 
 StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
@@ -720,7 +732,8 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
                        request.GetOption<WithObjectMetadata>().value())
                        .dump();
   }
-  auto response = builder.BuildRequest().MakeRequest(json_payload);
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(json_payload);
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -758,7 +771,8 @@ StatusOr<ListBucketAclResponse> CurlClient::ListBucketAcl(
   if (!status.ok()) {
     return status;
   }
-  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -778,7 +792,7 @@ StatusOr<BucketAccessControl> CurlClient::GetBucketAcl(
     return status;
   }
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
@@ -795,7 +809,7 @@ StatusOr<BucketAccessControl> CurlClient::CreateBucketAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
@@ -807,7 +821,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteBucketAcl(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
@@ -824,7 +839,7 @@ StatusOr<BucketAccessControl> CurlClient::UpdateBucketAcl(
   patch["entity"] = request.entity();
   patch["role"] = request.role();
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(patch.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(patch.dump()));
 }
 
 StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
@@ -838,7 +853,7 @@ StatusOr<BucketAccessControl> CurlClient::PatchBucketAcl(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<internal::BucketAccessControlParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      builder.BuildRequest(client_options()).MakeRequest(request.payload()));
 }
 
 StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
@@ -853,7 +868,7 @@ StatusOr<ListObjectAclResponse> CurlClient::ListObjectAcl(
     return status;
   }
   return ParseFromHttpResponse<ListObjectAclResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
@@ -871,7 +886,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
@@ -885,7 +900,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteObjectAcl(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
@@ -900,7 +916,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetObjectAcl(
     return status;
   }
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
@@ -919,7 +935,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(object.dump()));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
@@ -935,7 +951,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchObjectAcl(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      builder.BuildRequest(client_options()).MakeRequest(request.payload()));
 }
 
 StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
@@ -949,7 +965,7 @@ StatusOr<ListDefaultObjectAclResponse> CurlClient::ListDefaultObjectAcl(
     return status;
   }
   return ParseFromHttpResponse<ListDefaultObjectAclResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
@@ -966,7 +982,7 @@ StatusOr<ObjectAccessControl> CurlClient::CreateDefaultObjectAcl(
   object["role"] = request.role();
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(object.dump()));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
@@ -979,7 +995,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteDefaultObjectAcl(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
@@ -993,7 +1010,7 @@ StatusOr<ObjectAccessControl> CurlClient::GetDefaultObjectAcl(
     return status;
   }
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
@@ -1011,7 +1028,7 @@ StatusOr<ObjectAccessControl> CurlClient::UpdateDefaultObjectAcl(
   object["entity"] = request.entity();
   object["role"] = request.role();
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(object.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(object.dump()));
 }
 
 StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
@@ -1026,7 +1043,7 @@ StatusOr<ObjectAccessControl> CurlClient::PatchDefaultObjectAcl(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<ObjectAccessControlParser>(
-      builder.BuildRequest().MakeRequest(request.payload()));
+      builder.BuildRequest(client_options()).MakeRequest(request.payload()));
 }
 
 StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
@@ -1039,7 +1056,7 @@ StatusOr<ServiceAccount> CurlClient::GetServiceAccount(
     return status;
   }
   return ParseFromString<ServiceAccount>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<ListHmacKeysResponse> CurlClient::ListHmacKeys(
@@ -1052,7 +1069,7 @@ StatusOr<ListHmacKeysResponse> CurlClient::ListHmacKeys(
     return status;
   }
   return ParseFromHttpResponse<ListHmacKeysResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
@@ -1067,7 +1084,7 @@ StatusOr<CreateHmacKeyResponse> CurlClient::CreateHmacKey(
   builder.AddQueryParameter("serviceAccountEmail", request.service_account());
   builder.AddHeader("content-length: 0");
   return ParseFromHttpResponse<CreateHmacKeyResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteHmacKey(
@@ -1080,7 +1097,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteHmacKey(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<HmacKeyMetadata> CurlClient::GetHmacKey(
@@ -1094,7 +1112,7 @@ StatusOr<HmacKeyMetadata> CurlClient::GetHmacKey(
     return status;
   }
   return CheckedFromString<HmacKeyMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<HmacKeyMetadata> CurlClient::UpdateHmacKey(
@@ -1116,7 +1134,7 @@ StatusOr<HmacKeyMetadata> CurlClient::UpdateHmacKey(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<HmacKeyMetadataParser>(
-      builder.BuildRequest().MakeRequest(payload.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(payload.dump()));
 }
 
 StatusOr<SignBlobResponse> CurlClient::SignBlob(
@@ -1135,7 +1153,7 @@ StatusOr<SignBlobResponse> CurlClient::SignBlob(
   }
   builder.AddHeader("Content-Type: application/json");
   return ParseFromHttpResponse<SignBlobResponse>(
-      builder.BuildRequest().MakeRequest(payload.dump()));
+      builder.BuildRequest(client_options()).MakeRequest(payload.dump()));
 }
 
 StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
@@ -1149,7 +1167,7 @@ StatusOr<ListNotificationsResponse> CurlClient::ListNotifications(
     return status;
   }
   return ParseFromHttpResponse<ListNotificationsResponse>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<NotificationMetadata> CurlClient::CreateNotification(
@@ -1163,7 +1181,8 @@ StatusOr<NotificationMetadata> CurlClient::CreateNotification(
   }
   builder.AddHeader("Content-Type: application/json");
   return CheckedFromString<NotificationMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.json_payload()));
+      builder.BuildRequest(client_options())
+          .MakeRequest(request.json_payload()));
 }
 
 StatusOr<NotificationMetadata> CurlClient::GetNotification(
@@ -1177,7 +1196,7 @@ StatusOr<NotificationMetadata> CurlClient::GetNotification(
     return status;
   }
   return CheckedFromString<NotificationMetadataParser>(
-      builder.BuildRequest().MakeRequest(std::string{}));
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteNotification(
@@ -1190,7 +1209,8 @@ StatusOr<EmptyResponse> CurlClient::DeleteNotification(
   if (!status.ok()) {
     return status;
   }
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  return ReturnEmptyResponse(
+      builder.BuildRequest(client_options()).MakeRequest(std::string{}));
 }
 
 void CurlClient::LockShared() { mu_.lock(); }
@@ -1271,7 +1291,8 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
 
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
-  auto response = builder.BuildRequest().MakeRequest(request.contents());
+  auto response =
+      builder.BuildRequest(client_options()).MakeRequest(request.contents());
   if (!response.ok()) {
     return std::move(response).status();
   }
@@ -1340,7 +1361,7 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObjectXml(
   }
 
   std::unique_ptr<CurlReadStreambuf> buf(new CurlReadStreambuf(
-      builder.BuildDownloadRequest(std::string{}),
+      builder.BuildDownloadRequest(client_options()),
       client_options().download_buffer_size(), CreateHashValidator(request)));
   auto peek = buf->Peek();
   if (!peek) {
@@ -1417,7 +1438,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(
   auto contents = std::move(writer).str();
   builder.AddHeader("Content-Length: " + std::to_string(contents.size()));
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(contents));
+      builder.BuildRequest(client_options()).MakeRequest(contents));
 }
 
 std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {
@@ -1457,7 +1478,7 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaSimple(
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.contents().size()));
   return CheckedFromString<ObjectMetadataParser>(
-      builder.BuildRequest().MakeRequest(request.contents()));
+      builder.BuildRequest(client_options()).MakeRequest(request.contents()));
 }
 
 StatusOr<std::unique_ptr<ObjectWriteStreambuf>>

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_DOWNLOAD_REQUEST_H_
 
 #include "google/cloud/log.h"
+#include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/internal/curl_request.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
@@ -37,7 +38,7 @@ namespace internal {
  */
 class CurlDownloadRequest {
  public:
-  explicit CurlDownloadRequest(std::size_t initial_buffer_size);
+  explicit CurlDownloadRequest(ClientOptions const& options);
 
   ~CurlDownloadRequest() {
     if (!factory_) {
@@ -50,7 +51,6 @@ class CurlDownloadRequest {
   CurlDownloadRequest(CurlDownloadRequest&& rhs) noexcept(false)
       : url_(std::move(rhs.url_)),
         headers_(std::move(rhs.headers_)),
-        payload_(std::move(rhs.payload_)),
         user_agent_(std::move(rhs.user_agent_)),
         logging_enabled_(rhs.logging_enabled_),
         handle_(std::move(rhs.handle_)),
@@ -58,14 +58,14 @@ class CurlDownloadRequest {
         factory_(std::move(rhs.factory_)),
         closing_(rhs.closing_),
         curl_closed_(rhs.curl_closed_),
-        initial_buffer_size_(rhs.initial_buffer_size_) {
+        initial_buffer_size_(rhs.initial_buffer_size_),
+        no_signal_(rhs.no_signal_) {
     ResetOptions();
   }
 
   CurlDownloadRequest& operator=(CurlDownloadRequest&& rhs) noexcept {
     url_ = std::move(rhs.url_);
     headers_ = std::move(rhs.headers_);
-    payload_ = std::move(rhs.payload_);
     user_agent_ = std::move(rhs.user_agent_);
     logging_enabled_ = rhs.logging_enabled_;
     handle_ = std::move(rhs.handle_);
@@ -74,6 +74,7 @@ class CurlDownloadRequest {
     closing_ = rhs.closing_;
     curl_closed_ = rhs.curl_closed_;
     initial_buffer_size_ = rhs.initial_buffer_size_;
+    no_signal_ = rhs.no_signal_;
     ResetOptions();
     return *this;
   }
@@ -145,7 +146,6 @@ class CurlDownloadRequest {
 
   std::string url_;
   CurlHeaders headers_;
-  std::string payload_;
   std::string user_agent_;
   CurlReceivedHeaders received_headers_;
   bool logging_enabled_;
@@ -167,6 +167,7 @@ class CurlDownloadRequest {
   bool curl_closed_;
 
   std::size_t initial_buffer_size_;
+  long no_signal_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -44,7 +44,7 @@ void CurlRequest::ResetOptions() {
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
-  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  handle_.SetOption(CURLOPT_NOSIGNAL, no_signal_);
   handle_.SetWriterCallback(
       [this](void* ptr, std::size_t size, std::size_t nmemb) {
         response_payload_.append(static_cast<char*>(ptr), size * nmemb);

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -51,7 +51,8 @@ class CurlRequest {
         received_headers_(std::move(rhs.received_headers_)),
         logging_enabled_(rhs.logging_enabled_),
         handle_(std::move(rhs.handle_)),
-        factory_(std::move(rhs.factory_)) {
+        factory_(std::move(rhs.factory_)),
+        no_signal_(rhs.no_signal_) {
     ResetOptions();
   }
 
@@ -64,6 +65,7 @@ class CurlRequest {
     logging_enabled_ = rhs.logging_enabled_;
     handle_ = std::move(rhs.handle_);
     factory_ = std::move(rhs.factory_);
+    no_signal_ = rhs.no_signal_;
 
     ResetOptions();
     return *this;
@@ -92,6 +94,7 @@ class CurlRequest {
   bool logging_enabled_;
   CurlHandle handle_;
   std::shared_ptr<CurlHandleFactory> factory_;
+  long no_signal_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -48,14 +48,20 @@ CurlRequest CurlRequestBuilder::BuildRequest() {
   return request;
 }
 
-CurlDownloadRequest CurlRequestBuilder::BuildDownloadRequest(
-    std::string payload) {
+CurlRequest CurlRequestBuilder::BuildRequest(ClientOptions const& options) {
   ValidateBuilderState(__func__);
-  CurlDownloadRequest request(initial_buffer_size_);
+  auto request = BuildRequest();
+  request.no_signal_ = options.enable_libcurl_nosignal() ? 1L : 0L;
+  return request;
+}
+
+CurlDownloadRequest CurlRequestBuilder::BuildDownloadRequest(
+    ClientOptions const& options) {
+  ValidateBuilderState(__func__);
+  CurlDownloadRequest request(options);
   request.url_ = std::move(url_);
   request.headers_ = std::move(headers_);
   request.user_agent_ = user_agent_prefix_ + UserAgentSuffix();
-  request.payload_ = std::move(payload);
   request.handle_ = std::move(handle_);
   request.multi_ = factory_->CreateMultiHandle();
   request.factory_ = factory_;

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -38,7 +38,15 @@ class CurlRequestBuilder {
                               std::shared_ptr<CurlHandleFactory> factory);
 
   /**
-   * Creates a http request with the given payload.
+   * Creates a http request with the given options.
+   *
+   * This function invalidates the builder. The application should not use this
+   * builder once this function is called.
+   */
+  CurlRequest BuildRequest(ClientOptions const& options);
+
+  /**
+   * Creates a http request with default parameters.
    *
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
@@ -51,7 +59,7 @@ class CurlRequestBuilder {
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
    */
-  CurlDownloadRequest BuildDownloadRequest(std::string payload);
+  CurlDownloadRequest BuildDownloadRequest(ClientOptions const& options);
 
   /// Adds one of the well-known parameters as a query parameter
   template <typename P>

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(storage_client_integration_tests
     service_account_integration_test.cc
     signed_url_conformance_test.cc
     signed_url_integration_test.cc
+    slow_reader_integration_test.cc
     storage_include_test.cc
     thread_integration_test.cc)
 

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdlib>
@@ -42,7 +43,8 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
       HttpBinEndpoint() + "/stream/" + std::to_string(kDownloadedLines),
       storage::internal::GetDefaultCurlHandleFactory());
 
-  auto download = request.BuildDownloadRequest(std::string{});
+  auto download = request.BuildDownloadRequest(
+      ClientOptions(oauth2::CreateAnonymousCredentials()));
 
   StatusOr<HttpResponse> response;
   std::string buffer;

--- a/google/cloud/storage/tests/slow_reader_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_integration_test.cc
@@ -1,0 +1,143 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/random.h"
+#include "google/cloud/log.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::testing::HasSubstr;
+
+// Initialized in main() below.
+char const* flag_project_id;
+char const* flag_bucket_name;
+
+class SlowReaderIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {
+ protected:
+  std::string CreateLargeText(long desired_size) {
+    auto const line_size = 128;
+    auto const lines = desired_size / line_size;
+    std::string result;
+    for (long i = 0; i != lines; ++i) {
+      result.append(google::cloud::internal::Sample(generator_, line_size - 1,
+                                                    "abcdefghijklmnopqrstuvwxyz"
+                                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                    "012456789"));
+      result.push_back('\n');
+    }
+    return result;
+  }
+};
+
+TEST_F(SlowReaderIntegrationTest, StreamingRead) {
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string const bucket_name = flag_bucket_name;
+  auto object_name = MakeRandomObjectName();
+  auto file_name = MakeRandomObjectName();
+
+  // Construct a large object, or at least large enough that it is not
+  // downloaded in the first chunk.
+  auto large_text = CreateLargeText(16 * 1024 * 1024);
+
+  // Create an object with the contents to download.
+  StatusOr<ObjectMetadata> source_meta = client->InsertObject(
+      bucket_name, object_name, large_text, IfGenerationMatch(0));
+  ASSERT_STATUS_OK(source_meta);
+
+  // Create a iostream to read the object back, when running against the
+  // testbench we can fail quickly by asking the testbench to break the stream
+  // in the middle.
+  ObjectReadStream stream;
+  auto slow_reader_period = std::chrono::seconds(400);
+  if (UsingTestbench()) {
+    stream = client->ReadObject(
+        bucket_name, object_name,
+        CustomHeader("x-goog-testbench-instructions", "return-broken-stream"));
+    slow_reader_period = std::chrono::seconds(1);
+  } else {
+    stream = client->ReadObject(bucket_name, object_name);
+  }
+
+  auto const max_slow_reader_period = std::chrono::minutes(10);
+  std::vector<char> buffer;
+  long const size = 1024 * 1024;
+  buffer.resize(size);
+  stream.read(buffer.data(), size);
+  EXPECT_STATUS_OK(stream.status());
+
+  std::cout << "Reading " << std::flush;
+  while (!stream.eof()) {
+    std::cout << ' ' << slow_reader_period.count() << "s" << std::flush;
+    std::this_thread::sleep_for(slow_reader_period);
+    stream.read(buffer.data(), size);
+    if (!stream.status().ok()) {
+      // TODO(#2655) - automatically restart the download.
+      // Until recently, the code crashed before this point, so mark this as a
+      // "success", though obviously (#2655) we want to do better.
+      std::cout << " DONE (" << stream.status() << ")\n" << std::flush;
+      auto status = client->DeleteObject(bucket_name, object_name);
+      EXPECT_STATUS_OK(status);
+      return;
+    }
+    EXPECT_STATUS_OK(stream.status());
+    if (slow_reader_period < max_slow_reader_period) {
+      slow_reader_period += std::chrono::minutes(1);
+    }
+  }
+  std::cout << " DONE\n" << std::flush;
+  EXPECT_STATUS_OK(stream.status());
+
+  stream.Close();
+  EXPECT_STATUS_OK(stream.status());
+
+  auto status = client->DeleteObject(bucket_name, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
+}  // anonymous namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 3) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <project-id> <bucket-name>\n";
+    return 1;
+  }
+
+  google::cloud::storage::flag_project_id = argv[1];
+  google::cloud::storage::flag_bucket_name = argv[2];
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -34,6 +34,7 @@ storage_client_integration_tests = [
     "service_account_integration_test.cc",
     "signed_url_conformance_test.cc",
     "signed_url_integration_test.cc",
+    "slow_reader_integration_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
 ]


### PR DESCRIPTION
Make the use of CURLOPT_NOSIGNAL optional. Some applications need this
to avoid the signals generated by timeouts in DNS lookups, but
CURLOPT_NOSIGNAL does more than just disabling timeout signals, it also
enables SIGPIPE for closed connections (or more accurately: it disables
the automatic disabling of SIGPIPE), which can make the application
crash on broken connections.

I considered using the approach described here:

https://curl.haxx.se/mail/lib-2010-11/0008.html

but that is problematic on libraries supporting multi-threaded
applications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2658)
<!-- Reviewable:end -->
