### PR TITLE
bug: use separate policy instances for each UploadChunk request

### DIFF
--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -87,15 +87,17 @@ RetryResumableUploadSession::UploadGenericChunk(
         // If it's a final chunk and it was sent successfully, return.
         return result;
       }
-      if (next_expected_byte() - next_byte == buffer_to_use->size()) {
+      auto current_next_expected_byte = next_expected_byte();
+      if (current_next_expected_byte - next_byte == buffer_to_use->size()) {
         // Otherwise, return only if there were no failures and it wasn't a
         // short write.
         return result;
       }
       std::stringstream os;
       os << "Short write. Previous next_byte=" << next_byte
-         << ", current next_byte=" << next_expected_byte()
-         << ", inteded to write " << buffer_to_use->size();
+         << ", current next_byte=" << current_next_expected_byte
+         << ", intended to write=" << buffer_to_use->size()
+         << ", wrote=" << current_next_expected_byte - next_byte;
       last_status = Status(StatusCode::kUnavailable, os.str());
       // Don't reset the session on a short write nor wait according to the
       // backoff policy - we did get a response from the server after all.

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -61,7 +61,9 @@ RetryResumableUploadSession::UploadGenericChunk(
   // TODO(#3036): change the APIs to avoid this extra copy.
   std::string const* buffer_to_use = &buffer;
   std::string truncated_buffer;
-  while (!retry_policy_->IsExhausted()) {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  while (!retry_policy->IsExhausted()) {
     std::uint64_t new_next_byte = session_->next_expected_byte();
     if (new_next_byte < next_byte) {
       std::stringstream os;
@@ -82,7 +84,7 @@ RetryResumableUploadSession::UploadGenericChunk(
     if (result.ok()) {
       if (is_final_chunk &&
           result->upload_state == ResumableUploadResponse::kDone) {
-        // If it's a final chunk and it succeded, return.
+        // If it's a final chunk and it was sent successfully, return.
         return result;
       }
       if (next_expected_byte() - next_byte == buffer_to_use->size()) {
@@ -100,13 +102,13 @@ RetryResumableUploadSession::UploadGenericChunk(
       continue;
     }
     last_status = std::move(result).status();
-    if (!retry_policy_->OnFailure(last_status)) {
-      return ReturnError(std::move(last_status), *retry_policy_, __func__);
+    if (!retry_policy->OnFailure(last_status)) {
+      return ReturnError(std::move(last_status), *retry_policy, __func__);
     }
-    auto delay = backoff_policy_->OnCompletion();
+    auto delay = backoff_policy->OnCompletion();
     std::this_thread::sleep_for(delay);
 
-    result = ResetSession();
+    result = ResetSession(*retry_policy, *backoff_policy);
     if (!result.ok()) {
       return result;
     }
@@ -116,24 +118,31 @@ RetryResumableUploadSession::UploadGenericChunk(
   return Status(last_status.code(), os.str());
 }
 
-StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {
+StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession(
+    RetryPolicy& retry_policy, BackoffPolicy& backoff_policy) {
   Status last_status(StatusCode::kDeadlineExceeded,
                      "Retry policy exhausted before first attempt was made.");
-  while (!retry_policy_->IsExhausted()) {
+  while (!retry_policy.IsExhausted()) {
     auto result = session_->ResetSession();
     if (result.ok()) {
       return result;
     }
     last_status = std::move(result).status();
-    if (!retry_policy_->OnFailure(last_status)) {
-      return ReturnError(std::move(last_status), *retry_policy_, __func__);
+    if (!retry_policy.OnFailure(last_status)) {
+      return ReturnError(std::move(last_status), retry_policy, __func__);
     }
-    auto delay = backoff_policy_->OnCompletion();
+    auto delay = backoff_policy.OnCompletion();
     std::this_thread::sleep_for(delay);
   }
   std::ostringstream os;
   os << "Retry policy exhausted in " << __func__ << ": " << last_status;
   return Status(last_status.code(), os.str());
+}
+
+StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {
+  auto retry_policy = retry_policy_->clone();
+  auto backoff_policy = backoff_policy_->clone();
+  return ResetSession(*retry_policy, *backoff_policy);
 }
 
 std::uint64_t RetryResumableUploadSession::next_expected_byte() const {

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -55,6 +55,11 @@ class RetryResumableUploadSession : public ResumableUploadSession {
   // Retry either UploadChunk or either UploadFinalChunk.
   StatusOr<ResumableUploadResponse> UploadGenericChunk(
       std::string const& buffer, optional<std::uint64_t> const& upload_size);
+
+  // Reset the current session using previously cloned policies.
+  StatusOr<ResumableUploadResponse> ResetSession(RetryPolicy& retry_policy,
+                                                 BackoffPolicy& backoff_policy);
+
   std::unique_ptr<ResumableUploadSession> session_;
   std::unique_ptr<RetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -1017,8 +1017,7 @@ TEST_F(RetryResumableUploadSessionTest, ShortWriteRetryExhausted) {
         return StatusOr<ResumableUploadResponse>(TransientError());
       }));
 
-  EXPECT_CALL(*mock, ResetSession())
-  .WillRepeatedly(Invoke([&]() {
+  EXPECT_CALL(*mock, ResetSession()).WillRepeatedly(Invoke([&]() {
     return make_status_or(ResumableUploadResponse{
         "", neb - 1, {}, ResumableUploadResponse::kInProgress});
   }));
@@ -1070,11 +1069,10 @@ TEST_F(RetryResumableUploadSessionTest, ShortWriteRetrySucceeds) {
             "", neb - 1, {}, ResumableUploadResponse::kInProgress});
       }));
 
-  EXPECT_CALL(*mock, ResetSession())
-      .WillRepeatedly(Invoke([&]() {
-        return make_status_or(ResumableUploadResponse{
-            "", neb - 1, {}, ResumableUploadResponse::kInProgress});
-      }));
+  EXPECT_CALL(*mock, ResetSession()).WillRepeatedly(Invoke([&]() {
+    return make_status_or(ResumableUploadResponse{
+        "", neb - 1, {}, ResumableUploadResponse::kInProgress});
+  }));
 
   RetryResumableUploadSession session(std::move(mock),
                                       LimitedErrorCountRetryPolicy(10).clone(),

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -30,6 +30,7 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
@@ -359,36 +360,14 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnReset) {
   // 2. next_expected_byte() -> returns 0
   // 3. UploadChunk() -> returns transient error
   // 4. ResetSession() -> returns transient error
-  // 5. ResetSession() -> returns success (0 bytes committed)
-  // 6. next_expected_byte() -> returns 0
-  // RetryResumableUploadSession::UploadChunk() is called
-  // 7. UploadChunk() -> returns success (quantum bytes committed)
-  // 8. next_expected_byte() -> returns quantum
-  // RetryResumableUploadSession::UploadChunk() is called
-  // 9. next_expected_byte() -> returns quantum
-  // 10. next_expected_byte() -> returns quantum
-  // 11. UploadChunk() -> returns transient error, the policy is exhausted.
+  // 5. ResetSession() -> returns transient error, the policy is exhausted
   //
-  EXPECT_CALL(*mock, UploadChunk(_))
-      .WillOnce(Invoke([&](std::string const& p) {
-        ++count;
-        EXPECT_EQ(3, count);
-        EXPECT_EQ(payload, p);
-        return StatusOr<ResumableUploadResponse>(TransientError());
-      }))
-      .WillOnce(Invoke([&](std::string const& p) {
-        ++count;
-        EXPECT_EQ(7, count);
-        EXPECT_EQ(payload, p);
-        return make_status_or(ResumableUploadResponse{
-            "", quantum - 1, {}, ResumableUploadResponse::kInProgress});
-      }))
-      .WillOnce(Invoke([&](std::string const& p) {
-        ++count;
-        EXPECT_EQ(11, count);
-        EXPECT_EQ(payload, p);
-        return StatusOr<ResumableUploadResponse>(TransientError());
-      }));
+  EXPECT_CALL(*mock, UploadChunk(_)).WillOnce(Invoke([&](std::string const& p) {
+    ++count;
+    EXPECT_EQ(3, count);
+    EXPECT_EQ(payload, p);
+    return StatusOr<ResumableUploadResponse>(TransientError());
+  }));
 
   EXPECT_CALL(*mock, ResetSession())
       .WillOnce(Invoke([&]() {
@@ -399,8 +378,7 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnReset) {
       .WillOnce(Invoke([&]() {
         ++count;
         EXPECT_EQ(5, count);
-        return make_status_or(ResumableUploadResponse{
-            "", 0, {}, ResumableUploadResponse::kInProgress});
+        return StatusOr<ResumableUploadResponse>(TransientError());
       }));
 
   EXPECT_CALL(*mock, next_expected_byte())
@@ -411,36 +389,150 @@ TEST_F(RetryResumableUploadSessionTest, TooManyTransientOnReset) {
       .WillOnce(Invoke([&]() {
         EXPECT_EQ(2, ++count);
         return 0;
-      }))
-      .WillOnce(Invoke([&]() {
-        EXPECT_EQ(6, ++count);
-        return 0;
-      }))
-      .WillOnce(Invoke([&]() {
-        EXPECT_EQ(8, ++count);
-        return quantum;
-      }))
-      .WillOnce(Invoke([&]() {
-        EXPECT_EQ(9, ++count);
-        return quantum;
-      }))
-      .WillOnce(Invoke([&]() {
-        EXPECT_EQ(10, ++count);
-        return quantum;
       }));
 
-  // We only tolerate 4 transient errors, the first call to UploadChunk() will
-  // consume the full budget.
+  // We only tolerate 2 transient errors, the third causes a permanent failure.
+  // As described above, the first call to UploadChunk() will consume the full
+  // budget.
   RetryResumableUploadSession session(
       std::move(mock), LimitedErrorCountRetryPolicy(2).clone(),
       ExponentialBackoffPolicy(10_ms, 160_ms, 2).clone());
 
   StatusOr<ResumableUploadResponse> response = session.UploadChunk(payload);
+  EXPECT_FALSE(response.ok());
+}
+
+/// @test Verify that transients (or elapsed time) from different chunks do not
+/// accumulate.
+TEST_F(RetryResumableUploadSessionTest, HandleTransiensOnSeparateChunks) {
+  auto mock = google::cloud::internal::make_unique<
+      testing::MockResumableUploadSession>();
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(quantum, '0');
+
+  // Keep track of the sequence of calls.
+  int count = 0;
+  std::uint64_t next_expected_byte = 0;
+
+  // In this test we do not care about how many times or when next
+  // expected_byte() is called, but it does need to return the right values,
+  // the other mock functions set the correct return value using a local
+  // variable.
+  EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly(Invoke([&]() {
+    return next_expected_byte;
+  }));
+
+  // The sequence of messages is split across two EXPECT_CALL() and hard to see,
+  // basically we want this to happen:
+  //
+  // Ignore next_expected_byte() in tests - it will always return 0.
+  // 1. UploadChunk() -> returns transient error
+  // 2. ResetSession() -> returns success (0 bytes committed)
+  // 3. UploadChunk() -> returns success
+  // 4. UploadChunk() -> returns transient error
+  // 5. ResetSession() -> returns success (0 bytes committed)
+  // 6. UploadChunk() -> returns success
+  // 7. UploadChunk() -> returns transient error
+  // 8. ResetSession() -> returns success (0 bytes committed)
+  // 9. UploadChunk() -> returns success
+  //
+  EXPECT_CALL(*mock, UploadChunk(_))
+      .WillOnce(Invoke([&](std::string const& p) {
+        ++count;
+        EXPECT_EQ(1, count);
+        EXPECT_EQ(payload, p);
+        return StatusOr<ResumableUploadResponse>(TransientError());
+      }))
+      .WillOnce(Invoke([&](std::string const& p) {
+        ++count;
+        EXPECT_EQ(3, count);
+        EXPECT_EQ(payload, p);
+        next_expected_byte = quantum;
+        return make_status_or(
+            ResumableUploadResponse{"",
+                                    next_expected_byte - 1,
+                                    {},
+                                    ResumableUploadResponse::kInProgress});
+      }))
+      .WillOnce(Invoke([&](std::string const& p) {
+        ++count;
+        EXPECT_EQ(4, count);
+        EXPECT_EQ(payload, p);
+        return StatusOr<ResumableUploadResponse>(TransientError());
+      }))
+      .WillOnce(Invoke([&](std::string const& p) {
+        ++count;
+        EXPECT_EQ(6, count);
+        EXPECT_EQ(payload, p);
+        next_expected_byte = 2 * quantum;
+        return make_status_or(
+            ResumableUploadResponse{"",
+                                    next_expected_byte - 1,
+                                    {},
+                                    ResumableUploadResponse::kInProgress});
+      }))
+      .WillOnce(Invoke([&](std::string const& p) {
+        ++count;
+        EXPECT_EQ(7, count);
+        EXPECT_EQ(payload, p);
+        return StatusOr<ResumableUploadResponse>(TransientError());
+      }))
+      .WillOnce(Invoke([&](std::string const& p) {
+        ++count;
+        EXPECT_EQ(9, count);
+        EXPECT_EQ(payload, p);
+        next_expected_byte = 3 * quantum;
+        return make_status_or(
+            ResumableUploadResponse{"",
+                                    next_expected_byte - 1,
+                                    {},
+                                    ResumableUploadResponse::kInProgress});
+      }));
+
+  EXPECT_CALL(*mock, ResetSession())
+      .WillOnce(Invoke([&]() {
+        ++count;
+        EXPECT_EQ(2, count);
+        return make_status_or(ResumableUploadResponse{
+            "", 0, {}, ResumableUploadResponse::kInProgress});
+      }))
+      .WillOnce(Invoke([&]() {
+        ++count;
+        EXPECT_EQ(5, count);
+        return make_status_or(
+            ResumableUploadResponse{"",
+                                    next_expected_byte - 1,
+                                    {},
+                                    ResumableUploadResponse::kInProgress});
+      }))
+      .WillOnce(Invoke([&]() {
+        ++count;
+        EXPECT_EQ(8, count);
+        return make_status_or(
+            ResumableUploadResponse{"",
+                                    next_expected_byte - 1,
+                                    {},
+                                    ResumableUploadResponse::kInProgress});
+      }));
+
+  // Configure a session that tolerates 2 transient errors per call. None of
+  // the calls to UploadChunk() should use more than these.
+  RetryResumableUploadSession session(
+      std::move(mock), LimitedErrorCountRetryPolicy(2).clone(),
+      ExponentialBackoffPolicy(1_us, 2_us, 2).clone());
+
+  StatusOr<ResumableUploadResponse> response = session.UploadChunk(payload);
   EXPECT_STATUS_OK(response);
-  EXPECT_EQ(quantum - 1, response->last_committed_byte);
+  EXPECT_EQ(response->last_committed_byte, quantum - 1);
 
   response = session.UploadChunk(payload);
-  EXPECT_FALSE(response.ok());
+  EXPECT_STATUS_OK(response);
+  EXPECT_EQ(response->last_committed_byte, 2 * quantum - 1);
+
+  response = session.UploadChunk(payload);
+  EXPECT_STATUS_OK(response);
+  EXPECT_EQ(response->last_committed_byte, 3 * quantum - 1);
 }
 
 /// @test Verify that a permanent error on UploadFinalChunk results in a

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -34,6 +34,12 @@ class StorageIntegrationTest : public ::testing::Test {
   google::cloud::StatusOr<google::cloud::storage::Client>
   MakeIntegrationTestClient();
 
+  google::cloud::StatusOr<google::cloud::storage::Client>
+  MakeIntegrationTestClient(std::unique_ptr<RetryPolicy> retry_policy);
+
+  std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
+  std::unique_ptr<RetryPolicy> TestRetryPolicy();
+
   std::string MakeRandomObjectName();
 
   std::string LoremIpsum() const;


### PR DESCRIPTION
Sharing the retry policy through the lifetime of an upload is a bad idea.
Long lived uploads just fail because they started a long time ago, even
if there have been no errors. We need to use a new instance of the
retry policy for each `UploadChunk()` call, but share them with the
`ResetSession()` calls because these are part of the same logical
operation.

Fixes #3212.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3213)
<!-- Reviewable:end -->
