### PR TITLE
bug: calls to resumable_session_id() result in segfaults

### DIFF
--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -145,10 +145,12 @@ TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
     return StatusOr<std::unique_ptr<internal::ResumableUploadSession>>(
         std::unique_ptr<internal::ResumableUploadSession>(mock_session));
   };
+  std::string const empty;
   EXPECT_CALL(*mock, CreateResumableSession(_)).WillOnce(Invoke(returner));
   EXPECT_CALL(*mock_session, UploadChunk(_))
       .WillRepeatedly(Return(PermanentError()));
   EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
+  EXPECT_CALL(*mock_session, session_id()).WillRepeatedly(ReturnRef(empty));
   auto stream = client->WriteObject("test-bucket-name", "test-object-name");
 
   // make sure it is actually sent

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -23,6 +23,7 @@
 #include "google/cloud/storage/version.h"
 #include <iostream>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -150,8 +150,8 @@ class ResumableUploadSessionError : public ResumableUploadSession {
 
  private:
   StatusOr<ResumableUploadResponse> last_response_;
-  std::uint64_t const next_expected_byte_ = 0;
-  std::string const id_;
+  std::uint64_t next_expected_byte_ = 0;
+  std::string id_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -113,22 +113,32 @@ std::ostream& operator<<(std::ostream& os, ResumableUploadResponse const& r);
 class ResumableUploadSessionError : public ResumableUploadSession {
  public:
   explicit ResumableUploadSessionError(Status status)
-      : status_(std::move(status)), last_response_(status_) {}
+      : last_response_(std::move(status)) {}
+
+  ResumableUploadSessionError(Status status, std::uint64_t next_expected_byte,
+                              std::string id)
+      : last_response_(std::move(status)),
+        next_expected_byte_(next_expected_byte),
+        id_(id) {}
 
   ~ResumableUploadSessionError() override = default;
 
   StatusOr<ResumableUploadResponse> UploadChunk(std::string const&) override {
-    return status_;
+    return last_response_;
   }
 
   StatusOr<ResumableUploadResponse> UploadFinalChunk(std::string const&,
                                                      std::uint64_t) override {
-    return status_;
+    return last_response_;
   }
 
-  StatusOr<ResumableUploadResponse> ResetSession() override { return status_; }
+  StatusOr<ResumableUploadResponse> ResetSession() override {
+    return last_response_;
+  }
 
-  std::uint64_t next_expected_byte() const override { return 0; }
+  std::uint64_t next_expected_byte() const override {
+    return next_expected_byte_;
+  }
 
   std::string const& session_id() const override { return id_; }
 
@@ -139,9 +149,9 @@ class ResumableUploadSessionError : public ResumableUploadSession {
   }
 
  private:
-  Status status_;
   StatusOr<ResumableUploadResponse> last_response_;
-  std::string id_;
+  const std::uint64_t next_expected_byte_ = 0;
+  const std::string id_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -150,8 +150,8 @@ class ResumableUploadSessionError : public ResumableUploadSession {
 
  private:
   StatusOr<ResumableUploadResponse> last_response_;
-  const std::uint64_t next_expected_byte_ = 0;
-  const std::string id_;
+  std::uint64_t const next_expected_byte_ = 0;
+  std::string const id_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
This fixes the problem as discussed in the issue.

Fixes #3047 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3062)
<!-- Reviewable:end -->
