### PR TITLE
bug: CurlRequestBuilder not initializing all members.

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -54,7 +54,7 @@ class CurlDownloadRequest : public ObjectReadSource {
         user_agent_(std::move(rhs.user_agent_)),
         logging_enabled_(rhs.logging_enabled_),
         socket_options_(rhs.socket_options_),
-        download_stall_timeout_(0),
+        download_stall_timeout_(rhs.download_stall_timeout_),
         handle_(std::move(rhs.handle_)),
         multi_(std::move(rhs.multi_)),
         factory_(std::move(rhs.factory_)),

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -33,7 +33,8 @@ CurlRequestBuilder::CurlRequestBuilder(
       headers_(nullptr, &curl_slist_free_all),
       url_(std::move(base_url)),
       query_parameter_separator_("?"),
-      logging_enabled_(false) {}
+      logging_enabled_(false),
+      download_stall_timeout_(0) {}
 
 CurlRequest CurlRequestBuilder::BuildRequest() {
   ValidateBuilderState(__func__);


### PR DESCRIPTION
This fixes the flakiness in the code coverage build. It did not affect
the other tests because the member variable is set by the CurlClient,
but this integration test uses the class in isolation.

This fixes #3003

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3035)
<!-- Reviewable:end -->
