### PR TITLE
Migrate UBSAN build to Bazel.

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -42,10 +42,10 @@ elif [[ "${BUILD_NAME}" = "noex" ]]; then
   export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   # Compile with the UndefinedBehaviorSanitizer enabled.
-  export BUILD_TYPE=Debug
   export CC=clang
   export CXX=clang++
-  export CMAKE_FLAGS="-DSANITIZE_UNDEFINED=yes"
+  export BAZEL_CONFIG="ubsan"
+  in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
   # Compile with clang-tidy(1) turned on. The build treats clang-tidy warnings
   # as errors.


### PR DESCRIPTION
For what is worth, I tested this by enabling the right test in
google/cloud/bigtable/force_sanitizer_failures_test.cc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2733)
<!-- Reviewable:end -->
