### PR TITLE
cleanup: Fix OpenCensus warnings in bigtable example.

### DIFF
--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -70,9 +70,15 @@ int main(int argc, char* argv[]) try {
   // For more details, see the documentation
   //   https://github.com/census-instrumentation/opencensus-cpp/tree/master/opencensus/exporters/stats/stackdriver#opencensus-stackdriver-stats-exporter
 
-  opencensus::exporters::stats::StackdriverExporter::Register(
-      project_id, "bigtable-opencensus-0@unspecified-host");
-  opencensus::exporters::trace::StackdriverExporter::Register(project_id);
+  opencensus::exporters::stats::StackdriverOptions stats_opts;
+  stats_opts.project_id = project_id;
+  stats_opts.opencensus_task = "bigtable-opencensus-0@unspecified-host";
+
+  opencensus::exporters::trace::StackdriverOptions trace_opts;
+  trace_opts.project_id = project_id;
+
+  opencensus::exporters::stats::StackdriverExporter::Register(stats_opts);
+  opencensus::exporters::trace::StackdriverExporter::Register(trace_opts);
 
   // Connect to the Cloud Bigtable Admin API.
   //! [connect admin]


### PR DESCRIPTION
Fixes #2837

It is deprecated to use `opencensus::exporters::{stats, trace}::StackdriverExporter::Register` without `StackdriverOptions`. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2889)
<!-- Reviewable:end -->
