### PR TITLE
testing: Fix build on windows 2019

### DIFF
--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -23,6 +23,9 @@ if (-not (Test-Path env:CONFIG)) {
 }
 $CONFIG = $env:CONFIG
 
+# Add 7-zip to Path
+$env:Path += ";C:\Program Files\7-Zip"
+
 # Set BUILD_CACHE, defauting to the original value
 if (-not (Test-Path env:BUILD_CACHE)) {
     $BUILD_CACHE = "gs://cloud-cpp-kokoro-results/" +

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -63,7 +63,7 @@ Get-Date -Format o
 gsutil cp $BUILD_CACHE .
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
-    Write-Host "extracting build cache failed with exit code $LastExitCode"
+    Write-Host "gsutil download failed with exit code $LastExitCode"
 }
 
 Write-Host "Extracting build cache."
@@ -71,7 +71,7 @@ Get-Date -Format o
 7z x vcpkg-installed.zip -aoa
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
-    Write-Host "gsutil download failed with exit code $LastExitCode"
+    Write-Host "extracting build cache failed with exit code $LastExitCode"
 }
 
 Write-Host "Bootstrap vcpkg."

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -34,6 +34,8 @@ if (-not (Test-Path env:BUILD_CACHE)) {
     $BUILD_CACHE = $env:BUILD_CACHE
 }
 
+$BUILD_CACHE_FILENAME = Split-Path $BUILD_CACHE -leaf
+
 # Update or clone the 'vcpkg' package manager, this is a bit overly complicated,
 # but it works well on your workstation where you may want to run this script
 # multiple times while debugging vcpkg installs.  It also works on AppVeyor
@@ -68,7 +70,7 @@ if ($LastExitCode) {
 
 Write-Host "Extracting build cache."
 Get-Date -Format o
-7z x vcpkg-installed.zip -aoa
+7z x $BUILD_CACHE_FILENAME -aoa
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
     Write-Host "extracting build cache failed with exit code $LastExitCode"

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -23,9 +23,6 @@ if (-not (Test-Path env:CONFIG)) {
 }
 $CONFIG = $env:CONFIG
 
-# Add 7-zip to Path
-$env:Path += ";C:\Program Files\7-Zip"
-
 # Set BUILD_CACHE, defauting to the original value
 if (-not (Test-Path env:BUILD_CACHE)) {
     $BUILD_CACHE = "gs://cloud-cpp-kokoro-results/" +
@@ -33,8 +30,6 @@ if (-not (Test-Path env:BUILD_CACHE)) {
 } else {
     $BUILD_CACHE = $env:BUILD_CACHE
 }
-
-$BUILD_CACHE_FILENAME = Split-Path $BUILD_CACHE -leaf
 
 # Update or clone the 'vcpkg' package manager, this is a bit overly complicated,
 # but it works well on your workstation where you may want to run this script
@@ -62,7 +57,7 @@ if ($LastExitCode) {
 
 Write-Host "Downloading build cache."
 Get-Date -Format o
-gsutil cp $BUILD_CACHE .
+gsutil cp $BUILD_CACHE vcpkg-installed.zip
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
     Write-Host "gsutil download failed with exit code $LastExitCode"
@@ -70,7 +65,7 @@ if ($LastExitCode) {
 
 Write-Host "Extracting build cache."
 Get-Date -Format o
-7z x $BUILD_CACHE_FILENAME -aoa
+C:\Windows\system32\cmd /c 7z x vcpkg-installed.zip -aoa
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
     Write-Host "extracting build cache failed with exit code $LastExitCode"
@@ -124,7 +119,7 @@ Write-Host "================================================================"
 Write-Host "================================================================"
 Write-Host "Create cache zip file."
 Get-Date -Format o
-7z a vcpkg-installed.zip installed\
+C:\Windows\system32\cmd /c 7z a vcpkg-installed.zip installed\
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
     Write-Host "zip build cache failed with exit code $LastExitCode"

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -68,7 +68,7 @@ if ($LastExitCode) {
 
 Write-Host "Extracting build cache."
 Get-Date -Format o
-cmd /c 7z x vcpkg-installed.zip -aoa
+7z x vcpkg-installed.zip -aoa
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
     Write-Host "gsutil download failed with exit code $LastExitCode"
@@ -122,7 +122,7 @@ Write-Host "================================================================"
 Write-Host "================================================================"
 Write-Host "Create cache zip file."
 Get-Date -Format o
-cmd /c 7z a vcpkg-installed.zip installed\
+7z a vcpkg-installed.zip installed\
 if ($LastExitCode) {
     # Ignore errors, caching failures should not break the build.
     Write-Host "zip build cache failed with exit code $LastExitCode"

--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -29,6 +29,9 @@ $CONFIG = $env:CONFIG
 $PROVIDER = $env:PROVIDER
 $GENERATOR = "Ninja"
 
+# Set TEMP explicitly for windows 2019 image
+$Env:TEMP = "T:\tmp\"
+
 # By default assume "module", use the configuration parameters and build in the `cmake-out` directory.
 $cmake_flags=@("-G$GENERATOR", "-DCMAKE_BUILD_TYPE=$CONFIG", "-H.", "-Bcmake-out")
 

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -44,7 +44,7 @@ set test_errorlevel=%errorlevel%
 @rem not interesting artifacts.
 echo %date% %time%
 cd "%KOKORO_ARTIFACTS_DIR%"
-powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item}"
+powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item -Recurse -Force}"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 if %test_errorlevel% neq 0 exit /b %test_errorlevel%


### PR DESCRIPTION
I need to use the full path of cmd in order to run 7-zip in both images. Probably because some difference between cygwin on windows 2016 image and msys2 on windows 2019 image.

Do we want to keep builds on windows 2016? If not, I'll eventually remove files for windows 2016 builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2932)
<!-- Reviewable:end -->
