### PR TITLE
Fix openSuSE build.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,7 +206,7 @@ Install the minimal development tools:
 ```bash
 sudo zypper refresh && \
 sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel make tar wget
+        libcurl-devel libopenssl-devel make tar wget zlib-devel
 ```
 
 OpenSUSE:tumbleweed provides packages for gRPC, libcurl, and protobuf, and the

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig zlib-devel
 ```bash
 sudo zypper refresh && \
 sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel make tar wget
+        libcurl-devel libopenssl-devel make tar wget zlib-devel
 ```
 
 ### OpenSUSE (Leap)

--- a/ci/test-readme/Dockerfile.opensuse
+++ b/ci/test-readme/Dockerfile.opensuse
@@ -24,7 +24,7 @@ FROM opensuse/tumbleweed:${DISTRO_VERSION}
 # ```bash
 RUN zypper refresh && \
     zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel make tar wget
+        libcurl-devel libopenssl-devel make tar wget zlib-devel
 # ```
 
 ## [END README.md]

--- a/ci/test-readme/dockerfile2markdown.sh
+++ b/ci/test-readme/dockerfile2markdown.sh
@@ -42,12 +42,12 @@ sed \
         removing_blanks=0;
       }
       {
-        if ("$0" != "") {
+        if ($0 != "") {
           removing_blanks = 0;
-          print "$0";
+          print $0;
         } else if (removing_blanks != 1) {
           removing_blanks = 1;
-          print "$0";
+          print $0;
         }
       }
     '


### PR DESCRIPTION
Evidently openSuSE refatored some of its dependencies and zlib-devel
does not get automatically installed by some of the other libraries.
Fixed the build scripts to install zlib-devel, and regenerate the
instructions to include this new dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2669)
<!-- Reviewable:end -->
