### PR TITLE
making partial errors/last_status available to `ObjectWriteStream`

### DIFF
--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -201,8 +201,7 @@ ObjectWriteStreambuf::ObjectWriteStreambuf(
     : upload_session_(std::move(upload_session)),
       max_buffer_size_(UploadChunkRequest::RoundUpToQuantum(max_buffer_size)),
       hash_validator_(std::move(hash_validator)),
-      last_response_{HttpResponse{400, {}, {}}},
-      last_status_(Status()) {
+      last_response_{HttpResponse{400, {}, {}}} {
   current_ios_buffer_.reserve(max_buffer_size_);
   auto pbeg = &current_ios_buffer_[0];
   auto pend = pbeg + current_ios_buffer_.size();
@@ -299,7 +298,7 @@ StatusOr<HttpResponse> ObjectWriteStreambuf::FlushFinal() {
   if (!result) {
     // This was an unrecoverable error, time to store status and signal an
     // error.
-    last_status_ = result.status();
+    last_response_ = result.status();
     return std::move(result).status();
   }
   // Reset the iostream put area with valid pointers, but empty.
@@ -312,7 +311,6 @@ StatusOr<HttpResponse> ObjectWriteStreambuf::FlushFinal() {
   // If `result.ok() == false` we never get to this point, so the last response
   // was actually successful. Represent that by a HTTP 200 status code.
   last_response_ = HttpResponse{200, std::move(result).value().payload, {}};
-  last_status_ = Status();
   return last_response_;
 }
 
@@ -338,7 +336,7 @@ StatusOr<HttpResponse> ObjectWriteStreambuf::Flush() {
   if (!result) {
     // This was an unrecoverable error, time to store status and signal an
     // error.
-    last_status_ = result.status();
+    last_response_ = result.status();
     return std::move(result).status();
   }
   // Reset the put area, preserve any data not setn.
@@ -353,7 +351,6 @@ StatusOr<HttpResponse> ObjectWriteStreambuf::Flush() {
   // If `result.ok() == false` we never get to this point, so the last response
   // was actually successful. Represent that by a HTTP 200 status code.
   last_response_ = HttpResponse{200, std::move(result).value().payload, {}};
-  last_status_ = Status();
   return last_response_;
 }
 

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -202,7 +202,7 @@ ObjectWriteStreambuf::ObjectWriteStreambuf(
       max_buffer_size_(UploadChunkRequest::RoundUpToQuantum(max_buffer_size)),
       hash_validator_(std::move(hash_validator)),
       last_response_{HttpResponse{400, {}, {}}},
-      last_status_(Status()) {
+      last_status_() {
   current_ios_buffer_.reserve(max_buffer_size_);
   auto pbeg = &current_ios_buffer_[0];
   auto pend = pbeg + current_ios_buffer_.size();

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -202,7 +202,7 @@ ObjectWriteStreambuf::ObjectWriteStreambuf(
       max_buffer_size_(UploadChunkRequest::RoundUpToQuantum(max_buffer_size)),
       hash_validator_(std::move(hash_validator)),
       last_response_{HttpResponse{400, {}, {}}},
-      last_status_() {
+      last_status_(Status()) {
   current_ios_buffer_.reserve(max_buffer_size_);
   auto pbeg = &current_ios_buffer_[0];
   auto pend = pbeg + current_ios_buffer_.size();

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -125,7 +125,12 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
     return upload_session_->next_expected_byte();
   }
 
-  virtual Status const& last_status() const { return last_status_; }
+  virtual Status last_status() const {
+    if (last_response_) {
+      return Status();
+    }
+    return last_response_.status();
+  }
 
  protected:
   int sync() override;
@@ -148,7 +153,6 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   HashValidator::Result hash_validator_result_;
 
   StatusOr<HttpResponse> last_response_;
-  Status last_status_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -125,6 +125,8 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
     return upload_session_->next_expected_byte();
   }
 
+  virtual Status const& last_status() const { return last_status_; }
+
  protected:
   int sync() override;
   std::streamsize xsputn(char const* s, std::streamsize count) override;
@@ -146,6 +148,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   HashValidator::Result hash_validator_result_;
 
   StatusOr<HttpResponse> last_response_;
+  Status last_status_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -342,7 +342,7 @@ TEST(ObjectWriteStreambufTest, CreatedForFinalizedUpload) {
 }
 
 /// @test Verify that last error status is accessible for small payload.
-TEST(ObjectWriteStreambufTest, erroneousStream) {
+TEST(ObjectWriteStreambufTest, ErroneousStream) {
   auto mock = google::cloud::internal::make_unique<
       testing::MockResumableUploadSession>();
   EXPECT_CALL(*mock, done).WillRepeatedly(Return(false));
@@ -352,11 +352,11 @@ TEST(ObjectWriteStreambufTest, erroneousStream) {
 
   int count = 0;
   EXPECT_CALL(*mock, UploadFinalChunk(_, _))
-      .WillOnce(Invoke([&](std::string const& p, std::uint64_t s) {
+      .WillOnce(Invoke([&](std::string const& p, std::uint64_t n) {
         ++count;
         EXPECT_EQ(1, count);
         EXPECT_EQ(payload, p);
-        EXPECT_EQ(payload.size(), s);
+        EXPECT_EQ(payload.size(), n);
         return Status(StatusCode::kInvalidArgument, "Invalid Argument");
       }));
   EXPECT_CALL(*mock, next_expected_byte()).WillOnce(Return(0));
@@ -375,7 +375,7 @@ TEST(ObjectWriteStreambufTest, erroneousStream) {
 }
 
 /// @test Verify that last error status is accessible for large payloads.
-TEST(ObjectWriteStreambufTest, errorInLargePayload) {
+TEST(ObjectWriteStreambufTest, ErrorInLargePayload) {
   auto mock = google::cloud::internal::make_unique<
       testing::MockResumableUploadSession>();
   EXPECT_CALL(*mock, done).WillRepeatedly(Return(false));
@@ -401,11 +401,11 @@ TEST(ObjectWriteStreambufTest, errorInLargePayload) {
             "", last_commited_byte, {}, ResumableUploadResponse::kInProgress});
       }));
   EXPECT_CALL(*mock, UploadFinalChunk(_, _))
-      .WillOnce(Invoke([&](std::string const& p, std::uint64_t s) {
+      .WillOnce(Invoke([&](std::string const& p, std::uint64_t n) {
         ++count;
         EXPECT_EQ(3, count);
         EXPECT_EQ(payload_2, p);
-        EXPECT_EQ(payload_1.size() + payload_2.size(), s);
+        EXPECT_EQ(payload_1.size() + payload_2.size(), n);
         auto last_committed_byte = payload_1.size() + payload_2.size() - 1;
         return make_status_or(
             ResumableUploadResponse{"{}",

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -349,6 +349,9 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * Application may write multiple times before closing the stream, this
    * function gives the capability to find out status even before stream
    * closure.
+   *
+   * This function is different then `metadata()` as calling `metadata()`
+   * before Close() is undefined.
    */
   Status const& last_status() const { return buf_->last_status(); }
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -350,7 +350,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * function gives the capability to find out status even before stream
    * closure.
    *
-   * This function is different then `metadata()` as calling `metadata()`
+   * This function is different than `metadata()` as calling `metadata()`
    * before Close() is undefined.
    */
   Status const& last_status() const { return buf_->last_status(); }

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -353,7 +353,7 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * This function is different than `metadata()` as calling `metadata()`
    * before Close() is undefined.
    */
-  Status const& last_status() const { return buf_->last_status(); }
+  Status last_status() const { return buf_->last_status(); }
 
  private:
   /**

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -343,6 +343,15 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    */
   void Suspend() &&;
 
+  /**
+   * Returns the status of partial errors.
+   *
+   * Application may write multiple times before closing the stream, this
+   * function gives the capability to find out status even before stream
+   * closure.
+   */
+  Status const& last_status() const { return buf_->last_status(); }
+
  private:
   /**
    * Closes the underlying object write stream.


### PR DESCRIPTION
`ObjectWriteStreamBuf` now offers `last_status` and this status can be used by `ObjectWriteStream` to determine partial errors. 

This fixes #2827.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2919)
<!-- Reviewable:end -->
