### PR TITLE
cleanup: Refactor install for Cloud SDK.

### DIFF
--- a/ci/install-cloud-sdk.sh
+++ b/ci/install-cloud-sdk.sh
@@ -21,7 +21,6 @@ readonly TARBALL="google-cloud-sdk-233.0.0-linux-x86_64.tar.gz"
 readonly SHA256="a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a"
 wget -q "${SITE}/${TARBALL}"
 
-echo "${SHA256} ${TARBALL}" >check.sha256.txt
-sha256sum --check check.sha256.txt
+echo "${SHA256} ${TARBALL}" | sha256sum --check -
 tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable

--- a/ci/install-cloud-sdk.sh
+++ b/ci/install-cloud-sdk.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+readonly SITE="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads"
+readonly TARBALL="google-cloud-sdk-233.0.0-linux-x86_64.tar.gz"
+readonly SHA256="a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a"
+wget -q "${SITE}/${TARBALL}"
+
+echo "${SHA256} ${TARBALL}" >check.sha256.txt
+sha256sum --check check.sha256.txt
+tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
+/usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -108,6 +108,7 @@ echo "Creating Docker image with all the development tools $(date)."
 # is an error, so disabling from this point on is the right choice.
 set +e
 mkdir -p "${BUILD_OUTPUT}"
+echo "Logging to ${BUILD_OUTPUT}/create-build-docker-image.log"
 "${PROJECT_ROOT}/ci/install-retry.sh" \
     "${PROJECT_ROOT}/ci/travis/install-linux.sh" \
     >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null

--- a/ci/travis/Dockerfile.centos
+++ b/ci/travis/Dockerfile.centos
@@ -47,14 +47,9 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
-    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
-RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
 
-# Install Bazel too.
-WORKDIR /var/tmp/ci
-COPY install-bazel.sh /var/tmp/ci
+# Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/travis/Dockerfile.fedora
+++ b/ci/travis/Dockerfile.fedora
@@ -48,14 +48,9 @@ RUN pip install httpbin flask gevent gunicorn crc32c
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
-    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
-RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
 
-# Install Bazel too.
-WORKDIR /var/tmp/ci
-COPY install-bazel.sh /var/tmp/ci
+# Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/travis/Dockerfile.ubuntu
+++ b/ci/travis/Dockerfile.ubuntu
@@ -71,14 +71,9 @@ RUN pip install flask httpbin gevent gunicorn crc32c
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
-    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
-RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
 
-# Install Bazel too.
-WORKDIR /var/tmp/ci
-COPY install-bazel.sh /var/tmp/ci
+# Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/travis/Dockerfile.ubuntu-install
+++ b/ci/travis/Dockerfile.ubuntu-install
@@ -70,15 +70,6 @@ RUN pip install numpy cmake_format==0.4.0
 # Install Python packages used in the integration tests.
 RUN pip install flask httpbin gevent gunicorn crc32c
 
-# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
-# client.  They are used in the integration tests.
-WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
-    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
-RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
-
 # Parallelize the builds if possible. The default is chosen to work well on
 # Travis, but developers may want to override this value when building on their
 # workstations.
@@ -174,7 +165,11 @@ RUN ldconfig
 
 RUN find /usr/local -type d | xargs chmod 777
 
-# Install Bazel too.
-WORKDIR /var/tmp/ci
-COPY install-bazel.sh /var/tmp/ci
+# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
+# client.  They are used in the integration tests.
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
+
+# Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/travis/Dockerfile.ubuntu-trusty
+++ b/ci/travis/Dockerfile.ubuntu-trusty
@@ -53,14 +53,9 @@ RUN pip install flask httpbin gevent gunicorn crc32c
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.
-WORKDIR /var/tmp/install/cbt-components
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
-    grep -q '^a04ff6c4dcfc59889737810174b5d3c702f7a0a20e5ffcec3a5c3fccc59c3b7a '
-RUN tar x -C /usr/local -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
-RUN /usr/local/google-cloud-sdk/bin/gcloud --quiet components install cbt bigtable
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
 
-# Install Bazel too.
-WORKDIR /var/tmp/ci
-COPY install-bazel.sh /var/tmp/ci
+# Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh


### PR DESCRIPTION
Refactor the code to install the Cloud SDK (and some modules) to a
single script shared by all the Dockerfiles. That makes it easier to
upgrade to a newer version from time to time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2740)
<!-- Reviewable:end -->
