### PR TITLE
feat: improve stalled reads regression test

### DIFF
--- a/google/cloud/storage/tests/read_object_stall_regression/Dockerfile
+++ b/google/cloud/storage/tests/read_object_stall_regression/Dockerfile
@@ -17,19 +17,8 @@ FROM ubuntu:bionic AS devtools
 # Install the typical development tools and some additions:
 RUN apt update && \
     apt install -y build-essential cmake git gcc g++ cmake \
-        libssl-dev make pkg-config tar wget zlib1g-dev
-
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/curl/curl/archive/curl-7_64_0.tar.gz
-RUN tar -xf curl-7_64_0.tar.gz
-WORKDIR /var/tmp/build/curl-curl-7_64_0
-RUN ls -l
-RUN cmake -H. -B.build \
-        -DHTTP_ONLY=ON \
-        -DCMAKE_USE_OPENSSL=ON \
-        -DBUILD_SHARED_LIBS=OFF \
-        -DCURL_STATICLIB=ON
-RUN cmake --build .build --target install -- -j $(nproc)
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
+        pkg-config tar wget zlib1g-dev
 
 FROM devtools AS build
 
@@ -40,18 +29,12 @@ COPY . /w
 ARG CMAKE_BUILD_TYPE=Release
 ARG SHORT_SHA=""
 
-RUN cmake -H. -B.build \
+RUN cmake -Hsuper -B.build \
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
     -DGOOGLE_CLOUD_CPP_BUILD_METADATA=${SHORT_SHA}
 
 RUN cmake \
     --build .build \
-    --target read_object_stall_test \
-    -- -j $(nproc)
-
-RUN cmake \
-    --build .build \
-    --target storage_object_samples \
     -- -j $(nproc)
 
 # ================================================================
@@ -60,13 +43,13 @@ RUN cmake \
 # dependencies are installed.
 FROM ubuntu:bionic
 RUN apt update && \
-    apt install -y libstdc++6 zlib1g binutils ca-certificates \
-        tcpdump coreutils strace procps
+    apt install -y libstdc++6 libc-ares2 libcurl4 zlib1g binutils \
+        ca-certificates tcpdump coreutils strace procps
 RUN /usr/sbin/update-ca-certificates
 
 COPY --from=build \
-    /w/.build/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test \
-    /w/.build/google/cloud/storage/examples/storage_object_samples \
+    /w/.build/build/google-cloud-cpp/src/google_cloud_cpp_project-build/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test \
+    /w/.build/build/google-cloud-cpp/src/google_cloud_cpp_project-build/google/cloud/storage/examples/storage_object_samples \
     /r/
 
 CMD ["/bin/false"]

--- a/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test.cc
+++ b/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test.cc
@@ -48,7 +48,7 @@ struct ReadSummary {
 };
 
 std::ostream& operator<<(std::ostream& os, ReadSummary const& x) {
-  return os << "ReadSummary={bucket_name" << x.bucket_name
+  return os << "ReadSummary={bucket_name=" << x.bucket_name
             << ", object_name=" << x.object_name
             << ", received_hashes=" << x.received_hashes
             << ", computed_hashes=" << x.computed_hashes << ", size=" << x.size
@@ -96,7 +96,7 @@ void UpdateFromReader(ReadSummary& read_summary, ObjectReadStream& r,
       r.gcount());
 
   EXPECT_FALSE(r.bad()) << "ERROR: bad bit detected: " << r.status();
-  EXPECT_FALSE(!r.status().ok() && !r.bad())
+  EXPECT_EQ(r.status().ok(), !r.bad())
       << "ERROR: mismatched status vs. bad: " << r.status();
   bool short_read = (static_cast<std::size_t>(r.gcount()) != buffer.size());
   EXPECT_EQ(r.fail(), short_read)

--- a/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test.cc
+++ b/google/cloud/storage/tests/read_object_stall_regression/read_object_stall_test.cc
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/internal/big_endian.h"
 #include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
+#include <crc32c/crc32c.h>
 #include <gmock/gmock.h>
 #include <thread>
 
@@ -31,7 +34,119 @@ using ::testing::HasSubstr;
 // Initialized in main() below.
 char const* flag_src_bucket_name;
 char const* flag_dst_bucket_name;
-double flag_average_delay;
+double flag_average_delay = 1.0;
+int flag_object_count = 32;
+
+struct ReadSummary {
+  std::string bucket_name;
+  std::string object_name;
+  std::string received_hashes;
+  std::string computed_hashes;
+  std::size_t size = 0;
+  std::uint32_t crc32c = 0;
+  bool logged = false;
+};
+
+std::ostream& operator<<(std::ostream& os, ReadSummary const& x) {
+  return os << "ReadSummary={bucket_name" << x.bucket_name
+            << ", object_name=" << x.object_name
+            << ", received_hashes=" << x.received_hashes
+            << ", computed_hashes=" << x.computed_hashes << ", size=" << x.size
+            << ", crc32c=" << x.crc32c << ", logged=" << x.logged << "}";
+}
+
+void WriteSummary(Client client, std::string const& summary_name,
+                  std::vector<ReadSummary> const& object_summaries) {
+  std::ostringstream summary;
+  for (auto const& s : object_summaries) {
+    summary << s << "\n";
+  }
+  auto metadata =
+      client.InsertObject(flag_dst_bucket_name, summary_name, summary.str());
+  EXPECT_STATUS_OK(metadata);
+}
+
+void VerifySummary(Client client, std::vector<ReadSummary> object_summaries) {
+  int i = 0;
+  for (auto const& summary : object_summaries) {
+    SCOPED_TRACE("Checking headers and metadata for file [" +
+                 std::to_string(i) + "]=" + summary.object_name);
+
+    auto actual_crc32c = internal::Base64Encode(
+        google::cloud::internal::EncodeBigEndian(summary.crc32c));
+
+    auto metadata =
+        client.GetObjectMetadata(summary.bucket_name, summary.object_name);
+    ASSERT_STATUS_OK(metadata) << "ERROR: cannot read metadata for object[" << i
+                               << "]=" << summary.object_name;
+
+    EXPECT_EQ(metadata->size(), summary.size)
+        << "ERROR: mismatched object size " << *metadata;
+    EXPECT_EQ(metadata->crc32c(), actual_crc32c)
+        << "ERROR: mismatched crc32c checksum " << *metadata;
+    ++i;
+  }
+}
+
+void UpdateFromReader(ReadSummary& read_summary, ObjectReadStream& r,
+                      std::vector<char> const& buffer) {
+  read_summary.size += r.gcount();
+  read_summary.crc32c = crc32c::Extend(
+      read_summary.crc32c, reinterpret_cast<std::uint8_t const*>(buffer.data()),
+      r.gcount());
+
+  EXPECT_FALSE(r.bad()) << "ERROR: bad bit detected: " << r.status();
+  EXPECT_FALSE(!r.status().ok() && !r.bad())
+      << "ERROR: mismatched status vs. bad: " << r.status();
+  bool short_read = (static_cast<std::size_t>(r.gcount()) != buffer.size());
+  EXPECT_EQ(r.fail(), short_read)
+      << "mismatched fail and short read: " << r.status();
+  EXPECT_EQ(r.eof(), short_read)
+      << "mismatched eof and short read: " << r.status();
+
+  if (!r.eof()) {
+    return;
+  }
+
+  read_summary.received_hashes = r.received_hash();
+  read_summary.computed_hashes = r.computed_hash();
+  read_summary.logged = true;
+
+  auto actual_crc32c = internal::Base64Encode(
+      google::cloud::internal::EncodeBigEndian(read_summary.crc32c));
+
+  auto const& headers = r.headers();
+  for (auto const& kv : headers) {
+    std::cout << "    " << kv.first << ": " << kv.second << "\n";
+  }
+  auto object_size_begin = headers.lower_bound("x-goog-stored-content-length");
+  EXPECT_TRUE(object_size_begin != headers.end())
+      << "ERROR: cloud not x-goog-stored-content-length header";
+  if (object_size_begin != headers.end()) {
+    auto expected_object_size = std::stoll(object_size_begin->second);
+    EXPECT_EQ(expected_object_size, read_summary.size)
+        << "ERROR: mismatched x-goog-stored-content-length header"
+        << " vs. received size " << r.received_hash()
+        << ", computed=" << r.computed_hash();
+  }
+  auto x_goog_hash_begin = headers.lower_bound("x-goog-hash");
+  auto x_goog_hash_end = headers.upper_bound("x-goog-hash");
+  bool found = false;
+  for (auto h = x_goog_hash_begin; h != x_goog_hash_end; ++h) {
+    if (h->second.rfind("crc32c=", 0) == 0) {
+      EXPECT_THAT(h->second, HasSubstr(actual_crc32c))
+          << "ERROR: mismatched x-goog-hash header for crc32c and "
+             "computed "
+             "crc32c checksum "
+          << r.received_hash() << ", computed=" << r.computed_hash();
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found) << "ERROR: could not find x-goog-hash header with "
+                        "crc32c checksum";
+}
+
+}  // namespace
 
 class ReadObjectStallTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -91,12 +206,150 @@ class ReadObjectStallTest
                     [&] { return all_object_names.at(pick(generator_)); });
     return object_names;
   }
+
+  std::vector<ReadSummary> ReadStreaming(
+      Client client, std::vector<std::string> const& object_names) {
+    std::vector<ReadSummary> read_summaries(object_names.size());
+    auto summary_name = MakeRandomObjectName();
+
+    std::vector<ObjectReadStream> readers;
+    readers.reserve(object_names.size());
+    std::size_t index = 0;
+    for (auto const& name : object_names) {
+      read_summaries[index].bucket_name = flag_src_bucket_name;
+      read_summaries[index].object_name = name;
+      ++index;
+      readers.emplace_back(client.ReadObject(flag_src_bucket_name, name));
+    }
+
+    std::geometric_distribution<int> sleep_period(1.0 / flag_average_delay);
+
+    std::size_t offset = 0;
+    int open_count;
+    do {
+      open_count = 0;
+      std::size_t const chunk_size = 1 * 1024 * 1024L;
+      std::vector<char> buffer(chunk_size);
+      index = 0;
+      for (auto& r : readers) {
+        auto& read_summary = read_summaries[index++];
+        if (!r.IsOpen()) {
+          continue;
+        }
+        r.read(buffer.data(), buffer.size());
+        UpdateFromReader(read_summary, r, buffer);
+        ++open_count;
+      }
+      offset += chunk_size;
+      // Flush because we want to see the output in the GKE logs.
+      int sleep_seconds = sleep_period(generator_);
+      std::cout << '.' << std::flush;
+      std::this_thread::sleep_for(std::chrono::seconds(sleep_seconds));
+      WriteSummary(client, summary_name, read_summaries);
+    } while (open_count != 0);
+    std::cout << "DONE: All files closed\n";
+    return read_summaries;
+  }
+
+  std::vector<ReadSummary> ReadByRange(
+      Client client, std::vector<std::string> const& object_names) {
+    auto summary_name = MakeRandomObjectName();
+    struct Reader {
+      std::size_t offset = 0;
+      bool closed = false;
+    };
+    std::vector<ReadSummary> read_summaries(object_names.size());
+    std::vector<Reader> readers(object_names.size());
+
+    std::size_t index = 0;
+    for (auto const& name : object_names) {
+      read_summaries[index].bucket_name = flag_src_bucket_name;
+      read_summaries[index].object_name = name;
+      ++index;
+    }
+
+    std::geometric_distribution<int> sleep_period(1.0 / flag_average_delay);
+
+    std::size_t offset = 0;
+    int open_count;
+    do {
+      open_count = 0;
+      std::size_t const chunk_size = 1 * 1024 * 1024L;
+      std::vector<char> buffer(chunk_size);
+      index = 0;
+      for (auto& reader : readers) {
+        auto& read_summary = read_summaries[index++];
+        if (reader.closed) {
+          continue;
+        }
+        auto r = client.ReadObject(
+            read_summary.bucket_name, read_summary.object_name,
+            ReadRange(reader.offset, reader.offset + chunk_size));
+        r.read(buffer.data(), buffer.size());
+        UpdateFromReader(read_summary, r, buffer);
+        ++open_count;
+        reader.offset += r.gcount();
+        reader.closed = r.eof();
+      }
+      offset += chunk_size;
+      // Flush because we want to see the output in the GKE logs.
+      int sleep_seconds = sleep_period(generator_);
+      std::cout << "Reading, still has " << open_count
+                << " open files at offset=" << offset << "\n"
+                << "Sleeping for " << sleep_seconds << "s\n"
+                << std::flush;
+      std::this_thread::sleep_for(std::chrono::seconds(sleep_seconds));
+      WriteSummary(client, summary_name, read_summaries);
+    } while (open_count != 0);
+    std::cout << "DONE: All files closed\n";
+    return read_summaries;
+  }
+
+  std::vector<ReadSummary> ReadByFile(
+      Client client, std::vector<std::string> const& object_names) {
+    auto summary_name = MakeRandomObjectName();
+
+    std::vector<ReadSummary> read_summaries(object_names.size());
+
+    std::size_t index = 0;
+    for (auto const& name : object_names) {
+      read_summaries[index].bucket_name = flag_src_bucket_name;
+      read_summaries[index].object_name = name;
+      ++index;
+    }
+
+    int max_chunks = 0;
+    for (auto& read_summary : read_summaries) {
+      std::size_t const chunk_size = 1 * 1024 * 1024L;
+      std::vector<char> buffer(chunk_size);
+      auto r =
+          client.ReadObject(read_summary.bucket_name, read_summary.object_name);
+      int chunks = 0;
+      while (!r.eof() && !r.bad()) {
+        r.read(buffer.data(), buffer.size());
+        UpdateFromReader(read_summary, r, buffer);
+        ++chunks;
+      }
+      max_chunks = (std::max)(chunks, max_chunks);
+      std::cout << "Reading done for " << read_summary.object_name
+                << ", max_chunks=" << max_chunks << "\n"
+                << std::flush;
+    }
+    std::geometric_distribution<int> sleep_period(1.0 / flag_average_delay);
+    for (int i = 0; i != max_chunks; ++i) {
+      int sleep_seconds = sleep_period(generator_);
+      std::cout << "Sleeping for " << sleep_seconds << "s\n" << std::flush;
+      std::this_thread::sleep_for(std::chrono::seconds(sleep_seconds));
+
+      WriteSummary(client, summary_name, read_summaries);
+    }
+
+    std::cout << "DONE\n";
+    return read_summaries;
+  }
 };
 
 TEST_F(ReadObjectStallTest, Streaming) {
-  // Give the other programs in the test (such as tcpdump) time to start up.
-  std::this_thread::sleep_for(std::chrono::seconds(30));
-
   auto options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(options)
       << "ERROR: Aborting test, cannot create client options";
@@ -107,61 +360,9 @@ TEST_F(ReadObjectStallTest, Streaming) {
 
   PreparePhase(client, 1000);
 
-  auto summary_name = MakeRandomObjectName();
-
-  auto object_names = PickObjects(client, 32);
-  std::vector<ObjectReadStream> readers;
-  readers.reserve(object_names.size());
-  for (auto const& name : object_names) {
-    readers.emplace_back(client.ReadObject(flag_src_bucket_name, name));
-  }
-
-  std::geometric_distribution<int> sleep_period(1.0 / flag_average_delay);
-
-  bool has_open;
-  std::size_t offset = 0;
-  do {
-    has_open = false;
-    std::size_t const chunk_size = 1 * 1024 * 1024L;
-    std::vector<char> buffer(chunk_size);
-    int open_count = 0;
-    for (auto& r : readers) {
-      if (!r.IsOpen()) {
-        continue;
-      }
-      has_open = true;
-      r.read(buffer.data(), buffer.size());
-      if (r.bad()) {
-        std::cerr << "Bad bit detected: " << r.status() << "\n";
-      }
-      ++open_count;
-    }
-    offset += chunk_size;
-    // Flush because we want to see the output in the GKE logs.
-    int sleep_seconds = sleep_period(generator_);
-    std::cout << "Reading, still has " << open_count
-              << " open files at offset=" << offset << "\n"
-              << "Sleeping for " << sleep_seconds << "s\n"
-              << std::flush;
-    std::this_thread::sleep_for(std::chrono::seconds(sleep_seconds));
-
-    std::ostringstream summary;
-    std::size_t index = 0;
-    for (auto const& o : object_names) {
-      summary << o << " " << index;
-      if (index < readers.size()) {
-        auto const& r = readers[index];
-        summary << " " << r.IsOpen() << " " << r.computed_hash() << " "
-                << r.headers().size();
-      }
-      summary << "\n";
-      ++index;
-    }
-    auto metadata =
-        client.InsertObject(flag_dst_bucket_name, summary_name, summary.str());
-    EXPECT_STATUS_OK(metadata);
-  } while (has_open);
-  std::cout << "DONE: All files closed\n";
+  auto object_names = PickObjects(client, flag_object_count);
+  auto download_summaries = ReadStreaming(client, object_names);
+  EXPECT_NO_FATAL_FAILURE(VerifySummary(client, download_summaries));
 }
 
 TEST_F(ReadObjectStallTest, ByRange) {
@@ -169,71 +370,9 @@ TEST_F(ReadObjectStallTest, ByRange) {
   ASSERT_STATUS_OK(client) << "ERROR: Aborting test, cannot create client";
 
   PreparePhase(*client, 1000);
-  auto summary_name = MakeRandomObjectName();
-
-  struct State {
-    bool closed;
-    std::size_t offset;
-    std::string name;
-  };
-  std::vector<State> readers;
-  readers.reserve(32);
-  for (auto const& name : PickObjects(*client, 32)) {
-    readers.emplace_back(State{false, 0, name});
-  }
-
-  std::geometric_distribution<int> sleep_period(1.0 / flag_average_delay);
-
-  bool has_open;
-  std::size_t offset = 0;
-  do {
-    has_open = false;
-    std::size_t const chunk_size = 1 * 1024 * 1024L;
-    std::vector<char> buffer(chunk_size);
-    int open_count = 0;
-    for (auto& state : readers) {
-      if (state.closed) {
-        continue;
-      }
-      auto r = client->ReadObject(
-          flag_src_bucket_name, state.name,
-          ReadRange(state.offset, state.offset + chunk_size));
-      EXPECT_FALSE(r.eof());
-      EXPECT_FALSE(r.bad()) << "status=" << r.status();
-      if (r.bad() || r.eof()) {
-        state.closed = true;
-        continue;
-      }
-      has_open = true;
-      r.read(buffer.data(), buffer.size());
-      state.offset += r.gcount();
-      if (r.eof()) {
-        state.closed = true;
-      }
-      EXPECT_FALSE(r.bad()) << "status=" << r.status() << "\n";
-      ++open_count;
-    }
-    offset += chunk_size;
-    // Flush because we want to see the output in the GKE logs.
-    int sleep_seconds = sleep_period(generator_);
-    std::cout << "Reading, still has " << open_count
-              << " open files at offset=" << offset << "\n"
-              << "Sleeping for " << sleep_seconds << "s\n"
-              << std::flush;
-    std::this_thread::sleep_for(std::chrono::seconds(sleep_seconds));
-
-    std::ostringstream summary;
-    std::size_t index = 0;
-    for (auto const& s : readers) {
-      summary << s.name << " " << index << " " << s.closed << " " << s.offset
-              << "\n";
-      ++index;
-    }
-    auto metadata =
-        client->InsertObject(flag_dst_bucket_name, summary_name, summary.str());
-    EXPECT_STATUS_OK(metadata);
-  } while (has_open);
-  std::cout << "DONE: All files closed\n";
+  auto object_names = PickObjects(*client, flag_object_count);
+  auto download_summaries = ReadByRange(*client, object_names);
+  EXPECT_NO_FATAL_FAILURE(VerifySummary(*client, download_summaries));
 }
 
 TEST_F(ReadObjectStallTest, ByFile) {
@@ -241,46 +380,11 @@ TEST_F(ReadObjectStallTest, ByFile) {
   ASSERT_STATUS_OK(client) << "ERROR: Aborting test, cannot create client";
 
   PreparePhase(*client, 1000);
-
-  auto summary_name = MakeRandomObjectName();
-
-  auto object_names = PickObjects(*client, 32);
-  int max_chunks = 0;
-  for (auto const& name : object_names) {
-    auto reader = client->ReadObject(flag_src_bucket_name, name);
-    std::size_t const chunk_size = 1 * 1024 * 1024L;
-    std::vector<char> buffer(chunk_size);
-    int chunks = 0;
-    while (!reader.eof() && !reader.bad()) {
-      reader.read(buffer.data(), buffer.size());
-      EXPECT_FALSE(reader.bad());
-      EXPECT_TRUE(buffer.size() == static_cast<std::size_t>(reader.gcount()) ||
-                  reader.eof());
-      ++chunks;
-    }
-    EXPECT_FALSE(reader.bad());
-    EXPECT_STATUS_OK(reader.status());
-    max_chunks = (std::max)(chunks, max_chunks);
-    std::cout << "Reading done for " << name << ", max_chunks=" << max_chunks
-              << "\n"
-              << std::flush;
-  }
-
-  std::geometric_distribution<int> sleep_period(1.0 / flag_average_delay);
-  for (int i = 0; i != max_chunks; ++i) {
-    int sleep_seconds = sleep_period(generator_);
-    std::cout << "Sleeping for " << sleep_seconds << "s\n" << std::flush;
-    std::this_thread::sleep_for(std::chrono::seconds(sleep_seconds));
-
-    auto meta =
-        client->InsertObject(flag_dst_bucket_name, summary_name, "test only");
-    EXPECT_STATUS_OK(meta);
-  }
-
-  std::cout << "DONE\n";
+  auto object_names = PickObjects(*client, flag_object_count);
+  auto download_summaries = ReadByFile(*client, object_names);
+  EXPECT_NO_FATAL_FAILURE(VerifySummary(*client, download_summaries));
 }
 
-}  // anonymous namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud
@@ -290,18 +394,21 @@ int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
 
   // Make sure the arguments are valid.
-  if (argc != 4) {
+  if (argc != 4 && argc != 5) {
     std::string const cmd = argv[0];
     auto last_slash = std::string(argv[0]).find_last_of('/');
     std::cerr << "Usage: " << cmd.substr(last_slash + 1)
               << " <source-bucket-name> <destination-bucket-name>"
-                 " <average-delay>\n";
+                 " <average-delay> [object-count]\n";
     return 1;
   }
 
   google::cloud::storage::flag_src_bucket_name = argv[1];
   google::cloud::storage::flag_dst_bucket_name = argv[2];
   google::cloud::storage::flag_average_delay = std::stod(argv[3]);
+  if (argc > 4) {
+    google::cloud::storage::flag_object_count = std::stol(argv[4]);
+  }
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
The test for stalled reads was a bit too difficult to follow.
This change simplifies the test, refactoring some common code.
It also makes the test more strict, validating that the
download results have the correct size and checksum values.
The test validates the computed size and checksums against the headers
available when the full object is read, as well as comparing these
against the object metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3059)
<!-- Reviewable:end -->
