### PR TITLE
feat: Add CMake super build. 

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -137,11 +137,21 @@ _EOF_
 fi
 
 if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
-  # Run the tests and output any failures.
-  echo
-  echo "${COLOR_YELLOW}Running unit tests $(date)${COLOR_RESET}"
-  echo
-  (cd "${BINARY_DIR}" && ctest --output-on-failure)
+  # When the user does a super-build the tests are hidden in a subdirectory.
+  # We can tell that ${BINARY_DIR} does not have the tests by checking for this
+  # file:
+  if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
+    # It is Okay to skip the tests in this case because the super build
+    # automatically runs them.
+    echo
+    echo "${COLOR_YELLOW}Running unit tests $(date)${COLOR_RESET}"
+    echo
+    (cd "${BINARY_DIR}" && ctest --output-on-failure)
+
+    echo
+    echo "${COLOR_YELLOW}Completed unit tests $(date)${COLOR_RESET}"
+    echo
+  fi
 
   if [[ "${RUN_INTEGRATION_TESTS:-}" != "no" ]]; then
     echo
@@ -160,9 +170,6 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     echo "${COLOR_YELLOW}Completed integration tests $(date)${COLOR_RESET}"
     echo
   fi
-  echo
-  echo "${COLOR_YELLOW}Completed unit tests $(date)${COLOR_RESET}"
-  echo
 fi
 
 # Test the install rule and that the installation works.

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -139,19 +139,29 @@ fi
 if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
   # Run the tests and output any failures.
   echo
-  echo "${COLOR_YELLOW}Running unit and integration tests $(date)${COLOR_RESET}"
+  echo "${COLOR_YELLOW}Running unit tests $(date)${COLOR_RESET}"
   echo
   (cd "${BINARY_DIR}" && ctest --output-on-failure)
 
-  # Run the integration tests. Not all projects have them, so just iterate over
-  # the ones that do.
-  for subdir in google/cloud google/cloud/bigtable google/cloud/storage; do
+  if [[ "${RUN_INTEGRATION_TESTS:-}" != "no" ]]; then
     echo
-    echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
-    (cd "${BINARY_DIR}" && "${PROJECT_ROOT}/${subdir}/ci/run_integration_tests.sh")
-  done
+    echo "${COLOR_YELLOW}Running integration tests $(date)${COLOR_RESET}"
+    echo
+
+    # Run the integration tests. Not all projects have them, so just iterate over
+    # the ones that do.
+    for subdir in google/cloud google/cloud/bigtable google/cloud/storage; do
+      echo
+      echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
+      (cd "${BINARY_DIR}" && "${PROJECT_ROOT}/${subdir}/ci/run_integration_tests.sh")
+    done
+
+    echo
+    echo "${COLOR_YELLOW}Completed integration tests $(date)${COLOR_RESET}"
+    echo
+  fi
   echo
-  echo "${COLOR_YELLOW}Completed unit and integration tests $(date)${COLOR_RESET}"
+  echo "${COLOR_YELLOW}Completed unit tests $(date)${COLOR_RESET}"
   echo
 fi
 

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -57,6 +57,12 @@ elif [[ "${BUILD_NAME}" = "centos-7" ]] || [[ "${BUILD_NAME}" = "gcc-4.8" ]]; th
   # Compile under centos:7. This distro uses gcc-4.8.
   export DISTRO=centos
   export DISTRO_VERSION=7
+elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
+  export CMAKE_SOURCE_DIR="ci/super"
+  # Note that the integration tests are run by default. This is the opposite of
+  # what spanner does where RUN_INTEGRATION_TESTS is explicitly set to yes.
+  export RUN_INTEGRATION_TESTS="no"
+  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "gcc-9" ]]; then
   # Compile under fedora:30. This distro uses gcc-9.
   export DISTRO=fedora
@@ -235,6 +241,9 @@ docker_flags=(
     # If set, run the scripts to check (and fix) the code formatting (i.e.
     # clang-format, cmake-format, and buildifier).
     "--env" "CHECK_STYLE=${CHECK_STYLE:-}"
+
+    # If set to 'no', skip the integration tests.
+    "--env" "RUN_INTEGRATION_TESTS=${RUN_INTEGRATION_TESTS:-}"
 
     # If set, run the scripts to generate Doxygen docs. Note that the scripts
     # to upload said docs are not part of the build, they run afterwards on

--- a/ci/kokoro/readme/Dockerfile.centos
+++ b/ci/kokoro/readme/Dockerfile.centos
@@ -42,12 +42,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.debian
+++ b/ci/kokoro/readme/Dockerfile.debian
@@ -43,12 +43,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.fedora
+++ b/ci/kokoro/readme/Dockerfile.fedora
@@ -35,12 +35,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.opensuse
+++ b/ci/kokoro/readme/Dockerfile.opensuse
@@ -31,12 +31,13 @@ FROM devtools AS README
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.opensuse-leap
+++ b/ci/kokoro/readme/Dockerfile.opensuse-leap
@@ -31,12 +31,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.ubuntu
+++ b/ci/kokoro/readme/Dockerfile.ubuntu
@@ -35,12 +35,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-trusty
@@ -69,12 +69,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-xenial
@@ -35,12 +35,13 @@ FROM devtools AS readme
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using
-# external projects.
-WORKDIR /home/build/external
-COPY . /home/build/external
-RUN cmake -H. -Bcmake-out -DCMAKE_BUILD_TYPE=Debug
+# the super build.
+WORKDIR /home/build/super
+COPY . /home/build/super
+RUN cmake -Hci/super -Bcmake-out \
+        -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 RUN cmake --build cmake-out -- -j $(nproc)
-RUN (cd cmake-out && ctest --output-on-failure)
+# The tests will already be run as part of the build, no need to run it again.
 ## [END IGNORED]
 
 ## [END README.md]

--- a/ci/super/CMakeLists.txt
+++ b/ci/super/CMakeLists.txt
@@ -1,0 +1,78 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-super-build CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(GOOGLE_CLOUD_CPP_ROOT "${PROJECT_SOURCE_DIR}/../..")
+list(APPEND CMAKE_MODULE_PATH "${GOOGLE_CLOUD_CPP_ROOT}/cmake")
+
+set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX "${CMAKE_BINARY_DIR}/local")
+
+include(external/curl)
+include(external/crc32c)
+include(external/grpc)
+include(external/googleapis)
+include(external/googletest)
+
+include(ExternalProjectHelper)
+set_external_project_prefix_vars()
+
+set_external_project_build_parallel_level(PARALLEL)
+
+set(GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST
+    grpc_project
+    curl_project
+    crc32c_project
+    googleapis_project
+    googletest_project)
+
+include(ExternalProject)
+externalproject_add(
+    google_cloud_cpp_project
+    DEPENDS ${GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST}
+    EXCLUDE_FROM_ALL OFF
+    PREFIX "${CMAKE_BINARY_DIR}/build/google-cloud-cpp"
+    INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+    SOURCE_DIR
+    "${GOOGLE_CLOUD_CPP_ROOT}"
+    LIST_SEPARATOR
+    |
+    CMAKE_ARGS -G${CMAKE_GENERATOR}
+               -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package
+               -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+               -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+               -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+               -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    BUILD_COMMAND ${CMAKE_COMMAND}
+                  --build
+                  <BINARY_DIR>
+                  ${PARALLEL}
+                  TEST_COMMAND
+                  ${CMAKE_CTEST_COMMAND}
+                  --output-on-failure
+    LOG_DOWNLOAD OFF
+    LOG_CONFIGURE OFF
+    LOG_BUILD OFF
+    LOG_INSTALL OFF)
+
+# This makes it easy to compile the dependencies before the code.
+add_custom_target(google-cloud-cpp-dependencies)
+add_dependencies(google-cloud-cpp-dependencies
+                 ${GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST})

--- a/ci/super/CMakeLists.txt
+++ b/ci/super/CMakeLists.txt
@@ -23,8 +23,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(GOOGLE_CLOUD_CPP_ROOT "${PROJECT_SOURCE_DIR}/../..")
 list(APPEND CMAKE_MODULE_PATH "${GOOGLE_CLOUD_CPP_ROOT}/cmake")
 
-set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX "${CMAKE_BINARY_DIR}/local")
-
 include(external/curl)
 include(external/crc32c)
 include(external/grpc)

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -140,15 +140,14 @@ function (set_external_project_build_parallel_level var_name)
 endfunction ()
 
 function (set_external_project_prefix_vars)
-    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64"
-        PARENT_SCOPE)
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
 
     # On Linux, using an RPATH that is neither an absolute or relative path is
     # considered a security risk and will cause package building to fail. We use
     # the Linux-specific variable $ORIGIN to resolve this.
     if (UNIX AND NOT APPLE)
         set(GOOGLE_CLOUD_CPP_INSTALL_RPATH
-            "\\\$ORIGIN/../lib;\\\$ORIGIN/../lib64" PARENT_SCOPE)
+            "\\\$ORIGIN/../lib;\\\$ORIGIN/../lib64")
     endif ()
 
     # When passing a semi-colon delimited list to ExternalProject_Add, we need
@@ -162,12 +161,16 @@ function (set_external_project_prefix_vars)
     string(REPLACE ";"
                    "|"
                    GOOGLE_CLOUD_CPP_INSTALL_RPATH
-                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}"
-                   PARENT_SCOPE)
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
 
     set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
     string(REPLACE ";"
                    "|"
                    GOOGLE_CLOUD_CPP_PREFIX_PATH
                    "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${GOOGLE_CLOUD_CPP_PREFIX_PATH}"
+        PARENT_SCOPE)
+    set(GOOGLE_CLOUD_CPP_PREFIX_RPATH "${GOOGLE_CLOUD_CPP_PREFIX_RPATH}"
+        PARENT_SCOPE)
 endfunction ()

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -16,6 +16,10 @@
 
 include(GNUInstallDirs)
 
+set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX "${CMAKE_BINARY_DIR}/external"
+    CACHE STRING "Configure where the external projects are installed.")
+mark_as_advanced(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX)
+
 function (set_library_properties_for_external_project _target _lib)
     cmake_parse_arguments(F_OPT "ALWAYS_SHARED;ALWAYS_LIB" "" "" ${ARGN})
     # This is the main disadvantage of external projects. The typicaly flow with
@@ -135,7 +139,7 @@ function (set_external_project_build_parallel_level var_name)
     endif ()
 endfunction ()
 
-function (set_external_project_install_rpath)
+function (set_external_project_prefix_vars)
     set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64"
         PARENT_SCOPE)
 
@@ -160,4 +164,10 @@ function (set_external_project_install_rpath)
                    GOOGLE_CLOUD_CPP_INSTALL_RPATH
                    "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}"
                    PARENT_SCOPE)
+
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_PREFIX_PATH
+                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
 endfunction ()

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -29,26 +29,14 @@ if (NOT TARGET c_ares_project)
     create_external_project_library_byproduct_list(c_ares_byproducts
                                                    ALWAYS_SHARED "cares")
 
-    # When passing a semi-colon delimited list to ExternalProject_Add, we need
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_PREFIX_PATH
-                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+    set_external_project_prefix_vars()
 
     include(ExternalProject)
     externalproject_add(
         c_ares_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_C_ARES_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -26,26 +26,14 @@ if (NOT TARGET crc32c_project)
 
     create_external_project_library_byproduct_list(crc32c_byproducts "crc32c")
 
-    # When passing a semi-colon delimited list to ExternalProject_Add, we need
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_PREFIX_PATH
-                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+    set_external_project_prefix_vars()
 
     include(ExternalProject)
     externalproject_add(
         crc32c_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_CRC32C_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -28,25 +28,7 @@ if (NOT TARGET curl_project)
 
     set_external_project_build_parallel_level(PARALLEL)
 
-    # When passing a semi-colon delimited list to ExternalProject_Add, we need
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
-                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
-
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_PREFIX_PATH
-                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+    set_external_project_prefix_vars()
 
     create_external_project_library_byproduct_list(curl_byproducts "curl")
 
@@ -56,7 +38,7 @@ if (NOT TARGET curl_project)
         DEPENDS c_ares_project ssl_project zlib_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/curl"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_CURL_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CURL_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/googleapis.cmake
+++ b/cmake/external/googleapis.cmake
@@ -31,7 +31,7 @@ if (NOT TARGET googleapis_project)
 
     set_external_project_build_parallel_level(PARALLEL)
 
-    set_external_project_install_rpath()
+    set_external_project_prefix_vars()
 
     create_external_project_library_byproduct_list(
         googleapis_byproducts
@@ -79,7 +79,7 @@ if (NOT TARGET googleapis_project)
         DEPENDS grpc_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -34,25 +34,14 @@ if (NOT TARGET googletest_project)
                                                    "gmock"
                                                    "gmock_main")
 
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_PREFIX_PATH
-                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+    set_external_project_prefix_vars()
 
     include(ExternalProject)
     externalproject_add(
         googletest_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/googletest"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_GOOGLETEST_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -29,25 +29,7 @@ if (NOT TARGET grpc_project)
 
     set_external_project_build_parallel_level(PARALLEL)
 
-    # When passing a semi-colon delimited list to ExternalProject_Add, we need
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
-                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
-
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_PREFIX_PATH
-                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+    set_external_project_prefix_vars()
 
     create_external_project_library_byproduct_list(grpc_byproducts
                                                    "grpc"
@@ -60,7 +42,7 @@ if (NOT TARGET grpc_project)
         DEPENDS c_ares_project protobuf_project ssl_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/grpc"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_GRPC_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -28,19 +28,7 @@ if (NOT TARGET protobuf_project)
 
     set_external_project_build_parallel_level(PARALLEL)
 
-    # When passing a semi-colon delimited list to ExternalProject_Add, we need
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
-                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+    set_external_project_prefix_vars()
 
     create_external_project_library_byproduct_list(protobuf_byproducts
                                                    "protobuf")
@@ -64,7 +52,7 @@ if (NOT TARGET protobuf_project)
         DEPENDS zlib_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_PROTOBUF_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_PROTOBUF_SHA256}
         LIST_SEPARATOR |

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -26,25 +26,14 @@ if (NOT TARGET zlib_project)
 
     create_external_project_library_byproduct_list(zlib_byproducts "z")
 
-    # to escape the semi-colon. Quoting does not work and escaping the semi-
-    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
-    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
-    # then be replaced by an escaped semi-colon by CMake. This allows us to use
-    # multiple directories for our RPATH. Normally, it'd make sense to use : as
-    # a delimiter since it is a typical path-list separator, but it is a special
-    # character in CMake.
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
-    string(REPLACE ";"
-                   "|"
-                   GOOGLE_CLOUD_CPP_PREFIX_PATH
-                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+    set_external_project_prefix_vars()
 
     include(ExternalProject)
     externalproject_add(
         zlib_project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
-        INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_ZLIB_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_ZLIB_SHA256}
         LIST_SEPARATOR |


### PR DESCRIPTION
Thanks to @tmatsuo's work on cpp-cmakefiles this is now possible. Similar to google-cloud-cpp-spanner, this PR adds a super build. It piggybacks on the existing external project files.

Note about some specific changes here that differ from spanner:
- Unlike spanner where `RUN_INTEGRATION_TESTS` is set to "yes" for each build that should run those tests, we set it to "no" for builds that skip the tests. This is because (I think) the integration tests run by default for all of the builds.

- I changed the `INSTALL_DIR` for the external projects to `GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX`. This allows us to reuse those files with minimal fuss.

TODO: Documentation still needs to be added.

Another TODO: some of the Dockerfiles do `COPY . /var/tmp/ci` which means modifying `ci/super` triggers a rebuild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2898)
<!-- Reviewable:end -->
