### PR TITLE
fix: correct environment variable name

### DIFF
--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -55,7 +55,7 @@ class ClientOptionsDefaultEndpointTest : public ::testing::Test {
   ClientOptionsDefaultEndpointTest()
       : bigtable_emulator_host_("BIGTABLE_EMULATOR_HOST"),
         bigtable_instance_admin_emulator_host_(
-            "BIGTABLE_INSTANCE_EMULATOR_HOST"),
+            "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST_"),
         google_cloud_enable_direct_path_("GOOGLE_CLOUD_ENABLE_DIRECT_PATH") {}
 
  protected:


### PR DESCRIPTION
Fix the name of an environment variable so `EnvironmentVariableRestore`
will re-establish its previous value at test end.  Without this, other
test cases will fail if the tests are executed in a particular order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3353)
<!-- Reviewable:end -->
