### PR TITLE
doc: fix generator for INSTALL.md

### DIFF
--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -189,7 +189,7 @@ echo "### Fedora (30)"
 
 echo
 echo "### openSUSE (Tumbleweed)"
-"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.opensuse"
+"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.opensuse-tumbleweed"
 
 echo
 echo "### openSUSE (Leap)"
@@ -197,7 +197,7 @@ echo "### openSUSE (Leap)"
 
 echo
 echo "### Ubuntu (18.04 - Bionic Beaver)"
-"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.ubuntu"
+"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.ubuntu-bionic"
 
 echo
 echo "### Ubuntu (16.04 - Xenial Xerus)"
@@ -209,8 +209,8 @@ echo "### Ubuntu (14.04 - Trusty Tahr)"
 
 echo
 echo "### Debian (Stretch)"
-"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.debian"
+"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.debian-stretch"
 
 echo
 echo "### CentOS (7)"
-"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.centos"
+"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.centos-7"


### PR DESCRIPTION
It was referring to the old build names for centos-7, ubuntu-bionic,
opensuse-tumbleweed, and debian-stretch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3243)
<!-- Reviewable:end -->
