### PR TITLE
Refactor command-line parsing for benchmarks.

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -53,8 +53,10 @@ export_list_to_bazel("storage_benchmark_programs.bzl"
 
 if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
-    set(storage_benchmarks_unit_tests benchmark_parser_test.cc
-        benchmark_make_random_test.cc)
+    set(storage_benchmarks_unit_tests
+        benchmark_parser_test.cc
+        benchmark_make_random_test.cc
+        benchmark_parse_args_test.cc)
 
     foreach (fname ${storage_benchmarks_unit_tests})
         string(REPLACE "/"

--- a/google/cloud/storage/benchmarks/benchmark_parse_args_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_parse_args_test.cc
@@ -63,6 +63,27 @@ TEST(StorageBenchmarksParseArgsTest, Simple) {
   EXPECT_EQ(option2_val, "value2");
 }
 
+TEST(StorageBenchmarksParseArgsTest, PrefixArgument) {
+  std::string option1_with_suffix_val = "not-set";
+  std::string option1_val = "not-set";
+
+  std::vector<OptionDescriptor> desc{
+      {"--option1-with-suffix", "help-for-option1-with-suffix",
+       [&](std::string const& v) { option1_with_suffix_val = v; }},
+      {"--option1", "help-for-option1",
+       [&](std::string const& v) { option1_val = v; }},
+  };
+
+  auto unparsed =
+      OptionsParse(desc, {"command-name", "--option1-with-suffix=suffix1",
+                          "skip1", "skip2", "--option1=value1"});
+
+  EXPECT_THAT(unparsed,
+              ::testing::ElementsAre("command-name", "skip1", "skip2"));
+  EXPECT_EQ(option1_with_suffix_val, "suffix1");
+  EXPECT_EQ(option1_val, "value1");
+}
+
 }  // namespace
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/benchmark_parse_args_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_parse_args_test.cc
@@ -1,0 +1,69 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(StorageBenchmarksParseArgsTest, UsageSimple) {
+  std::vector<OptionDescriptor> desc{
+      {"--option1", "help-for-option1", [](std::string const&) {}},
+      {"--option2", "help-for-option2", [](std::string const&) {}},
+  };
+  auto usage = BuildUsage(desc, "command-name");
+  EXPECT_THAT(usage, HasSubstr("command-name"));
+  EXPECT_THAT(usage, HasSubstr("--option1"));
+  EXPECT_THAT(usage, HasSubstr("--option2"));
+  EXPECT_THAT(usage, HasSubstr("help-for-option1"));
+  EXPECT_THAT(usage, HasSubstr("help-for-option2"));
+}
+
+TEST(StorageBenchmarksParseArgsTest, Empty) {
+  OptionDescriptor d{"--unused", "should not be called",
+                     [](std::string const& val) { FAIL() << "value=" << val; }};
+  auto unparsed = OptionsParse({d}, {});
+  EXPECT_TRUE(unparsed.empty());
+}
+
+TEST(StorageBenchmarksParseArgsTest, Simple) {
+  std::string option1_val = "not-set";
+  std::string option2_val = "not-set";
+
+  std::vector<OptionDescriptor> desc{
+      {"--option1", "help-for-option1",
+       [&](std::string const& v) { option1_val = v; }},
+      {"--option2", "help-for-option2",
+       [&](std::string const& v) { option2_val = v; }},
+  };
+
+  auto unparsed =
+      OptionsParse(desc, {"command-name", "skip1", "--option2=value2", "skip2",
+                          "skip3", "--option1=value1", "skip4", "skip5"});
+
+  EXPECT_THAT(unparsed, ::testing::ElementsAre("command-name", "skip1", "skip2",
+                                               "skip3", "skip4", "skip5"));
+  EXPECT_EQ(option1_val, "value1");
+  EXPECT_EQ(option2_val, "value2");
+}
+
+}  // namespace
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/benchmarks/benchmark_parser_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_parser_test.cc
@@ -51,7 +51,7 @@ TEST(StorageBenchmarksUtilsTest, ParseBoolean) {
   EXPECT_EQ(true, ParseBoolean("True", false));
 
   EXPECT_EQ(false, ParseBoolean("false", true));
-  EXPECT_EQ(false, ParseBoolean("False", false));
+  EXPECT_EQ(false, ParseBoolean("False", true));
 }
 
 }  // namespace

--- a/google/cloud/storage/benchmarks/benchmark_parser_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_parser_test.cc
@@ -43,6 +43,17 @@ TEST(StorageBenchmarksUtilsTest, ParseDuration) {
   EXPECT_EQ(s(1800).count(), ParseDuration("1800s").count());
 }
 
+TEST(StorageBenchmarksUtilsTest, ParseBoolean) {
+  EXPECT_EQ(true, ParseBoolean("", true));
+  EXPECT_EQ(false, ParseBoolean("", false));
+
+  EXPECT_EQ(true, ParseBoolean("true", false));
+  EXPECT_EQ(true, ParseBoolean("True", false));
+
+  EXPECT_EQ(false, ParseBoolean("false", true));
+  EXPECT_EQ(false, ParseBoolean("False", false));
+}
+
 }  // namespace
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -186,13 +186,10 @@ std::vector<std::string> OptionsParse(std::vector<OptionDescriptor> const& desc,
       d.parser(val);
       // This is a match, consume the argument and stop the search.
       matched = true;
-      next_arg = argv.erase(next_arg);
       break;
     }
-    // If it was not matched just skip it,
-    if (!matched) {
-      ++next_arg;
-    }
+    // If next_arg is matched against any option erase it, otherwise skip it.
+    next_arg = matched ? argv.erase(next_arg) : next_arg + 1;
   }
   return argv;
 }

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <cctype>
 #include <sstream>
 #include <stdexcept>
 
@@ -124,7 +125,7 @@ bool ParseBoolean(std::string const& val, bool default_value) {
   }
   auto lower = val;
   std::transform(lower.begin(), lower.end(), lower.begin(),
-                 [](char x) { return std::tolower(x); });
+                 [](char x) { return static_cast<char>(std::tolower(x)); });
   if (lower == "true") {
     return true;
   } else if (lower == "false") {

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -140,7 +140,7 @@ std::string Basename(std::string const& path) {
   // With C++17 we would use std::filesytem::path, until then do the poor's
   // person version.
 #if _WIN32
-  return path.substr(path.find_last_of('\\/') + 1);
+  return path.substr(path.find_last_of("\\/") + 1);
 #else
   return path.substr(path.find_last_of('/') + 1);
 #endif  // _WIN32

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -132,8 +132,8 @@ bool ParseBoolean(std::string const& val, bool default_value) {
   } else if (lower == "false") {
     return false;
   }
-  google::cloud::internal::ThrowRuntimeError(
-      "Cannot parse " + val + " as a boolean");
+  google::cloud::internal::ThrowRuntimeError("Cannot parse " + val +
+                                             " as a boolean");
 }
 
 std::string Basename(std::string const& path) {

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -57,6 +57,28 @@ std::int64_t ParseSize(std::string const& val);
 /// second (s) suffixes.
 std::chrono::seconds ParseDuration(std::string const& val);
 
+/// Parse a string as a boolean, with a default value if the string is empty.
+bool ParseBoolean(std::string const& val, bool default_value);
+
+/// Defines a command-line option.
+struct OptionDescriptor {
+  using OptionParser = std::function<void(std::string const&)>;
+
+  std::string option;
+  std::string help;
+  OptionParser parser;
+};
+
+/// Build the `Usage` string from a list of command-line option descriptions.
+std::string BuildUsage(std::vector<OptionDescriptor> const& desc,
+                       std::string const& command_path);
+
+/**
+ * Parse @p argv using the descriptions in @p desc, return unparsed arguments.
+ */
+std::vector<std::string> OptionsParse(std::vector<OptionDescriptor> const& desc,
+                                      std::vector<std::string> argv);
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -47,13 +47,13 @@ run_example ./storage_latency_benchmark \
 run_example ./storage_throughput_benchmark \
       --duration=1 \
       --object-count=8 \
-      --object-chunk-count=10 \
+      --object-size=10MiB \
       "${FAKE_REGION}"
 run_example ./storage_throughput_benchmark \
       --enable-xml-api=false \
       --duration=1 \
       --object-count=8 \
-      --object-chunk-count=10 \
+      --object-size=10MiB \
       "${FAKE_REGION}"
 
 if [[ "${EXIT_STATUS}" = "0" ]]; then

--- a/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
@@ -19,4 +19,5 @@
 storage_benchmarks_unit_tests = [
     "benchmark_parser_test.cc",
     "benchmark_make_random_test.cc",
+    "benchmark_parse_args_test.cc",
 ]

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -23,73 +23,59 @@
 #include <iomanip>
 #include <sstream>
 
-/**
- * @file
- *
- * A thoughput benchmark for the Google Cloud Storage C++ client library.
- *
- * This program first creates a Bucket that will contain all the Objects used in
- * the test.  The Bucket is deleted at the end of the test. The name of the
- * Bucket is selected at random, that way multiple instances of this test can
- * run simultaneously. The Bucket uses the `REGIONAL` storage class, in a region
- * set via the command-line.
- *
- * After creating this Bucket the program creates a number of objects, all the
- * objects have the same contents, but the contents are generated at random.
- *
- * The size of the objects can be configured in the command-line, but they are
- * typically 250MiB is size.  The program reports the time it takes to upload
- * the first 10 MiB, the first 20 MiB, the first 30 MiB, and so forth until the
- * total size of the object is uploaded.
- *
- * Once the object creation phase is completed, the program starts N threads,
- * each thread executes a simple loop:
- * - Pick one of the objects at random, with equal probability for each Object.
- * - Pick, with equal probably, an action (`read` or `write`) at random.
- * - If the action was `write` then write to the object, capturing throughput
- *   information, which is reported when the thread finishes running.
- * - If the action was `read` then read the object. Capture the time taken to
- *   read the first 10 MiB, the first 20 MiB, and so forth until the full
- *   object is read.
- *
- * The loop runs for a prescribed number of seconds. At the end of the loop the
- * program prints the captured performance data.
- *
- * Then the program removes all the objects in the bucket and reports the time
- * taken to delete each one.
- *
- * A helper script in this directory can generate pretty graphs from the report.
- */
-
 namespace {
 namespace gcs = google::cloud::storage;
 namespace gcs_bm = google::cloud::storage_benchmarks;
 
-constexpr std::chrono::seconds kDefaultDuration(60);
-constexpr unsigned long kDefaultObjectCount = 1000;
-constexpr unsigned long kChunkSize = 1 * gcs_bm::kMiB;
-constexpr int kDefaultObjectChunkCount = 250;
-constexpr int kThroughputReportIntervalInChunks = 4;
+char const kDescription[] = R"""(
+A throughput benchmark for the Google Cloud Storage C++ client library.
+
+This program first creates a Bucket that will contain all the Objects used in
+the test.  The Bucket is deleted at the end of the test. The name of the Bucket
+is selected at random, so multiple instances of this benchmark can run
+simultaneously. The Bucket uses the `REGIONAL` storage class, in a region set
+via the command-line.
+
+After creating this Bucket the program creates a number of objects, all the
+objects have the same contents, but the contents are generated at random.
+
+The size of the objects can be configured in the command-line, but they are
+typically 250MiB is size.  The program reports the time it takes to upload the
+first 10 MiB, the first 20 MiB, the first 30 MiB, and so forth until the total
+size of the object is uploaded.
+
+Once the object creation phase is completed, the program starts N threads, each
+thread executes a simple loop:
+- Pick one of the objects at random, with equal probability for each Object.
+- Pick, with equal probably, an action (`read` or `write`) at random.
+- If the action was `write` then write to the object, capturing throughput
+  information, which is reported when the thread finishes running.
+- If the action was `read` then read the object. Capture the time taken to
+  read the first 10 MiB, the first 20 MiB, and so forth until the full
+  object is read.
+
+The loop runs for a prescribed number of seconds. At the end of the loop the
+program prints the captured performance data.
+
+Then the program removes all the objects in the bucket and reports the time
+taken to delete each one.
+
+A helper script in this directory can generate pretty graphs from the outut of
+this program.
+)""";
+
+constexpr auto kChunkSize = 1 * gcs_bm::kMiB;
+constexpr auto kThroughputReportInterval = 4 * gcs_bm::kMiB;
 
 struct Options {
+  std::string project_id;
   std::string region;
-  std::chrono::seconds duration;
-  long object_count;
-  int thread_count;
-  int object_chunk_count;
-  bool enable_connection_pool;
-  bool enable_xml_api;
-
-  Options()
-      : duration(kDefaultDuration),
-        object_count(kDefaultObjectCount),
-        thread_count(1),
-        object_chunk_count(kDefaultObjectChunkCount),
-        enable_connection_pool(true),
-        enable_xml_api(true) {}
-
-  void ParseArgs(int& argc, char* argv[]);
-  std::string ConsumeArg(int& argc, char* argv[], char const* arg_name);
+  std::chrono::seconds duration = std::chrono::seconds(60);
+  long object_count = 1000;
+  int thread_count = 1;
+  std::int64_t object_size = 250 * gcs_bm::kMiB;
+  bool enable_connection_pool = true;
+  bool enable_xml_api = true;
 };
 
 enum OpType { OP_READ, OP_WRITE, OP_CREATE, OP_DELETE, OP_LAST };
@@ -115,16 +101,12 @@ void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
                       Options const& options,
                       std::vector<std::string> const& object_names);
 
+Options ParseArgs(int argc, char* argv[]);
+
 }  // namespace
 
 int main(int argc, char* argv[]) try {
-  Options options;
-  options.ParseArgs(argc, argv);
-
-  if (!google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").has_value()) {
-    std::cerr << "GOOGLE_CLOUD_PROJECT environment variable must be set\n";
-    return 1;
-  }
+  Options options = ParseArgs(argc, argv);
 
   google::cloud::StatusOr<gcs::ClientOptions> client_options =
       gcs::ClientOptions::CreateDefaultClientOptions();
@@ -135,6 +117,9 @@ int main(int argc, char* argv[]) try {
   }
   if (!options.enable_connection_pool) {
     client_options->set_connection_pool_size(0);
+  }
+  if (!options.project_id.empty()) {
+    client_options->set_project_id(options.project_id);
   }
   gcs::Client client(*std::move(client_options));
 
@@ -163,7 +148,8 @@ int main(int argc, char* argv[]) try {
             << gcs::internal::FormatRfc3339(std::chrono::system_clock::now())
             << "\n# Region: " << options.region
             << "\n# Object Count: " << options.object_count
-            << "\n# Object Chunk Count: " << options.object_chunk_count
+            << "\n# Object Size: " << options.object_size
+            << "\n# Object Size (MiB): " << options.object_size / gcs_bm::kMiB
             << "\n# Thread Count: " << options.thread_count
             << "\n# Enable connection pool: " << options.enable_connection_pool
             << "\n# Enable XML API: " << options.enable_xml_api
@@ -187,15 +173,6 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
-std::string Basename(std::string const& path) {
-  // Sure would be nice to be using C++17 where std::filesystem is a thing.
-#if _WIN32
-  return path.substr(path.find_last_of('\\') + 1);
-#else
-  return path.substr(path.find_last_of('/') + 1);
-#endif  // _WIN32
-}
-
 char const* ToString(OpType type) {
   static char const* kOpTypeNames[] = {"READ", "WRITE", "CREATE", "DELETE",
                                        "LAST"};
@@ -219,28 +196,29 @@ TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
   auto start = std::chrono::steady_clock::now();
 
   TestResult result;
-  result.reserve(options.object_chunk_count /
-                 kThroughputReportIntervalInChunks);
+  result.reserve(options.object_size / kThroughputReportInterval);
   gcs::ObjectWriteStream stream;
   if (options.enable_xml_api) {
     stream = client.WriteObject(bucket_name, object_name, gcs::Fields(""));
   } else {
     stream = client.WriteObject(bucket_name, object_name);
   }
-  for (int i = 0; i < options.object_chunk_count; ++i) {
+  auto next_report = kThroughputReportInterval;
+  for (std::int64_t size = 0; size < options.object_size; size += kChunkSize) {
     stream.write(data_chunk.data(), data_chunk.size());
-    if (i != 0 && i % kThroughputReportIntervalInChunks == 0) {
+    if (size > next_report) {
       auto elapsed = std::chrono::steady_clock::now() - start;
       result.emplace_back(
-          IterationResult{op_type, i * data_chunk.size(),
+          IterationResult{op_type, static_cast<std::size_t>(size),
                           std::chrono::duration_cast<milliseconds>(elapsed)});
+      next_report += kThroughputReportInterval;
     }
   }
   try {
     stream.Close();
     auto elapsed = std::chrono::steady_clock::now() - start;
     result.emplace_back(
-        IterationResult{op_type, options.object_chunk_count * data_chunk.size(),
+        IterationResult{op_type, static_cast<std::size_t>(options.object_size),
                         std::chrono::duration_cast<milliseconds>(elapsed)});
   } catch (std::exception const& ex) {
     std::cerr << ex.what() << "\n";
@@ -270,7 +248,7 @@ TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
   using std::chrono::milliseconds;
   auto start = std::chrono::steady_clock::now();
   TestResult result;
-  result.reserve(kDefaultObjectChunkCount);
+  result.reserve(options.object_size / kThroughputReportInterval);
 
   gcs::ObjectReadStream stream;
   if (options.enable_xml_api) {
@@ -280,18 +258,19 @@ TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
                                gcs::IfGenerationNotMatch(0));
   }
   std::size_t total_size = 0;
-  constexpr auto report = kThroughputReportIntervalInChunks * kChunkSize;
+  auto next_report = kThroughputReportInterval;
   char buf[4096];
   while (stream.read(buf, sizeof(buf))) {
     if (stream.gcount() == 0) {
       continue;
     }
     total_size += stream.gcount();
-    if (total_size != 0 && total_size % report == 0) {
+    if (total_size > static_cast<std::size_t>(next_report)) {
       auto elapsed = std::chrono::steady_clock::now() - start;
       result.emplace_back(
           IterationResult{OP_READ, total_size,
                           std::chrono::duration_cast<milliseconds>(elapsed)});
+      next_report += kThroughputReportInterval;
     }
   }
   auto elapsed = std::chrono::steady_clock::now() - start;
@@ -453,95 +432,72 @@ void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
             << "ms\n";
 }
 
-void Options::ParseArgs(int& argc, char* argv[]) {
-  region = ConsumeArg(argc, argv, "region");
-}
+Options ParseArgs(int argc, char* argv[]) {
+  Options options;
+  bool wants_help = false;
+  bool wants_description = false;
+  std::vector<gcs_bm::OptionDescriptor> desc{
+      {"--help", "print usage information",
+       [&wants_help](std::string const& v) { wants_help = true; }},
+      {"--description", "print benchmark description",
+       [&wants_description](std::string const& v) {
+         wants_description = true;
+       }},
+      {"--duration", "set the total execution time for the benchmark",
+       [&options](std::string const& val) {
+         options.duration = gcs_bm::ParseDuration(val);
+       }},
+      {"--object-count", "set the number of objects created by the benchmark",
+       [&options](std::string const& val) {
+         options.object_count = std::stoi(val);
+       }},
+      {"--object-size", "size of the objects created by the benchmark",
+       [&options](std::string const& val) {
+         options.object_size = gcs_bm::ParseSize(val);
+       }},
+      {"--thread-count", "set the number of threads in the benchmark",
+       [&options](std::string const& val) {
+         options.thread_count = std::stoi(val);
+       }},
+      {"--enable-connection-pool", "enable the client library connection pool",
+       [&options](std::string const& val) {
+         options.enable_connection_pool = gcs_bm::ParseBoolean(val, true);
+       }},
+      {"--enable-xml-api", "enable the XML API for the benchmark",
+       [&options](std::string const& val) {
+         options.enable_xml_api = gcs_bm::ParseBoolean(val, true);
+       }},
+      {"--project-id", "use the given project id for the benchmark",
+       [&options](std::string const& val) { options.project_id = val; }},
+      {"--region", "use the given region for the benchmark",
+       [&options](std::string const& val) { options.region = val; }},
+  };
+  auto usage = gcs_bm::BuildUsage(desc, argv[0]);
 
-std::string Options::ConsumeArg(int& argc, char* argv[], char const* arg_name) {
-  std::string const duration = "--duration=";
-  std::string const object_count = "--object-count=";
-  std::string const object_chunk_count = "--object-chunk-count=";
-  std::string const thread_count = "--thread-count=";
-  std::string const enable_connection_pool = "--enable-connection-pool=";
-  std::string const enable_xml_api = "--enable-xml-api=";
-
-  std::string const usage = R""(
-[options] <region>
-The options are:
-    --help: produce this message.
-    --duration (in seconds): for how long should the test run.
-    --object-count: the number of objects to use in the benchmark.
-    --object-chunk-count: the number of chunks (1 MiB blocks) in each object.
-    --thread-count: the number of threads to use in the benchmark.
-    --enable-connection-pool: reuse connections across requests.
-    --enable-xml-api: configure read+write operations to use XML API.
-
-    region: a Google Cloud Storage region where all the objects used in this
-       test will be located.
-)"";
-
-  std::string error = "Missing argument ";
-  error += arg_name;
-  while (argc >= 2) {
-    std::string argument(argv[1]);
-    std::copy(argv + 2, argv + argc, argv + 1);
-    argc--;
-    if (argument == "--help") {
-    } else if (0 == argument.rfind(duration, 0)) {
-      std::string val = argument.substr(duration.size());
-      this->duration = gcs_bm::ParseDuration(val);
-    } else if (0 == argument.rfind(object_count, 0)) {
-      auto arg = argument.substr(object_count.size());
-      auto val = std::stol(arg);
-      if (val <= 0) {
-        error = "Invalid object-count argument (" + arg + ")";
-        break;
-      }
-      this->object_count = val;
-    } else if (0 == argument.rfind(object_chunk_count, 0)) {
-      auto arg = argument.substr(object_chunk_count.size());
-      auto val = std::stol(arg);
-      if (val <= 0) {
-        error = "Invalid object-chunk-count argument (" + arg + ")";
-        break;
-      }
-      this->object_chunk_count = val;
-    } else if (0 == argument.rfind(thread_count, 0)) {
-      auto arg = argument.substr(object_count.size());
-      auto val = std::stoi(arg);
-      if (val <= 0) {
-        error = "Invalid thread-count argument (" + arg + ")";
-        break;
-      }
-      this->thread_count = val;
-    } else if (0 == argument.rfind(enable_connection_pool, 0)) {
-      auto arg = argument.substr(enable_connection_pool.size());
-      if (arg == "true" or arg == "yes" or arg == "1") {
-        this->enable_connection_pool = true;
-      } else if (arg == "false" or arg == "no" or arg == "0") {
-        this->enable_connection_pool = false;
-      } else {
-        error = "Invalid enable-connection-pool argument (" + arg + ")";
-        break;
-      }
-    } else if (0 == argument.rfind(enable_xml_api, 0)) {
-      auto arg = argument.substr(enable_xml_api.size());
-      if (arg == "true" or arg == "yes" or arg == "1") {
-        this->enable_xml_api = true;
-      } else if (arg == "false" or arg == "no" or arg == "0") {
-        this->enable_xml_api = false;
-      } else {
-        error = "Invalid enable-xml-api argument (" + arg + ")";
-        break;
-      }
-    } else {
-      return argument;
-    }
+  auto unparsed = gcs_bm::OptionsParse(desc, {argv, argv + argc});
+  if (wants_help) {
+    std::cout << usage << "\n";
   }
-  std::ostringstream os;
-  os << error << "\n";
-  os << "Usage: " << Basename(argv[0]) << usage << "\n";
-  throw std::runtime_error(os.str());
+
+  if (wants_description) {
+    std::cout << kDescription << "\n";
+  }
+
+  if (unparsed.size() > 2U) {
+    std::ostringstream os;
+    os << "Unknown arguments or options\n" << usage << "\n";
+    throw std::runtime_error(std::move(os).str());
+  }
+  if (unparsed.size() == 2U) {
+    options.region = unparsed[1];
+  }
+  if (options.region.empty()) {
+    std::ostringstream os;
+    os << "Missing value for --region option" << usage << "\n";
+    throw std::runtime_error(std::move(os).str());
+  }
+
+  return options;
 }
 
 }  // namespace


### PR DESCRIPTION
Wrote helper function to parse command-line, and use it in both benchmarks.
I changed how the throughput benchmark specifies object sizes, because now
we have something better than "N chunks" where the user has to guess (or
read the code) to figure out what is a chunk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2671)
<!-- Reviewable:end -->
