### PR TITLE
bug: Fix build for continuous benchmark tests.

### DIFF
--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -59,6 +59,18 @@ RUN make -j $(nproc)
 RUN make install
 RUN ldconfig
 
+# #### googleapis
+
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
+RUN tar -xf v0.1.3.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN cmake \
+    -DBUILD_SHARED_LIBS=YES \
+    -H. -Bcmake-out
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
+RUN ldconfig
+
 # Get the source code
 
 FROM google-cloud-cpp-dependencies AS google-cloud-cpp-build


### PR DESCRIPTION
The googleapis/cpp-cmakefiles dependency was missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2987)
<!-- Reviewable:end -->
