### PR TITLE
chore: update release notes for v0.16

### DIFF
--- a/google/cloud/storage/README.md
+++ b/google/cloud/storage/README.md
@@ -47,6 +47,7 @@ Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
 ### v1.8.x - TBD
 
 ### v1.7.x - 2019-12
+* fix: add logic to ObjectWriteStreambuf for handling jumps in upload ranges to fix #3280 (#3283)
 * bug: fix error messages in resumable sessions (#3263)
 
 ### v1.6.x - 2019-11


### PR DESCRIPTION
Includes the fix for corrupted resumable uploads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3284)
<!-- Reviewable:end -->
