### PR TITLE
Partially change benchmarks to use StatusOr instead of exceptions.

### DIFF
--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -143,9 +143,11 @@ int main(int argc, char* argv[]) {
   for (auto& future : tasks) {
     auto result = future.get();
     if (!result) {
-      std::cerr << result.status() << "\n";
+      std::cerr << "Standard exception raised by task[" << count
+                << "]: " << result.status() << "\n";
+    } else {
+      append(combined, *result);
     }
-    append(combined, *result);
     ++count;
   }
   auto latency_test_elapsed =

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
   benchmark.CreateTable();
   auto populate_results = benchmark.PopulateTable();
   if (!populate_results) {
-    std::cerr << populate_results.status();
+    std::cerr << populate_results.status() << "\n";
     return 1;
   }
 
@@ -143,7 +143,7 @@ int main(int argc, char* argv[]) {
   for (auto& future : tasks) {
     auto result = future.get();
     if (!result) {
-      std::cerr << result.status();
+      std::cerr << result.status() << "\n";
       return 1;
     }
     append(combined, *result);

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -82,10 +82,9 @@ struct LatencyBenchmarkResult {
 };
 
 /// Run an iteration of the test.
-LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
-                                    std::string app_profile_id,
-                                    std::string const& table_id,
-                                    std::chrono::seconds test_duration);
+google::cloud::StatusOr<LatencyBenchmarkResult> RunBenchmark(
+    bigtable::benchmarks::Benchmark& benchmark, std::string app_profile_id,
+    std::string const& table_id, std::chrono::seconds test_duration);
 
 //@{
 /// @name Test constants.  Defined as requirements in the original bug (#189).
@@ -95,7 +94,7 @@ constexpr int kBenchmarkProgressMarks = 4;
 
 }  // anonymous namespace
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[]) {
   bigtable::benchmarks::BenchmarkSetup setup("perf", argc, argv);
 
   Benchmark benchmark(setup);
@@ -103,15 +102,20 @@ int main(int argc, char* argv[]) try {
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();
   auto populate_results = benchmark.PopulateTable();
+  if (!populate_results) {
+    std::cerr << populate_results.status();
+    return 1;
+  }
 
   benchmark.PrintThroughputResult(std::cout, "perf", "Upload",
-                                  populate_results);
+                                  *populate_results);
 
   auto data_client = benchmark.MakeDataClient();
   // Start the threads running the latency test.
   std::cout << "Running Latency Benchmark " << std::flush;
   auto latency_test_start = std::chrono::steady_clock::now();
-  std::vector<std::future<LatencyBenchmarkResult>> tasks;
+  std::vector<std::future<google::cloud::StatusOr<LatencyBenchmarkResult>>>
+      tasks;
   for (int i = 0; i != setup.thread_count(); ++i) {
     auto launch_policy = std::launch::async;
     if (setup.thread_count() == 1) {
@@ -137,13 +141,12 @@ int main(int argc, char* argv[]) try {
     append_ops(destination.read_results, source.read_results);
   };
   for (auto& future : tasks) {
-    try {
-      auto result = future.get();
-      append(combined, result);
-    } catch (std::exception const& ex) {
-      std::cerr << "Standard exception raised by task[" << count
-                << "]: " << ex.what() << "\n";
+    auto result = future.get();
+    if (!result) {
+      std::cerr << result.status();
+      return 1;
     }
+    append(combined, *result);
     ++count;
   }
   auto latency_test_elapsed =
@@ -162,7 +165,7 @@ int main(int argc, char* argv[]) try {
 
   std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << "\n";
   benchmark.PrintResultCsv(std::cout, "perf", "BulkApply()", "Latency",
-                           populate_results);
+                           *populate_results);
   benchmark.PrintResultCsv(std::cout, "perf", "Apply()", "Latency",
                            combined.apply_results);
   benchmark.PrintResultCsv(std::cout, "perf", "ReadRow()", "Latency",
@@ -171,9 +174,6 @@ int main(int argc, char* argv[]) try {
   benchmark.DeleteTable();
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
-  return 1;
 }
 
 namespace {
@@ -183,32 +183,26 @@ OperationResult RunOneApply(bigtable::Table& table, std::string row_key,
   for (int field = 0; field != kNumFields; ++field) {
     mutation.emplace_back(MakeRandomMutation(generator, field));
   }
-  auto op = [&table, &mutation]() {
-    auto status = table.Apply(std::move(mutation));
-    if (!status.ok()) {
-      throw std::runtime_error(status.message());
-    }
+  auto op = [&table, &mutation]() -> google::cloud::Status {
+    return table.Apply(std::move(mutation));
   };
 
   return Benchmark::TimeOperation(std::move(op));
 }
 
 OperationResult RunOneReadRow(bigtable::Table& table, std::string row_key) {
-  auto op = [&table, &row_key]() {
-    auto row = table.ReadRow(
-        std::move(row_key),
-        bigtable::Filter::ColumnRangeClosed(kColumnFamily, "field0", "field9"));
-    if (!row) {
-      throw std::runtime_error(row.status().message());
-    }
+  auto op = [&table, &row_key]() -> google::cloud::Status {
+    return table
+        .ReadRow(std::move(row_key), bigtable::Filter::ColumnRangeClosed(
+                                         kColumnFamily, "field0", "field9"))
+        .status();
   };
   return Benchmark::TimeOperation(std::move(op));
 }
 
-LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
-                                    std::string app_profile_id,
-                                    std::string const& table_id,
-                                    std::chrono::seconds test_duration) {
+google::cloud::StatusOr<LatencyBenchmarkResult> RunBenchmark(
+    bigtable::benchmarks::Benchmark& benchmark, std::string app_profile_id,
+    std::string const& table_id, std::chrono::seconds test_duration) {
   LatencyBenchmarkResult result = {};
 
   auto data_client = benchmark.MakeDataClient();
@@ -224,12 +218,18 @@ LatencyBenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark& benchmark,
     auto row_key = benchmark.MakeRandomKey(generator);
 
     if (prng_operation(generator) == 0) {
-      result.apply_results.operations.emplace_back(
-          RunOneApply(table, row_key, generator));
+      auto op_result = RunOneApply(table, row_key, generator);
+      if (!op_result.status.ok()) {
+        return op_result.status;
+      }
+      result.apply_results.operations.emplace_back(op_result);
       ++result.apply_results.row_count;
     } else {
-      result.read_results.operations.emplace_back(
-          RunOneReadRow(table, row_key));
+      auto op_result = RunOneReadRow(table, row_key);
+      if (!op_result.status.ok()) {
+        return op_result.status;
+      }
+      result.read_results.operations.emplace_back(op_result);
       ++result.read_results.row_count;
     }
     if (now >= mark) {

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -144,7 +144,6 @@ int main(int argc, char* argv[]) {
     auto result = future.get();
     if (!result) {
       std::cerr << result.status() << "\n";
-      return 1;
     }
     append(combined, *result);
     ++count;

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -112,12 +112,14 @@ google::cloud::StatusOr<BenchmarkResult> Benchmark::PopulateTable() {
   for (auto& t : tasks) {
     auto shard_result = t.get();
     if (!shard_result) {
-      return shard_result;
+      std::cerr << "Exception raised by PopulateTask/" << count
+                << "]: " << shard_result.status() << "\n";
+    } else {
+      result.row_count += shard_result->row_count;
+      result.operations.insert(result.operations.end(),
+                               shard_result->operations.begin(),
+                               shard_result->operations.end());
     }
-    result.row_count += shard_result->row_count;
-    result.operations.insert(result.operations.end(),
-                             shard_result->operations.begin(),
-                             shard_result->operations.end());
     ++count;
   }
   using std::chrono::duration_cast;

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -129,7 +129,8 @@ TEST(BenchmarkTest, PrintLatencyResult) {
   result.operations.resize(100);
   int count = 0;
   std::generate(result.operations.begin(), result.operations.end(), [&count]() {
-    return OperationResult{true, std::chrono::microseconds(++count * 100)};
+    return OperationResult{google::cloud::Status{},
+                           std::chrono::microseconds(++count * 100)};
   });
 
   std::ostringstream os;
@@ -162,7 +163,8 @@ TEST(BenchmarkTest, PrintCsv) {
   result.operations.resize(100);
   int count = 0;
   std::generate(result.operations.begin(), result.operations.end(), [&count]() {
-    return OperationResult{true, std::chrono::microseconds(++count * 100)};
+    return OperationResult{google::cloud::Status{},
+                           std::chrono::microseconds(++count * 100)};
   });
 
   std::string header = bm.ResultsCsvHeader();

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -95,8 +95,9 @@ int main(int argc, char* argv[]) {
     if (!result) {
       std::cerr << "Error returned by task[" << count
                 << "]: " << result.status() << "\n";
+    } else {
+      combined += *result;
     }
-    combined += *result;
     ++count;
   }
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -93,8 +93,7 @@ int main(int argc, char* argv[]) {
   for (auto& future : tasks) {
     auto result = future.get();
     if (!result) {
-      std::cerr << result.status() << "\n";
-      return 1;
+      std::cerr << "Error returned by task[" << count << "]: " << result.status() << "\n";
     }
     combined += *result;
     ++count;

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -93,7 +93,8 @@ int main(int argc, char* argv[]) {
   for (auto& future : tasks) {
     auto result = future.get();
     if (!result) {
-      std::cerr << "Error returned by task[" << count << "]: " << result.status() << "\n";
+      std::cerr << "Error returned by task[" << count
+                << "]: " << result.status() << "\n";
     }
     combined += *result;
     ++count;

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) try {
   benchmark.CreateTable();
   auto populate_results = benchmark.PopulateTable();
   benchmark.PrintThroughputResult(std::cout, "scant", "Upload",
-                                  populate_results);
+                                  *populate_results);
 
   auto data_client = benchmark.MakeDataClient();
   std::map<std::string, BenchmarkResult> results_by_size;
@@ -101,7 +101,7 @@ int main(int argc, char* argv[]) try {
 
   std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << "\n";
   benchmark.PrintResultCsv(std::cout, "scant", "BulkApply()", "Latency",
-                           populate_results);
+                           *populate_results);
   for (auto& kv : results_by_size) {
     benchmark.PrintResultCsv(std::cout, "scant", kv.first, "IterationTime",
                              kv.second);
@@ -134,12 +134,19 @@ BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
         bigtable::RowRange::StartingAt(benchmark.MakeKey(prng(generator)));
 
     long count = 0;
-    auto op = [&count, &table, &scan_size, &range]() {
+    auto op = [&count, &table, &scan_size, &range]() -> google::cloud::Status {
       auto reader =
           table.ReadRows(bigtable::RowSet(std::move(range)), scan_size,
                          bigtable::Filter::ColumnRangeClosed(
                              kColumnFamily, "field0", "field9"));
-      count = std::distance(reader.begin(), reader.end());
+      for (auto& row : reader) {
+        if (!row) {
+          return row.status();
+          break;
+        }
+        ++count;
+      }
+      return google::cloud::Status{};
     };
     result.operations.push_back(Benchmark::TimeOperation(op));
     result.row_count += count;

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -142,7 +142,6 @@ BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
       for (auto& row : reader) {
         if (!row) {
           return row.status();
-          break;
         }
         ++count;
       }


### PR DESCRIPTION
Part of the work for #2877 

The only thing I haven't done yet is change `BenchmarkSetup` (see above issue for discussion). I prefer someone with more experience to tackle that.

The gist of this PR is that all try/catch blocks are replaced with reporting the error then returning. Instead of a `successful` flag `OperationResult` now contains a `google::cloud::Status`. This also means that the `op` functors return a `Status` as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2881)
<!-- Reviewable:end -->
