### PR TITLE
Allow an arbitrary subdir for uploading docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,3 +260,21 @@ which combinations are tested regularly.
  * `CREATE_GRAPHVIZ`: if set to `yes`, use `CMake` to generate a dependency
    graph of each target. This is useful when troubleshooting dependencies, or
    simply when trying to document them.
+
+### Upload generated document to personal github pages
+
+If you are using your personal fork as the git origin, there is an easy way to
+upload generated doxygen document to your personal github pages. The following
+command will upload the document under
+`cmake-out/gcpp-ci-ubuntu-18.04-gcc-Release` to `my-fancy-feature`
+subdirectory in the gh-pages branch of your personal fork. The document will be
+publicly available at:
+`http://<username>.github.io/google-cloud-cpp/my-fancy-feature`.
+
+```console
+TRAVIS_PULL_REQUEST=false \
+  DOCS_SUBDIR=my-fancy-feature \
+  GENERATE_DOCS=yes \
+  BUILD_OUTPUT=cmake-out/gcpp-ci-ubuntu-18.04-gcc-Release \
+  ./ci/travis/upload-docs.sh
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,11 +265,10 @@ which combinations are tested regularly.
 
 If you are using your personal fork as the git origin, there is an easy way to
 upload generated doxygen document to your personal github pages. The following
-command will upload the document under
-`cmake-out/gcpp-ci-ubuntu-18.04-gcc-Release` to `my-fancy-feature`
-subdirectory in the gh-pages branch of your personal fork. The document will be
-publicly available at:
-`http://<username>.github.io/google-cloud-cpp/my-fancy-feature`.
+command will upload the documentation under
+`cmake-out/gcpp-ci-ubuntu-18.04-gcc-Release` to `my-fancy-feature` subdirectory
+in the gh-pages branch of your personal fork. The documentation will be publicly
+available at: `http://<username>.github.io/google-cloud-cpp/my-fancy-feature`.
 
 ```console
 DOCS_SUBDIR=my-fancy-feature \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,11 +261,11 @@ which combinations are tested regularly.
    graph of each target. This is useful when troubleshooting dependencies, or
    simply when trying to document them.
 
-### Upload generated document to personal github pages
+### Upload generated documentation to personal github pages
 
 If you are using your personal fork as the git origin, there is an easy way to
-upload generated doxygen document to your personal github pages. The following
-command will upload the documentation under
+upload generated doxygen documentation to your personal github pages. The
+following command will upload the documentation under
 `cmake-out/gcpp-ci-ubuntu-18.04-gcc-Release` to `my-fancy-feature` subdirectory
 in the gh-pages branch of your personal fork. The documentation will be publicly
 available at: `http://<username>.github.io/google-cloud-cpp/my-fancy-feature`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,8 +272,7 @@ publicly available at:
 `http://<username>.github.io/google-cloud-cpp/my-fancy-feature`.
 
 ```console
-TRAVIS_PULL_REQUEST=false \
-  DOCS_SUBDIR=my-fancy-feature \
+DOCS_SUBDIR=my-fancy-feature \
   GENERATE_DOCS=yes \
   BUILD_OUTPUT=cmake-out/gcpp-ci-ubuntu-18.04-gcc-Release \
   ./ci/travis/upload-docs.sh

--- a/ci/travis/upload-docs.sh
+++ b/ci/travis/upload-docs.sh
@@ -19,7 +19,10 @@ set -eu
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
 fi
-source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
+
+if [ "${BUILD_OUTPUT:-}" == "" ]; then
+  source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
+fi
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   echo "Skipping document generation as it is disabled for pull requests."
@@ -32,7 +35,10 @@ if [ "${GENERATE_DOCS:-}" != "yes" ]; then
 fi
 
 subdir=""
-case "${TRAVIS_BRANCH:-}" in
+if [ "${DOCS_SUBDIR:-}" != "" ]; then
+  subdir="${DOCS_SUBDIR}"
+else
+  case "${TRAVIS_BRANCH:-}" in
     master)
       subdir="latest"
       ;;
@@ -43,7 +49,8 @@ case "${TRAVIS_BRANCH:-}" in
       echo "Skipping document generation as it is only used in master and release branches."
       exit 0
       ;;
-esac
+  esac
+fi
 
 # The usual way to host documentation in ${GIT_NAME}.github.io/${PROJECT_NAME}
 # is to create a branch (gh-pages) and post the documentation in that branch.

--- a/ci/travis/upload-docs.sh
+++ b/ci/travis/upload-docs.sh
@@ -24,7 +24,7 @@ if [ "${BUILD_OUTPUT:-}" == "" ]; then
   source "${PROJECT_ROOT}/ci/travis/linux-config.sh"
 fi
 
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ "${TRAVIS_PULL_REQUEST:-false}" != "false" ]; then
   echo "Skipping document generation as it is disabled for pull requests."
   exit 0
 fi


### PR DESCRIPTION
I uploaded the doc at:
https://tmatsuo.github.io/google-cloud-cpp/docs-subdir/

with the exact command in `CONTRIBUTING.md`.

fixes #257 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2751)
<!-- Reviewable:end -->
