### PR TITLE
feat: implement install components.

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -264,8 +264,21 @@ install(EXPORT google_cloud_cpp_common-targets
 install(TARGETS google_cloud_cpp_common google_cloud_cpp_common_options
         EXPORT google_cloud_cpp_common-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                COMPONENT google_cloud_cpp_spanner_runtime
+        NAMELINK_SKIP
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
+install(TARGETS google_cloud_cpp_common google_cloud_cpp_common_options
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development
+                NAMELINK_ONLY
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+
 google_cloud_cpp_install_headers(google_cloud_cpp_common include/google/cloud)
 
 # Setup global variables used in the following *.in files.

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -266,7 +266,7 @@ install(TARGETS google_cloud_cpp_common google_cloud_cpp_common_options
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_runtime
+                COMPONENT google_cloud_cpp_runtime
         NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_development)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -369,7 +369,7 @@ install(TARGETS bigtable_protos bigtable_common_options
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_runtime
+                COMPONENT google_cloud_cpp_runtime
         NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_development)
@@ -391,7 +391,7 @@ install(TARGETS bigtable_client
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_runtime
+                COMPONENT google_cloud_cpp_runtime
         NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_development)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -367,8 +367,20 @@ endif (GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
 install(TARGETS bigtable_protos bigtable_common_options
         EXPORT bigtable-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                COMPONENT google_cloud_cpp_spanner_runtime
+        NAMELINK_SKIP
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
+install(TARGETS bigtable_protos bigtable_common_options
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development
+                NAMELINK_ONLY
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
 
 # Export the CMake targets to make it easy to create configuration files.
 install(EXPORT bigtable-targets
@@ -377,8 +389,21 @@ install(EXPORT bigtable-targets
 install(TARGETS bigtable_client
         EXPORT bigtable-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                COMPONENT google_cloud_cpp_spanner_runtime
+        NAMELINK_SKIP
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
+install(TARGETS bigtable_client
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development
+                NAMELINK_ONLY
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+
 google_cloud_cpp_install_headers(bigtable_client include/google/cloud/bigtable)
 
 # Setup global variables used in the following *.in files.

--- a/google/cloud/grpc_utils/CMakeLists.txt
+++ b/google/cloud/grpc_utils/CMakeLists.txt
@@ -174,7 +174,7 @@ install(TARGETS google_cloud_cpp_grpc_utils
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_runtime
+                COMPONENT google_cloud_cpp_runtime
         NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_development)

--- a/google/cloud/grpc_utils/CMakeLists.txt
+++ b/google/cloud/grpc_utils/CMakeLists.txt
@@ -172,8 +172,21 @@ install(EXPORT grpc_utils-targets
 install(TARGETS google_cloud_cpp_grpc_utils
         EXPORT grpc_utils-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                COMPONENT google_cloud_cpp_spanner_runtime
+        NAMELINK_SKIP
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
+install(TARGETS google_cloud_cpp_grpc_utils
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development
+                NAMELINK_ONLY
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+
 google_cloud_cpp_install_headers(google_cloud_cpp_grpc_utils
                                  include/google/cloud/grpc_utils)
 

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -444,7 +444,7 @@ install(TARGETS storage_client
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_runtime
+                COMPONENT google_cloud_cpp_runtime
         NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_development)

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -442,8 +442,21 @@ install(EXPORT storage-targets
 install(TARGETS storage_client
         EXPORT storage-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                COMPONENT google_cloud_cpp_spanner_runtime
+        NAMELINK_SKIP
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
+install(TARGETS storage_client
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development
+                NAMELINK_ONLY
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_development)
+
 google_cloud_cpp_install_headers(storage_client include/google/cloud/storage)
 install(
     FILES

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -78,8 +78,21 @@ if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL)
     install(TARGETS google_cloud_cpp_testing
             EXPORT google_cloud_cpp_testing-targets
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                    COMPONENT google_cloud_cpp_runtime
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                    COMPONENT google_cloud_cpp_spanner_runtime
+            NAMELINK_SKIP
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    COMPONENT google_cloud_cpp_development)
+    # With CMake-3.12 and higher we could avoid this separate command (and the
+    # duplication).
+    install(TARGETS google_cloud_cpp_testing
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    COMPONENT google_cloud_cpp_development
+                    NAMELINK_ONLY
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                    COMPONENT google_cloud_cpp_development)
+
     google_cloud_cpp_install_headers(google_cloud_cpp_testing
                                      include/google/cloud/testing_util)
 

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -80,7 +80,7 @@ if (BUILD_TESTING OR GOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL)
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                     COMPONENT google_cloud_cpp_runtime
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                    COMPONENT google_cloud_cpp_spanner_runtime
+                    COMPONENT google_cloud_cpp_runtime
             NAMELINK_SKIP
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                     COMPONENT google_cloud_cpp_development)


### PR DESCRIPTION
Package maintainers may want to have different components for runtime
support (typically just the .so and/or .DLL/.LIB) vs. developers
(typically all the headers and .a files).

This fixes #3064.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3178)
<!-- Reviewable:end -->
