### PR TITLE
Remove substring after space in language_version.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -191,6 +191,7 @@ if (BUILD_TESTING)
         iam_bindings_test.cc
         internal/backoff_policy_test.cc
         internal/big_endian_test.cc
+        internal/build_info_test.cc
         internal/filesystem_test.cc
         internal/future_impl_test.cc
         internal/invoke_result_test.cc

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -82,7 +82,8 @@ ClientOptions& ClientOptions::set_connection_pool_size(std::size_t size) {
 }
 
 std::string ClientOptions::UserAgentPrefix() {
-  std::string agent = "gcloud-cpp/" + version_string();
+  std::string agent = "gcloud-cpp/" + version_string() + " " +
+                      google::cloud::internal::compiler();
   return agent;
 }
 

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -24,6 +24,7 @@ google_cloud_cpp_common_unit_tests = [
     "iam_bindings_test.cc",
     "internal/backoff_policy_test.cc",
     "internal/big_endian_test.cc",
+    "internal/build_info_test.cc",
     "internal/filesystem_test.cc",
     "internal/future_impl_test.cc",
     "internal/invoke_result_test.cc",

--- a/google/cloud/internal/build_info.cc.in
+++ b/google/cloud/internal/build_info.cc.in
@@ -35,7 +35,10 @@ std::string language_version() {
     // NOLINTNEXTLINE(readability-redundant-string-init)
     std::string v =
         R"""(@CMAKE_CXX_COMPILER_ID@-@CMAKE_CXX_COMPILER_VERSION@)""";
-    std::replace(v.begin(), v.end(), ' ', '_');
+    auto pos = v.find(' ');
+    if (pos != std::string::npos) {
+      v = v.substr(0, pos);
+    }
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     v += "-ex";
 #else

--- a/google/cloud/internal/build_info_test.cc
+++ b/google/cloud/internal/build_info_test.cc
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/build_info.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::MatchesRegex;
+
+TEST(BuildInfo, LanguageVersion) {
+  auto lv = language_version();
+  EXPECT_THAT(lv, ::testing::AnyOf(HasSubstr("-noex-"), HasSubstr("-ex-")));
+  EXPECT_THAT(lv, MatchesRegex(R"([0-9A-Za-z_.-]+)"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/build_info_test.cc
+++ b/google/cloud/internal/build_info_test.cc
@@ -27,7 +27,12 @@ using ::testing::MatchesRegex;
 TEST(BuildInfo, LanguageVersion) {
   auto lv = language_version();
   EXPECT_THAT(lv, ::testing::AnyOf(HasSubstr("-noex-"), HasSubstr("-ex-")));
+#ifndef _WIN32
   EXPECT_THAT(lv, MatchesRegex(R"([0-9A-Za-z_.-]+)"));
+#else
+  // Brackets for regex above don't work on windows.
+  EXPECT_THAT(lv, Not(HasSubstr(" ")));
+#endif
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_request_builder.h"
+#include "google/cloud/internal/build_info.h"
 #include "google/cloud/storage/version.h"
 
 namespace google {
@@ -118,8 +119,9 @@ std::string CurlRequestBuilder::UserAgentSuffix() const {
   ValidateBuilderState(__func__);
   // Pre-compute and cache the user agent string:
   static std::string const user_agent_suffix = [] {
-    std::string agent = "gcloud-cpp/" + storage::version_string();
+    std::string agent = "gcloud-cpp/" + storage::version_string() + " ";
     agent += curl_version();
+    agent += " " + google::cloud::internal::compiler();
     return agent;
   }();
   return user_agent_suffix;


### PR DESCRIPTION
I found out that the internal analytics pipeline doesn't work well with parentheses; `(` and `)`. I decided to cut the compiler version string after the first space, which is enough for our telemetry purpose.

Examples:

Good x-goog-api-client header: GNU-6.3.0-ex-2011
Bad x-goog-api-client header: compiler-gcc-4.9_(ubuntu_blah_blah)_-ex-2011

This change will cut off the `_(ubuntu_blah_blah)_` part above, from the `x-goog-api-client` header. Just in case some interesting info there, I also add `google::cloud::internal::compiler` to `user-agent` headers so that we won't lose them if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2679)
<!-- Reviewable:end -->
