### PR TITLE
Change refdocs portion of the release process

### DIFF
--- a/ci/kokoro/refdocs.sh
+++ b/ci/kokoro/refdocs.sh
@@ -69,12 +69,13 @@ if [[ -z "${KOKORO_GITHUB_COMMIT:-}" ]]; then
   echo "KOKORO_GITHUB_COMMIT not found, aborting..."
   exit 1
 else
-  branch=$(git branch --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
+  branch=$(git branch --all --no-color --contains "${KOKORO_GITHUB_COMMIT}" \
     | grep -v HEAD | head -1)
   # trim branch
   shopt -s extglob
   branch="${branch##*( )}"
   branch="${branch%%*( )}"
+  branch="${branch##remotes/origin/}"
   shopt -u extglob
   echo "branch detected: ${branch}"
 fi

--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -93,12 +93,13 @@ git push --set-upstream origin "${RELEASE}.x"
 
 ## Generate and upload the documentation to googleapis.dev
 
-Manually run a kokoro job
-`prod:cloud-devrel/client-libraries/cpp/google-cloud-cpp/refdocs` with
-specifying the branch name (e.g. `v0.11.x`) as `Committish` field. This job will
-generate and upload the doxygen documentation to the staging bucket for
-googleapis.dev hosting. The uploaded documentation will be live generally in an
-hour at URLs like `https://googleapis.dev/cpp/google-cloud-bigtable/latest/`.
+Manually run a Kokoro job
+`cloud-devrel/client-libraries/cpp/google-cloud-cpp/refdocs` in the Cloud C++
+internal testing dashboard and specify the branch name (e.g. `v0.11.x`) in the
+`Committish` field. This job will generate and upload the doxygen documentation
+to the staging bucket for googleapis.dev hosting. The uploaded documentation
+will generally be live in an hour at URLs like
+`https://googleapis.dev/cpp/google-cloud-bigtable/latest/`.
 
 You are now finished with this "releases" clone of the repo that we created in
 the instructions above. You may now remove this directory.

--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -91,27 +91,14 @@ git push --set-upstream origin "${RELEASE}.x"
 
 **NOTE:** No code review or Pull Request is needed as part of this step.
 
-## Update the documentation links
+## Generate and upload the documentation to googleapis.dev
 
-Pushing the branch should start the CI builds. You can find and watch the
-triggered builds at https://travis-ci.com/googleapis/google-cloud-cpp. One of
-the CI builds automatically pushes a new version of the documentation to the
-`gh-pages` branch. Wait for this build to complete, then you should checkout
-`gh-pages` and change the `index.html` page to link to this new version and
-commit it:
-
-```bash
-git checkout gh-pages
-git pull
-```
-
-Change the value of the meta tag's `URL=` parameter to refer to the
-`index.html` file in the directory matching the new release version number.
-
-```
-git commit -am "Update documentation to ${RELEASE}"
-git push
-```
+Manually run a kokoro job
+`prod:cloud-devrel/client-libraries/cpp/google-cloud-cpp/refdocs` with
+specifying the branch name (e.g. `v0.11.x`) as `Committish` field. This job will
+generate and upload the doxygen documentation to the staging bucket for
+googleapis.dev hosting. The uploaded documentation will be live generally in an
+hour at URLs like `https://googleapis.dev/cpp/google-cloud-bigtable/latest/`.
 
 You are now finished with this "releases" clone of the repo that we created in
 the instructions above. You may now remove this directory.


### PR DESCRIPTION
I already put a new `index.html` in the gh-pages branch with links to googleapis.dev.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2801)
<!-- Reviewable:end -->
