### PR TITLE
cleanup!: Use google::cloud::future.

### DIFF
--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -585,13 +585,9 @@ class TableAdmin {
    * @par Example
    * @snippet table_admin_snippets.cc wait for consistency check
    */
-  std::future<StatusOr<Consistency>> WaitForConsistencyCheck(
+  google::cloud::future<StatusOr<Consistency>> WaitForConsistency(
       bigtable::TableId const& table_id,
-      bigtable::ConsistencyToken const& consistency_token) {
-    return std::async(std::launch::async,
-                      &TableAdmin::WaitForConsistencyCheckImpl, this, table_id,
-                      consistency_token);
-  }
+      bigtable::ConsistencyToken const& consistency_token);
 
   /**
    * Asynchronously wait until a table is consistent with the given @p token.
@@ -667,14 +663,6 @@ class TableAdmin {
   }
 
  private:
-  /**
-   * Implements the polling loop for `WaitForConsistencyCheck` on a
-   * separate thread
-   */
-  StatusOr<Consistency> WaitForConsistencyCheckImpl(
-      bigtable::TableId const& table_id,
-      bigtable::ConsistencyToken const& consistency_token);
-
   //@{
   /// @name Helper functions to implement constructors with changed policies.
   void ChangePolicy(RPCRetryPolicy& policy) {

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -297,9 +297,9 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
   // Wait until all the mutations before the `consistency_token` have propagated
   // everywhere.
-  std::future<google::cloud::StatusOr<bigtable::Consistency>> result =
-      table_admin.WaitForConsistencyCheck(bigtable::TableId(random_table_id),
-                                          *consistency_token);
+  google::cloud::future<google::cloud::StatusOr<bigtable::Consistency>> result =
+      table_admin.WaitForConsistency(bigtable::TableId(random_table_id),
+                                     *consistency_token);
   auto is_consistent = result.get();
   ASSERT_STATUS_OK(is_consistent);
   EXPECT_EQ(bigtable::Consistency::kConsistent, *is_consistent);


### PR DESCRIPTION
BREAKING CHANGE: Fix the last function that returned `std::future` to
return `google::cloud::future<>`. The function name changes too, to
be more consistent with similar functions.

I removed the unit tests because (a) the tests would only be checking that
WaitForConsistency() calls AsyncWaitForConsistency(), and (b) because we
already have coverage via the integration tests and example.

Fixes #2563.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2680)
<!-- Reviewable:end -->
