### PR TITLE
fix: handle completed uploads in UploadChunk

### DIFF
--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -52,7 +52,8 @@ class CurlResumableUploadSession : public ResumableUploadSession {
   }
 
  private:
-  void Update(StatusOr<ResumableUploadResponse> const& result);
+  void Update(StatusOr<ResumableUploadResponse> const& result,
+              std::size_t chunk_size);
 
   std::shared_ptr<CurlClient> client_;
   std::string session_id_;

--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -130,7 +130,7 @@ Status AsStatus(HttpResponse const& http_response) {
 }
 
 std::ostream& operator<<(std::ostream& os, HttpResponse const& rhs) {
-  os << "status_code=" << rhs.status_code << ", {";
+  os << "status_code=" << rhs.status_code << ", headers={";
   char const* sep = "";
   for (auto const& kv : rhs.headers) {
     os << sep << kv.first << ": " << kv.second;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -205,6 +205,7 @@ LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
   auto result = MakeCallNoResponseLogging(
       *client_, &RawClient::CreateResumableSession, request, __func__);
   if (!result.ok()) {
+    GCP_LOG(INFO) << __func__ << "() >> status={" << result.status() << "}";
     return std::move(result).status();
   }
   return std::unique_ptr<ResumableUploadSession>(

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -24,12 +24,12 @@ namespace internal {
 
 StatusOr<ResumableUploadResponse> LoggingResumableUploadSession::UploadChunk(
     std::string const& buffer) {
-  GCP_LOG(INFO) << __func__ << "(), buffer.size=" << buffer.size();
+  GCP_LOG(INFO) << __func__ << "() << {buffer.size=" << buffer.size() << "}";
   auto response = session_->UploadChunk(buffer);
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }
@@ -41,47 +41,47 @@ LoggingResumableUploadSession::UploadFinalChunk(std::string const& buffer,
                 << ", buffer.size=" << buffer.size();
   auto response = session_->UploadFinalChunk(buffer, upload_size);
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }
 
 StatusOr<ResumableUploadResponse>
 LoggingResumableUploadSession::ResetSession() {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto response = session_->ResetSession();
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }
 
 std::uint64_t LoggingResumableUploadSession::next_expected_byte() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto response = session_->next_expected_byte();
-  GCP_LOG(INFO) << __func__ << " >> " << response;
+  GCP_LOG(INFO) << __func__ << "() >> " << response;
   return response;
 }
 
 std::string const& LoggingResumableUploadSession::session_id() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto const& response = session_->session_id();
-  GCP_LOG(INFO) << __func__ << " >> " << response;
+  GCP_LOG(INFO) << __func__ << "() >> " << response;
   return response;
 }
 
 StatusOr<ResumableUploadResponse> const&
 LoggingResumableUploadSession::last_response() const {
-  GCP_LOG(INFO) << __func__ << " << ()";
+  GCP_LOG(INFO) << __func__ << "() << {}}";
   auto const& response = session_->last_response();
   if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << " >> payload={" << response.value() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
   } else {
-    GCP_LOG(INFO) << __func__ << " >> status={" << response.status() << "}";
+    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
   }
   return response;
 }

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -76,7 +76,7 @@ std::string const& LoggingResumableUploadSession::session_id() const {
 
 StatusOr<ResumableUploadResponse> const&
 LoggingResumableUploadSession::last_response() const {
-  GCP_LOG(INFO) << __func__ << "() << {}}";
+  GCP_LOG(INFO) << __func__ << "() << {}";
   auto const& response = session_->last_response();
   if (response.ok()) {
     GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -92,9 +92,11 @@ RetryResumableUploadSession::UploadGenericChunk(
                       ? session_->UploadFinalChunk(*buffer_to_use, *upload_size)
                       : session_->UploadChunk(*buffer_to_use);
     if (result.ok()) {
-      if (is_final_chunk &&
-          result->upload_state == ResumableUploadResponse::kDone) {
-        // If it's a final chunk and it was sent successfully, return.
+      if (result->upload_state == ResumableUploadResponse::kDone) {
+        // The upload was completed. This can happen even if
+        // `is_final_chunk == false`, for example, if the application includes
+        // the X-Upload-Content-Length` header, which allows the server to
+        // detect a completed upload "early".
         return result;
       }
       auto current_next_expected_byte = next_expected_byte();

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -266,7 +266,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLength) {
 
   for (auto const desired_size : {2 * MiB, 3 * MiB, 4 * MiB}) {
     auto object_name = MakeRandomObjectName();
-    SCOPED_TRACE("Testing with desired_size = " + std::to_string(desired_size) +
+    SCOPED_TRACE("Testing with desired_size=" + std::to_string(desired_size) +
                  ", name=" + object_name);
     auto os = client.WriteObject(
         bucket_name, object_name, IfGenerationMatch(0),
@@ -279,7 +279,6 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLength) {
       offset += n;
     }
 
-    // This operation should fail because the object already exists.
     os.Close();
     EXPECT_FALSE(os.bad());
     EXPECT_STATUS_OK(os.metadata());
@@ -306,7 +305,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLengthRandom) {
   for (int i = 0; i != 10; ++i) {
     auto object_name = MakeRandomObjectName();
     auto const desired_size = size_gen(generator_);
-    SCOPED_TRACE("Testing with desired_size = " + std::to_string(desired_size) +
+    SCOPED_TRACE("Testing with desired_size=" + std::to_string(desired_size) +
                  ", name=" + object_name);
     auto os = client.WriteObject(
         bucket_name, object_name, IfGenerationMatch(0),
@@ -319,7 +318,6 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLengthRandom) {
       offset += n;
     }
 
-    // This operation should fail because the object already exists.
     os.Close();
     EXPECT_FALSE(os.bad());
     EXPECT_STATUS_OK(os.metadata());
@@ -355,11 +353,12 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithInvalidXUploadContentLength) {
     offset += n;
   }
 
-  // This operation should fail because the object already exists.
+  // This operation should fail because the x-upload-content-length header does
+  // not match the amount of data sent in the upload.
   os.Close();
   EXPECT_TRUE(os.bad());
   EXPECT_FALSE(os.metadata().ok());
-  // No need to delete the object, it is not created.
+  // No need to delete the object, as it is never created.
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Applications can provide the `X-Upload-Content-Length` header in their
resumable uploads. This let's GCS know how many bytes to expect, and GCS
completes an upload as soon as that many bytes arrive. In this case the
response does not have a `Range:` header indicating the last committed
byte, and these responses must be handled differently.

Fixes #3342

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3348)
<!-- Reviewable:end -->
