### PR TITLE
feat: implement tuple filtering

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -171,6 +171,7 @@ add_library(
     internal/sign_blob_requests.cc
     internal/signed_url_requests.h
     internal/signed_url_requests.cc
+    internal/tuple_filter.h
     lifecycle_rule.h
     lifecycle_rule.cc
     list_buckets_reader.h
@@ -363,6 +364,7 @@ if (BUILD_TESTING)
         internal/sha256_hash_test.cc
         internal/sign_blob_requests_test.cc
         internal/signed_url_requests_test.cc
+        internal/tuple_filter_test.cc
         lifecycle_rule_test.cc
         list_buckets_reader_test.cc
         list_hmac_keys_reader_test.cc

--- a/google/cloud/storage/internal/tuple_filter.h
+++ b/google/cloud/storage/internal/tuple_filter.h
@@ -43,8 +43,8 @@ struct TupleTypePrepend<std::tuple<Args...>, T> {
 /**
  * A helper class to filter a single element from a tuple.
  *
- * Depending on whether to filter the element of not, appropriate tuple type is
- * generate and a "filtering" member function, which either returns an empty
+ * Depending on whether to filter the element or not, appropriate tuple type is
+ * generated and a "filtering" member function, which either returns an empty
  * tuple or a tuple containing the argument.
  *
  * @tparam T of the filtered element

--- a/google/cloud/storage/internal/tuple_filter.h
+++ b/google/cloud/storage/internal/tuple_filter.h
@@ -1,0 +1,146 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_TUPLE_FILTER_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_TUPLE_FILTER_H_
+
+#include "google/cloud/internal/disjunction.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/tuple.h"
+#include "google/cloud/internal/utility.h"
+#include "google/cloud/storage/version.h"
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+/**
+ * A helper class to filter a single element from a tuple.
+ *
+ * Depending on whether to filter the element of not, appropriate tuple type is
+ * generate and a "filtering" member function, which either returns an empty
+ * tuple or a tuple containing the argument.
+ *
+ * @tparam T of the filtered element
+ * @tparam Filter whether to filter the element.
+ */
+template <typename T, bool Filter>
+struct TupleFilterItem {};
+
+/**
+ * Implementation of TupleFilterItem - true branch.
+ */
+template <typename T>
+struct TupleFilterItem<T, true> {
+  using Result = std::tuple<T>;
+  Result operator()(T&& t) const { return Result(std::forward<T>(t)); }
+};
+
+/**
+ * Implementation of TupleFilterItem - false branch.
+ */
+template <typename T>
+struct TupleFilterItem<T, false> {
+  using Result = std::tuple<>;
+  Result operator()(T&&) const { return Result(); }
+};
+
+/**
+ * A helper to compute the return type of `StaticTupleFilter`.
+ *
+ * @tparam TPred a type predicate telling if an element stays or is filtered out
+ * @tparam Tuple the type of the tuple to filter elements from
+ */
+template <template <class> class TPred, typename Tuple>
+struct FilteredTupleReturnType {};
+
+/**
+ * Implementation of FilteredTupleReturnType - recursive case.
+ *
+ * @tparam TPred a type predicate telling if an element stays or is filtered out
+ * @tparam Head the type of the first tuple's element
+ * @tparam Tail the remaining types tuple's elements
+ */
+template <template <class> class TPred, typename Head, typename... Tail>
+struct FilteredTupleReturnType<TPred, std::tuple<Head, Tail...>> {
+  using Result = typename std::conditional<
+      TPred<Head>::value,
+      typename google::cloud::internal::invoke_result<
+          decltype(std::tuple_cat<std::tuple<Head>,
+                                  typename FilteredTupleReturnType<
+                                      TPred, std::tuple<Tail...>>::Result>),
+          std::tuple<Head>,
+          typename FilteredTupleReturnType<TPred,
+                                           std::tuple<Tail...>>::Result>::type,
+      typename FilteredTupleReturnType<TPred,
+                                       std::tuple<Tail...>>::Result>::type;
+};
+
+/**
+ * Implementation of FilteredTupleReturnType - recursion end / empty tuple.
+ *
+ * @tparam TPred a type predicate telling if an element stays or is filtered out
+ */
+template <template <class> class TPred>
+struct FilteredTupleReturnType<TPred, std::tuple<>> {
+  using Result = std::tuple<>;
+};
+
+/**
+ * Filter elements from a tuple based on their type.
+ *
+ * A new tuple is returned with only the elements whose type satisfied the
+ * provided type predicate.
+ *
+ * @tparam TPred a type predicate telling if an element stays or is filtered out
+ * @tparam Args the type of the tuple's elements
+ *
+ * @param tuple the tuple to filter elements from
+ */
+template <template <class> class TPred, typename... Args>
+typename FilteredTupleReturnType<TPred, std::tuple<Args...>>::Result
+StaticTupleFilter(std::tuple<Args...> t) {
+  return std::tuple_cat(google::cloud::internal::apply(
+      [](Args&&... args) {
+        return std::tuple_cat(TupleFilterItem<Args, TPred<Args>::value>()(
+            std::forward<Args>(args))...);
+      },
+      std::forward<std::tuple<Args...>>(t)));
+}
+
+/**
+ * A factory of template predicates checking for lack of presence on a type list
+ *
+ * @tparam Types the list of types which for which the predicate returns false.
+ */
+template <typename... Types>
+struct NotAmong {
+  template <typename T>
+  using TPred = std::integral_constant<
+      bool, !google::cloud::internal::disjunction<
+                std::is_same<typename std::decay<T>::type, Types>...>::value>;
+};
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_TUPLE_FILTER_H_

--- a/google/cloud/storage/internal/tuple_filter_test.cc
+++ b/google/cloud/storage/internal/tuple_filter_test.cc
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/tuple_filter.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+TEST(TupleFilter, EmptyTuple) {
+  auto res = StaticTupleFilter<std::is_integral>(std::tuple<>());
+  static_assert(std::tuple_size<decltype(res)>::value == 0, "");
+}
+
+TEST(TupleFilter, FullMatch) {
+  auto res = StaticTupleFilter<std::is_integral>(
+      std::tuple<int, short, long>(1, 2, 3));
+  static_assert(std::tuple_size<decltype(res)>::value == 3, "");
+  auto i1 = std::get<0>(res);
+  auto i2 = std::get<1>(res);
+  auto i3 = std::get<2>(res);
+  static_assert(std::is_same<decltype(i1), int>::value, "");
+  static_assert(std::is_same<decltype(i2), short>::value, "");
+  static_assert(std::is_same<decltype(i3), long>::value, "");
+  EXPECT_EQ(1, std::get<0>(res));
+  EXPECT_EQ(2, std::get<1>(res));
+  EXPECT_EQ(3, std::get<2>(res));
+}
+
+TEST(TupleFilter, NoMatch) {
+  auto res =
+      StaticTupleFilter<std::is_pointer>(std::tuple<int, short, long>(1, 2, 3));
+  static_assert(std::tuple_size<decltype(res)>::value == 0, "");
+}
+
+TEST(TupleFilter, Selective) {
+  auto res = StaticTupleFilter<NotAmong<long, short>::TPred>(
+      std::tuple<int, std::string, short>(5, "asd", 7));
+  static_assert(std::tuple_size<decltype(res)>::value == 2, "");
+  auto i1 = std::get<0>(res);
+  auto i2 = std::get<1>(res);
+  static_assert(std::is_same<decltype(i1), int>::value, "");
+  static_assert(std::is_same<decltype(i2), std::string>::value, "");
+  EXPECT_EQ(5, std::get<0>(res));
+  EXPECT_EQ("asd", std::get<1>(res));
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/tuple_filter_test.cc
+++ b/google/cloud/storage/internal/tuple_filter_test.cc
@@ -82,6 +82,19 @@ TEST(TupleFilter, ByReference) {
   EXPECT_EQ(42, *res);
 }
 
+// Test that forwarding references works.
+TEST(TupleFilter, TupleByReference) {
+  std::unique_ptr<int> iptr = google::cloud::internal::make_unique<int>(42);
+  auto t = std::tie(iptr);
+  // This wouldn't work because get<0> returns a std::unique_ptr<int>&:
+  // auto res = std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(
+  //     std::tie(iptr)));
+  auto& res = std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(t));
+  // res is only an alias to iptr
+  EXPECT_EQ(&res, &iptr);
+  EXPECT_EQ(42, *res);
+}
+
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -74,6 +74,7 @@ storage_client_hdrs = [
     "internal/sha256_hash.h",
     "internal/sign_blob_requests.h",
     "internal/signed_url_requests.h",
+    "internal/tuple_filter.h",
     "lifecycle_rule.h",
     "list_buckets_reader.h",
     "list_hmac_keys_reader.h",

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -73,6 +73,7 @@ storage_client_unit_tests = [
     "internal/sha256_hash_test.cc",
     "internal/sign_blob_requests_test.cc",
     "internal/signed_url_requests_test.cc",
+    "internal/tuple_filter_test.cc",
     "lifecycle_rule_test.cc",
     "list_buckets_reader_test.cc",
     "list_hmac_keys_reader_test.cc",


### PR DESCRIPTION
This is a part of #3016.

Composing GCS objects consists of multiple operations under the hood.
Different subsets of the options passed to the recursive compose
operation have to be passed on to the underlying operations.

By GCS C++ client convention, options are passed as parameter packs,
hence in the general case the filtering has to be done in compile time.

An easy way to filter these parameters is to pack them in a
std::tuple, filter it and apply it via std::apply.

The intended use is available at https://github.com/dopiera/google-cloud-cpp/commit/60fa4402bb317c56a6c8cea6e558119c7024bcb7 and https://github.com/dopiera/google-cloud-cpp/commit/bd75ad53f05cdbfd3f32557357b4e9bb3cc08b38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3221)
<!-- Reviewable:end -->
