### PR TITLE
ci: use gRPC-1.26.x to workaround a known bug

### DIFF
--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -93,9 +93,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -72,9 +72,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -67,9 +67,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -88,9 +88,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -60,9 +60,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.9.1.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -75,9 +75,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.23.1.tar.gz && \
-    tar -xf v1.23.1.tar.gz && \
-    cd grpc-1.23.1 && \
+RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
     make -j ${NCPU:-4} && \
     make install && \
     ldconfig

--- a/super/external/grpc.cmake
+++ b/super/external/grpc.cmake
@@ -23,9 +23,10 @@ if (NOT TARGET grpc-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/v1.26.0.tar.gz")
+        "https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz"
+    )
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81")
+        "a2034a1c8127e35c0cc7b86c1b5ad6d8e79a62c5e133c379b8b22a78ba370015")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Workaround grpc/grpc#21280 by compiling against a specific commit
(without a tag) of the v1.26.x gRPC branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3363)
<!-- Reviewable:end -->
