### PR TITLE
cleanup: Use vcpkg for all dependencies in Windows build.

### DIFF
--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -103,7 +103,8 @@ Get-Date -Format o
 $packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
               "protobuf:x64-windows-static", "c-ares:x64-windows-static",
               "grpc:x64-windows-static", "curl:x64-windows-static",
-              "gtest:x64-windows-static", "crc32c:x64-windows-static")
+              "gtest:x64-windows-static", "crc32c:x64-windows-static"
+              "googleapis:x64-windows-static")
 foreach ($pkg in $packages) {
     .\vcpkg.exe install $pkg
     if ($LastExitCode) {

--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -45,8 +45,6 @@ $cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.
 $cmake_flags += "-DVCPKG_TARGET_TRIPLET=x64-windows-static"
 $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"
 $cmake_flags += "-DCMAKE_CXX_COMPILER=cl.exe"
-# Temporary Testing the external/googleapis.cmake
-$cmake_flags += "-DGOOGLE_CLOUD_CPP_GOOGLEAPIS_PROVIDER=external"
 
 # Configure CMake and create the build directory.
 Write-Host


### PR DESCRIPTION
Now that googleapis/cpp-cmakefiles is a vcpkg port we can simplify the
build configuration.

Fixes #2895.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2962)
<!-- Reviewable:end -->
