### PR TITLE
Fix one warning by Clang's static analyzer.

### DIFF
--- a/google/cloud/bigtable/internal/rowreaderiterator.cc
+++ b/google/cloud/bigtable/internal/rowreaderiterator.cc
@@ -29,19 +29,21 @@ RowReaderIterator::RowReaderIterator() : owner_() {}
 
 // Defined here because it needs to see the definition of RowReader
 RowReaderIterator& RowReaderIterator::operator++() {
-  if (owner_ != nullptr && !row_) {
+  if (owner_ == nullptr) {
+    // This is the `end()` iterator, using operator++ on it is UB, we can do
+    // whatever we want, we chose to do nothing.
+    return *this;
+  }
+  if (!row_) {
     // If the iterator dereferences to a bad status, the next value is end().
     owner_ = nullptr;
     return *this;
   }
-  // TODO(#1402): GCP_ASSERT(owner_);  // assert it's not end()
   Advance();
   return *this;
 }
 
 void RowReaderIterator::Advance() {
-  // clang-tidy complains that owner_ can be nullptr. It can indeed.
-  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
   auto status_or_optional_row = owner_->Advance();
   if (!status_or_optional_row) {
     row_ = StatusOr<Row>(std::move(status_or_optional_row).status());


### PR DESCRIPTION
The static analyzer points out that the code can crash, and it is true:
the application could call `operator++()` on the `.end()` iterator.
While that is UB and crashing would be "Okay", so is /not/ crashing and
doing nothing. I think the code is more readable like this anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2747)
<!-- Reviewable:end -->
