### PR TITLE
Remove storage location to match other code samples

### DIFF
--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -39,8 +39,8 @@ int main(int argc, char* argv[]) {
   }
 
   google::cloud::StatusOr<gcs::BucketMetadata> bucket_metadata =
-      client->CreateBucketForProject(bucket_name, project_id,
-          gcs::BucketMetadata());
+      client->CreateBucketForProject(
+          bucket_name, project_id, gcs::BucketMetadata());
 
   if (!bucket_metadata) {
     std::cerr << "Error creating bucket " << bucket_name

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -42,7 +42,6 @@ int main(int argc, char* argv[]) {
       client->CreateBucketForProject(
           bucket_name, project_id,
           gcs::BucketMetadata()
-              .set_location("us-east1")
               .set_storage_class(gcs::storage_class::Regional()));
 
   if (!bucket_metadata) {

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -39,8 +39,8 @@ int main(int argc, char* argv[]) {
   }
 
   google::cloud::StatusOr<gcs::BucketMetadata> bucket_metadata =
-      client->CreateBucketForProject(
-          bucket_name, project_id, gcs::BucketMetadata());
+      client->CreateBucketForProject(bucket_name, project_id,
+                                     gcs::BucketMetadata());
 
   if (!bucket_metadata) {
     std::cerr << "Error creating bucket " << bucket_name

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -39,10 +39,8 @@ int main(int argc, char* argv[]) {
   }
 
   google::cloud::StatusOr<gcs::BucketMetadata> bucket_metadata =
-      client->CreateBucketForProject(
-          bucket_name, project_id,
-          gcs::BucketMetadata()
-              .set_storage_class(gcs::storage_class::Regional()));
+      client->CreateBucketForProject(bucket_name, project_id,
+          gcs::BucketMetadata());
 
   if (!bucket_metadata) {
     std::cerr << "Error creating bucket " << bucket_name


### PR DESCRIPTION
All other languages do not set a location for the bucket metadata. We shouldn't do so here.

See other languages:
https://cloud.google.com/storage/docs/reference/libraries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2760)
<!-- Reviewable:end -->
