### PR TITLE
bug: Fix nlohmann json macro leaks.

### DIFF
--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -46,8 +46,14 @@
 // nlohmann::json. This is safe because google/cloud/storage always includes
 // the nlohmann::json through this header, so after the first time our own
 // include guards are enough.
+#undef NLOHMANN_BASIC_JSON_TPL
+#undef NLOHMANN_BASIC_JSON_TPL_DECLARATION
 #undef NLOHMANN_JSON_HPP
 #undef NLOHMANN_JSON_FWD_HPP
+#undef NLOHMANN_JSON_SERIALIZE_ENUM
+#undef NLOHMANN_JSON_VERSION_MAJOR
+#undef NLOHMANN_JSON_VERSION_MINOR
+#undef NLOHMANN_JSON_VERSION_PATCH
 
 namespace nlohmann {
 //


### PR DESCRIPTION
Unfortunately we still expose the nlohmann headers in our public
headers, which results in leaks of macros to the user's namespace. Until
we have a better fix (see #2772) this removes all the macros I could
find (i.e. anything starting with `NLOHMANN_`).

Fixes #2771.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2774)
<!-- Reviewable:end -->
