### PR TITLE
Tidy cleanup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,27 +2,27 @@
 # Configure clang-tidy for this project.
 
 # Disabled:
-#  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
+#  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
-Checks: >-
+Checks: >
+  -*,
   bugprone-*,
-  google-readability-*,
-  misc-*,
-  modernize-*,
-  readability-*,
-  performance-*,
-  -google-readability-namespace-comments,
-  -readability-named-parameter
-
-# Enable most warnings as errors.
-WarningsAsErrors: >-
-  bugprone-*,
-  clang-*,
   google-*,
   misc-*,
   modernize-*,
+  performance-*,
+  portability-*,
   readability-*,
-  performance-*
+  -google-readability-namespace-comments,
+  -google-runtime-int,
+  -google-runtime-references,
+  -misc-non-private-member-variables-in-classes,
+  -readability-named-parameter,
+  -readability-braces-around-statements,
+  -readability-magic-numbers
+
+# Turn all the warnings from the checks above into errors.
+WarningsAsErrors: "*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
@@ -31,15 +31,13 @@ CheckOptions:
   - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
   - { key: readability-identifier-naming.FunctionCase,           value: CamelCase  }
   - { key: readability-identifier-naming.VariableCase,           value: lower_case }
-  - { key: readability-identifier-naming.LocalConstantCase,      value: lower_case }
-  - { key: readability-identifier-naming.LocalConstantCase,      value: lower_case }
   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
   - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
-  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
-  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
   - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
   - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
   - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
   - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
   - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }

--- a/google/cloud/internal/backoff_policy.cc
+++ b/google/cloud/internal/backoff_policy.cc
@@ -29,6 +29,9 @@ std::unique_ptr<BackoffPolicy> ExponentialBackoffPolicy::clone() const {
 }
 
 std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion() {
+  using std::chrono::duration_cast;
+  using std::chrono::microseconds;
+  using std::chrono::milliseconds;
   // We do not want to copy the seed in `clone()` because then all operations
   // will have the same sequence of backoffs. Nor do we want to use a shared
   // PRNG because that would require locking and some more complicated lifecycle
@@ -42,7 +45,6 @@ std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion() {
   if (!generator_) {
     generator_ = google::cloud::internal::MakeDefaultPRNG();
   }
-  using namespace std::chrono;
   std::uniform_int_distribution<microseconds::rep> rng_distribution(
       current_delay_range_.count() / 2, current_delay_range_.count());
   // Randomized sleep period because it is possible that after some time all

--- a/google/cloud/terminate_handler.cc
+++ b/google/cloud/terminate_handler.cc
@@ -23,7 +23,7 @@ namespace {
 
 class TerminateFunction {
  public:
-  TerminateFunction(TerminateHandler f) : f_(std::move(f)) {}
+  explicit TerminateFunction(TerminateHandler f) : f_(std::move(f)) {}
 
   TerminateHandler Get() {
     std::lock_guard<std::mutex> l(m_);


### PR DESCRIPTION
This change copies the .clang-tidy file from https://github.com/googleapis/google-cloud-cpp-spanner/blob/master/.clang-tidy

The only difference is that for this project we disable the `google-runtime-int` check, which suggests avoiding types like `long` and `long long` in favor of explicitly sized types like `std::int64_t`. However, it appears that the curl library requires that are specifically `long` or `long long`, so keeping this warning would require lots of `NOLINT`, which simply doesn't seem worth it.

FWIW, I've always found this particular warning to be of dubious value anyway, so I don't mind turning it off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2958)
<!-- Reviewable:end -->
