### PR TITLE
bug: Pass along error message in Table::Apply retry loop 

### DIFF
--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -100,9 +100,7 @@ Status Table::Apply(SingleRowMutation mut) {
     // It is up to the policy to terminate this loop, it could run
     // forever, but that would be a bad policy (pun intended).
     if (!rpc_policy->OnFailure(status) || !is_idempotent) {
-      return grpc_utils::MakeStatusFromRpcError(
-          status.error_code(),
-          "Permanent (or too many transient) errors in Table::Apply()");
+      return grpc_utils::MakeStatusFromRpcError(status);
     }
     auto delay = backoff_policy->OnCompletion(status);
     std::this_thread::sleep_for(delay);


### PR DESCRIPTION
We just need to keep the error message from the status.

Addresses bug #3191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3208)
<!-- Reviewable:end -->
