### PR TITLE
cleanup: don't set CURL_STATICLIB in libcurl super build file

### DIFF
--- a/super/external/curl.cmake
+++ b/super/external/curl.cmake
@@ -55,7 +55,6 @@ if (NOT TARGET curl-project)
             -DHTTP_ONLY=ON
             -DCMAKE_ENABLE_OPENSSL=ON
             -DENABLE_ARES=ON
-            -DCURL_STATICLIB=$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>
             -DCMAKE_DEBUG_POSTFIX=
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
         LOG_DOWNLOAD ON


### PR DESCRIPTION
Fixes #3269

curl now uses `BUILD_SHARED_LIBS` to set `CURL_STATICLIB`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3270)
<!-- Reviewable:end -->
