### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/google/cloud/bigtable/tools/convert_acceptance_tests.py
+++ b/google/cloud/bigtable/tools/convert_acceptance_tests.py
@@ -29,6 +29,7 @@ Usage:
       | python ../tools/convert_acceptance_tests.py \
       | clang-format >readrowsparser_acceptance_tests.inc
 """
+from __future__ import print_function
 
 import json
 import sys
@@ -114,9 +115,9 @@ def print_test(t):
 def main():
     t = json.loads(sys.stdin.read())
 
-    print FILE_HEADER.lstrip()
+    print(FILE_HEADER.lstrip())
     for tt in t['tests']:
-        print print_test(tt)
+        print(print_test(tt))
 
 
 if __name__ == '__main__':

--- a/google/cloud/bigtable/tools/generate_rpc_policy_parameters.py
+++ b/google/cloud/bigtable/tools/generate_rpc_policy_parameters.py
@@ -30,6 +30,7 @@ Usage:
     python ../tools/generate_rpc_policy_parameters.py \
     | clang-format > rpc_policy_parameters.inc
 """
+from __future__ import print_function
 
 import collections
 import yaml
@@ -65,10 +66,10 @@ def print_defines(interface):
     constants['_DEFAULT_MAXIMUM_DELAY'] = 'max_retry_delay_millis'
     constants['_DEFAULT_MAXIMUM_RETRY_PERIOD'] = 'total_timeout_millis'
 
-    print "// Define the defaults using a pre-processor macro, this allows"
-    print "// the application developers to change the defaults for their"
-    print "// application by compiling with different values."
-    print ""
+    print("// Define the defaults using a pre-processor macro, this allows")
+    print("// the application developers to change the defaults for their")
+    print("// application by compiling with different values.")
+    print("")
     for constant in constants:
         name = prefix + constant
         val = interface['retry_params_def'][0]
@@ -76,17 +77,17 @@ def print_defines(interface):
         o += " std::chrono::milliseconds(" + str(val[constants[constant]])
         o += ")"
 
-        print "#ifndef " + name
-        print o
-        print "#endif //" + name
-        print ""
+        print("#ifndef " + name)
+        print(o)
+        print("#endif //" + name)
+        print("")
 
         defines.append(name)
-    print ""
-    print "RPCPolicyParameters const k" + struct + "Limits = {"
+    print("")
+    print("RPCPolicyParameters const k" + struct + "Limits = {")
     for constant in constants:
-        print prefix + constant + ","
-    print "};"
+        print(prefix + constant + ",")
+    print("};")
     return defines
 
 
@@ -97,23 +98,23 @@ def main():
         "https://raw.githubusercontent.com/googleapis/googleapis/master/google/bigtable/v2/bigtable_gapic.yaml"
     ]
 
-    print FILE_HEADER.lstrip()
+    print(FILE_HEADER.lstrip())
 
     for link in links:
         f = urllib.urlopen(link)
         myfile = f.read()
         t = yaml.load(myfile)
         for intf in t['interfaces']:
-            print ""
-            print '// Interface name: "' + intf['name'] + '"'
+            print("")
+            print('// Interface name: "' + intf['name'] + '"')
             intf_defines = print_defines(intf)
             all_defines.append(intf_defines)
-            print ""
+            print("")
 
     flat_list = [item for sublist in all_defines for item in sublist]
 
     for define in flat_list:
-        print "#undef " + define
+        print("#undef " + define)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2899)
<!-- Reviewable:end -->
