### PR TITLE
Fix other places where we mention http_archive().

### DIFF
--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -20,8 +20,9 @@ workspace(name="com_github_googleapis_google_cloud_cpp_test_install")
 #
 # http_archive(
 #     name = "com_github_googleapis_google_cloud_cpp",
-#     url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.2.0.tar.gz",
-#     sha256 = "5fa6577828e5f949178b13ed0411dd634527c9d2d8f00e433edbd6ef9e42a281",
+#     url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.9.0.tar.gz",
+#     strip_prefix = "google-cloud-cpp-0.9.0",
+#     sha256 = "a072103546cfa041ad8bfc599fe5a20c58e005a1a0ee18e94b2554dc3d485604",
 # )
 #
 # But we want to test that the *current* version is correct.

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -102,8 +102,9 @@ commands to your `WORKSPACE` file:
 # Update the version and SHA256 digest as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp",
-    url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.7.0.tar.gz",
-    sha256 = "06bc735a117ec7ea92ea580e7f2ffa4b1cd7539e0e04f847bf500588d7f0fe90",
+    url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.9.0.tar.gz",
+    strip_prefix = "google-cloud-cpp-0.9.0",
+    sha256 = "a072103546cfa041ad8bfc599fe5a20c58e005a1a0ee18e94b2554dc3d485604",
 )
 
 load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")

--- a/google/cloud/bigtable/doc/bigtable-main.dox
+++ b/google/cloud/bigtable/doc/bigtable-main.dox
@@ -102,7 +102,8 @@ and install the library, for example:
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp",
     url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.9.0.tar.gz",
-    sha256 = "a072103546cfa041ad8bfc599fe5a20c58e005a1a0ee18e94b2554dc3d485604"
+    strip_prefix = "google-cloud-cpp-0.9.0",
+    sha256 = "a072103546cfa041ad8bfc599fe5a20c58e005a1a0ee18e94b2554dc3d485604",
 )
 @endcode
 

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -121,8 +121,9 @@ and install the library, for example:
 # Change the version and SHA256 hash as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp",
-    url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.8.1.tar.gz",
-    sha256 = "f5600fdf3efd28e3142a60c20574e349511104fc6f658faf7974f6ae2def245a"
+    url = "http://github.com/googleapis/google-cloud-cpp/archive/v0.9.0.tar.gz",
+    strip_prefix = "google-cloud-cpp-0.9.0",
+    sha256 = "a072103546cfa041ad8bfc599fe5a20c58e005a1a0ee18e94b2554dc3d485604",
 )
 @endcode
 


### PR DESCRIPTION
We need to use `strip_prefix` with `http_archive()` or things don't
work. This PR fixes other random places where we mentioned
`http_archive()` but missed the `strip_prefix` argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2719)
<!-- Reviewable:end -->
