### PR TITLE
`future<>::then()` doesn't destroy l-value refs.

### DIFF
--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -615,6 +615,64 @@ TEST(FutureTestVoid, conform_2_10_4) {
   SUCCEED();
 }
 
+class MockFunctor {
+ public:
+  MockFunctor() : moved_from_() {}
+  MockFunctor(MockFunctor&& other) { other.moved_from_ = true; }
+  MockFunctor(MockFunctor const& other) = default;
+
+  void operator()(future<void>) {}
+
+  bool moved_from_;
+};
+
+TEST(FutureTestVoid, RValueThenFunctorIsMoved) {
+  promise<void> promise;
+  future<void> fut = promise.get_future();
+  MockFunctor fun;
+  fut.then(std::move(fun));
+  promise.set_value();
+  EXPECT_TRUE(fun.moved_from_);
+}
+
+TEST(FutureTestVoid, LValueThenFunctorIsCopied) {
+  promise<void> promise;
+  future<void> fut = promise.get_future();
+  MockFunctor fun;
+  fut.then(fun);
+  promise.set_value();
+  EXPECT_FALSE(fun.moved_from_);
+}
+
+class MockUnwrapFunctor {
+ public:
+  MockUnwrapFunctor() : moved_from_() {}
+  MockUnwrapFunctor(MockUnwrapFunctor&& other) { other.moved_from_ = true; }
+  MockUnwrapFunctor(MockUnwrapFunctor const& other) = default;
+
+  future<void> operator()(future<void>) { return make_ready_future(); }
+
+  bool moved_from_;
+};
+
+TEST(FutureTestVoid, RValueThenUnwrapFunctorIsMoved) {
+  promise<void> promise;
+  future<void> fut = promise.get_future();
+  MockUnwrapFunctor fun;
+  fut.then(std::move(fun));
+  promise.set_value();
+  EXPECT_TRUE(fun.moved_from_);
+}
+
+TEST(FutureTestVoid, LValueThenUnwrapFunctorIsCopied) {
+  promise<void> promise;
+  future<void> fut = promise.get_future();
+  MockUnwrapFunctor fun;
+  fut.then(fun);
+  promise.set_value();
+  EXPECT_FALSE(fun.moved_from_);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -63,7 +63,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   // instead of a lambda, as support for move+capture in lambdas is a C++14
   // feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(std::move(func)) {}
+    explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> functor_result_t {
@@ -104,7 +104,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   // Because we need to support C++11, we use a local class instead of a lambda,
   // as support for move+capture in lambdas is a C++14 feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(std::move(func)) {}
+    explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> std::shared_ptr<internal::future_shared_state<result_t>> {
@@ -146,7 +146,7 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   // instead of a lambda, as support for move+capture in lambdas is a C++14
   // feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(std::move(func)) {}
+    explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> functor_result_t {
@@ -186,7 +186,7 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   // Because we need to support C++11, we use a local class instead of a lambda,
   // as support for move+capture in lambdas is a C++14 feature.
   struct adapter {
-    explicit adapter(F&& func) : functor(std::move(func)) {}
+    explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
         -> std::shared_ptr<internal::future_shared_state<result_t>> {


### PR DESCRIPTION
Before this PR, if an l-value reference was passed to
`future<>::then()`, it was moved from. This was wrong - they should have
been copied from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2670)
<!-- Reviewable:end -->
