### PR TITLE
bug: Unit tests are too slow.

### DIFF
--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -58,7 +58,9 @@ void TooManyFailuresStatusTest(
   using ::testing::Return;
   // A storage::Client with a simple to test policy.
   Client client{std::shared_ptr<internal::RawClient>(mock),
-                LimitedErrorCountRetryPolicy(2)};
+                LimitedErrorCountRetryPolicy(2),
+                ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                                         std::chrono::milliseconds(1), 2.0)};
 
   // Expect exactly 3 calls before the retry policy is exhausted and an error
   // status is returned.
@@ -107,7 +109,9 @@ void NonIdempotentFailuresStatusTest(
   // A storage::Client with the strict idempotency policy, but with a generous
   // retry policy.
   Client client{std::shared_ptr<internal::RawClient>(mock),
-                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(10)};
+                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(10),
+                ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                                         std::chrono::milliseconds(1), 2.0)};
 
   // The first transient error should stop the retries for non-idempotent
   // operations.
@@ -155,7 +159,9 @@ void IdempotentFailuresStatusTest(
   // A storage::Client with the strict idempotency policy, and with an
   // easy-to-test retry policy.
   Client client{std::shared_ptr<internal::RawClient>(mock),
-                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2)};
+                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2),
+                ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                                         std::chrono::milliseconds(1), 2.0)};
 
   // Expect exactly 3 calls before the retry policy is exhausted and an error
   // status is returned.


### PR DESCRIPTION
After I changed the default backoff policy some of the unit tests got
really slow. The tests were using the default backoff policy, which
starts at 1 second, some of the tests try multiple times, so the delays
got into the multiple-second range. This change make the unit tests (and
the integration tests when running against the testbench) use a much
shorter initial backoff period.

Fixes #3019.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3021)
<!-- Reviewable:end -->
