### PR TITLE
feat: Support setting 64-bit integers mutations.

### DIFF
--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -41,10 +41,8 @@ TEST(MutationsTest, SetCell) {
 }
 
 TEST(MutationsTest, SetCellNumericValue) {
-  using google::cloud::internal::DecodeBigEndian;
-  using google::cloud::internal::EncodeBigEndian;
-  auto actual = bigtable::SetCell("family", "col", 1234_ms,
-                                  EncodeBigEndian(std::int64_t{9876543210}));
+  auto actual =
+      bigtable::SetCell("family", "col", 1234_ms, std::int64_t{9876543210});
   ASSERT_TRUE(actual.op.has_set_cell());
   EXPECT_EQ("family", actual.op.set_cell().family_name());
   EXPECT_EQ("col", actual.op.set_cell().column_qualifier());
@@ -54,8 +52,7 @@ TEST(MutationsTest, SetCellNumericValue) {
   EXPECT_STATUS_OK(decoded);
   EXPECT_EQ(9876543210, *decoded);
 
-  auto server_set =
-      bigtable::SetCell("fam", "col", EncodeBigEndian(std::int64_t{32234401}));
+  auto server_set = bigtable::SetCell("fam", "col", std::int64_t{32234401});
   ASSERT_TRUE(server_set.op.has_set_cell());
   EXPECT_EQ("fam", server_set.op.set_cell().family_name());
   EXPECT_EQ("col", server_set.op.set_cell().column_qualifier());


### PR DESCRIPTION
This creates overloads for `bigtable::SetCell()` that set the cell value
to a 64-bit integer (stored as a big endian). This is useful when
creating cells that will be incremented with `CheckAndMutate()`.
Funnily, we had the operations to *read* such cells, and to increment
their value, and we (obviously) had the functions to create such values,
but the functions are in the `internal::` namespace.

This fixes #2863

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2866)
<!-- Reviewable:end -->
