### PR TITLE
Update to Fedora 30.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,7 +135,7 @@ these dependencies.
 
 ## Table of Contents
 
-- [Fedora 29](#fedora-29)
+- [Fedora 30](#fedora-30)
 - [openSUSE (Tumbleweed)](#opensuse-tumbleweed)
 - [openSUSE (Leap)](#opensuse-leap)
 - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804---bionic-beaver)
@@ -144,7 +144,7 @@ these dependencies.
 - [Debian (Stretch)](#debian-stretch)
 - [CentOS 7](#centos-7)
 
-### Fedora (29)
+### Fedora (30)
 
 Install the minimal development tools:
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ at the [Beta](#versioning) quality level:
 - [Install Dependencies](#install-dependencies)
   - [CentOS (7)](#centos-7)
   - [Debian (Stretch)](#debian-stretch)
-  - [Fedora (29)](#fedora-29)
+  - [Fedora (30)](#fedora-30)
   - [OpenSuSE (Tumbleweed)](#opensuse-tumbleweed)
   - [OpenSuSE (Leap)](#opensuse-leap)
   - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804---bionic-beaver)
@@ -186,7 +186,7 @@ sudo apt install -y build-essential cmake git gcc g++ cmake \
         pkg-config tar wget zlib1g-dev
 ```
 
-### Fedora (29)
+### Fedora (30)
 
 [![Kokoro install fedora status][kokoro-install-fedora-shield]][kokoro-install-fedora-link]
 

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -57,7 +57,7 @@ elif [[ "${BUILD_NAME}" = "libcxx" ]]; then
   export CXX=clang++
   export CMAKE_FLAGS=-DBUILD_SHARED_LIBS=ON
   export DISTRO=fedora
-  export DISTRO_VERSION=29
+  export DISTRO_VERSION=30
   export USE_LIBCXX=yes
 elif [[ "${BUILD_NAME}" = "shared" ]]; then
   # Compile with shared libraries. Needs to have the dependencies pre-installed.

--- a/ci/test-readme/Dockerfile.fedora
+++ b/ci/test-readme/Dockerfile.fedora
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=29
+ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION}
 
 # Please keep the formatting below, it is used by `extract-readme.sh` and

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -156,7 +156,7 @@ these dependencies.
 
 ## Table of Contents
 
-- [Fedora 29](#fedora-29)
+- [Fedora 30](#fedora-30)
 - [openSUSE (Tumbleweed)](#opensuse-tumbleweed)
 - [openSUSE (Leap)](#opensuse-leap)
 - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804---bionic-beaver)
@@ -167,7 +167,7 @@ these dependencies.
 END_OF_PREAMBLE
 
 echo
-echo "### Fedora (29)"
+echo "### Fedora (30)"
 "${BINDIR}/extract-install.sh" "${BINDIR}/Dockerfile.fedora"
 
 echo

--- a/ci/test-readme/generate-readme.sh
+++ b/ci/test-readme/generate-readme.sh
@@ -37,7 +37,7 @@ echo "### Debian (Stretch)"
 badge debian
 "${BINDIR}/extract-readme.sh" "${BINDIR}/Dockerfile.debian"
 
-echo "### Fedora (29)"
+echo "### Fedora (30)"
 badge fedora
 "${BINDIR}/extract-readme.sh" "${BINDIR}/Dockerfile.fedora"
 

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=28
+ARG DISTRO_VERSION=30
 FROM fedora:${DISTRO_VERSION}
 
 RUN dnf makecache && dnf install -y \


### PR DESCRIPTION
This is not strictly necessary, Fedora 29 will be supported until more or less the end of this year. But we get testing with clang-8.0 and g++-9.0 by upgrading to Fedora 30.

Fixes #2685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2687)
<!-- Reviewable:end -->
