### PR TITLE
fix: use MetadataUpdatePolicy::FromClusterId.

### DIFF
--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -508,8 +508,8 @@ Status InstanceAdmin::DeleteCluster(std::string const& instance_id,
   btadmin::DeleteClusterRequest request;
   request.set_name(ClusterName(instance_id, cluster_id));
 
-  MetadataUpdatePolicy metadata_update_policy(
-      ClusterName(instance_id, cluster_id), MetadataParamTypes::NAME);
+  auto metadata_update_policy = MetadataUpdatePolicy::FromClusterId(
+      instance_id, MetadataParamTypes::NAME, cluster_id);
 
   // This API is not idempotent, lets call it without retry
   ClientUtils::MakeNonIdemponentCall(

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -156,8 +156,8 @@ class RowReaderTest : public bigtable::testing::TableTestFixture {
   RowReaderTest()
       : retry_policy_(new RetryPolicyMock),
         backoff_policy_(new BackoffPolicyMock),
-        metadata_update_policy_(kTableName,
-                                bigtable::MetadataParamTypes::TABLE_NAME),
+        metadata_update_policy_(bigtable::MetadataUpdatePolicy::FromTableId(
+            kInstanceName, bigtable::MetadataParamTypes::TABLE_NAME, kTableId)),
         parser_factory_(new ReadRowsParserMockFactory) {}
 
   std::unique_ptr<RetryPolicyMock> retry_policy_;

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -216,7 +216,8 @@ class Table {
             bigtable::DefaultRPCRetryPolicy(internal::kBigtableLimits)),
         rpc_backoff_policy_(
             bigtable::DefaultRPCBackoffPolicy(internal::kBigtableLimits)),
-        metadata_update_policy_(table_name(), MetadataParamTypes::TABLE_NAME),
+        metadata_update_policy_(MetadataUpdatePolicy::FromTableId(
+            InstanceName(client_), MetadataParamTypes::TABLE_NAME, table_id)),
         idempotent_mutation_policy_(
             bigtable::DefaultIdempotentMutationPolicy()) {}
 


### PR DESCRIPTION
This is a part of #2704.

These are the only place where these ctors can be used (I checked by making the `  MetadataUpdatePolicy(std::string const& resource_name, MetadataParamTypes const& metadata_param_type)` ctor private temporarily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2968)
<!-- Reviewable:end -->
