### PR TITLE
feat: Document/test the behavior of passing an empty string to SetEnv on Windows

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -220,6 +220,7 @@ if (BUILD_TESTING)
         internal/random_test.cc
         internal/retry_policy_test.cc
         internal/throw_delegate_test.cc
+        internal/env_test.cc
         log_test.cc
         optional_test.cc
         status_or_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -33,6 +33,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/random_test.cc",
     "internal/retry_policy_test.cc",
     "internal/throw_delegate_test.cc",
+    "internal/env_test.cc",
     "log_test.cc",
     "optional_test.cc",
     "status_or_test.cc",

--- a/google/cloud/internal/env_test.cc
+++ b/google/cloud/internal/env_test.cc
@@ -23,7 +23,11 @@ using google::cloud::internal::UnsetEnv;
 /// @test Verify passing an empty string creates an environment variable.
 TEST(SetEnv, SetEmptyEnvVar) {
   SetEnv("foo", "");
+#ifdef _WIN32
+  EXPECT_FALSE(GetEnv("foo").has_value());
+#else
   EXPECT_TRUE(GetEnv("foo").has_value());
+#endif // _WIN32
 }
 
 /// @test Verify we can unset an environment variable with nullptr.

--- a/google/cloud/internal/env_test.cc
+++ b/google/cloud/internal/env_test.cc
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/setenv.h"
+#include <gmock/gmock.h>
+
+using google::cloud::internal::GetEnv;
+using google::cloud::internal::SetEnv;
+using google::cloud::internal::UnsetEnv;
+
+/// @test Verify passing an empty string creates an environment variable.
+TEST(SetEnv, SetEmptyEnvVar) {
+  SetEnv("foo", "");
+  EXPECT_TRUE(GetEnv("foo").has_value());
+}
+
+/// @test Verify we can unset an environment variable with nullptr.
+TEST(SetEnv, UnsetEnvWithNullptr) {
+  SetEnv("foo", "");
+  EXPECT_TRUE(GetEnv("foo").has_value());
+  SetEnv("foo", nullptr);
+  EXPECT_FALSE(GetEnv("foo").has_value());
+}
+
+/// @test Verify we can unset an environment variable.
+TEST(SetEnv, UnsetEnv) {
+  SetEnv("foo", "");
+  EXPECT_TRUE(GetEnv("foo").has_value());
+  UnsetEnv("foo");
+  EXPECT_FALSE(GetEnv("foo").has_value());
+}

--- a/google/cloud/internal/env_test.cc
+++ b/google/cloud/internal/env_test.cc
@@ -27,7 +27,7 @@ TEST(SetEnv, SetEmptyEnvVar) {
   EXPECT_FALSE(GetEnv("foo").has_value());
 #else
   EXPECT_TRUE(GetEnv("foo").has_value());
-#endif // _WIN32
+#endif  // _WIN32
 }
 
 /// @test Verify we can unset an environment variable with nullptr.

--- a/google/cloud/internal/env_test.cc
+++ b/google/cloud/internal/env_test.cc
@@ -33,7 +33,11 @@ TEST(SetEnv, SetEmptyEnvVar) {
 /// @test Verify we can unset an environment variable with nullptr.
 TEST(SetEnv, UnsetEnvWithNullptr) {
   SetEnv("foo", "");
+#ifdef _WIN32
+  EXPECT_FALSE(GetEnv("foo").has_value());
+#else
   EXPECT_TRUE(GetEnv("foo").has_value());
+#endif  // _WIN32
   SetEnv("foo", nullptr);
   EXPECT_FALSE(GetEnv("foo").has_value());
 }
@@ -41,7 +45,11 @@ TEST(SetEnv, UnsetEnvWithNullptr) {
 /// @test Verify we can unset an environment variable.
 TEST(SetEnv, UnsetEnv) {
   SetEnv("foo", "");
+#ifdef _WIN32
+  EXPECT_FALSE(GetEnv("foo").has_value());
+#else
   EXPECT_TRUE(GetEnv("foo").has_value());
+#endif  // _WIN32
   UnsetEnv("foo");
   EXPECT_FALSE(GetEnv("foo").has_value());
 }

--- a/google/cloud/internal/env_test.cc
+++ b/google/cloud/internal/env_test.cc
@@ -32,24 +32,16 @@ TEST(SetEnv, SetEmptyEnvVar) {
 
 /// @test Verify we can unset an environment variable with nullptr.
 TEST(SetEnv, UnsetEnvWithNullptr) {
-  SetEnv("foo", "");
-#ifdef _WIN32
-  EXPECT_FALSE(GetEnv("foo").has_value());
-#else
+  SetEnv("foo", "bar");
   EXPECT_TRUE(GetEnv("foo").has_value());
-#endif  // _WIN32
   SetEnv("foo", nullptr);
   EXPECT_FALSE(GetEnv("foo").has_value());
 }
 
 /// @test Verify we can unset an environment variable.
 TEST(SetEnv, UnsetEnv) {
-  SetEnv("foo", "");
-#ifdef _WIN32
-  EXPECT_FALSE(GetEnv("foo").has_value());
-#else
+  SetEnv("foo", "bar");
   EXPECT_TRUE(GetEnv("foo").has_value());
-#endif  // _WIN32
   UnsetEnv("foo");
   EXPECT_FALSE(GetEnv("foo").has_value());
 }

--- a/google/cloud/internal/setenv.cc
+++ b/google/cloud/internal/setenv.cc
@@ -20,6 +20,7 @@
 // On Unix-like systems we need setenv()/unsetenv(), which are defined here:
 #include <cstdlib>
 #endif  // _WIN32
+#include <cstring>
 
 namespace google {
 namespace cloud {
@@ -40,7 +41,13 @@ void SetEnv(char const* variable, char const* value) {
     return;
   }
 #ifdef _WIN32
-  (void)_putenv_s(variable, value);
+  // On Windows an empty string passed to _putenv_s will delete the environment
+  // variable. As a workaround, we pass a space.
+  if (std::strlen(value) == 0) {
+    (void)_putenv_s(variable, " ");
+  } else {
+    (void)_putenv_s(variable, value);
+  }
 #else
   (void)setenv(variable, value, 1);
 #endif  // _WIN32

--- a/google/cloud/internal/setenv.cc
+++ b/google/cloud/internal/setenv.cc
@@ -20,7 +20,6 @@
 // On Unix-like systems we need setenv()/unsetenv(), which are defined here:
 #include <cstdlib>
 #endif  // _WIN32
-#include <cstring>
 
 namespace google {
 namespace cloud {
@@ -41,13 +40,7 @@ void SetEnv(char const* variable, char const* value) {
     return;
   }
 #ifdef _WIN32
-  // On Windows an empty string passed to _putenv_s will delete the environment
-  // variable. As a workaround, we pass a space.
-  if (std::strlen(value) == 0) {
-    (void)_putenv_s(variable, " ");
-  } else {
-    (void)_putenv_s(variable, value);
-  }
+  (void)_putenv_s(variable, value);
 #else
   (void)setenv(variable, value, 1);
 #endif  // _WIN32

--- a/google/cloud/internal/setenv.h
+++ b/google/cloud/internal/setenv.h
@@ -29,6 +29,9 @@ void UnsetEnv(char const* variable);
  * Set the @p variable environment variable to @p value.
  *
  * If @value is the null pointer then the variable is unset.
+ *
+ * @note On Windows, due to the underlying API function, an empty @value unsets
+ * the variable, while on Linux an empty environment variable is created.
  */
 void SetEnv(char const* variable, char const* value);
 

--- a/google/cloud/internal/setenv.h
+++ b/google/cloud/internal/setenv.h
@@ -32,6 +32,9 @@ void UnsetEnv(char const* variable);
  *
  * @note On Windows, due to the underlying API function, an empty @value unsets
  * the variable, while on Linux an empty environment variable is created.
+ *
+ * @see
+ * https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-s-wputenv-s?view=vs-2019
  */
 void SetEnv(char const* variable, char const* value);
 


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-cpp/issues/3027

~This is a quick PR to implement my suggestion. Note that I'm not 100% behind this idea because it may be surprising that the env var isn't actually empty when using `SetEnv(var, "")` on Windows.~

This documents the Windows behavior and adds some tests.

cc @tmatsuo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3030)
<!-- Reviewable:end -->
