### PR TITLE
bug: Use decorators for WriteObject.

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -73,20 +73,21 @@ ObjectReadStream Client::ReadObjectImpl(
 
 ObjectWriteStream Client::WriteObjectImpl(
     internal::ResumableUploadRequest const& request) {
-  using google::cloud::internal::make_unique;
   auto session = raw_client_->CreateResumableSession(request);
   if (!session) {
-    auto error = make_unique<internal::ObjectWriteErrorStreambuf>(
-        std::move(session).status());
+    auto error = google::cloud::internal::make_unique<
+        internal ::ObjectWriteErrorStreambuf>(std::move(session).status());
 
     ObjectWriteStream error_stream(std::move(error));
     error_stream.setstate(std::ios::badbit | std::ios::eofbit);
     error_stream.Close();
     return error_stream;
   }
-  return ObjectWriteStream(make_unique<internal::CurlResumableStreambuf>(
-      *std::move(session), raw_client_->client_options().upload_buffer_size(),
-      internal::CreateHashValidator(request)));
+  return ObjectWriteStream(
+      google::cloud::internal::make_unique<internal::CurlResumableStreambuf>(
+          *std::move(session),
+          raw_client_->client_options().upload_buffer_size(),
+          internal::CreateHashValidator(request)));
 }
 
 bool Client::UseSimpleUpload(std::string const& file_name) const {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -995,7 +995,8 @@ class Client {
   ObjectWriteStream WriteObject(std::string const& bucket_name,
                                 std::string const& object_name,
                                 Options&&... options) {
-    internal::InsertObjectStreamingRequest request(bucket_name, object_name);
+    // internal::InsertObjectStreamingRequest request(bucket_name, object_name);
+    internal::ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return WriteObjectImpl(request);
   }
@@ -2831,7 +2832,7 @@ class Client {
       internal::ReadObjectRangeRequest const& request);
 
   ObjectWriteStream WriteObjectImpl(
-      internal::InsertObjectStreamingRequest const& request);
+      internal::ResumableUploadRequest const& request);
 
   // The version of UploadFile() where UseResumableUploadSession is one of the
   // options. Note how this does not use InsertObjectMedia at all.

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -995,7 +995,6 @@ class Client {
   ObjectWriteStream WriteObject(std::string const& bucket_name,
                                 std::string const& object_name,
                                 Options&&... options) {
-    // internal::InsertObjectStreamingRequest request(bucket_name, object_name);
     internal::ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return WriteObjectImpl(request);

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -85,6 +85,12 @@ std::unique_ptr<HashValidator> CreateHashValidator(
                              request.HasOption<DisableCrc32cChecksum>());
 }
 
+std::unique_ptr<HashValidator> CreateHashValidator(
+    ResumableUploadRequest const& request) {
+  return CreateHashValidator(request.HasOption<DisableMD5Hash>(),
+                             request.HasOption<DisableCrc32cChecksum>());
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -101,6 +101,7 @@ class CompositeValidator : public HashValidator {
 
 class ReadObjectRangeRequest;
 class InsertObjectStreamingRequest;
+class ResumableUploadRequest;
 
 /// Create a hash validator configured by @p request.
 std::unique_ptr<HashValidator> CreateHashValidator(
@@ -109,6 +110,10 @@ std::unique_ptr<HashValidator> CreateHashValidator(
 /// Create a hash validator configured by @p request.
 std::unique_ptr<HashValidator> CreateHashValidator(
     InsertObjectStreamingRequest const& request);
+
+/// Create a hash validator configured by @p request.
+std::unique_ptr<HashValidator> CreateHashValidator(
+    ResumableUploadRequest const& request);
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -86,12 +86,7 @@ LoggingResumableUploadSession::last_response() const {
   return response;
 }
 
-bool LoggingResumableUploadSession::done() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
-  auto const& response = session_->done();
-  GCP_LOG(INFO) << __func__ << " >> " << std::boolalpha << response;
-  return response;
-}
+bool LoggingResumableUploadSession::done() const { return session_->done(); }
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -169,19 +169,6 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
   EXPECT_EQ(1, CountLines("[FAILED_PRECONDITION]"));
 }
 
-TEST_F(LoggingResumableUploadSessionTest, Done) {
-  auto mock = google::cloud::internal::make_unique<
-      testing::MockResumableUploadSession>();
-
-  EXPECT_CALL(*mock, done()).WillOnce(Return(false));
-
-  LoggingResumableUploadSession session(std::move(mock));
-
-  EXPECT_FALSE(session.done());
-
-  EXPECT_EQ(1, CountLines("false"));
-}
-
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
This enables the retry and logging decorators for
`storage::Client::WriteObject()`.  There is a lot of cleanup left to do,
but I think that can wait as this fixes a bug where transient failures
during an upload are not retried.

This fixes #2831. I will open new issues to cleanup the code that we no longer need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2835)
<!-- Reviewable:end -->
