### PR TITLE
Fix support for empty chunks in resumable upload.

### DIFF
--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -519,8 +519,8 @@ std::string UploadChunkRequest::RangeHeader() const {
     // This typically happens when the sender realizes too late that the
     // previous chunk was really the last chunk (e.g. the file is exactly a
     // multiple of the quantum, reading the last chunk from a file, or sending
-    // it as apart of a stream does not detect the EOF), the formatting of the
-    // range is special in this case.
+    // it as apart of a stream that does not detect the EOF), the formatting of
+    // the range is special in this case.
     os << "*";
   } else {
     os << range_begin() << "-" << range_begin() + payload().size() - 1;

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -519,7 +519,7 @@ std::string UploadChunkRequest::RangeHeader() const {
     // This typically happens when the sender realizes too late that the
     // previous chunk was really the last chunk (e.g. the file is exactly a
     // multiple of the quantum, reading the last chunk from a file, or sending
-    // it as apart of a stream that does not detect the EOF), the formatting of
+    // it as part of a stream that does not detect the EOF), the formatting of
     // the range is special in this case.
     os << "*";
   } else {

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -514,15 +514,16 @@ std::ostream& operator<<(std::ostream& os, ResumableUploadRequest const& r) {
 
 std::string UploadChunkRequest::RangeHeader() const {
   std::ostringstream os;
-  os << "Content-Range: bytes " << range_begin() << "-";
+  os << "Content-Range: bytes ";
   if (payload().empty()) {
     // This typically happens when the sender realizes too late that the
     // previous chunk was really the last chunk (e.g. the file is exactly a
-    // multiple of the quantum, reading the last chunk does not detect the EOF),
-    // the formatting of the range is special in this case.
-    os << range_begin();
+    // multiple of the quantum, reading the last chunk from a file, or sending
+    // it as apart of a stream does not detect the EOF), the formatting of the
+    // range is special in this case.
+    os << "*";
   } else {
-    os << range_begin() + payload().size() - 1;
+    os << range_begin() << "-" << range_begin() + payload().size() - 1;
   }
   if (source_size() == 0) {
     os << "/*";

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -475,14 +475,14 @@ TEST(ObjectRequestsTest, UploadChunkContentRangeKnownSize) {
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeEmptyPayloadUnknownSize) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest request(url, 1024, "", 0U);
-  EXPECT_EQ("Content-Range: bytes 1024-1024/*", request.RangeHeader());
+  UploadChunkRequest request(url, 1024, std::string{}, 0U);
+  EXPECT_EQ("Content-Range: bytes */*", request.RangeHeader());
 }
 
 TEST(ObjectRequestsTest, UploadChunkContentRangeEmptyPayloadKnownSize) {
   std::string const url = "https://unused.googleapis.com/test-only";
-  UploadChunkRequest request(url, 2047, "", 2048U);
-  EXPECT_EQ("Content-Range: bytes 2047-2047/2048", request.RangeHeader());
+  UploadChunkRequest request(url, 2047, std::string{}, 2048U);
+  EXPECT_EQ("Content-Range: bytes */2048", request.RangeHeader());
 }
 
 TEST(ObjectRequestsTest, QueryResumableUpload) {


### PR DESCRIPTION
When doing resumable uploads we may need to send an empty chunk at the
end of the stream. For example, because the stream has a round number of
chunks, and all of them are sent before the stream is closed. At that
point we need to send some indication to the resumable upload session
that the upload is "done", and an empty chunk is the only choice.

Our support for this was broken, which was Okay-ish because we do not
use it (yet): our streams almost always have data in the buffer (that is
a separate bug), and flush this buffer in the last request.

With this change we fix the formatting of the Content-Range header to
support empty chunks, add an integration test to verify this works
against production, and fixed the testbench to parse these chunks
correctly.

This fixes #2663.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2666)
<!-- Reviewable:end -->
