### PR TITLE
feat: let clang-tidy build not fail if there are edited files

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -121,5 +121,11 @@ find . \( "${ignore[@]}" \) -prune -o \
     replace_original_if_changed "${file}" "${file}.tmp"
   done
 
-# Report any differences created by running the formatting tools.
-git diff --ignore-submodules=all --color --exit-code .
+# Report any differences created by running the formatting tools. Report any
+# differences created by running the formatting tools. IFF we are running as
+# part of a CI build. Otherwise, a human probably invoked this script in which
+# case we'll just leave the formatted files in their local git repo so they can
+# diff them and commit the correctly formatted files.
+if [[ "${RUNNING_CI}" != "no" ]]; then
+  git diff --ignore-submodules=all --color --exit-code .
+fi

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -37,6 +37,13 @@ elif [[ -n "${KOKORO_JOB_NAME:-}" ]]; then
   # name.
   BUILD_NAME="$(basename "${KOKORO_JOB_NAME}" "-presubmit")"
   export BUILD_NAME
+
+  # This is passed into the environment of the docker build and its scripts to
+  # tell them if they are running as part of a CI build rather than just a
+  # human invocation of "build.sh <build-name>". This allows scripts to be
+  # strict when run in a CI, but a little more friendly when run by a human.
+  RUNNING_CI="yes"
+  export RUNNING_CI
 else
  echo "Aborting build as the build name is not defined."
  echo "If you are invoking this script via the command line use:"
@@ -262,6 +269,9 @@ docker_flags=(
     # Let the Docker image script know what kind of terminal we are using, that
     # produces properly colorized error messages.
     "--env" "TERM=${TERM:-dumb}"
+
+    # Tells scripts whether they are running as part of a CI or not.
+    "--env" "RUNNING_CI=${RUNNING_CI:-no}"
 
     # Run the docker script and this user id. Because the docker image gets to
     # write in ${PWD} you typically want this to be your user id.


### PR DESCRIPTION
Copied from https://github.com/googleapis/google-cloud-cpp-spanner/pull/334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2957)
<!-- Reviewable:end -->
