### PR TITLE
cleanup: Fix usage of NCPU in Dockerfiles.

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=30
-ARG NCPU=4
 FROM fedora:${DISTRO_VERSION}
+ARG NCPU=4
 
 RUN dnf makecache && dnf install -y \
     autoconf \

--- a/ci/kokoro/docker/create-docker-image.sh
+++ b/ci/kokoro/docker/create-docker-image.sh
@@ -25,6 +25,6 @@ source "${PROJECT_ROOT}/ci/kokoro/docker/define-docker-variables.sh"
 
 cd "${PROJECT_ROOT}"
 sudo docker build -t "${IMAGE}:tip" \
-     --build-arg NCPU="${NCPU:-4}" \
+     --build-arg NCPU="${NCPU}" \
      --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
      -f "ci/kokoro/docker/Dockerfile.${DISTRO}" ci

--- a/ci/kokoro/install/Dockerfile.centos
+++ b/ci/kokoro/install/Dockerfile.centos
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=7
-ARG NCPU=4
 FROM centos:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.

--- a/ci/kokoro/install/Dockerfile.debian
+++ b/ci/kokoro/install/Dockerfile.debian
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=9
-ARG NCPU=4
 FROM debian:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=30
-ARG NCPU=4
 FROM fedora:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting below, it is used by `extract-readme.sh` and
 # `extract-install.md` to generate the contents of the top-level README.md and

--- a/ci/kokoro/install/Dockerfile.opensuse
+++ b/ci/kokoro/install/Dockerfile.opensuse
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=latest
-ARG NCPU=4
 FROM opensuse/tumbleweed:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 ## [START INSTALL.md]
 

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=latest
-ARG NCPU=4
 FROM opensuse/leap:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 ## [START INSTALL.md]
 

--- a/ci/kokoro/install/Dockerfile.ubuntu
+++ b/ci/kokoro/install/Dockerfile.ubuntu
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=bionic
-ARG NCPU=4
 FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=trusty
-ARG NCPU=4
 FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting below, it is used by `extract-readme.sh` and
 # `extract-install.md` to generate the contents of the top-level README.md and

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=xenial
-ARG NCPU=4
 FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -84,7 +84,7 @@ devtools_flags=(
   # Create the image with the same tag as the cache we are using, so we can
   # upload it.
   "-t" "${DEV_IMAGE}:latest"
-  "--build-arg" "NCPU=${NCPU:-4}"
+  "--build-arg" "NCPU=${NCPU}"
   "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
 )
 
@@ -113,6 +113,6 @@ echo "Run validation script for INSTALL instructions on ${DISTRO}."
 docker build \
   "--cache-from=${DEV_IMAGE}:latest" \
   "--target=install" \
-  "--build-arg" "NCPU=${NCPU:-4}" \
+  "--build-arg" "NCPU=${NCPU}" \
   -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
 echo "================================================================"

--- a/ci/kokoro/readme/Dockerfile.centos
+++ b/ci/kokoro/readme/Dockerfile.centos
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=7
-ARG NCPU=4
 FROM centos:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -40,6 +40,7 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/cte
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.debian
+++ b/ci/kokoro/readme/Dockerfile.debian
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=9
-ARG NCPU=4
 FROM debian:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -41,6 +41,7 @@ RUN apt update && \
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.fedora
+++ b/ci/kokoro/readme/Dockerfile.fedora
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=30
-ARG NCPU=4
 FROM fedora:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting below, it is used by `extract-readme.sh` and
 # `extract-install.md` to generate the contents of the top-level README.md and
@@ -33,6 +33,7 @@ RUN dnf makecache && \
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.opensuse
+++ b/ci/kokoro/readme/Dockerfile.opensuse
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=latest
-ARG NCPU=4
 FROM opensuse/tumbleweed:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 ## [START INSTALL.md]
 
@@ -29,6 +29,7 @@ RUN zypper refresh && \
 # ```
 
 FROM devtools AS README
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.opensuse-leap
+++ b/ci/kokoro/readme/Dockerfile.opensuse-leap
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=latest
-ARG NCPU=4
 FROM opensuse/leap:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 ## [START INSTALL.md]
 
@@ -29,6 +29,7 @@ RUN zypper refresh && \
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.ubuntu
+++ b/ci/kokoro/readme/Dockerfile.ubuntu
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=bionic
-ARG NCPU=4
 FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -33,6 +33,7 @@ RUN apt update && \
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-trusty
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=trusty
-ARG NCPU=4
 FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 COPY ci/install-retry.sh /retry3
 
@@ -67,6 +67,7 @@ ENV PKG_CONFIG_PATH=/usr/local/ssl/lib/pkgconfig
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/kokoro/readme/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-xenial
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 ARG DISTRO_VERSION=xenial
-ARG NCPU=4
 FROM ubuntu:${DISTRO_VERSION} AS devtools
+ARG NCPU=4
 
 # Please keep the formatting in these commands, it is optimized to cut & paste
 # into the README.md file.
@@ -33,6 +33,7 @@ RUN apt update && \
 # ```
 
 FROM devtools AS readme
+ARG NCPU=4
 
 ## [START IGNORED]
 # Verify that the tools above are enough to compile google-cloud-cpp when using

--- a/ci/test-readme/dockerfile2markdown.sh
+++ b/ci/test-readme/dockerfile2markdown.sh
@@ -20,6 +20,7 @@ set -eu
 sed \
     -e '/^## \[START IGNORED\]/,/^## \[END IGNORED\]/d' \
     -e '/^FROM /d' \
+    -e '/^ARG /d' \
     -e '/^## /d' \
     -e 's/^# //' \
     -e 's/^WORKDIR /cd /' \


### PR DESCRIPTION
Fixes #2928

As mentioned previously, due to scoping rules in Dockerfiles, NCPU
should appear after FROM statements. Variables defined outside FROM
statements do not belong to any stage. Furthermore, I cleaned up where
we use parameter expansion (`${NCPU:-4}`): in places where NCPU is always
defined, I removed it. However, we want it in the install/readme for
copy/paste-ability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2939)
<!-- Reviewable:end -->
