### PR TITLE
fix!: avoid duplicate cluster ids in bigtable::InstanceConfig

### DIFF
--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -30,15 +30,13 @@ inline namespace BIGTABLE_CLIENT_NS {
 class InstanceConfig {
  public:
   InstanceConfig(std::string instance_id, std::string display_name,
-                 std::vector<std::pair<std::string, ClusterConfig>> clusters) {
-    // TODO(#2589) - validate the `clusters` parameter.
+                 std::map<std::string, ClusterConfig> clusters) {
     proto_.set_instance_id(std::move(instance_id));
     proto_.mutable_instance()->set_display_name(std::move(display_name));
     for (auto& kv : clusters) {
       (*proto_.mutable_clusters())[kv.first] = std::move(kv.second).as_proto();
     }
   }
-
   //@{
   /// @name Convenient shorthands for the instance types.
   using InstanceType = google::bigtable::admin::v2::Instance::Type;


### PR DESCRIPTION
BREAKING CHANGE: replacing the constructor to stop allowing duplicate cluster

Fixes #2589 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3262)
<!-- Reviewable:end -->
