### PR TITLE
Favor small sizes in storage throughput benchmark.

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -73,8 +73,7 @@ if (BUILD_TESTING)
         benchmark_parser_test.cc
         benchmark_make_random_test.cc
         benchmark_parse_args_test.cc
-        benchmark_utils_test.cc
-        )
+        benchmark_utils_test.cc)
 
     foreach (fname ${storage_benchmarks_unit_tests})
         string(REPLACE "/"

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -72,7 +72,9 @@ if (BUILD_TESTING)
     set(storage_benchmarks_unit_tests
         benchmark_parser_test.cc
         benchmark_make_random_test.cc
-        benchmark_parse_args_test.cc)
+        benchmark_parse_args_test.cc
+        benchmark_utils_test.cc
+        )
 
     foreach (fname ${storage_benchmarks_unit_tests})
         string(REPLACE "/"

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -279,6 +279,28 @@ bool SimpleTimer::SupportPerThreadUsage() {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
 }
 
+static_assert(std::is_copy_constructible<SmallValuesBiasedDistribution>::value,
+              "SmallValuesBiasedDistribution shoud be copy constructible");
+static_assert(std::is_move_constructible<SmallValuesBiasedDistribution>::value,
+              "SmallValuesBiasedDistribution shoud be move constructible");
+static_assert(std::is_copy_assignable<SmallValuesBiasedDistribution>::value,
+              "SmallValuesBiasedDistribution shoud be copy assignable");
+static_assert(std::is_move_assignable<SmallValuesBiasedDistribution>::value,
+              "SmallValuesBiasedDistribution shoud be move assignable");
+
+double SmallValuesBiasedDistribution::PDF(result_type x) const {
+  return 1. / (x + 1) / (l_max_ - l_min_);
+}
+
+double SmallValuesBiasedDistribution::CDF(result_type x) const {
+  return (std::log(x + 1) - l_min_) / (l_max_ - l_min_);
+}
+
+SmallValuesBiasedDistribution::result_type
+SmallValuesBiasedDistribution::InvCDF(double x) const {
+  return std::round(std::exp(x * (l_max_ - l_min_) + l_min_) - 1);
+}
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/benchmark_utils_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils_test.cc
@@ -1,0 +1,79 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+namespace {
+
+TEST(SmallValuesBiasedDistribution, PdfRanges) {
+  SmallValuesBiasedDistribution d(100, 1000);
+  EXPECT_NEAR(0, d.CDF(100), 0.00001);
+  EXPECT_NEAR(1, d.CDF(1000), 0.00001);
+  EXPECT_EQ(100, d.InvCDF(0));
+  EXPECT_EQ(1000, d.InvCDF(1));
+}
+
+TEST(SmallValuesBiasedDistribution, PdfIntegration) {
+  // Approximate expected value by using PDF to verify if it's close to the
+  // expectation.
+  //
+  // The the expected value on range [m, M] is
+  // (M - ln(M+1) + m - ln(m+1)) / (ln(M+1)-ln(m+1))
+
+  SmallValuesBiasedDistribution::result_type m = 100;
+  SmallValuesBiasedDistribution::result_type M = 100000;
+  SmallValuesBiasedDistribution d(m, M);
+
+  double ex = 0;
+
+  double prev = m;
+  for (size_t i = m + 1; i <= M; prev = i++) {
+    double const prev_val = d.PDF(prev);
+    double const val = d.PDF(i);
+    double const avg = (prev * prev_val + i * val) / 2;
+    ex += avg;
+  }
+  // Less than 1% difference.
+  EXPECT_NEAR((M - std::log(M + 1) + m - std::log(m + 1)) /
+                  (std::log(M + 1) - std::log(m + 1)),
+              ex, ex / 100);
+}
+
+TEST(SmallValuesBiasedDistribution, RandomAverageConvergesToEx) {
+  // Test if average over picking at random converges to expected value.
+
+  SmallValuesBiasedDistribution::result_type m = 100;
+  SmallValuesBiasedDistribution::result_type M = 100000;
+  SmallValuesBiasedDistribution d(m, M);
+  google::cloud::internal::DefaultPRNG generator =
+      google::cloud::internal::MakeDefaultPRNG();
+  double sum = 0;
+  int const num_samples = 1000000;
+  for (int i = 0; i < num_samples; ++i) {
+    sum += d(generator);
+  }
+  // Less than 1% difference.
+  EXPECT_NEAR((M - std::log(M + 1) + m - std::log(m + 1)) /
+                  (std::log(M + 1) - std::log(m + 1)),
+              sum / num_samples, sum / 100);
+}
+
+}  // namespace
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
@@ -20,4 +20,5 @@ storage_benchmarks_unit_tests = [
     "benchmark_parser_test.cc",
     "benchmark_make_random_test.cc",
     "benchmark_parse_args_test.cc",
+    "benchmark_utils_test.cc",
 ]

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -407,7 +407,8 @@ google::cloud::StatusOr<Options> ParseArgs(int argc, char* argv[]) {
       {"--use_biased_generator",
        "use a size/chunk size random generator biased towards small values",
        [&options](std::string const& val) {
-         options.use_biased_generator = gcs_bm::ParseBoolean(val, true);
+         options.use_biased_generator =
+             gcs_bm::ParseBoolean(val).value_or(true);
        }},
   };
   auto usage = gcs_bm::BuildUsage(desc, argv[0]);


### PR DESCRIPTION
When picking a random size for a buffer from the range 128K and 64M a
uniform distribution is prohibitively wasteful.   It's unlikely that one
will need to decide whether 48M or 48.2M is better, but quite likely
need to decide between 128K and 256K. This PR introduces a distribution
which will produce twice as many samples between 0 and 1 than between 1
and 2 and so on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2942)
<!-- Reviewable:end -->
