### PR TITLE
bug: Account for when CreateHashValidator's options are set to false

### DIFF
--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -70,17 +70,43 @@ std::unique_ptr<HashValidator> CreateHashValidator(bool disable_md5,
 
 std::unique_ptr<HashValidator> CreateHashValidator(
     ReadObjectRangeRequest const& request) {
+  auto disable_md5 = false;
+  auto disable_crc32c = false;
   if (request.RequiresRangeHeader()) {
     return google::cloud::internal::make_unique<NullHashValidator>();
   }
-  return CreateHashValidator(request.HasOption<DisableMD5Hash>(),
-                             request.HasOption<DisableCrc32cChecksum>());
+  if (request.HasOption<DisableMD5Hash>()) {
+    disable_md5 = request.GetOption<DisableMD5Hash>().value();
+    if (!request.HasOption<DisableCrc32cChecksum>()) {
+      disable_crc32c = !disable_md5;
+    }
+  }
+  if (request.HasOption<DisableCrc32cChecksum>()) {
+    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value();
+    if (!request.HasOption<DisableMD5Hash>()) {
+      disable_md5 = !disable_crc32c;
+    }
+  }
+  return CreateHashValidator(disable_md5, disable_crc32c);
 }
 
 std::unique_ptr<HashValidator> CreateHashValidator(
     ResumableUploadRequest const& request) {
-  return CreateHashValidator(request.HasOption<DisableMD5Hash>(),
-                             request.HasOption<DisableCrc32cChecksum>());
+  auto disable_md5 = false;
+  auto disable_crc32c = false;
+  if (request.HasOption<DisableMD5Hash>()) {
+    disable_md5 = request.GetOption<DisableMD5Hash>().value();
+    if (!request.HasOption<DisableCrc32cChecksum>()) {
+      disable_crc32c = !disable_md5;
+    }
+  }
+  if (request.HasOption<DisableCrc32cChecksum>()) {
+    disable_crc32c = request.GetOption<DisableCrc32cChecksum>().value();
+    if (!request.HasOption<DisableMD5Hash>()) {
+      disable_md5 = !disable_crc32c;
+    }
+  }
+  return CreateHashValidator(disable_md5, disable_crc32c);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -112,10 +112,10 @@ class ResumableUploadRequest;
  * - If neither `DisableMD5Hash(true)` nor `DisableCrc32cChecksum(true)` are
  *   provided, then both MD5Hash and Crc32Checksum are used.
  * - If only `DisableMD5Hash(true)` is provided, then only Crc32cChecksum is
- * used.
+ *   used.
  * - If only `DisableCrc32c(true)` is provided, then only MD5Hash is used.
  * - If both `DisableMD5Hash(true)` and `DisableCrc32cChecksum(true)` are
- * provided, then neither are used.
+ *   provided, then neither are used.
  *
  * Specifying the option with `false` or no argument (default constructor) has
  * the same effect as not passing the option at all.

--- a/google/cloud/storage/internal/hash_validator.h
+++ b/google/cloud/storage/internal/hash_validator.h
@@ -102,6 +102,24 @@ class CompositeValidator : public HashValidator {
 class ReadObjectRangeRequest;
 class ResumableUploadRequest;
 
+/**
+ * @{
+ * The requests accepted by `CreateHashValidator` can be configured with the
+ * `DisableMD5Hash` and `DisableCrc32Checksum` options. You must explicitly
+ * pass these options to disable each respectively.
+ *
+ * The valid combinations are:
+ * - If neither `DisableMD5Hash(true)` nor `DisableCrc32cChecksum(true)` are
+ *   provided, then both MD5Hash and Crc32Checksum are used.
+ * - If only `DisableMD5Hash(true)` is provided, then only Crc32cChecksum is
+ * used.
+ * - If only `DisableCrc32c(true)` is provided, then only MD5Hash is used.
+ * - If both `DisableMD5Hash(true)` and `DisableCrc32cChecksum(true)` are
+ * provided, then neither are used.
+ *
+ * Specifying the option with `false` or no argument (default constructor) has
+ * the same effect as not passing the option at all.
+ */
 /// Create a hash validator configured by @p request.
 std::unique_ptr<HashValidator> CreateHashValidator(
     ReadObjectRangeRequest const& request);
@@ -109,6 +127,7 @@ std::unique_ptr<HashValidator> CreateHashValidator(
 /// Create a hash validator configured by @p request.
 std::unique_ptr<HashValidator> CreateHashValidator(
     ResumableUploadRequest const& request);
+/* @} */
 
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -240,6 +240,13 @@ TEST(CreateHashValidator, Read_OnlyCrc32c) {
   UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
   auto result = std::move(*validator).Finish();
   EXPECT_EQ(QUICK_FOX_CRC32C_CHECKSUM, result.computed);
+
+  validator = CreateHashValidator(
+      ReadObjectRangeRequest("test-bucket", "test-object")
+          .set_multiple_options(DisableCrc32cChecksum(false)));
+  UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
+  result = std::move(*validator).Finish();
+  EXPECT_EQ(QUICK_FOX_CRC32C_CHECKSUM, result.computed);
 }
 
 TEST(CreateHashValidator, Read_OnlyMD5) {
@@ -248,6 +255,13 @@ TEST(CreateHashValidator, Read_OnlyMD5) {
           .set_multiple_options(DisableCrc32cChecksum(true)));
   UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
   auto result = std::move(*validator).Finish();
+  EXPECT_EQ(QUICK_FOX_MD5_HASH, result.computed);
+
+  validator =
+      CreateHashValidator(ReadObjectRangeRequest("test-bucket", "test-object")
+                              .set_multiple_options(DisableMD5Hash(false)));
+  UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
+  result = std::move(*validator).Finish();
   EXPECT_EQ(QUICK_FOX_MD5_HASH, result.computed);
 }
 
@@ -277,6 +291,13 @@ TEST(CreateHashValidator, Write_OnlyCrc32c) {
   UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
   auto result = std::move(*validator).Finish();
   EXPECT_EQ(QUICK_FOX_CRC32C_CHECKSUM, result.computed);
+
+  validator = CreateHashValidator(
+      ResumableUploadRequest("test-bucket", "test-object")
+          .set_multiple_options(DisableCrc32cChecksum(false)));
+  UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
+  result = std::move(*validator).Finish();
+  EXPECT_EQ(QUICK_FOX_CRC32C_CHECKSUM, result.computed);
 }
 
 TEST(CreateHashValidator, Write_OnlyMD5) {
@@ -286,6 +307,13 @@ TEST(CreateHashValidator, Write_OnlyMD5) {
   UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
   auto result = std::move(*validator).Finish();
   EXPECT_EQ(QUICK_FOX_MD5_HASH, result.computed);
+
+  validator =
+      CreateHashValidator(ResumableUploadRequest("test-bucket", "test-object")
+                              .set_multiple_options(DisableMD5Hash(false)));
+  UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
+  result = std::move(*validator).Finish();
+  EXPECT_EQ(QUICK_FOX_MD5_HASH, result.computed);
 }
 
 TEST(CreateHashValidator, Write_Both) {
@@ -293,6 +321,15 @@ TEST(CreateHashValidator, Write_Both) {
       CreateHashValidator(ResumableUploadRequest("test-bucket", "test-object"));
   UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
   auto result = std::move(*validator).Finish();
+  EXPECT_THAT(result.computed, HasSubstr(QUICK_FOX_MD5_HASH));
+  EXPECT_THAT(result.computed, HasSubstr(QUICK_FOX_CRC32C_CHECKSUM));
+
+  validator = CreateHashValidator(
+      ResumableUploadRequest("test-bucket", "test-object")
+          .set_multiple_options(DisableCrc32cChecksum(false),
+                                DisableMD5Hash(false)));
+  UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
+  result = std::move(*validator).Finish();
   EXPECT_THAT(result.computed, HasSubstr(QUICK_FOX_MD5_HASH));
   EXPECT_THAT(result.computed, HasSubstr(QUICK_FOX_CRC32C_CHECKSUM));
 }

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -326,6 +326,14 @@ TEST(CreateHashValidator, Write_Both) {
 
   validator = CreateHashValidator(
       ResumableUploadRequest("test-bucket", "test-object")
+          .set_multiple_options(DisableCrc32cChecksum(), DisableMD5Hash()));
+  UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");
+  result = std::move(*validator).Finish();
+  EXPECT_THAT(result.computed, HasSubstr(QUICK_FOX_MD5_HASH));
+  EXPECT_THAT(result.computed, HasSubstr(QUICK_FOX_CRC32C_CHECKSUM));
+
+  validator = CreateHashValidator(
+      ResumableUploadRequest("test-bucket", "test-object")
           .set_multiple_options(DisableCrc32cChecksum(false),
                                 DisableMD5Hash(false)));
   UpdateValidator(*validator, "The quick brown fox jumps over the lazy dog");


### PR DESCRIPTION
Fixes #2978

Previously, the `CreateHashValidator` functions did not check the value of the
options, only the existence of the options. As a consequence, whether the user
specifies `true` or `false` doesn't matter. This PR checks the values of both
options and adds the logic to both overloads. One hitch (to preserve existing
behavior) is that the options are mutually exclusive IFF only one option is
specified.  It's possible that this approach can be simplified, but boolean
logic is hard.

cc: @Jseph

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2979)
<!-- Reviewable:end -->
