### PR TITLE
bug: use CalculateDefaultConnectionPoolSize in set_connection_pool_size

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -74,7 +74,7 @@ ClientOptions::ClientOptions() : ClientOptions(BigtableDefaultCredentials()) {
 // NOLINTNEXTLINE(readability-identifier-naming)
 ClientOptions& ClientOptions::set_connection_pool_size(std::size_t size) {
   if (size == 0) {
-    connection_pool_size_ = BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE;
+    connection_pool_size_ = CalculateDefaultConnectionPoolSize();
     return *this;
   }
   connection_pool_size_ = size;

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -164,8 +164,9 @@ TEST(ClientOptionsTest, ResetToDefaultConnectionPoolSize) {
   bigtable::ClientOptions client_options_object;
   auto& returned = client_options_object.set_connection_pool_size(0);
   EXPECT_EQ(&returned, &client_options_object);
-  EXPECT_EQ(BIGTABLE_CLIENT_DEFAULT_CONNECTION_POOL_SIZE,
-            returned.connection_pool_size());
+  // The number of connections should be >= 1, we "know" what the actual value
+  // is, but we do not want a change-detection-test.
+  EXPECT_LE(1UL, returned.connection_pool_size());
 }
 
 TEST(ClientOptionsTest, SetGrpclbFallbackTimeoutMS) {


### PR DESCRIPTION
Addresses #3260.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3261)
<!-- Reviewable:end -->
