### PR TITLE
chore: Update example PR for version number bump.

### DIFF
--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -134,7 +134,7 @@ the instructions above. You may now remove this directory.
 Working in your fork of `gooogle-cloud-cpp`: bump the version numbers to the
 *next* version (i.e., one version past the release you just did above), and
 send the PR for review against `master`. For an example, look at
-[#1962](https://github.com/googleapis/google-cloud-cpp/pull/1962)
+[#3182](https://github.com/googleapis/google-cloud-cpp/pull/3182)
 
 ## Review the branch protections
 


### PR DESCRIPTION
The existing example included files (*version.bzl) that no longer exist,
which I found a bit confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3189)
<!-- Reviewable:end -->
