### PR TITLE
Automatically build image for benchmarks.

### DIFF
--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -92,6 +92,7 @@ RUN /usr/sbin/update-ca-certificates
 
 COPY --from=google-cloud-cpp-build /usr/local/lib /usr/local/lib
 COPY --from=google-cloud-cpp-build /usr/local/bin /usr/local/bin
+COPY --from=google-cloud-cpp-build /w/cmake-out/google/cloud/bigtable/benchmarks/*_benchmark /r/
 COPY --from=google-cloud-cpp-build /w/cmake-out/google/cloud/storage/benchmarks/*_benchmark /r/
 COPY --from=google-cloud-cpp-build /w/cmake-out/google/cloud/storage/examples/*_samples /r/
 COPY --from=google-cloud-cpp-build /w/ci/benchmarks/storage/*.sh /r

--- a/ci/benchmarks/README.md
+++ b/ci/benchmarks/README.md
@@ -20,7 +20,21 @@ Google Cloud Build:
 ```console
 $ gcloud builds submit \
     --substitutions=SHORT_SHA=$(git rev-parse --short HEAD) \
-    --config cloudbuild.yaml .
+    --config ci/benchmarks/cloudbuild.yaml .
+```
+
+## Automate the Docker image creation
+
+Finally we create a trigger to automatically build this Docker image on each
+commit to master:
+
+```console
+$ gcloud alpha builds triggers create github \
+    --project=${PROJECT_ID} \
+    --repo_name=google-cloud-cpp \
+    --repo_owner=googleapis \
+    --branch_pattern='master' \
+    --build_config=ci/benchmarks/cloudbuild.yaml
 ```
 
 ## Setting up GKE and other configuration


### PR DESCRIPTION
In this PR we describe how to automate the steps to create the Docker
image for the benchmarks. Once this is merged to `master`, we can enable
the benchmarks and save their logs, but that will come in separate PRs.

Also include the bigtable benchmarks in the image, as we will enable
those in a future PR too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2787)
<!-- Reviewable:end -->
