### PR TITLE
Install protos in googleapis

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -14,36 +14,77 @@
 # limitations under the License.
 # ~~~
 
+# Introduce a new TARGET property to associate proto files with a target.
+#
+# We use a function to define the property so it can be called multiple times
+# without introducing the property over and over.
+function (google_cloud_cpp_add_protos_property)
+    set_property(TARGET
+                 PROPERTY PROTO_SOURCES
+                          BRIEF_DOCS
+                          "The list of .proto files for a target."
+                          FULL_DOCS
+                          "List of .proto files specified for a target.")
+endfunction ()
+
 # Generate C++ for .proto files preserving the directory hierarchy
-function (PROTOBUF_GENERATE_CPP SRCS HDRS)
-    if (NOT ARGN)
-        message(
-            SEND_ERROR
-                "Error: PROTOBUF_GENERATE_CPP() called without any proto files")
+#
+# Receives a list of `.proto` file names and (a) creates the runs to convert
+# these files to `.pb.h` and `.pb.cc` output files, (b) returns the list of
+# `.pb.cc` files and `.pb.h` files in @p HDRS, and (c) creates the list of files
+# preserving the directory hierarchy, such that if a `.proto` file says:
+#
+# import "foo/bar/baz.proto"
+#
+# the resulting C++ code says:
+#
+# #include <foo/bar/baz.pb.h>
+#
+# Use the `PROTO_PATH` option to provide one or more directories to search for
+# proto files in the import.
+#
+# @par Example
+#
+# google_cloud_cpp_generate_proto( MY_PB_FILES "foo/bar/baz.proto"
+# "foo/bar/qux.proto" PROTO_PATH_DIRECTORIES "another/dir/with/protos")
+#
+# Note that `protoc` the protocol buffer compiler requires your protos to be
+# somewhere in the search path defined by the `--proto_path` (aka -I) options.
+# For example, if you want to generate the `.pb.{h,cc}` files for
+# `foo/bar/baz.proto` then the directory containing `foo` must be in the search
+# path.
+function (google_cloud_cpp_generate_proto SRCS)
+    cmake_parse_arguments(_opt "" "" "PROTO_PATH_DIRECTORIES" ${ARGN})
+    if (NOT _opt_UNPARSED_ARGUMENTS)
+        message(SEND_ERROR "Error: google_cloud_cpp_generate_proto() called"
+                           " without any proto files")
         return()
     endif ()
 
-    if (DEFINED PROTOBUF_IMPORT_DIRS)
-        foreach (DIR ${PROTOBUF_IMPORT_DIRS})
-            get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
-            list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-            if (${_contains_already} EQUAL -1)
-                list(APPEND _protobuf_include_path -I ${ABS_PATH})
-            endif ()
-        endforeach ()
-    endif ()
+    # Build the list of `--proto_path` options. Use the absolute path for each
+    # option given, and do not include any path more than once.
+    set(protobuf_include_path)
+    foreach (dir ${_opt_PROTO_PATH_DIRECTORIES})
+        get_filename_component(absolute_path ${dir} ABSOLUTE)
+        list(FIND protobuf_include_path "${absolute_path}"
+                  already_in_search_path)
+        if (${already_in_search_path} EQUAL -1)
+            list(APPEND protobuf_include_path "--proto_path" "${absolute_path}")
+        endif ()
+    endforeach ()
 
     set(${SRCS})
-    set(${HDRS})
-    foreach (FIL ${ARGN})
-        get_filename_component(DIR ${FIL} DIRECTORY)
-        get_filename_component(FIL_WE ${FIL} NAME_WE)
+    foreach (filename ${_opt_UNPARSED_ARGUMENTS})
+        get_filename_component(file_directory "${filename}" DIRECTORY)
+        # This gets the filename without the extension, analogous to $(basename
+        # "${filename}" .proto)
+        get_filename_component(file_stem "${filename}" NAME_WE)
 
-        # Strip all the prefixes in ${PROTOBUF_IMPORT_DIRS} from the source
-        # proto directory
-        set(D ${DIR})
-        if (DEFINED PROTOBUF_IMPORT_DIRS)
-            foreach (P ${PROTOBUF_IMPORT_DIRS})
+        # Strip all the prefixes in ${_opt_PROTO_PATH_DIRECTORIES} from the
+        # source proto directory
+        set(D "${file_directory}")
+        if (DEFINED _opt_PROTO_PATH_DIRECTORIES)
+            foreach (P ${_opt_PROTO_PATH_DIRECTORIES})
                 string(REGEX
                        REPLACE "^${P}"
                                ""
@@ -52,81 +93,83 @@ function (PROTOBUF_GENERATE_CPP SRCS HDRS)
                 set(D ${T})
             endforeach ()
         endif ()
-        set(SRC "${CMAKE_CURRENT_BINARY_DIR}/${D}/${FIL_WE}.pb.cc")
-        set(HDR "${CMAKE_CURRENT_BINARY_DIR}/${D}/${FIL_WE}.pb.h")
-        list(APPEND ${SRCS} ${SRC})
-        list(APPEND ${HDRS} ${HDR})
+        set(pb_cc "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.pb.cc")
+        set(pb_h "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.pb.h")
+        list(APPEND ${SRCS} "${pb_cc}" "${pb_h}")
         add_custom_command(
-            OUTPUT ${SRC} ${HDR}
+            OUTPUT "${pb_cc}" "${pb_h}"
             COMMAND $<TARGET_FILE:protobuf::protoc>
                     ARGS
-                    --cpp_out ${CMAKE_CURRENT_BINARY_DIR}
-                              ${_protobuf_include_path} ${FIL}
-            DEPENDS ${FIL} protobuf::protoc
-            COMMENT "Running C++ protocol buffer compiler on ${FIL}"
+                    --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+                              ${protobuf_include_path} "${filename}"
+            DEPENDS "${filename}" protobuf::protoc
+            COMMENT "Running C++ protocol buffer compiler on ${filename}"
             VERBATIM)
     endforeach ()
 
-    set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+    set_source_files_properties(${${SRCS}} PROPERTIES GENERATED TRUE)
     set(${SRCS} ${${SRCS}} PARENT_SCOPE)
-    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
 endfunction ()
 
-# Generate gRPC  C++ code from .profo files, preserving the directory hierarchy.
-# See https://github.com/coryan/jaybeams/issues/158 for my rant on the subject.
-function (GRPC_GENERATE_CPP SRCS HDRS)
-    grpc_generate_cpp_base(${SRCS} ${HDRS} UNUSED False ${ARGN})
-    set(${SRCS} ${${SRCS}} PARENT_SCOPE)
-    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
-endfunction ()
-
-# Generate gRPC C++ mock classes from .proto files, preserving the directory
-# hierarchy. See https://github.com/coryan/jaybeams/issues/158 for my rant on
-# the subject.
-function (GRPC_GENERATE_CPP_MOCKS SRCS HDRS MHDRS)
-    grpc_generate_cpp_base(${SRCS} ${HDRS} ${MHDRS} True ${ARGN})
-    set(${SRCS} ${${SRCS}} PARENT_SCOPE)
-    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
-    set(${MHDRS} ${${MHDRS}} PARENT_SCOPE)
-endfunction ()
-
-# Refactor common sections of GRPC_GENERATE_CPP_MOCKS() and GRPC_GENERATE_CPP().
-function (GRPC_GENERATE_CPP_BASE SRCS HDRS MHDRS WITH_MOCK)
-    if (NOT ARGN)
+# Generate gRPC C++ files from .proto files preserving the directory hierarchy.
+#
+# Receives a list of `.proto` file names and (a) creates the runs to convert
+# these files to `.grpc.pb.h` and `.grpc.pb.cc` output files, (b) returns the
+# list of `.grpc.pb.cc` and `.pb.h` files in @p SRCS, and (c) creates the list
+# of files preserving the directory hierarchy, such that if a `.proto` file says
+#
+# import "foo/bar/baz.proto"
+#
+# the resulting C++ code says:
+#
+# #include <foo/bar/baz.pb.h>
+#
+# Use the `PROTO_PATH` option to provide one or more directories to search for
+# proto files in the import.
+#
+# @par Example
+#
+# google_cloud_cpp_generate_grpc( MY_GRPC_PB_FILES "foo/bar/baz.proto"
+# "foo/bar/qux.proto" PROTO_PATH_DIRECTORIES "another/dir/with/protos")
+#
+# Note that `protoc` the protocol buffer compiler requires your protos to be
+# somewhere in the search path defined by the `--proto_path` (aka -I) options.
+# For example, if you want to generate the `.pb.{h,cc}` files for
+# `foo/bar/baz.proto` then the directory containing `foo` must be in the search
+# path.
+function (google_cloud_cpp_generate_grpcpp SRCS)
+    cmake_parse_arguments(_opt "" "" "PROTO_PATH_DIRECTORIES" ${ARGN})
+    if (NOT _opt_UNPARSED_ARGUMENTS)
         message(
-            SEND_ERROR
-                "Error: GRPC_GENERATE_CPP_BASE() called without any proto files"
-            )
+            SEND_ERROR "Error: google_cloud_cpp_generate_grpc() called without"
+                       " any proto files")
         return()
     endif ()
 
-    set(GRPC_OUT_EXTRA)
-    if (${WITH_MOCK})
-        set(GRPC_OUT_EXTRA "generate_mock_code=true:")
-    endif ()
-
-    if (DEFINED PROTOBUF_IMPORT_DIRS)
-        foreach (DIR ${PROTOBUF_IMPORT_DIRS})
-            get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
-            list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-            if (${_contains_already} EQUAL -1)
-                list(APPEND _protobuf_include_path -I ${ABS_PATH})
-            endif ()
-        endforeach ()
-    endif ()
+    # Build the list of `--proto_path` options. Use the absolute path for each
+    # option given, and do not include any path more than once.
+    set(protobuf_include_path)
+    foreach (dir ${_opt_PROTO_PATH_DIRECTORIES})
+        get_filename_component(absolute_path ${dir} ABSOLUTE)
+        list(FIND protobuf_include_path "${absolute_path}"
+                  already_in_search_path)
+        if (${already_in_search_path} EQUAL -1)
+            list(APPEND protobuf_include_path "--proto_path" "${absolute_path}")
+        endif ()
+    endforeach ()
 
     set(${SRCS})
-    set(${HDRS})
-    set(${MHDRS})
-    foreach (FIL ${ARGN})
-        get_filename_component(DIR ${FIL} DIRECTORY)
-        get_filename_component(FIL_WE ${FIL} NAME_WE)
+    foreach (filename ${_opt_UNPARSED_ARGUMENTS})
+        get_filename_component(file_directory "${filename}" DIRECTORY)
+        # This gets the filename without the extension, analogous to $(basename
+        # "${filename}" .proto)
+        get_filename_component(file_stem "${filename}" NAME_WE)
 
-        # Strip all the prefixes in ${PROTOBUF_IMPORT_DIRS} from the source
-        # proto directory
-        set(D ${DIR})
-        if (DEFINED PROTOBUF_IMPORT_DIRS)
-            foreach (P ${PROTOBUF_IMPORT_DIRS})
+        # Strip all the prefixes in ${_opt_PROTO_PATH_DIRECTORIES} from the
+        # source proto directory
+        set(D "${file_directory}")
+        if (DEFINED _opt_PROTO_PATH_DIRECTORIES)
+            foreach (P ${_opt_PROTO_PATH_DIRECTORIES})
                 string(REGEX
                        REPLACE "^${P}"
                                ""
@@ -135,31 +178,109 @@ function (GRPC_GENERATE_CPP_BASE SRCS HDRS MHDRS WITH_MOCK)
                 set(D ${T})
             endforeach ()
         endif ()
-        set(SRC "${CMAKE_CURRENT_BINARY_DIR}/${D}/${FIL_WE}.grpc.pb.cc")
-        set(HDR "${CMAKE_CURRENT_BINARY_DIR}/${D}/${FIL_WE}.grpc.pb.h")
-        set(MHDR "${CMAKE_CURRENT_BINARY_DIR}/${D}/${FIL_WE}_mock.grpc.pb.h")
-        list(APPEND ${SRCS} "${SRC}")
-        list(APPEND ${HDRS} "${HDR}")
-        list(APPEND ${MHDRS} "${MHDR}")
+        set(grpc_pb_cc
+            "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.grpc.pb.cc")
+        set(grpc_pb_h "${CMAKE_CURRENT_BINARY_DIR}/${D}/${file_stem}.grpc.pb.h")
+        list(APPEND ${SRCS} "${grpc_pb_cc}" "${grpc_pb_h}")
         add_custom_command(
-            OUTPUT "${SRC}" "${HDR}"
+            OUTPUT "${grpc_pb_cc}" "${grpc_pb_h}"
             COMMAND
                 $<TARGET_FILE:protobuf::protoc>
                 ARGS
                 --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
-                --grpc_out=${GRPC_OUT_EXTRA}${CMAKE_CURRENT_BINARY_DIR}
-                --cpp_out=${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path}
-                                                      ${FIL}
-            DEPENDS ${FIL} protobuf::protoc gRPC::grpc_cpp_plugin
-            COMMENT "Running gRPC++ protocol buffer compiler on ${FIL}"
+                    "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
+                    "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
+                    ${protobuf_include_path} "${filename}"
+            DEPENDS "${filename}" protobuf::protoc gRPC::grpc_cpp_plugin
+            COMMENT "Running gRPC C++ protocol buffer compiler on ${filename}"
             VERBATIM)
     endforeach ()
 
-    set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+    set_source_files_properties(${${SRCS}} PROPERTIES GENERATED TRUE)
     set(${SRCS} ${${SRCS}} PARENT_SCOPE)
-    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
-    if (${WITH_MOCK})
-        set_source_files_properties(${${MHDRS}} PROPERTIES GENERATED TRUE)
-        set(${MHDRS} ${${MHDRS}} PARENT_SCOPE)
+endfunction ()
+
+include(GNUInstallDirs)
+
+# Install headers for a C++ proto library.
+function (google_cloud_cpp_install_proto_library_headers target)
+    get_target_property(target_sources ${target} SOURCES)
+    foreach (header ${target_sources})
+        # Skip anything that is not a header file.
+        if (NOT "${header}" MATCHES "\\.h$")
+            continue()
+        endif ()
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
+                       ""
+                       relative
+                       "${header}")
+        get_filename_component(dir "${relative}" DIRECTORY)
+        install(FILES "${header}" DESTINATION
+                      "${CMAKE_INSTALL_INCLUDEDIR}/${dir}")
+    endforeach ()
+endfunction ()
+
+# Install protos for a C++ proto library.
+function (google_cloud_cpp_install_proto_library_protos target)
+    get_target_property(target_protos ${target} PROTO_SOURCES)
+    foreach (header ${target_protos})
+        # Skip anything that is not a header file.
+        if (NOT "${header}" MATCHES "\\.proto$")
+            continue()
+        endif ()
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
+                       ""
+                       relative
+                       "${header}")
+        get_filename_component(dir "${relative}" DIRECTORY)
+        # This is modeled after the Protobuf library, it installs the basic
+        # protos (think google/protobuf/any.proto) in the include directory for
+        # C/C++ code. :shrug:
+        install(FILES "${header}" DESTINATION
+                      "${CMAKE_INSTALL_INCLUDEDIR}/${dir}")
+    endforeach ()
+endfunction ()
+
+function (google_cloud_cpp_proto_library libname)
+    cmake_parse_arguments(_opt "" "" "PROTO_PATH_DIRECTORIES" ${ARGN})
+    if (NOT _opt_UNPARSED_ARGUMENTS)
+        message(SEND_ERROR "Error: google_cloud_cpp_proto_library() called"
+                           " without any proto files")
+        return()
     endif ()
+
+    google_cloud_cpp_generate_proto(proto_sources
+                                    ${_opt_UNPARSED_ARGUMENTS}
+                                    PROTO_PATH_DIRECTORIES
+                                    ${_opt_PROTO_PATH_DIRECTORIES})
+
+    add_library(${libname} ${proto_sources})
+    set_property(TARGET ${libname}
+                 PROPERTY PROTO_SOURCES ${_opt_UNPARSED_ARGUMENTS})
+    target_link_libraries(${libname}
+                          PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+    target_include_directories(
+        ${libname}
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+               $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+               $<INSTALL_INTERFACE:include>)
+endfunction ()
+
+function (google_cloud_cpp_grpcpp_library libname)
+    cmake_parse_arguments(_opt "" "" "PROTO_PATH_DIRECTORIES" ${ARGN})
+    if (NOT _opt_UNPARSED_ARGUMENTS)
+        message(SEND_ERROR "Error: google_cloud_cpp_proto_library() called"
+                           " without any proto files")
+        return()
+    endif ()
+
+    google_cloud_cpp_generate_grpcpp(grpcpp_sources
+                                     ${_opt_UNPARSED_ARGUMENTS}
+                                     PROTO_PATH_DIRECTORIES
+                                     ${_opt_PROTO_PATH_DIRECTORIES})
+    google_cloud_cpp_proto_library(${libname}
+                                   ${_opt_UNPARSED_ARGUMENTS}
+                                   PROTO_PATH_DIRECTORIES
+                                   ${_opt_PROTO_PATH_DIRECTORIES})
+    target_sources(${libname} PRIVATE ${grpcpp_sources})
 endfunction ()

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -130,7 +130,6 @@ if (NOT TARGET googleapis_project)
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
-                   -DGOOGLE_CLOUD_CPP_USE_LIBCXX=${GOOGLE_CLOUD_CPP_USE_LIBCXX}
                    ${_googleapis_toolchain_flag}
                    ${_googleapis_triplet_flag}
         BUILD_COMMAND ${CMAKE_COMMAND}
@@ -139,9 +138,9 @@ if (NOT TARGET googleapis_project)
                       ${PARALLEL}
         BUILD_BYPRODUCTS ${googleapis_byproducts}
         LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
-        LOG_BUILD ON
-        LOG_INSTALL ON)
+        LOG_CONFIGURE OFF
+        LOG_BUILD OFF
+        LOG_INSTALL OFF)
 
     unset(_googleapis_toolchain_flag)
     unset(_googleapis_triplet_flag)

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -138,9 +138,9 @@ if (NOT TARGET googleapis_project)
                       ${PARALLEL}
         BUILD_BYPRODUCTS ${googleapis_byproducts}
         LOG_DOWNLOAD ON
-        LOG_CONFIGURE OFF
-        LOG_BUILD OFF
-        LOG_INSTALL OFF)
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
 
     unset(_googleapis_toolchain_flag)
     unset(_googleapis_triplet_flag)

--- a/cmake/external/googleapis/CMakeLists.txt
+++ b/cmake/external/googleapis/CMakeLists.txt
@@ -24,6 +24,13 @@ set(GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR 0)
 set(GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR 2)
 set(GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH 0)
 
+string(CONCAT GOOGLE_APIS_CPP_PROTOS_VERSION
+              "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}"
+              "."
+              "${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}"
+              "."
+              "${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}")
+
 # Configure the compiler options, we will be using C++11 features.
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -33,6 +40,7 @@ find_package(ProtobufTargets REQUIRED)
 find_package(gRPC REQUIRED)
 
 # Configure the location of proto files, particulary the googleapis protos.
+# TODO(coryan) - remove once all libraries are refactored.
 list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_SOURCE_DIR}")
 
 # Sometimes (this happens often with vcpkg) protobuf is installed in a non-
@@ -43,388 +51,167 @@ if (PROTO_INCLUDE_DIR)
     list(INSERT PROTOBUF_IMPORT_DIRS 0 "${PROTO_INCLUDE_DIR}")
 endif ()
 
-# Include the functions to compile proto files.
-include(CompileProtos)
-
 add_library(googleapis_cpp_common_flags INTERFACE)
 
 include(SelectMSVCRuntime)
 
-protobuf_generate_cpp(API_HTTP_PROTO_SOURCES API_HTTP_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/api/http.proto)
-grpc_generate_cpp(API_HTTP_GRPCPP_SOURCES API_HTTP_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/api/http.proto)
-add_library(googleapis_cpp_api_http_protos
-            ${API_HTTP_PROTO_SOURCES}
-            ${API_HTTP_PROTO_HDRS}
-            ${API_HTTP_GRPCPP_SOURCES}
-            ${API_HTTP_GRPCPP_HDRS})
-target_link_libraries(googleapis_cpp_api_http_protos
-                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
-                      PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_api_http_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_api_http_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(
-    googleapis-c++::api_http_protos ALIAS googleapis_cpp_api_http_protos)
+# Include the functions to compile proto files.
+include(CompileProtos)
 
-protobuf_generate_cpp(API_ANNOTATIONS_PROTO_SOURCES API_ANNOTATIONS_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/api/annotations.proto)
-grpc_generate_cpp(API_ANNOTATIONS_GRPCPP_SOURCES API_ANNOTATIONS_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/api/annotations.proto)
-add_library(googleapis_cpp_api_annotations_protos
-            ${API_ANNOTATIONS_PROTO_SOURCES}
-            ${API_ANNOTATIONS_PROTO_HDRS}
-            ${API_ANNOTATIONS_GRPCPP_SOURCES}
-            ${API_ANNOTATIONS_GRPCPP_HDRS})
+google_cloud_cpp_add_protos_property()
+
+function (googleapis_cpp_set_version_and_alias short_name)
+    set_target_properties("googleapis_cpp_${short_name}"
+                          PROPERTIES VERSION
+                                     "${GOOGLE_APIS_CPP_PROTOS_VERSION}"
+                                     SOVERSION
+                                     ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
+    add_library("googleapis-c++::${short_name}" ALIAS
+                "googleapis_cpp_${short_name}")
+endfunction ()
+
+google_cloud_cpp_grpcpp_library(googleapis_cpp_api_http_protos
+                                google/api/http.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(api_http_protos)
+target_link_libraries(googleapis_cpp_api_http_protos
+                      PRIVATE googleapis_cpp_common_flags)
+
+google_cloud_cpp_grpcpp_library(googleapis_cpp_api_annotations_protos
+                                google/api/annotations.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(api_annotations_protos)
 target_link_libraries(googleapis_cpp_api_annotations_protos
                       PUBLIC googleapis-c++::api_http_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_api_annotations_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_api_annotations_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::api_annotations_protos ALIAS
-            googleapis_cpp_api_annotations_protos)
 
-protobuf_generate_cpp(API_AUTH_PROTO_SOURCES API_AUTH_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/api/auth.proto)
-grpc_generate_cpp(API_AUTH_GRPCPP_SOURCES API_AUTH_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/api/auth.proto)
-add_library(googleapis_cpp_api_auth_protos
-            ${API_AUTH_PROTO_SOURCES}
-            ${API_AUTH_PROTO_HDRS}
-            ${API_AUTH_GRPCPP_SOURCES}
-            ${API_AUTH_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_api_auth_protos
+                                google/api/auth.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(api_auth_protos)
 target_link_libraries(googleapis_cpp_api_auth_protos
                       PUBLIC googleapis-c++::api_annotations_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_api_auth_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_api_auth_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(
-    googleapis-c++::api_auth_protos ALIAS googleapis_cpp_api_auth_protos)
 
-protobuf_generate_cpp(API_RESOURCE_PROTO_SOURCES API_RESOURCE_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/api/resource.proto)
-grpc_generate_cpp(API_RESOURCE_GRPCPP_SOURCES API_RESOURCE_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/api/resource.proto)
-add_library(googleapis_cpp_api_resource_protos
-            ${API_RESOURCE_PROTO_SOURCES}
-            ${API_RESOURCE_PROTO_HDRS}
-            ${API_RESOURCE_GRPCPP_SOURCES}
-            ${API_RESOURCE_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_api_resource_protos
+                                google/api/resource.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(api_resource_protos)
 target_link_libraries(googleapis_cpp_api_resource_protos
-                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_api_resource_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_api_resource_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::api_resource_protos ALIAS
-            googleapis_cpp_api_resource_protos)
 
-protobuf_generate_cpp(TYPE_EXPR_PROTO_SOURCES TYPE_EXPR_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/type/expr.proto)
-add_library(googleapis_cpp_type_expr_protos ${TYPE_EXPR_PROTO_SOURCES}
-            ${TYPE_EXPR_PROTO_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_type_expr_protos
+                                google/type/expr.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(type_expr_protos)
 target_link_libraries(googleapis_cpp_type_expr_protos
-                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_type_expr_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_type_expr_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::type_expr_protos ALIAS
-            googleapis_cpp_type_expr_protos)
 
-protobuf_generate_cpp(RPC_ERROR_DETAILS_PROTO_SOURCES
-                      RPC_ERROR_DETAILS_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/rpc/error_details.proto)
-grpc_generate_cpp(RPC_ERROR_DETAILS_GRPCPP_SOURCES RPC_ERROR_DETAILS_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/rpc/error_details.proto)
-add_library(googleapis_cpp_rpc_error_details_protos
-            ${RPC_ERROR_DETAILS_PROTO_SOURCES}
-            ${RPC_ERROR_DETAILS_PROTO_HDRS}
-            ${RPC_ERROR_DETAILS_GRPCPP_SOURCES}
-            ${RPC_ERROR_DETAILS_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_rpc_error_details_protos
+                                google/rpc/error_details.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(rpc_error_details_protos)
 target_link_libraries(googleapis_cpp_rpc_error_details_protos
-                      PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_rpc_error_details_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_rpc_error_details_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::rpc_error_details_protos ALIAS
-            googleapis_cpp_rpc_error_details_protos)
 
-protobuf_generate_cpp(RPC_STATUS_PROTO_SOURCES RPC_STATUS_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/rpc/status.proto)
-grpc_generate_cpp(RPC_STATUS_GRPCPP_SOURCES RPC_STATUS_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/rpc/status.proto)
-add_library(googleapis_cpp_rpc_status_protos
-            ${RPC_STATUS_PROTO_SOURCES}
-            ${RPC_STATUS_PROTO_HDRS}
-            ${RPC_STATUS_GRPCPP_SOURCES}
-            ${RPC_STATUS_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_rpc_status_protos
+                                google/rpc/status.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(rpc_status_protos)
 target_link_libraries(googleapis_cpp_rpc_status_protos
                       PUBLIC googleapis-c++::rpc_error_details_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_rpc_status_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_rpc_status_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::rpc_status_protos ALIAS
-            googleapis_cpp_rpc_status_protos)
 
-protobuf_generate_cpp(IAM_V1_POLICY_PROTO_SOURCES IAM_V1_POLICY_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/iam/v1/policy.proto)
-grpc_generate_cpp(IAM_V1_POLICY_GRPCPP_SOURCES IAM_V1_POLICY_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/iam/v1/policy.proto)
-add_library(googleapis_cpp_iam_v1_policy_protos
-            ${IAM_V1_POLICY_PROTO_SOURCES}
-            ${IAM_V1_POLICY_PROTO_HDRS}
-            ${IAM_V1_POLICY_GRPCPP_SOURCES}
-            ${IAM_V1_POLICY_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_iam_v1_policy_protos
+                                google/iam/v1/policy.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(iam_v1_policy_protos)
 target_link_libraries(googleapis_cpp_iam_v1_policy_protos
                       PUBLIC googleapis-c++::api_annotations_protos
                              googleapis-c++::api_resource_protos
                              googleapis-c++::type_expr_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_iam_v1_policy_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_iam_v1_policy_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::iam_v1_policy_protos ALIAS
-            googleapis_cpp_iam_v1_policy_protos)
 
-protobuf_generate_cpp(IAM_V1_IAM_POLICY_PROTO_SOURCES
-                      IAM_V1_IAM_POLICY_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/iam/v1/iam_policy.proto)
-grpc_generate_cpp(IAM_V1_IAM_POLICY_GRPCPP_SOURCES IAM_V1_IAM_POLICY_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/iam/v1/iam_policy.proto)
-add_library(googleapis_cpp_iam_v1_iam_policy_protos
-            ${IAM_V1_IAM_POLICY_PROTO_SOURCES}
-            ${IAM_V1_IAM_POLICY_PROTO_HDRS}
-            ${IAM_V1_IAM_POLICY_GRPCPP_SOURCES}
-            ${IAM_V1_IAM_POLICY_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_iam_v1_iam_policy_protos
+                                google/iam/v1/iam_policy.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(iam_v1_iam_policy_protos)
 target_link_libraries(googleapis_cpp_iam_v1_iam_policy_protos
                       PUBLIC googleapis-c++::api_annotations_protos
                              googleapis-c++::iam_v1_policy_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_iam_v1_iam_policy_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_iam_v1_iam_policy_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::iam_v1_iam_policy_protos ALIAS
-            googleapis_cpp_iam_v1_iam_policy_protos)
 
-protobuf_generate_cpp(LONGRUNNING_OPERATIONS_PROTO_SOURCES
-                      LONGRUNNING_OPERATIONS_PROTO_HDRS
-                      ${PROJECT_SOURCE_DIR}/google/longrunning/operations.proto)
-grpc_generate_cpp(LONGRUNNING_OPERATIONS_GRPCPP_SOURCES
-                  LONGRUNNING_OPERATIONS_GRPCPP_HDRS
-                  ${PROJECT_SOURCE_DIR}/google/longrunning/operations.proto)
-add_library(googleapis_cpp_longrunning_operations_protos
-            ${LONGRUNNING_OPERATIONS_PROTO_SOURCES}
-            ${LONGRUNNING_OPERATIONS_PROTO_HDRS}
-            ${LONGRUNNING_OPERATIONS_GRPCPP_SOURCES}
-            ${LONGRUNNING_OPERATIONS_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(googleapis_cpp_longrunning_operations_protos
+                                google/longrunning/operations.proto
+                                PROTO_PATH_DIRECTORIES
+                                "${PROJECT_SOURCE_DIR}"
+                                "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(longrunning_operations_protos)
 target_link_libraries(googleapis_cpp_longrunning_operations_protos
                       PUBLIC googleapis-c++::api_annotations_protos
                              googleapis-c++::rpc_status_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_longrunning_operations_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_longrunning_operations_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::longrunning_operations_protos ALIAS
-            googleapis_cpp_longrunning_operations_protos)
 
-protobuf_generate_cpp(
-    BIGTABLE_PROTO_SOURCES
-    BIGTABLE_PROTO_HDRS
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_instance_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_table_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/common.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/instance.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/table.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/v2/bigtable.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/v2/data.proto)
-grpc_generate_cpp(
-    BIGTABLE_GRPCPP_SOURCES
-    BIGTABLE_GRPCPP_HDRS
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_instance_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/admin/v2/bigtable_table_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/bigtable/v2/bigtable.proto
-    ${PROJECT_SOURCE_DIR}/google/longrunning/operations.proto)
-
-# Create a library with the generated files from the relevant protos. When
-# adding new services (e.g. Spanner) please create a new library and refactor
-# common protos
-add_library(googleapis_cpp_bigtable_protos
-            ${BIGTABLE_PROTO_SOURCES}
-            ${BIGTABLE_PROTO_HDRS}
-            ${BIGTABLE_GRPCPP_SOURCES}
-            ${BIGTABLE_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(
+    googleapis_cpp_bigtable_protos
+    google/bigtable/admin/v2/bigtable_instance_admin.proto
+    google/bigtable/admin/v2/bigtable_table_admin.proto
+    google/bigtable/admin/v2/common.proto
+    google/bigtable/admin/v2/instance.proto
+    google/bigtable/admin/v2/table.proto
+    google/bigtable/v2/bigtable.proto
+    google/bigtable/v2/data.proto
+    PROTO_PATH_DIRECTORIES
+    "${PROJECT_SOURCE_DIR}"
+    "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(bigtable_protos)
 target_link_libraries(googleapis_cpp_bigtable_protos
                       PUBLIC googleapis-c++::api_annotations_protos
                              googleapis-c++::api_auth_protos
                              googleapis-c++::longrunning_operations_protos
                              googleapis-c++::rpc_status_protos
                              googleapis-c++::iam_v1_iam_policy_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_bigtable_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_bigtable_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(
-    googleapis-c++::bigtable_protos ALIAS googleapis_cpp_bigtable_protos)
 
-protobuf_generate_cpp(
-    SPANNER_PROTO_SOURCES
-    SPANNER_PROTO_HDRS
-    ${PROJECT_SOURCE_DIR}/google/spanner/admin/database/v1/spanner_database_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/admin/instance/v1/spanner_instance_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/keys.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/mutation.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/query_plan.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/result_set.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/spanner.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/transaction.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/type.proto)
-grpc_generate_cpp(
-    SPANNER_GRPCPP_SOURCES
-    SPANNER_GRPCPP_HDRS
-    ${PROJECT_SOURCE_DIR}/google/spanner/admin/database/v1/spanner_database_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/admin/instance/v1/spanner_instance_admin.proto
-    ${PROJECT_SOURCE_DIR}/google/spanner/v1/spanner.proto)
-add_library(googleapis_cpp_spanner_protos
-            ${SPANNER_PROTO_SOURCES}
-            ${SPANNER_PROTO_HDRS}
-            ${SPANNER_GRPCPP_SOURCES}
-            ${SPANNER_GRPCPP_HDRS})
+google_cloud_cpp_grpcpp_library(
+    googleapis_cpp_spanner_protos
+    google/spanner/admin/database/v1/spanner_database_admin.proto
+    google/spanner/admin/instance/v1/spanner_instance_admin.proto
+    google/spanner/v1/keys.proto
+    google/spanner/v1/mutation.proto
+    google/spanner/v1/query_plan.proto
+    google/spanner/v1/result_set.proto
+    google/spanner/v1/spanner.proto
+    google/spanner/v1/transaction.proto
+    google/spanner/v1/type.proto
+    PROTO_PATH_DIRECTORIES
+    "${PROJECT_SOURCE_DIR}"
+    "${PROTO_INCLUDE_DIR}")
+googleapis_cpp_set_version_and_alias(spanner_protos)
 target_link_libraries(googleapis_cpp_spanner_protos
                       PUBLIC googleapis-c++::api_annotations_protos
                              googleapis-c++::longrunning_operations_protos
                              googleapis-c++::rpc_status_protos
                              googleapis-c++::iam_v1_iam_policy_protos
-                             gRPC::grpc++
-                             gRPC::grpc
-                             protobuf::libprotobuf
                       PRIVATE googleapis_cpp_common_flags)
-target_include_directories(googleapis_cpp_spanner_protos
-                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-                                  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include>)
-set_target_properties(
-    googleapis_cpp_spanner_protos
-    PROPERTIES
-        VERSION
-        "${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_MINOR}.${GOOGLEAPIS_CPP_PROTOS_VERSION_PATCH}"
-        SOVERSION
-        ${GOOGLEAPIS_CPP_PROTOS_VERSION_MAJOR})
-add_library(googleapis-c++::spanner_protos ALIAS googleapis_cpp_spanner_protos)
 
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs
@@ -451,26 +238,9 @@ install(TARGETS ${googleapis_cpp_installed_libraries_list}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# Install proto generated files into include/google.
-function (googleapis_cpp_install_headers target)
-    get_target_property(target_sources ${target} SOURCES)
-    foreach (header ${target_sources})
-        # Skip anything that is not a header file.
-        if (NOT "${header}" MATCHES "\\.h$")
-            continue()
-        endif ()
-        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/"
-                       ""
-                       relative
-                       "${header}")
-        get_filename_component(dir "${relative}" DIRECTORY)
-        install(FILES "${header}" DESTINATION
-                      "${CMAKE_INSTALL_INCLUDEDIR}/${dir}")
-    endforeach ()
-endfunction ()
-
 foreach (target ${googleapis_cpp_installed_libraries_list})
-    googleapis_cpp_install_headers("${target}")
+    google_cloud_cpp_install_proto_library_headers("${target}")
+    google_cloud_cpp_install_proto_library_protos("${target}")
 endforeach ()
 
 # Export the CMake targets to make it easy to create configuration files.


### PR DESCRIPTION
When we compile the googleapi libraries we should install their proto
files too, that way other protos that import them may use them too. I
refactored the code to generate these libraries because it was really
tedious to change them otherwise. Note that the destination directory
for these proto files is `$PREFIX/include`, the protobuf library places
its own protos there, so I figured it was the right place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2799)
<!-- Reviewable:end -->
