### PR TITLE
cleanup: Fix integration tests for failures.

### DIFF
--- a/google/cloud/bigtable/async_read_stream_test.cc
+++ b/google/cloud/bigtable/async_read_stream_test.cc
@@ -174,7 +174,7 @@ TEST_F(AsyncReadStreamTest, MetaFunctions) {
 /// @test Verify that AsyncReadStream works even if the server does not exist.
 TEST_F(AsyncReadStreamTest, CannotConnect) {
   std::shared_ptr<grpc::Channel> channel =
-      grpc::CreateChannel("localhost:0", grpc::InsecureChannelCredentials());
+      grpc::CreateChannel("localhost:1", grpc::InsecureChannelCredentials());
   std::unique_ptr<google::bigtable::v2::Bigtable::StubInterface> stub =
       google::bigtable::v2::Bigtable::NewStub(channel);
 

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -68,10 +68,10 @@ class CurlClientTest : public ::testing::Test,
       };
     } else if (error_type == "libcurl-failure") {
       google::cloud::internal::SetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
-                                      "http://localhost:0");
+                                      "http://localhost:1");
       client_ =
           CurlClient::Create(ClientOptions(oauth2::CreateAnonymousCredentials())
-                                 .set_endpoint("http://localhost:0"));
+                                 .set_endpoint("http://localhost:1"));
       // We do not know what libcurl will return. Some kind of error, but varies
       // by version of libcurl. Just make sure it is an error and the CURL
       // details are included in the error message.
@@ -99,13 +99,13 @@ TEST_P(CurlClientTest, UploadChunk) {
   auto actual =
       client_
           ->UploadChunk(UploadChunkRequest(
-              "http://localhost:0/invalid-session-id", 0, std::string{}, 0))
+              "http://localhost:1/invalid-session-id", 0, std::string{}, 0))
           .status();
   CheckStatus(actual);
 }
 
 TEST_P(CurlClientTest, QueryResumableUpload) {
-  // Use http://localhost:0 to force a libcurl failure
+  // Use http://localhost:1 to force a libcurl failure
   auto actual = client_
                     ->QueryResumableUpload(QueryResumableUploadRequest(
                         "http://localhost:9/invalid-session-id"))

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -89,8 +89,8 @@ TEST_F(ClientOptionsTest, SetEndpoint) {
 
 TEST_F(ClientOptionsTest, SetIamEndpoint) {
   ClientOptions options(oauth2::CreateAnonymousCredentials());
-  options.set_iam_endpoint("http://localhost:0/v2");
-  EXPECT_EQ("http://localhost:0/v2", options.iam_endpoint());
+  options.set_iam_endpoint("http://localhost:1/v2");
+  EXPECT_EQ("http://localhost:1/v2", options.iam_endpoint());
 }
 
 TEST_F(ClientOptionsTest, SetCredentials) {

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -57,7 +57,7 @@ TEST(CurlRequestTest, FailedGET) {
   // This test fails if somebody manages to run a https server on port 0 (you
   // can't, but just documenting the assumptions in this test).
   storage::internal::CurlRequestBuilder request(
-      "https://localhost:0/", storage::internal::GetDefaultCurlHandleFactory());
+      "https://localhost:1/", storage::internal::GetDefaultCurlHandleFactory());
 
   auto response = request.BuildRequest().MakeRequest(std::string{});
   EXPECT_FALSE(response.ok());

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -835,7 +835,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:0"),
+                    .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
 
   std::string bucket_name = flag_bucket_name;
@@ -856,9 +856,9 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadXML) {
   google::cloud::internal::SetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
-                                  "http://localhost:0");
+                                  "http://localhost:1");
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:0"),
+                    .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
 
   std::string bucket_name = flag_bucket_name;
@@ -875,7 +875,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadXML) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteJSON) {
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:0"),
+                    .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
 
   std::string bucket_name = flag_bucket_name;
@@ -894,9 +894,9 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteJSON) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteXML) {
   google::cloud::internal::SetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
-                                  "http://localhost:0");
+                                  "http://localhost:1");
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:0"),
+                    .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
 
   std::string bucket_name = flag_bucket_name;
@@ -912,9 +912,9 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteXML) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureDownloadFile) {
   google::cloud::internal::SetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
-                                  "http://localhost:0");
+                                  "http://localhost:1");
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:0"),
+                    .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
 
   std::string bucket_name = flag_bucket_name;
@@ -928,9 +928,9 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureDownloadFile) {
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureUploadFile) {
   google::cloud::internal::SetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
-                                  "http://localhost:0");
+                                  "http://localhost:1");
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
-                    .set_endpoint("http://localhost:0"),
+                    .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
 
   std::string bucket_name = flag_bucket_name;


### PR DESCRIPTION
Some of the integration tests for failures used "localhost:0" as a
destination address that was known to fail. Recent versions of libcurl
generate a different error for those addresses. Use "localhost:1" which
should work unless the build is running on a machine running ancient
Unix.

I am planning to update our version of libcurl for external projects, and this
is a pre-requisite for that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2778)
<!-- Reviewable:end -->
