### PR TITLE
Remove unnecessary 'unsigned' literals.

### DIFF
--- a/google/cloud/bigtable/app_profile_config_test.cc
+++ b/google/cloud/bigtable/app_profile_config_test.cc
@@ -70,7 +70,7 @@ TEST(AppProfileConfig, SingleClusterRoutingWithTransactionalWrites) {
 
 bool HasFieldNameOnce(google::protobuf::FieldMask const& mask,
                       std::string const& name) {
-  return 1U == std::count(mask.paths().begin(), mask.paths().end(), name);
+  return std::count(mask.paths().begin(), mask.paths().end(), name) == 1;
 }
 
 TEST(AppProfileUpdateConfig, SetDescription) {

--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -337,7 +337,7 @@ TEST_F(AsyncReadStreamTest, Return3ThenFail) {
       request, std::move(context),
       [&result, &server_barrier](btproto::MutateRowsResponse r) {
         result.reads.emplace_back(std::move(r));
-        if (result.reads.size() == 3U) {
+        if (result.reads.size() == 3) {
           server_barrier.Lift();
         }
         return make_ready_future(true);
@@ -422,7 +422,7 @@ TEST_F(AsyncReadStreamTest, Return3LastIsBlocked) {
   auto on_read = [&client_barrier, &server_barrier,
                   &result](btproto::MutateRowsResponse r) {
     result.reads.emplace_back(std::move(r));
-    if (result.reads.size() == 3U) {
+    if (result.reads.size() == 3) {
       client_barrier.Wait();
       server_barrier.Lift();
     }
@@ -473,7 +473,7 @@ TEST_F(AsyncReadStreamTest, CancelWhileBlocked) {
   HandlerResult result;
   auto on_read = [&client_barrier, &result](btproto::MutateRowsResponse r) {
     result.reads.emplace_back(std::move(r));
-    if (result.reads.size() == 2U) {
+    if (result.reads.size() == 2) {
       client_barrier.Wait();
       return make_ready_future(false);
     }
@@ -536,7 +536,7 @@ TEST_F(AsyncReadStreamTest, DoubleCancel) {
   auto on_read = [&read_received_barrier, &cancel_done_read_barrier,
                   &result](btproto::MutateRowsResponse r) {
     result.reads.emplace_back(std::move(r));
-    if (result.reads.size() == 2U) {
+    if (result.reads.size() == 2) {
       read_received_barrier.Lift();
       cancel_done_read_barrier.Wait();
     }

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -38,7 +38,7 @@ void PrintUsage(std::string const& cmd, std::string const& msg) {
 void AsyncApply(google::cloud::bigtable::Table table,
                 google::cloud::bigtable::CompletionQueue cq,
                 std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-apply <project-id> <instance-id> <table-id> <row-key>"};
   }
 
@@ -72,7 +72,7 @@ void AsyncApply(google::cloud::bigtable::Table table,
 void AsyncBulkApply(google::cloud::bigtable::Table table,
                     google::cloud::bigtable::CompletionQueue cq,
                     std::vector<std::string> argv) {
-  if (argv.size() != 1U) {
+  if (argv.size() != 1) {
     throw Usage{"async-bulk-apply <project-id> <instance-id> <table-id>"};
   }
 
@@ -129,7 +129,7 @@ void AsyncBulkApply(google::cloud::bigtable::Table table,
 void AsyncReadRows(google::cloud::bigtable::Table table,
                    google::cloud::bigtable::CompletionQueue cq,
                    std::vector<std::string> argv) {
-  if (argv.size() != 1U) {
+  if (argv.size() != 1) {
     throw Usage{"async-read-rows <project-id> <instance-id> <table-id>"};
   }
 
@@ -176,7 +176,7 @@ void AsyncReadRows(google::cloud::bigtable::Table table,
 void AsyncReadRowsWithLimit(google::cloud::bigtable::Table table,
                             google::cloud::bigtable::CompletionQueue cq,
                             std::vector<std::string> argv) {
-  if (argv.size() != 1U) {
+  if (argv.size() != 1) {
     throw Usage{
         "async-read-rows-with-limit <project-id> <instance-id> <table-id>"};
   }
@@ -224,7 +224,7 @@ void AsyncReadRowsWithLimit(google::cloud::bigtable::Table table,
 void AsyncReadRow(google::cloud::bigtable::Table table,
                   google::cloud::bigtable::CompletionQueue cq,
                   std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{
         "async-read-row <project-id> <instance-id> <table-id> <row-key>"};
   }
@@ -273,7 +273,7 @@ void AsyncReadRow(google::cloud::bigtable::Table table,
 void AsyncCheckAndMutate(google::cloud::bigtable::Table table,
                          google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{
         "async-check-and-mutate <project-id> <instance-id> <table-id>"
         " <row-key>"};
@@ -317,7 +317,7 @@ void AsyncCheckAndMutate(google::cloud::bigtable::Table table,
 void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
                           google::cloud::bigtable::CompletionQueue cq,
                           std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{
         "async-read-modify-write <project-id> <instance-id> <table-id>"
         " <row-key>"};

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -38,8 +38,8 @@ void PrintUsage(std::string const& cmd, std::string const& msg) {
 void AsyncCreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
                          google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
-    throw Usage{"async-create-instance: <project-id> <instance-id> <zone>"};
+  if (argv.size() != 3) {
+    throw Usage{"async-create-instance <project-id> <instance-id> <zone>"};
   }
   //! [async create instance]
   namespace cbt = google::cloud::bigtable;
@@ -75,7 +75,7 @@ void AsyncCreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncCreateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
                         google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
-  if (argv.size() != 4U) {
+  if (argv.size() != 4) {
     throw Usage{
         "async-create-cluster <project-id> <instance-id> <cluster-id> <zone>"};
   }
@@ -109,7 +109,7 @@ void AsyncCreateAppProfile(
     google::cloud::bigtable::InstanceAdmin instance_admin,
     google::cloud::bigtable::CompletionQueue cq,
     std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
         "async-create-app-profile <project-id> <instance-id> <profile-id>"};
   }
@@ -143,8 +143,8 @@ void AsyncCreateAppProfile(
 void AsyncGetInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
                       google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
-    throw Usage{"async-get-instance: <project-id> <instance-id>"};
+  if (argv.size() != 2) {
+    throw Usage{"async-get-instance <project-id> <instance-id>"};
   }
 
   //! [async get instance]
@@ -176,8 +176,8 @@ void AsyncGetInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncListInstances(google::cloud::bigtable::InstanceAdmin instance_admin,
                         google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
-  if (argv.size() != 1U) {
-    throw Usage{"async-list-instances: <project-id>"};
+  if (argv.size() != 1) {
+    throw Usage{"async-list-instances <project-id>"};
   }
 
   //! [async list instances]
@@ -217,8 +217,8 @@ void AsyncListInstances(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncGetCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
                      google::cloud::bigtable::CompletionQueue cq,
                      std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
-    throw Usage{"async-get-cluster: <project-id> <instance-id> <cluster-id>"};
+  if (argv.size() != 3) {
+    throw Usage{"async-get-cluster <project-id> <instance-id> <cluster-id>"};
   }
 
   //! [async get cluster]
@@ -254,9 +254,9 @@ void AsyncGetCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncGetAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
                         google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
-        "async-get-app-profile: <project-id> <instance-id> <app_profile-id>"};
+        "async-get-app-profile <project-id> <instance-id> <app_profile-id>"};
   }
 
   //! [async get app profile]
@@ -291,8 +291,8 @@ void AsyncGetAppProfile(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncGetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
                        google::cloud::bigtable::CompletionQueue cq,
                        std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
-    throw Usage{"async-get-iam-policy: <project-id> <instance-id>"};
+  if (argv.size() != 2) {
+    throw Usage{"async-get-iam-policy <project-id> <instance-id>"};
   }
 
   //! [async get iam policy]
@@ -322,7 +322,7 @@ void AsyncGetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncListClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
                        google::cloud::bigtable::CompletionQueue cq,
                        std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-list-clusters: <project-id> <instance-id>"};
   }
 
@@ -365,7 +365,7 @@ void AsyncListClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncListAllClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
                           google::cloud::bigtable::CompletionQueue cq,
                           std::vector<std::string> argv) {
-  if (argv.size() != 1U) {
+  if (argv.size() != 1) {
     throw Usage{"async-list-all-clusters: <project-id>"};
   }
 
@@ -407,7 +407,7 @@ void AsyncListAllClusters(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncListAppProfiles(google::cloud::bigtable::InstanceAdmin instance_admin,
                           google::cloud::bigtable::CompletionQueue cq,
                           std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-list-app-profiles: <project-id> <instance-id>"};
   }
 
@@ -443,7 +443,7 @@ void AsyncListAppProfiles(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncUpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
                          google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"update-instance: <project-id> <instance-id>"};
   }
 
@@ -491,7 +491,7 @@ void AsyncUpdateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncUpdateCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
                         google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{"async-update-cluster <project-id> <instance-id> <cluster-id>"};
   }
 
@@ -538,7 +538,7 @@ void AsyncUpdateAppProfile(
     google::cloud::bigtable::InstanceAdmin instance_admin,
     google::cloud::bigtable::CompletionQueue cq,
     std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{"update-cluster: <project-id> <instance-id> <profile-id>"};
   }
 
@@ -573,7 +573,7 @@ void AsyncUpdateAppProfile(
 void AsyncDeleteInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
                          google::cloud::bigtable::CompletionQueue cq,
                          std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-delete-instance: <project-id> <instance-id> "};
   }
 
@@ -598,7 +598,7 @@ void AsyncDeleteInstance(google::cloud::bigtable::InstanceAdmin instance_admin,
 void AsyncDeleteCluster(google::cloud::bigtable::InstanceAdmin instance_admin,
                         google::cloud::bigtable::CompletionQueue cq,
                         std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
         "async-delete-cluster: <project-id> <instance-id> <cluster-id> "};
   }
@@ -625,7 +625,7 @@ void AsyncDeleteAppProfile(
     google::cloud::bigtable::InstanceAdmin instance_admin,
     google::cloud::bigtable::CompletionQueue cq,
     std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
         "async-delete-app-profile <project-id> <instance-id> "
         "<app-profile-id> "};
@@ -653,7 +653,7 @@ void AsyncDeleteAppProfile(
 void AsyncSetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
                        google::cloud::bigtable::CompletionQueue cq,
                        std::vector<std::string> argv) {
-  if (argv.size() < 2U) {
+  if (argv.size() < 2) {
     throw Usage{
         "async-set-iam-policy: <project-id> <instance-id>"
         " <permission> <new-member>\n"
@@ -710,7 +710,7 @@ void AsyncTestIamPermissions(
     google::cloud::bigtable::InstanceAdmin instance_admin,
     google::cloud::bigtable::CompletionQueue cq,
     std::vector<std::string> argv) {
-  if (argv.size() < 2U) {
+  if (argv.size() < 2) {
     throw Usage{
         "async-test-iam-permissions: <project-id> <resource-id> "
         "[permission ...]"};

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -35,7 +35,7 @@ void PrintUsage(std::string const& cmd, std::string const& msg) {
 void AsyncCreateTable(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-create-table <project-id> <instance-id> <table-id>"};
   }
 
@@ -70,7 +70,7 @@ void AsyncCreateTable(google::cloud::bigtable::TableAdmin admin,
 void AsyncListTables(google::cloud::bigtable::TableAdmin admin,
                      google::cloud::bigtable::CompletionQueue cq,
                      std::vector<std::string> argv) {
-  if (argv.size() != 1U) {
+  if (argv.size() != 1) {
     throw Usage{"async-list-tables <project-id> <instance-id>"};
   }
 
@@ -103,7 +103,7 @@ void AsyncListTables(google::cloud::bigtable::TableAdmin admin,
 void AsyncGetTable(google::cloud::bigtable::TableAdmin admin,
                    google::cloud::bigtable::CompletionQueue cq,
                    std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-get-table <project-id> <instance-id> <table-id>"};
   }
 
@@ -142,7 +142,7 @@ void AsyncGetTable(google::cloud::bigtable::TableAdmin admin,
 void AsyncDeleteTable(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-delete-table <project-id> <instance-id> <table-id>"};
   }
 
@@ -171,7 +171,7 @@ void AsyncDeleteTable(google::cloud::bigtable::TableAdmin admin,
 void AsyncModifyTable(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-modify-table <project-id> <instance-id> <table-id>"};
   }
 
@@ -212,7 +212,7 @@ void AsyncModifyTable(google::cloud::bigtable::TableAdmin admin,
 void AsyncDropRowsByPrefix(google::cloud::bigtable::TableAdmin admin,
                            google::cloud::bigtable::CompletionQueue cq,
                            std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
         "async-drop-rows-by-prefix <project-id> <instance-id> <table-id> "
         "<row-key>"};
@@ -243,7 +243,7 @@ void AsyncDropRowsByPrefix(google::cloud::bigtable::TableAdmin admin,
 void AsyncDropAllRows(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::bigtable::CompletionQueue cq,
                       std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{"async-drop-all-rows <project-id> <instance-id> <table-id>"};
   }
 
@@ -272,7 +272,7 @@ void AsyncDropAllRows(google::cloud::bigtable::TableAdmin admin,
 void AsyncCheckConsistency(google::cloud::bigtable::TableAdmin admin,
                            google::cloud::bigtable::CompletionQueue cq,
                            std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
         "async-check-consistency <project-id> <instance-id> <table-id> "
         "<consistency_token>"};
@@ -308,7 +308,7 @@ void AsyncCheckConsistency(google::cloud::bigtable::TableAdmin admin,
 void AsyncGenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
                                    google::cloud::bigtable::CompletionQueue cq,
                                    std::vector<std::string> argv) {
-  if (argv.size() != 2U) {
+  if (argv.size() != 2) {
     throw Usage{
         "async-generate-consistency-token <project-id> <instance-id> "
         "<table-id>"};
@@ -337,7 +337,7 @@ void AsyncGenerateConsistencyToken(google::cloud::bigtable::TableAdmin admin,
 void AsyncWaitForConsistency(google::cloud::bigtable::TableAdmin admin,
                              google::cloud::bigtable::CompletionQueue cq,
                              std::vector<std::string> argv) {
-  if (argv.size() != 3U) {
+  if (argv.size() != 3) {
     throw Usage{
         "async-wait-for-consistency <project-id> <instance-id> "
         "<table-id> <consistency-token>"};

--- a/google/cloud/bigtable/internal/completion_queue_impl.cc
+++ b/google/cloud/bigtable/internal/completion_queue_impl.cc
@@ -88,7 +88,7 @@ void CompletionQueueImpl::ForgetOperation(void* tag) {
   std::lock_guard<std::mutex> lk(mu_);
   auto const num_erased =
       pending_ops_.erase(reinterpret_cast<std::intptr_t>(tag));
-  if (1U != num_erased) {
+  if (num_erased != 1) {
     google::cloud::internal::ThrowRuntimeError(
         "assertion failure: searching for async op tag when trying to "
         "unregister");

--- a/google/cloud/examples/gcs2cbt.cc
+++ b/google/cloud/examples/gcs2cbt.cc
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) try {
   int const report_worker_progress_rate = 500000;
   // The size of the thread pool pushing data to Cloud Bigtable
   std::size_t const thread_pool_size = []() -> std::size_t {
-    if (std::thread::hardware_concurrency() != 0U) {
+    if (std::thread::hardware_concurrency() != 0) {
       return std::thread::hardware_concurrency() - 1;
     }
     return 1;

--- a/google/cloud/firestore/field_path.cc
+++ b/google/cloud/firestore/field_path.cc
@@ -95,8 +95,8 @@ bool operator==(FieldPath const& lhs, FieldPath const& rhs) {
 bool operator<(FieldPath const& lhs, FieldPath const& rhs) {
   auto const lhs_size = lhs.parts_.size();
   auto const rhs_size = rhs.parts_.size();
-  auto const min_length = std::min(lhs_size, rhs_size);
-  for (auto i = 0u; i < min_length; i++) {
+  auto const min_length = (std::min)(lhs_size, rhs_size);
+  for (auto i = 0U; i != min_length; i++) {
     if (lhs.parts_[i] < rhs.parts_[i]) {
       return true;
     }

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -86,7 +86,7 @@ void LogSink::Log(LogRecord log_record) {
   // must make a copy if needed.  But if there is only one backend we can give
   // the backend an opportunity to optimize things by transferring ownership of
   // the LogRecord to it.
-  if (1U == copy.size()) {
+  if (copy.size() == 1) {
     copy.begin()->second->ProcessWithOwnership(std::move(log_record));
     return;
   }

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -222,12 +222,12 @@ Options ParseArgs(int& argc, char* argv[]) {
     std::cout << kDescription << "\n";
   }
 
-  if (unparsed.size() > 2U) {
+  if (unparsed.size() > 2) {
     std::ostringstream os;
     os << "Unknown arguments or options\n" << usage << "\n";
     throw std::runtime_error(std::move(os).str());
   }
-  if (unparsed.size() == 2U) {
+  if (unparsed.size() == 2) {
     options.region = unparsed[1];
   }
   if (options.region.empty()) {

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -441,12 +441,12 @@ Options ParseArgs(int argc, char* argv[]) {
     std::cout << kDescription << "\n";
   }
 
-  if (unparsed.size() > 2U) {
+  if (unparsed.size() > 2) {
     std::ostringstream os;
     os << "Unknown arguments or options\n" << usage << "\n";
     throw std::runtime_error(std::move(os).str());
   }
-  if (unparsed.size() == 2U) {
+  if (unparsed.size() == 2) {
     options.region = unparsed[1];
   }
   if (options.region.empty()) {

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -481,12 +481,12 @@ Options ParseArgs(int argc, char* argv[]) {
     std::cout << kDescription << "\n";
   }
 
-  if (unparsed.size() > 2U) {
+  if (unparsed.size() > 2) {
     std::ostringstream os;
     os << "Unknown arguments or options\n" << usage << "\n";
     throw std::runtime_error(std::move(os).str());
   }
-  if (unparsed.size() == 2U) {
+  if (unparsed.size() == 2) {
     options.region = unparsed[1];
   }
   if (options.region.empty()) {

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -379,12 +379,12 @@ Options ParseArgs(int argc, char* argv[]) {
     std::cout << kDescription << "\n";
   }
 
-  if (unparsed.size() > 2U) {
+  if (unparsed.size() > 2) {
     std::ostringstream os;
     os << "Unknown arguments or options\n" << usage << "\n";
     throw std::runtime_error(std::move(os).str());
   }
-  if (unparsed.size() == 2U) {
+  if (unparsed.size() == 2) {
     options.region = unparsed[1];
   }
   if (options.region.empty()) {

--- a/google/cloud/storage/internal/access_control_common.cc
+++ b/google/cloud/storage/internal/access_control_common.cc
@@ -35,7 +35,7 @@ Status AccessControlCommon::ParseFromJson(AccessControlCommon& result,
   result.kind_ = json.value("kind", "");
   result.role_ = json.value("role", "");
   result.self_link_ = json.value("selfLink", "");
-  if (json.count("projectTeam") != 0U) {
+  if (json.count("projectTeam") != 0) {
     auto tmp = json["projectTeam"];
     ProjectTeam p;
     p.project_number = tmp.value("projectNumber", "");

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -591,7 +591,7 @@ StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload) {
   IamPolicy policy;
   policy.version = 0;
   policy.etag = json.value("etag", "");
-  if (json.count("bindings") != 0U) {
+  if (json.count("bindings") != 0) {
     if (!json["bindings"].is_array()) {
       std::ostringstream os;
       os << "Invalid IamPolicy payload, expected array for 'bindings' field."
@@ -600,7 +600,7 @@ StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload) {
     }
     for (auto const& kv : json["bindings"].items()) {
       auto binding = kv.value();
-      if (binding.count("role") == 0U or binding.count("members") == 0U) {
+      if (binding.count("role") == 0 or binding.count("members") == 0) {
         std::ostringstream os;
         os << "Invalid IamPolicy payload, expected 'role' and 'members'"
            << " fields for element #" << kv.key() << ". payload=" << payload;

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -44,7 +44,7 @@ extern "C" void CurlShareUnlockCallback(CURL*, curl_lock_data data,
 
 std::shared_ptr<CurlHandleFactory> CreateHandleFactory(
     ClientOptions const& options) {
-  if (options.connection_pool_size() == 0U) {
+  if (options.connection_pool_size() == 0) {
     return std::make_shared<DefaultCurlHandleFactory>();
   }
   return std::make_shared<PooledCurlHandleFactory>(

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -99,7 +99,7 @@ TEST_P(CurlClientTest, UploadChunk) {
   auto actual =
       client_
           ->UploadChunk(UploadChunkRequest(
-              "http://localhost:0/invalid-session-id", 0U, std::string{}, 0U))
+              "http://localhost:0/invalid-session-id", 0, std::string{}, 0))
           .status();
   CheckStatus(actual);
 }
@@ -179,7 +179,7 @@ TEST_P(CurlClientTest, TestBucketIamPermissions) {
 TEST_P(CurlClientTest, LockBucketRetentionPolicy) {
   auto actual = client_
                     ->LockBucketRetentionPolicy(
-                        LockBucketRetentionPolicyRequest("bkt", 0U))
+                        LockBucketRetentionPolicyRequest("bkt", 0))
                     .status();
   CheckStatus(actual);
 }

--- a/google/cloud/storage/internal/notification_requests.cc
+++ b/google/cloud/storage/internal/notification_requests.cc
@@ -27,7 +27,7 @@ StatusOr<NotificationMetadata> NotificationMetadataParser::FromJson(
   }
   NotificationMetadata result{};
 
-  if (json.count("custom_attributes") != 0U) {
+  if (json.count("custom_attributes") != 0) {
     for (auto const& kv : json["custom_attributes"].items()) {
       result.custom_attributes_.emplace(kv.key(),
                                         kv.value().get<std::string>());
@@ -35,7 +35,7 @@ StatusOr<NotificationMetadata> NotificationMetadataParser::FromJson(
   }
   result.etag_ = json.value("etag", "");
 
-  if (json.count("event_types") != 0U) {
+  if (json.count("event_types") != 0) {
     for (auto const& kv : json["event_types"].items()) {
       result.event_types_.emplace_back(kv.value().get<std::string>());
     }

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -537,7 +537,7 @@ StatusOr<RewriteObjectResponse> RewriteObjectResponse::FromHttpResponse(
   result.object_size = ParseUnsignedLongField(object, "objectSize");
   result.done = object.value("done", false);
   result.rewrite_token = object.value("rewriteToken", "");
-  if (object.count("resource") != 0U) {
+  if (object.count("resource") != 0) {
     auto parsed = internal::ObjectMetadataParser::FromJson(object["resource"]);
     if (!parsed.ok()) {
       return std::move(parsed).status();

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -442,9 +442,9 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
 
  private:
   std::string upload_session_url_;
-  std::uint64_t range_begin_ = 0U;
+  std::uint64_t range_begin_ = 0;
   std::string payload_;
-  std::uint64_t source_size_ = 0U;
+  std::uint64_t source_size_ = 0;
   bool last_chunk_ = false;
 };
 

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -104,7 +104,7 @@ TEST_F(RetryResumableUploadSessionTest, HandleTransient) {
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(3, count);
-        return make_status_or(ResumableUploadResponse{"", 0U, {}});
+        return make_status_or(ResumableUploadResponse{"", 0, {}});
       }))
       .WillOnce(Invoke([&]() {
         ++count;
@@ -244,12 +244,12 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnUploadChunk) {
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(2, count);
-        return make_status_or(ResumableUploadResponse{"", 0U, {}});
+        return make_status_or(ResumableUploadResponse{"", 0, {}});
       }))
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(4, count);
-        return make_status_or(ResumableUploadResponse{"", 0U, {}});
+        return make_status_or(ResumableUploadResponse{"", 0, {}});
       }));
 
   // We only tolerate 4 transient errors, the first call to UploadChunk() will
@@ -312,7 +312,7 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnReset) {
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(3, count);
-        return make_status_or(ResumableUploadResponse{"", 0U, {}});
+        return make_status_or(ResumableUploadResponse{"", 0, {}});
       }));
 
   // We only tolerate 4 transient errors, the first call to UploadChunk() will
@@ -413,12 +413,12 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnUploadFinalChunk) {
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(2, count);
-        return make_status_or(ResumableUploadResponse{"", 0U, {}});
+        return make_status_or(ResumableUploadResponse{"", 0, {}});
       }))
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(4, count);
-        return make_status_or(ResumableUploadResponse{"", 0U, {}});
+        return make_status_or(ResumableUploadResponse{"", 0, {}});
       }));
 
   // We only tolerate 4 transient errors, the first call to UploadChunk() will

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -37,7 +37,7 @@ StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
   char const token_uri_key[] = "token_uri";  // Not required; often not present.
   for (auto const& key :
        {client_id_key, client_secret_key, refresh_token_key}) {
-    if (credentials.count(key) == 0U) {
+    if (credentials.count(key) == 0) {
       return Status(StatusCode::kInvalidArgument,
                     "Invalid AuthorizedUserCredentials, the " +
                         std::string(key) +

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -100,10 +100,10 @@ class AuthorizedUserCredentials : public Credentials {
     auto access_token =
         storage::internal::nl::json::parse(response->payload, nullptr, false);
     if (access_token.is_discarded() ||
-        access_token.count("access_token") == 0U ||
-        access_token.count("expires_in") == 0U ||
-        access_token.count("id_token") == 0U ||
-        access_token.count("token_type") == 0U) {
+        access_token.count("access_token") == 0 ||
+        access_token.count("expires_in") == 0 ||
+        access_token.count("id_token") == 0 ||
+        access_token.count("token_type") == 0) {
       response->payload +=
           "Could not find all required fields in response (access_token,"
           " id_token, expires_in, token_type).";

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -152,8 +152,8 @@ class ComputeEngineCredentials : public Credentials {
     // JSON array. At minimum, for the request to succeed, the instance must
     // have been granted the scope that allows it to retrieve info from the
     // metadata server.
-    if (response_body.is_discarded() || response_body.count("email") == 0U ||
-        response_body.count("scopes") == 0U) {
+    if (response_body.is_discarded() || response_body.count("email") == 0 ||
+        response_body.count("scopes") == 0) {
       response->payload +=
           "Could not find all required fields in response (email, scopes).";
       return AsStatus(*response);
@@ -190,9 +190,9 @@ class ComputeEngineCredentials : public Credentials {
     // "token_type".
     nl::json access_token = nl::json::parse(response->payload, nullptr, false);
     if (access_token.is_discarded() ||
-        access_token.count("access_token") == 0U or
-        access_token.count("expires_in") == 0U or
-        access_token.count("token_type") == 0U) {
+        access_token.count("access_token") == 0 or
+        access_token.count("expires_in") == 0 or
+        access_token.count("token_type") == 0) {
       response->payload +=
           "Could not find all required fields in response (access_token,"
           " expires_in, token_type).";

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -42,7 +42,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
   char const client_email_key[] = "client_email";
   for (auto const& key :
        {private_key_id_key, private_key_key, client_email_key}) {
-    if (credentials.count(key) == 0U) {
+    if (credentials.count(key) == 0) {
       return Status(StatusCode::kInvalidArgument,
                     "Invalid ServiceAccountCredentials, the " +
                         std::string(key) +
@@ -56,7 +56,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
     }
   }
   // The token_uri field may be missing, but may not be empty:
-  if (credentials.count(token_uri_key) != 0U &&
+  if (credentials.count(token_uri_key) != 0 &&
       credentials.value(token_uri_key, "").empty()) {
     return Status(StatusCode::kInvalidArgument,
                   "Invalid ServiceAccountCredentials, the " +

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -229,9 +229,9 @@ class ServiceAccountCredentials : public Credentials {
     auto access_token =
         storage::internal::nl::json::parse(response->payload, nullptr, false);
     if (access_token.is_discarded() ||
-        access_token.count("access_token") == 0U or
-        access_token.count("expires_in") == 0U or
-        access_token.count("token_type") == 0U) {
+        access_token.count("access_token") == 0 or
+        access_token.count("expires_in") == 0 or
+        access_token.count("token_type") == 0) {
       response->payload +=
           "Could not find all required fields in response (access_token,"
           " expires_in, token_type).";

--- a/google/cloud/storage/policy_document.cc
+++ b/google/cloud/storage/policy_document.cc
@@ -45,7 +45,7 @@ std::ostream& operator<<(std::ostream& os, PolicyDocument const& rhs) {
   os << "expiration=" << google::cloud::internal::FormatRfc3339(rhs.expiration)
      << ", ";
   os << "conditions=[";
-  for (auto i = 0u; i < rhs.conditions.size(); ++i) {
+  for (auto i = 0U; i != rhs.conditions.size(); ++i) {
     os << rhs.conditions[i];
     if (i + 1 < rhs.conditions.size()) {
       os << ", ";

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -206,7 +206,7 @@ TEST_F(CurlResumableUploadIntegrationTest, Empty) {
 
   ASSERT_STATUS_OK(session);
 
-  auto response = (*session)->UploadFinalChunk(std::string{}, 0U);
+  auto response = (*session)->UploadFinalChunk(std::string{}, 0);
   ASSERT_STATUS_OK(response.status());
 
   EXPECT_FALSE(response->payload.empty());


### PR DESCRIPTION
Probably because I am lazy, I started using unsigned literals when
comparing to an unsigned. This is not needed, warnings are produced when
comparing signed vs. unsigned *variables*, but the literals are promoted
to the larger (unsigned) type.

This fixes #2742.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2744)
<!-- Reviewable:end -->
