### PR TITLE
Improve efficency of ObjectWriteStreambuf by replacing O(n^2) code.

### DIFF
--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -247,7 +247,8 @@ std::streamsize ObjectWriteStreambuf::xsputn(char const* s,
   std::streamsize bytes_copied = 0;
   while (bytes_copied != count) {
     std::streamsize remaining_buffer_size = epptr() - pptr();
-    std::streamsize bytes_to_copy = std::min(count - bytes_copied, remaining_buffer_size);
+    std::streamsize bytes_to_copy =
+        std::min(count - bytes_copied, remaining_buffer_size);
     std::copy(s, s + bytes_to_copy, pptr());
     pbump(static_cast<int>(bytes_to_copy));
     bytes_copied += bytes_to_copy;

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/object_stream.h"
 #include <cstring>
-#include <stdint.h>
 
 namespace google {
 namespace cloud {
@@ -245,12 +244,12 @@ std::streamsize ObjectWriteStreambuf::xsputn(char const* s,
     return traits_type::eof();
   }
 
-  std::int64_t bytes_copied{0};
+  std::streamsize bytes_copied = 0;
   while (bytes_copied != count) {
-    auto remaining_buffer_size = epptr() - pptr();
-    auto bytes_to_copy = std::min(count - bytes_copied, remaining_buffer_size);
+    std::streamsize remaining_buffer_size = epptr() - pptr();
+    std::streamsize bytes_to_copy = std::min(count - bytes_copied, remaining_buffer_size);
     std::copy(s, s + bytes_to_copy, pptr());
-    pbump(bytes_to_copy);
+    pbump(static_cast<int>(bytes_to_copy));
     bytes_copied += bytes_to_copy;
     s += bytes_to_copy;
     last_response_ = Flush();
@@ -336,7 +335,7 @@ StatusOr<ResumableUploadResponse> ObjectWriteStreambuf::Flush() {
   }
   std::copy(pbase() + chunk_size, epptr(), pbase());
   setp(pbase(), epptr());
-  pbump(actual_size - chunk_size);
+  pbump(static_cast<int>(actual_size - chunk_size));
   return last_response_;
 }
 

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -141,7 +141,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
 
   std::unique_ptr<ResumableUploadSession> upload_session_;
 
-  std::string current_ios_buffer_;
+  std::vector<char> current_ios_buffer_;
   std::size_t max_buffer_size_;
 
   std::unique_ptr<HashValidator> hash_validator_;

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -33,9 +33,9 @@ using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::InSequence;
 using ::testing::Invoke;
-using ::testing::Property;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::SizeIs;
 
 /// @test Verify that uploading an empty stream creates a single chunk.
 TEST(ObjectWriteStreambufTest, EmptyStream) {
@@ -378,8 +378,7 @@ TEST(ObjectWriteStreambufTest, ErrorInLargePayload) {
   std::string const payload_1(3 * quantum, '*');
   std::string const payload_2("trailer");
 
-  EXPECT_CALL(*mock,
-              UploadChunk(::testing::Property(&std::string::size, quantum)))
+  EXPECT_CALL(*mock, UploadChunk(SizeIs(quantum)))
       .WillOnce(
           Return(Status(StatusCode::kInvalidArgument, "Invalid Argument")));
 


### PR DESCRIPTION
Changes ObjectWriteStreambuf to always use the same buffer.

Right now `ObjectWriteStreambuf` reallocates `current_ios_buffer_` every time `xsputn()` is called.  This has O(n^2) efficency.  Using this library with a 2MiB buffer size with 1KiB writes to the buffer causes major CPU usage (image attached).  This change makes uploads O(n) for bytes uploaded regardless of the ratio of stream write size to buffer size.

![TaskEfficiency](https://user-images.githubusercontent.com/5247900/63367332-71680600-c330-11e9-9f7e-108e7cfb0b6f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2989)
<!-- Reviewable:end -->
