### PR TITLE
Return an enum from Table::CheckAndMutateRow.

### DIFF
--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -471,7 +471,7 @@ void CheckAndMutate(google::cloud::bigtable::Table table, int argc,
     // If the predicate matches, change the latest value to "off", otherwise,
     // change the latest value to "on".  Modify the "flop-flip" column at the
     // same time.
-    StatusOr<bool> branch =
+    StatusOr<cbt::MutationBranch> branch =
         table.CheckAndMutateRow(row_key, std::move(predicate),
                                 {cbt::SetCell("fam", "flip-flop", "off"),
                                  cbt::SetCell("fam", "flop-flip", "on")},
@@ -481,8 +481,11 @@ void CheckAndMutate(google::cloud::bigtable::Table table, int argc,
     if (!branch) {
       throw std::runtime_error(branch.status().message());
     }
-    std::cout << "The predicate " << (*branch ? "was" : "was not")
-              << " matched\n";
+    if (*branch == cbt::MutationBranch::kPredicateMatched) {
+      std::cout << "The predicate was matched\n";
+    } else {
+      std::cout << "The predicate was not matched\n";
+    }
   }
   //! [check and mutate]
   (std::move(table), row_key);
@@ -508,15 +511,18 @@ void CheckAndMutateNotPresent(google::cloud::bigtable::Table table, int argc,
         cbt::Filter::Latest(1));
     // If the predicate matches, do nothing, otherwise set the
     // "had-test-column" to "false":
-    StatusOr<bool> branch = table.CheckAndMutateRow(
+    StatusOr<cbt::MutationBranch> branch = table.CheckAndMutateRow(
         row_key, std::move(predicate), {},
         {cbt::SetCell("fam", "had-test-column", "false")});
 
     if (!branch) {
       throw std::runtime_error(branch.status().message());
     }
-    std::cout << "The CheckAndMutateRow() predicate "
-              << (*branch ? "was" : "was not") << " matched\n";
+    if (*branch == cbt::MutationBranch::kPredicateMatched) {
+      std::cout << "The predicate was matched\n";
+    } else {
+      std::cout << "The predicate was not matched\n";
+    }
   }
   //! [check and mutate not present]
   (std::move(table), row_key);

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -40,12 +40,12 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 /// The branch taken by a Table::CheckAndMutateRow operation.
 enum class MutationBranch {
+  /// The predicate provided to CheckAndMutateRow did not match and the
+  /// corresponding mutations (if any) were applied.
   kPredicateNotMatched,
-  ///< The predicate provided to CheckAndMutateRow did not match and the
-  ///< corresponding mutations (if any) were applied.
+  /// The predicate provided to CheckAndMutateRow matched and the corresponding
+  /// mutations (if any) were applied.
   kPredicateMatched,
-  ///< The predicate provided to CheckAndMutateRow matched and the corresponding
-  ///< mutations (if any) were applied.
 };
 
 class MutationBatcher;

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -41,10 +41,10 @@ inline namespace BIGTABLE_CLIENT_NS {
 /// The branch taken by a Table::CheckAndMutateRow operation.
 enum class MutationBranch {
   /// The predicate provided to CheckAndMutateRow did not match and the
-  /// corresponding mutations (if any) were applied.
+  /// `false_mutations` (if any) were applied.
   kPredicateNotMatched,
-  /// The predicate provided to CheckAndMutateRow matched and the corresponding
-  /// mutations (if any) were applied.
+  /// The predicate provided to CheckAndMutateRow matched and the
+  /// `true_mutations` (if any) were applied.
   kPredicateMatched,
 };
 

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -38,6 +38,16 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+/// The branch taken by a Table::CheckAndMutateRow operation.
+enum class MutationBranch {
+  kPredicateNotMatched,
+  ///< The predicate provided to CheckAndMutateRow did not match and the
+  ///< corresponding mutations (if any) were applied.
+  kPredicateMatched,
+  ///< The predicate provided to CheckAndMutateRow matched and the corresponding
+  ///< mutations (if any) were applied.
+};
+
 class MutationBatcher;
 
 /**
@@ -488,9 +498,9 @@ class Table {
    * @par Check for Cell Presence Example
    * @snippet data_snippets.cc check and mutate not present
    */
-  StatusOr<bool> CheckAndMutateRow(std::string row_key, Filter filter,
-                                   std::vector<Mutation> true_mutations,
-                                   std::vector<Mutation> false_mutations);
+  StatusOr<MutationBranch> CheckAndMutateRow(
+      std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
+      std::vector<Mutation> false_mutations);
 
   /**
    * Make an asynchronous request to conditionally mutate a row.
@@ -517,7 +527,7 @@ class Table {
    * @par Example
    * @snippet data_async_snippets.cc async check and mutate
    */
-  future<StatusOr<bool>> AsyncCheckAndMutateRow(
+  future<StatusOr<MutationBranch>> AsyncCheckAndMutateRow(
       std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
       std::vector<Mutation> false_mutations, CompletionQueue& cq);
 

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -328,7 +328,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowPass) {
       {bigtable::SetCell(family4, "c2", 0_ms, "v2000")},
       {bigtable::SetCell(family4, "c3", 0_ms, "v3000")});
   ASSERT_STATUS_OK(result);
-  EXPECT_TRUE(*result);
+  EXPECT_EQ(bigtable::MutationBranch::kPredicateMatched, *result);
   std::vector<bigtable::Cell> expected{{key, family4, "c1", 0, "v1000"},
                                        {key, family4, "c2", 0, "v2000"}};
   auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
@@ -346,7 +346,7 @@ TEST_F(DataIntegrationTest, TableCheckAndMutateRowFail) {
       {bigtable::SetCell(family4, "c2", 0_ms, "v2000")},
       {bigtable::SetCell(family4, "c3", 0_ms, "v3000")});
   ASSERT_STATUS_OK(result);
-  EXPECT_FALSE(*result);
+  EXPECT_EQ(bigtable::MutationBranch::kPredicateNotMatched, *result);
   std::vector<bigtable::Cell> expected{{key, family4, "c1", 0, "v1000"},
                                        {key, family4, "c3", 0, "v3000"}};
   auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());


### PR DESCRIPTION
Returning a bool via `StatusOr<>` is prone to errors, too easy to say
`!status_or` when you mean `!*status_or`.

This fixes #2651.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2699)
<!-- Reviewable:end -->
