### PR TITLE
cleanup: Move FakeClock to its own header

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -278,6 +278,7 @@ if (BUILD_TESTING)
     add_library(storage_client_testing
                 testing/canonical_errors.h
                 testing/mock_client.h
+                testing/mock_fake_clock.h
                 testing/mock_http_request.h
                 testing/mock_http_request.cc
                 testing/retry_tests.h

--- a/google/cloud/storage/storage_client_testing.bzl
+++ b/google/cloud/storage/storage_client_testing.bzl
@@ -19,6 +19,7 @@
 storage_client_testing_hdrs = [
     "testing/canonical_errors.h",
     "testing/mock_client.h",
+    "testing/mock_fake_clock.h",
     "testing/mock_http_request.h",
     "testing/retry_tests.h",
     "testing/storage_integration_test.h",

--- a/google/cloud/storage/testing/mock_fake_clock.h
+++ b/google/cloud/storage/testing/mock_fake_clock.h
@@ -1,0 +1,59 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_FAKE_CLOCK_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_FAKE_CLOCK_H_
+
+#include <gmock/gmock.h>
+#include <chrono>
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+/**
+ * Represents a fake std::chrono::system_clock.
+ *
+ * When testing functionality that deals with time, it can be useful to
+ * reset the clock to arbitrary timepoints.
+ */
+struct FakeClock : public std::chrono::system_clock {
+ public:
+  static long now_value;
+
+  // gmock doesn't easily allow copying mock objects, but we require this
+  // struct to be copyable. So while the usual approach would be mocking this
+  // method and defining its return value in each test, we instead override
+  // this method and hard-code the return value for all instances.
+  static std::chrono::system_clock::time_point now() {
+    return std::chrono::system_clock::from_time_t(
+        static_cast<std::time_t>(now_value));
+  }
+
+  static void reset_clock(long fixed_time_stamp) {
+    now_value = fixed_time_stamp;
+  }
+};
+
+// We need to define this value since it is static; set it to an arbitrary
+// value.
+long FakeClock::now_value = 1530060324;
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_FAKE_CLOCK_H_


### PR DESCRIPTION
`FakeClock` is a useful construct that only appears in
`service_account_credentials_test.cc`, but I think that it can be used in other
tests as well. I plan on using it in an upcoming PR in a different file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3000)
<!-- Reviewable:end -->
