### PR TITLE
feat: implement a regression test for large uploads

### DIFF
--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -68,5 +68,6 @@ include(CreateBazelConfig)
 export_list_to_bazel("storage_client_integration_tests.bzl"
                      "storage_client_integration_tests")
 
+add_subdirectory(parallel_upload_regression)
 add_subdirectory(read_object_stall_regression)
 add_subdirectory(write_deadlock_regression)

--- a/google/cloud/storage/tests/parallel_upload_regression/CMakeLists.txt
+++ b/google/cloud/storage/tests/parallel_upload_regression/CMakeLists.txt
@@ -1,0 +1,29 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+add_executable(parallel_upload_test parallel_upload_test.cc)
+target_link_libraries(parallel_upload_test
+                      PRIVATE storage_client
+                              storage_client_testing
+                              google_cloud_cpp_testing
+                              google_cloud_cpp_common
+                              GTest::gmock_main
+                              GTest::gmock
+                              GTest::gtest
+                              CURL::libcurl
+                              Threads::Threads
+                              nlohmann_json
+                              storage_common_options)

--- a/google/cloud/storage/tests/parallel_upload_regression/Dockerfile
+++ b/google/cloud/storage/tests/parallel_upload_regression/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:bionic AS devtools
+
+# Install the typical development tools and some additions:
+RUN apt update && \
+    apt install -y build-essential cmake git gcc g++ cmake \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
+        pkg-config tar wget zlib1g-dev
+
+FROM devtools AS build
+
+# Copy the source code to /w, and then compile the program(s) we need.
+WORKDIR /w
+COPY . /w
+
+ARG CMAKE_BUILD_TYPE=Release
+ARG SHORT_SHA=""
+
+RUN cmake -Hsuper -B.build \
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+    -DGOOGLE_CLOUD_CPP_BUILD_METADATA=${SHORT_SHA}
+
+RUN cmake \
+    --build .build \
+    -- -j $(nproc)
+
+# ================================================================
+
+# Prepare the final image, this image is much smaller because only the required
+# dependencies are installed.
+FROM ubuntu:bionic
+RUN apt update && \
+    apt install -y libstdc++6 libc-ares2 libcurl4 zlib1g binutils \
+        ca-certificates tcpdump coreutils strace procps
+RUN /usr/sbin/update-ca-certificates
+
+COPY --from=build \
+    /w/.build/build/google-cloud-cpp/src/google_cloud_cpp_project-build/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test \
+    /r/
+
+CMD ["/bin/false"]

--- a/google/cloud/storage/tests/parallel_upload_regression/README.md
+++ b/google/cloud/storage/tests/parallel_upload_regression/README.md
@@ -1,0 +1,61 @@
+# Running the read_object_stall_test.
+
+This is a regression test for a problem
+
+
+```bash
+PROJECT_ID=.... # Your project
+
+ZONE=...
+REGION=...
+
+gcloud beta container clusters create --project=${PROJECT_ID} \
+      --zone=${ZONE} --machine-type=n1-highmem-2 --num-nodes=35 \
+      --enable-stackdriver-kubernetes regression-tests
+gcloud container clusters get-credentials --project ${PROJECT_ID} \
+          --zone "${ZONE}" regression-tests
+
+SA_NAME=storage-stall-regression-sa
+gcloud iam service-accounts create --project=${PROJECT_ID} ${SA_NAME} \
+    --display-name="Service account to run GCS C++ Stall Regression"
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+      --member serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com \
+      --role roles/storage.admin
+
+
+gcloud iam service-accounts keys create \
+      --iam-account ${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com \
+      /dev/shm/key.json
+
+kubectl create secret generic service-account-key \
+        --from-file=key.json=/dev/shm/key.json
+```
+
+Create source and target buckets:
+
+```
+export DST_BUCKET_NAME=...
+gsutil mb -s regional -l us-west1 gs://${DST_BUCKET_NAME}
+```
+
+Create a docker image to run the job:
+
+```sh
+gcloud builds submit \
+     --substitutions=SHORT_SHA=$(git rev-parse --short HEAD) \
+     --config=google/cloud/storage/tests/parallel_upload_regression/cloudbuild.yaml
+```
+
+You may need to fetch the k8s credentials:
+
+```sh
+gcloud container clusters get-credentials regression-tests \
+    --zone us-west1-a
+```
+
+Start the k8s job:
+
+```sh
+./google/cloud/storage/tests/parallel_upload_regression/create-job.sh | \
+    kubectl apply -f -
+```

--- a/google/cloud/storage/tests/parallel_upload_regression/cloudbuild.yaml
+++ b/google/cloud/storage/tests/parallel_upload_regression/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
            '--target', 'devtools',
            '-t', 'gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools',
            '--cache-from', 'gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools',
-           '-f', 'google/cloud/storage/tests/read_object_stall_regression/Dockerfile',
+           '-f', 'google/cloud/storage/tests/parallel_upload_regression/Dockerfile',
            '--build-arg', 'CMAKE_BUILD_TYPE=${_CMAKE_BUILD_TYPE}',
            '.']
     timeout: 3600s

--- a/google/cloud/storage/tests/parallel_upload_regression/cloudbuild.yaml
+++ b/google/cloud/storage/tests/parallel_upload_regression/cloudbuild.yaml
@@ -1,0 +1,59 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # Try to pull the image from the container registry, if it exists that can
+  # speed up the build because previous layers are reused.
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'docker pull gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools || exit 0'
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '--target', 'devtools',
+           '-t', 'gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools',
+           '-f', 'google/cloud/storage/tests/read_object_stall_regression/Dockerfile',
+           '--build-arg', 'CMAKE_BUILD_TYPE=${_CMAKE_BUILD_TYPE}',
+           '.']
+    timeout: 3600s
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'docker pull gcr.io/${PROJECT_ID}/parallel-upload-regression || exit 0'
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '-t', 'gcr.io/${PROJECT_ID}/parallel-upload-regression',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools',
+           '--cache-from', 'gcr.io/${PROJECT_ID}/parallel-upload-regression',
+           '-f', 'google/cloud/storage/tests/parallel_upload_regression/Dockerfile',
+           '--build-arg', 'CMAKE_BUILD_TYPE=${_CMAKE_BUILD_TYPE}',
+           '.']
+    timeout: 3600s
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['tag',
+           'gcr.io/${PROJECT_ID}/parallel-upload-regression:latest',
+           'gcr.io/${PROJECT_ID}/parallel-upload-regression:${SHORT_SHA}']
+    timeout: 3600s
+options:
+  machineType: 'N1_HIGHCPU_8'
+substitutions:
+  _CMAKE_BUILD_TYPE: 'Release'
+timeout: 7200s
+images:
+  - 'gcr.io/${PROJECT_ID}/parallel-upload-regression'
+  - 'gcr.io/${PROJECT_ID}/parallel-upload-regression-devtools'
+  - 'gcr.io/${PROJECT_ID}/parallel-upload-regression:${SHORT_SHA}'

--- a/google/cloud/storage/tests/parallel_upload_regression/create-job.sh
+++ b/google/cloud/storage/tests/parallel_upload_regression/create-job.sh
@@ -25,8 +25,8 @@ metadata:
   labels:
     app: parallel-upload-regression
 spec:
-  parallelism: 5
-  completions: 5
+  parallelism: 15
+  completions: 15
   template:
     spec:
       restartPolicy: OnFailure
@@ -41,11 +41,12 @@ spec:
           imagePullPolicy: Always
           args: [
             '/r/parallel_upload_test',
-            '@DST_BUCKET_NAME@'
+            '@DST_BUCKET_NAME@',
+            '--gtest_repeat=5'
           ]
           resources:
             requests:
-              memory: "40Mi"
+              memory: "200Mi"
               cpu: "25m"
               ephemeral-storage: "128Mi"
           volumeMounts:

--- a/google/cloud/storage/tests/parallel_upload_regression/create-job.sh
+++ b/google/cloud/storage/tests/parallel_upload_regression/create-job.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+sed -e "s/@PROJECT_ID@/${PROJECT_ID}/" \
+    -e "s/@ID@/$(date +%s)-${RANDOM}/" \
+    -e "s/@DST_BUCKET_NAME@/${DST_BUCKET_NAME}/" <<'_EOF_'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: regression-@ID@
+  labels:
+    app: parallel-upload-regression
+spec:
+  parallelism: 5
+  completions: 5
+  template:
+    spec:
+      restartPolicy: OnFailure
+      activeDeadlineSeconds: 1800
+      volumes:
+        - name: google-cloud-key
+          secret:
+            secretName: service-account-key
+      containers:
+        - name: parallel-upload-regression
+          image: gcr.io/@PROJECT_ID@/parallel-upload-regression:latest
+          imagePullPolicy: Always
+          args: [
+            '/r/parallel_upload_test',
+            '@DST_BUCKET_NAME@'
+          ]
+          resources:
+            requests:
+              memory: "40Mi"
+              cpu: "25m"
+              ephemeral-storage: "128Mi"
+          volumeMounts:
+            - name: google-cloud-key
+              mountPath: /var/secrets/google
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /var/secrets/google/key.json
+_EOF_

--- a/google/cloud/storage/tests/parallel_upload_regression/create-job.sh
+++ b/google/cloud/storage/tests/parallel_upload_regression/create-job.sh
@@ -46,8 +46,8 @@ spec:
           ]
           resources:
             requests:
-              memory: "200Mi"
-              cpu: "25m"
+              memory: "2Gi"
+              cpu: "1000m"
               ephemeral-storage: "128Mi"
           volumeMounts:
             - name: google-cloud-key

--- a/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
+++ b/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
@@ -1,0 +1,193 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/big_endian.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <crc32c/crc32c.h>
+#include <algorithm>
+#include <future>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::testing::HasSubstr;
+
+// Initialized in main() below.
+char const* flag_dst_bucket_name;
+
+class ParallelUploadTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {
+ protected:
+  static constexpr auto max_object_size = 128 * 1024 * 1024L;
+  static constexpr auto object_count_per_thread = 4;
+
+  void SetUp() override {
+    StorageIntegrationTest::SetUp();
+    std::cout << "Creating upload data " << std::flush;
+    upload_contents_ = MakeRandomData(max_object_size);
+    std::cout << "DONE\n";
+    auto crc32c_value = crc32c::Crc32c(upload_contents_);
+    expected_crc32c_ = internal::Base64Encode(
+        google::cloud::internal::EncodeBigEndian(crc32c_value));
+  }
+
+  void UploadStreamByChunk(Client client) {
+    for (int i = 0; i != object_count_per_thread; ++i) {
+      auto name = MakeRandomObjectName();
+
+      std::size_t chunk_size = 1024 * 1024L;
+      auto writer = client.WriteObject(flag_dst_bucket_name, name);
+      for (std::size_t offset = 0; offset < upload_contents_.size();
+           offset += chunk_size) {
+        auto count = (std::min)(chunk_size, upload_contents_.size() - offset);
+        writer.write(upload_contents_.data() + offset, count);
+        EXPECT_FALSE(writer.bad());
+        EXPECT_STATUS_OK(writer.last_status());
+        std::cout << '.' << std::flush;
+      }
+      writer.Close();
+      auto metadata = writer.metadata();
+      EXPECT_STATUS_OK(metadata);
+      EXPECT_EQ(upload_contents_.size(), metadata->size());
+      EXPECT_EQ(expected_crc32c_, metadata->crc32c());
+    }
+  }
+
+  void UploadStreamAll(Client client) {
+    for (int i = 0; i != object_count_per_thread; ++i) {
+      auto name = MakeRandomObjectName();
+
+      auto writer = client.WriteObject(flag_dst_bucket_name, name);
+      EXPECT_FALSE(writer.bad());
+      writer << upload_contents_;
+      writer.Close();
+      auto metadata = writer.metadata();
+      EXPECT_STATUS_OK(metadata);
+      EXPECT_EQ(upload_contents_.size(), metadata->size());
+      EXPECT_EQ(expected_crc32c_, metadata->crc32c());
+    }
+  }
+
+  void UploadInsert(Client client) {
+    for (int i = 0; i != object_count_per_thread; ++i) {
+      auto name = MakeRandomObjectName();
+
+      auto metadata =
+          client.InsertObject(flag_dst_bucket_name, name, upload_contents_);
+      EXPECT_STATUS_OK(metadata);
+      EXPECT_EQ(upload_contents_.size(), metadata->size());
+      EXPECT_EQ(expected_crc32c_, metadata->crc32c());
+    }
+  }
+
+  static int ThreadCount() {
+    auto count = std::thread::hardware_concurrency();
+    if (count == 0) {
+      return 4;
+    }
+    return 4 * static_cast<int>(count);
+  }
+
+ private:
+  std::string upload_contents_;
+  std::string expected_crc32c_;
+};
+
+TEST_F(ParallelUploadTest, StreamingByChunk) {
+  auto options = ClientOptions::CreateDefaultClientOptions();
+  ASSERT_STATUS_OK(options)
+      << "ERROR: Aborting test, cannot create client options";
+
+  Client client(options->set_maximum_socket_recv_size(128 * 1024)
+                    .set_maximum_socket_send_size(128 * 1024)
+                    .set_download_stall_timeout(std::chrono::seconds(30)));
+
+  std::vector<std::future<void>> tasks(ThreadCount());
+  for (auto& t : tasks) {
+    t = std::async(std::launch::async,
+                   [this, client] { UploadStreamByChunk(client); });
+  }
+  for (auto& t : tasks) {
+    t.get();
+  }
+}
+
+TEST_F(ParallelUploadTest, StreamingAll) {
+  auto options = ClientOptions::CreateDefaultClientOptions();
+  ASSERT_STATUS_OK(options)
+      << "ERROR: Aborting test, cannot create client options";
+
+  Client client(options->set_maximum_socket_recv_size(128 * 1024)
+                    .set_maximum_socket_send_size(128 * 1024)
+                    .set_download_stall_timeout(std::chrono::seconds(30)));
+
+  std::vector<std::future<void>> tasks(ThreadCount());
+  for (auto& t : tasks) {
+    t = std::async(std::launch::async,
+                   [this, client] { UploadStreamAll(client); });
+  }
+  for (auto& t : tasks) {
+    t.get();
+  }
+}
+
+TEST_F(ParallelUploadTest, Insert) {
+  auto options = ClientOptions::CreateDefaultClientOptions();
+  ASSERT_STATUS_OK(options)
+      << "ERROR: Aborting test, cannot create client options";
+
+  Client client(options->set_maximum_socket_recv_size(128 * 1024)
+                    .set_maximum_socket_send_size(128 * 1024)
+                    .set_download_stall_timeout(std::chrono::seconds(30)));
+
+  std::vector<std::future<void>> tasks(ThreadCount());
+  for (auto& t : tasks) {
+    t = std::async(std::launch::async,
+                   [this, client] { UploadInsert(client); });
+  }
+  for (auto& t : tasks) {
+    t.get();
+  }
+}
+
+}  // anonymous namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // Make sure the arguments are valid.
+  if (argc != 2) {
+    std::string const cmd = argv[0];
+    auto last_slash = std::string(argv[0]).find_last_of('/');
+    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
+              << " <destination-bucket-name>\n";
+    return 1;
+  }
+
+  google::cloud::storage::flag_dst_bucket_name = argv[1];
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
+++ b/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
@@ -38,7 +38,7 @@ class ParallelUploadTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   static constexpr auto max_object_size = 128 * 1024 * 1024L;
-  static constexpr auto object_count_per_thread = 4;
+  static constexpr auto object_count_per_thread = 16;
 
   void SetUp() override {
     StorageIntegrationTest::SetUp();
@@ -62,13 +62,16 @@ class ParallelUploadTest
         writer.write(upload_contents_.data() + offset, count);
         EXPECT_FALSE(writer.bad());
         EXPECT_STATUS_OK(writer.last_status());
-        std::cout << '.' << std::flush;
       }
       writer.Close();
+      std::cout << '.' << std::flush;
       auto metadata = writer.metadata();
       EXPECT_STATUS_OK(metadata);
-      EXPECT_EQ(upload_contents_.size(), metadata->size());
-      EXPECT_EQ(expected_crc32c_, metadata->crc32c());
+      if (!metadata) continue;
+      EXPECT_EQ(upload_contents_.size(), metadata->size())
+          << "ERROR: mismatched size, metadata=" << *metadata;
+      EXPECT_EQ(expected_crc32c_, metadata->crc32c())
+          << "ERROR: mismatched size, metadata=" << *metadata;
     }
   }
 
@@ -80,10 +83,14 @@ class ParallelUploadTest
       EXPECT_FALSE(writer.bad());
       writer << upload_contents_;
       writer.Close();
+      std::cout << '.' << std::flush;
       auto metadata = writer.metadata();
       EXPECT_STATUS_OK(metadata);
-      EXPECT_EQ(upload_contents_.size(), metadata->size());
-      EXPECT_EQ(expected_crc32c_, metadata->crc32c());
+      if (!metadata) continue;
+      EXPECT_EQ(upload_contents_.size(), metadata->size())
+          << "ERROR: mismatched size, metadata=" << *metadata;
+      EXPECT_EQ(expected_crc32c_, metadata->crc32c())
+          << "ERROR: mismatched size, metadata=" << *metadata;
     }
   }
 
@@ -93,9 +100,13 @@ class ParallelUploadTest
 
       auto metadata =
           client.InsertObject(flag_dst_bucket_name, name, upload_contents_);
+      std::cout << '.' << std::flush;
       EXPECT_STATUS_OK(metadata);
-      EXPECT_EQ(upload_contents_.size(), metadata->size());
-      EXPECT_EQ(expected_crc32c_, metadata->crc32c());
+      if (!metadata) continue;
+      EXPECT_EQ(upload_contents_.size(), metadata->size())
+          << "ERROR: mismatched size, metadata=" << *metadata;
+      EXPECT_EQ(expected_crc32c_, metadata->crc32c())
+          << "ERROR: mismatched size, metadata=" << *metadata;
     }
   }
 

--- a/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
+++ b/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
@@ -38,7 +38,7 @@ class ParallelUploadTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   static constexpr auto max_object_size = 128 * 1024 * 1024L;
-  static constexpr auto object_count_per_thread = 16;
+  static constexpr auto object_count_per_thread = 100;
 
   void SetUp() override {
     StorageIntegrationTest::SetUp();
@@ -113,9 +113,9 @@ class ParallelUploadTest
   static int ThreadCount() {
     auto count = std::thread::hardware_concurrency();
     if (count == 0) {
-      return 4;
+      return 2;
     }
-    return 4 * static_cast<int>(count);
+    return 2 * static_cast<int>(count);
   }
 
  private:

--- a/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
+++ b/google/cloud/storage/tests/parallel_upload_regression/parallel_upload_test.cc
@@ -132,6 +132,8 @@ TEST_F(ParallelUploadTest, StreamingByChunk) {
                     .set_maximum_socket_send_size(128 * 1024)
                     .set_download_stall_timeout(std::chrono::seconds(30)));
 
+  std::cout << "Uploading, using WriteObject and multiple .write() calls "
+            << std::flush;
   std::vector<std::future<void>> tasks(ThreadCount());
   for (auto& t : tasks) {
     t = std::async(std::launch::async,
@@ -140,6 +142,7 @@ TEST_F(ParallelUploadTest, StreamingByChunk) {
   for (auto& t : tasks) {
     t.get();
   }
+  std::cout << " DONE\n";
 }
 
 TEST_F(ParallelUploadTest, StreamingAll) {
@@ -151,6 +154,8 @@ TEST_F(ParallelUploadTest, StreamingAll) {
                     .set_maximum_socket_send_size(128 * 1024)
                     .set_download_stall_timeout(std::chrono::seconds(30)));
 
+  std::cout << "Uploading, using WriteObject and a single operator<<() call "
+            << std::flush;
   std::vector<std::future<void>> tasks(ThreadCount());
   for (auto& t : tasks) {
     t = std::async(std::launch::async,
@@ -159,6 +164,7 @@ TEST_F(ParallelUploadTest, StreamingAll) {
   for (auto& t : tasks) {
     t.get();
   }
+  std::cout << " DONE\n";
 }
 
 TEST_F(ParallelUploadTest, Insert) {
@@ -170,6 +176,7 @@ TEST_F(ParallelUploadTest, Insert) {
                     .set_maximum_socket_send_size(128 * 1024)
                     .set_download_stall_timeout(std::chrono::seconds(30)));
 
+  std::cout << "Uploading using a single InsertObject call " << std::flush;
   std::vector<std::future<void>> tasks(ThreadCount());
   for (auto& t : tasks) {
     t = std::async(std::launch::async,
@@ -178,6 +185,7 @@ TEST_F(ParallelUploadTest, Insert) {
   for (auto& t : tasks) {
     t.get();
   }
+  std::cout << " DONE\n";
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
This is a regression test, but so far does not reproduce a problem. But
it might help us diagnose the problem reported in #3029 

The test runs multiple threads, all of them uploading a mid-sized
object (128MiB). The test uses `InsertObject()` and `WriteObject()`
to perform the upload, and in the case of `WriteObject()` it both
uploads the object using a single `operator<<` call, and multiple
`.write()` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3066)
<!-- Reviewable:end -->
