### PR TITLE
fix: StatusOr<T> assignable from Status

### DIFF
--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -109,6 +109,20 @@ class StatusOr final {
     }
   }
 
+  /**
+   * Assigns the given non-OK Status to this `StatusOr<T>`.
+   *
+   * @throws std::invalid_argument if `status.ok()`. If exceptions are disabled
+   *     the program terminates via `google::cloud::Terminate()`
+   */
+  StatusOr& operator=(Status status) {
+    if (status.ok()) {
+      google::cloud::internal::ThrowInvalidArgument(__func__);
+    }
+    status_ = std::move(status);
+    return *this;
+  }
+
   StatusOr(StatusOr&& rhs) : status_(std::move(rhs.status_)) {
     if (status_.ok()) {
       new (&value_) T(std::move(*rhs));

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -116,8 +116,7 @@ class StatusOr final {
    *     the program terminates via `google::cloud::Terminate()`
    */
   StatusOr& operator=(Status status) {
-    StatusOr tmp(std::move(status));
-    return *this = std::move(tmp);
+    return *this = StatusOr(std::move(tmp));
   }
 
   StatusOr(StatusOr&& rhs) : status_(std::move(rhs.status_)) {

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -116,11 +116,8 @@ class StatusOr final {
    *     the program terminates via `google::cloud::Terminate()`
    */
   StatusOr& operator=(Status status) {
-    if (status.ok()) {
-      google::cloud::internal::ThrowInvalidArgument(__func__);
-    }
-    status_ = std::move(status);
-    return *this;
+    StatusOr tmp(std::move(status));
+    return *this = std::move(tmp);
   }
 
   StatusOr(StatusOr&& rhs) : status_(std::move(rhs.status_)) {

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -116,7 +116,7 @@ class StatusOr final {
    *     the program terminates via `google::cloud::Terminate()`
    */
   StatusOr& operator=(Status status) {
-    return *this = StatusOr(std::move(tmp));
+    return *this = StatusOr(std::move(status));
   }
 
   StatusOr(StatusOr&& rhs) : status_(std::move(rhs.status_)) {

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -48,6 +48,14 @@ TEST(StatusOrTest, StatusConstructorInvalid) {
       "exceptions are disabled: ");
 }
 
+TEST(StatusOrTest, StatusAssignment) {
+  auto const error = Status(StatusCode::kUnknown, "blah");
+  StatusOr<int> sor;
+  sor = error;
+  EXPECT_FALSE(sor.ok());
+  EXPECT_EQ(error, sor.status());
+}
+
 TEST(StatusOrTest, ValueConstructor) {
   StatusOr<int> actual(42);
   EXPECT_STATUS_OK(actual);


### PR DESCRIPTION
Adds an assignment operator so that `StatusOr<T>` can be assigned to
from a non-OK `Status`.

Fixes #2816

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2817)
<!-- Reviewable:end -->
