### PR TITLE
feature: Implement option to read from an offset.

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -910,7 +910,8 @@ class Client {
    *     Valid types for this operation include `DisableCrc32cChecksum`,
    *     `DisableMD5Hash`, `IfGenerationMatch`, `EncryptionKey`, `Generation`,
    *     `IfGenerationMatch`, `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *     `IfMetagenerationNotMatch`, `ReadRange`, and `UserProject`.
+   *     `IfMetagenerationNotMatch`, `ReadFromOffset`, `ReadRange`, and
+   *     `UserProject`.
    *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
@@ -1055,7 +1056,8 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *   Valid types for this operation include `IfGenerationMatch`,
    *   `IfGenerationNotMatch`, `IfMetagenerationMatch`,
-   *   `IfMetagenerationNotMatch`, `Generation`, `ReadRange`, and `UserProject`.
+   *   `IfMetagenerationNotMatch`, `Generation`, `ReadFromOffset`, `ReadRange`,
+   *   and `UserProject`.
    *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -48,6 +48,15 @@ inline std::ostream& operator<<(std::ostream& os, ReadRangeData const& rhs) {
             << "}";
 }
 
+/**
+ * Download all the data from the GCS object starting at the given offset.
+ */
+struct ReadFromOffset
+    : public internal::ComplexOption<ReadFromOffset, std::int64_t> {
+  using ComplexOption::ComplexOption;
+  static char const* name() { return "read-offset"; }
+};
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -564,16 +564,10 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObject(
     return status;
   }
   builder.AddQueryParameter("alt", "media");
-  if (request.HasOption<ReadRange>()) {
-    auto range = request.GetOption<ReadRange>().value();
-    std::string header = "Range: bytes=" + std::to_string(range.begin) + "-" +
-                         std::to_string(range.end - 1);
-    builder.AddHeader(header);
-    // When doing a range read we need to disable decompression because range
-    // reads do not work in that case:
-    //   https://cloud.google.com/storage/docs/transcoding#range
-    // and
-    //   https://cloud.google.com/storage/docs/transcoding#decompressive_transcoding
+  if (request.RequiresRangeHeader()) {
+    builder.AddHeader(request.RangeHeader());
+  }
+  if (request.RequiresNoCache()) {
     builder.AddHeader("Cache-Control: no-transform");
   }
 
@@ -1295,16 +1289,10 @@ StatusOr<std::unique_ptr<ObjectReadStreambuf>> CurlClient::ReadObjectXml(
   // QuotaUser cannot be set, checked by the caller.
   // UserIp cannot be set, checked by the caller.
 
-  if (request.HasOption<ReadRange>()) {
-    auto range = request.GetOption<ReadRange>().value();
-    std::string header = "Range: bytes=" + std::to_string(range.begin) + "-" +
-                         std::to_string(range.end - 1);
-    builder.AddHeader(header);
-    // When doing a range read we need to disable decompression because range
-    // reads do not work in that case:
-    //   https://cloud.google.com/storage/docs/transcoding#range
-    // and
-    //   https://cloud.google.com/storage/docs/transcoding#decompressive_transcoding
+  if (request.RequiresRangeHeader()) {
+    builder.AddHeader(request.RangeHeader());
+  }
+  if (request.RequiresNoCache()) {
     builder.AddHeader("Cache-Control: no-transform");
   }
 

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -158,7 +158,7 @@ std::unique_ptr<HashValidator> CreateHashValidator(bool disable_md5,
 /// Create a HashValidator for a download request.
 std::unique_ptr<HashValidator> CreateHashValidator(
     ReadObjectRangeRequest const& request) {
-  if (request.HasOption<ReadRange>()) {
+  if (request.RequiresRangeHeader()) {
     return google::cloud::internal::make_unique<NullHashValidator>();
   }
   return CreateHashValidator(request.HasOption<DisableMD5Hash>(),

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -201,10 +201,14 @@ class ReadObjectRangeRequest
     : public GenericObjectRequest<
           ReadObjectRangeRequest, DisableCrc32cChecksum, DisableMD5Hash,
           EncryptionKey, Generation, IfGenerationMatch, IfGenerationNotMatch,
-          IfMetagenerationMatch, IfMetagenerationNotMatch, ReadRange,
-          UserProject> {
+          IfMetagenerationMatch, IfMetagenerationNotMatch, ReadFromOffset,
+          ReadRange, UserProject> {
  public:
   using GenericObjectRequest::GenericObjectRequest;
+
+  bool RequiresNoCache() const;
+  bool RequiresRangeHeader() const;
+  std::string RangeHeader() const;
 };
 
 std::ostream& operator<<(std::ostream& os, ReadObjectRangeRequest const& r);

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -445,10 +445,13 @@ def objects_get_common(bucket_name, object_name, revision):
     if range_header is not None:
         m = re.match('bytes=([0-9]+)-([0-9]+)', range_header)
         if m:
-            print("\n\n\nmatch = %s\n\n" % m)
             begin = int(m.group(1))
             end = int(m.group(2))
             response_payload = response_payload[begin:end + 1]
+        m = re.match('bytes=([0-9]+)-$', range_header)
+        if m:
+            begin = int(m.group(1))
+            response_payload = response_payload[begin:]
     # Process custom headers to test error conditions.
     instructions = flask.request.headers.get('x-goog-testbench-instructions')
     if instructions == 'return-broken-stream':

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -612,7 +612,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   std::string bucket_name = flag_bucket_name;
   auto object_name = MakeRandomObjectName();
 
-  // This produces a 64 KiB text object, normally applications should download
+  // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
   long const chunk = 16 * 1024L;
@@ -654,7 +654,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   std::string bucket_name = flag_bucket_name;
   auto object_name = MakeRandomObjectName();
 
-  // This produces a 64 KiB text object, normally applications should download
+  // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
   long const chunk = 16 * 1024L;
@@ -695,7 +695,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
   std::string bucket_name = flag_bucket_name;
   auto object_name = MakeRandomObjectName();
 
-  // This produces a 64 KiB text object, normally applications should download
+  // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
   long const chunk = 16 * 1024L;
@@ -737,7 +737,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
   std::string bucket_name = flag_bucket_name;
   auto object_name = MakeRandomObjectName();
 
-  // This produces a 64 KiB text object, normally applications should download
+  // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
   long const chunk = 16 * 1024L;


### PR DESCRIPTION
Allow application developers to read an object starting at a given
offset. This will also be used to restart downloads from the last
received byte. Fix the code to properly combine this option and the
gcs::ReadRange() option: the highest of the range beginning and the
offset is used as the starting point.

Refactored some code to avoid duplication.

Part of the work for #2655.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2690)
<!-- Reviewable:end -->
