### PR TITLE
Revert "bug: Fix nlohmann json macro leaks. (#2774)"

### DIFF
--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -46,14 +46,8 @@
 // nlohmann::json. This is safe because google/cloud/storage always includes
 // the nlohmann::json through this header, so after the first time our own
 // include guards are enough.
-#undef NLOHMANN_BASIC_JSON_TPL
-#undef NLOHMANN_BASIC_JSON_TPL_DECLARATION
 #undef NLOHMANN_JSON_HPP
 #undef NLOHMANN_JSON_FWD_HPP
-#undef NLOHMANN_JSON_SERIALIZE_ENUM
-#undef NLOHMANN_JSON_VERSION_MAJOR
-#undef NLOHMANN_JSON_VERSION_MINOR
-#undef NLOHMANN_JSON_VERSION_PATCH
 
 namespace nlohmann {
 //


### PR DESCRIPTION
This reverts commit ef9d062721d7a6522c5f6e00fe1f93ad8b700c12.

These changes should no longer be necessary since `nljson.h` is no longer
included in any public header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2959)
<!-- Reviewable:end -->
