### PR TITLE
Convert BenchmarkSetup to use StatusOr.

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -349,9 +349,9 @@ if (BUILD_TESTING)
     add_subdirectory(tests)
 endif ()
 
+add_subdirectory(benchmarks)
+
 if (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
-    # TODO(#2877) - Change the benchmarks to compile with exceptions disabled.
-    add_subdirectory(benchmarks)
     # The examples are more readable if we use exceptions for error handling. We
     # had to tradeoff readability vs. "making them compile everywhere".
     add_subdirectory(examples)

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -95,9 +95,14 @@ constexpr int kBenchmarkProgressMarks = 4;
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  bigtable::benchmarks::BenchmarkSetup setup("perf", argc, argv);
+  google::cloud::StatusOr<bigtable::benchmarks::BenchmarkSetup> setup =
+      MakeBenchmarkSetup("perf", argc, argv);
+  if (!setup) {
+    std::cerr << setup.status() << "\n";
+    return -1;
+  }
 
-  Benchmark benchmark(setup);
+  Benchmark benchmark(*setup);
 
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();
@@ -116,15 +121,15 @@ int main(int argc, char* argv[]) {
   auto latency_test_start = std::chrono::steady_clock::now();
   std::vector<std::future<google::cloud::StatusOr<LatencyBenchmarkResult>>>
       tasks;
-  for (int i = 0; i != setup.thread_count(); ++i) {
+  for (int i = 0; i != setup->thread_count(); ++i) {
     auto launch_policy = std::launch::async;
-    if (setup.thread_count() == 1) {
+    if (setup->thread_count() == 1) {
       // If the user requests only one thread, use the current thread.
       launch_policy = std::launch::deferred;
     }
     tasks.emplace_back(std::async(launch_policy, RunBenchmark,
-                                  std::ref(benchmark), setup.app_profile_id(),
-                                  setup.table_id(), setup.test_duration()));
+                                  std::ref(benchmark), setup->app_profile_id(),
+                                  setup->table_id(), setup->test_duration()));
   }
 
   // Wait for the threads and combine all the results.

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -95,8 +95,7 @@ constexpr int kBenchmarkProgressMarks = 4;
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  google::cloud::StatusOr<bigtable::benchmarks::BenchmarkSetup> setup =
-      MakeBenchmarkSetup("perf", argc, argv);
+  auto setup = MakeBenchmarkSetup("perf", argc, argv);
   if (!setup) {
     std::cerr << setup.status() << "\n";
     return -1;

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/benchmarks/benchmark.h"
 #include "google/cloud/internal/build_info.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 using namespace google::cloud::bigtable::benchmarks;
@@ -33,10 +34,12 @@ char arg7[] = "True";
 TEST(BenchmarkTest, Create) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("create", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("create", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
   {
-    Benchmark bm(setup);
+    Benchmark bm(*setup);
     EXPECT_EQ(0, bm.create_table_count());
     std::string table_id = bm.CreateTable();
     EXPECT_EQ(1, bm.create_table_count());
@@ -52,9 +55,11 @@ TEST(BenchmarkTest, Create) {
 TEST(BenchmarkTest, Populate) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("populate", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("populate", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
-  Benchmark bm(setup);
+  Benchmark bm(*setup);
   bm.CreateTable();
   EXPECT_EQ(0, bm.mutate_rows_count());
   bm.PopulateTable();
@@ -67,9 +72,11 @@ TEST(BenchmarkTest, Populate) {
 TEST(BenchmarkTest, MakeRandomKey) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("key", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("key", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
-  Benchmark bm(setup);
+  Benchmark bm(*setup);
   auto gen = google::cloud::internal::MakeDefaultPRNG();
 
   // First make sure that the keys are not always the same.
@@ -95,9 +102,11 @@ TEST(BenchmarkTest, MakeRandomKey) {
 TEST(BenchmarkTest, PrintThroughputResult) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("throughput", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("throughput", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
-  Benchmark bm(setup);
+  Benchmark bm(*setup);
   BenchmarkResult result{};
   result.elapsed = std::chrono::milliseconds(10000);
   result.row_count = 1230;
@@ -120,9 +129,11 @@ TEST(BenchmarkTest, PrintThroughputResult) {
 TEST(BenchmarkTest, PrintLatencyResult) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("latency", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("latency", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
-  Benchmark bm(setup);
+  Benchmark bm(*setup);
   BenchmarkResult result{};
   result.elapsed = std::chrono::milliseconds(1000);
   result.row_count = 100;
@@ -154,9 +165,11 @@ TEST(BenchmarkTest, PrintLatencyResult) {
 TEST(BenchmarkTest, PrintCsv) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("latency", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("latency", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
-  Benchmark bm(setup);
+  Benchmark bm(*setup);
   BenchmarkResult result{};
   result.elapsed = std::chrono::milliseconds(1000);
   result.row_count = 123;

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -34,8 +34,7 @@ char arg7[] = "True";
 TEST(BenchmarkTest, Create) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("create", argc, argv);
+  auto setup = MakeBenchmarkSetup("create", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   {
@@ -55,8 +54,7 @@ TEST(BenchmarkTest, Create) {
 TEST(BenchmarkTest, Populate) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("populate", argc, argv);
+  auto setup = MakeBenchmarkSetup("populate", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   Benchmark bm(*setup);
@@ -72,8 +70,7 @@ TEST(BenchmarkTest, Populate) {
 TEST(BenchmarkTest, MakeRandomKey) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("key", argc, argv);
+  auto setup = MakeBenchmarkSetup("key", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   Benchmark bm(*setup);
@@ -102,8 +99,7 @@ TEST(BenchmarkTest, MakeRandomKey) {
 TEST(BenchmarkTest, PrintThroughputResult) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("throughput", argc, argv);
+  auto setup = MakeBenchmarkSetup("throughput", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   Benchmark bm(*setup);
@@ -129,8 +125,7 @@ TEST(BenchmarkTest, PrintThroughputResult) {
 TEST(BenchmarkTest, PrintLatencyResult) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("latency", argc, argv);
+  auto setup = MakeBenchmarkSetup("latency", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   Benchmark bm(*setup);
@@ -165,8 +160,7 @@ TEST(BenchmarkTest, PrintLatencyResult) {
 TEST(BenchmarkTest, PrintCsv) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("latency", argc, argv);
+  auto setup = MakeBenchmarkSetup("latency", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   Benchmark bm(*setup);

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -66,8 +66,7 @@ google::cloud::StatusOr<long> RunBenchmark(
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  google::cloud::StatusOr<bigtable::benchmarks::BenchmarkSetup> setup =
-      bigtable::benchmarks::MakeBenchmarkSetup("long", argc, argv);
+  auto setup = bigtable::benchmarks::MakeBenchmarkSetup("long", argc, argv);
   if (!setup) {
     std::cerr << setup.status() << "\n";
     return -1;

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -66,9 +66,14 @@ google::cloud::StatusOr<long> RunBenchmark(
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  bigtable::benchmarks::BenchmarkSetup setup("long", argc, argv);
+  google::cloud::StatusOr<bigtable::benchmarks::BenchmarkSetup> setup =
+      bigtable::benchmarks::MakeBenchmarkSetup("long", argc, argv);
+  if (!setup) {
+    std::cerr << setup.status() << "\n";
+    return -1;
+  }
 
-  Benchmark benchmark(setup);
+  Benchmark benchmark(*setup);
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();
 
@@ -76,15 +81,15 @@ int main(int argc, char* argv[]) {
   std::cout << "# Running Endurance Benchmark:\n";
   auto latency_test_start = std::chrono::steady_clock::now();
   std::vector<std::future<google::cloud::StatusOr<long>>> tasks;
-  for (int i = 0; i != setup.thread_count(); ++i) {
+  for (int i = 0; i != setup->thread_count(); ++i) {
     auto launch_policy = std::launch::async;
-    if (setup.thread_count() == 1) {
+    if (setup->thread_count() == 1) {
       // If the user requests only one thread, use the current thread.
       launch_policy = std::launch::deferred;
     }
     tasks.emplace_back(std::async(launch_policy, RunBenchmark,
-                                  std::ref(benchmark), setup.app_profile_id(),
-                                  setup.table_id(), setup.test_duration()));
+                                  std::ref(benchmark), setup->app_profile_id(),
+                                  setup->table_id(), setup->test_duration()));
   }
 
   // Wait for the threads and combine all the results.

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -70,8 +70,7 @@ BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  google::cloud::StatusOr<bigtable::benchmarks::BenchmarkSetup> setup =
-      bigtable::benchmarks::MakeBenchmarkSetup("scant", argc, argv);
+  auto setup = bigtable::benchmarks::MakeBenchmarkSetup("scant", argc, argv);
   if (!setup) {
     std::cerr << setup.status() << "\n";
     return -1;

--- a/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/scan_throughput_benchmark.cc
@@ -69,10 +69,15 @@ BenchmarkResult RunBenchmark(bigtable::benchmarks::Benchmark const& benchmark,
                              std::chrono::seconds test_duration);
 }  // anonymous namespace
 
-int main(int argc, char* argv[]) try {
-  bigtable::benchmarks::BenchmarkSetup setup("scant", argc, argv);
+int main(int argc, char* argv[]) {
+  google::cloud::StatusOr<bigtable::benchmarks::BenchmarkSetup> setup =
+      bigtable::benchmarks::MakeBenchmarkSetup("scant", argc, argv);
+  if (!setup) {
+    std::cerr << setup.status() << "\n";
+    return -1;
+  }
 
-  Benchmark benchmark(setup);
+  Benchmark benchmark(*setup);
 
   // Create and populate the table for the benchmark.
   benchmark.CreateTable();
@@ -85,9 +90,9 @@ int main(int argc, char* argv[]) try {
   for (auto scan_size : kScanSizes) {
     std::cout << "# Running benchmark [" << scan_size << "] " << std::flush;
     auto start = std::chrono::steady_clock::now();
-    auto combined = RunBenchmark(benchmark, data_client, setup.table_size(),
-                                 setup.app_profile_id(), setup.table_id(),
-                                 scan_size, setup.test_duration());
+    auto combined = RunBenchmark(benchmark, data_client, setup->table_size(),
+                                 setup->app_profile_id(), setup->table_id(),
+                                 scan_size, setup->test_duration());
     using std::chrono::duration_cast;
     combined.elapsed = duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now() - start);
@@ -110,9 +115,6 @@ int main(int argc, char* argv[]) try {
   benchmark.DeleteTable();
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
-  return 1;
 }
 
 namespace {

--- a/google/cloud/bigtable/benchmarks/setup.h
+++ b/google/cloud/bigtable/benchmarks/setup.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_BENCHMARKS_SETUP_H_
 
 #include "google/cloud/bigtable/benchmarks/constants.h"
+#include "google/cloud/status_or.h"
 #include <chrono>
 #include <string>
 #include <vector>
@@ -25,41 +26,59 @@ namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 /**
+ * The configuration data for a benchmark.
+ */
+struct BenchmarkSetupData {
+  std::string start_time;
+  std::string notes;
+  std::string project_id;
+  std::string instance_id;
+  std::string app_profile_id;
+  std::string table_id;
+  int thread_count;
+  long table_size;
+  std::chrono::seconds test_duration;
+  bool use_embedded_server;
+};
+
+/**
  * The configuration for a benchmark.
  */
 class BenchmarkSetup {
  public:
-  BenchmarkSetup(std::string const& prefix, int& argc, char* argv[]);
+  explicit BenchmarkSetup(BenchmarkSetupData setup_data);
 
   /// When did the benchmark start, this is used in reporting the results.
-  std::string const& start_time() const { return start_time_; }
+  std::string const& start_time() const { return setup_data_.start_time; }
   /// Benchmark annotations, e.g., compiler version and flags.
-  std::string const& notes() const { return notes_; }
-  std::string const& project_id() const { return project_id_; }
-  std::string const& instance_id() const { return instance_id_; }
-  std::string const& app_profile_id() const { return app_profile_id_; }
+  std::string const& notes() const { return setup_data_.notes; }
+  std::string const& project_id() const { return setup_data_.project_id; }
+  std::string const& instance_id() const { return setup_data_.instance_id; }
+  std::string const& app_profile_id() const {
+    return setup_data_.app_profile_id;
+  }
 
   /// The randomly generated table id for the benchmark.
-  std::string const& table_id() const { return table_id_; }
+  std::string const& table_id() const { return setup_data_.table_id; }
 
-  long table_size() const { return table_size_; }
-  int thread_count() const { return thread_count_; }
-  std::chrono::seconds test_duration() const { return test_duration_; }
-  bool use_embedded_server() const { return use_embedded_server_; }
+  long table_size() const { return setup_data_.table_size; }
+  int thread_count() const { return setup_data_.thread_count; }
+  std::chrono::seconds test_duration() const {
+    return setup_data_.test_duration;
+  }
+  bool use_embedded_server() const { return setup_data_.use_embedded_server; }
 
  private:
-  std::string start_time_;
-  std::string notes_;
-  std::string project_id_;
-  std::string instance_id_;
-  std::string app_profile_id_;
-  std::string table_id_;
-  int thread_count_ = kDefaultThreads;
-  long table_size_ = kDefaultTableSize;
-  std::chrono::seconds test_duration_ =
-      std::chrono::seconds(kDefaultTestDuration * 60);
-  bool use_embedded_server_ = false;
+  BenchmarkSetupData setup_data_;
 };
+
+/**
+ * Does the actual work in constructing a BenchmarkSetup. Since we do not want
+ * to use exceptions here, we factor out the logic in which an error can occur
+ * into a separate function.
+ */
+google::cloud::StatusOr<BenchmarkSetup> MakeBenchmarkSetup(
+    std::string const& prefix, int& argc, char* argv[]);
 
 }  // namespace benchmarks
 }  // namespace bigtable

--- a/google/cloud/bigtable/benchmarks/setup_test.cc
+++ b/google/cloud/bigtable/benchmarks/setup_test.cc
@@ -33,8 +33,7 @@ char arg8[] = "Unused";
 TEST(BenchmarksSetup, Basic) {
   char* argv[] = {arg0, arg1, arg2, arg3};
   int argc = 4;
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("pre", argc, argv);
+  auto setup = MakeBenchmarkSetup("pre", argc, argv);
   ASSERT_STATUS_OK(setup);
   EXPECT_EQ("foo", setup->project_id());
   EXPECT_EQ("bar", setup->instance_id());
@@ -57,11 +56,9 @@ TEST(BenchmarksSetup, Different) {
   int argc_0 = sizeof(argv_0) / sizeof(argv_0[0]);
   char* argv_1[] = {arg0, arg1, arg2, arg3};
   int argc_1 = sizeof(argv_1) / sizeof(argv_1[0]);
-  google::cloud::StatusOr<BenchmarkSetup> s0 =
-      MakeBenchmarkSetup("pre", argc_0, argv_0);
+  auto s0 = MakeBenchmarkSetup("pre", argc_0, argv_0);
   ASSERT_STATUS_OK(s0);
-  google::cloud::StatusOr<BenchmarkSetup> s1 =
-      MakeBenchmarkSetup("pre", argc_1, argv_1);
+  auto s1 = MakeBenchmarkSetup("pre", argc_1, argv_1);
   ASSERT_STATUS_OK(s1);
   // The probability of this test failing is tiny, but if it does, run it again.
   // Sorry for the flakiness, but randomness is hard.
@@ -71,8 +68,7 @@ TEST(BenchmarksSetup, Different) {
 TEST(BenchmarkSetup, Parse) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("pre", argc, argv);
+  auto setup = MakeBenchmarkSetup("pre", argc, argv);
   ASSERT_STATUS_OK(setup);
 
   EXPECT_EQ(2, argc);
@@ -91,8 +87,7 @@ TEST(BenchmarkSetup, Parse) {
 TEST(BenchmarkSetup, Test7) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("t6", argc, argv);
+  auto setup = MakeBenchmarkSetup("t6", argc, argv);
   ASSERT_STATUS_OK(setup);
   EXPECT_TRUE(setup->use_embedded_server());
 }
@@ -100,8 +95,7 @@ TEST(BenchmarkSetup, Test7) {
 TEST(BenchmarkSetup, Test6) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("t5", argc, argv);
+  auto setup = MakeBenchmarkSetup("t5", argc, argv);
   ASSERT_STATUS_OK(setup);
   EXPECT_EQ(10000, setup->table_size());
   EXPECT_FALSE(setup->use_embedded_server());
@@ -110,8 +104,7 @@ TEST(BenchmarkSetup, Test6) {
 TEST(BenchmarkSetup, Test5) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("t4", argc, argv);
+  auto setup = MakeBenchmarkSetup("t4", argc, argv);
   ASSERT_STATUS_OK(setup);
   EXPECT_EQ(300, setup->test_duration().count());
 }
@@ -119,8 +112,7 @@ TEST(BenchmarkSetup, Test5) {
 TEST(BenchmarkSetup, Test4) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("t3", argc, argv);
+  auto setup = MakeBenchmarkSetup("t3", argc, argv);
   ASSERT_STATUS_OK(setup);
   EXPECT_EQ(4, setup->thread_count());
 }
@@ -128,8 +120,7 @@ TEST(BenchmarkSetup, Test4) {
 TEST(BenchmarkSetup, Test3) {
   char* argv[] = {arg0, arg1, arg2, arg3};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  google::cloud::StatusOr<BenchmarkSetup> setup =
-      MakeBenchmarkSetup("t2", argc, argv);
+  auto setup = MakeBenchmarkSetup("t2", argc, argv);
   ASSERT_STATUS_OK(setup);
   EXPECT_EQ("foo", setup->project_id());
   EXPECT_EQ("bar", setup->instance_id());

--- a/google/cloud/bigtable/benchmarks/setup_test.cc
+++ b/google/cloud/bigtable/benchmarks/setup_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/benchmarks/setup.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 using namespace google::cloud::bigtable::benchmarks;
@@ -32,17 +33,19 @@ char arg8[] = "Unused";
 TEST(BenchmarksSetup, Basic) {
   char* argv[] = {arg0, arg1, arg2, arg3};
   int argc = 4;
-  BenchmarkSetup setup("pre", argc, argv);
-  EXPECT_EQ("foo", setup.project_id());
-  EXPECT_EQ("bar", setup.instance_id());
-  EXPECT_EQ("profile", setup.app_profile_id());
-  EXPECT_EQ(0, setup.table_id().find("pre"));
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("pre", argc, argv);
+  ASSERT_STATUS_OK(setup);
+  EXPECT_EQ("foo", setup->project_id());
+  EXPECT_EQ("bar", setup->instance_id());
+  EXPECT_EQ("profile", setup->app_profile_id());
+  EXPECT_EQ(0, setup->table_id().find("pre"));
   std::size_t expected = 4 + kTableIdRandomLetters;
-  EXPECT_EQ(expected, setup.table_id().size());
+  EXPECT_EQ(expected, setup->table_id().size());
 
-  EXPECT_EQ(kDefaultTableSize, setup.table_size());
-  EXPECT_EQ(kDefaultTestDuration * 60, setup.test_duration().count());
-  EXPECT_FALSE(setup.use_embedded_server());
+  EXPECT_EQ(kDefaultTableSize, setup->table_size());
+  EXPECT_EQ(kDefaultTestDuration * 60, setup->test_duration().count());
+  EXPECT_FALSE(setup->use_embedded_server());
 }
 
 TEST(BenchmarksSetup, Different) {
@@ -54,86 +57,102 @@ TEST(BenchmarksSetup, Different) {
   int argc_0 = sizeof(argv_0) / sizeof(argv_0[0]);
   char* argv_1[] = {arg0, arg1, arg2, arg3};
   int argc_1 = sizeof(argv_1) / sizeof(argv_1[0]);
-  BenchmarkSetup s0("pre", argc_0, argv_0);
-  BenchmarkSetup s1("pre", argc_1, argv_1);
+  google::cloud::StatusOr<BenchmarkSetup> s0 =
+      MakeBenchmarkSetup("pre", argc_0, argv_0);
+  ASSERT_STATUS_OK(s0);
+  google::cloud::StatusOr<BenchmarkSetup> s1 =
+      MakeBenchmarkSetup("pre", argc_1, argv_1);
+  ASSERT_STATUS_OK(s1);
   // The probability of this test failing is tiny, but if it does, run it again.
   // Sorry for the flakiness, but randomness is hard.
-  EXPECT_NE(s0.table_id(), s1.table_id());
+  EXPECT_NE(s0->table_id(), s1->table_id());
 }
 
 TEST(BenchmarkSetup, Parse) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("pre", argc, argv);
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("pre", argc, argv);
+  ASSERT_STATUS_OK(setup);
 
   EXPECT_EQ(2, argc);
   EXPECT_EQ(std::string("program"), argv[0]);
   EXPECT_EQ(std::string("Unused"), argv[1]);
 
-  EXPECT_EQ("foo", setup.project_id());
-  EXPECT_EQ("bar", setup.instance_id());
-  EXPECT_EQ("profile", setup.app_profile_id());
-  EXPECT_EQ(4, setup.thread_count());
-  EXPECT_EQ(300, setup.test_duration().count());
-  EXPECT_EQ(10000, setup.table_size());
-  EXPECT_TRUE(setup.use_embedded_server());
+  EXPECT_EQ("foo", setup->project_id());
+  EXPECT_EQ("bar", setup->instance_id());
+  EXPECT_EQ("profile", setup->app_profile_id());
+  EXPECT_EQ(4, setup->thread_count());
+  EXPECT_EQ(300, setup->test_duration().count());
+  EXPECT_EQ(10000, setup->table_size());
+  EXPECT_TRUE(setup->use_embedded_server());
 }
 
 TEST(BenchmarkSetup, Test7) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("t6", argc, argv);
-  EXPECT_TRUE(setup.use_embedded_server());
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("t6", argc, argv);
+  ASSERT_STATUS_OK(setup);
+  EXPECT_TRUE(setup->use_embedded_server());
 }
 
 TEST(BenchmarkSetup, Test6) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("t5", argc, argv);
-  EXPECT_EQ(10000, setup.table_size());
-  EXPECT_FALSE(setup.use_embedded_server());
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("t5", argc, argv);
+  ASSERT_STATUS_OK(setup);
+  EXPECT_EQ(10000, setup->table_size());
+  EXPECT_FALSE(setup->use_embedded_server());
 }
 
 TEST(BenchmarkSetup, Test5) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("t4", argc, argv);
-  EXPECT_EQ(300, setup.test_duration().count());
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("t4", argc, argv);
+  ASSERT_STATUS_OK(setup);
+  EXPECT_EQ(300, setup->test_duration().count());
 }
 
 TEST(BenchmarkSetup, Test4) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("t3", argc, argv);
-  EXPECT_EQ(4, setup.thread_count());
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("t3", argc, argv);
+  ASSERT_STATUS_OK(setup);
+  EXPECT_EQ(4, setup->thread_count());
 }
 
 TEST(BenchmarkSetup, Test3) {
   char* argv[] = {arg0, arg1, arg2, arg3};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  BenchmarkSetup setup("t2", argc, argv);
-  EXPECT_EQ("foo", setup.project_id());
-  EXPECT_EQ("bar", setup.instance_id());
-  EXPECT_EQ("profile", setup.app_profile_id());
-  EXPECT_EQ(kDefaultThreads, setup.thread_count());
+  google::cloud::StatusOr<BenchmarkSetup> setup =
+      MakeBenchmarkSetup("t2", argc, argv);
+  ASSERT_STATUS_OK(setup);
+  EXPECT_EQ("foo", setup->project_id());
+  EXPECT_EQ("bar", setup->instance_id());
+  EXPECT_EQ("profile", setup->app_profile_id());
+  EXPECT_EQ(kDefaultThreads, setup->thread_count());
 }
 
 TEST(BenchmarkSetup, Test2) {
   char* argv[] = {arg0, arg1, arg2};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  EXPECT_THROW(BenchmarkSetup("t1", argc, argv), std::exception);
+  EXPECT_FALSE(MakeBenchmarkSetup("t1", argc, argv));
 }
 
 TEST(BenchmarkSetup, Test1) {
   char* argv[] = {arg0, arg1};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  EXPECT_THROW(BenchmarkSetup("t1", argc, argv), std::exception);
+  EXPECT_FALSE(MakeBenchmarkSetup("t1", argc, argv));
 }
 
 TEST(BenchmarkSetup, Test0) {
   char* argv[] = {arg0};
   int argc = sizeof(argv) / sizeof(argv[0]);
-  EXPECT_THROW(BenchmarkSetup("t0", argc, argv), std::exception);
+  EXPECT_FALSE(MakeBenchmarkSetup("t0", argc, argv));
 }
 
 TEST(BenchmarkSetup, TestDuration) {
@@ -142,7 +161,7 @@ TEST(BenchmarkSetup, TestDuration) {
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   // Test duration parameter should be >= 0.
-  EXPECT_THROW(BenchmarkSetup("test-duration", argc, argv), std::exception);
+  EXPECT_FALSE(MakeBenchmarkSetup("test-duration", argc, argv));
 }
 
 TEST(BenchmarkSetup, TableSize) {
@@ -151,5 +170,5 @@ TEST(BenchmarkSetup, TableSize) {
   int argc = sizeof(argv) / sizeof(argv[0]);
 
   // TableSize parameter should be >= 100.
-  EXPECT_THROW(BenchmarkSetup("table-size", argc, argv), std::exception);
+  EXPECT_FALSE(MakeBenchmarkSetup("table-size", argc, argv));
 }


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-cpp/issues/2877

As we do not want to use exceptions, we create a "factory" function named `MakeBenchmarkSetup` that does all of the actual work and returns a `StatusOr`. As suggested by @coryan, I moved all of the fields from `BenchmarkSetup` into `BenchmarkSetupData`, which is accepted by the former's public constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2897)
<!-- Reviewable:end -->
