### PR TITLE
bug: Need to set startingDeadlineSeconds to handle failures.

### DIFF
--- a/ci/benchmarks/bigtable/endurance-job.yaml
+++ b/ci/benchmarks/bigtable/endurance-job.yaml
@@ -22,6 +22,11 @@ metadata:
     app: bigtable-endurance-test
 spec:
   schedule: '* * */1 * *' # daily
+  # Only count the failures in the last 60 seconds towards the
+  # "FailedNeedsStart" limit, and allow the job to start even if it missed the
+  # start time in the last 60 seconds.
+  #    https://stackoverflow.com/questions/51065538
+  startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/ci/benchmarks/bigtable/latency-job.yaml
+++ b/ci/benchmarks/bigtable/latency-job.yaml
@@ -22,6 +22,11 @@ metadata:
     app: bigtable-latency-benchmark
 spec:
   schedule: '* */1 * * *' # hourly
+  # Only count the failures in the last 60 seconds towards the
+  # "FailedNeedsStart" limit, and allow the job to start even if it missed the
+  # start time in the last 60 seconds.
+  #    https://stackoverflow.com/questions/51065538
+  startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/ci/benchmarks/bigtable/scan-job.yaml
+++ b/ci/benchmarks/bigtable/scan-job.yaml
@@ -22,6 +22,11 @@ metadata:
     app: bigtable-scan-benchmark
 spec:
   schedule: '* */1 * * *' # hourly
+  # Only count the failures in the last 60 seconds towards the
+  # "FailedNeedsStart" limit, and allow the job to start even if it missed the
+  # start time in the last 60 seconds.
+  #    https://stackoverflow.com/questions/51065538
+  startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/ci/benchmarks/bigtable/throughput-job.yaml
+++ b/ci/benchmarks/bigtable/throughput-job.yaml
@@ -22,6 +22,11 @@ metadata:
     app: bigtable-throughput-benchmark
 spec:
   schedule: '* */1 * * *' # hourly
+  # Only count the failures in the last 60 seconds towards the
+  # "FailedNeedsStart" limit, and allow the job to start even if it missed the
+  # start time in the last 60 seconds.
+  #    https://stackoverflow.com/questions/51065538
+  startingDeadlineSeconds: 60
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/ci/benchmarks/storage/throughput-vs-cpu-job.yaml
+++ b/ci/benchmarks/storage/throughput-vs-cpu-job.yaml
@@ -21,7 +21,12 @@ metadata:
   labels:
     app: storage-throughput-vs-cpu
 spec:
-  schedule: "* */1 * * *"
+  schedule: "* */1 * * *" # hourly
+  # Only count the failures in the last 60 seconds towards the
+  # "FailedNeedsStart" limit, and allow the job to start even if it missed the
+  # start time in the last 60 seconds.
+  #    https://stackoverflow.com/questions/51065538
+  startingDeadlineSeconds: 60
   concurrencyPolicy: "Forbid"
   jobTemplate:
     spec:


### PR DESCRIPTION
TIL (well a couple of weeks ago...): without `startingDeadlineSeconds`
the cronjobs eventually stop running. With this change they have been
running for about 2 weeks now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2859)
<!-- Reviewable:end -->
