### PR TITLE
feat: use Bigtable direct path if configured

### DIFF
--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -26,6 +26,9 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 struct InstanceAdminTraits;
+std::string DefaultDataEndpoint();
+std::string DefaultAdminEndpoint();
+std::string DefaultInstanceAdminEndpoint();
 }  // namespace internal
 
 /**

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -200,7 +200,8 @@ TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminNoEnv) {
   google::cloud::internal::UnsetEnv("BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST");
   google::cloud::internal::UnsetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH");
 
-  EXPECT_EQ("bigtableadmin.googleapis.com", internal::DefaultInstanceAdminEndpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com",
+            internal::DefaultInstanceAdminEndpoint());
 }
 
 TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminDirectPathNoEffect) {
@@ -209,7 +210,8 @@ TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminDirectPathNoEffect) {
   google::cloud::internal::SetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
                                   "bigtable");
 
-  EXPECT_EQ("bigtableadmin.googleapis.com", internal::DefaultInstanceAdminEndpoint());
+  EXPECT_EQ("bigtableadmin.googleapis.com",
+            internal::DefaultInstanceAdminEndpoint());
 }
 
 TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminEmulatorOverrides) {


### PR DESCRIPTION
Use the GOOGLE_CLOUD_ENABLE_DIRECT_PATH environment variable to
automatically switch to the Bigtable direct path endpoint.

Fixes #3331

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3338)
<!-- Reviewable:end -->
