### PR TITLE
chore: workaround gcc-8.2 build failures.

### DIFF
--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -103,7 +103,7 @@ TEST(ObjectWriteStreambufTest, EmptyTrailer) {
       testing::MockResumableUploadSession>();
   EXPECT_CALL(*mock, done).WillRepeatedly(Return(false));
 
-  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '*');
 
   int count = 0;

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -345,7 +345,7 @@ TEST_F(RetryResumableUploadSessionTest, PermanentErrorOnUploadFinalChunk) {
   auto mock = google::cloud::internal::make_unique<
       testing::MockResumableUploadSession>();
 
-  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
 
   // Keep track of the sequence of calls.
@@ -382,7 +382,7 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnUploadFinalChunk) {
   auto mock = google::cloud::internal::make_unique<
       testing::MockResumableUploadSession>();
 
-  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
 
   // Keep track of the sequence of calls.


### PR DESCRIPTION
For reasons that are unclear to me code like this:

```C++
auto const foo = Class::static_constexpr_variable;

[&](...) {
  EXPECT_EQ(foo, bar);
}
```

Fails to build with gcc-8.2 on my workstation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2991)
<!-- Reviewable:end -->
