### PR TITLE
fix: correct environment handling in client_options_test

### DIFF
--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -55,7 +55,7 @@ class ClientOptionsDefaultEndpointTest : public ::testing::Test {
   ClientOptionsDefaultEndpointTest()
       : bigtable_emulator_host_("BIGTABLE_EMULATOR_HOST"),
         bigtable_instance_admin_emulator_host_(
-            "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST_"),
+            "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST"),
         google_cloud_enable_direct_path_("GOOGLE_CLOUD_ENABLE_DIRECT_PATH") {}
 
  protected:
@@ -69,6 +69,7 @@ class ClientOptionsDefaultEndpointTest : public ::testing::Test {
   void TearDown() override {
     bigtable_emulator_host_.TearDown();
     bigtable_instance_admin_emulator_host_.TearDown();
+    google_cloud_enable_direct_path_.TearDown();
   }
 
   std::string GetInstanceAdminEndpoint(ClientOptions const& options) {


### PR DESCRIPTION
Correct a typo in the environment-variable name from #3353.

Add a missing environment-variable `TearDown()` from #3338.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3374)
<!-- Reviewable:end -->
