### PR TITLE
Do not use Etags in HMAC Key tests or samples.

### DIFF
--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -255,9 +255,7 @@ void UpdateHmacKey(google::cloud::storage::Client client, int& argc,
     }
 
     StatusOr<gcs::HmacKeyMetadata> updated_metadata = client.UpdateHmacKey(
-        access_id, gcs::HmacKeyMetadata()
-                       .set_state(std::move(state))
-                       .set_etag(current_metadata->etag()));
+        access_id, gcs::HmacKeyMetadata().set_state(std::move(state)));
 
     if (!updated_metadata) {
       throw std::runtime_error(updated_metadata.status().message());
@@ -278,16 +276,9 @@ void ActivateHmacKey(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string access_id) {
-    StatusOr<gcs::HmacKeyMetadata> current_metadata =
-        client.GetHmacKey(access_id);
-    if (!current_metadata) {
-      throw std::runtime_error(current_metadata.status().message());
-    }
-
     StatusOr<gcs::HmacKeyMetadata> updated_metadata = client.UpdateHmacKey(
-        access_id, gcs::HmacKeyMetadata()
-                       .set_state(gcs::HmacKeyMetadata::state_active())
-                       .set_etag(current_metadata->etag()));
+        access_id,
+        gcs::HmacKeyMetadata().set_state(gcs::HmacKeyMetadata::state_active()));
 
     if (!updated_metadata) {
       throw std::runtime_error(updated_metadata.status().message());
@@ -312,16 +303,9 @@ void DeactivateHmacKey(google::cloud::storage::Client client, int& argc,
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string access_id) {
-    StatusOr<gcs::HmacKeyMetadata> current_metadata =
-        client.GetHmacKey(access_id);
-    if (!current_metadata) {
-      throw std::runtime_error(current_metadata.status().message());
-    }
-
     StatusOr<gcs::HmacKeyMetadata> updated_metadata = client.UpdateHmacKey(
-        access_id, gcs::HmacKeyMetadata()
-                       .set_state(gcs::HmacKeyMetadata::state_inactive())
-                       .set_etag(current_metadata->etag()));
+        access_id, gcs::HmacKeyMetadata().set_state(
+                       gcs::HmacKeyMetadata::state_inactive()));
 
     if (!updated_metadata) {
       throw std::runtime_error(updated_metadata.status().message());

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -112,7 +112,11 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   ASSERT_STATUS_OK(get_details);
 
   EXPECT_EQ(access_id, get_details->access_id());
-  EXPECT_EQ(key->first, *get_details);
+  HmacKeyMetadata original = key->first;
+  // TODO(#3806) - remove this workaround: the etag may have changed since we
+  // the key was created.
+  original.set_etag(get_details->etag());
+  EXPECT_EQ(original, *get_details);
 
   StatusOr<HmacKeyMetadata> update_details =
       client.UpdateHmacKey(access_id, HmacKeyMetadata().set_state("INACTIVE"));

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -114,9 +114,8 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   EXPECT_EQ(access_id, get_details->access_id());
   EXPECT_EQ(key->first, *get_details);
 
-  StatusOr<HmacKeyMetadata> update_details = client.UpdateHmacKey(
-      access_id,
-      HmacKeyMetadata().set_state("INACTIVE").set_etag(get_details->etag()));
+  StatusOr<HmacKeyMetadata> update_details =
+      client.UpdateHmacKey(access_id, HmacKeyMetadata().set_state("INACTIVE"));
   ASSERT_STATUS_OK(update_details);
   EXPECT_EQ("INACTIVE", update_details->state());
 

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -113,8 +113,8 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
 
   EXPECT_EQ(access_id, get_details->access_id());
   HmacKeyMetadata original = key->first;
-  // TODO(#3806) - remove this workaround: the etag may have changed since we
-  // the key was created.
+  // TODO(#3806) - remove this workaround: the etag may have changed since the
+  // key was created.
   original.set_etag(get_details->etag());
   EXPECT_EQ(original, *get_details);
 


### PR DESCRIPTION
Apparently they do not work as I expect, until we figure out if my expectations
or the code are wrong, just don't use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2805)
<!-- Reviewable:end -->
