### PR TITLE
ci: improve define-docker-variables.sh

### DIFF
--- a/ci/kokoro/define-docker-variables.sh
+++ b/ci/kokoro/define-docker-variables.sh
@@ -29,15 +29,40 @@ fi
 if [[ -n "${IMAGE+x}" ]]; then
   echo "IMAGE is already defined."
 else
-  if [[ -n "${DISTRO_VERSION+x}" ]]; then
-    readonly IMAGE_BASENAME="gcpp-ci-${DISTRO}-${DISTRO_VERSION}"
-    if [[ -n "${PROJECT_ID:-}" ]]; then
-      IMAGE="gcr.io/${PROJECT_ID}/google-cloud-cpp/${IMAGE_BASENAME}"
-    else
-      IMAGE="${IMAGE_BASENAME}"
-    fi
-    readonly IMAGE
-    readonly BUILD_OUTPUT="cmake-out/${IMAGE_BASENAME}-${BUILD_NAME}"
-    readonly BUILD_HOME="cmake-out/home/${IMAGE_BASENAME}-${BUILD_NAME}"
+  DOCKER_IMAGE_BASENAME="ci-${DISTRO}"
+  DOCKER_README_IMAGE_BASENAME="ci-readme-${DISTRO}"
+  DOCKER_INSTALL_IMAGE_BASENAME="ci-install-${DISTRO}"
+  if [[ -n "${DISTRO_VERSION:-}" ]]; then
+    DOCKER_IMAGE_BASENAME="${DOCKER_IMAGE_BASENAME}-${DISTRO_VERSION}"
+    DOCKER_README_IMAGE_BASENAME="${DOCKER_README_IMAGE_BASENAME}-${DISTRO_VERSION}"
+    DOCKER_INSTALL_IMAGE_BASENAME="${DOCKER_INSTALL_IMAGE_BASENAME}-${DISTRO_VERSION}"
   fi
+  readonly DOCKER_README_IMAGE_BASENAME
+  readonly DOCKER_INSTALL_IMAGE_BASENAME
+  readonly DOCKER_IMAGE_BASENAME
+
+  if [[ -n "${PROJECT_ID:-}" ]]; then
+    DOCKER_IMAGE_PREFIX="gcr.io/${PROJECT_ID}/google-cloud-cpp"
+  else
+    # We want a prefix that works when running interactively, so it must be a
+    # (syntactically) valid project id, this works.
+    DOCKER_IMAGE_PREFIX="gcr.io/cloud-cpp-reserved/google-cloud-cpp"
+  fi
+  readonly DOCKER_IMAGE_PREFIX
+
+  IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
+  README_IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_README_IMAGE_BASENAME}"
+  INSTALL_IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_INSTALL_IMAGE_BASENAME}"
+  readonly IMAGE
+  readonly README_IMAGE
+  readonly README_INSTALL_IMAGE
+
+  BUILD_OUTPUT="cmake-out/${DOCKER_IMAGE_BASENAME}"
+  BUILD_HOME="cmake-out/home/${DOCKER_IMAGE_BASENAME}"
+  if [[ -n "${BUILD_NAME:-}" ]]; then
+    BUILD_OUTPUT="${BUILD_OUTPUT}-${BUILD_NAME}"
+    BUILD_HOME="${BUILD_HOME}-${BUILD_NAME}"
+  fi
+  readonly BUILD_OUTPUT
+  readonly BUILD_NAME
 fi

--- a/ci/kokoro/readme/build.sh
+++ b/ci/kokoro/readme/build.sh
@@ -71,11 +71,10 @@ if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
 fi
 gcloud auth configure-docker
 
-readonly DEV_IMAGE="gcr.io/${PROJECT_ID:-__invalid-project-id__}/google-cloud-cpp/test-readme-${DISTRO}"
 echo "================================================================"
 echo "Download existing image (if available) for ${DISTRO} $(date)."
 has_cache="false"
-if docker pull "${DEV_IMAGE}:latest"; then
+if docker pull "${README_IMAGE}:latest"; then
   echo "Existing image successfully downloaded."
   has_cache="true"
 fi
@@ -90,7 +89,7 @@ devtools_flags=(
   "--target" "devtools"
   # Create the image with the same tag as the cache we are using, so we can
   # upload it.
-  "-t" "${DEV_IMAGE}:latest"
+  "-t" "${README_IMAGE}:latest"
   "--build-arg" "NCPU=${NCPU}"
   "-f" "ci/kokoro/readme/Dockerfile.${DISTRO}"
 )
@@ -113,13 +112,13 @@ if "${update_cache}" && [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
   echo "================================================================"
   echo "Uploading updated base image for ${DISTRO} $(date)."
   # Do not stop the build on a failure to update the cache.
-  docker push "${DEV_IMAGE}:latest" || true
+  docker push "${README_IMAGE}:latest" || true
 fi
 
 echo "================================================================"
 echo "Run validation script for README instructions on ${DISTRO}."
 docker build \
-  "--cache-from=${DEV_IMAGE}:latest" \
+  "--cache-from=${README_IMAGE}:latest" \
   "--target=readme" \
   "--build-arg" "NCPU=${NCPU}" \
   -f "ci/kokoro/readme/Dockerfile.${DISTRO}" .


### PR DESCRIPTION
Use a fuller version that (like we do in other repositories) defines the
Docker image for the ci/kokoro/{readme,install,docker} builds. Use the
new variables in the CI scripts.

Part of the work for #3228

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3240)
<!-- Reviewable:end -->
