### PR TITLE
cleanup: Prefer the CMake CONFIG module for CURL.

### DIFF
--- a/cmake/IncludeCurl.cmake
+++ b/cmake/IncludeCurl.cmake
@@ -34,49 +34,65 @@ set_property(CACHE GOOGLE_CLOUD_CPP_CURL_PROVIDER
 if ("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "external")
     include(external/curl)
 elseif("${GOOGLE_CLOUD_CPP_CURL_PROVIDER}" STREQUAL "package")
-    # Search for libcurl, in CMake 3.5 this does not define a target, but it
-    # will in 3.12 (see https://cmake.org/cmake/help/git-
-    # stage/module/FindCURL.html for details).  Until then, define the target
-    # ourselves if it is missing.
-    find_package(CURL REQUIRED)
-    if (NOT TARGET CURL::libcurl)
-        add_library(CURL::libcurl UNKNOWN IMPORTED)
-        set_property(TARGET CURL::libcurl
-                     APPEND
-                     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                              "${CURL_INCLUDE_DIR}")
-        set_property(TARGET CURL::libcurl
-                     APPEND
-                     PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
-    endif ()
-    # If the library is static, we need to explicitly link its dependencies.
-    # However, we should not do so for shared libraries, because the version of
-    # OpenSSL (for example) found by find_package() may be newer than the
-    # version linked against libcurl.
-    if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
-        find_package(OpenSSL REQUIRED)
-        find_package(ZLIB REQUIRED)
-        set_property(TARGET CURL::libcurl
-                     APPEND
-                     PROPERTY INTERFACE_LINK_LIBRARIES
-                              OpenSSL::SSL
-                              OpenSSL::Crypto
-                              ZLIB::ZLIB)
-        message(STATUS "CURL linkage will be static")
-        if (WIN32)
+    # Try to find libcurl using the CMake config file installed by libcurl
+    # itself, that can fail if libcurl was installed in your system using Make,
+    # which many distros continue to do.
+    find_package(CURL CONFIG QUIET)
+    if (CURL_FOUND)
+        message(STATUS "CURL found using via CONFIG module")
+    else()
+        # As searching for libcurl using CONFIG mode failed, try again using the
+        # CMake config module. We will need to fix up a few things if the module
+        # is found this way.
+        find_package(CURL REQUIRED)
+        # Before CMake 3.12 the module does not define a target, compare:
+        # https://cmake.org/cmake/help/v3.12/module/FindCURL.html vs
+        # https://cmake.org/cmake/help/v3.11/module/FindCURL.html
+        #
+        # Manually define the target if it does not exist so the rest of the
+        # code does not have to deal with these details:
+        if (NOT TARGET CURL::libcurl)
+            add_library(CURL::libcurl UNKNOWN IMPORTED)
+            set_property(TARGET CURL::libcurl
+                         APPEND
+                         PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                                  "${CURL_INCLUDE_DIR}")
+            set_property(TARGET CURL::libcurl
+                         APPEND
+                         PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+        endif ()
+        # If the library is static, we need to explicitly link its dependencies.
+        # The CMake module does not do so. However, we should not do so for
+        # shared libraries, because the version of OpenSSL (for example) found
+        # by find_package() may be newer than the version linked against
+        # libcurl.
+        if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+            find_package(OpenSSL REQUIRED)
+            find_package(ZLIB REQUIRED)
             set_property(TARGET CURL::libcurl
                          APPEND
                          PROPERTY INTERFACE_LINK_LIBRARIES
-                                  crypt32
-                                  wsock32
-                                  ws2_32)
+                                  OpenSSL::SSL
+                                  OpenSSL::Crypto
+                                  ZLIB::ZLIB)
+            message(STATUS "CURL linkage will be static")
+            # On WIN32 and APPLE there are even more libraries needed for static
+            # linking.
+            if (WIN32)
+                set_property(TARGET CURL::libcurl
+                             APPEND
+                             PROPERTY INTERFACE_LINK_LIBRARIES
+                                      crypt32
+                                      wsock32
+                                      ws2_32)
+            endif ()
+            if (APPLE)
+                set_property(TARGET CURL::libcurl
+                             APPEND
+                             PROPERTY INTERFACE_LINK_LIBRARIES ldap)
+            endif ()
+        else()
+            message(STATUS "CURL linkage will be non-static")
         endif ()
-        if (APPLE)
-            set_property(TARGET CURL::libcurl
-                         APPEND
-                         PROPERTY INTERFACE_LINK_LIBRARIES ldap)
-        endif ()
-    else()
-        message(STATUS "CURL linkage will be non-static")
-    endif ()
+    endif (CURL_FOUND)
 endif ()


### PR DESCRIPTION
This gives us the standard targets, with the correct dependencies and
flags. Fallback on the native CMake module if nothing else is available.
This is a port of the `vcpkg` patch for google-cloud-cpp, once merged we
can cleanup the patch from the `vcpkg` port.

Fixes #2640.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2720)
<!-- Reviewable:end -->
