### PR TITLE
cleanup: Fix constant names and enforce them.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,10 +31,18 @@ CheckOptions:
   - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
   - { key: readability-identifier-naming.FunctionCase,           value: CamelCase  }
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.LocalConstantCase,      value: lower_case }
+  - { key: readability-identifier-naming.LocalConstantCase,      value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
   - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
-  - { key: readability-identifier-naming.ConstexprVariableCase,  value: UPPER_CASE }
-  - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
-  - { key: readability-identifier-naming.MemberConstantCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -49,8 +49,8 @@ ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
       data_endpoint_("bigtable.googleapis.com"),
       admin_endpoint_("bigtableadmin.googleapis.com"),
       instance_admin_endpoint_("bigtableadmin.googleapis.com") {
-  static std::string const user_agent_prefix = UserAgentPrefix();
-  channel_arguments_.SetUserAgentPrefix(user_agent_prefix);
+  static std::string const kUserAgentPrefix = UserAgentPrefix();
+  channel_arguments_.SetUserAgentPrefix(kUserAgentPrefix);
   channel_arguments_.SetMaxSendMessageSize(
       BIGTABLE_CLIENT_DEFAULT_MAX_MESSAGE_LENGTH);
   channel_arguments_.SetMaxReceiveMessageSize(

--- a/google/cloud/bigtable/cluster_config.cc
+++ b/google/cloud/bigtable/cluster_config.cc
@@ -17,9 +17,16 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// The names for these constants are taken from the proto, and follow the
+// conventions from proto files.
+
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr ClusterConfig::StorageType ClusterConfig::STORAGE_TYPE_UNSPECIFIED;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr ClusterConfig::StorageType ClusterConfig::SSD;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr ClusterConfig::StorageType ClusterConfig::HDD;
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/instance_config.cc
+++ b/google/cloud/bigtable/instance_config.cc
@@ -18,9 +18,16 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// The names for these constants are taken from the proto, and follow the
+// conventions from proto files.
+
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceConfig::InstanceType InstanceConfig::TYPE_UNSPECIFIED;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceConfig::InstanceType InstanceConfig::PRODUCTION;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceConfig::InstanceType InstanceConfig::DEVELOPMENT;
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/instance_update_config.cc
+++ b/google/cloud/bigtable/instance_update_config.cc
@@ -18,14 +18,25 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// The names for these constants are taken from the proto, and follow the
+// conventions from proto files.
+
 constexpr InstanceUpdateConfig::InstanceType
+    // NOLINTNEXTLINE(readability-identifier-naming)
     InstanceUpdateConfig::TYPE_UNSPECIFIED;
+
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceUpdateConfig::InstanceType InstanceUpdateConfig::PRODUCTION;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceUpdateConfig::InstanceType InstanceUpdateConfig::DEVELOPMENT;
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceUpdateConfig::StateType InstanceUpdateConfig::STATE_NOT_KNOWN;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceUpdateConfig::StateType InstanceUpdateConfig::READY;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr InstanceUpdateConfig::StateType InstanceUpdateConfig::CREATING;
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/internal/completion_queue_impl.cc
+++ b/google/cloud/bigtable/internal/completion_queue_impl.cc
@@ -19,7 +19,7 @@
 // There is no wait to unblock the gRPC event loop, not even calling Shutdown(),
 // so we periodically wake up from the loop to check if the application has
 // shutdown the run.
-constexpr std::chrono::milliseconds LOOP_TIMEOUT(50);
+constexpr std::chrono::milliseconds kLoopTimeout(50);
 
 namespace google {
 namespace cloud {
@@ -30,7 +30,7 @@ void CompletionQueueImpl::Run(CompletionQueue& cq) {
   while (!shutdown_.load()) {
     void* tag;
     bool ok;
-    auto deadline = std::chrono::system_clock::now() + LOOP_TIMEOUT;
+    auto deadline = std::chrono::system_clock::now() + kLoopTimeout;
     auto status = cq_.AsyncNext(&tag, &ok, deadline);
     if (status == grpc::CompletionQueue::SHUTDOWN) {
       break;

--- a/google/cloud/bigtable/metadata_update_policy.cc
+++ b/google/cloud/bigtable/metadata_update_policy.cc
@@ -21,9 +21,14 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+// These we cannot change because they are part of the public API.
+// NOLINTNEXTLINE(readability-identifier-naming)
 MetadataParamTypes const MetadataParamTypes::PARENT("parent");
+// NOLINTNEXTLINE(readability-identifier-naming)
 MetadataParamTypes const MetadataParamTypes::NAME("name");
+// NOLINTNEXTLINE(readability-identifier-naming)
 MetadataParamTypes const MetadataParamTypes::RESOURCE("resource");
+// NOLINTNEXTLINE(readability-identifier-naming)
 MetadataParamTypes const MetadataParamTypes::TABLE_NAME("table_name");
 
 MetadataUpdatePolicy::MetadataUpdatePolicy(

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -31,10 +31,15 @@ static_assert(std::is_copy_constructible<bigtable::TableAdmin>::value,
 static_assert(std::is_copy_assignable<bigtable::TableAdmin>::value,
               "bigtable::TableAdmin must be assignable");
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr TableAdmin::TableView TableAdmin::VIEW_UNSPECIFIED;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr TableAdmin::TableView TableAdmin::NAME_ONLY;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr TableAdmin::TableView TableAdmin::SCHEMA_VIEW;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr TableAdmin::TableView TableAdmin::REPLICATION_VIEW;
+// NOLINTNEXTLINE(readability-identifier-naming)
 constexpr TableAdmin::TableView TableAdmin::FULL;
 
 /// Shortcuts to avoid typing long names over and over.

--- a/google/cloud/bigtable/version.cc
+++ b/google/cloud/bigtable/version.cc
@@ -22,7 +22,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string version_string() {
-  static std::string const version = [] {
+  static std::string const kVersion = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
        << version_patch();
@@ -31,7 +31,7 @@ std::string version_string() {
     }
     return os.str();
   }();
-  return version;
+  return kVersion;
 }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/internal/build_info.cc.in
+++ b/google/cloud/internal/build_info.cc.in
@@ -23,18 +23,16 @@ namespace internal {
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string compiler() {
-  // NOLINTNEXTLINE(readability-redundant-string-init)
-  static std::string const compiler_name =
+  static char const kCompilerName[] =
       R"""(@CMAKE_CXX_COMPILER_ID@ @CMAKE_CXX_COMPILER_VERSION@)""";
-  return compiler_name;
+  return kCompilerName;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string language_version() {
-  static std::string const language_version = [] {
-    // NOLINTNEXTLINE(readability-redundant-string-init)
-    std::string v =
-        R"""(@CMAKE_CXX_COMPILER_ID@-@CMAKE_CXX_COMPILER_VERSION@)""";
+  static std::string const kLanguageVersion = [] {
+    std::string v(
+      R"""(@CMAKE_CXX_COMPILER_ID@-@CMAKE_CXX_COMPILER_VERSION@)""");
     auto pos = v.find(' ');
     if (pos != std::string::npos) {
       v = v.substr(0, pos);
@@ -62,36 +60,39 @@ std::string language_version() {
     }
     return v;
   }();
-  return language_version;
+  return kLanguageVersion;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string compiler_flags() {
-  // NOLINTNEXTLINE(readability-redundant-string-init)
-  static std::string const compiler_flags =
+  static char const kCompilerFlags[] =
       R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${GOOGLE_CLOUD_CPP_BUILD_TYPE_UPPER}})""";
-  return compiler_flags;
+  return kCompilerFlags;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 bool is_release() {
-  static bool const is_release = []() -> bool {
+  static bool const kIsRelease = []() -> bool {
+    // Sometimes GOOGLE_CLOUD_CPP_IS_RELEASE string expands to nothing, and then
+    // clang-tidy complains.
     // NOLINTNEXTLINE(readability-redundant-string-init)
-    std::string value = R"""(@GOOGLE_CLOUD_CPP_IS_RELEASE@)""";
+    std::string value(R"""(@GOOGLE_CLOUD_CPP_IS_RELEASE@)""");
     std::transform(
         value.begin(), value.end(), value.begin(),
         [](char c) -> char { return static_cast<char>(std::tolower(c)); });
     return value == "yes" || value == "1" || value == "true";
   }();
 
-  return is_release;
+  return kIsRelease;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string build_metadata() {
+  // Sometimes GOOGLE_CLOUD_CPP_BUILD_METADATA string expands to nothing, and
+  // then clang-tidy complains.
   // NOLINTNEXTLINE(readability-redundant-string-init)
-  static char const build_metadata[] = R"""(@GOOGLE_CLOUD_CPP_BUILD_METADATA@)""";
-  return build_metadata;
+  static char const kBuildMetadata[] = R"""(@GOOGLE_CLOUD_CPP_BUILD_METADATA@)""";
+  return kBuildMetadata;
 }
 
 }  // namespace internal

--- a/google/cloud/internal/parse_rfc3339.cc
+++ b/google/cloud/internal/parse_rfc3339.cc
@@ -181,7 +181,7 @@ std::chrono::system_clock::time_point ParseRfc3339(
   // does not change during the lifetime of the program.  This function takes
   // the current time, converts to UTC and then convert back to a time_t.  The
   // difference is the offset.
-  static std::chrono::seconds const localtime_offset = []() {
+  static std::chrono::seconds const kLocalTimeOffset = []() {
     auto now = std::time(nullptr);
     std::tm lcl;
 // The standard C++ function to convert time_t to a struct tm is not thread
@@ -205,7 +205,7 @@ std::chrono::system_clock::time_point ParseRfc3339(
 
   time_point += fractional_seconds;
   time_point -= offset;
-  time_point -= localtime_offset;
+  time_point -= kLocalTimeOffset;
   return time_point;
 }
 

--- a/google/cloud/internal/parse_rfc3339.cc
+++ b/google/cloud/internal/parse_rfc3339.cc
@@ -47,9 +47,9 @@ std::chrono::system_clock::time_point ParseDateTime(
       std::sscanf(buffer, "%4d-%2d-%2d%c%2d:%2d:%2d%n", &year, &month, &day,
                   &date_time_separator, &hours, &minutes, &seconds, &pos);
   // All the fields up to this point have fixed width, so total width must be:
-  constexpr int EXPECTED_WIDTH = 19;
-  constexpr int EXPECTED_FIELDS = 7;
-  if (count != EXPECTED_FIELDS || pos != EXPECTED_WIDTH) {
+  constexpr int kExpectedWidth = 19;
+  constexpr int kExpectedFields = 7;
+  if (count != kExpectedFields || pos != kExpectedWidth) {
     ReportError(timestamp,
                 "Invalid format for RFC 3339 timestamp detected while parsing"
                 " the base date and time portion.");
@@ -60,7 +60,7 @@ std::chrono::system_clock::time_point ParseDateTime(
   if (month < 1 || month > 12) {
     ReportError(timestamp, "Out of range month.");
   }
-  constexpr int MAX_DAYS_IN_MONTH[] = {
+  constexpr int kMaxDaysInMonth[] = {
       31,  // January
       29,  // February (non-leap years checked below)
       31,  // March
@@ -74,7 +74,7 @@ std::chrono::system_clock::time_point ParseDateTime(
       30,  // November
       31,  // December
   };
-  if (day < 1 || day > MAX_DAYS_IN_MONTH[month - 1]) {
+  if (day < 1 || day > kMaxDaysInMonth[month - 1]) {
     ReportError(timestamp, "Out of range day for given month.");
   }
   if (2 == month && day > 28 && !IsLeapYear(year)) {
@@ -142,9 +142,9 @@ std::chrono::seconds ParseOffset(char const*& buffer,
     // Parse the HH:MM offset.
     int hours, minutes, pos;
     auto count = std::sscanf(buffer, "%2d:%2d%n", &hours, &minutes, &pos);
-    constexpr int EXPECTED_OFFSET_WIDTH = 5;
-    constexpr int EXPECTED_OFFSET_FIELDS = 2;
-    if (count != EXPECTED_OFFSET_FIELDS || pos != EXPECTED_OFFSET_WIDTH) {
+    constexpr int kExpectedOffsetWidth = 5;
+    constexpr int kExpectedOffsetFields = 2;
+    if (count != kExpectedOffsetFields || pos != kExpectedOffsetWidth) {
       ReportError(timestamp, "Invalid timezone offset, expected [+-]HH:MM.");
     }
     if (hours < 0 || hours > 23) {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1416,10 +1416,10 @@ std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {
     std::unique_lock<std::mutex> lk(mu_);
     return google::cloud::internal::Sample(generator_, n, chars);
   };
-  constexpr int INITIAL_CANDIDATE_SIZE = 16;
-  constexpr int CANDIDATE_GROWTH_SIZE = 4;
+  constexpr int kCandidateInitialSize = 16;
+  constexpr int kCandidateGrowthSize = 4;
   return GenerateMessageBoundary(text_to_avoid, std::move(generate_candidate),
-                                 INITIAL_CANDIDATE_SIZE, CANDIDATE_GROWTH_SIZE);
+                                 kCandidateInitialSize, kCandidateGrowthSize);
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaSimple(

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1411,10 +1411,10 @@ std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {
   // larger than `text_to_avoid`.  And we only make (approximately) one pass
   // over `text_to_avoid`.
   auto generate_candidate = [this](int n) {
-    static std::string const chars =
+    static std::string const kChars =
         "abcdefghijklmnopqrstuvwxyz012456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     std::unique_lock<std::mutex> lk(mu_);
-    return google::cloud::internal::Sample(generator_, n, chars);
+    return google::cloud::internal::Sample(generator_, n, kChars);
   };
   constexpr int kCandidateInitialSize = 16;
   constexpr int kCandidateGrowthSize = 4;

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -25,7 +25,7 @@ namespace {
 
 using ::google::cloud::storage::internal::BinaryDataAsDebugString;
 
-std::size_t const MAX_DATA_DEBUG_SIZE = 48;
+std::size_t const kMaxDataDebugSize = 48;
 
 extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
                                        std::size_t size, void* userptr) {
@@ -43,12 +43,12 @@ extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
     case CURLINFO_DATA_IN:
       *debug_buffer += ">> curl(Recv Data): size=";
       *debug_buffer += std::to_string(size) + "\n";
-      *debug_buffer += BinaryDataAsDebugString(data, size, MAX_DATA_DEBUG_SIZE);
+      *debug_buffer += BinaryDataAsDebugString(data, size, kMaxDataDebugSize);
       break;
     case CURLINFO_DATA_OUT:
       *debug_buffer += ">> curl(Send Data): size=";
       *debug_buffer += std::to_string(size) + "\n";
-      *debug_buffer += BinaryDataAsDebugString(data, size, MAX_DATA_DEBUG_SIZE);
+      *debug_buffer += BinaryDataAsDebugString(data, size, kMaxDataDebugSize);
       break;
     case CURLINFO_SSL_DATA_IN:
     case CURLINFO_SSL_DATA_OUT:

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -118,13 +118,13 @@ CurlRequestBuilder& CurlRequestBuilder::SetInitialBufferSize(std::size_t size) {
 std::string CurlRequestBuilder::UserAgentSuffix() const {
   ValidateBuilderState(__func__);
   // Pre-compute and cache the user agent string:
-  static std::string const user_agent_suffix = [] {
+  static std::string const kUserAgentSuffix = [] {
     std::string agent = "gcloud-cpp/" + storage::version_string() + " ";
     agent += curl_version();
     agent += " " + google::cloud::internal::compiler();
     return agent;
   }();
-  return user_agent_suffix;
+  return kUserAgentSuffix;
 }
 
 void CurlRequestBuilder::ValidateBuilderState(char const* where) const {

--- a/google/cloud/storage/oauth2/google_application_default_credentials_file.cc
+++ b/google/cloud/storage/oauth2/google_application_default_credentials_file.cc
@@ -20,13 +20,13 @@ namespace {
 
 std::string const& GoogleWellKnownAdcFilePathSuffix() {
 #ifdef _WIN32
-  static std::string const suffix =
+  static std::string const kSuffix =
       "/gcloud/application_default_credentials.json";
 #else
-  static std::string const suffix =
+  static std::string const kSuffix =
       "/.config/gcloud/application_default_credentials.json";
 #endif
-  return suffix;
+  return kSuffix;
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -22,7 +22,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string version_string() {
-  static std::string const version = [] {
+  static std::string const kVersion = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
        << version_patch();
@@ -31,18 +31,18 @@ std::string version_string() {
     }
     return os.str();
   }();
-  return version;
+  return kVersion;
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string x_goog_api_client() {
-  static std::string const x_goog_api_client = [] {
+  static std::string const kXGoogApiClient = [] {
     std::ostringstream os;
     os << "gl-cpp/" << google::cloud::internal::language_version() << " gccl/"
        << version_string();
     return os.str();
   }();
-  return x_goog_api_client;
+  return kXGoogApiClient;
 }
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
We were inconsistent in our naming of constant variables, and the
enforcing was broken. The Google Style Guide requires constants to use
`kCamelCase`. I changed the `.clang-tidy` configuration to enforce this
naming.

I did not change any constants that were part of the public API, I did
not see the point of breaking the API for this.

I would appreciate somebody checking my math on the .clang-tidy settings.

This fixes #894.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2824)
<!-- Reviewable:end -->
