### PR TITLE
feat: implement deleting objects by prefix

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3112,7 +3112,7 @@ StatusOr<ObjectMetadata> CreateRandomPrefix(Client& client,
 
 namespace internal {
 
-// Just a wrapper to allow for using use in `google::cloud::internal::apply`.
+// Just a wrapper to allow for using in `google::cloud::internal::apply`.
 struct DeleteApplyHelper {
   template <typename... Options>
   Status operator()(Options... options) const {
@@ -3131,9 +3131,9 @@ struct DeleteApplyHelper {
  *
  * @param client the client on which to perform the operation.
  * @param bucket_name the name of the bucket that will contain the object.
- *     Maximum length is 1008 characters.
- * @param prefix the prefix of the objects to be deleted
+ * @param prefix the prefix of the objects to be deleted.
  * @param options a list of optional query parameters and/or request headers.
+ *     Valid types for this operation include `QuotaUser`, `UserIp`,
  *     `UserProject` and `Versions`.
  */
 template <typename... Options>
@@ -3146,9 +3146,11 @@ Status DeleteByPrefix(Client& client, std::string const& bucket_name,
 
   static_assert(
       std::tuple_size<decltype(
-              StaticTupleFilter<NotAmong<UserProject, Versions>::TPred>(
+              StaticTupleFilter<
+                  NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
                   all_options))>::value == 0,
-      "This functions accepts only options of type UserProject or Versions.");
+      "This functions accepts only options of type QuotaUser, UserIp, "
+      "UserProject or Versions.");
   for (auto const& object :
        client.ListObjects(bucket_name, Projection::NoAcl(), Prefix(prefix),
                           std::forward<Options>(options)...)) {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -25,6 +25,7 @@
 #include "google/cloud/storage/internal/policy_document_request.h"
 #include "google/cloud/storage/internal/retry_client.h"
 #include "google/cloud/storage/internal/signed_url_requests.h"
+#include "google/cloud/storage/internal/tuple_filter.h"
 #include "google/cloud/storage/list_buckets_reader.h"
 #include "google/cloud/storage/list_hmac_keys_reader.h"
 #include "google/cloud/storage/list_objects_reader.h"
@@ -3107,6 +3108,65 @@ StatusOr<ObjectMetadata> CreateRandomPrefix(Client& client,
   return client.InsertObject(bucket_name, object_name, std::string(),
                              IfGenerationMatch(0),
                              std::forward<Options>(options)...);
+}
+
+namespace internal {
+
+// Just a wrapper to allow for using use in `google::cloud::internal::apply`.
+struct DeleteApplyHelper {
+  template <typename... Options>
+  Status operator()(Options... options) const {
+    return client.DeleteObject(bucket_name, object_name, std::move(options)...);
+  }
+
+  Client& client;
+  std::string const& bucket_name;
+  std::string const& object_name;
+};
+
+}  // namespace internal
+
+/**
+ * Delete objects whose names match a given prefix
+ *
+ * @param client the client on which to perform the operation.
+ * @param bucket_name the name of the bucket that will contain the object.
+ *     Maximum length is 1008 characters.
+ * @param prefix the prefix of the objects to be deleted
+ * @param options a list of optional query parameters and/or request headers.
+ *     `UserProject` and `Versions`.
+ */
+template <typename... Options>
+Status DeleteByPrefix(Client& client, std::string const& bucket_name,
+                      std::string const& prefix, Options&&... options) {
+  using internal::NotAmong;
+  using internal::StaticTupleFilter;
+
+  auto all_options = std::tie(options...);
+
+  static_assert(
+      std::tuple_size<decltype(
+              StaticTupleFilter<NotAmong<UserProject, Versions>::TPred>(
+                  all_options))>::value == 0,
+      "This functions accepts only options of type UserProject or Versions.");
+  for (auto const& object :
+       client.ListObjects(bucket_name, Projection::NoAcl(), Prefix(prefix),
+                          std::forward<Options>(options)...)) {
+    if (!object) {
+      return object.status();
+    }
+
+    auto deletion_status = google::cloud::internal::apply(
+        internal::DeleteApplyHelper{client, bucket_name, object->name()},
+        std::tuple_cat(
+            std::make_tuple(IfGenerationMatch(object->generation())),
+            StaticTupleFilter<NotAmong<Versions>::TPred>(all_options)));
+
+    if (!deletion_status.ok()) {
+      return deletion_status;
+    }
+  }
+  return Status();
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -166,6 +166,40 @@ TEST_F(ObjectIntegrationTest, BasicCRUD) {
   EXPECT_EQ(0, name_counter(object_name, current_list));
 }
 
+TEST_F(ObjectIntegrationTest, PrefixOps) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+
+  std::set<std::string> initial_list;
+  for (auto&& o : client->ListObjects(bucket_name)) {
+    ASSERT_TRUE(initial_list.insert(std::move(o).value().name()).second);
+  }
+
+  auto prefix_md = CreateRandomPrefix(*client, bucket_name, "");
+  ASSERT_STATUS_OK(prefix_md);
+  std::string const& prefix = prefix_md->name();
+
+  std::set<std::string> common_prefix;
+  for (int i = 0; i < 10; ++i) {
+    auto random_file = CreateRandomPrefix(*client, bucket_name, prefix);
+    ASSERT_STATUS_OK(random_file);
+    ASSERT_TRUE(common_prefix.insert(random_file->name()).second);
+  }
+  auto deletion_status =
+      DeleteByPrefix(*client, bucket_name, prefix, Versions());
+  ASSERT_STATUS_OK(deletion_status);
+
+  std::set<std::string> after_delete_by_prefix_list;
+  for (auto&& o : client->ListObjects(bucket_name)) {
+    ASSERT_TRUE(
+        after_delete_by_prefix_list.insert(std::move(o).value().name()).second);
+  }
+  ASSERT_EQ(initial_list.size(), after_delete_by_prefix_list.size());
+  EXPECT_EQ(initial_list, after_delete_by_prefix_list);
+}
+
 TEST_F(ObjectIntegrationTest, FullPatch) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -187,8 +187,8 @@ TEST_F(ObjectIntegrationTest, PrefixOps) {
   ASSERT_STATUS_OK(deletion_status);
 
   for (auto&& o : client->ListObjects(bucket_name)) {
-    EXPECT_THAT(std::move(o).value().name(),
-                ::testing::Not(::testing::StartsWith(prefix)));
+    ASSERT_STATUS_OK(o);
+    EXPECT_THAT(o->name(), ::testing::Not(::testing::StartsWith(prefix)));
   }
 }
 

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -172,17 +172,12 @@ TEST_F(ObjectIntegrationTest, PrefixOps) {
 
   std::string bucket_name = flag_bucket_name;
 
-  std::set<std::string> initial_list;
-  for (auto&& o : client->ListObjects(bucket_name)) {
-    ASSERT_TRUE(initial_list.insert(std::move(o).value().name()).second);
-  }
-
   auto prefix_md = CreateRandomPrefix(*client, bucket_name, "");
   ASSERT_STATUS_OK(prefix_md);
   std::string const& prefix = prefix_md->name();
 
   std::set<std::string> common_prefix;
-  for (int i = 0; i < 10; ++i) {
+  for (int i = 0; i != 10; ++i) {
     auto random_file = CreateRandomPrefix(*client, bucket_name, prefix);
     ASSERT_STATUS_OK(random_file);
     ASSERT_TRUE(common_prefix.insert(random_file->name()).second);
@@ -191,13 +186,10 @@ TEST_F(ObjectIntegrationTest, PrefixOps) {
       DeleteByPrefix(*client, bucket_name, prefix, Versions());
   ASSERT_STATUS_OK(deletion_status);
 
-  std::set<std::string> after_delete_by_prefix_list;
   for (auto&& o : client->ListObjects(bucket_name)) {
-    ASSERT_TRUE(
-        after_delete_by_prefix_list.insert(std::move(o).value().name()).second);
+    EXPECT_THAT(std::move(o).value().name(),
+                ::testing::Not(::testing::StartsWith(prefix)));
   }
-  ASSERT_EQ(initial_list.size(), after_delete_by_prefix_list.size());
-  EXPECT_EQ(initial_list, after_delete_by_prefix_list);
 }
 
 TEST_F(ObjectIntegrationTest, FullPatch) {


### PR DESCRIPTION
This is a part of #3016.

It basically lists the objects and deletes them one-by-one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3235)
<!-- Reviewable:end -->
