### PR TITLE
Reject IAM Binding protos with unknown fields.

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -1034,6 +1034,7 @@ class InstanceAdmin {
       for (auto field_desc : field_descs) {
         if (field_desc->name() != "members" && field_desc->name() != "role") {
           std::stringstream os;
+          // TODO(#2732): Advise alternative API after it's implemented.
           os << "IamBinding field \"" << field_desc->name()
              << "\" is unknown to Bigtable C++ client. Please use a client in "
                 "another language.";

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -602,12 +602,13 @@ StatusOr<IamPolicy> ParseIamPolicyFromString(std::string const& payload) {
       auto binding = kv.value();
       if (!binding.is_object()) {
         std::ostringstream os;
+        // TODO(#2732): Advise alternative API after it's implemented.
         os << "Invalid IamPolicy payload, expected objects for 'bindings' "
               "entries."
            << "  payload=" << payload;
         return Status(StatusCode::kInvalidArgument, os.str());
       }
-      for (auto const binding_kv : binding.items()) {
+      for (auto const& binding_kv : binding.items()) {
         auto const& key = binding_kv.key();
         if (key != "members" && key != "role") {
           std::ostringstream os;

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -731,20 +731,11 @@ TEST(BucketRequestsTest, ParseIamPolicyFromStringMissingRole) {
 
        }},
   };
-
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        ParseIamPolicyFromString(expected_payload.dump());
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("expected 'role' and 'members'"));
-        throw;
-      },
-      std::invalid_argument);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(ParseIamPolicyFromString(expected_payload.dump()),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto res = ParseIamPolicyFromString(expected_payload.dump());
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("expected 'role' and 'members'"));
 }
 
 TEST(BucketRequestsTest, ParseIamPolicyFromStringMissingMembers) {
@@ -756,19 +747,11 @@ TEST(BucketRequestsTest, ParseIamPolicyFromStringMissingMembers) {
                    }}},
   };
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        ParseIamPolicyFromString(expected_payload.dump());
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("expected 'role' and 'members'"));
-        throw;
-      },
-      std::invalid_argument);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(ParseIamPolicyFromString(expected_payload.dump()),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto res = ParseIamPolicyFromString(expected_payload.dump());
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("expected 'role' and 'members'"));
 }
 
 TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidMembers) {
@@ -781,19 +764,11 @@ TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidMembers) {
                    }}},
   };
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        ParseIamPolicyFromString(expected_payload.dump());
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("expected array for 'members'"));
-        throw;
-      },
-      std::invalid_argument);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(ParseIamPolicyFromString(expected_payload.dump()),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto res = ParseIamPolicyFromString(expected_payload.dump());
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("expected array for 'members'"));
 }
 
 TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidBindings) {
@@ -803,19 +778,44 @@ TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidBindings) {
       {"bindings", "invalid"},
   };
 
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-  EXPECT_THROW(
-      try {
-        ParseIamPolicyFromString(expected_payload.dump());
-      } catch (std::exception const& ex) {
-        EXPECT_THAT(ex.what(), HasSubstr("expected array for 'bindings'"));
-        throw;
-      },
-      std::invalid_argument);
-#else
-  EXPECT_DEATH_IF_SUPPORTED(ParseIamPolicyFromString(expected_payload.dump()),
-                            "exceptions are disabled");
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  auto res = ParseIamPolicyFromString(expected_payload.dump());
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("expected array for 'bindings'"));
+}
+
+TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidBindingsEntries) {
+  nl::json expected_payload{
+      {"kind", "storage#policy"},
+      {"etag", "XYZ="},
+      {"bindings", std::vector<nl::json>{"not_an_object"}},
+  };
+
+  auto res = ParseIamPolicyFromString(expected_payload.dump());
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("expected objects for 'bindings' entries"));
+}
+
+TEST(BucketRequestsTest, ParseIamPolicyFromStringInvalidExtras) {
+  nl::json expected_payload{
+      {"kind", "storage#policy"},
+      {"etag", "XYZ="},
+      {"bindings",
+       {
+           nl::json{{"role", "roles/storage.admin"},
+                    {"members", std::vector<std::string>{"test-user-1"}},
+                    {"condition", "some_condition"}},
+       }},
+  };
+
+  auto res = ParseIamPolicyFromString(expected_payload.dump());
+  ASSERT_FALSE(res);
+  EXPECT_EQ(StatusCode::kInvalidArgument, res.status().code());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("unexpected member 'condition' in element #0"));
 }
 
 TEST(BucketRequestsTest, SetIamPolicy) {


### PR DESCRIPTION
The key motivation is the `condition` field, which breaks the assumption
that the there is one member list per-role. However, to make it a tiny
bit more robust we reject all Binding`s unknown fields.

As a byproduct, parsing JSON was changed to return Status instead of
throwing (it had been doing both).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2764)
<!-- Reviewable:end -->
