### PR TITLE
cleanup: Mark CMake configuration options as advanced.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,17 +76,23 @@ endif (APPLE)
 # configuration agnostic as to wether ccache is installed or not.
 option(
     GOOGLE_CLOUD_CPP_ENABLE_CCACHE "Automatically use ccache if available" ON)
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_CCACHE)
 
 if ("${GOOGLE_CLOUD_CPP_ENABLE_CCACHE}")
-    find_program(CCACHE_FOUND ccache NAMES /usr/bin/ccache)
-    if (CCACHE_FOUND)
-        message(STATUS "ccache found: ${CCACHE_FOUND}")
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_FOUND}")
-        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_FOUND}")
+    find_program(GOOGLE_CLOUD_CPP_CCACHE_PROGRAM ccache NAMES /usr/bin/ccache)
+    mark_as_advanced(GOOGLE_CLOUD_CPP_CCACHE_PROGRAM)
+    if (GOOGLE_CLOUD_CPP_CCACHE_PROGRAM)
+        message(STATUS "ccache found: ${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
+        set_property(GLOBAL
+                     PROPERTY RULE_LAUNCH_COMPILE
+                              "${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
+        set_property(GLOBAL
+                     PROPERTY RULE_LAUNCH_LINK
+                              "${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
 
         set(GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE
-            "-DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE_FOUND}"
-            "-DCMAKE_CC_COMPILER_LAUNCHER=${CCACHE_FOUND}")
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}"
+            "-DCMAKE_CC_COMPILER_LAUNCHER=${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
     endif ()
 endif ()
 
@@ -122,6 +128,7 @@ set_property(CACHE GOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER
 # googleapis.dev hositng.
 option(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV
        "Use relative URLs in docs for googleapis.dev" OFF)
+mark_as_advanced(GOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV)
 
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/cmake/EnableClangTidy.cmake
+++ b/cmake/EnableClangTidy.cmake
@@ -16,6 +16,7 @@
 
 option(GOOGLE_CLOUD_CPP_CLANG_TIDY
        "If set compiles the Cloud Cloud C++ Libraries with clang-tidy." "")
+mark_as_advanced(GOOGLE_CLOUD_CPP_CLANG_TIDY)
 
 if (${CMAKE_VERSION} VERSION_LESS "3.6")
     message(STATUS "clang-tidy is not enabled because cmake version is too old")
@@ -23,13 +24,14 @@ else()
     if (${CMAKE_VERSION} VERSION_LESS "3.8")
         message(WARNING "clang-tidy exit code ignored in this version of cmake")
     endif ()
-    find_program(CLANG_TIDY_EXE
+    find_program(GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM
                  NAMES "clang-tidy"
                  DOC "Path to clang-tidy executable")
-
-    if (NOT CLANG_TIDY_EXE)
+    mark_as_advanced(GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM)
+    if (NOT GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM)
         message(STATUS "clang-tidy not found.")
     else()
-        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+        message(
+            STATUS "clang-tidy found: ${GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM}")
     endif ()
 endif ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -131,9 +131,10 @@ function (google_cloud_cpp_add_common_options target)
 endfunction ()
 
 function (google_cloud_cpp_add_clang_tidy target)
-    if (CLANG_TIDY_EXE AND GOOGLE_CLOUD_CPP_CLANG_TIDY)
-        set_target_properties(${target}
-                              PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+    if (GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM AND GOOGLE_CLOUD_CPP_CLANG_TIDY)
+        set_target_properties(
+            ${target}
+            PROPERTIES CXX_CLANG_TIDY "${GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM}")
     endif ()
 endfunction ()
 

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -342,14 +342,15 @@ if (BUILD_TESTING)
     endforeach ()
 endif ()
 
-option(FORCE_STATIC_ANALYZER_ERRORS
+option(GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS
        "If set, enable tests that force errors detected by the static analyzer."
        "")
-if (FORCE_STATIC_ANALYZER_ERRORS)
+mark_as_advanced(GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS)
+if (GOOGLE_CLOUD_CPP_FORCE_STATIC_ANALYZER_ERRORS)
     target_compile_definitions(bigtable_client_force_sanitizer_failures_test
                                PRIVATE
                                -DBIGTABLE_CLIENT_FORCE_STATIC_ANALYZER_ERRORS)
-endif (FORCE_STATIC_ANALYZER_ERRORS)
+endif ()
 
 if (BUILD_TESTING)
     add_subdirectory(tests)


### PR DESCRIPTION
Mark the options that are unlikely to be used by a user as "advanced", so they
do not show up in the CMake UI. Prefix all the options (that I could
find) with `GOOGLE_CLOUD_CPP_` so folks can tell what they are about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2777)
<!-- Reviewable:end -->
