### PR TITLE
test: don't build benchmarks without tests

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -14,55 +14,56 @@
 # limitations under the License.
 # ~~~
 
-add_library(storage_benchmarks benchmark_utils.h benchmark_utils.cc)
-target_link_libraries(
-    storage_benchmarks
-    PUBLIC storage_client
-    PRIVATE storage_common_options google_cloud_cpp_common_options)
-
-include(CheckCXXSymbolExists)
-check_cxx_symbol_exists(getrusage sys/resource.h
-                        GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE)
-check_cxx_symbol_exists(RUSAGE_THREAD sys/resource.h
-                        GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD)
-target_compile_definitions(
-    storage_benchmarks
-    PUBLIC
-    GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE=$<BOOL:${GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE}>
-    GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD=$<BOOL:${GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD}>
-)
-
-include(CreateBazelConfig)
-create_bazel_config(storage_benchmarks YEAR 2019)
-
-set(storage_benchmark_programs
-    storage_file_transfer_benchmark.cc
-    storage_latency_benchmark.cc
-    storage_shard_throughput_benchmark.cc
-    storage_throughput_benchmark.cc
-    storage_throughput_vs_cpu_benchmark.cc
-    storage_parallel_uploads_benchmark.cc)
-
-foreach (fname ${storage_benchmark_programs})
-    string(REPLACE "/" "_" target ${fname})
-    string(REPLACE ".cc" "" target ${target})
-    add_executable(${target} ${fname})
-    target_link_libraries(
-        ${target}
-        PRIVATE storage_benchmarks
-                storage_client
-                google_cloud_cpp_common
-                CURL::libcurl
-                Threads::Threads
-                nlohmann_json
-                storage_common_options
-                google_cloud_cpp_common_options)
-endforeach ()
-
-export_list_to_bazel("storage_benchmark_programs.bzl"
-                     "storage_benchmark_programs" YEAR 2019)
-
 if (BUILD_TESTING)
+
+    add_library(storage_benchmarks benchmark_utils.h benchmark_utils.cc)
+    target_link_libraries(
+        storage_benchmarks
+        PUBLIC storage_client
+        PRIVATE storage_common_options google_cloud_cpp_common_options)
+
+    include(CheckCXXSymbolExists)
+    check_cxx_symbol_exists(getrusage sys/resource.h
+                            GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE)
+    check_cxx_symbol_exists(RUSAGE_THREAD sys/resource.h
+                            GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD)
+    target_compile_definitions(
+        storage_benchmarks
+        PUBLIC
+        GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE=$<BOOL:${GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE}>
+        GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD=$<BOOL:${GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD}>
+    )
+
+    include(CreateBazelConfig)
+    create_bazel_config(storage_benchmarks YEAR 2019)
+
+    set(storage_benchmark_programs
+        storage_file_transfer_benchmark.cc
+        storage_latency_benchmark.cc
+        storage_shard_throughput_benchmark.cc
+        storage_throughput_benchmark.cc
+        storage_throughput_vs_cpu_benchmark.cc
+        storage_parallel_uploads_benchmark.cc)
+
+    foreach (fname ${storage_benchmark_programs})
+        string(REPLACE "/" "_" target ${fname})
+        string(REPLACE ".cc" "" target ${target})
+        add_executable(${target} ${fname})
+        target_link_libraries(
+            ${target}
+            PRIVATE storage_benchmarks
+                    storage_client
+                    google_cloud_cpp_common
+                    CURL::libcurl
+                    Threads::Threads
+                    nlohmann_json
+                    storage_common_options
+                    google_cloud_cpp_common_options)
+    endforeach ()
+
+    export_list_to_bazel("storage_benchmark_programs.bzl"
+                         "storage_benchmark_programs" YEAR 2019)
+
     # List the unit tests, then setup the targets and dependencies.
     set(storage_benchmarks_unit_tests
         benchmark_parser_test.cc benchmark_make_random_test.cc


### PR DESCRIPTION
Benchmarks could benefit from using testing libraries, but they are not
available in build configurations which skip tests. Since benchmarks are
usually not needed they are now not built if tests aren't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3322)
<!-- Reviewable:end -->
