### PR TITLE
cleanup: Don't include nljson.h from public oauth2 headers.

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -189,6 +189,7 @@ add_library(storage_client
             oauth2/authorized_user_credentials.h
             oauth2/authorized_user_credentials.cc
             oauth2/compute_engine_credentials.h
+            oauth2/compute_engine_credentials.cc
             oauth2/credential_constants.h
             oauth2/credentials.h
             oauth2/credentials.cc

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -1,0 +1,81 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/oauth2/compute_engine_credentials.h"
+#include "google/cloud/storage/internal/nljson.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace oauth2 {
+StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
+    storage::internal::HttpResponse const& response) {
+  auto response_body =
+      storage::internal::nl::json::parse(response.payload, nullptr, false);
+  // Note that the "scopes" attribute will always be present and contain a
+  // JSON array. At minimum, for the request to succeed, the instance must
+  // have been granted the scope that allows it to retrieve info from the
+  // metadata server.
+  if (response_body.is_discarded() || response_body.count("email") == 0 ||
+      response_body.count("scopes") == 0) {
+    auto status_payload =
+        response.payload +
+        "Could not find all required fields in response (email, scopes).";
+    return AsStatus(storage::internal::HttpResponse{
+        response.status_code, response.payload, response.headers});
+  }
+  ServiceAccountMetadata metadata;
+  // Do not update any state until all potential errors are handled.
+  metadata.email = response_body.value("email", "");
+  // We need to call the .get<>() helper because the conversion is ambiguous
+  // otherwise.
+  metadata.scopes =
+      response_body["scopes"].template get<std::set<std::string>>();
+  return std::move(metadata);
+}
+
+StatusOr<RefreshingCredentialsWrapper::TemporaryToken> ParseRefeshResponse(
+    storage::internal::HttpResponse const& response) {
+  namespace nl = storage::internal::nl;
+  // Response should have the attributes "access_token", "expires_in", and
+  // "token_type".
+  nl::json access_token = nl::json::parse(response.payload, nullptr, false);
+  if (access_token.is_discarded() || access_token.count("access_token") == 0 or
+      access_token.count("expires_in") == 0 or
+      access_token.count("token_type") == 0) {
+    auto payload =
+        response.payload +
+        "Could not find all required fields in response (access_token,"
+        " expires_in, token_type).";
+    return AsStatus(storage::internal::HttpResponse{response.status_code,
+                                                    payload, response.headers});
+  }
+  std::string header = "Authorization: ";
+  header += access_token.value("token_type", "");
+  header += ' ';
+  header += access_token.value("access_token", "");
+  auto expires_in =
+      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto new_expiration = std::chrono::system_clock::now() + expires_in;
+
+  return RefreshingCredentialsWrapper::TemporaryToken{std::move(header),
+                                                      new_expiration};
+}
+
+}  // namespace oauth2
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -43,7 +43,7 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
   // otherwise.
   metadata.scopes =
       response_body["scopes"].template get<std::set<std::string>>();
-  return std::move(metadata);
+  return metadata;
 }
 
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -30,11 +30,11 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
   // metadata server.
   if (response_body.is_discarded() || response_body.count("email") == 0 ||
       response_body.count("scopes") == 0) {
-    auto status_payload =
+    auto payload =
         response.payload +
         "Could not find all required fields in response (email, scopes).";
     return AsStatus(storage::internal::HttpResponse{
-        response.status_code, response.payload, response.headers});
+        response.status_code, payload, response.headers});
   }
   ServiceAccountMetadata metadata;
   // Do not update any state until all potential errors are handled.

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -33,8 +33,8 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     auto payload =
         response.payload +
         "Could not find all required fields in response (email, scopes).";
-    return AsStatus(storage::internal::HttpResponse{
-        response.status_code, payload, response.headers});
+    return AsStatus(storage::internal::HttpResponse{response.status_code,
+                                                    payload, response.headers});
   }
   ServiceAccountMetadata metadata;
   // Do not update any state until all potential errors are handled.
@@ -46,7 +46,8 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
   return std::move(metadata);
 }
 
-StatusOr<RefreshingCredentialsWrapper::TemporaryToken> ParseRefeshResponse(
+StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
+ParseComputeEngineRefeshResponse(
     storage::internal::HttpResponse const& response) {
   namespace nl = storage::internal::nl;
   // Response should have the attributes "access_token", "expires_in", and

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -44,7 +44,8 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     storage::internal::HttpResponse const& response);
 
 /// Parses a refresh response JSON string into a TemporaryToken.
-StatusOr<RefreshingCredentialsWrapper::TemporaryToken> ParseRefeshResponse(
+StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
+ParseComputeEngineRefeshResponse(
     storage::internal::HttpResponse const& response);
 
 /**
@@ -184,7 +185,7 @@ class ComputeEngineCredentials : public Credentials {
       return AsStatus(*response);
     }
 
-    return ParseRefeshResponse(*response);
+    return ParseComputeEngineRefeshResponse(*response);
   }
 
   mutable std::mutex mu_;

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -184,7 +184,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
 
 std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,
-    std::chrono::system_clock::time_point const& now) {
+    std::chrono::system_clock::time_point now) {
   storage::internal::nl::json assertion_header = {
       {"alg", "RS256"}, {"kid", info.private_key_id}, {"typ", "JWT"}};
 
@@ -237,7 +237,7 @@ std::string MakeJWTAssertion(std::string const& header,
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
 ParseServiceAccountRefreshResponse(
     storage::internal::HttpResponse const& response,
-    std::chrono::system_clock::time_point const& now) {
+    std::chrono::system_clock::time_point now) {
   auto access_token =
       storage::internal::nl::json::parse(response.payload, nullptr, false);
   if (access_token.is_discarded() || access_token.count("access_token") == 0 or

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -179,6 +180,87 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
                                        default_token_uri,
                                        /*scopes*/ {},
                                        /*subject*/ {}};
+}
+
+std::pair<std::string, std::string> AssertionComponentsFromInfo(
+    ServiceAccountCredentialsInfo const& info,
+    std::chrono::system_clock::time_point const& now) {
+  storage::internal::nl::json assertion_header = {
+      {"alg", "RS256"}, {"kid", info.private_key_id}, {"typ", "JWT"}};
+
+  // Scopes must be specified in a comma-delimited string.
+  std::string scope_str;
+  if (!info.scopes) {
+    scope_str = GoogleOAuthScopeCloudPlatform();
+  } else {
+    char const* sep = "";
+    for (const auto& scope : *(info.scopes)) {
+      scope_str += sep + scope;
+      sep = ",";
+    }
+  }
+
+  auto expiration = now + GoogleOAuthAccessTokenLifetime();
+  // As much as possible, do the time arithmetic using the std::chrono types.
+  // Convert to longs only when we are dealing with timestamps since the
+  // epoch.
+  auto now_from_epoch =
+      static_cast<long>(std::chrono::system_clock::to_time_t(now));
+  auto expiration_from_epoch =
+      static_cast<long>(std::chrono::system_clock::to_time_t(expiration));
+  storage::internal::nl::json assertion_payload = {
+      {"iss", info.client_email},
+      {"scope", scope_str},
+      {"aud", info.token_uri},
+      {"iat", now_from_epoch},
+      // Resulting access token should be expire after one hour.
+      {"exp", expiration_from_epoch}};
+  if (info.subject) {
+    assertion_payload["sub"] = *(info.subject);
+  }
+
+  // Note: we don't move here as it would prevent copy elision.
+  return std::make_pair(assertion_header.dump(), assertion_payload.dump());
+}
+
+std::string MakeJWTAssertion(std::string const& header,
+                             std::string const& payload,
+                             std::string const& pem_contents) {
+  std::string encoded_header = internal::UrlsafeBase64Encode(header);
+  std::string encoded_payload = internal::UrlsafeBase64Encode(payload);
+  std::string encoded_signature = internal::UrlsafeBase64Encode(
+      internal::SignStringWithPem(encoded_header + '.' + encoded_payload,
+                                  pem_contents, JwtSigningAlgorithms::RS256));
+  return encoded_header + '.' + encoded_payload + '.' + encoded_signature;
+}
+
+StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
+ParseServiceAccountRefreshResponse(
+    storage::internal::HttpResponse const& response,
+    std::chrono::system_clock::time_point const& now) {
+  auto access_token =
+      storage::internal::nl::json::parse(response.payload, nullptr, false);
+  if (access_token.is_discarded() || access_token.count("access_token") == 0 or
+      access_token.count("expires_in") == 0 or
+      access_token.count("token_type") == 0) {
+    auto payload =
+        response.payload +
+        "Could not find all required fields in response (access_token,"
+        " expires_in, token_type).";
+    return AsStatus(storage::internal::HttpResponse{response.status_code,
+                                                    payload, response.headers});
+  }
+  // Response should have the attributes "access_token", "expires_in", and
+  // "token_type".
+  std::string header =
+      "Authorization: " + access_token.value("token_type", "") + " " +
+      access_token.value("access_token", "");
+  auto expires_in =
+      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto new_expiration = now + expires_in;
+
+  return RefreshingCredentialsWrapper::TemporaryToken{std::move(header),
+                                                      new_expiration};
 }
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -75,7 +75,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
  */
 std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,
-    std::chrono::system_clock::time_point const& now);
+    std::chrono::system_clock::time_point now);
 
 /**
  * Given a key and a JSON header and payload, creates a JWT assertion string.
@@ -91,7 +91,7 @@ std::string MakeJWTAssertion(std::string const& header,
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
 ParseServiceAccountRefreshResponse(
     storage::internal::HttpResponse const& response,
-    std::chrono::system_clock::time_point const& now);
+    std::chrono::system_clock::time_point now);
 
 /**
  * Wrapper class for Google OAuth 2.0 service account credentials.

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
-#include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/internal/sha256_hash.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
@@ -64,6 +63,35 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
 StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
     std::string const& source,
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
+
+/**
+ * Splits a ServiceAccountCredentialsInfo into header and payload components
+ * and uses the current time to make a JWT assertion.
+ *
+ * @see
+ * https://cloud.google.com/endpoints/docs/frameworks/java/troubleshoot-jwt
+ *
+ * @see https://tools.ietf.org/html/rfc7523
+ */
+std::pair<std::string, std::string> AssertionComponentsFromInfo(
+    ServiceAccountCredentialsInfo const& info,
+    std::chrono::system_clock::time_point const& now);
+
+/**
+ * Given a key and a JSON header and payload, creates a JWT assertion string.
+ *
+ * @see https://tools.ietf.org/html/rfc7519
+ */
+std::string MakeJWTAssertion(std::string const& header,
+                             std::string const& payload,
+                             std::string const& pem_contents);
+
+/// Parses a refresh response JSON string and uses the current time to create a
+/// TemporaryToken.
+StatusOr<RefreshingCredentialsWrapper::TemporaryToken>
+ParseServiceAccountRefreshResponse(
+    storage::internal::HttpResponse const& response,
+    std::chrono::system_clock::time_point const& now);
 
 /**
  * Wrapper class for Google OAuth 2.0 service account credentials.
@@ -146,73 +174,9 @@ class ServiceAccountCredentials : public Credentials {
   std::string KeyId() const override { return info_.private_key_id; }
 
  private:
-  /**
-   * Returns the header and payload components needed to make a JWT assertion.
-   *
-   * @see
-   * https://cloud.google.com/endpoints/docs/frameworks/java/troubleshoot-jwt
-   *
-   * @see https://tools.ietf.org/html/rfc7523
-   */
-  std::pair<storage::internal::nl::json, storage::internal::nl::json>
-  AssertionComponentsFromInfo(ServiceAccountCredentialsInfo const& info) const {
-    storage::internal::nl::json assertion_header = {
-        {"alg", "RS256"}, {"kid", info.private_key_id}, {"typ", "JWT"}};
-
-    // Scopes must be specified in a comma-delimited string.
-    std::string scope_str;
-    if (!info.scopes) {
-      scope_str = GoogleOAuthScopeCloudPlatform();
-    } else {
-      char const* sep = "";
-      for (const auto& scope : *(info.scopes)) {
-        scope_str += sep + scope;
-        sep = ",";
-      }
-    }
-
-    auto now = clock_.now();
-    auto expiration = now + GoogleOAuthAccessTokenLifetime();
-    // As much as possible, do the time arithmetic using the std::chrono types.
-    // Convert to longs only when we are dealing with timestamps since the
-    // epoch.
-    auto now_from_epoch =
-        static_cast<long>(std::chrono::system_clock::to_time_t(now));
-    auto expiration_from_epoch =
-        static_cast<long>(std::chrono::system_clock::to_time_t(expiration));
-    storage::internal::nl::json assertion_payload = {
-        {"iss", info.client_email},
-        {"scope", scope_str},
-        {"aud", info.token_uri},
-        {"iat", now_from_epoch},
-        // Resulting access token should be expire after one hour.
-        {"exp", expiration_from_epoch}};
-    if (info.subject) {
-      assertion_payload["sub"] = *(info.subject);
-    }
-
-    return std::make_pair(std::move(assertion_header),
-                          std::move(assertion_payload));
-  }
-
-  /**
-   * Given a key and a JSON header and payload, creates a JWT assertion string.
-   *
-   * @see https://tools.ietf.org/html/rfc7519
-   */
-  std::string MakeJWTAssertion(storage::internal::nl::json const& header,
-                               storage::internal::nl::json const& payload,
-                               std::string const& pem_contents) const {
-    std::string encoded_header = internal::UrlsafeBase64Encode(header.dump());
-    std::string encoded_payload = internal::UrlsafeBase64Encode(payload.dump());
-    std::string encoded_signature = internal::UrlsafeBase64Encode(
-        internal::SignStringWithPem(encoded_header + '.' + encoded_payload,
-                                    pem_contents, JwtSigningAlgorithms::RS256));
-    return encoded_header + '.' + encoded_payload + '.' + encoded_signature;
-  }
-
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh() {
-    auto assertion_components = std::move(AssertionComponentsFromInfo(info_));
+    auto assertion_components =
+        std::move(AssertionComponentsFromInfo(info_, clock_.now()));
     std::string payload = grant_type_;
     payload += "&assertion=";
     payload += MakeJWTAssertion(assertion_components.first,
@@ -226,28 +190,7 @@ class ServiceAccountCredentials : public Credentials {
       return AsStatus(*response);
     }
 
-    auto access_token =
-        storage::internal::nl::json::parse(response->payload, nullptr, false);
-    if (access_token.is_discarded() ||
-        access_token.count("access_token") == 0 or
-        access_token.count("expires_in") == 0 or
-        access_token.count("token_type") == 0) {
-      response->payload +=
-          "Could not find all required fields in response (access_token,"
-          " expires_in, token_type).";
-      return AsStatus(*response);
-    }
-    // Response should have the attributes "access_token", "expires_in", and
-    // "token_type".
-    std::string header =
-        "Authorization: " + access_token.value("token_type", "") + " " +
-        access_token.value("access_token", "");
-    auto expires_in =
-        std::chrono::seconds(access_token.value("expires_in", int(0)));
-    auto new_expiration = clock_.now() + expires_in;
-
-    return RefreshingCredentialsWrapper::TemporaryToken{std::move(header),
-                                                        new_expiration};
+    return ParseServiceAccountRefreshResponse(*response, clock_.now());
   }
 
   typename HttpRequestBuilderType::RequestType request_;

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -158,6 +158,7 @@ storage_client_srcs = [
     "notification_metadata.cc",
     "oauth2/anonymous_credentials.cc",
     "oauth2/authorized_user_credentials.cc",
+    "oauth2/compute_engine_credentials.cc",
     "oauth2/credentials.cc",
     "oauth2/google_application_default_credentials_file.cc",
     "oauth2/google_credentials.cc",


### PR DESCRIPTION
Fixes #2772

Per @coryan's suggestion, this approach factors out any logic w.r.t JSON into
separate functions. For the functions dealing with JWT assertions, since they
were not only private functions but also essentially standalone, they were
moved out of the `ServiceAccountCredentials` class and made to accept a
`time_point` parameter. Functions which would normally take just a payload take
a `HttpResponse` to preserve the status. Finally, a `ServiceAccountMetadata`
struct was added; `ComputeEngineCredentials` was not modified to accept this to
prevent API breakage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2954)
<!-- Reviewable:end -->
