### PR TITLE
Disable optional's converting c'tor when U == optional.

### DIFF
--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -68,16 +68,20 @@ class optional {
     }
   }
   template <typename U = T,
-            typename std::enable_if<std::is_constructible<T, U&&>::value &&
-                                        AllowImplicit<T, U>::value,
-                                    int>::type = 0>
+            typename std::enable_if<
+                !std::is_same<typename std::decay<U>::type, optional>::value &&
+                    std::is_constructible<T, U&&>::value &&
+                    AllowImplicit<T, U>::value,
+                int>::type = 0>
   optional(U&& x) : has_value_(true) {
     new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(x));
   }
   template <typename U = T,
-            typename std::enable_if<std::is_constructible<T, U&&>::value &&
-                                        !AllowImplicit<T, U>::value,
-                                    int>::type = 0>
+            typename std::enable_if<
+                !std::is_same<typename std::decay<U>::type, optional>::value &&
+                    std::is_constructible<T, U&&>::value &&
+                    !AllowImplicit<T, U>::value,
+                int>::type = 0>
   explicit optional(U&& x) : has_value_(true) {
     new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(x));
   }

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -385,6 +385,14 @@ TEST(OptionalTest, OptionalReturnWithoutValue) {
   EXPECT_FALSE(x.has_value());
 }
 
+TEST(OptionalTest, OptionalBoolCopy) {
+  // This test previously broke on gcc 4.8 because optional's converting
+  // constructor was being chosen instead of its copy constructor.
+  optional<bool> opt_b(false);
+  optional<bool> copy(opt_b);
+  EXPECT_EQ(copy, opt_b);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud


### PR DESCRIPTION
This change disables optionals converting constructors (i.e.,
`optional(U&&)`) when `U` is the same as `optional<T>`. In this
situation we instead want to use optional's normal copy constructor.

This bug showed up in our gcc 4.8 tests when using `optional<bool>`. I
*think* gcc 4.8 exposed this issue because it probably *copies* the
optional bools (e.g., on resize) instead of moving them. And an lvalue
of type `optional<bool>` *is* explicitly convertible to type `bool`
because of its `explicit operator bool()`, so the converting constructor
was in the overload set, and in fact it was a better match for a
non-const lvalue than was the copy constructor whose argument type was a
const value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2757)
<!-- Reviewable:end -->
