### PR TITLE
chore: update release process

### DIFF
--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -21,18 +21,16 @@ these commands should be useful in identifying important changes:
 
 ```bash
 # Summarize the output of this into google/cloud/bigtable/README.md
-git log upstream/master -- google/cloud/bigtable
+git log --no-merges --format="format:* %s" \
+    $(git describe --tags --abbrev=0 upstream/master)..HEAD \
+    upstream/master -- google/cloud/bigtable
 ```
 
 ```bash
 # Summarize the output of this into google/cloud/storage/README.md
-git log upstream/master -- google/cloud/storage
-```
-
-Do not forget to update `google/cloud/README.md` too:
-
-```bash
-git log upstream/master -- google/cloud ":(exclude)google/cloud/storage" ":(exclude)google/cloud/bigtable"
+git log --no-merges --format="format:* %s" \
+    $(git describe --tags --abbrev=0 upstream/master)..HEAD \
+    upstream/master -- google/cloud/storage
 ```
 
 It is not recommended that you create the release branch before this PR is


### PR DESCRIPTION
* Use the `git log` commands from `google-cloud-cpp-common` to show
  only changes since the last release, and format them as they appear in
  the release notes.
* Remove the part about updating `google/cloud/README.md` which is no
  longer necessary since we have `google-cloud-cpp-common`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3282)
<!-- Reviewable:end -->
