### PR TITLE
feat: implement Delimiter option for ListObjects

### DIFF
--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -54,8 +54,8 @@ internal::nl::json ObjectMetadataJsonForUpdate(ObjectMetadata const& meta);
  * Represents a request to the `Objects: list` API.
  */
 class ListObjectsRequest
-    : public GenericRequest<ListObjectsRequest, MaxResults, Prefix, Projection,
-                            UserProject, Versions> {
+    : public GenericRequest<ListObjectsRequest, MaxResults, Prefix, Delimiter,
+                            Projection, UserProject, Versions> {
  public:
   ListObjectsRequest() = default;
   explicit ListObjectsRequest(std::string bucket_name)

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -432,7 +432,14 @@ struct Prefix : public internal::WellKnownParameter<Prefix, std::string> {
 };
 
 /**
+ * Returns results in a directory-like mode.
  *
+ * Used in `Client::ListObjects` to return only those objects that do **not**
+ * contain the delimiter, unless said delimiter appears in the `Prefix`
+ * parameter (if any).
+ *
+ * @see https://cloud.google.com/storage/docs/json_api/v1/objects/list for more
+ *   information.
  */
 struct Delimiter : public internal::WellKnownParameter<Delimiter, std::string> {
   using WellKnownParameter<Delimiter, std::string>::WellKnownParameter;

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -432,6 +432,14 @@ struct Prefix : public internal::WellKnownParameter<Prefix, std::string> {
 };
 
 /**
+ *
+ */
+struct Delimiter : public internal::WellKnownParameter<Delimiter, std::string> {
+  using WellKnownParameter<Delimiter, std::string>::WellKnownParameter;
+  static char const* well_known_parameter_name() { return "delimiter"; }
+};
+
+/**
  * Controls what metadata fields are included in the response.
  *
  * For those operations that return the metadata of an Object or Bucket, this


### PR DESCRIPTION
Somehow we completely missed this option in the initial implementation.

Fixes #3319

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3320)
<!-- Reviewable:end -->
