### PR TITLE
feat: build Chain filter from a range

### DIFF
--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -572,6 +572,31 @@ class Filter {
   }
 
   /**
+   * Return a chain filter.
+   *
+   * The filter returned by this function acts like a pipeline.  The output
+   * row from each stage is passed on as input for the next stage.
+   *
+   * @tparam Iterator an InputIterator whose `value_type` is `Filter`.
+   * @param begin the start of the range.
+   * @param end the end of the range.
+   */
+  template <typename Iterator>
+  static Filter ChainFromRange(Iterator begin, Iterator end) {
+    static_assert(
+        std::is_convertible<typename std::iterator_traits<Iterator>::value_type,
+                            Filter>::value,
+        "The value type of the Iterator arguments passed to"
+        " InterleaveFromRange(...) must be convertible to Filter");
+    Filter tmp;
+    auto& chain = *tmp.filter_.mutable_chain();
+    for (auto it = begin; it != end; ++it) {
+      *chain.add_filters() = it->as_proto();
+    }
+    return tmp;
+  }
+
+  /**
    * Return a filter that interleaves the results of many other filters.
    *
    * This filter executes each stream in parallel and then merges the results by

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -252,6 +252,48 @@ TEST(FiltersTest, ChainOneArg) {
   EXPECT_EQ(2, chain.filters(0).cells_per_column_limit_filter());
 }
 
+/// @test Verify that `bigtable::Filter::ChainFromRange` works as expected.
+TEST(FiltersTest, ChainFromRangeMany) {
+  using F = bigtable::Filter;
+  std::vector<F> filter_collection{F::FamilyRegex("fam"), F::ColumnRegex("col"),
+                                   F::CellsRowOffset(2), F::Latest(1)};
+  auto filter =
+      F::ChainFromRange(filter_collection.begin(), filter_collection.end());
+  auto proto = filter.as_proto();
+  ASSERT_TRUE(proto.has_chain());
+  auto const& chain = proto.chain();
+  ASSERT_EQ(4, chain.filters_size());
+  EXPECT_EQ("fam", chain.filters(0).family_name_regex_filter());
+  EXPECT_EQ("col", chain.filters(1).column_qualifier_regex_filter());
+  EXPECT_EQ(2, chain.filters(2).cells_per_row_offset_filter());
+  EXPECT_EQ(1, chain.filters(3).cells_per_column_limit_filter());
+}
+
+/// @test Verify that `bigtable::Filter::ChainFromRange` works as expected.
+TEST(FiltersTest, ChainFromRangeEmpty) {
+  using F = bigtable::Filter;
+  std::vector<F> filter_collection{};
+  auto filter =
+      F::ChainFromRange(filter_collection.begin(), filter_collection.end());
+  auto proto = filter.as_proto();
+  ASSERT_TRUE(proto.has_chain());
+  auto const& chain = proto.chain();
+  ASSERT_EQ(0, chain.filters_size());
+}
+
+/// @test Verify that `bigtable::Filter::ChainFromRange` works as expected.
+TEST(FiltersTest, ChainFromRangeSingle) {
+  using F = bigtable::Filter;
+  std::vector<F> filter_collection{F::Latest(2)};
+  auto filter =
+      F::ChainFromRange(filter_collection.begin(), filter_collection.end());
+  auto proto = filter.as_proto();
+  ASSERT_TRUE(proto.has_chain());
+  auto const& Chain = proto.chain();
+  ASSERT_EQ(1, Chain.filters_size());
+  EXPECT_EQ(2, Chain.filters(0).cells_per_column_limit_filter());
+}
+
 /// @test Verify that `bigtable::Filter::Interleave` works as expected.
 TEST(FiltersTest, InterleaveMultipleArgs) {
   using F = bigtable::Filter;

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -506,6 +506,30 @@ TEST_F(FilterIntegrationTest, Chain) {
   CheckEqualUnordered(expected, actual);
 }
 
+TEST_F(FilterIntegrationTest, ChainFromRange) {
+  auto table = GetTable();
+  std::string const prefix = "chain-prefix";
+  std::vector<bigtable::Cell> created{
+      {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
+      {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
+      {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
+      {prefix + "/fgh0", "family1", "c3", 4000, "v4000"},
+      {prefix + "/hij0", "family2", "c4", 4000, "v5000"},
+      {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
+  };
+  CreateCells(table, created);
+  std::vector<bigtable::Cell> expected{
+      {prefix + "/fgh0", "family1", "c3", 4000, ""},
+  };
+
+  using F = bigtable::Filter;
+  auto range = {F::ValueRangeClosed("v2000", "v5000"),
+                F::StripValueTransformer(),
+                F::ColumnRangeClosed("family1", "c2", "c3")};
+  auto actual = ReadRows(table, F::ChainFromRange(range.begin(), range.end()));
+  CheckEqualUnordered(expected, actual);
+}
+
 TEST_F(FilterIntegrationTest, Interleave) {
   auto table = GetTable();
   std::string const prefix = "interleave-prefix";


### PR DESCRIPTION
Allow application developers to build chain filters dynamically, from a
collection (or range) of filters.

Fixes #3291

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3303)
<!-- Reviewable:end -->
