### PR TITLE
feat: Add functions to convert google::rpc::Status.

### DIFF
--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -17,6 +17,17 @@ licenses(["notice"])  # Apache 2.0
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
+cc_library(
+    name = "grpc_utils_protos",
+    includes = [
+        ".",
+    ],
+    deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        "//google/rpc:status_cc_proto"
+    ],
+)
+
 cc_proto_library(
     name = "bigtableadmin_cc_proto",
     deps = ["//google/bigtable/admin/v2:bigtableadmin_proto"],

--- a/google/cloud/bigtable/mutations.cc
+++ b/google/cloud/bigtable/mutations.cc
@@ -32,21 +32,6 @@ Mutation DeleteFromRow() {
   return m;
 }
 
-grpc::Status FailedMutation::ToGrpcStatus(google::rpc::Status const& status) {
-  std::string details;
-  if (!google::protobuf::TextFormat::PrintToString(status, &details)) {
-    details = "error [could not print details as string]";
-  }
-  return grpc::Status(static_cast<grpc::StatusCode>(status.code()),
-                      status.message(), details);
-}
-
-google::cloud::Status FailedMutation::ToGCStatus(
-    google::rpc::Status const& status) {
-  grpc::Status grpc_status = FailedMutation::ToGrpcStatus(status);
-  return grpc_utils::MakeStatusFromRpcError(grpc_status);
-}
-
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -352,10 +352,11 @@ class SingleRowMutation {
 class FailedMutation {
  public:
   FailedMutation(google::cloud::Status status, int index)
-      : status_(status), original_index_(index) {}
+      : status_(std::move(status)), original_index_(index) {}
 
-  FailedMutation(google::rpc::Status status, int index)
-      : status_(ToGCStatus(status)), original_index_(index) {}
+  FailedMutation(google::rpc::Status const& status, int index)
+      : status_(grpc_utils::MakeStatusFromRpcError(status)),
+        original_index_(index) {}
 
   FailedMutation(FailedMutation&&) = default;
   FailedMutation& operator=(FailedMutation&&) = default;
@@ -369,10 +370,6 @@ class FailedMutation {
   //@}
 
   friend class BulkMutation;
-
- private:
-  static grpc::Status ToGrpcStatus(google::rpc::Status const& status);
-  static google::cloud::Status ToGCStatus(google::rpc::Status const& status);
 
  private:
   google::cloud::Status status_;

--- a/google/cloud/grpc_utils/BUILD
+++ b/google/cloud/grpc_utils/BUILD
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//:grpc_utils_protos",
     ],
 )
 
@@ -38,6 +39,7 @@ load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//:grpc_utils_protos",
         "@com_google_googletest//:gtest",
     ],
 ) for test in google_cloud_cpp_grpc_utils_unit_tests]

--- a/google/cloud/grpc_utils/CMakeLists.txt
+++ b/google/cloud/grpc_utils/CMakeLists.txt
@@ -60,6 +60,8 @@ endif ()
 add_library(grpc_utils_common_options INTERFACE)
 google_cloud_cpp_add_common_options(grpc_utils_common_options)
 
+include(external/googleapis)
+
 # Enable unit tests
 include(CTest)
 
@@ -77,7 +79,10 @@ add_library(google_cloud_cpp_grpc_utils
             version.cc
             version_info.h)
 target_link_libraries(google_cloud_cpp_grpc_utils
-                      PUBLIC google_cloud_cpp_common gRPC::grpc++ gRPC::grpc
+                      PUBLIC googleapis-c++::rpc_status_protos
+                             google_cloud_cpp_common
+                             gRPC::grpc++
+                             gRPC::grpc
                       PRIVATE grpc_utils_common_options)
 target_include_directories(google_cloud_cpp_grpc_utils
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/google/cloud/grpc_utils/config.cmake.in
+++ b/google/cloud/grpc_utils/config.cmake.in
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
+find_dependency(googleapis)
 find_dependency(gRPC)
 find_dependency(google_cloud_cpp_common)
 

--- a/google/cloud/grpc_utils/grpc_error_delegate.cc
+++ b/google/cloud/grpc_utils/grpc_error_delegate.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/grpc_utils/grpc_error_delegate.h"
+#include <google/protobuf/text_format.h>
 
 namespace google {
 namespace cloud {
@@ -70,6 +71,17 @@ google::cloud::Status MakeStatusFromRpcError(grpc::StatusCode code,
   // TODO(#1912): Pass along status.error_details() once we have absl::Status
   // or some version that supports binary blobs of data.
   return google::cloud::Status(MapStatusCode(code), std::move(what));
+}
+
+google::cloud::Status MakeStatusFromRpcError(
+    google::rpc::Status const& status) {
+  StatusCode code = StatusCode::kUnknown;
+  if (status.code() >= 0 &&
+      status.code() <=
+          static_cast<std::int32_t>(StatusCode::kUnauthenticated)) {
+    code = static_cast<StatusCode>(status.code());
+  }
+  return Status(code, status.message());
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_GRPC_UTILS_NS

--- a/google/cloud/grpc_utils/grpc_error_delegate.h
+++ b/google/cloud/grpc_utils/grpc_error_delegate.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/grpc_utils/version.h"
 #include "google/cloud/status.h"
+#include <google/rpc/status.pb.h>
 #include <grpcpp/grpcpp.h>
 
 namespace google {
@@ -33,6 +34,15 @@ google::cloud::Status MakeStatusFromRpcError(grpc::Status const& status);
  */
 google::cloud::Status MakeStatusFromRpcError(grpc::StatusCode code,
                                              std::string what);
+
+/**
+ * Creates a `google::cloud::Status` from a `google:rpc::Status` proto.
+ *
+ * Some gRPC services return the `google::rpc::Status` proto for errors. The
+ * libraries in `google-cloud-cpp` represent these errors using a
+ * `google::cloud::Status`.
+ */
+google::cloud::Status MakeStatusFromRpcError(google::rpc::Status const& status);
 
 }  // namespace GOOGLE_CLOUD_CPP_GRPC_UTILS_NS
 }  // namespace grpc_utils


### PR DESCRIPTION
This refactors a function to convert `google::rpc::Status` (a proto, similar but
distinct from `grpc::Status`) to `google::cloud::Status`.  We need a similar
function in the Cloud Spanner library, this is the first step to refactor it.

----

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2838)
<!-- Reviewable:end -->
