### PR TITLE
chore: speed up packaging builds

### DIFF
--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -71,24 +71,6 @@ RUN cmake \
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 WORKDIR /var/tmp/build
@@ -99,7 +81,7 @@ WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
 # libraries
 RUN cmake -H. -Bcmake-out \
     -DBUILD_TESTING=OFF \
-    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=OFF
 RUN cmake --build cmake-out -- -j $(nproc)
 RUN cmake --build cmake-out --target install
 RUN ldconfig

--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -71,6 +71,39 @@ RUN cmake \
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
 
+# #### googletest
+
+# We need a recent version of GoogleTest to compile the unit and integration
+# tests.
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+RUN tar -xf release-1.10.0.tar.gz
+WORKDIR /var/tmp/build/googletest-release-1.10.0
+RUN cmake \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=yes \
+      -H. -Bcmake-out
+RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
+RUN ldconfig
+# ```
+
+# #### google-cloud-cpp-common
+
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz
+RUN tar -xf v0.13.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
+# Compile without the tests because we are testing google-cloud-cpp, not the base
+# libraries
+RUN cmake -H. -Bcmake-out \
+    -DBUILD_TESTING=OFF \
+    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+RUN cmake --build cmake-out -- -j $(nproc)
+RUN cmake --build cmake-out --target install
+RUN ldconfig
+
 # Get the source code
 
 FROM google-cloud-cpp-dependencies AS google-cloud-cpp-build

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -17,7 +17,6 @@
 find_package(googleapis)
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
 find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
-find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
 # This should be included from the top level CMakeLists file
 set(BIGTABLE_CLIENT_VERSION_MAJOR 1)
@@ -206,6 +205,8 @@ create_bazel_config(bigtable_client)
 google_cloud_cpp_add_clang_tidy(bigtable_client)
 
 if (BUILD_TESTING)
+    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
     add_library(
         bigtable_client_testing
         testing/embedded_server_test_fixture.h

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -15,7 +15,6 @@
 # ~~~
 
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
-find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
 # This should be included from the top level CMakeLists file
 set(FIRESTORE_CLIENT_VERSION_MAJOR 0)
@@ -78,6 +77,8 @@ create_bazel_config(firestore_client)
 google_cloud_cpp_add_clang_tidy(firestore_client)
 
 if (BUILD_TESTING)
+    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
     # List the unit tests, then setup the targets and dependencies.
     set(firestore_client_unit_tests field_path_test.cc)
 

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -15,7 +15,6 @@
 # ~~~
 
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
-find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
 # This should be included from the top level CMakeLists file
 set(STORAGE_CLIENT_VERSION_MAJOR 1)
@@ -279,6 +278,8 @@ create_bazel_config(storage_client)
 google_cloud_cpp_add_clang_tidy(storage_client)
 
 if (BUILD_TESTING)
+    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
     add_library(
         storage_client_testing
         testing/canonical_errors.h


### PR DESCRIPTION
The builds always required google test and the testing library
from `google-cloud-cpp-common`, even when the tests were
disabled. I noticed this while fixing the benchmarks Dockerfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3220)
<!-- Reviewable:end -->
