### PR TITLE
fix: handle CURLE_GOT_NOTHING as retryable

### DIFF
--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -226,26 +226,36 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
     case CURLE_NOT_BUILT_IN:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_COULDNT_RESOLVE_PROXY:
     case CURLE_COULDNT_RESOLVE_HOST:
     case CURLE_COULDNT_CONNECT:
-    case CURLE_WEIRD_SERVER_REPLY:
       code = StatusCode::kUnavailable;
       break;
+
+#if LIBCURL_VERSION_NUM >= 0x075100
+    case CURLE_WEIRD_SERVER_REPLY:
+      code = StatusCode::kUnknown;
+      break;
+#endif  // CURL >= 7.51.0
+
     case CURLE_REMOTE_ACCESS_DENIED:
       code = StatusCode::kPermissionDenied;
       break;
+
     case CURLE_FTP_ACCEPT_FAILED:
     case CURLE_FTP_WEIRD_PASS_REPLY:
     case CURLE_FTP_WEIRD_227_FORMAT:
     case CURLE_FTP_CANT_GET_HOST:
-    case CURLE_HTTP2:
+    // case CURLE_HTTP2:  unavailable in old versions of libcurl
     case CURLE_FTP_COULDNT_SET_TYPE:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_PARTIAL_FILE:
       code = StatusCode::kUnavailable;
       break;
+
     case CURLE_FTP_COULDNT_RETR_FILE:
     case CURLE_QUOTE_ERROR:
     case CURLE_WRITE_ERROR:
@@ -254,37 +264,46 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
     case CURLE_OUT_OF_MEMORY:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_OPERATION_TIMEDOUT:
       code = StatusCode::kDeadlineExceeded;
       break;
+
     case CURLE_FTP_PORT_FAILED:
     case CURLE_FTP_COULDNT_USE_REST:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_RANGE_ERROR:
       // This is defined as "the server does not *support or *accept* range
       // requests", so it means something stronger than "your range value is
       // not valid".
       code = StatusCode::kUnimplemented;
       break;
+
     case CURLE_HTTP_POST_ERROR:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_SSL_CONNECT_ERROR:
       code = StatusCode::kUnavailable;
       break;
+
     case CURLE_BAD_DOWNLOAD_RESUME:
       code = StatusCode::kInvalidArgument;
       break;
+
     case CURLE_FILE_COULDNT_READ_FILE:
     case CURLE_LDAP_CANNOT_BIND:
     case CURLE_LDAP_SEARCH_FAILED:
     case CURLE_FUNCTION_NOT_FOUND:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_ABORTED_BY_CALLBACK:
       code = StatusCode::kAborted;
       break;
+
     case CURLE_BAD_FUNCTION_ARGUMENT:
     case CURLE_INTERFACE_FAILED:
     case CURLE_TOO_MANY_REDIRECTS:
@@ -292,16 +311,20 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
     case CURLE_TELNET_OPTION_SYNTAX:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_GOT_NOTHING:
       code = StatusCode::kUnavailable;
       break;
+
     case CURLE_SSL_ENGINE_NOTFOUND:
       code = StatusCode::kUnknown;
       break;
+
     case CURLE_RECV_ERROR:
     case CURLE_SEND_ERROR:
       code = StatusCode::kUnavailable;
       break;
+
     case CURLE_SSL_CERTPROBLEM:
     case CURLE_SSL_CIPHER:
     case CURLE_PEER_FAILED_VERIFICATION:
@@ -331,7 +354,6 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
 
     case CURLE_SSH:
     case CURLE_SSL_SHUTDOWN_FAILED:
-
     case CURLE_AGAIN:
       // Only returned by curl_easy_{recv,send}, but should not with the
       // configuration we use for libcurl. And the recovery action is to call

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -218,7 +218,7 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
   os << where << "() - CURL error [" << e << "]=" << curl_easy_strerror(e);
   // Map the CURLE* errors using the documentation on:
   //   https://curl.haxx.se/libcurl/c/libcurl-errors.html
-  // the error codes are listed in the same order as shown on that page, so
+  // The error codes are listed in the same order as shown on that page, so
   // one can quickly find out how an error code is handled. All the error codes
   // are listed, but those that do not appear in old libcurl versions are
   // commented out and handled by the `default:` case.

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -45,13 +45,14 @@ TEST(CurlHandleTest, AsStatus) {
       {CURLE_REMOTE_FILE_NOT_FOUND, StatusCode::kNotFound},
       {CURLE_FAILED_INIT, StatusCode::kUnknown},
       {CURLE_FTP_PORT_FAILED, StatusCode::kUnknown},
+      {CURLE_GOT_NOTHING, StatusCode::kUnavailable},
       {CURLE_AGAIN, StatusCode::kUnknown},
   };
 
   for (auto const& codes : expected_codes) {
     auto const expected = Status(codes.expected, "ignored");
     auto const actual = CurlHandle::AsStatus(codes.curl, "in-test");
-    EXPECT_EQ(expected.code(), actual.code());
+    EXPECT_EQ(expected.code(), actual.code()) << "CURL code=" << codes.curl;
     if (!actual.ok()) {
       EXPECT_THAT(actual.message(), HasSubstr("in-test"));
       EXPECT_THAT(actual.message(), HasSubstr(curl_easy_strerror(codes.curl)));


### PR DESCRIPTION
Getting nothing is approximately the same as getting a timeout, so we
should treat that as a kUnavailable (one of the retryable errors). The
application can use the strict idempotency policy and some preconditions
if they worry about the operation being too destructive when sent twice
to the server.

Changed the code to make it easier to review what error codes are handled
already. Fixes #3315.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3316)
<!-- Reviewable:end -->
