### PR TITLE
bug: fix unit test for developers that configure ADC

### DIFF
--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -420,6 +420,10 @@ TEST_F(GoogleCredentialsTest,
   // Make sure other higher-precedence credentials (ADC env var, gcloud ADC from
   // well-known path) aren't loaded.
   UnsetEnv(GoogleAdcEnvVar());
+  // The developer may have configured something that are not service account
+  // credentials in the well-known path. Change the search location to a
+  // directory that should have have developer configuration files.
+  SetEnv(GoogleAdcHomeEnvVar(), ::testing::TempDir());
   // Test that when CreateServiceAccountCredentialsFromDefaultPaths cannot
   // find any credentials, it fails.
   auto creds = CreateServiceAccountCredentialsFromDefaultPaths();


### PR DESCRIPTION
One of the unit tests was failing if the developer had configured
Application Default Credentials (ADC). The fix is to change the ADC
search path to a location where the developer would not put
configuration files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3055)
<!-- Reviewable:end -->
