### PR TITLE
cleanup: Remove instances of redundant std::move

### DIFF
--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -58,13 +58,13 @@ class InstanceUpdateConfig {
   //@}
 
   InstanceUpdateConfig& set_type(InstanceType type) {
-    proto_.mutable_instance()->set_type(std::move(type));
+    proto_.mutable_instance()->set_type(type);
     AddPathIfNotPresent("type");
     return *this;
   }
 
   InstanceUpdateConfig& set_state(StateType state) {
-    proto_.mutable_instance()->set_state(std::move(state));
+    proto_.mutable_instance()->set_state(state);
     AddPathIfNotPresent("state");
     return *this;
   }

--- a/google/cloud/iam_bindings.h
+++ b/google/cloud/iam_bindings.h
@@ -39,12 +39,12 @@ class IamBindings {
 
   explicit IamBindings(std::vector<IamBinding> bindings) {
     for (auto& it : bindings) {
-      bindings_.insert({std::move(it.role()), std::move(it.members())});
+      bindings_.insert({it.role(), it.members()});
     }
   }
 
   IamBindings(std::string const& role, std::set<std::string> const& members) {
-    bindings_.insert({std::move(role), std::move(members)});
+    bindings_.insert({role, members});
   }
 
   using iterator = std::map<std::string, std::set<std::string>>::const_iterator;

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -780,7 +780,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return retention_policy_;
   }
   BucketMetadata& set_retention_policy(BucketRetentionPolicy v) {
-    retention_policy_ = std::move(v);
+    retention_policy_ = v;
     return *this;
   }
 

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -31,7 +31,8 @@ namespace internal {
 class PolicyDocumentRequest {
  public:
   PolicyDocumentRequest() = default;
-  PolicyDocumentRequest(PolicyDocument document) : document_(document) {}
+  PolicyDocumentRequest(PolicyDocument document)
+      : document_(std::move(document)) {}
 
   PolicyDocument const& policy_document() const { return document_; }
 

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -192,7 +192,7 @@ class LifecycleRule {
 
   static LifecycleRuleCondition MatchesStorageClasses(
       std::initializer_list<std::string> list) {
-    std::vector<std::string> classes(std::move(list));
+    std::vector<std::string> classes(list);
     LifecycleRuleCondition result;
     result.matches_storage_class.emplace(std::move(classes));
     return result;


### PR DESCRIPTION
There were instances where `std::move` was called on `const` or trivial types.
These were spotted by enabling `clang-tidy` on the headers. Enabling it
wholesale has too many false positives, I only used it to spot these errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/2998)
<!-- Reviewable:end -->
