### PR TITLE
Mocking examples of `raw_client` for failed scenarios.

### DIFF
--- a/google/cloud/storage/doc/storage-mocking.dox
+++ b/google/cloud/storage/doc/storage-mocking.dox
@@ -9,28 +9,28 @@ for developer using GCS C++ client library.
 
 ### Mocking Successful call of `ReadObject`
 
-Mocking of ReadObject can be achieved by mocking `ObjectReadSource`, following code snippet
+Mocking of ReadObject can be achieved by mocking `ObjectReadSource`. The following code snippet
 explains this
 
 @snippet storage_client_mock_samples.cc mock successful readobject
 
 ### Mocking Failed call of `ReadObject`
 
-Mocking of ReadObject can be achieved by mocking `ObjectReadSource`, following code snippet
+Mocking of ReadObject can be achieved by mocking `ObjectReadSource`. The following code snippet
 explains this
 
 @snippet storage_client_mock_samples.cc mock failed readobject
 
 ### Mocking Successful call of `WriteObject`
 
-Mocking of ReadObject can be achieved by mocking `ObjectWriteStreambuf`, following code snippet
+Mocking of ReadObject can be achieved by mocking `ObjectWriteStreambuf`. The following code snippet
 explains this
 
 @snippet storage_client_mock_samples.cc mock successful writeobject
 
 ### Mocking Failed call of `WriteObject`
 
-Mocking of ReadObject can be achieved by mocking `ObjectWriteStreambuf`, following code snippet
+Mocking of ReadObject can be achieved by mocking `ObjectWriteStreambuf`. The following code snippet
 explains this
 
 @snippet storage_client_mock_samples.cc mock failed writeobject

--- a/google/cloud/storage/doc/storage-mocking.dox
+++ b/google/cloud/storage/doc/storage-mocking.dox
@@ -14,6 +14,13 @@ explains this
 
 @snippet storage_client_mock_samples.cc mock successful readobject
 
+### Mocking Failed call of `ReadObject`
+
+Mocking of ReadObject can be achieved by mocking `ObjectReadSource`, following code snippet
+explains this
+
+@snippet storage_client_mock_samples.cc mock failed readobject
+
 ### Mocking Successful call of `WriteObject`
 
 Mocking of ReadObject can be achieved by mocking `ObjectWriteStreambuf`, following code snippet
@@ -21,6 +28,12 @@ explains this
 
 @snippet storage_client_mock_samples.cc mock successful writeobject
 
+### Mocking Failed call of `WriteObject`
+
+Mocking of ReadObject can be achieved by mocking `ObjectWriteStreambuf`, following code snippet
+explains this
+
+@snippet storage_client_mock_samples.cc mock failed writeobject
 
 The documentation for each member function in the [Client] class includes short
 snippets on how to call the function. The snippets for

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -1178,6 +1178,10 @@ run_mocking_client_examples() {
       "${bucket_name}" "${object_name}"
   run_example ./storage_client_mock_samples mock-write-object \
       "${bucket_name}" "${object_name}"
+  run_example ./storage_client_mock_samples mock-read-object-failure \
+      "${bucket_name}" "${object_name}"
+  run_example ./storage_client_mock_samples mock-write-object-failure \
+      "${bucket_name}" "${object_name}"
 
   # Verify that calling without a command produces the right exit status and
   # some kind of Usage message.


### PR DESCRIPTION
Mocking examples of `raw_client` for failed scenarios of `ReadObject` and `WriteObject`.

This completes remaining open points in #2710.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2924)
<!-- Reviewable:end -->
