### PR TITLE
fix: handle completed uploads with X-Upload-Content-Length header

### DIFF
--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -52,7 +52,8 @@ class CurlResumableUploadSession : public ResumableUploadSession {
   }
 
  private:
-  void Update(StatusOr<ResumableUploadResponse> const& result);
+  void Update(StatusOr<ResumableUploadResponse> const& result,
+              std::size_t chunk_size);
 
   std::shared_ptr<CurlClient> client_;
   std::string session_id_;

--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -130,7 +130,7 @@ Status AsStatus(HttpResponse const& http_response) {
 }
 
 std::ostream& operator<<(std::ostream& os, HttpResponse const& rhs) {
-  os << "status_code=" << rhs.status_code << ", {";
+  os << "status_code=" << rhs.status_code << ", headers={";
   char const* sep = "";
   for (auto const& kv : rhs.headers) {
     os << sep << kv.first << ": " << kv.second;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -205,7 +205,20 @@ LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto result = MakeCallNoResponseLogging(
       *client_, &RawClient::CreateResumableSession, request, __func__);
   if (!result.ok()) {
+    GCP_LOG(INFO) << __func__ << "() >> status={" << result.status() << "}";
     return std::move(result).status();
+  }
+  GCP_LOG(INFO) << __func__ << "() >> payload={session.session_id="
+                << result.value()->session_id()
+                << ", session.next_expected_byte="
+                << result.value()->next_expected_byte()
+                << ", done=" << result.value()->done() << "}";
+  if (result.value()->last_response()) {
+    GCP_LOG(INFO) << __func__ << "() >> payload={session.last_response="
+                  << *result.value()->last_response() << "}";
+  } else {
+    GCP_LOG(INFO) << __func__ << "() >> payload={session.last_response.status="
+                  << result.value()->last_response().status() << "}";
   }
   return std::unique_ptr<ResumableUploadSession>(
       google::cloud::internal::make_unique<LoggingResumableUploadSession>(

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -24,12 +24,12 @@ namespace internal {
 
 StatusOr<ResumableUploadResponse> LoggingResumableUploadSession::UploadChunk(
     std::string const& buffer) {
-  GCP_LOG(INFO) << __func__ << "(), buffer.size=" << buffer.size();
+  GCP_LOG(INFO) << __func__ << "() << {buffer.size=" << buffer.size() << "}";
   auto response = session_->UploadChunk(buffer);
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }
@@ -41,47 +41,47 @@ LoggingResumableUploadSession::UploadFinalChunk(std::string const& buffer,
                 << ", buffer.size=" << buffer.size();
   auto response = session_->UploadFinalChunk(buffer, upload_size);
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }
 
 StatusOr<ResumableUploadResponse>
 LoggingResumableUploadSession::ResetSession() {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto response = session_->ResetSession();
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }
 
 std::uint64_t LoggingResumableUploadSession::next_expected_byte() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto response = session_->next_expected_byte();
-  GCP_LOG(INFO) << __func__ << " >> " << response;
+  GCP_LOG(INFO) << __func__ << "() >> " << response;
   return response;
 }
 
 std::string const& LoggingResumableUploadSession::session_id() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto const& response = session_->session_id();
-  GCP_LOG(INFO) << __func__ << " >> " << response;
+  GCP_LOG(INFO) << __func__ << "() >> " << response;
   return response;
 }
 
 StatusOr<ResumableUploadResponse> const&
 LoggingResumableUploadSession::last_response() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}}";
   auto const& response = session_->last_response();
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -92,9 +92,11 @@ RetryResumableUploadSession::UploadGenericChunk(
                       ? session_->UploadFinalChunk(*buffer_to_use, *upload_size)
                       : session_->UploadChunk(*buffer_to_use);
     if (result.ok()) {
-      if (is_final_chunk &&
-          result->upload_state == ResumableUploadResponse::kDone) {
-        // If it's a final chunk and it was sent successfully, return.
+      if (result->upload_state == ResumableUploadResponse::kDone) {
+        // The upload was completed. This can happen even if
+        // `is_final_chunk == false`, for example, if the application includes
+        // the X-Upload-Content-Length` header, which allows the server to
+        // detect a completed upload "early".
         return result;
       }
       auto current_next_expected_byte = next_expected_byte();

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -252,6 +252,40 @@ TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteSlow) {
   EXPECT_STATUS_OK(status);
 }
 
+TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteChunkMultiple) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  std::string bucket_name = flag_bucket_name;
+  auto object_name = MakeRandomObjectName();
+
+  auto const MiB = 1024 * 1024L;
+  auto const chunk_size = 2 * MiB;
+  auto const chunk = MakeRandomData(chunk_size);
+
+  for (auto const desired_size : {2 * MiB, 3 * MiB, 4 * MiB}) {
+    SCOPED_TRACE("Testing with desired_size = " + std::to_string(desired_size));
+    auto os =
+        client->WriteObject(bucket_name, object_name, IfGenerationMatch(0));
+    auto offset = 0L;
+    while (offset < desired_size) {
+      auto const n = (std::min)(desired_size - offset, chunk_size);
+      os.write(chunk.data(), n);
+      ASSERT_FALSE(os.bad());
+      offset += n;
+    }
+
+    // This operation should fail because the object already exists.
+    os.Close();
+    EXPECT_FALSE(os.bad());
+    EXPECT_STATUS_OK(os.metadata());
+    EXPECT_EQ(desired_size, os.metadata()->size());
+
+    auto status = client->DeleteObject(bucket_name, object_name);
+    EXPECT_STATUS_OK(status);
+  }
+}
+
 }  // anonymous namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
Applications can provide the `X-Upload-Content-Length` header in their
resumable uploads. This let's GCS know how many bytes to expect, and
GCS completes an upload as soon as that many bytes arrive. In this case
the response does not have a `Range:` header indicating the last committed
byte, and these responses must be handled differently.

This fixes #3342

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3346)
<!-- Reviewable:end -->
