### PR TITLE
fix: don't throw on expired retry policies

### DIFF
--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -69,7 +69,8 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
     bool is_idempotent, RawClient& client, MemberFunction function,
     typename Signature<MemberFunction>::RequestType const& request,
     char const* error_message) {
-  Status last_status;
+  Status last_status(StatusCode::kDeadlineExceeded,
+                     "Retry policy exhausted before first attempt was made.");
   auto error = [&last_status](std::string const& msg) {
     return Status(last_status.code(), msg);
   };

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -90,6 +90,22 @@ TEST_F(RetryClientTest, TooManyTransientsHandling) {
   EXPECT_EQ(TransientError().code(), result.status().code());
 }
 
+/// @test Verify that the retry loop works with exhausted retry policy.
+TEST_F(RetryClientTest, ExpiredRetryPolicy) {
+  RetryClient client(std::shared_ptr<internal::RawClient>(mock),
+                     LimitedTimeRetryPolicy(std::chrono::milliseconds(0)),
+                     ExponentialBackoffPolicy(1_us, 2_us, 2));
+
+  StatusOr<ObjectMetadata> result = client.GetObjectMetadata(
+      GetObjectMetadataRequest("test-bucket", "test-object"));
+  ASSERT_FALSE(result);
+  EXPECT_EQ(StatusCode::kDeadlineExceeded, result.status().code());
+  EXPECT_EQ(
+      "Retry policy exhausted in GetObjectMetadata: Retry policy exhausted "
+      "before first attempt was made. [DEADLINE_EXCEEDED]",
+      result.status().message());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -100,10 +100,8 @@ TEST_F(RetryClientTest, ExpiredRetryPolicy) {
       GetObjectMetadataRequest("test-bucket", "test-object"));
   ASSERT_FALSE(result);
   EXPECT_EQ(StatusCode::kDeadlineExceeded, result.status().code());
-  EXPECT_EQ(
-      "Retry policy exhausted in GetObjectMetadata: Retry policy exhausted "
-      "before first attempt was made. [DEADLINE_EXCEEDED]",
-      result.status().message());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("Retry policy exhausted before first attempt"));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -38,7 +38,8 @@ StatusOr<ResumableUploadResponse> ReturnError(Status&& last_status,
 
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadChunk(
     std::string const& buffer) {
-  Status last_status;
+  Status last_status(StatusCode::kDeadlineExceeded,
+                     "Retry policy exhausted before first attempt was made.");
   while (!retry_policy_->IsExhausted()) {
     auto result = session_->UploadChunk(buffer);
     if (result.ok()) {
@@ -63,7 +64,8 @@ StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadChunk(
 
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadFinalChunk(
     std::string const& buffer, std::uint64_t upload_size) {
-  Status last_status;
+  Status last_status(StatusCode::kDeadlineExceeded,
+                     "Retry policy exhausted before first attempt was made.");
   while (!retry_policy_->IsExhausted()) {
     auto result = session_->UploadFinalChunk(buffer, upload_size);
     if (result.ok()) {
@@ -87,7 +89,8 @@ StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadFinalChunk(
 }
 
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {
-  Status last_status;
+  Status last_status(StatusCode::kDeadlineExceeded,
+                     "Retry policy exhausted before first attempt was made.");
   while (!retry_policy_->IsExhausted()) {
     auto result = session_->ResetSession();
     if (result.ok()) {

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -476,10 +476,8 @@ TEST(RetryResumableUploadSession, UploadChunkPolicyExhaustedOnStart) {
       std::string(UploadChunkRequest::kChunkSizeQuantum, 'X'));
   ASSERT_FALSE(res);
   EXPECT_EQ(StatusCode::kDeadlineExceeded, res.status().code());
-  EXPECT_EQ(
-      "Retry policy exhausted in UploadChunk: Retry policy exhausted before "
-      "first attempt was made. [DEADLINE_EXCEEDED]",
-      res.status().message());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("Retry policy exhausted before first attempt"));
 }
 
 TEST(RetryResumableUploadSession, UploadFinalChunkPolicyExhaustedOnStart) {
@@ -491,10 +489,8 @@ TEST(RetryResumableUploadSession, UploadFinalChunkPolicyExhaustedOnStart) {
   auto res = session.UploadFinalChunk("blah", 4);
   ASSERT_FALSE(res);
   EXPECT_EQ(StatusCode::kDeadlineExceeded, res.status().code());
-  EXPECT_EQ(
-      "Retry policy exhausted in UploadFinalChunk: Retry policy exhausted "
-      "before first attempt was made. [DEADLINE_EXCEEDED]",
-      res.status().message());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("Retry policy exhausted before first attempt"));
 }
 
 TEST(RetryResumableUploadSession, ResetSessionPolicyExhaustedOnStart) {
@@ -506,10 +502,8 @@ TEST(RetryResumableUploadSession, ResetSessionPolicyExhaustedOnStart) {
   auto res = session.ResetSession();
   ASSERT_FALSE(res);
   EXPECT_EQ(StatusCode::kDeadlineExceeded, res.status().code());
-  EXPECT_EQ(
-      "Retry policy exhausted in ResetSession: Retry policy exhausted "
-      "before first attempt was made. [DEADLINE_EXCEEDED]",
-      res.status().message());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("Retry policy exhausted before first attempt"));
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -221,10 +221,9 @@ TEST_F(ErrorInjectionIntegrationTest, InjectErrorOnStreamingWrite) {
   EXPECT_FALSE(os.metadata());
   EXPECT_FALSE(os.metadata().ok());
   EXPECT_EQ(StatusCode::kDeadlineExceeded, os.metadata().status().code());
-  EXPECT_EQ(
-      "Retry policy exhausted in ResetSession: Retry policy exhausted before "
-      "first attempt was made. [DEADLINE_EXCEEDED]",
-      os.metadata().status().message());
+  EXPECT_THAT(
+      os.metadata().status().message(),
+      ::testing::HasSubstr("Retry policy exhausted before first attempt"));
 }
 
 TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {


### PR DESCRIPTION
This fixes #2955.

Before this PR, if any of the modified places was called with an expired
`RetryPolicy` an exception would be thrown because a `StatusOr<>` with
an `OK` status was created. This could be deterministically triggered by
the `RetryClient` logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3023)
<!-- Reviewable:end -->
