### PR TITLE
Use check_cxx_symbol_exists() to search for RUSAGE_THREAD.

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(storage_benchmarks
 
 include(CheckSymbolExists)
 check_symbol_exists(getrusage sys/resource.h GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE)
+set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
 check_symbol_exists(RUSAGE_THREAD sys/resource.h
                     GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD)
 target_compile_definitions(

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -20,11 +20,11 @@ target_link_libraries(storage_benchmarks
                       PRIVATE storage_common_options
                               google_cloud_cpp_common_options)
 
-include(CheckSymbolExists)
-check_symbol_exists(getrusage sys/resource.h GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE)
-set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE=1")
-check_symbol_exists(RUSAGE_THREAD sys/resource.h
-                    GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD)
+include(CheckCXXSymbolExists)
+check_cxx_symbol_exists(
+    getrusage sys/resource.h GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE)
+check_cxx_symbol_exists(RUSAGE_THREAD sys/resource.h
+                        GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD)
 target_compile_definitions(
     storage_benchmarks
     PUBLIC


### PR DESCRIPTION
We were using check_symbol_exists() which uses the C compiler. On Linux, the C++ compiler defines `_GNU_SOURCE` by default, that enables `RUSAGE_THREAD`, and we can use it in our code. The CMake test based on the C compiler could not find the symbol because the C compiler does not define `_GNU_SOURCE`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2752)
<!-- Reviewable:end -->
