### PR TITLE
feat: Ignore warnings in generated code.

### DIFF
--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -259,8 +259,8 @@ function (google_cloud_cpp_proto_library libname)
                  PROPERTY PROTO_SOURCES ${_opt_UNPARSED_ARGUMENTS})
     target_link_libraries(${libname}
                           PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
-    # We want to treat the generate code as "system" headers so they get ignored
-    # by the more aggressive warnings.
+    # We want to treat the generated code as "system" headers so they get
+    # ignored by the more aggressive warnings.
     target_include_directories(
         ${libname} SYSTEM
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -259,8 +259,10 @@ function (google_cloud_cpp_proto_library libname)
                  PROPERTY PROTO_SOURCES ${_opt_UNPARSED_ARGUMENTS})
     target_link_libraries(${libname}
                           PUBLIC gRPC::grpc++ gRPC::grpc protobuf::libprotobuf)
+    # We want to treat the generate code as "system" headers so they get ignored
+    # by the more aggressive warnings.
     target_include_directories(
-        ${libname}
+        ${libname} SYSTEM
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                $<INSTALL_INTERFACE:include>)


### PR DESCRIPTION
We want to ignore any warnings in headers generated by the protobuf
compiler (or the gRPC plugin) because (a) they generate a lot of
warnings, and (b) we cannot easily fix those warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2948)
<!-- Reviewable:end -->
