### PR TITLE
ci: make super build configuration more consistent

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -104,6 +104,8 @@ elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="super"
+  export BUILD_TYPE=Release
+  export CMAKE_FLAGS=-DBUILD_SHARED_LIBS=yes
   # Note that the integration tests are run by default. This is the opposite of
   # what spanner does where RUN_INTEGRATION_TESTS is explicitly set to yes.
   export RUN_INTEGRATION_TESTS="no"

--- a/super/CMakeLists.txt
+++ b/super/CMakeLists.txt
@@ -31,13 +31,12 @@ include(external/googletest)
 include(external/google-cloud-cpp-common)
 
 include(ExternalProjectHelper)
-set_external_project_prefix_vars()
-
 set_external_project_build_parallel_level(PARALLEL)
+set_external_project_vars()
 
 set(GOOGLE_CLOUD_CPP_DEPENDENCIES_LIST
-    grpc_project curl_project crc32c_project googleapis_project
-    googletest_project google-cloud-cpp-common-project)
+    grpc-project curl-project crc32c-project googleapis-project
+    googletest-project google-cloud-cpp-common-project)
 
 include(ExternalProject)
 ExternalProject_Add(
@@ -51,7 +50,7 @@ ExternalProject_Add(
         "${GOOGLE_CLOUD_CPP_ROOT}"
         LIST_SEPARATOR
         |
-    CMAKE_ARGS -G${CMAKE_GENERATOR}
+    CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
                -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/super/ExternalProjectHelper.cmake
+++ b/super/ExternalProjectHelper.cmake
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ~~~
 
+include(ExternalProject)
 include(GNUInstallDirs)
 
 set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX
@@ -42,7 +43,7 @@ function (set_external_project_build_parallel_level var_name)
     endif ()
 endfunction ()
 
-function (set_external_project_prefix_vars)
+function (set_external_project_vars)
     set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
 
     # On Linux, using an RPATH that is neither an absolute or relative path is
@@ -52,6 +53,17 @@ function (set_external_project_prefix_vars)
         set(GOOGLE_CLOUD_CPP_INSTALL_RPATH
             "\\\$ORIGIN/../lib;\\\$ORIGIN/../lib64")
     endif ()
+
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH
+        "${CMAKE_PREFIX_PATH}" "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        "<INSTALL_DIR>")
+
+    set(GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS
+        ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS})
 
     # When passing a semi-colon delimited list to ExternalProject_Add, we need
     # to escape the semi-colon. Quoting does not work and escaping the semi-
@@ -63,15 +75,17 @@ function (set_external_project_prefix_vars)
     # character in CMake.
     string(REPLACE ";" "|" GOOGLE_CLOUD_CPP_INSTALL_RPATH
                    "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
-
-    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
     string(REPLACE ";" "|" GOOGLE_CLOUD_CPP_PREFIX_PATH
                    "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
 
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH
+        "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}"
+        PARENT_SCOPE)
     set(GOOGLE_CLOUD_CPP_PREFIX_PATH
         "${GOOGLE_CLOUD_CPP_PREFIX_PATH}"
         PARENT_SCOPE)
-    set(GOOGLE_CLOUD_CPP_PREFIX_RPATH
-        "${GOOGLE_CLOUD_CPP_PREFIX_RPATH}"
+    set(GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS
+        "${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}"
         PARENT_SCOPE)
+
 endfunction ()

--- a/super/external/c-ares.cmake
+++ b/super/external/c-ares.cmake
@@ -16,7 +16,7 @@
 
 include(ExternalProjectHelper)
 
-if (NOT TARGET c_ares_project)
+if (NOT TARGET c-ares-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_C_ARES_URL
@@ -25,12 +25,11 @@ if (NOT TARGET c_ares_project)
         "62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        c_ares_project
+        c-ares-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -38,11 +37,9 @@ if (NOT TARGET c_ares_project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
                  LIST_SEPARATOR
                  |
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON

--- a/super/external/crc32c.cmake
+++ b/super/external/crc32c.cmake
@@ -16,7 +16,7 @@
 
 include(ExternalProjectHelper)
 
-if (NOT TARGET crc32c_project)
+if (NOT TARGET crc32c-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_CRC32C_URL
@@ -25,12 +25,11 @@ if (NOT TARGET crc32c_project)
         "6b3b1d861bb8307658b2407bc7a4c59e566855ef5368a60b35c893551e4788e9")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        crc32c_project
+        crc32c-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -38,16 +37,13 @@ if (NOT TARGET crc32c_project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
                  LIST_SEPARATOR
                  |
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DCRC32C_BUILD_TESTS=OFF
                    -DCRC32C_BUILD_BENCHMARKS=OFF
                    -DCRC32C_USE_GLOG=OFF
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON

--- a/super/external/curl.cmake
+++ b/super/external/curl.cmake
@@ -18,7 +18,7 @@ include(external/c-ares)
 include(external/ssl)
 include(external/zlib)
 
-if (NOT TARGET curl_project)
+if (NOT TARGET curl-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_CURL_URL
@@ -27,13 +27,12 @@ if (NOT TARGET curl_project)
         "4376ac72b95572fb6c4fbffefb97c7ea0dd083e1974c0e44cd7e49396f454839")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        curl_project
-        DEPENDS c_ares_project ssl_project zlib_project
+        curl-project
+        DEPENDS c-ares-project ssl-project zlib-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/curl"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -42,7 +41,10 @@ if (NOT TARGET curl_project)
                  LIST_SEPARATOR
                  |
         CMAKE_ARGS
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
+            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             # libcurl automatically enables a number of protocols. With static
             # libraries this is a problem. The indirect dependencies, such as
             # libldap, become hard to predict and manage. Setting HTTP_ONLY=ON
@@ -52,16 +54,9 @@ if (NOT TARGET curl_project)
             # defining the `curl_project` target.
             -DHTTP_ONLY=ON
             -DCMAKE_ENABLE_OPENSSL=ON
-            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
             -DENABLE_ARES=ON
             -DCURL_STATICLIB=$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>
             -DCMAKE_DEBUG_POSTFIX=
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ~~~
 
-include(ExternalProject)
 include(ExternalProjectHelper)
 include(external/grpc)
 include(external/googleapis)
@@ -29,13 +28,12 @@ if (NOT TARGET google-cloud-cpp-common-project)
     set(GOOGLE_CLOUD_CPP_SHA256
         "d53c12e901f2d76bd2bf8a1e57769bbe0fb96338eaaa3f2c57f92cba703bada8")
 
-    set_external_project_prefix_vars()
-
     set_external_project_build_parallel_level(PARALLEL)
+    set_external_project_vars()
 
     ExternalProject_Add(
         google-cloud-cpp-common-project
-        DEPENDS googleapis_project googletest_project grpc_project
+        DEPENDS googleapis-project googletest-project grpc-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp-common"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -43,14 +41,20 @@ if (NOT TARGET google-cloud-cpp-common-project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_SHA256}
                  LIST_SEPARATOR
                  |
-        CMAKE_ARGS -DBUILD_TESTING=OFF
-                   -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
-                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            -G${CMAKE_GENERATOR}
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
+            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DBUILD_TESTING=OFF
+            -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+            -H<SOURCE_DIR>
+            -B<BINARY_DIR>
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON
-        LOG_CONFIGURE OFF
-        LOG_BUILD OFF
-        LOG_INSTALL OFF)
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
 endif ()

--- a/super/external/googleapis.cmake
+++ b/super/external/googleapis.cmake
@@ -19,7 +19,7 @@ find_package(Threads REQUIRED)
 
 include(external/grpc)
 
-if (NOT TARGET googleapis_project)
+if (NOT TARGET googleapis-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
@@ -28,13 +28,12 @@ if (NOT TARGET googleapis_project)
         "f1443a10c545114b19fe9dc352568cb03b588813b12cc5db8780b64ae9a09ce1")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        googleapis_project
-        DEPENDS grpc_project
+        googleapis-project
+        DEPENDS grpc-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -45,14 +44,10 @@ if (NOT TARGET googleapis_project)
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND}
             -G${CMAKE_GENERATOR}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
             -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
             -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             -H<SOURCE_DIR>
             -B<BINARY_DIR>
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}

--- a/super/external/googletest.cmake
+++ b/super/external/googletest.cmake
@@ -16,7 +16,7 @@
 
 include(ExternalProjectHelper)
 
-if (NOT TARGET googletest_project)
+if (NOT TARGET googletest-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLETEST_URL
@@ -25,12 +25,11 @@ if (NOT TARGET googletest_project)
         "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        googletest_project
+        googletest-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/googletest"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -38,12 +37,9 @@ if (NOT TARGET googletest_project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
                  LIST_SEPARATOR
                  |
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON

--- a/super/external/grpc.cmake
+++ b/super/external/grpc.cmake
@@ -19,7 +19,7 @@ include(external/c-ares)
 include(external/ssl)
 include(external/protobuf)
 
-if (NOT TARGET grpc_project)
+if (NOT TARGET grpc-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
@@ -28,13 +28,12 @@ if (NOT TARGET grpc_project)
         "c84b3fa140fcd6cce79b3f9de6357c5733a0071e04ca4e65ba5f8d306f10f033")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        grpc_project
-        DEPENDS c_ares_project protobuf_project ssl_project
+        grpc-project
+        DEPENDS c-ares-project protobuf-project ssl-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/grpc"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -42,14 +41,10 @@ if (NOT TARGET grpc_project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
                  LIST_SEPARATOR
                  |
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
-                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DgRPC_BUILD_TESTS=OFF
                    -DgRPC_ZLIB_PROVIDER=package
                    -DgRPC_SSL_PROVIDER=package

--- a/super/external/protobuf.cmake
+++ b/super/external/protobuf.cmake
@@ -19,22 +19,21 @@ find_package(Threads REQUIRED)
 include(ExternalProjectHelper)
 include(external/zlib)
 
-if (NOT TARGET protobuf_project)
+if (NOT TARGET protobuf-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
-        "https://github.com/google/protobuf/archive/v3.7.1.tar.gz")
+        "https://github.com/google/protobuf/archive/v3.9.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
-        "f1748989842b46fa208b2a6e4e2785133cfcc3e4d43c17fecb023733f0f5443f")
+        "98e615d592d237f94db8bf033fba78cd404d979b0b70351a9e5aaff725398357")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        protobuf_project
-        DEPENDS zlib_project
+        protobuf-project
+        DEPENDS zlib-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -45,14 +44,10 @@ if (NOT TARGET protobuf_project)
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND}
             -G${CMAKE_GENERATOR}
-            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-            -DCMAKE_BUILD_TYPE=Debug
-            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
             -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
             -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
             # Protobuf installs using `CMAKE_INSTALL_LIBDIR`, as it should,
             # which expands to `lib` or `lib64`. But hard-codes RPATH to
             # `$ORIGIN/../lib`, so change the default `LIBDIR` to something that

--- a/super/external/ssl.cmake
+++ b/super/external/ssl.cmake
@@ -14,13 +14,13 @@
 # limitations under the License.
 # ~~~
 
-if (NOT TARGET ssl_project)
+if (NOT TARGET ssl-project)
     # For OpenSSL we don't really support external projects. OpenSSL build
     # system is notoriously finicky. Use vcpkg on Windows, or install OpenSSL
     # using your operating system packages instead.
     #
     # This file is here to simplify the definition of external projects, such as
     # curl and gRPC, that depend on a SSL library.
-    add_custom_target(ssl_project)
     find_package(OpenSSL REQUIRED)
+    add_custom_target(ssl-project)
 endif ()

--- a/super/external/zlib.cmake
+++ b/super/external/zlib.cmake
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-if (NOT TARGET zlib_project)
+if (NOT TARGET zlib-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_ZLIB_URL
@@ -23,12 +23,11 @@ if (NOT TARGET zlib_project)
         "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
 
     set_external_project_build_parallel_level(PARALLEL)
-
-    set_external_project_prefix_vars()
+    set_external_project_vars()
 
     include(ExternalProject)
     ExternalProject_Add(
-        zlib_project
+        zlib-project
         EXCLUDE_FROM_ALL ON
         PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
@@ -36,12 +35,9 @@ if (NOT TARGET zlib_project)
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_ZLIB_SHA256}
                  LIST_SEPARATOR
                  |
-        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE}
-                   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                   -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+        CMAKE_ARGS ${GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CMAKE_FLAGS}
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON


### PR DESCRIPTION
Some CMake configuration options were not consistently used in the super
build, including `CMAKE_BUILD_TYPE`, `BUILD_SHARED_LIBS`,
`CMAKE_CXX_COMPILER`, and `CMAKE_C_COMPILER`.

This is basically a copy of the `super/*` files from `google-cloud-cpp-common`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3265)
<!-- Reviewable:end -->
