### PR TITLE
feat: Minimize contention in Bigtable Client initialization.

### DIFF
--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -115,8 +115,8 @@ class CommonClient {
     } else {
       // Some other thread created the pool and saved it in `stubs_`. The work
       // in this thread was superfluous. We release the lock while clearing the
-      // channels to minimize contention, this seems to workaround other bugs
-      // inside the Google implementation of std::mutex.
+      // channels to minimize contention. This seems to workaround other bugs
+      // inside Google.
       lk.unlock();
       tmp.clear();
       channels.clear();

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -112,6 +112,15 @@ class CommonClient {
       channels.swap(channels_);
       tmp.swap(stubs_);
       current_index_ = 0;
+    } else {
+      // Some other thread created the pool and saved it in `stubs_`. The work
+      // in this thread was superfluous. We release the lock while clearing the
+      // channels to minimize contention, this seems to workaround other bugs
+      // inside the Google implementation of std::mutex.
+      lk.unlock();
+      tmp.clear();
+      channels.clear();
+      lk.lock();
     }
   }
 


### PR DESCRIPTION
Channel pools for Bigtable clients are lazy initialized, the first
thread that needs them creates them. To avoid deadlocks and unbound
priority inversions this thread releases the locks while creating the
pools, and relocks before saving the newly created pool.

In some cases two (or more) threads may create the pool, in this case
the pool created by the second thread is discarded. We were discarding
this work with the lock held, which resulted in deadlocks for some
users inside Google (this should not affect external users).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2923)
<!-- Reviewable:end -->
