### PR TITLE
Fixes bug caused by moving from a forward reference

### DIFF
--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -72,14 +72,14 @@ class optional {
                                         AllowImplicit<T, U>::value,
                                     int>::type = 0>
   optional(U&& x) : has_value_(true) {
-    new (reinterpret_cast<T*>(&buffer_)) T(std::move(x));
+    new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(x));
   }
   template <typename U = T,
             typename std::enable_if<std::is_constructible<T, U&&>::value &&
                                         !AllowImplicit<T, U>::value,
                                     int>::type = 0>
   explicit optional(U&& x) : has_value_(true) {
-    new (reinterpret_cast<T*>(&buffer_)) T(std::move(x));
+    new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(x));
   }
   ~optional() { reset(); }
 

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -192,10 +192,10 @@ TEST(OptionalTest, CopyAssign_Lvalue) {
   Observable::reset_counters();
   Observable original("foo");
   OptionalObservable other(original);
-  EXPECT_EQ("foo", other.value().str());
+  EXPECT_EQ("foo", original.str());
+  EXPECT_EQ("foo", other->str());
   EXPECT_EQ(0, Observable::move_constructor);
   EXPECT_EQ(1, Observable::copy_constructor);
-  EXPECT_EQ(original.str(), other->str());
 }
 
 TEST(OptionalTest, CopyAssignment_NoValue_NoValue) {

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -188,6 +188,16 @@ TEST(OptionalTest, MoveAssignment_Value_T) {
   EXPECT_EQ("moved-out", other.str());
 }
 
+TEST(OptionalTest, CopyAssign_Lvalue) {
+  Observable::reset_counters();
+  Observable original("foo");
+  OptionalObservable other(original);
+  EXPECT_EQ("foo", other.value().str());
+  EXPECT_EQ(0, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(original.str(), other->str());
+}
+
 TEST(OptionalTest, CopyAssignment_NoValue_NoValue) {
   OptionalObservable other;
   OptionalObservable assigned;


### PR DESCRIPTION
Fixes: #2715 

A forward reference, such as `T&&` when T is an immediate template parameter, can bind to lvalues and rvalues. On such types, we should use `std::forward` rather than `std::move`, so that we preserve the original objects reference type.

The current bug was caused by our use of `std::move` turning a caller-provided non-const lvalue into an rvalue whose contents were subsequently moved-from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2716)
<!-- Reviewable:end -->
