### PR TITLE
bug: Fix ReadObject() when reading the last chunk.

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -113,6 +113,9 @@ class CurlDownloadRequest : public ObjectReadSource {
   /// Reset the underlying CurlHandle options after a move operation.
   void ResetOptions();
 
+  /// Copy any available data from the spill buffer to `buffer_`
+  void DrainSpillBuffer();
+
   /// Called by libcurl to show that more data is available in the download.
   std::size_t WriteCallback(void* ptr, std::size_t size, std::size_t nmemb);
 

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -140,15 +140,19 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
 
   StatusOr<ReadSourceResult> read_result =
       source_->Read(s + offset, static_cast<std::size_t>(count - offset));
-  GCP_LOG(INFO) << __func__ << "(): count=" << count
-                << ", in_avail=" << in_avail() << ", offset=" << offset
-                << ", status=" << read_result.status();
   // If there was an error set the internal state, but we still return the
   // number of bytes.
   if (!read_result) {
+    GCP_LOG(INFO) << __func__ << "(): count=" << count
+                  << ", in_avail=" << in_avail() << ", offset=" << offset
+                  << ", status=" << read_result.status();
     status_ = std::move(read_result).status();
     return offset;
   }
+  GCP_LOG(INFO) << __func__ << "(): count=" << count
+                << ", in_avail=" << in_avail() << ", offset=" << offset
+                << ", read_result->bytes_received="
+                << read_result->bytes_received;
 
   hash_validator_->Update(s + offset, read_result->bytes_received);
   offset += read_result->bytes_received;

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -327,19 +327,21 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
 
   // This produces an object larger than 3MiB, but with a size that is not a
   // multiple of 128KiB.
-  auto const kKiB = 1024L;
-  auto const kMiB = 1024L * kKiB;
-  auto const object_size = 3 * kMiB + 129 * kKiB;
-  auto const lines = object_size / 128;
+  auto constexpr kKiB = 1024L;
+  auto constexpr kMiB = 1024L * kKiB;
+  auto constexpr object_size = 3 * kMiB + 129 * kKiB;
+  auto constexpr line_size = 128;
+  auto constexpr lines = object_size / line_size;
   std::string large_text;
   for (long i = 0; i != lines; ++i) {
-    auto line = google::cloud::internal::Sample(generator_, 127,
+    auto line = google::cloud::internal::Sample(generator_, line_size - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                 "012456789");
     large_text += line + "\n";
   }
-  static_assert(object_size % 128 == 0, "Object must be multiple of line size");
+  static_assert(object_size % line_size == 0,
+                "Object must be multiple of line size");
   EXPECT_EQ(object_size, large_text.size());
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
@@ -376,19 +378,21 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
   auto object_name = MakeRandomObjectName();
 
   // This produces a 3.25 MiB text object.
-  auto const kKiB = 1024L;
-  auto const kMiB = 1024L * kKiB;
-  auto const object_size = 3 * kMiB + 129 * kKiB;
-  auto const lines = object_size / 128;
+  auto constexpr kKiB = 1024L;
+  auto constexpr kMiB = 1024L * kKiB;
+  auto constexpr object_size = 3 * kMiB + 129 * kKiB;
+  auto constexpr line_size = 128;
+  auto constexpr lines = object_size / line_size;
   std::string large_text;
   for (long i = 0; i != lines; ++i) {
-    auto line = google::cloud::internal::Sample(generator_, 127,
+    auto line = google::cloud::internal::Sample(generator_, line_size - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                 "012456789");
     large_text += line + "\n";
   }
-  static_assert(object_size % 128 == 0, "Object must be multiple of line size");
+  static_assert(object_size % line_size == 0,
+                "Object must be multiple of line size");
   EXPECT_EQ(object_size, large_text.size());
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
@@ -428,7 +432,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
   std::string actual(buffer.data(), stream.gcount());
   auto expected = large_text.substr(3 * kMiB);
   EXPECT_EQ(expected.size(), actual.size());
-  // EXPECT_EQ(expected, actual);
+  EXPECT_EQ(expected, actual);
 
   auto status = client->DeleteObject(bucket_name, object_name);
   EXPECT_STATUS_OK(status);

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -317,6 +317,123 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
   EXPECT_STATUS_OK(status);
 }
 
+/// @test Read the last chunk of an object.
+TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  auto object_name = MakeRandomObjectName();
+
+  // This produces an object larger than 3MiB, but with a size that is not a
+  // multiple of 128KiB.
+  auto const kKiB = 1024L;
+  auto const kMiB = 1024L * kKiB;
+  auto const object_size = 3 * kMiB + 129 * kKiB;
+  auto const lines = object_size / 128;
+  std::string large_text;
+  for (long i = 0; i != lines; ++i) {
+    auto line = google::cloud::internal::Sample(generator_, 127,
+                                                "abcdefghijklmnopqrstuvwxyz"
+                                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                "012456789");
+    large_text += line + "\n";
+  }
+  static_assert(object_size % 128 == 0, "Object must be multiple of line size");
+  EXPECT_EQ(object_size, large_text.size());
+
+  StatusOr<ObjectMetadata> source_meta = client->InsertObject(
+      bucket_name, object_name, large_text, IfGenerationMatch(0));
+  ASSERT_STATUS_OK(source_meta);
+
+  EXPECT_EQ(object_name, source_meta->name());
+  EXPECT_EQ(bucket_name, source_meta->bucket());
+
+  // Create an iostream to read the last 256KiB of the object, but simulate an
+  // application that does not know how large that last chunk is.
+  auto stream = client->ReadObject(bucket_name, object_name,
+                                   ReadRange(3 * kMiB, 4 * kMiB));
+
+  std::vector<char> buffer(1 * kMiB);
+  stream.read(buffer.data(), buffer.size());
+  EXPECT_TRUE(stream.eof());
+  EXPECT_TRUE(stream.fail());
+  EXPECT_FALSE(stream.bad());
+  EXPECT_EQ(object_size - 3 * kMiB, stream.gcount());
+  std::string actual(buffer.data(), stream.gcount());
+  EXPECT_EQ(large_text.substr(3 * kMiB), actual);
+
+  auto status = client->DeleteObject(bucket_name, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
+/// @test Read an object by chunks of equal size.
+TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
+  StatusOr<Client> client = Client::CreateDefaultClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  auto object_name = MakeRandomObjectName();
+
+  // This produces a 3.25 MiB text object.
+  auto const kKiB = 1024L;
+  auto const kMiB = 1024L * kKiB;
+  auto const object_size = 3 * kMiB + 129 * kKiB;
+  auto const lines = object_size / 128;
+  std::string large_text;
+  for (long i = 0; i != lines; ++i) {
+    auto line = google::cloud::internal::Sample(generator_, 127,
+                                                "abcdefghijklmnopqrstuvwxyz"
+                                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                "012456789");
+    large_text += line + "\n";
+  }
+  static_assert(object_size % 128 == 0, "Object must be multiple of line size");
+  EXPECT_EQ(object_size, large_text.size());
+
+  StatusOr<ObjectMetadata> source_meta = client->InsertObject(
+      bucket_name, object_name, large_text, IfGenerationMatch(0));
+  ASSERT_STATUS_OK(source_meta);
+
+  EXPECT_EQ(object_name, source_meta->name());
+  EXPECT_EQ(bucket_name, source_meta->bucket());
+
+  std::vector<char> buffer(1 * kMiB);
+  for (int i = 0; i != 3; ++i) {
+    SCOPED_TRACE("Reading chunk from object, chunk=" + std::to_string(i));
+    // Create an iostream to read from (i * kMiB) to ((i + 1) * kMiB).
+    auto stream = client->ReadObject(bucket_name, object_name,
+                                     ReadRange(i * kMiB, (i + 1) * kMiB));
+
+    stream.read(buffer.data(), buffer.size());
+    EXPECT_FALSE(stream.eof());
+    EXPECT_FALSE(stream.fail());
+    EXPECT_FALSE(stream.bad());
+    EXPECT_EQ(1 * kMiB, stream.gcount());
+    std::string actual(buffer.data(), stream.gcount());
+
+    EXPECT_EQ(large_text.substr(i * kMiB, 1 * kMiB), actual);
+  }
+
+  // Create an iostream to read the last 256KiB of the object, but simulate an
+  // application that does not know how large that last chunk is.
+  auto stream = client->ReadObject(bucket_name, object_name,
+                                   ReadRange(3 * kMiB, 4 * kMiB));
+
+  stream.read(buffer.data(), buffer.size());
+  EXPECT_TRUE(stream.eof());
+  EXPECT_TRUE(stream.fail());
+  EXPECT_FALSE(stream.bad());
+  EXPECT_EQ(object_size - 3 * kMiB, stream.gcount());
+  std::string actual(buffer.data(), stream.gcount());
+  auto expected = large_text.substr(3 * kMiB);
+  EXPECT_EQ(expected.size(), actual.size());
+  // EXPECT_EQ(expected, actual);
+
+  auto status = client->DeleteObject(bucket_name, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
                     .set_endpoint("http://localhost:1"),


### PR DESCRIPTION
When reading the last chunk, if the chunk is between 128KiB and
128KiB+16KiB, the library would return a short chunk (sometimes, it is
complicated). Basically opening the stream would "peek" the data stream,
with 128KiB. When unlucky, the stream would download all the data (not
just the first 128KiB), mark the stream as closed, and save the extra bytes
in the spill buffer.

Future reads would not retrieve the data from the spill buffer because the
stream was already closed.

This fixes #2860

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2864)
<!-- Reviewable:end -->
