### PR TITLE
fix: GenericRequest::set_option() accepts crefs

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -340,6 +340,7 @@ if (BUILD_TESTING)
         internal/curl_wrappers_enable_sigpipe_handler_test.cc
         internal/default_object_acl_requests_test.cc
         internal/generate_message_boundary_test.cc
+        internal/generic_request_test.cc
         internal/hash_validator_test.cc
         internal/hmac_key_requests_test.cc
         internal/http_response_test.cc

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -63,7 +63,7 @@ class GenericRequestBase;
 template <typename Derived, typename Option>
 class GenericRequestBase<Derived, Option> {
  public:
-  Derived& set_option(Option&& p) {
+  Derived& set_option(Option p) {
     option_ = std::move(p);
     return *static_cast<Derived*>(this);
   }
@@ -108,7 +108,7 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
  public:
   using GenericRequestBase<Derived, Options...>::set_option;
 
-  Derived& set_option(Option&& p) {
+  Derived& set_option(Option p) {
     option_ = std::move(p);
     return *static_cast<Derived*>(this);
   }

--- a/google/cloud/storage/internal/generic_request_test.cc
+++ b/google/cloud/storage/internal/generic_request_test.cc
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/generic_request.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+struct Dummy : public GenericRequest<Dummy> {};
+
+TEST(GenericRequestTest, SetOptionRValueFirstBase) {
+  Dummy req;
+  req.set_option(QuotaUser("user1"));
+  EXPECT_TRUE(req.HasOption<QuotaUser>());
+  EXPECT_EQ("user1", req.GetOption<QuotaUser>().value());
+}
+
+TEST(GenericRequestTest, SetOptionLValueFirstBase) {
+  Dummy req;
+  QuotaUser arg("user1");
+  req.set_option(arg);
+  EXPECT_TRUE(req.HasOption<QuotaUser>());
+  EXPECT_EQ("user1", req.GetOption<QuotaUser>().value());
+}
+
+TEST(GenericRequestTest, SetOptionRValueLastBase) {
+  Dummy req;
+  req.set_option(CustomHeader("header1", "val1"));
+  EXPECT_TRUE(req.HasOption<CustomHeader>());
+  EXPECT_EQ("header1", req.GetOption<CustomHeader>().custom_header_name());
+}
+
+TEST(GenericRequestTest, SetOptionLValueLastBase) {
+  Dummy req;
+  CustomHeader arg("header1", "val1");
+  req.set_option(arg);
+  EXPECT_TRUE(req.HasOption<CustomHeader>());
+  EXPECT_EQ("header1", req.GetOption<CustomHeader>().custom_header_name());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -49,6 +49,7 @@ storage_client_unit_tests = [
     "internal/curl_wrappers_enable_sigpipe_handler_test.cc",
     "internal/default_object_acl_requests_test.cc",
     "internal/generate_message_boundary_test.cc",
+    "internal/generic_request_test.cc",
     "internal/hash_validator_test.cc",
     "internal/hmac_key_requests_test.cc",
     "internal/http_response_test.cc",


### PR DESCRIPTION
This fixes #3285.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3287)
<!-- Reviewable:end -->
