### PR TITLE
bug: fix Debian install build

### DIFF
--- a/ci/kokoro/install/Dockerfile.debian
+++ b/ci/kokoro/install/Dockerfile.debian
@@ -37,8 +37,6 @@ RUN apt update && \
         pkg-config tar wget zlib1g-dev
 # ```
 
-FROM devtools AS install
-
 # #### crc32c
 
 # There is no Debian package for this library. To install it use:


### PR DESCRIPTION
The `install` stage was duplicated in the Dockerfile, resulting in
incomplete builds (and bad caching). I looked at other files
looking for similar errors.

I caught this working on #3174, but it is otherwise unrelated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3175)
<!-- Reviewable:end -->
