### PR TITLE
bug: verify checksums and hashes on xgetsn()

### DIFF
--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -507,6 +507,83 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
   EXPECT_STATUS_OK(status);
 }
 
+/// @test Verify that MD5 hash mismatches are reported when using .read().
+TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
+  if (!UsingTestbench()) {
+    // This test is disabled when not using the testbench as it relies on the
+    // testbench to inject faults.
+    return;
+  }
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  auto object_name = MakeRandomObjectName();
+  auto contents = MakeRandomData(1024 * 1024);
+
+  // Create an object and a stream to read it back.
+  StatusOr<ObjectMetadata> meta =
+      client->InsertObject(bucket_name, object_name, contents,
+                           IfGenerationMatch(0), Projection::Full());
+  ASSERT_STATUS_OK(meta);
+
+  auto stream = client->ReadObject(
+      bucket_name, object_name, DisableCrc32cChecksum(true),
+      CustomHeader("x-goog-testbench-instructions", "return-corrupted-data"));
+
+  // Create a buffer large enough to hold the results and read pas EOF.
+  std::vector<char> buffer(2 * contents.size());
+  stream.read(buffer.data(), buffer.size());
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_TRUE(stream.bad());
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_EQ(StatusCode::kDataLoss, stream.status().code());
+  EXPECT_NE(stream.received_hash(), stream.computed_hash());
+  EXPECT_EQ(stream.received_hash(), meta->md5_hash());
+
+  auto status = client->DeleteObject(bucket_name, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
+/// @test Verify that MD5 hash mismatches are reported when using .read().
+TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
+  if (!UsingTestbench()) {
+    // This test is disabled when not using the testbench as it relies on the
+    // testbench to inject faults.
+    return;
+  }
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  auto object_name = MakeRandomObjectName();
+  auto contents = MakeRandomData(1024 * 1024);
+
+  // Create an object and a stream to read it back.
+  StatusOr<ObjectMetadata> meta =
+      client->InsertObject(bucket_name, object_name, contents,
+                           IfGenerationMatch(0), Projection::Full());
+  ASSERT_STATUS_OK(meta);
+
+  auto stream = client->ReadObject(
+      bucket_name, object_name, DisableCrc32cChecksum(true),
+      IfMetagenerationNotMatch(0),
+      CustomHeader("x-goog-testbench-instructions", "return-corrupted-data"));
+
+  // Create a buffer large enough to hold the results and read pas EOF.
+  std::vector<char> buffer(2 * contents.size());
+  stream.read(buffer.data(), buffer.size());
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_TRUE(stream.bad());
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+  EXPECT_EQ(StatusCode::kDataLoss, stream.status().code());
+  EXPECT_NE(stream.received_hash(), stream.computed_hash());
+  EXPECT_EQ(stream.received_hash(), meta->md5_hash());
+
+  auto status = client->DeleteObject(bucket_name, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteJSON) {
   if (!UsingTestbench()) {


### PR DESCRIPTION
If the application reads data via `.read()` we were neglecting to check
hashes and checksums on the download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3057)
<!-- Reviewable:end -->
