### PR TITLE
fix: remove curl_download_request_integration_test

### DIFF
--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 set(storage_client_integration_tests
     bucket_integration_test.cc
-    curl_download_request_integration_test.cc
     curl_request_integration_test.cc
     object_write_streambuf_integration_test.cc
     curl_resumable_upload_session_integration_test.cc

--- a/google/cloud/storage/tests/run_integration_tests_testbench.sh
+++ b/google/cloud/storage/tests/run_integration_tests_testbench.sh
@@ -44,10 +44,6 @@ echo "Running storage::internal::CurlRequest integration test."
 ./curl_request_integration_test
 
 echo
-echo "Running storage::internal::CurlRequestDownload integration test."
-./curl_download_request_integration_test
-
-echo
 echo "Running storage::internal::CurlResumableUploadSession integration tests."
 ./curl_resumable_upload_session_integration_test "${BUCKET_NAME}"
 

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -18,7 +18,6 @@
 
 storage_client_integration_tests = [
     "bucket_integration_test.cc",
-    "curl_download_request_integration_test.cc",
     "curl_request_integration_test.cc",
     "object_write_streambuf_integration_test.cc",
     "curl_resumable_upload_session_integration_test.cc",


### PR DESCRIPTION
This fixes #3003.

This test tests a curl download. Occasionally, it times out. It is never
retried because it's a test for the lowest layer of communication.

It is no longer needed because other, higher level tests with retries
are testing this path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3034)
<!-- Reviewable:end -->
