### PR TITLE
bug: fix runtime install directory

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -263,7 +263,7 @@ install(EXPORT google_cloud_cpp_common-targets
 # GNUInstallDirs
 install(TARGETS google_cloud_cpp_common google_cloud_cpp_common_options
         EXPORT google_cloud_cpp_common-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 google_cloud_cpp_install_headers(google_cloud_cpp_common include/google/cloud)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -366,7 +366,7 @@ endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 # GNUInstallDirs
 install(TARGETS bigtable_protos bigtable_common_options
         EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -376,7 +376,7 @@ install(EXPORT bigtable-targets
 
 install(TARGETS bigtable_client
         EXPORT bigtable-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 google_cloud_cpp_install_headers(bigtable_client include/google/cloud/bigtable)

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -109,7 +109,7 @@ endif ()
 # GNUInstallDirs
 install(TARGETS
         EXPORT firestore-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -120,7 +120,7 @@ install(EXPORT firestore-targets
 
 install(TARGETS firestore_client firestore_common_options
         EXPORT firestore-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 google_cloud_cpp_install_headers(

--- a/google/cloud/grpc_utils/CMakeLists.txt
+++ b/google/cloud/grpc_utils/CMakeLists.txt
@@ -161,7 +161,7 @@ endif ()
 # GNUInstallDirs
 install(TARGETS grpc_utils_common_options
         EXPORT grpc_utils-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -171,7 +171,7 @@ install(EXPORT grpc_utils-targets
 
 install(TARGETS google_cloud_cpp_grpc_utils
         EXPORT grpc_utils-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 google_cloud_cpp_install_headers(google_cloud_cpp_grpc_utils

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -431,7 +431,7 @@ endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 # GNUInstallDirs
 install(TARGETS storage_common_options nlohmann_json
         EXPORT storage-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -441,7 +441,7 @@ install(EXPORT storage-targets
 
 install(TARGETS storage_client
         EXPORT storage-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 google_cloud_cpp_install_headers(storage_client include/google/cloud/storage)

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -77,7 +77,7 @@ if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL)
     # GNUInstallDirs
     install(TARGETS google_cloud_cpp_testing
             EXPORT google_cloud_cpp_testing-targets
-            RUNTIME DESTINATION bin
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
     google_cloud_cpp_install_headers(google_cloud_cpp_testing


### PR DESCRIPTION
TIL: Use the right variable to set the runtime install directory for DLLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3063)
<!-- Reviewable:end -->
