### PR TITLE
ci: configuration files for CI generators

### DIFF
--- a/ci/etc/install-config.sh
+++ b/ci/etc/install-config.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+GOOGLE_CLOUD_CPP_BAZEL_VERSION="1.0.0"
+readonly GOOGLE_CLOUD_CPP_BAZEL_VERSION
+
+GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION="266.0.0"
+readonly GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION
+
+GOOGLE_CLOUD_CPP_SDK_SHA256="e2b2cd5e49e1dc73ffe1d57ba2bcc1b76620ae9549d2aa27ece05d819a8f4bbc"
+readonly GOOGLE_CLOUD_CPP_SDK_SHA256

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -A ORIGINAL_COPYRIGHT_YEAR=(
+  [centos-7]=2018
+  [centos-8]=2019
+  [debian-buster]=2019
+  [debian-stretch]=2018
+  [fedora]=2018
+  [opensuse-leap]=2019
+  [opensuse-tumbleweed]=2018
+  [ubuntu-trusty]=2018
+  [ubuntu-xenial]=2018
+  [ubuntu-bionic]=2018
+)
+
+BUILD_AND_TEST_PROJECT_FRAGMENT=$(replace_fragments \
+      "INSTALL_CRC32C_FROM_SOURCE" \
+      "INSTALL_CPP_CMAKEFILES_FROM_SOURCE" \
+      "INSTALL_GOOGLETEST_FROM_SOURCE" \
+      "INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE" <<'_EOF_'
+# #### crc32c
+
+# The project depends on the Crc32c library, we need to compile this from
+# source:
+
+# ```bash
+@INSTALL_CRC32C_FROM_SOURCE@
+# ```
+
+# #### googleapis
+
+# We need a recent version of the Google Cloud Platform proto C++ libraries:
+
+# ```bash
+@INSTALL_CPP_CMAKEFILES_FROM_SOURCE@
+# ```
+
+# #### googletest
+
+# We need a recent version of GoogleTest to compile the unit and integration
+# tests.
+
+# ```bash
+@INSTALL_GOOGLETEST_FROM_SOURCE@
+# ```
+
+# #### google-cloud-cpp-common
+
+# The project also depends on google-cloud-cpp-common, the libraries shared by
+# all the Google Cloud C++ client libraries:
+
+# ```bash
+@INSTALL_GOOGLETEST_FROM_SOURCE@
+# ```
+
+FROM devtools AS install
+ARG NCPU=4
+
+# #### Compile and install the main project
+
+# We can now compile, test, and install `@GOOGLE_CLOUD_CPP_REPOSITORY@`.
+
+# ```bash
+WORKDIR /home/build/project
+COPY . /home/build/project
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
+RUN ctest -LE integration-tests --output-on-failure
+RUN cmake --build . --target install
+# ```
+
+## [END INSTALL.md]
+
+ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
+
+# Verify that the installed files are actually usable
+WORKDIR /home/build/test-install-plain-make
+COPY ci/test-install /home/build/test-install-plain-make
+RUN make
+
+WORKDIR /home/build/test-install-cmake-bigtable
+COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
+
+WORKDIR /home/build/test-install-cmake-storage
+COPY ci/test-install/storage /home/build/test-install-cmake-storage
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
+_EOF_
+)

--- a/ci/etc/kokoro/install/run-installed-programs.sh
+++ b/ci/etc/kokoro/install/run-installed-programs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+run_args=(
+  # Remove the container after running
+  "--rm"
+)
+
+echo "================================================================"
+echo "Run Bigtable test programs against installed libraries ${DISTRO}."
+docker run "${run_args[@]}" "${INSTALL_RUN_IMAGE}" "/i/bigtable/bigtable_install_test"
+
+echo "Run Storage test programs against installed libraries ${DISTRO}."
+docker run "${run_args[@]}" "${INSTALL_RUN_IMAGE}" "/i/storage/storage_install_test"
+echo "================================================================"

--- a/ci/etc/kokoro/readme/project-config.sh
+++ b/ci/etc/kokoro/readme/project-config.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -A ORIGINAL_COPYRIGHT_YEAR=(
+  [centos-7]=2018
+  [centos-8]=2019
+  [debian-buster]=2019
+  [debian-stretch]=2018
+  [fedora]=2018
+  [opensuse-leap]=2019
+  [opensuse-tumbleweed]=2018
+  [ubuntu-trusty]=2018
+  [ubuntu-xenial]=2018
+  [ubuntu-bionic]=2018
+)

--- a/ci/etc/publish-refdocs.sh
+++ b/ci/etc/publish-refdocs.sh
@@ -18,7 +18,7 @@ set -eu
 # This script is meant to source from ci/kokoro/docker/publish_refdocs.sh.
 
 upload_docs "google-cloud-bigtable" "${BUILD_OUTPUT}/google/cloud/bigtable/html" \
-  "cloud.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"
+  "bigtable.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"
 
 upload_docs "google-cloud-storage" "${BUILD_OUTPUT}/google/cloud/storage/html" \
-  "cloud.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"
+  "storage.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"

--- a/ci/etc/publish-refdocs.sh
+++ b/ci/etc/publish-refdocs.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script is meant to source from ci/kokoro/docker/publish_refdocs.sh.
+
+upload_docs "google-cloud-bigtable" "${BUILD_OUTPUT}/google/cloud/bigtable/html" \
+  "cloud.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"
+
+upload_docs "google-cloud-storage" "${BUILD_OUTPUT}/google/cloud/storage/html" \
+  "cloud.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"

--- a/ci/etc/repo-config.sh
+++ b/ci/etc/repo-config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script is sourced from several other scripts in `ci/` to configure the
+# repository name (and short name). It makes those scripts portable across
+# `google-cloud-cpp*` repositories.
+
+GOOGLE_CLOUD_CPP_REPOSITORY="google-cloud-cpp"
+readonly GOOGLE_CLOUD_CPP_REPOSITORY
+
+GOOGLE_CLOUD_CPP_REPOSITORY_SHORT="cpp"
+readonly GOOGLE_CLOUD_CPP_REPOSITORY_SHORT


### PR DESCRIPTION
These files configure the generators for `ci/kokoro/readme` and
`ci/kokoro/install`. The files on those directories are not automatically
generated just yet, but this is (I hope) the last PR before we can do
so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3236)
<!-- Reviewable:end -->
