### PR TITLE
bug: return all bytes when stream is closed

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -94,7 +94,7 @@ class CurlDownloadRequest : public ObjectReadSource {
     return *this;
   }
 
-  bool IsOpen() const override { return !curl_closed_; }
+  bool IsOpen() const override { return !(curl_closed_ && spill_offset_ == 0); }
   StatusOr<HttpResponse> Close() override;
 
   /**


### PR DESCRIPTION
Sometimes the last few bytes of a download were not returned to the
application. The download was done, and CurlDownloadRequest was
returning `IsOpen() == true` even though it still had data in its
spill buffer.

This fixes #3051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3054)
<!-- Reviewable:end -->
