### PR TITLE
ci: log when building the docker image fails

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -253,9 +253,10 @@ set +e
 mkdir -p "${BUILD_OUTPUT}"
 if timeout 3600s docker build "${docker_build_flags[@]}" ci \
     >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null; then
-   update_cache="true"
-fi
-if [[ "$?" != 0 ]]; then
+  update_cache="true"
+  echo "Docker image successfully rebuilt"
+else
+  echo "Error updating Docker image, using cached image for this build"
   dump_log "${BUILD_OUTPUT}/create-build-docker-image.log"
 fi
 


### PR DESCRIPTION
We fall back on the previously cached docker image, but showing the log
would be useful in the rare cases when *not* having an up-to-date image
is a "Bad Thing":tm:.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3367)
<!-- Reviewable:end -->
