### PR TITLE
bug: Fix build for macOS+CMake.

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -21,10 +21,15 @@ target_link_libraries(storage_benchmarks
                               google_cloud_cpp_common_options)
 
 include(CheckSymbolExists)
-check_symbol_exists(getrusage sys/resource.h GOOGLE_CLOUD_CPP_HAS_GETRUSAGE)
+check_symbol_exists(getrusage sys/resource.h GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE)
+check_symbol_exists(RUSAGE_THREAD sys/resource.h
+                    GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD)
 target_compile_definitions(
-    storage_benchmarks PUBLIC
-    GOOGLE_CLOUD_CPP_HAS_GETRUSAGE=$<BOOL:${GOOGLE_CLOUD_CPP_HAS_GETRUSAGE}>)
+    storage_benchmarks
+    PUBLIC
+    GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE=$<BOOL:${GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE}>
+    GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD=$<BOOL:${GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD}>
+    )
 
 include(CreateBazelConfig)
 create_bazel_config(storage_benchmarks YEAR 2019)

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -194,6 +194,7 @@ std::vector<std::string> OptionsParse(std::vector<OptionDescriptor> const& desc,
   return argv;
 }
 
+#if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 namespace {
 int rusage_who() {
 #if GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
@@ -203,6 +204,7 @@ int rusage_who() {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
 }
 }  // namespace
+#endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 
 void SimpleTimer::Start() {
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -19,9 +19,9 @@
 #include <chrono>
 #include <functional>
 #include <string>
-#if GOOGLE_CLOUD_CPP_HAS_GETRUSAGE
+#if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 #include <sys/resource.h>
-#endif  // GOOGLE_CLOUD_CPP_HAS_GETRUSAGE
+#endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 
 namespace google {
 namespace cloud {
@@ -103,13 +103,15 @@ class SimpleTimer {
   std::string const& annotations() const { return annotations_; }
   //@}
 
+  static bool SupportPerThreadUsage();
+
  private:
   std::chrono::steady_clock::time_point start_;
   std::chrono::microseconds elapsed_time_;
   std::chrono::microseconds cpu_time_;
-#if GOOGLE_CLOUD_CPP_HAS_GETRUSAGE
+#if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
   struct rusage start_usage_;
-#endif  // GOOGLE_CLOUD_CPP_HAS_GETRUSAGE
+#endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
   std::string annotations_;
 };
 

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -407,6 +407,14 @@ Options ParseArgs(int argc, char* argv[]) {
     throw std::runtime_error(std::move(os).str());
   }
 
+  if (!gcs_bm::SimpleTimer::SupportPerThreadUsage() &&
+      options.thread_count > 1) {
+    std::ostringstream os;
+    os << "Your platform does not support per-thread usage metrics"
+          " (see getrusage(2)). Running more than one thread is not supported.";
+    throw std::runtime_error(std::move(os).str());
+  }
+
   return options;
 }
 


### PR DESCRIPTION
I did not think about macOS when using RUSAGE_THREAD, which is not a
thing on BSD-based systems. Fixed the code to detect if the symbol exists,
if it does use it, if it does not, do not allow more than one thread in
the benchmark that measure CPU utilization.

Fixes #2697.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2698)
<!-- Reviewable:end -->
