### PR TITLE
cleanup: Enable unit test for WriteObject.

### DIFF
--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -234,11 +234,6 @@ TEST_P(CurlClientTest, ReadObjectJson) {
 }
 
 TEST_P(CurlClientTest, WriteObject) {
-  std::string const error_type = GetParam();
-  if (error_type != "credentials-failure") {
-    // TODO(#1735) - enable this test when ObjectWriteStream uses StatusOr.
-    return;
-  }
   auto actual =
       client_->WriteObject(InsertObjectStreamingRequest("bkt", "obj")).status();
   CheckStatus(actual);


### PR DESCRIPTION
Evidently we fixed the bug (#1735) preventing us from running this test,
but neglected to enable it at the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2684)
<!-- Reviewable:end -->
