### PR TITLE
ci: upgrade builds to use Bazel 1.0

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,5 @@
+ci/
+cmake-out/
+cmake-build-*/
+cmake-build-debug/
+cmake-build-release/

--- a/.bazelignore
+++ b/.bazelignore
@@ -1,5 +1,4 @@
 ci/
 cmake-out/
-cmake-build-*/
 cmake-build-debug/
 cmake-build-release/

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,15 +31,6 @@ load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_com
 
 google_cloud_cpp_common_deps()
 
-load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
-
-# Configure @com_google_googleapis to only compile C++ and gRPC:
-switched_rules_by_language(
-    name = "com_google_googleapis_imports",
-    cc = True,  # C++ support is only "Partially implemented", roll our own.
-    grpc = True,
-)
-
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,15 @@ load("//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 
+# Configure @com_google_googleapis to only compile C++ and gRPC libraries.
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,  # C++ support is only "Partially implemented", roll our own.
+    grpc = True,
+)
+
 load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_common_deps.bzl", "google_cloud_cpp_common_deps")
 
 google_cloud_cpp_common_deps()
@@ -31,8 +40,6 @@ switched_rules_by_language(
     grpc = True,
 )
 
-# Have to manually call the corresponding function for gRPC:
-#   https://github.com/bazelbuild/bazel/issues/1550
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -64,10 +64,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/a8ee1416f4c588f2ab92da72e7c1f588c784d3e6.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/9c9f778aedde02f9826d2ae5d0f9c96409ba0f25.tar.gz",
             ],
-            strip_prefix = "googleapis-a8ee1416f4c588f2ab92da72e7c1f588c784d3e6",
-            sha256 = "6b8a9b2bcb4476e9a5a9872869996f0d639c8d5df76dd8a893e79201f211b1cf",
+            strip_prefix = "googleapis-9c9f778aedde02f9826d2ae5d0f9c96409ba0f25",
+            sha256 = "13af135d8cc9b81b47d6fbfc258fe790a151956d06e01fd16671aa49fe536ab1",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 
@@ -83,6 +83,18 @@ def google_cloud_cpp_deps():
             ],
             sha256 = "c84b3fa140fcd6cce79b3f9de6357c5733a0071e04ca4e65ba5f8d306f10f033",
         )
+
+    # We use the cc_proto_library() rule from @com_google_protobuf, which
+    # assumes that grpc_cpp_plugin and grpc_lib are in the //external: module
+    native.bind(
+        name = "grpc_cpp_plugin",
+        actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+    )
+
+    native.bind(
+        name = "grpc_lib",
+        actual = "@com_github_grpc_grpc//:grpc++",
+    )
 
     # We need libcurl for the Google Cloud Storage client.
     if "com_github_curl_curl" not in native.existing_rules():
@@ -117,15 +129,3 @@ def google_cloud_cpp_deps():
             sha256 = "6b3b1d861bb8307658b2407bc7a4c59e566855ef5368a60b35c893551e4788e9",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:crc32c.BUILD",
         )
-
-    # We use the cc_proto_library() rule from @com_google_protobuf, which
-    # assumes that grpc_cpp_plugin and grpc_lib are in the //external: module
-    native.bind(
-        name = "grpc_cpp_plugin",
-        actual = "@com_github_grpc_grpc//:grpc_cpp_plugin",
-    )
-
-    native.bind(
-        name = "grpc_lib",
-        actual = "@com_github_grpc_grpc//:grpc++",
-    )

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -16,10 +16,16 @@
 
 set -eu
 
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  PROJECT_ROOT="$(cd "$(dirname "$0")/.."; pwd)"
+  readonly PROJECT_ROOT
+fi
+source "${PROJECT_ROOT}/ci/etc/install-config.sh"
+
 readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-readonly BAZEL_VERSION="0.24.0"
+readonly BAZEL_VERSION="${GOOGLE_CLOUD_CPP_BAZEL_VERSION}"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -35,11 +35,6 @@ load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl",
 
 google_cloud_cpp_deps()
 
-load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_common_deps.bzl", "google_cloud_cpp_common_deps")
-
-google_cloud_cpp_common_deps()
-
-# Configure @com_google_googleapis to only compile C++ and gRPC:
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
 switched_rules_by_language(
@@ -47,6 +42,10 @@ switched_rules_by_language(
     cc = True,  # C++ support is only "Partially implemented", roll our own.
     grpc = True,
 )
+
+load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_common_deps.bzl", "google_cloud_cpp_common_deps")
+
+google_cloud_cpp_common_deps()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 


### PR DESCRIPTION
Also upgrade Bazel for this repository. Mostly this entails upgrading
several dependencies (notably gRPC). There are a couple of new
warnings in the Bazel build, I think those should be fixed in a
separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3248)
<!-- Reviewable:end -->
