### PR TITLE
doc: fix CentOS 7 build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -437,7 +437,7 @@ directories, there are multiple ways to solve this problem, the following
 steps are one solution:
 
 ```bash
-(echo "/usr/local/lib" ; "/usr/local/lib64") | \
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
 sudo tee /etc/ld.so.conf.d/usrlocal.conf
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -387,7 +387,7 @@ does not search for shared libraries in these directories by default, there
 are multiple ways to solve this problem, the following steps are one solution:
 
 ```bash
-(echo "/usr/local/lib" ; "/usr/local/lib64") | \
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
 sudo tee /etc/ld.so.conf.d/usrlocal.conf
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -382,6 +382,15 @@ sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
         libcurl-devel libopenssl-devel make tar wget
 ```
 
+The following steps will install libraries and tools in `/usr/local`. CentOS
+does not search for shared libraries in these directories by default, there
+are multiple ways to solve this problem, the following steps are one solution:
+
+```bash
+(echo "/usr/local/lib" ; "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
+```
+
 #### crc32c
 
 There is no openSUSE package for this library. To install it, use:
@@ -420,6 +429,16 @@ cmake \
         -H. -Bcmake-out
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
 sudo ldconfig
+```
+
+The following steps will install libraries and tools in `/usr/local`.
+By default openSUSE/Leap does not search for shared libraries in these
+directories, there are multiple ways to solve this problem, the following
+steps are one solution:
+
+```bash
+(echo "/usr/local/lib" ; "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
 ```
 
 #### c-ares
@@ -464,7 +483,6 @@ wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
 tar -xf v1.19.1.tar.gz
 cd $HOME/Downloads/grpc-1.19.1
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 export PATH=/usr/local/bin:${PATH}
 make -j ${NCPU:-4}
 sudo make install
@@ -519,7 +537,7 @@ libraries
 cmake -H. -Bcmake-out \
     -DBUILD_TESTING=OFF \
     -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-cmake --build cmake-out -- -j $(nproc)
+cmake --build cmake-out -- -j ${NCPU:-4}
 sudo cmake --build cmake-out --target install
 sudo ldconfig
 ```
@@ -1179,13 +1197,25 @@ distributed with CentOS (notably CMake) are too old to build
 [Software Collections](https://www.softwarecollections.org/).
 
 ```bash
-rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-sudo yum install -y centos-release-scl
+sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+sudo yum install -y centos-release-scl yum-utils
 sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
 sudo yum makecache && \
 sudo yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
-ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
+sudo ln -sf /usr/bin/cmake3 /usr/bin/cmake && sudo ln -sf /usr/bin/ctest3 /usr/bin/ctest
+```
+
+The following steps will install libraries and tools in `/usr/local`. By
+default CentOS-7 does not search for shared libraries in these directories,
+there are multiple ways to solve this problem, the following steps are one
+solution:
+
+```bash
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export PATH=/usr/local/bin:${PATH}
 ```
 
 #### crc32c
@@ -1194,17 +1224,17 @@ There is no CentOS package for this library. To install it use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
-tar -xf 1.0.6.tar.gz
-cd $HOME/Downloads/crc32c-1.0.6
-cmake \
+wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz && \
+    tar -xf 1.0.6.tar.gz && \
+    cd crc32c-1.0.6 && \
+    cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
       -DCRC32C_BUILD_TESTS=OFF \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out/crc32c
-sudo cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4}
+      -H. -Bcmake-out/crc32c && \
+sudo cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1214,15 +1244,15 @@ Likewise, manually install protobuf:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-tar -xf v3.6.1.tar.gz
-cd $HOME/Downloads/protobuf-3.6.1/cmake
-cmake \
+wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz && \
+    tar -xf v3.6.1.tar.gz && \
+    cd protobuf-3.6.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+        -H. -Bcmake-out && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1233,11 +1263,13 @@ distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-tar -xf cares-1_14_0.tar.gz
-cd $HOME/Downloads/c-ares-cares-1_14_0
-./buildconf && ./configure && make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && \
+    ./configure && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -1247,14 +1279,11 @@ Can be manually installed using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-tar -xf v1.19.1.tar.gz
-cd $HOME/Downloads/grpc-1.19.1
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-export PATH=/usr/local/bin:${PATH}
-make -j ${NCPU:-4}
-sudo make install
+wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz && \
+    tar -xf v1.19.1.tar.gz && \
+    cd grpc-1.19.1 && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
 sudo ldconfig
 ```
 
@@ -1264,13 +1293,14 @@ There is no CentOS package for this library. To install it, use:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-tar -xf v0.1.5.tar.gz
-cd $HOME/Downloads/cpp-cmakefiles-0.1.5
-cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake \
+      -DBUILD_SHARED_LIBS=YES \
+      -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1281,14 +1311,15 @@ tests.
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-tar -xf release-1.10.0.tar.gz
-cd $HOME/Downloads/googletest-release-1.10.0
-cmake \
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4}
+      -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -1298,16 +1329,14 @@ We need to install the Google Cloud C++ common libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.15.0.tar.gz
-tar -xf v0.15.0.tar.gz
-cd $HOME/Downloads/google-cloud-cpp-common-0.15.0
-Compile without the tests because we are testing google-cloud-cpp, not the base
-libraries
-cmake -H. -Bcmake-out \
-    -DBUILD_TESTING=OFF \
-    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.15.0.tar.gz && \
+    tar -xf v0.15.0.tar.gz && \
+    cd google-cloud-cpp-common-0.15.0 && \
+    cmake -H. -Bcmake-out \
+      -DBUILD_TESTING=OFF \
+      -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install && \
 sudo ldconfig
 ```
 

--- a/ci/kokoro/install/Dockerfile.centos
+++ b/ci/kokoro/install/Dockerfile.centos
@@ -28,12 +28,24 @@ ARG NCPU=4
 
 # ```bash
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum install -y centos-release-scl
+RUN yum install -y centos-release-scl yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
     yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
+# ```
+
+# The following steps will install libraries and tools in `/usr/local`. By
+# default CentOS-7 does not search for shared libraries in these directories,
+# there are multiple ways to solve this problem, the following steps are one
+# solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+ENV PATH=/usr/local/bin:${PATH}
 # ```
 
 # #### crc32c
@@ -42,18 +54,18 @@ RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/cte
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
-RUN tar -xf 1.0.6.tar.gz
-WORKDIR /var/tmp/build/crc32c-1.0.6
-RUN cmake \
+RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz && \
+    tar -xf 1.0.6.tar.gz && \
+    cd crc32c-1.0.6 && \
+    cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
       -DCRC32C_BUILD_TESTS=OFF \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out/crc32c
-RUN cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4}
-RUN ldconfig
+      -H. -Bcmake-out/crc32c && \
+    cmake --build cmake-out/crc32c --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### Protobuf
@@ -62,16 +74,16 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz
-RUN tar -xf v3.6.1.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.6.1/cmake
-RUN cmake \
+RUN wget -q https://github.com/google/protobuf/archive/v3.6.1.tar.gz && \
+    tar -xf v3.6.1.tar.gz && \
+    cd protobuf-3.6.1/cmake && \
+    cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+        -H. -Bcmake-out && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### c-ares
@@ -81,12 +93,14 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN ./buildconf && ./configure && make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
+    tar -xf cares-1_14_0.tar.gz && \
+    cd c-ares-cares-1_14_0 && \
+    ./buildconf && \
+    ./configure && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### gRPC
@@ -95,15 +109,12 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
-RUN tar -xf v1.19.1.tar.gz
-WORKDIR /var/tmp/build/grpc-1.19.1
-ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
-ENV PATH=/usr/local/bin:${PATH}
-RUN make -j ${NCPU:-4}
-RUN make install
-RUN ldconfig
+RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz && \
+    tar -xf v1.19.1.tar.gz && \
+    cd grpc-1.19.1 && \
+    make -j ${NCPU:-4} && \
+    make install && \
+    ldconfig
 # ```
 
 # #### googleapis
@@ -112,14 +123,15 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
-RUN tar -xf v0.1.5.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
-RUN cmake \
-    -DBUILD_SHARED_LIBS=YES \
-    -H. -Bcmake-out
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz && \
+    tar -xf v0.1.5.tar.gz && \
+    cd cpp-cmakefiles-0.1.5 && \
+    cmake \
+      -DBUILD_SHARED_LIBS=YES \
+      -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### googletest
@@ -129,15 +141,16 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
+RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
-RUN ldconfig
+      -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
 # ```
 
 # #### google-cloud-cpp-common
@@ -146,17 +159,18 @@ RUN ldconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.15.0.tar.gz
-RUN tar -xf v0.15.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.15.0
-# Compile without the tests because we are testing google-cloud-cpp, not the base
-# libraries
-RUN cmake -H. -Bcmake-out \
-    -DBUILD_TESTING=OFF \
-    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-RUN cmake --build cmake-out -- -j $(nproc)
-RUN cmake --build cmake-out --target install
-RUN ldconfig
+## Compile without the tests because we are testing google-cloud-cpp, not the
+## common libraries, but we need the testing_utils because we use it in the
+## google-cloud-cpp tests.
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.15.0.tar.gz && \
+    tar -xf v0.15.0.tar.gz && \
+    cd google-cloud-cpp-common-0.15.0 && \
+    cmake -H. -Bcmake-out \
+      -DBUILD_TESTING=OFF \
+      -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install && \
+    ldconfig
 # ```
 
 FROM devtools AS install

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -26,6 +26,15 @@ RUN zypper refresh && \
         libcurl-devel libopenssl-devel make tar wget
 # ```
 
+# The following steps will install libraries and tools in `/usr/local`. CentOS
+# does not search for shared libraries in these directories by default, there
+# are multiple ways to solve this problem, the following steps are one solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
+# ```
+
 # #### crc32c
 
 # There is no openSUSE package for this library. To install it, use:
@@ -64,6 +73,16 @@ RUN cmake \
         -H. -Bcmake-out
 RUN cmake --build cmake-out --target install -- -j ${NCPU:-4}
 RUN ldconfig
+# ```
+
+# The following steps will install libraries and tools in `/usr/local`.
+# By default openSUSE/Leap does not search for shared libraries in these
+# directories, there are multiple ways to solve this problem, the following
+# steps are one solution:
+
+# ```bash
+RUN (echo "/usr/local/lib" ; "/usr/local/lib64") | \
+    tee /etc/ld.so.conf.d/usrlocal.conf
 # ```
 
 # #### c-ares
@@ -108,7 +127,6 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.19.1.tar.gz
 RUN tar -xf v1.19.1.tar.gz
 WORKDIR /var/tmp/build/grpc-1.19.1
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 ENV PATH=/usr/local/bin:${PATH}
 RUN make -j ${NCPU:-4}
 RUN make install
@@ -163,7 +181,7 @@ WORKDIR /var/tmp/build/google-cloud-cpp-common-0.15.0
 RUN cmake -H. -Bcmake-out \
     -DBUILD_TESTING=OFF \
     -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-RUN cmake --build cmake-out -- -j $(nproc)
+RUN cmake --build cmake-out -- -j ${NCPU:-4}
 RUN cmake --build cmake-out --target install
 RUN ldconfig
 # ```

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -81,7 +81,7 @@ RUN ldconfig
 # steps are one solution:
 
 # ```bash
-RUN (echo "/usr/local/lib" ; "/usr/local/lib64") | \
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
     tee /etc/ld.so.conf.d/usrlocal.conf
 # ```
 

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -31,7 +31,7 @@ RUN zypper refresh && \
 # are multiple ways to solve this problem, the following steps are one solution:
 
 # ```bash
-RUN (echo "/usr/local/lib" ; "/usr/local/lib64") | \
+RUN (echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
     tee /etc/ld.so.conf.d/usrlocal.conf
 # ```
 

--- a/ci/test-readme/dockerfile2markdown.sh
+++ b/ci/test-readme/dockerfile2markdown.sh
@@ -17,29 +17,59 @@
 set -eu
 
 # shellcheck disable=SC2016
-sed \
-    -e '/^## \[START IGNORED\]/,/^## \[END IGNORED\]/d' \
-    -e '/^FROM /d' \
-    -e '/^ARG /d' \
-    -e '/^## /d' \
-    -e 's/^# //' \
-    -e 's/^WORKDIR /cd /' \
-    -e 's/^RUN //' \
-    -e 's|/retry3 ||' \
-    -e 's/^ENV /export /' \
-    -e '/^COPY /d' \
-    -e 's/update-alternatives/sudo update-alternatives/g' \
-    -e 's/add-apt-repository/sudo add-apt-repository/g' \
-    -e 's/apt /sudo apt /g' \
-    -e 's/dnf/sudo dnf/g' \
-    -e 's/yum/sudo yum/g' \
-    -e 's/zypper/sudo zypper/g' \
-    -e 's/ldconfig/sudo ldconfig/g' \
-    -e 's/^\(cmake.*--target install.*\)/sudo \1/g' \
-    -e 's/^make install/sudo make install/' \
-    -e 's;/home/build;$HOME;' \
-    -e 's;/var/tmp/build;$HOME/Downloads;' \
-    -e 's/^    sudo/sudo/' "$@" | \
+sed_args=(
+    # Delete any sections marked as ignored.
+    '-e' '/^## \[START IGNORED\]/,/^## \[END IGNORED\]/d'
+    # Remove the Docker commands to define the base image and/or copy files.
+    '-e' '/^FROM /d'
+    '-e' '/^ARG /d'
+    '-e' '/^COPY /d'
+    # Things that are double comments are removed. This allows us to insert
+    # comments in the Dockerfile that are not transferred to the image.
+    '-e' '/^## /d'
+    # Regular comments are converted to text, this is where we put most of the
+    # markdown and explanations we intend to output to the INSTALL or README
+    # file
+    '-e' 's/^# //'
+    # Regular Dockerfile commands just become commands.
+    '-e' 's/^RUN //'
+    # Change some Dockerfile commands to the shell counterparts
+    '-e' 's/^WORKDIR /cd /'
+    '-e' 's/^ENV /export /'
+    # To workaround transient download failures the CI builds execute some
+    # commands 3 times, we do not need that in the README or INSTALL
+    # instructions
+    '-e' 's,/retry3 ,,'
+    # A number of commands need to be executed as sudo when the user is running
+    # them. The Dockerfile runs as root, and does not need the sudo prefix, but
+    # also, sudo may not even be installed.
+    '-e' 's/update-alternatives/sudo update-alternatives/g'
+    '-e' 's/add-apt-repository/sudo add-apt-repository/g'
+    '-e' 's/apt /sudo apt /g'
+    '-e' 's/dnf /sudo dnf /g'
+    '-e' 's/rpm /sudo rpm /g'
+    '-e' 's/yum /sudo yum /g'
+    '-e' 's/yum-config-manager /sudo yum-config-manager /g'
+    '-e' 's/zypper /sudo zypper /g'
+    '-e' 's/ldconfig/sudo ldconfig/g'
+    # Any 'make install' or 'cmake ... --target install' commands need sudo.
+    '-e' 's/\(cmake.*--target install.*\)/sudo \1/g'
+    '-e' 's/make install/sudo make install/'
+    # A standard technique to write files with root permissions is tee.
+    '-e' 's,tee /,sudo tee /,g'
+    # In some cases we link paths in /usr/bin, this is a bit too generous of a
+    # match, but works in practice.
+    '-e' 's/ln -sf /sudo ln -sf /g'
+    # The Dockerfile can use absolute paths for some directories, in the README
+    # or INSTALL instructions we prefer to use $HOME
+    '-e' 's;/home/build;$HOME;'
+    '-e' 's;/var/tmp/build;$HOME/Downloads;'
+    # Remove additional indentation for the sudo commands. The Docker files
+    # are more readable with the indentation, the markdown files not so much.
+    '-e' 's/^    sudo/sudo/'
+)
+
+sed "${sed_args[@]}" "$@" | \
     awk '
       BEGIN {
         removing_blanks=0;


### PR DESCRIPTION
The CentOS instructions did not quite work out of the box. The main
problem was using `LD_LIBRARY_PATH` and `sudo`, the latter unsets the
environment variables. The gRPC and googleapis build need tools
installed in `/usr/local/` with shared libraries in that directory. One
fix for that is to make ld.so search `/usr/local/lib{,64}/` by default.
These directories will be needed anyway, our libraries (and our
dependencies), install .so's there.

There were other minor problems, like missing `sudo` in some of the
commands that need root privileges.

Finally, I changed the Dockerfile to create fewer layers (see #3224),
otherwise I could not iterate quickly on my workstation. I just worked
around the issue by issuing multiple commands in each `RUN` line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3226)
<!-- Reviewable:end -->
