### PR TITLE
Increase download and upload buffers.

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -44,12 +44,15 @@ std::size_t DefaultConnectionPoolSize() {
   return 4 * nthreads;
 }
 
-// There is nothing special about the buffer sizes here. They are relatively
-// small, because we do not want to consume too much memory from the
-// application. They are larger than the typical socket buffer size (64KiB), to
-// be able to read the full buffer into userspace if it happens to be full.
-#ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
-#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE (128 * 1024)
+// This magic number was obtained by experimentation summarized in #2657
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_UPLOAD_BUFFER_SIZE
+#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_UPLOAD_BUFFER_SIZE (8 * 1024 * 1024)
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
+
+// This magic number was obtained by experimentation summarized in #2657
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_BUFFER_SIZE
+#define GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_BUFFER_SIZE \
+  (3 * 1024 * 1024 / 2)
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE
 
 // The documentation recommends uploads below "5MiB" to use simple uploads:
@@ -77,8 +80,9 @@ ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials)
       enable_http_tracing_(false),
       enable_raw_client_tracing_(false),
       connection_pool_size_(DefaultConnectionPoolSize()),
-      download_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE),
-      upload_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE),
+      download_buffer_size_(
+          GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_BUFFER_SIZE),
+      upload_buffer_size_(GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_UPLOAD_BUFFER_SIZE),
       maximum_simple_upload_size_(
           GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_MAXIMUM_SIMPLE_UPLOAD_SIZE) {
   auto emulator =
@@ -126,7 +130,8 @@ void ClientOptions::SetupFromEnvironment() {
 
 ClientOptions& ClientOptions::SetDownloadBufferSize(std::size_t size) {
   if (size == 0) {
-    download_buffer_size_ = GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE;
+    download_buffer_size_ =
+        GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_BUFFER_SIZE;
   } else {
     download_buffer_size_ = size;
   }
@@ -135,7 +140,7 @@ ClientOptions& ClientOptions::SetDownloadBufferSize(std::size_t size) {
 
 ClientOptions& ClientOptions::SetUploadBufferSize(std::size_t size) {
   if (size == 0) {
-    upload_buffer_size_ = GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_BUFFER_SIZE;
+    upload_buffer_size_ = GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_UPLOAD_BUFFER_SIZE;
   } else {
     upload_buffer_size_ = size;
   }


### PR DESCRIPTION
This fixes #2657.

Experiments, which back these numbers are described in #2657.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2945)
<!-- Reviewable:end -->
