### PR TITLE
cleanup!: DeleteAppProfile defaults to `ignore_warnings=true`.

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -859,7 +859,9 @@ class InstanceAdmin {
    * @param instance_id the instance to look the profile in.
    * @param profile_id the id of the profile within that instance.
    * @param ignore_warnings if true, ignore safety checks when deleting the
-   *     application profile.
+   *     application profile. This value is to to `true` by default. Passing
+   *     `false` causes this function to fail even when no operations are
+   *     pending.
    *
    * @par Idempotency
    * This operation is always treated as non-idempotent.
@@ -869,7 +871,7 @@ class InstanceAdmin {
    */
   Status DeleteAppProfile(bigtable::InstanceId const& instance_id,
                           bigtable::AppProfileId const& profile_id,
-                          bool ignore_warnings = false);
+                          bool ignore_warnings = true);
 
   /**
    * Asynchronously delete an existing application profile.
@@ -880,7 +882,9 @@ class InstanceAdmin {
    * @param instance_id the instance to look the profile in.
    * @param profile_id the id of the profile within that instance.
    * @param ignore_warnings if true, ignore safety checks when deleting the
-   *     application profile.
+   *     application profile. This value is to to `true` by default. Passing
+   *     `false` causes this function to fail even when no operations are
+   *     pending.
    *
    * @return a future satisfied when either (a) the app profile is deleted or
    *     (b) an unretriable error occurs or (c) retry policy has been exhausted.
@@ -894,7 +898,7 @@ class InstanceAdmin {
   future<Status> AsyncDeleteAppProfile(CompletionQueue& cq,
                                        bigtable::InstanceId const& instance_id,
                                        bigtable::AppProfileId const& profile_id,
-                                       bool ignore_warnings = false);
+                                       bool ignore_warnings = true);
 
   /**
    * Gets the policy for @p instance_id.


### PR DESCRIPTION
BREAKING CHANGE: While his changes the behavior of the function when
using the default value, the RPC *always fails* with `ignore_warnings=false`,
so only code that was performing failed RPCs is affected.  Changing the
default is a better experience for our customers.

Fixes #2590.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2692)
<!-- Reviewable:end -->
