### PR TITLE
feat: Make integration tests client configurable.

### DIFF
--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_STORAGE_INTEGRATION_TEST_H_
 
 #include "google/cloud/internal/random.h"
+#include "google/cloud/storage/client.h"
 #include "google/cloud/storage/well_known_headers.h"
 #include <gmock/gmock.h>
 #include <string>
@@ -30,6 +31,9 @@ namespace testing {
  */
 class StorageIntegrationTest : public ::testing::Test {
  protected:
+  google::cloud::StatusOr<google::cloud::storage::Client>
+  MakeIntegrationTestClient();
+
   std::string MakeRandomObjectName();
 
   std::string LoremIpsum() const;

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -46,7 +46,7 @@ class BucketIntegrationTest
 TEST_F(BucketIntegrationTest, BasicCRUD) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto buckets = client->ListBucketsForProject(project_id);
@@ -140,7 +140,7 @@ TEST_F(BucketIntegrationTest, CreatePredefinedAcl) {
     SCOPED_TRACE(std::string("Testing with ") +
                  acl.well_known_parameter_name() + "=" + acl.value());
     std::string bucket_name = MakeRandomBucketName();
-    StatusOr<Client> client = Client::CreateDefaultClient();
+    StatusOr<Client> client = MakeIntegrationTestClient();
     ASSERT_STATUS_OK(client);
 
     auto metadata = client->CreateBucketForProject(
@@ -168,7 +168,7 @@ TEST_F(BucketIntegrationTest, CreatePredefinedDefaultObjectAcl) {
     SCOPED_TRACE(std::string("Testing with ") +
                  acl.well_known_parameter_name() + "=" + acl.value());
     std::string bucket_name = MakeRandomBucketName();
-    StatusOr<Client> client = Client::CreateDefaultClient();
+    StatusOr<Client> client = MakeIntegrationTestClient();
     ASSERT_STATUS_OK(client);
 
     auto metadata = client->CreateBucketForProject(
@@ -185,7 +185,7 @@ TEST_F(BucketIntegrationTest, CreatePredefinedDefaultObjectAcl) {
 TEST_F(BucketIntegrationTest, FullPatch) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // We need to have an available bucket for logging ...
@@ -329,7 +329,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 TEST_F(BucketIntegrationTest, BucketPolicyOnlyPatch) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a Bucket, use the default settings for all fields. Fetch the full
@@ -360,7 +360,7 @@ TEST_F(BucketIntegrationTest, BucketPolicyOnlyPatch) {
 
 TEST_F(BucketIntegrationTest, GetMetadata) {
   std::string bucket_name = flag_bucket_name;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto metadata = client->GetBucketMetadata(bucket_name);
@@ -372,7 +372,7 @@ TEST_F(BucketIntegrationTest, GetMetadata) {
 
 TEST_F(BucketIntegrationTest, GetMetadataFields) {
   std::string bucket_name = flag_bucket_name;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto metadata = client->GetBucketMetadata(bucket_name, Fields("name"));
@@ -384,7 +384,7 @@ TEST_F(BucketIntegrationTest, GetMetadataFields) {
 
 TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
   std::string bucket_name = flag_bucket_name;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto metadata = client->GetBucketMetadata(bucket_name);
@@ -402,7 +402,7 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
 
 TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatch_Failure) {
   std::string bucket_name = flag_bucket_name;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto metadata = client->GetBucketMetadata(bucket_name);
@@ -420,7 +420,7 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatch_Failure) {
 TEST_F(BucketIntegrationTest, AccessControlCRUD) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test, with the "private" PredefinedAcl so
@@ -500,7 +500,7 @@ TEST_F(BucketIntegrationTest, AccessControlCRUD) {
 TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test, with the "private"
@@ -577,7 +577,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
 TEST_F(BucketIntegrationTest, NotificationsCRUD) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test.
@@ -632,7 +632,7 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
 TEST_F(BucketIntegrationTest, IamCRUD) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test.
@@ -688,7 +688,7 @@ TEST_F(BucketIntegrationTest, IamCRUD) {
 TEST_F(BucketIntegrationTest, NativeIamCRUD) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test.
@@ -766,7 +766,7 @@ TEST_F(BucketIntegrationTest, NativeIamCRUD) {
 TEST_F(BucketIntegrationTest, BucketLock) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Create a new bucket to run the test.
@@ -794,7 +794,7 @@ TEST_F(BucketIntegrationTest, BucketLock) {
 TEST_F(BucketIntegrationTest, BucketLockFailure) {
   std::string project_id = flag_project_id;
   std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // This should fail because the bucket does not exist.
@@ -804,7 +804,7 @@ TEST_F(BucketIntegrationTest, BucketLockFailure) {
 }
 
 TEST_F(BucketIntegrationTest, ListFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Project IDs must end with a letter or number, test with an invalid ID.
@@ -815,7 +815,7 @@ TEST_F(BucketIntegrationTest, ListFailure) {
 }
 
 TEST_F(BucketIntegrationTest, CreateFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   // Try to create an invalid bucket (the name should not start with an
@@ -828,7 +828,7 @@ TEST_F(BucketIntegrationTest, CreateFailure) {
 }
 
 TEST_F(BucketIntegrationTest, GetFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -839,7 +839,7 @@ TEST_F(BucketIntegrationTest, GetFailure) {
 }
 
 TEST_F(BucketIntegrationTest, DeleteFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -850,7 +850,7 @@ TEST_F(BucketIntegrationTest, DeleteFailure) {
 }
 
 TEST_F(BucketIntegrationTest, UpdateFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -861,7 +861,7 @@ TEST_F(BucketIntegrationTest, UpdateFailure) {
 }
 
 TEST_F(BucketIntegrationTest, PatchFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -872,7 +872,7 @@ TEST_F(BucketIntegrationTest, PatchFailure) {
 }
 
 TEST_F(BucketIntegrationTest, GetBucketIamPolicyFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -883,7 +883,7 @@ TEST_F(BucketIntegrationTest, GetBucketIamPolicyFailure) {
 }
 
 TEST_F(BucketIntegrationTest, SetBucketIamPolicyFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -894,7 +894,7 @@ TEST_F(BucketIntegrationTest, SetBucketIamPolicyFailure) {
 }
 
 TEST_F(BucketIntegrationTest, TestBucketIamPermissionsFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -905,7 +905,7 @@ TEST_F(BucketIntegrationTest, TestBucketIamPermissionsFailure) {
 }
 
 TEST_F(BucketIntegrationTest, ListAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -915,7 +915,7 @@ TEST_F(BucketIntegrationTest, ListAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, CreateAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -926,7 +926,7 @@ TEST_F(BucketIntegrationTest, CreateAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, GetAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -937,7 +937,7 @@ TEST_F(BucketIntegrationTest, GetAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, UpdateAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -950,7 +950,7 @@ TEST_F(BucketIntegrationTest, UpdateAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, PatchAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -963,7 +963,7 @@ TEST_F(BucketIntegrationTest, PatchAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, DeleteAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -974,7 +974,7 @@ TEST_F(BucketIntegrationTest, DeleteAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, ListDefaultAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
 
@@ -984,7 +984,7 @@ TEST_F(BucketIntegrationTest, ListDefaultAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, CreateDefaultAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -997,7 +997,7 @@ TEST_F(BucketIntegrationTest, CreateDefaultAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, GetDefaultAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -1008,7 +1008,7 @@ TEST_F(BucketIntegrationTest, GetDefaultAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, UpdateDefaultAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -1024,7 +1024,7 @@ TEST_F(BucketIntegrationTest, UpdateDefaultAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, PatchDefaultAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();
@@ -1040,7 +1040,7 @@ TEST_F(BucketIntegrationTest, PatchDefaultAccessControlFailure) {
 }
 
 TEST_F(BucketIntegrationTest, DeleteDefaultAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string bucket_name = MakeRandomBucketName();
   auto entity_name = MakeEntityName();

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -35,7 +35,7 @@ class CurlSignBlobIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(CurlSignBlobIntegrationTest, Simple) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
   std::string service_account = flag_service_account;
 

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -38,7 +38,7 @@ class ObjectChecksumIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32c) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -65,7 +65,7 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32c) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -92,7 +92,7 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32c) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -108,7 +108,7 @@ TEST_F(ObjectChecksumIntegrationTest, InsertWithCrc32cFailure) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32cFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -124,7 +124,7 @@ TEST_F(ObjectChecksumIntegrationTest, XmlInsertWithCrc32cFailure) {
 }
 
 TEST_F(ObjectChecksumIntegrationTest, InsertWithComputedCrc32c) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -223,7 +223,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
 
 /// @test Verify that CRC32C checksums are computed by default on downloads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadXML) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -249,7 +249,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadXML) {
 
 /// @test Verify that CRC32C checksums are computed by default on downloads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -276,7 +276,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingReadJSON) {
 
 /// @test Verify that CRC32C checksums are computed by default on uploads.
 TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingWriteJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -308,7 +308,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadXML) {
     // testbench to inject faults.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -355,7 +355,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
     // testbench to inject faults.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -402,7 +402,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingWriteJSON) {
     // testbench to inject faults.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -40,7 +40,7 @@ class ObjectFileIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(ObjectFileIntegrationTest, XmlDownloadFile) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -75,7 +75,7 @@ TEST_F(ObjectFileIntegrationTest, XmlDownloadFile) {
 }
 
 TEST_F(ObjectFileIntegrationTest, JsonDownloadFile) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -110,7 +110,7 @@ TEST_F(ObjectFileIntegrationTest, JsonDownloadFile) {
 }
 
 TEST_F(ObjectFileIntegrationTest, DownloadFileFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -123,7 +123,7 @@ TEST_F(ObjectFileIntegrationTest, DownloadFileFailure) {
 }
 
 TEST_F(ObjectFileIntegrationTest, DownloadFileCannotOpenFile) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -146,7 +146,7 @@ TEST_F(ObjectFileIntegrationTest, DownloadFileCannotOpenFile) {
 
 TEST_F(ObjectFileIntegrationTest, DownloadFileCannotWriteToFile) {
 #if GTEST_OS_LINUX
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -177,7 +177,7 @@ TEST_F(ObjectFileIntegrationTest, DownloadFileCannotWriteToFile) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFile) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
@@ -216,7 +216,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
     // The testbench does not support binary payloads.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
@@ -259,7 +259,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileEmpty) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
@@ -289,7 +289,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileEmpty) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileMissingFileFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = MakeRandomObjectName();
@@ -304,7 +304,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileMissingFileFailure) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileUploadFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
@@ -336,7 +336,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
   // do on Linux, and hard to do on the other platforms we support, so just run
   // the test there.
 #if GTEST_OS_LINUX || GTEST_OS_MAC
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
@@ -376,7 +376,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
 }
 
 TEST_F(ObjectFileIntegrationTest, XmlUploadFile) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();
@@ -463,7 +463,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableBySize) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileResumableByOption) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto file_name = ::testing::TempDir() + MakeRandomObjectName();

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -184,7 +184,7 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
 
 /// @test Verify that MD5 hashes are computed by default on downloads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadXML) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -210,7 +210,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadXML) {
 
 /// @test Verify that MD5 hashes are computed by default on downloads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -237,7 +237,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingReadJSON) {
 
 /// @test Verify that hashes and checksums can be disabled on downloads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadXML) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -265,7 +265,7 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadXML) {
 
 /// @test Verify that hashes and checksums can be disabled on downloads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -293,7 +293,7 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingReadJSON) {
 
 /// @test Verify that MD5 hashes are computed by default on uploads.
 TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingWriteJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -319,7 +319,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5StreamingWriteJSON) {
 
 /// @test Verify MD5 hash value before upload.
 TEST_F(ObjectHashIntegrationTest, VerifyValidMD5StreamingWriteJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -346,7 +346,7 @@ TEST_F(ObjectHashIntegrationTest, VerifyValidMD5StreamingWriteJSON) {
 
 /// @test Verify invalid MD5 hash value before upload.
 TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -369,7 +369,7 @@ TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteJSON) {
 
 /// @test Verify MD5 hashe before upload.
 TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteXML) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -392,7 +392,7 @@ TEST_F(ObjectHashIntegrationTest, InvalidMD5StreamingWriteXML) {
 
 /// @test Verify that hashes and checksums can be disabled in uploads.
 TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteJSON) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -423,7 +423,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML) {
     // testbench to inject faults.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -468,7 +468,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
     // testbench to inject faults.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -514,7 +514,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteJSON) {
     // testbench to inject faults.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -39,7 +39,7 @@ class ObjectInsertIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -65,7 +65,7 @@ TEST_F(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -90,7 +90,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertWithNonUrlSafeName) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -115,7 +115,7 @@ TEST_F(ObjectInsertIntegrationTest, MultipartInsertWithNonUrlSafeName) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithMD5) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -141,7 +141,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithMD5) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -167,7 +167,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithComputedMD5) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -193,7 +193,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertWithMD5) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithMetadata) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -224,7 +224,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithMetadata) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -245,7 +245,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -271,7 +271,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -298,7 +298,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -321,7 +321,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -343,7 +343,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -364,7 +364,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -390,7 +390,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
 
 TEST_F(ObjectInsertIntegrationTest,
        XmlInsertPredefinedAclBucketOwnerFullControl) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -420,7 +420,7 @@ TEST_F(ObjectInsertIntegrationTest,
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -450,7 +450,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -476,7 +476,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPrivate) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -502,7 +502,7 @@ TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclProjectPrivate) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, XmlInsertPredefinedAclPublicRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -670,7 +670,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertWithContentType) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -689,7 +689,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertWithContentType) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -714,7 +714,7 @@ TEST_F(ObjectInsertIntegrationTest, InsertFailure) {
 }
 
 TEST_F(ObjectInsertIntegrationTest, InsertXmlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -47,7 +47,7 @@ class ObjectIntegrationTest
 
 /// @test Verify the Object CRUD (Create, Get, Update, Delete, List) operations.
 TEST_F(ObjectIntegrationTest, BasicCRUD) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -158,7 +158,7 @@ TEST_F(ObjectIntegrationTest, BasicCRUD) {
 }
 
 TEST_F(ObjectIntegrationTest, FullPatch) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -232,7 +232,7 @@ TEST_F(ObjectIntegrationTest, FullPatch) {
 }
 
 TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -304,7 +304,7 @@ TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
 }
 
 TEST_F(ObjectIntegrationTest, BasicReadWrite) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -330,7 +330,7 @@ TEST_F(ObjectIntegrationTest, BasicReadWrite) {
 }
 
 TEST_F(ObjectIntegrationTest, EncryptedReadWrite) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -362,7 +362,7 @@ TEST_F(ObjectIntegrationTest, EncryptedReadWrite) {
 }
 
 TEST_F(ObjectIntegrationTest, ReadNotFound) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -378,7 +378,7 @@ TEST_F(ObjectIntegrationTest, ReadNotFound) {
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWrite) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -410,7 +410,7 @@ TEST_F(ObjectIntegrationTest, StreamingWrite) {
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWriteAutoClose) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -436,7 +436,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteAutoClose) {
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWriteEmpty) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -461,7 +461,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteEmpty) {
 }
 
 TEST_F(ObjectIntegrationTest, XmlStreamingWrite) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -495,7 +495,7 @@ TEST_F(ObjectIntegrationTest, XmlStreamingWrite) {
 }
 
 TEST_F(ObjectIntegrationTest, XmlReadWrite) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -521,7 +521,7 @@ TEST_F(ObjectIntegrationTest, XmlReadWrite) {
 }
 
 TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -594,7 +594,7 @@ TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
 }
 
 TEST_F(ObjectIntegrationTest, WriteWithContentType) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -619,7 +619,7 @@ TEST_F(ObjectIntegrationTest, WriteWithContentType) {
 }
 
 TEST_F(ObjectIntegrationTest, GetObjectMetadataFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -631,7 +631,7 @@ TEST_F(ObjectIntegrationTest, GetObjectMetadataFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWriteFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -666,7 +666,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWriteFailureNoex) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -696,7 +696,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailureNoex) {
 
 TEST_F(ObjectIntegrationTest, ListObjectsFailure) {
   auto bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   ListObjectsReader reader = client->ListObjects(bucket_name, Versions(true));
@@ -711,7 +711,7 @@ TEST_F(ObjectIntegrationTest, ListObjectsFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, DeleteObjectFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -723,7 +723,7 @@ TEST_F(ObjectIntegrationTest, DeleteObjectFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, UpdateObjectFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -736,7 +736,7 @@ TEST_F(ObjectIntegrationTest, UpdateObjectFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, PatchObjectFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -749,7 +749,7 @@ TEST_F(ObjectIntegrationTest, PatchObjectFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, ListAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -761,7 +761,7 @@ TEST_F(ObjectIntegrationTest, ListAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, CreateAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -775,7 +775,7 @@ TEST_F(ObjectIntegrationTest, CreateAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, GetAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -788,7 +788,7 @@ TEST_F(ObjectIntegrationTest, GetAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, UpdateAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -803,7 +803,7 @@ TEST_F(ObjectIntegrationTest, UpdateAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, PatchAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -818,7 +818,7 @@ TEST_F(ObjectIntegrationTest, PatchAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, DeleteAccessControlFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -50,7 +50,7 @@ class ObjectMediaIntegrationTest
 };
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -90,7 +90,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
 /// @test Read a portion of a relatively large object using the JSON API.
 TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   // The testbench always requires multiple iterations to copy this object.
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -132,7 +132,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
 /// @test Read a portion of a relatively large object using the XML API.
 TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   // The testbench always requires multiple iterations to copy this object.
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -173,7 +173,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
 /// @test Read a portion of a relatively large object using the JSON API.
 TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
   // The testbench always requires multiple iterations to copy this object.
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -215,7 +215,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
 /// @test Read a portion of a relatively large object using the XML API.
 TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
   // The testbench always requires multiple iterations to copy this object.
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -256,7 +256,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
 /// @test Read a relatively large object using chunks of different sizes.
 TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
   // The testbench always requires multiple iterations to copy this object.
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -319,7 +319,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
 
 /// @test Read the last chunk of an object.
 TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -371,7 +371,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
 
 /// @test Read an object by chunks of equal size.
 TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -34,7 +34,7 @@ class ObjectResumableWriteIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentType) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -66,7 +66,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentType) {
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentTypeFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName();
@@ -85,7 +85,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithContentTypeFailure) {
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteWithUseResumable) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -115,7 +115,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteWithUseResumable) {
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -155,7 +155,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteResume) {
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WriteResumeFinalizedUpload) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -190,7 +190,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteResumeFinalizedUpload) {
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -40,7 +40,7 @@ class ObjectRewriteIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(ObjectRewriteIntegrationTest, Copy) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -75,7 +75,7 @@ TEST_F(ObjectRewriteIntegrationTest, Copy) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -103,7 +103,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclAuthenticatedRead) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -136,7 +136,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerFullControl) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -169,7 +169,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclBucketOwnerRead) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -198,7 +198,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPrivate) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -227,7 +227,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclProjectPrivate) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -255,7 +255,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyPredefinedAclPublicRead) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -286,7 +286,7 @@ TEST_F(ObjectRewriteIntegrationTest, ComposeSimple) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposedUsingEncryptedObject) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -323,7 +323,7 @@ TEST_F(ObjectRewriteIntegrationTest, ComposedUsingEncryptedObject) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteSimple) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -353,7 +353,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteSimple) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteEncrypted) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -390,7 +390,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteEncrypted) {
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
   // The testbench always requires multiple iterations to copy this object.
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -437,7 +437,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, CopyFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -451,7 +451,7 @@ TEST_F(ObjectRewriteIntegrationTest, CopyFailure) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, ComposeFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -467,7 +467,7 @@ TEST_F(ObjectRewriteIntegrationTest, ComposeFailure) {
 }
 
 TEST_F(ObjectRewriteIntegrationTest, RewriteFailure) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -37,7 +37,7 @@ class ObjectWriteStreambufIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   void CheckUpload(int line_count, int line_size) {
-    StatusOr<Client> client = Client::CreateDefaultClient();
+    StatusOr<Client> client = MakeIntegrationTestClient();
     ASSERT_STATUS_OK(client);
     std::string bucket_name = flag_bucket_name;
     auto object_name = MakeRandomObjectName();

--- a/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test.cc
+++ b/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test.cc
@@ -164,7 +164,7 @@ TEST_F(ReadObjectStallTest, Streaming) {
 }
 
 TEST_F(ReadObjectStallTest, ByRange) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client) << "ERROR: Aborting test, cannot create client";
 
   PreparePhase(*client, 1000);
@@ -236,7 +236,7 @@ TEST_F(ReadObjectStallTest, ByRange) {
 }
 
 TEST_F(ReadObjectStallTest, ByFile) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client) << "ERROR: Aborting test, cannot create client";
 
   PreparePhase(*client, 1000);

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
@@ -30,9 +31,12 @@ using ::testing::HasSubstr;
 char const* flag_project_id;
 char const* flag_service_account;
 
-TEST(ServiceAccountIntegrationTest, Get) {
+class ServiceAccountIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+TEST_F(ServiceAccountIntegrationTest, Get) {
   std::string project_id = flag_project_id;
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   StatusOr<ServiceAccount> a1 = client->GetServiceAccountForProject(project_id);
@@ -49,7 +53,7 @@ TEST(ServiceAccountIntegrationTest, Get) {
   EXPECT_EQ(*a1, *a2);
 }
 
-TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
+TEST_F(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
   std::string project_id = flag_project_id;
   std::string service_account = flag_service_account;
 
@@ -73,7 +77,7 @@ TEST(ServiceAccountIntegrationTest, CreateHmacKeyForProject) {
   ASSERT_STATUS_OK(deleted_key);
 }
 
-TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
+TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   std::string project_id = flag_project_id;
   std::string service_account = flag_service_account;
 
@@ -130,7 +134,7 @@ TEST(ServiceAccountIntegrationTest, HmacKeyCRUD) {
   EXPECT_THAT(post_delete_access_ids, Not(Contains(access_id)));
 }
 
-TEST(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
+TEST_F(ServiceAccountIntegrationTest, HmacKeyCRUDFailures) {
   std::string project_id = flag_project_id;
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   std::string service_account = flag_service_account;

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -41,7 +41,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
     // The testbench does not implement signed URLs.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -79,7 +79,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
     // The testbench does not implement signed URLs.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -117,7 +117,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
     // The testbench does not implement signed URLs.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;
@@ -155,7 +155,7 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
     // The testbench does not implement signed URLs.
     return;
   }
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/slow_reader_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_integration_test.cc
@@ -52,7 +52,7 @@ class SlowReaderIntegrationTest
 };
 
 TEST_F(SlowReaderIntegrationTest, StreamingRead) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string const bucket_name = flag_bucket_name;
@@ -113,7 +113,7 @@ TEST_F(SlowReaderIntegrationTest, StreamingRead) {
 }
 
 TEST_F(SlowReaderIntegrationTest, StreamingReadRestart) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   std::string const bucket_name = flag_bucket_name;

--- a/google/cloud/storage/tests/write_deadlock_regression/object_write_deadlock_regression_test.cc
+++ b/google/cloud/storage/tests/write_deadlock_regression/object_write_deadlock_regression_test.cc
@@ -105,7 +105,7 @@ class ObjectWriteDeadlockRegressionTest
   }
 
   std::string WritePhase() {
-    StatusOr<Client> client = Client::CreateDefaultClient();
+    StatusOr<Client> client = MakeIntegrationTestClient();
     EXPECT_STATUS_OK(client) << "ERROR: Aborting test, cannot create client";
     if (!client) {
       std::exit(1);
@@ -133,7 +133,7 @@ class ObjectWriteDeadlockRegressionTest
 };
 
 TEST_F(ObjectWriteDeadlockRegressionTest, StreamingWrite) {
-  StatusOr<Client> client = Client::CreateDefaultClient();
+  StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client) << "ERROR: Aborting test, cannot create client";
 
   auto object_names = PreparePhase(*client, 32);


### PR DESCRIPTION
This PR makes the `storage::Client` used in integration tests
configurable, so we can run all the tests with different configurations.
For now we just change the idempotency policy, but I anticipate other
changes in the future, for example, different client option parameters,
changing the endpoints, changing the stack of `RawClients`, and more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2970)
<!-- Reviewable:end -->
