### PR TITLE
chore: upgrade most builds to gRPC-1.24.3

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -76,12 +76,12 @@ def google_cloud_cpp_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.23.0",
+            strip_prefix = "grpc-1.24.3",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.23.0.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.23.0.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.24.3.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.24.3.tar.gz",
             ],
-            sha256 = "f56ced18740895b943418fa29575a65cc2396ccfa3159fa40d318ef5f59471f9",
+            sha256 = "c84b3fa140fcd6cce79b3f9de6357c5733a0071e04ca4e65ba5f8d306f10f033",
         )
 
     # We need libcurl for the Google Cloud Storage client.

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -95,9 +95,9 @@ RUN ldconfig
 # - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
 #   as the dependent (gRPC or google-cloud-cpp) works.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-RUN tar -xf v3.6.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.6.1/cmake
+RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz
+RUN tar -xf v3.9.1.tar.gz
+WORKDIR /var/tmp/build/protobuf-3.9.1/cmake
 RUN for build_type in "Debug" "Release"; do \
     cmake \
         -DCMAKE_BUILD_TYPE="${build_type}" \
@@ -130,10 +130,10 @@ RUN ldconfig
 # Install gRPC. Note that we use the system's zlib and ssl libraries.
 # For similar reasons to c-ares (see above), we need two install steps.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-RUN tar -xf v1.19.1.tar.gz
+RUN wget -q https://github.com/grpc/grpc/archive/v1.24.3.tar.gz
+RUN tar -xf v1.24.3.tar.gz
 RUN ls -l
-WORKDIR /var/tmp/build/grpc-1.19.1
+WORKDIR /var/tmp/build/grpc-1.24.3
 RUN ls -l
 RUN cmake \
       -DCMAKE_BUILD_TYPE="Release" \

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -1069,6 +1069,12 @@ StatusOr<google::cloud::IamPolicy> InstanceAdmin::ProtoToWrapper(
   result.etag = std::move(*proto.mutable_etag());
   for (auto& binding : *proto.mutable_bindings()) {
     std::vector<google::protobuf::FieldDescriptor const*> field_descs;
+    // On newer versions of Protobuf (circa 3.9.1) `GetReflection()` changed
+    // from a virtual member function to a static member function. clang-tidy
+    // warns (and we turn all warnings to errors) about using the static
+    // version via the object, as we do below. Disable the warning because that
+    // seems like the only portable solution.
+    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
     binding.GetReflection()->ListFields(binding, &field_descs);
     for (auto field_desc : field_descs) {
       if (field_desc->name() != "members" && field_desc->name() != "role") {

--- a/super/external/grpc.cmake
+++ b/super/external/grpc.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET grpc_project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.21.0.tar.gz")
+        "https://github.com/grpc/grpc/archive/v1.24.3.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "8da7f32cc8978010d2060d740362748441b81a34e5425e108596d3fcd63a97f2")
+        "c84b3fa140fcd6cce79b3f9de6357c5733a0071e04ca4e65ba5f8d306f10f033")
 
     set_external_project_build_parallel_level(PARALLEL)
 


### PR DESCRIPTION
Upgrade the Bazel and CMake super builds to gRPC-1.24.3. Did not update
all the builds because that requires more changes (upgrading Protobuf
for example). This fixes the build problems on openSUSE/Tumbleweed.

I had to make a code change because, depending on the Protobuf version,
the `GetReflection()` function generated in a proto may be static or
not. clang-tidy generates a warning when the function is static and we
use it as a non-static member function. The code does not compile when
used as a static member function.

Note that the openSUSE/Tumbleweed PR builds are disabled, but I ran
it manually and it worked.

Fixes #3214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3217)
<!-- Reviewable:end -->
