### PR TITLE
bug: handle CURLE_PARTIAL_FILE as recoverable

### DIFF
--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -225,6 +225,7 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
     case CURLE_COULDNT_CONNECT:
     case CURLE_RECV_ERROR:
     case CURLE_SEND_ERROR:
+    case CURLE_PARTIAL_FILE:
       code = StatusCode::kUnavailable;
       break;
     case CURLE_REMOTE_ACCESS_DENIED:

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -32,6 +32,7 @@ TEST(CurlHandleTest, AsStatus) {
       {CURLE_OK, StatusCode::kOk},
       {CURLE_RECV_ERROR, StatusCode::kUnavailable},
       {CURLE_SEND_ERROR, StatusCode::kUnavailable},
+      {CURLE_PARTIAL_FILE, StatusCode::kUnavailable},
       {CURLE_COULDNT_RESOLVE_HOST, StatusCode::kUnavailable},
       {CURLE_COULDNT_RESOLVE_PROXY, StatusCode::kUnavailable},
       {CURLE_COULDNT_CONNECT, StatusCode::kUnavailable},


### PR DESCRIPTION
Now that we have much better code to recover from partial downloads
we can treat this error as a recoverable failure.

Fixes #3053

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3061)
<!-- Reviewable:end -->
