### PR TITLE
fix: remove storage class 'ARCHIVE' as this feature is still not supported.

### DIFF
--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -54,10 +54,6 @@ LifecycleRuleAction LifecycleRule::SetStorageClassDurableReducedAvailability() {
   return SetStorageClass(storage_class::DurableReducedAvailability());
 }
 
-LifecycleRuleAction LifecycleRule::SetStorageClassArchive() {
-  return SetStorageClass(storage_class::Archive());
-}
-
 LifecycleRuleAction LifecycleRule::SetStorageClass(std::string storage_class) {
   return LifecycleRuleAction{"SetStorageClass", std::move(storage_class)};
 }

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -149,7 +149,6 @@ class LifecycleRule {
   static LifecycleRuleAction SetStorageClassNearline();
   static LifecycleRuleAction SetStorageClassColdline();
   static LifecycleRuleAction SetStorageClassDurableReducedAvailability();
-  static LifecycleRuleAction SetStorageClassArchive();
   static LifecycleRuleAction SetStorageClass(std::string storage_class);
   //@}
 
@@ -231,10 +230,6 @@ class LifecycleRule {
   static LifecycleRuleCondition
   MatchesStorageClassDurableReducedAvailability() {
     return MatchesStorageClass(storage_class::DurableReducedAvailability());
-  }
-
-  static LifecycleRuleCondition MatchesStorageClassArchive() {
-    return MatchesStorageClass(storage_class::Archive());
   }
 
   static LifecycleRuleCondition NumNewerVersions(std::int32_t days) {

--- a/google/cloud/storage/lifecycle_rule_test.cc
+++ b/google/cloud/storage/lifecycle_rule_test.cc
@@ -72,8 +72,6 @@ TEST(LifecycleRuleTest, SetStorageClass) {
   EXPECT_EQ(LifecycleRule::SetStorageClass(
                 storage_class::DurableReducedAvailability()),
             LifecycleRule::SetStorageClassDurableReducedAvailability());
-  EXPECT_EQ(LifecycleRule::SetStorageClass(storage_class::Archive()),
-            LifecycleRule::SetStorageClassArchive());
 }
 
 /// @test Verify that LifecycleRuleCondition comparisons work as expected.
@@ -230,14 +228,6 @@ TEST(LifecycleRuleTest, MatchesStorageClassDurableReducedAvailability) {
   ASSERT_FALSE(condition.matches_storage_class->empty());
   EXPECT_EQ(storage_class::DurableReducedAvailability(),
             condition.matches_storage_class->front());
-}
-
-/// @test LifecycleRule::MatchesStorageClassArchive.
-TEST(LifecycleRuleTest, MatchesStorageClassArchive) {
-  auto condition = LifecycleRule::MatchesStorageClassArchive();
-  ASSERT_TRUE(condition.matches_storage_class.has_value());
-  ASSERT_FALSE(condition.matches_storage_class->empty());
-  EXPECT_EQ(storage_class::Archive(), condition.matches_storage_class->front());
 }
 
 /// @test Verify that LifecycleRule::NumNewerVersions() works as expected.

--- a/google/cloud/storage/storage_class.h
+++ b/google/cloud/storage/storage_class.h
@@ -53,11 +53,6 @@ inline char const* DurableReducedAvailability() {
   return kStorageClass;
 }
 
-inline char const* Archive() {
-  static constexpr char kStorageClass[] = "ARCHIVE";
-  return kStorageClass;
-}
-
 }  // namespace storage_class
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/storage_class_test.cc
+++ b/google/cloud/storage/storage_class_test.cc
@@ -31,7 +31,6 @@ TEST(StorageClassTest, Values) {
   EXPECT_EQ(std::string("COLDLINE"), Coldline());
   EXPECT_EQ(std::string("DURABLE_REDUCED_AVAILABILITY"),
             DurableReducedAvailability());
-  EXPECT_EQ(std::string("ARCHIVE"), Archive());
 }
 
 }  // namespace


### PR DESCRIPTION
This closes #3253

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3271)
<!-- Reviewable:end -->
