### PR TITLE
feat: treat CURLE_SSL_CONNECT_ERROR as retryable

### DIFF
--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -226,6 +226,7 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
     case CURLE_RECV_ERROR:
     case CURLE_SEND_ERROR:
     case CURLE_PARTIAL_FILE:
+    case CURLE_SSL_CONNECT_ERROR:
       code = StatusCode::kUnavailable;
       break;
     case CURLE_REMOTE_ACCESS_DENIED:

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -33,6 +33,7 @@ TEST(CurlHandleTest, AsStatus) {
       {CURLE_RECV_ERROR, StatusCode::kUnavailable},
       {CURLE_SEND_ERROR, StatusCode::kUnavailable},
       {CURLE_PARTIAL_FILE, StatusCode::kUnavailable},
+      {CURLE_SSL_CONNECT_ERROR, StatusCode::kUnavailable},
       {CURLE_COULDNT_RESOLVE_HOST, StatusCode::kUnavailable},
       {CURLE_COULDNT_RESOLVE_PROXY, StatusCode::kUnavailable},
       {CURLE_COULDNT_CONNECT, StatusCode::kUnavailable},


### PR DESCRIPTION
This fixes #2660. As described in this bug, I changed my mind about how we should treat this error: it is always safe to retry, maybe sometimes it is not worthwhile, but for the particular case of GCS it would be extremely rare to have a permanent problem with the SSL session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3077)
<!-- Reviewable:end -->
