### PR TITLE
docs: update doc/cutting-a-release.md

### DIFF
--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -97,9 +97,6 @@ uploaded documentation will generally be live in an hour at the following URLs:
 * https://googleapis.dev/cpp/google-cloud-storage/latest/
 * https://googleapis.dev/cpp/google-cloud-common/latest/
 
-You are now finished with this "releases" clone of the repo that we created in
-the instructions above. You may now remove this directory.
-
 ## Bump the version numbers in `master`
 
 Working in your fork of `gooogle-cloud-cpp`: bump the version numbers to the


### PR DESCRIPTION
Remove remnant text about removing a clone directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3369)
<!-- Reviewable:end -->
