### PR TITLE
fix!: insert logging layer only if requested

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2967,9 +2967,11 @@ class Client {
   template <typename... Policies>
   std::shared_ptr<internal::RawClient> Decorate(
       std::shared_ptr<internal::RawClient> client, Policies&&... policies) {
-    auto logging = std::make_shared<internal::LoggingClient>(std::move(client));
+    if (client->client_options().enable_raw_client_tracing()) {
+      client = std::make_shared<internal::LoggingClient>(std::move(client));
+    }
     auto retry = std::make_shared<internal::RetryClient>(
-        std::move(logging), std::forward<Policies>(policies)...);
+        std::move(client), std::forward<Policies>(policies)...);
     return retry;
   }
 

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -149,7 +149,6 @@ TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
   EXPECT_CALL(*mock, CreateResumableSession(_)).WillOnce(Invoke(returner));
   EXPECT_CALL(*mock_session, UploadChunk(_))
       .WillRepeatedly(Return(PermanentError()));
-  EXPECT_CALL(*mock_session, next_expected_byte()).WillRepeatedly(Return(0));
   EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
   EXPECT_CALL(*mock_session, session_id()).WillRepeatedly(ReturnRef(empty));
   auto stream = client->WriteObject("test-bucket-name", "test-object-name");

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -149,6 +149,7 @@ TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
   EXPECT_CALL(*mock, CreateResumableSession(_)).WillOnce(Invoke(returner));
   EXPECT_CALL(*mock_session, UploadChunk(_))
       .WillRepeatedly(Return(PermanentError()));
+  EXPECT_CALL(*mock_session, next_expected_byte()).WillRepeatedly(Return(0));
   EXPECT_CALL(*mock_session, done()).WillRepeatedly(Return(false));
   EXPECT_CALL(*mock_session, session_id()).WillRepeatedly(ReturnRef(empty));
   auto stream = client->WriteObject("test-bucket-name", "test-object-name");

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -19,11 +19,9 @@
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <gmock/gmock.h>
-#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 
 namespace {
@@ -68,10 +66,10 @@ void MockReadObject(int& argc, char* argv[]) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  gcs::Client client(mock);
-
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(testing::ReturnRef(client_options));
+
+  gcs::Client client(mock);
 
   std::string text = "this is a mock http response";
   using ::testing::_;
@@ -123,10 +121,10 @@ void MockWriteObject(int& argc, char* argv[]) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  gcs::Client client(mock);
-
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(testing::ReturnRef(client_options));
+
+  gcs::Client client(mock);
 
   gcs::ObjectMetadata expected_metadata;
 
@@ -183,10 +181,10 @@ void MockReadObjectFailure(int& argc, char* argv[]) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  gcs::Client client(mock);
-
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(testing::ReturnRef(client_options));
+
+  gcs::Client client(mock);
 
   std::string text = "this is a mock http response";
   using ::testing::_;
@@ -249,10 +247,10 @@ void MockWriteObjectFailure(int& argc, char* argv[]) {
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
-  gcs::Client client(mock);
-
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(testing::ReturnRef(client_options));
+
+  gcs::Client client(mock);
 
   using ::testing::_;
   using ::testing::Return;

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -443,6 +443,8 @@ TEST_F(ObjectTest, DeleteByPrefix) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects(_))
       .WillOnce(Invoke([](internal::ListObjectsRequest const& req)
                            -> StatusOr<internal::ListObjectsResponse> {
@@ -485,6 +487,8 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects(_))
       .WillOnce(Invoke([](internal::ListObjectsRequest const& req)
                            -> StatusOr<internal::ListObjectsResponse> {
@@ -523,6 +527,8 @@ TEST_F(ObjectTest, DeleteByPrefixListFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects(_))
       .WillOnce(Return(StatusOr<internal::ListObjectsResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
@@ -538,6 +544,8 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ListObjects(_))
       .WillOnce(Invoke([](internal::ListObjectsRequest const& req)
                            -> StatusOr<internal::ListObjectsResponse> {
@@ -567,6 +575,8 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
 
 TEST_F(ObjectTest, ComposeManyNone) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   Client client(mock);
 
   auto res =
@@ -607,6 +617,8 @@ ObjectMetadata MockObject(std::string const& bucket_name,
 
 TEST_F(ObjectTest, ComposeManyOne) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ComposeObject(_))
       .WillOnce(Invoke([](internal::ComposeObjectRequest const& req)
                            -> StatusOr<ObjectMetadata> {
@@ -644,6 +656,8 @@ TEST_F(ObjectTest, ComposeManyOne) {
 
 TEST_F(ObjectTest, ComposeManyThree) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
   EXPECT_CALL(*mock, ComposeObject(_))
       .WillOnce(Invoke([](internal::ComposeObjectRequest const& req)
                            -> StatusOr<ObjectMetadata> {
@@ -687,6 +701,8 @@ TEST_F(ObjectTest, ComposeManyThree) {
 
 TEST_F(ObjectTest, ComposeManyThreeLayers) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources.
 
@@ -778,6 +794,8 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
 
 TEST_F(ObjectTest, ComposeManyComposeFails) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources - second composition fails.
 
@@ -824,6 +842,8 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources - second composition fails.
 
@@ -862,6 +882,8 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
   // Test 63 sources - second composition fails.
 
@@ -901,6 +923,9 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
 
 TEST_F(ObjectTest, ComposeManyLockingPrefixFails) {
   auto mock = std::make_shared<testing::MockClient>();
+  auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
+
   EXPECT_CALL(*mock, InsertObjectMedia(_))
       .WillOnce(Return(
           Status(StatusCode::kFailedPrecondition, "Generation mismatch")));


### PR DESCRIPTION
**BREAKING CHANGE**: the `google::cloud::storage::Client` constructor
now calls `RawClient::client_options()`, which may need changes in how
you initialize any Mocks for this class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3349)
<!-- Reviewable:end -->
