### PR TITLE
Support new directory structure of the refdocs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,11 @@ production use.
 set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
              PROPERTY STRINGS "external" "package")
 
+# Generate docs with relative URLs matching with the directory
+# structure on googleapis.dev hositng.
+option(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV
+       "Use relative URLs in docs for googleapis.dev" OFF)
+
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,8 @@ production use.
 set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
              PROPERTY STRINGS "external" "package")
 
-# Generate docs with relative URLs matching with the directory
-# structure on googleapis.dev hositng.
+# Generate docs with relative URLs matching with the directory structure on
+# googleapis.dev hositng.
 option(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV
        "Use relative URLs in docs for googleapis.dev" OFF)
 

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -25,9 +25,11 @@ set(GOOGLE_CLOUD_CPP_VERSION_MINOR 8)
 set(GOOGLE_CLOUD_CPP_VERSION_PATCH 0)
 
 string(CONCAT GOOGLE_CLOUD_CPP_VERSION
-    "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}" "."
-    "${GOOGLE_CLOUD_CPP_VERSION_MINOR}" "."
-    "${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
+              "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}"
+              "."
+              "${GOOGLE_CLOUD_CPP_VERSION_MINOR}"
+              "."
+              "${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
 
 # Generate the version information from the CMake values.
 configure_file(internal/version_info.h.in internal/version_info.h)
@@ -168,13 +170,11 @@ if (MSVC)
                  PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
 endif ()
 
-set_target_properties(
-    google_cloud_cpp_common
-    PROPERTIES
-        VERSION
-        ${GOOGLE_CLOUD_CPP_VERSION}
-        SOVERSION
-        ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
+set_target_properties(google_cloud_cpp_common
+                      PROPERTIES VERSION
+                                 ${GOOGLE_CLOUD_CPP_VERSION}
+                                 SOVERSION
+                                 ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
 
 create_bazel_config(google_cloud_cpp_common)
 google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -172,7 +172,7 @@ set_target_properties(
     google_cloud_cpp_common
     PROPERTIES
         VERSION
-        ${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.${GOOGLE_CLOUD_CPP_VERSION_MINOR}.${GOOGLE_CLOUD_CPP_VERSION_PATCH}
+        ${GOOGLE_CLOUD_CPP_VERSION}
         SOVERSION
         ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
 

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -24,6 +24,11 @@ set(GOOGLE_CLOUD_CPP_VERSION_MAJOR 0)
 set(GOOGLE_CLOUD_CPP_VERSION_MINOR 8)
 set(GOOGLE_CLOUD_CPP_VERSION_PATCH 0)
 
+string(CONCAT GOOGLE_CLOUD_CPP_VERSION
+    "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}" "."
+    "${GOOGLE_CLOUD_CPP_VERSION_MINOR}" "."
+    "${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
+
 # Generate the version information from the CMake values.
 configure_file(internal/version_info.h.in internal/version_info.h)
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -40,7 +40,16 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/bigtable/tools/*"
     "*/google/cloud/bigtable/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
-set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
+
+if ("$ENV{GENERATE_DOCS_FOR_GOOGLEAPIDEV}" STREQUAL "true")
+  set(DOXYGEN_TAGFILES "\
+${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../../google-cloud-common/\
+${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.\
+${GOOGLE_CLOUD_CPP_VERSION_MINOR}.\
+${GOOGLE_CLOUD_CPP_VERSION_PATCH}/")
+else()
+  set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
+endif()
 
 include(GoogleCloudCppCommon)
 if (TARGET bigtable-docs AND TARGET cloud-docs)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -42,12 +42,13 @@ set(DOXYGEN_EXCLUDE_PATTERNS
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 
 if ("${GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV}")
-  set(DOXYGEN_TAGFILES "\
+    set(DOXYGEN_TAGFILES "\
 ${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../../google-cloud-common/\
 ${GOOGLE_CLOUD_CPP_VERSION}/")
 else()
-  set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
-endif()
+    set(DOXYGEN_TAGFILES
+        "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
+endif ()
 
 include(GoogleCloudCppCommon)
 if (TARGET bigtable-docs AND TARGET cloud-docs)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -41,12 +41,10 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/bigtable/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 
-if ("$ENV{GENERATE_DOCS_FOR_GOOGLEAPIDEV}" STREQUAL "true")
+if ("${GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV}")
   set(DOXYGEN_TAGFILES "\
 ${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../../google-cloud-common/\
-${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.\
-${GOOGLE_CLOUD_CPP_VERSION_MINOR}.\
-${GOOGLE_CLOUD_CPP_VERSION_PATCH}/")
+${GOOGLE_CLOUD_CPP_VERSION}/")
 else()
   set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 endif()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -36,7 +36,16 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/storage/tests/*"
     "*/google/cloud/storage/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
-set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
+
+if ("$ENV{GENERATE_DOCS_FOR_GOOGLEAPIDEV}" STREQUAL "true")
+  set(DOXYGEN_TAGFILES "\
+${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../../google-cloud-common/\
+${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.\
+${GOOGLE_CLOUD_CPP_VERSION_MINOR}.\
+${GOOGLE_CLOUD_CPP_VERSION_PATCH}/")
+else()
+  set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
+endif()
 
 include(GoogleCloudCppCommon)
 if (TARGET storage-docs AND TARGET cloud-docs)

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -37,12 +37,10 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/storage/*_test.cc")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 
-if ("$ENV{GENERATE_DOCS_FOR_GOOGLEAPIDEV}" STREQUAL "true")
+if ("${GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV}")
   set(DOXYGEN_TAGFILES "\
 ${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../../google-cloud-common/\
-${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.\
-${GOOGLE_CLOUD_CPP_VERSION_MINOR}.\
-${GOOGLE_CLOUD_CPP_VERSION_PATCH}/")
+${GOOGLE_CLOUD_CPP_VERSION}/")
 else()
   set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 endif()

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -38,12 +38,13 @@ set(DOXYGEN_EXCLUDE_PATTERNS
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 
 if ("${GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV}")
-  set(DOXYGEN_TAGFILES "\
+    set(DOXYGEN_TAGFILES "\
 ${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../../google-cloud-common/\
 ${GOOGLE_CLOUD_CPP_VERSION}/")
 else()
-  set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
-endif()
+    set(DOXYGEN_TAGFILES
+        "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
+endif ()
 
 include(GoogleCloudCppCommon)
 if (TARGET storage-docs AND TARGET cloud-docs)


### PR DESCRIPTION
Introduce a new option `GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV` which  changes the relative locations of the doxygen tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2731)
<!-- Reviewable:end -->
