### PR TITLE
chore: reformat for 80 columns; fix spacing

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -44,7 +44,8 @@ if [[ "${SCAN_BUILD}" == "yes" ]]; then
 fi
 
 echo
-echo "${COLOR_YELLOW}Starting docker build $(date) with ${NCPU} cores${COLOR_RESET}"
+echo "${COLOR_YELLOW}Starting docker build $(date) with ${NCPU}"\
+    "cores${COLOR_RESET}"
 echo
 
 echo "${COLOR_YELLOW}Started CMake config at: $(date)${COLOR_RESET}"
@@ -167,7 +168,8 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     for subdir in google/cloud google/cloud/bigtable google/cloud/storage; do
       echo
       echo "${COLOR_GREEN}Running integration tests for ${subdir}${COLOR_RESET}"
-      (cd "${BINARY_DIR}" && "${PROJECT_ROOT}/${subdir}/ci/run_integration_tests.sh")
+      (cd "${BINARY_DIR}" && \
+          "${PROJECT_ROOT}/${subdir}/ci/run_integration_tests.sh")
     done
 
     echo
@@ -185,8 +187,8 @@ if [[ "${TEST_INSTALL:-}" = "yes" ]]; then
   # Also verify that the install directory does not get unexpected files or
   # directories installed.
   echo
-  echo "${COLOR_YELLOW}Verify installed headers created only" \
-      " expected directories.${COLOR_RESET}"
+  echo "${COLOR_YELLOW}Verify installed headers created only expected" \
+      "directories.${COLOR_RESET}"
   if comm -23 \
       <(find /var/tmp/staging/include/google/cloud -type d | sort) \
       <(echo /var/tmp/staging/include/google/cloud ; \
@@ -198,7 +200,8 @@ if [[ "${TEST_INSTALL:-}" = "yes" ]]; then
         echo /var/tmp/staging/include/google/cloud/storage/oauth2 ; \
         echo /var/tmp/staging/include/google/cloud/storage/testing ; \
         /bin/true) | grep -q /var/tmp; then
-      echo "${COLOR_YELLOW}Installed directories do not match expectation.${COLOR_RESET}"
+      echo "${COLOR_YELLOW}Installed directories do not match" \
+          "expectation.${COLOR_RESET}"
       echo "${COLOR_RED}Found:"
       find /var/tmp/staging/include/google/cloud -type d | sort
       echo "${COLOR_RESET}"
@@ -215,6 +218,7 @@ fi
 # If document generation is enabled, run it now.
 if [[ "${GENERATE_DOCS}" == "yes" ]]; then
   echo
-  echo "${COLOR_YELLOW}Generating Doxygen documentation at: $(date).${COLOR_RESET}"
+  echo "${COLOR_YELLOW}Generating Doxygen documentation at:" \
+      "$(date).${COLOR_RESET}"
   cmake --build "${BINARY_DIR}" --target doxygen-docs -- -j "${NCPU}"
 fi


### PR DESCRIPTION
shell style guide specifies 80 columns

since `echo` adds spaces between its arguments the line that was already
split resulted in an extra space:

`Verify installed headers created only  expected directories.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3250)
<!-- Reviewable:end -->
