### PR TITLE
ci: run test install programs in CI builds

### DIFF
--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -199,13 +199,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -162,13 +162,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -172,13 +172,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -140,13 +140,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -213,13 +213,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -135,13 +135,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -165,13 +165,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.ubuntu-trusty
+++ b/ci/kokoro/install/Dockerfile.ubuntu-trusty
@@ -235,13 +235,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN cmake -H. -Bcmake-out -DCMAKE_FIND_ROOT_PATH="/usr/local/curl;/usr/local/ssl"
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN cmake -H. -B/i/bigtable -DCMAKE_FIND_ROOT_PATH="/usr/local/curl;/usr/local/ssl"
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN cmake -H. -Bcmake-out -DCMAKE_FIND_ROOT_PATH="/usr/local/curl;/usr/local/ssl"
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN cmake -H. -B/i/storage -DCMAKE_FIND_ROOT_PATH="/usr/local/curl;/usr/local/ssl"
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -188,13 +188,13 @@ RUN make
 
 WORKDIR /home/build/test-install-cmake-bigtable
 COPY ci/test-install/bigtable /home/build/test-install-cmake-bigtable
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-install-cmake-storage
 COPY ci/test-install/storage /home/build/test-install-cmake-storage
-RUN env -u PKG_CONFIG_PATH cmake -H. -Bcmake-out
-RUN cmake --build cmake-out -- -j ${NCPU:-4}
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
+RUN cmake --build /i/storage -- -j ${NCPU:-4}
 
 WORKDIR /home/build/test-submodule
 COPY ci/test-install /home/build/test-submodule

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -117,9 +117,12 @@ fi
 
 echo "================================================================"
 echo "Run validation script for INSTALL instructions on ${DISTRO}."
-docker build \
+readonly INSTALL_RUN_IMAGE="${DOCKER_IMAGE_PREFIX}/ci-install-runtime-${DISTRO}"
+docker build -t "${INSTALL_RUN_IMAGE}" \
   "--cache-from=${INSTALL_IMAGE}:latest" \
   "--target=install" \
   "--build-arg" "NCPU=${NCPU}" \
   -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
 echo "================================================================"
+
+source "${PROJECT_ROOT}/ci/etc/kokoro/install/run-installed-programs.sh"

--- a/ci/kokoro/install/common.cfg
+++ b/ci/kokoro/install/common.cfg
@@ -18,3 +18,5 @@ timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"

--- a/ci/test-install/storage/storage_install_test.cc
+++ b/ci/test-install/storage/storage_install_test.cc
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) try {
             << "\n";
 
   gcs::ObjectReadStream stream = client->ReadObject(bucket_name, object_name);
-  stream.exceptions(std::ios_base::badbit | std::ios_base::failbit);
+  stream.exceptions(std::ios_base::badbit);
 
   int count = 0;
   std::string line;


### PR DESCRIPTION
The CI builds to verify our install instructions work compile a couple
of test programs against the installed code. The programs were not
executed though. This PR proposes to run the tests as part of these CI
builds, note that these run against the production environment.

Fixes #3244

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3245)
<!-- Reviewable:end -->
