### PR TITLE
feat: Helpers for PredefinedDefaultObjectAcl.

### DIFF
--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -128,6 +128,60 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
   EXPECT_EQ(0, name_counter(bucket_name, current_buckets));
 }
 
+TEST_F(BucketIntegrationTest, CreatePredefinedAcl) {
+  std::vector<PredefinedAcl> test_values{
+      PredefinedAcl::AuthenticatedRead(), PredefinedAcl::Private(),
+      PredefinedAcl::ProjectPrivate(),    PredefinedAcl::PublicRead(),
+      PredefinedAcl::PublicReadWrite(),
+  };
+
+  std::string project_id = flag_project_id;
+  for (auto const& acl : test_values) {
+    SCOPED_TRACE(std::string("Testing with ") +
+                 acl.well_known_parameter_name() + "=" + acl.value());
+    std::string bucket_name = MakeRandomBucketName();
+    StatusOr<Client> client = Client::CreateDefaultClient();
+    ASSERT_STATUS_OK(client);
+
+    auto metadata = client->CreateBucketForProject(
+        bucket_name, project_id, BucketMetadata(), PredefinedAcl(acl));
+    ASSERT_STATUS_OK(metadata);
+    EXPECT_EQ(bucket_name, metadata->name());
+
+    auto status = client->DeleteBucket(bucket_name);
+    ASSERT_STATUS_OK(status);
+  }
+}
+
+TEST_F(BucketIntegrationTest, CreatePredefinedDefaultObjectAcl) {
+  std::vector<PredefinedDefaultObjectAcl> test_values{
+      PredefinedDefaultObjectAcl::AuthenticatedRead(),
+      PredefinedDefaultObjectAcl::BucketOwnerFullControl(),
+      PredefinedDefaultObjectAcl::BucketOwnerRead(),
+      PredefinedDefaultObjectAcl::Private(),
+      PredefinedDefaultObjectAcl::ProjectPrivate(),
+      PredefinedDefaultObjectAcl::PublicRead(),
+  };
+
+  std::string project_id = flag_project_id;
+  for (auto const& acl : test_values) {
+    SCOPED_TRACE(std::string("Testing with ") +
+                 acl.well_known_parameter_name() + "=" + acl.value());
+    std::string bucket_name = MakeRandomBucketName();
+    StatusOr<Client> client = Client::CreateDefaultClient();
+    ASSERT_STATUS_OK(client);
+
+    auto metadata = client->CreateBucketForProject(
+        bucket_name, project_id, BucketMetadata(),
+        PredefinedDefaultObjectAcl(acl));
+    ASSERT_STATUS_OK(metadata);
+    EXPECT_EQ(bucket_name, metadata->name());
+
+    auto status = client->DeleteBucket(bucket_name);
+    ASSERT_STATUS_OK(status);
+  }
+}
+
 TEST_F(BucketIntegrationTest, FullPatch) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -330,6 +330,9 @@ struct PredefinedAcl
     return PredefinedAcl("projectPrivate");
   }
   static PredefinedAcl PublicRead() { return PredefinedAcl("publicRead"); }
+  static PredefinedAcl PublicReadWrite() {
+    return PredefinedAcl("publicReadWrite");
+  }
 };
 
 /**
@@ -394,6 +397,25 @@ struct PredefinedDefaultObjectAcl
                            std::string>::WellKnownParameter;
   static char const* well_known_parameter_name() {
     return "predefinedDefaultObjectAcl";
+  }
+
+  static PredefinedDefaultObjectAcl AuthenticatedRead() {
+    return PredefinedDefaultObjectAcl("authenticatedRead");
+  }
+  static PredefinedDefaultObjectAcl BucketOwnerFullControl() {
+    return PredefinedDefaultObjectAcl("bucketOwnerFullControl");
+  }
+  static PredefinedDefaultObjectAcl BucketOwnerRead() {
+    return PredefinedDefaultObjectAcl("bucketOwnerRead");
+  }
+  static PredefinedDefaultObjectAcl Private() {
+    return PredefinedDefaultObjectAcl("private");
+  }
+  static PredefinedDefaultObjectAcl ProjectPrivate() {
+    return PredefinedDefaultObjectAcl("projectPrivate");
+  }
+  static PredefinedDefaultObjectAcl PublicRead() {
+    return PredefinedDefaultObjectAcl("publicRead");
   }
 };
 


### PR DESCRIPTION
The other Predefined*Acl options have helper functions to avoid typos in
things like "bucketOwnerFullControl". I also added integration tests to
make sure all the values are actually accepted by the service.

Fixes #2884.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2885)
<!-- Reviewable:end -->
