### PR TITLE
Add $ORIGIN to CMAKE_INSTALL_RPATH only on Linux.

### DIFF
--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -134,3 +134,30 @@ function (set_external_project_build_parallel_level var_name)
         set(${var_name} "" PARENT_SCOPE)
     endif ()
 endfunction ()
+
+function (set_external_project_install_rpath)
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64"
+        PARENT_SCOPE)
+
+    # On Linux, using an RPATH that is neither an absolute or relative path is
+    # considered a security risk and will cause package building to fail. We use
+    # the Linux-specific variable $ORIGIN to resolve this.
+    if (UNIX AND NOT APPLE)
+        set(GOOGLE_CLOUD_CPP_INSTALL_RPATH
+            "\\\$ORIGIN/../lib;\\\$ORIGIN/../lib64" PARENT_SCOPE)
+    endif ()
+
+    # When passing a semi-colon delimited list to ExternalProject_Add, we need
+    # to escape the semi-colon. Quoting does not work and escaping the semi-
+    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
+    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
+    # then be replaced by an escaped semi-colon by CMake. This allows us to use
+    # multiple directories for our RPATH. Normally, it'd make sense to use : as
+    # a delimiter since it is a typical path-list separator, but it is a special
+    # character in CMake.
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}"
+                   PARENT_SCOPE)
+endfunction ()

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -31,28 +31,9 @@ if (NOT TARGET googleapis_project)
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
         "6b8a9b2bcb4476e9a5a9872869996f0d639c8d5df76dd8a893e79201f211b1cf")
 
-    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles"
-        OR "${CMAKE_GENERATOR}" STREQUAL "Ninja")
-        include(ProcessorCount)
-        processorcount(NCPU)
-        set(PARALLEL "--" "-j" "${NCPU}")
-    else()
-        set(PARALLEL "")
-    endif ()
+    set_external_project_build_parallel_level(PARALLEL)
 
-    # When passing a semi-colon delimited list to ExternalProject_Add, we need
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
-                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+    set_external_project_install_rpath()
 
     create_external_project_library_byproduct_list(
         googleapis_byproducts


### PR DESCRIPTION
Supposedly there exists similar mechanisms on other platforms (`@rpath` on MacOS), however given that this will only affect a small amount of people (i.e, Linux maintainers building RPMs), there's no point in fixing what isn't broken. Similarly, I didn't change the other files because `googleapis` was the only library `check-rpaths` was complaining about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2830)
<!-- Reviewable:end -->
