### PR TITLE
Add option to disable CURL shared handle.

### DIFF
--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -147,6 +147,17 @@ class ClientOptions {
     return *this;
   }
 
+  /**
+   * Applications may want to disable the CURL shared resources to workaround
+   * bugs in the libcurl implementation.
+   * TODO(coryan) - Link a bug or code showing a bug, DO NOT MERGE.
+   */
+  bool enable_curl_shared() const { return enable_curl_shared_; }
+  ClientOptions& set_enable_curl_shared(bool v) {
+    enable_curl_shared_ = v;
+    return *this;
+  }
+
  private:
   void SetupFromEnvironment();
 
@@ -165,6 +176,7 @@ class ClientOptions {
   std::size_t maximum_simple_upload_size_;
   bool enable_ssl_locking_callbacks_ = true;
   bool enable_sigpipe_handler_ = true;
+  bool enable_curl_shared_ = true;
 };
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -177,6 +177,18 @@ TEST_F(ClientOptionsTest, SetEnableLockingCallbacks) {
   EXPECT_TRUE(client_options.enable_ssl_locking_callbacks());
 }
 
+TEST_F(ClientOptionsTest, SetEnableCurlShared) {
+  auto opts = ClientOptions::CreateDefaultClientOptions();
+  ASSERT_STATUS_OK(opts);
+  ClientOptions client_options = *opts;
+  auto default_value = client_options.enable_curl_shared();
+  EXPECT_TRUE(default_value);
+  client_options.set_enable_curl_shared(false);
+  EXPECT_FALSE(client_options.enable_curl_shared());
+  client_options.set_enable_curl_shared(true);
+  EXPECT_TRUE(client_options.enable_curl_shared());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
In some versions of libcurl (we are still trying to narrow down which ones) there
are locking bugs for the CURLSH* handles. Users may need to disable the
use of CURLSH* handles altogether (at a performance cost) to workaround
these bugs.

This is related to #2711.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2713)
<!-- Reviewable:end -->
