### PR TITLE
Fix resource leak in nightly test.

### DIFF
--- a/google/cloud/bigtable/examples/run_examples_utils.sh
+++ b/google/cloud/bigtable/examples/run_examples_utils.sh
@@ -133,9 +133,6 @@ function run_all_instance_admin_examples {
   run_example ./bigtable_instance_admin_snippets run \
       "${project_id}" "${RUN_INSTANCE}" "${RUN_INSTANCE}-c1" "${zone_id}"
 
-  run_example ./bigtable_instance_admin_snippets create-instance \
-      "${project_id}" "${INSTANCE}" "${zone_id}"
-
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.
   run_example_usage ./bigtable_instance_admin_snippets


### PR DESCRIPTION
The drive script just created one extra instance, did nothing with it,
and leaked it. I am not sure why I did that: a mistake I guess.

This fixes #2667.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2736)
<!-- Reviewable:end -->
