### PR TITLE
fix: return proper error code from upload metadata

### DIFF
--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -130,6 +131,60 @@ TEST_F(WriteObjectTest, WriteObjectPermanentFailure) {
   EXPECT_FALSE(stream.metadata().status().ok());
   EXPECT_EQ(PermanentError().code(), stream.metadata().status().code())
       << ", status=" << stream.metadata().status();
+}
+
+TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
+  testing::MockResumableUploadSession* mock_session =
+      new testing::MockResumableUploadSession;
+  auto returner = [mock_session](internal::ResumableUploadRequest const&) {
+    return StatusOr<std::unique_ptr<internal::ResumableUploadSession>>(
+        std::unique_ptr<internal::ResumableUploadSession>(mock_session));
+  };
+  EXPECT_CALL(*mock, CreateResumableSession(_)).WillOnce(Invoke(returner));
+  EXPECT_CALL(*mock_session, UploadChunk(_))
+      .WillRepeatedly(Return(PermanentError()));
+  EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
+  auto stream = client->WriteObject("test-bucket-name", "test-object-name");
+
+  // make sure it is acutally sent
+  std::vector<char> data(client_options.upload_buffer_size() + 1, 'X');
+  stream.write(data.data(), data.size());
+  EXPECT_TRUE(stream.bad());
+  stream.Close();
+  EXPECT_FALSE(stream.metadata());
+  EXPECT_EQ(PermanentError().code(), stream.metadata().status().code())
+      << ", status=" << stream.metadata().status();
+}
+
+TEST_F(WriteObjectTest, WriteObjectUnderhandedStreamClose) {
+  testing::MockResumableUploadSession* mock_session =
+      new testing::MockResumableUploadSession;
+  auto returner = [mock_session](internal::ResumableUploadRequest const&) {
+    return StatusOr<std::unique_ptr<internal::ResumableUploadSession>>(
+        std::unique_ptr<internal::ResumableUploadSession>(mock_session));
+  };
+  EXPECT_CALL(*mock, CreateResumableSession(_)).WillOnce(Invoke(returner));
+  EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
+  EXPECT_CALL(*mock_session, next_expected_byte()).WillRepeatedly(Return(0));
+  EXPECT_CALL(*mock_session, UploadFinalChunk(_, _))
+      .WillOnce(Return(make_status_or(internal::ResumableUploadResponse{
+          "fake-url", 0, ObjectMetadata(),
+          internal::ResumableUploadResponse::kDone})));
+
+  auto stream = client->WriteObject("test-bucket-name", "test-object-name");
+  stream << "Hello world!";
+  EXPECT_FALSE(stream.bad());
+
+  auto stream_buf = dynamic_cast<internal::ObjectWriteStreambuf*>(stream.rdbuf());
+  ASSERT_NE(nullptr, stream_buf);
+  stream_buf->Close();
+  stream.Close();
+  EXPECT_FALSE(stream.metadata());
+  EXPECT_EQ(StatusCode::kUnknown, stream.metadata().status().code());
+  EXPECT_EQ(
+      "The underlying buffer was closed successfully, but underhandedly. Can't "
+      "determine the upload metadata.",
+      stream.metadata().status().message());
 }
 
 }  // namespace

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -146,7 +146,7 @@ TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
   EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
   auto stream = client->WriteObject("test-bucket-name", "test-object-name");
 
-  // make sure it is acutally sent
+  // make sure it is actually sent
   std::vector<char> data(client_options.upload_buffer_size() + 1, 'X');
   stream.write(data.data(), data.size());
   EXPECT_TRUE(stream.bad());

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -84,16 +84,6 @@ void ObjectWriteStream::Close() {
 }
 
 void ObjectWriteStream::CloseBuf() {
-  if (!buf_->IsOpen()) {
-    if (buf_->last_status().ok()) {
-      metadata_ = Status(StatusCode::kUnknown,
-                         "The underlying buffer was closed successfully, but "
-                         "underhandedly. Can't determine the upload metadata.");
-      return;
-    }
-    metadata_ = buf_->last_status();
-    return;
-  }
   auto response = buf_->Close();
   if (!response.ok()) {
     metadata_ = std::move(response).status();


### PR DESCRIPTION
This fixes #3002.

Before this fix, if a fatal error occurred while uploading a stream,
`stream.metadata()` would return `StatusCode::kUnknown` irrespectively
of the underlying cause. This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3005)
<!-- Reviewable:end -->
