### PR TITLE
Allow specifying non-default scopes and subject in GoogleDefaultCredentials(). (#1866)

### DIFF
--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -145,8 +145,9 @@ StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromAdcPaths(
 
   // If the path was specified, try to load that file; explicitly fail if it
   // doesn't exist or can't be read and parsed.
-  return LoadCredsFromPath(path, non_service_account_ok, service_account_scopes,
-                           service_account_subject);
+  return LoadCredsFromPath(path, non_service_account_ok,
+                           std::move(service_account_scopes),
+                           std::move(service_account_subject));
 }
 
 StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials() {
@@ -278,7 +279,8 @@ StatusOr<std::shared_ptr<Credentials>>
 CreateServiceAccountCredentialsFromDefaultPaths(
     google::cloud::optional<std::set<std::string>> scopes,
     google::cloud::optional<std::string> subject) {
-  auto creds = MaybeLoadCredsFromAdcPaths(false, scopes, subject);
+  auto creds =
+      MaybeLoadCredsFromAdcPaths(false, std::move(scopes), std::move(subject));
   if (!creds) {
     return StatusOr<std::shared_ptr<Credentials>>(creds.status());
   }

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -36,13 +36,13 @@ constexpr char kAdcLink[] =
     "https://developers.google.com/identity/protocols/"
     "application-default-credentials";
 
-/// Parses the JSON or P12 file at `path` and creates the appropriate
-/// Credentials type.
-///
-/// If `service_account_scopes` or `service_account_subject` are specified, the
-/// file at `path` must be a P12 service account or a JSON service account. If
-/// a different type of credential file is found, this function returns
-/// nullptr to indicate a service account file wasn't found.
+// Parses the JSON or P12 file at `path` and creates the appropriate
+// Credentials type.
+//
+// If `service_account_scopes` or `service_account_subject` are specified, the
+// file at `path` must be a P12 service account or a JSON service account. If
+// a different type of credential file is found, this function returns
+// nullptr to indicate a service account file wasn't found.
 StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
     std::string const& path, bool non_service_account_ok,
     google::cloud::optional<std::set<std::string>> service_account_scopes,
@@ -110,17 +110,17 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
                  path + "."));
 }
 
-/// Tries to load the file at the path specified by the value of the Application
-/// Default %Credentials environment variable and to create the appropriate
-/// Credentials type.
-///
-/// Returns nullptr if the environment variable is not set or the path does not
-/// exist.
-///
-/// If `service_account_scopes` or `service_account_subject` are specified, the
-/// found file must be a P12 service account or a JSON service account. If a
-/// different type of credential file is found, this function returns nullptr
-/// to indicate a service account file wasn't found.
+// Tries to load the file at the path specified by the value of the Application
+// Default %Credentials environment variable and to create the appropriate
+// Credentials type.
+//
+// Returns nullptr if the environment variable is not set or the path does not
+// exist.
+//
+// If `service_account_scopes` or `service_account_subject` are specified, the
+// found file must be a P12 service account or a JSON service account. If a
+// different type of credential file is found, this function returns nullptr
+// to indicate a service account file wasn't found.
 StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromAdcPaths(
     bool non_service_account_ok,
     google::cloud::optional<std::set<std::string>> service_account_scopes,

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -32,7 +32,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
-constexpr char ADC_LINK[] =
+constexpr char kAdcLink[] =
     "https://developers.google.com/identity/protocols/"
     "application-default-credentials";
 
@@ -176,7 +176,7 @@ StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials() {
       Status(StatusCode::kUnknown,
              "Could not automatically determine credentials. For more "
              "information, please see " +
-                 std::string(ADC_LINK)));
+                 std::string(kAdcLink)));
 }
 
 std::shared_ptr<Credentials> CreateAnonymousCredentials() {
@@ -293,7 +293,8 @@ CreateServiceAccountCredentialsFromDefaultPaths(
       Status(StatusCode::kUnknown,
              "Could not create service account credentials using Application"
              "Default Credentials paths. For more information, please see " +
-                 std::string(ADC_LINK)));
+                 std::string(kAdcLink
+                            )));
 }
 
 StatusOr<std::shared_ptr<Credentials>>

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -34,7 +34,9 @@ namespace oauth2 {
 
 /// Parses the JSON file at `path` and creates the appropriate Credentials type.
 StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
-    std::string const& path) {
+    std::string const& path,
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
   namespace nl = google::cloud::storage::internal::nl;
 
   std::ifstream ifs(path);
@@ -55,6 +57,8 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
       return Status(StatusCode::kInvalidArgument,
                     "Invalid credentials file " + path);
     }
+    info->subject = std::move(subject);
+    info->scopes = std::move(scopes);
     auto credentials =
         google::cloud::internal::make_unique<ServiceAccountCredentials<>>(
             *info);
@@ -76,6 +80,8 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
     if (!info) {
       return info.status();
     }
+    info->subject = std::move(subject);
+    info->scopes = std::move(scopes);
     std::unique_ptr<Credentials> ptr =
         google::cloud::internal::make_unique<ServiceAccountCredentials<>>(
             *info);
@@ -88,18 +94,22 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
                  path + "."));
 }
 
-StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromAdcEnvVar() {
+StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromAdcEnvVar(
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
   auto path = GoogleAdcFilePathFromEnvVarOrEmpty();
   if (!path.empty()) {
     // If the path was specified, try to load that file; explicitly fail if it
     // doesn't exist or can't be read and parsed.
-    return LoadCredsFromPath(path);
+    return LoadCredsFromPath(path, std::move(scopes), std::move(subject));
   }
   // No ptr indicates that there was no path to attempt loading creds from.
   return StatusOr<std::unique_ptr<Credentials>>(nullptr);
 }
 
-StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromGcloudAdcFile() {
+StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromGcloudAdcFile(
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
   auto path = GoogleAdcFilePathFromWellKnownPathOrEmpty();
   if (!path.empty()) {
     // Just because we had the necessary information to build the path doesn't
@@ -107,7 +117,7 @@ StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromGcloudAdcFile() {
     std::error_code ec;
     auto adc_file_status = google::cloud::internal::status(path, ec);
     if (google::cloud::internal::exists(adc_file_status)) {
-      return LoadCredsFromPath(path);
+      return LoadCredsFromPath(path, std::move(scopes), std::move(subject));
     }
   }
   // Either we were unable to construct the well known path or no file existed
@@ -116,8 +126,14 @@ StatusOr<std::unique_ptr<Credentials>> MaybeLoadCredsFromGcloudAdcFile() {
 }
 
 StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials() {
+  return GoogleDefaultCredentials({}, {});
+}
+
+StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject) {
   // 1) Check if the GOOGLE_APPLICATION_CREDENTIALS environment variable is set.
-  auto creds = MaybeLoadCredsFromAdcEnvVar();
+  auto creds = MaybeLoadCredsFromAdcEnvVar(scopes, subject);
   if (!creds) {
     return StatusOr<std::shared_ptr<Credentials>>(creds.status());
   }
@@ -127,7 +143,8 @@ StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials() {
 
   // 2) If no path was specified via environment variable, check if the gcloud
   // ADC file exists.
-  creds = MaybeLoadCredsFromGcloudAdcFile();
+  creds =
+      MaybeLoadCredsFromGcloudAdcFile(std::move(scopes), std::move(subject));
   if (!creds) {
     return StatusOr<std::shared_ptr<Credentials>>(creds.status());
   }

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -32,7 +32,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
 
-constexpr char kAdcLink[] =
+constexpr char ADC_LINK[] =
     "https://developers.google.com/identity/protocols/"
     "application-default-credentials";
 
@@ -176,7 +176,7 @@ StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials() {
       Status(StatusCode::kUnknown,
              "Could not automatically determine credentials. For more "
              "information, please see " +
-                 std::string(kAdcLink)));
+                 std::string(ADC_LINK)));
 }
 
 std::shared_ptr<Credentials> CreateAnonymousCredentials() {
@@ -293,7 +293,7 @@ CreateServiceAccountCredentialsFromDefaultPaths(
       Status(StatusCode::kUnknown,
              "Could not create service account credentials using Application"
              "Default Credentials paths. For more information, please see " +
-                 std::string(kAdcLink)));
+                 std::string(ADC_LINK)));
 }
 
 StatusOr<std::shared_ptr<Credentials>>

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -293,8 +293,7 @@ CreateServiceAccountCredentialsFromDefaultPaths(
       Status(StatusCode::kUnknown,
              "Could not create service account credentials using Application"
              "Default Credentials paths. For more information, please see " +
-                 std::string(kAdcLink
-                            )));
+                 std::string(kAdcLink)));
 }
 
 StatusOr<std::shared_ptr<Credentials>>

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -32,14 +32,51 @@ namespace oauth2 {
  *
  * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
  * file it points to will be loaded and used to create a credential of the
- * specified type. Otherwise, if running on a Google-hosted environment (e.g.
- * Compute Engine), credentials for the the environment's default service
- * account will be used.
+ * specified type. If the file specifies a service account, the credentials
+ * use the cloud-platform OAuth 2.0 scope, defined by
+ * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes to be used in
+ * the case of service account credentials, use the overloaded version of this
+ * function.
+ *
+ * Otherwise, if running on a Google-hosted environment (e.g. Compute Engine),
+ * credentials for the the environment's default service account will be used.
  *
  * @see https://cloud.google.com/docs/authentication/production for details
  * about Application Default %Credentials.
  */
 StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials();
+
+/**
+ * Produces a Credentials type based on the runtime environment.
+ *
+ * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
+ * file it points to will be loaded and used to create a credential of the
+ * specified type. Otherwise, if running on a Google-hosted environment (e.g.
+ * Compute Engine), credentials for the the environment's default service
+ * account will be used.
+ *
+ * @param scopes the scopes to request during the authorization grant, if the
+ *     GOOGLE_APPLICATION_CREDENTIALS environment variable points to a service
+ *     account. If omitted, the cloud-platform scope, defined by
+ *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
+ * @param subject for domain-wide delegation, if the
+ *     GOOGLE_APPLICATION_CREDENTIALS environment variable points to a service
+ *     account; the email address of the user for which to request delegated
+ *     access. If omitted, no "subject" attribute is included in the
+ *     authorization grant.
+ *
+ * @see https://developers.google.com/identity/protocols/googlescopes for a list
+ *     of OAuth 2.0 scopes used with Google APIs.
+ *
+ * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+ *     for more information about domain-wide delegation.
+ *
+ * @see https://cloud.google.com/docs/authentication/production for details
+ * about Application Default %Credentials.
+ */
+StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject);
 
 //@{
 /**

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -32,51 +32,14 @@ namespace oauth2 {
  *
  * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
  * file it points to will be loaded and used to create a credential of the
- * specified type. If the file specifies a service account, the credentials
- * use the cloud-platform OAuth 2.0 scope, defined by
- * `GoogleOAuthScopeCloudPlatform()`. To specify alternate scopes to be used in
- * the case of service account credentials, use the overloaded version of this
- * function.
- *
- * Otherwise, if running on a Google-hosted environment (e.g. Compute Engine),
- * credentials for the the environment's default service account will be used.
+ * specified type. Otherwise, if running on a Google-hosted environment (e.g.
+ * Compute Engine), credentials for the the environment's default service
+ * account will be used.
  *
  * @see https://cloud.google.com/docs/authentication/production for details
  * about Application Default %Credentials.
  */
 StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials();
-
-/**
- * Produces a Credentials type based on the runtime environment.
- *
- * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
- * file it points to will be loaded and used to create a credential of the
- * specified type. Otherwise, if running on a Google-hosted environment (e.g.
- * Compute Engine), credentials for the the environment's default service
- * account will be used.
- *
- * @param scopes the scopes to request during the authorization grant, if the
- *     GOOGLE_APPLICATION_CREDENTIALS environment variable points to a service
- *     account. If omitted, the cloud-platform scope, defined by
- *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
- * @param subject for domain-wide delegation, if the
- *     GOOGLE_APPLICATION_CREDENTIALS environment variable points to a service
- *     account; the email address of the user for which to request delegated
- *     access. If omitted, no "subject" attribute is included in the
- *     authorization grant.
- *
- * @see https://developers.google.com/identity/protocols/googlescopes for a list
- *     of OAuth 2.0 scopes used with Google APIs.
- *
- * @see https://developers.google.com/identity/protocols/OAuth2ServiceAccount
- *     for more information about domain-wide delegation.
- *
- * @see https://cloud.google.com/docs/authentication/production for details
- * about Application Default %Credentials.
- */
-StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
-    google::cloud::optional<std::set<std::string>> scopes,
-    google::cloud::optional<std::string> subject);
 
 //@{
 /**

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -181,6 +181,48 @@ CreateServiceAccountCredentialsFromP12FilePath(
 //@}
 
 /**
+ * Produces a ServiceAccountCredentials type by trying to load the standard
+ * Application Default %Credentials paths.
+ *
+ * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
+ * or P12 file it points to will be loaded. Otherwise, if the gcloud utility
+ * has configured an Application Default %Credentials file, that file is
+ * loaded. The loaded file is used to create a ServiceAccountCredentials.
+ *
+ * @see https://cloud.google.com/docs/authentication/production for details
+ *     about Application Default %Credentials.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromDefaultPaths();
+
+/**
+ * Produces a ServiceAccountCredentials type by trying to load the standard
+ * Application Default %Credentials paths.
+ *
+ * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON
+ * or P12 file it points to will be loaded. Otherwise, if the gcloud utility
+ * has configured an Application Default %Credentials file, that file is
+ * loaded. The loaded file is used to create a ServiceAccountCredentials.
+ *
+ * @param scopes the scopes to request during the authorization grant. If
+ *     omitted, the cloud-platform scope, defined by
+ *     `GoogleOAuthScopeCloudPlatform()`, is used as a default.
+ * @param subject for domain-wide delegation; the email address of the user for
+ *     which to request delegated access. If omitted, no "subject" attribute is
+ *     included in the authorization grant.
+ *
+ * @see https://developers.google.com/identity/protocols/googlescopes for a list
+ *     of OAuth 2.0 scopes used with Google APIs.
+ *
+ * @see https://cloud.google.com/docs/authentication/production for details
+ *     about Application Default %Credentials.
+ */
+StatusOr<std::shared_ptr<Credentials>>
+CreateServiceAccountCredentialsFromDefaultPaths(
+    google::cloud::optional<std::set<std::string>> scopes,
+    google::cloud::optional<std::string> subject);
+
+/**
  * Creates a ServiceAccountCredentials from a JSON string.
  *
  * These credentials use the cloud-platform OAuth 2.0 scope, defined by

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -199,6 +199,24 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
 
+TEST_F(GoogleCredentialsTest,
+       LoadValidServiceAccountCredentialsWithOptionalArgs) {
+  std::string filename = ::testing::TempDir() + AUTHORIZED_USER_CRED_FILENAME;
+  SetupServiceAccountCredentialsFileForTest(filename);
+
+  // Test that the service account credentials are loaded as the default when
+  // specified via the well known environment variable.
+  SetEnv(GoogleAdcEnvVar(), filename.c_str());
+  auto creds = GoogleDefaultCredentials(
+      {{"https://www.googleapis.com/auth/devstorage.full_control"}},
+      "user@foo.bar");
+  ASSERT_STATUS_OK(creds);
+  // Need to create a temporary for the pointer because clang-tidy warns about
+  // using expressions with (potential) side-effects inside typeid().
+  auto* ptr = creds->get();
+  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
+}
+
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
   std::string filename = ::testing::TempDir() + SERVICE_ACCOUNT_CRED_FILENAME;
   SetupServiceAccountCredentialsFileForTest(filename);

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -199,24 +199,6 @@ TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsViaGcloudFile) {
   EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
 }
 
-TEST_F(GoogleCredentialsTest,
-       LoadValidServiceAccountCredentialsWithOptionalArgs) {
-  std::string filename = ::testing::TempDir() + AUTHORIZED_USER_CRED_FILENAME;
-  SetupServiceAccountCredentialsFileForTest(filename);
-
-  // Test that the service account credentials are loaded as the default when
-  // specified via the well known environment variable.
-  SetEnv(GoogleAdcEnvVar(), filename.c_str());
-  auto creds = GoogleDefaultCredentials(
-      {{"https://www.googleapis.com/auth/devstorage.full_control"}},
-      "user@foo.bar");
-  ASSERT_STATUS_OK(creds);
-  // Need to create a temporary for the pointer because clang-tidy warns about
-  // using expressions with (potential) side-effects inside typeid().
-  auto* ptr = creds->get();
-  EXPECT_EQ(typeid(*ptr), typeid(ServiceAccountCredentials<>));
-}
-
 TEST_F(GoogleCredentialsTest, LoadValidServiceAccountCredentialsFromFilename) {
   std::string filename = ::testing::TempDir() + SERVICE_ACCOUNT_CRED_FILENAME;
   SetupServiceAccountCredentialsFileForTest(filename);


### PR DESCRIPTION
This is to enable callers who don't know ahead of time what type of
credential they'll create (hence calling GoogleDefaultCredentials and
not one of the more specific functions), but who need to specify the
scopes and/or subject to be used if a service account file is used.

This augments the fix for the already-closed #1866.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2762)
<!-- Reviewable:end -->
