### PR TITLE
bug: Use separate service account in CI tests.

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -143,14 +143,15 @@ echo
 echo "================================================================"
 echo "Running Google Cloud Storage Integration Tests $(date)"
 echo "================================================================"
-TEST_SERVICE_ACCOUNT_NAME="hmac-sa-${RANDOM}-${RANDOM}-${RANDOM}"
-TEST_SERVICE_ACCOUNT="${TEST_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
-export TEST_SERVICE_ACCOUNT
+# Recall that each evaluation of ${RANDOM} produces a different value.
+HMAC_SERVICE_ACCOUNT_NAME="hmac-sa-$(date +%s)-${RANDOM}"
+HMAC_SERVICE_ACCOUNT="${HMAC_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+export HMAC_SERVICE_ACCOUNT
 
 gcloud iam service-accounts create "--project=${PROJECT_ID}" \
-    "${TEST_SERVICE_ACCOUNT_NAME}"
-gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-    --member "serviceAccount:${TEST_SERVICE_ACCOUNT}" \
+    "${HMAC_SERVICE_ACCOUNT_NAME}"
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member "serviceAccount:${HMAC_SERVICE_ACCOUNT}" \
     --role roles/iam.serviceAccountTokenCreator
 
 echo "Create service account to run the tests."
@@ -164,7 +165,7 @@ echo "Running Google Cloud Storage Examples"
 storage_examples_status=$?
 set -e
 
-gcloud iam service-accounts delete "${TEST_SERVICE_ACCOUNT}"
+gcloud iam service-accounts delete "${HMAC_SERVICE_ACCOUNT}"
 
 if [[ "${storage_integration_test_status}" != 0 ]]; then
   echo "Error in integration tests."

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -169,7 +169,7 @@ echo "Running Google Cloud Storage Examples"
 storage_examples_status=$?
 set -e
 
-gcloud iam service-accounts delete "${HMAC_SERVICE_ACCOUNT}"
+gcloud iam service-accounts delete --quiet "${HMAC_SERVICE_ACCOUNT}"
 
 if [[ "${storage_integration_test_status}" != 0 ]]; then
   echo "Error in integration tests."

--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -20,9 +20,6 @@ echo "================================================================"
 echo "Running Bazel build with integration tests against production $(date)."
 echo "================================================================"
 
-echo "Reading CI secret configuration parameters."
-source "${KOKORO_GFILE_DIR}/test-configuration.sh"
-
 echo "Running build and tests"
 cd "$(dirname "$0")/../../.."
 readonly PROJECT_ROOT="${PWD}"
@@ -95,10 +92,6 @@ echo "================================================================"
 echo "Download dependencies for integration tests $(date)."
 echo "================================================================"
 
-export TEST_KEY_FILE_JSON="${KOKORO_GFILE_DIR}/service-account.json"
-export TEST_KEY_FILE_P12="${KOKORO_GFILE_DIR}/service-account.p12"
-export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
-
 # Download the gRPC `roots.pem` file. Somewhere inside the bowels of Bazel, this
 # file might exist, but my attempts at using it have failed.
 echo "    Getting roots.pem for gRPC."
@@ -118,6 +111,15 @@ sha256sum google-cloud-sdk-233.0.0-linux-x86_64.tar.gz | \
 tar x -C "${HOME}" -f google-cloud-sdk-233.0.0-linux-x86_64.tar.gz
 "${HOME}/google-cloud-sdk/bin/gcloud" --quiet components install cbt
 export CBT="${HOME}/google-cloud-sdk/bin/cbt"
+
+echo "================================================================"
+echo "Setup environment for integration tests $(date)"
+export TEST_KEY_FILE_JSON="${KOKORO_GFILE_DIR}/service-account.json"
+export TEST_KEY_FILE_P12="${KOKORO_GFILE_DIR}/service-account.p12"
+export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
+
+echo "Reading CI secret configuration parameters."
+source "${KOKORO_GFILE_DIR}/test-configuration.sh"
 
 if [[ "${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS:-}" = "yes" ]]; then
   echo
@@ -148,6 +150,8 @@ HMAC_SERVICE_ACCOUNT_NAME="hmac-sa-$(date +%s)-${RANDOM}"
 HMAC_SERVICE_ACCOUNT="${HMAC_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 export HMAC_SERVICE_ACCOUNT
 
+gcloud auth activate-service-account --key-file \
+    "${KOKORO_GFILE_DIR}/service-account.json"
 gcloud iam service-accounts create "--project=${PROJECT_ID}" \
     "${HMAC_SERVICE_ACCOUNT_NAME}"
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \

--- a/google/cloud/storage/examples/run_examples_testbench.sh
+++ b/google/cloud/storage/examples/run_examples_testbench.sh
@@ -34,6 +34,7 @@ readonly DESTINATION_BUCKET_NAME="destination-bucket-${RANDOM}-${RANDOM}"
 readonly TOPIC_NAME="fake-topic-${RANDOM}-${RANDOM}"
 readonly STORAGE_CMEK_KEY="projects/${PROJECT_ID}/locations/global/keyRings/fake-key-ring/cryptoKeys/fake-key"
 readonly SERVICE_ACCOUNT="fake-service-account@example.com"
+readonly HMAC_SERVICE_ACCOUNT="fake-sa-hmac@example.com"
 
 # Most of the examples assume a bucket already exists, create one for them.
 run_example ./storage_bucket_samples create-bucket-for-project \

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -109,12 +109,12 @@ run_all_service_account_examples() {
   # a normal example.
   local access_id
   access_id=$(./storage_service_account_samples \
-      create-hmac-key-for-project "${PROJECT_ID}" "${TEST_SERVICE_ACCOUNT}" | \
+      create-hmac-key-for-project "${PROJECT_ID}" "${HMAC_SERVICE_ACCOUNT}" | \
       sed -n 's;.*, access_id=\([^,]*\),.*;\1;p')
   run_example ./storage_service_account_samples \
       list-hmac-keys
   run_example ./storage_service_account_samples \
-      list-hmac-keys-with-service-account "${TEST_SERVICE_ACCOUNT}"
+      list-hmac-keys-with-service-account "${HMAC_SERVICE_ACCOUNT}"
   run_example ./storage_service_account_samples \
       deactivate-hmac-key "${access_id}"
   run_example ./storage_service_account_samples \
@@ -122,7 +122,7 @@ run_all_service_account_examples() {
 
   # Create another key to test `update-hmac-key`.
   access_id=$(./storage_service_account_samples \
-      create-hmac-key "${TEST_SERVICE_ACCOUNT}" | \
+      create-hmac-key "${HMAC_SERVICE_ACCOUNT}" | \
       sed -n 's;.*, access_id=\([^,]*\),.*;\1;p')
   run_example ./storage_service_account_samples \
       get-hmac-key "${access_id}"

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -109,12 +109,12 @@ run_all_service_account_examples() {
   # a normal example.
   local access_id
   access_id=$(./storage_service_account_samples \
-      create-hmac-key-for-project "${PROJECT_ID}" "${SERVICE_ACCOUNT}" | \
+      create-hmac-key-for-project "${PROJECT_ID}" "${TEST_SERVICE_ACCOUNT}" | \
       sed -n 's;.*, access_id=\([^,]*\),.*;\1;p')
   run_example ./storage_service_account_samples \
       list-hmac-keys
   run_example ./storage_service_account_samples \
-      list-hmac-keys-with-service-account "${SERVICE_ACCOUNT}"
+      list-hmac-keys-with-service-account "${TEST_SERVICE_ACCOUNT}"
   run_example ./storage_service_account_samples \
       deactivate-hmac-key "${access_id}"
   run_example ./storage_service_account_samples \
@@ -122,7 +122,7 @@ run_all_service_account_examples() {
 
   # Create another key to test `update-hmac-key`.
   access_id=$(./storage_service_account_samples \
-      create-hmac-key "${SERVICE_ACCOUNT}" | \
+      create-hmac-key "${TEST_SERVICE_ACCOUNT}" | \
       sed -n 's;.*, access_id=\([^,]*\),.*;\1;p')
   run_example ./storage_service_account_samples \
       get-hmac-key "${access_id}"

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -86,7 +86,7 @@ echo "Running GCS Projects.serviceAccount integration tests."
 
 echo
 echo "Running GCS Projects.serviceAccount integration tests."
-./service_account_integration_test "${PROJECT_ID}" "${TEST_SERVICE_ACCOUNT}"
+./service_account_integration_test "${PROJECT_ID}" "${HMAC_SERVICE_ACCOUNT}"
 
 echo
 echo "Running V4 Signed URL conformance tests."

--- a/google/cloud/storage/tests/run_integration_tests_production.sh
+++ b/google/cloud/storage/tests/run_integration_tests_production.sh
@@ -84,9 +84,9 @@ echo
 echo "Running GCS Projects.serviceAccount integration tests."
 ./thread_integration_test "${PROJECT_ID}" "${STORAGE_REGION_ID}"
 
- echo
- echo "Running GCS Projects.serviceAccount integration tests."
- ./service_account_integration_test "${PROJECT_ID}" "${HMAC_SERVICE_ACCOUNT}"
+echo
+echo "Running GCS Projects.serviceAccount integration tests."
+./service_account_integration_test "${PROJECT_ID}" "${TEST_SERVICE_ACCOUNT}"
 
 echo
 echo "Running V4 Signed URL conformance tests."


### PR DESCRIPTION
We need to use a separate service account for each run of the CI tests,
otherwise they interfere with each other when more than one build runs
at the same time.

This fixes #2435 and (for real) fixes #2540.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2803)
<!-- Reviewable:end -->
