### PR TITLE
bug: include FindgRPC directly.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -205,9 +205,9 @@ There is no Fedora package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -292,9 +292,9 @@ There is no OpenSUSE package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -439,9 +439,9 @@ There is no OpenSUSE package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -553,9 +553,9 @@ There is no Ubuntu package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -691,9 +691,9 @@ There is no Ubuntu package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -874,9 +874,9 @@ There is no Ubuntu package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -996,9 +996,9 @@ There is no Debian package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out
@@ -1131,9 +1131,9 @@ There is no CentOS package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-tar -xf v0.1.3.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.3
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+tar -xf v0.1.5.tar.gz
+cd $HOME/Downloads/cpp-cmakefiles-0.1.5
 cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -62,9 +62,9 @@ RUN ldconfig
 # #### googleapis
 
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -66,9 +66,9 @@ RUN ldconfig
 
 # Install googleapis.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -150,9 +150,9 @@ RUN ldconfig
 
 # Install googleapis.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.centos
+++ b/ci/kokoro/install/Dockerfile.centos
@@ -112,9 +112,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.debian
+++ b/ci/kokoro/install/Dockerfile.debian
@@ -100,9 +100,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -66,9 +66,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.opensuse
+++ b/ci/kokoro/install/Dockerfile.opensuse
@@ -61,9 +61,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -121,9 +121,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.ubuntu
+++ b/ci/kokoro/install/Dockerfile.ubuntu
@@ -91,9 +91,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -161,9 +161,9 @@ RUN make install
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -115,9 +115,9 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz
-RUN tar -xf v0.1.3.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.3
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 RUN cmake \
     -DBUILD_SHARED_LIBS=YES \
     -H. -Bcmake-out

--- a/google/cloud/bigtable/config.cmake.in
+++ b/google/cloud/bigtable/config.cmake.in
@@ -13,17 +13,21 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-# googleapis finds both gRPC and Protobuf, no need to load it ourselves.
+# googleapis finds both gRPC and Protobuf, no need to load them here.
 find_dependency(googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 
 include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
 
-add_library(bigtable::protos IMPORTED INTERFACE)
-set_target_properties(bigtable::protos PROPERTIES
-    INTERFACE_LINK_LIBRARIES "bigtable_protos")
+if (NOT TARGET bigtable::protos)
+    add_library(bigtable::protos IMPORTED INTERFACE)
+    set_target_properties(bigtable::protos PROPERTIES
+        INTERFACE_LINK_LIBRARIES "bigtable_protos")
+endif ()
 
-add_library(bigtable::client IMPORTED INTERFACE)
-set_target_properties(bigtable::client PROPERTIES
-    INTERFACE_LINK_LIBRARIES "bigtable_client")
+if (NOT TARGET bigtable::client)
+    add_library(bigtable::client IMPORTED INTERFACE)
+    set_target_properties(bigtable::client PROPERTIES
+        INTERFACE_LINK_LIBRARIES "bigtable_client")
+endif ()

--- a/google/cloud/grpc_utils/config.cmake.in
+++ b/google/cloud/grpc_utils/config.cmake.in
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
+# googleapis finds both gRPC and Protobuf, no need to load them here.
 find_dependency(googleapis)
-find_dependency(gRPC)
-include("${CMAKE_CURRENT_LIST_DIR}/FindProtobufWithTargets.cmake")
 find_dependency(google_cloud_cpp_common)
 
 include("${CMAKE_CURRENT_LIST_DIR}/grpc_utils-targets.cmake")

--- a/super/external/googleapis.cmake
+++ b/super/external/googleapis.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET googleapis_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.3.tar.gz")
+        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz")
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-        "8abbefe4818070b0b7cc15dcfe72a8c316f39312eec53bb478f55b077beb5c20")
+        "f1443a10c545114b19fe9dc352568cb03b588813b12cc5db8780b64ae9a09ce1")
 
     set_external_project_build_parallel_level(PARALLEL)
 


### PR DESCRIPTION
Update to the latest cpp-cmakefiles release which supports CMake 3.15.

We also include `FindgRPC.cmake` directly because with CMake 3.16
`find_dependency()` can no longer find it.

Part of the work for #3032.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3033)
<!-- Reviewable:end -->
