### PR TITLE
Reduce friction for the next import.

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -1023,31 +1023,8 @@ class InstanceAdmin {
       std::vector<std::string> const& permissions);
 
  private:
-  static inline StatusOr<google::cloud::IamPolicy> ProtoToWrapper(
-      google::iam::v1::Policy proto) {
-    google::cloud::IamPolicy result;
-    result.version = proto.version();
-    result.etag = std::move(*proto.mutable_etag());
-    for (auto& binding : *proto.mutable_bindings()) {
-      std::vector<const google::protobuf::FieldDescriptor*> field_descs;
-      binding.GetReflection()->ListFields(binding, &field_descs);
-      for (auto field_desc : field_descs) {
-        if (field_desc->name() != "members" && field_desc->name() != "role") {
-          std::stringstream os;
-          // TODO(#2732): Advise alternative API after it's implemented.
-          os << "IamBinding field \"" << field_desc->name()
-             << "\" is unknown to Bigtable C++ client. Please use a client in "
-                "another language.";
-          return Status(StatusCode::kUnimplemented, os.str());
-        }
-      }
-      for (auto& member : *binding.mutable_members()) {
-        result.bindings.AddMember(binding.role(), std::move(member));
-      }
-    }
-
-    return result;
-  }
+  static StatusOr<google::cloud::IamPolicy> ProtoToWrapper(
+      google::iam::v1::Policy proto);
 
   std::unique_ptr<PollingPolicy> clone_polling_policy() {
     return polling_policy_->clone();


### PR DESCRIPTION
Need an exclude `#include` for `google::protobuf::FieldDescriptor`
inside google. And it seems better to move the function definition to
the .cc file since (a) it is big, (b) it requires more includes, and (c)
I do not think it is that performance critical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2792)
<!-- Reviewable:end -->
