### PR TITLE
feat!: move creating prefix marker to ComposeMany

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -1116,17 +1116,15 @@ void ComposeObjectFromMany(google::cloud::storage::Client client, int& argc,
   [](gcs::Client client, std::string bucket_name,
      std::string destination_object_name,
      std::vector<gcs::ComposeSourceObject> compose_objects) {
-    StatusOr<gcs::ObjectMetadata> prefix_md =
-        gcs::CreateRandomPrefix(client, bucket_name, ".tmpfiles");
-    if (!prefix_md) {
-      throw std::runtime_error(prefix_md.status().message());
-    }
-    std::string const prefix = prefix_md->name();
+    std::string prefix = gcs::CreateRandomPrefixName(".tmpfiles");
     StatusOr<gcs::ObjectMetadata> composed_object =
         ComposeMany(client, bucket_name, compose_objects, prefix,
                     destination_object_name, false);
 
     if (!composed_object) {
+      // If this is an effect of some transient unavailability, stray temporary
+      // might be left over. You can use `DeleteByPrefix()` with `prefix` as
+      // argument to delete them.
       throw std::runtime_error(composed_object.status().message());
     }
 

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -748,28 +748,6 @@ TEST_F(ObjectInsertIntegrationTest, InsertXmlFailure) {
   ASSERT_STATUS_OK(status);
 }
 
-TEST_F(ObjectInsertIntegrationTest, CreateRandomPrefix) {
-  StatusOr<Client> client = MakeIntegrationTestClient();
-  ASSERT_STATUS_OK(client);
-
-  std::string bucket_name = flag_bucket_name;
-  std::string prefix("prefix.");
-
-  auto object = CreateRandomPrefix(*client, bucket_name, prefix);
-
-  ASSERT_STATUS_OK(object);
-  ASSERT_EQ(prefix.length() + 16, object->name().length());
-  ASSERT_EQ(prefix, object->name().substr(0, prefix.length()));
-
-  // Create a iostream to read the object back.
-  auto stream = client->ReadObject(bucket_name, object->name());
-  std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ("", actual);
-
-  auto status = client->DeleteObject(bucket_name, object->name());
-  ASSERT_STATUS_OK(status);
-}
-
 }  // anonymous namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
**BREAKING CHANGE:** Before this PR, the user had to create a prefix
(which could fail), pass it to `ComposeMany` and remove it afterwards. It
was a lot of boilerplate.

With this PR, the prefix name is picked at random and `ComposeMany`
handles creating and deleting the marker file.

This is needed for #3279.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3296)
<!-- Reviewable:end -->
