### PR TITLE
ci: pin python modules used in integration tests

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -44,7 +44,8 @@ RUN dnf makecache && dnf install -y \
     zlib-devel
 
 RUN pip install --upgrade pip
-RUN pip install httpbin flask gevent gunicorn crc32c
+RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -48,7 +48,8 @@ RUN dnf makecache && dnf install -y \
     zlib-devel
 
 RUN pip install --upgrade pip
-RUN pip install httpbin flask gevent gunicorn crc32c
+RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -68,7 +68,8 @@ RUN pip install --upgrade pip
 RUN pip install cmake_format==0.6.0
 
 # Install Python packages used in the integration tests.
-RUN pip install flask httpbin gevent gunicorn crc32c
+RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -70,7 +70,8 @@ RUN pip install --upgrade pip
 RUN pip install cmake_format==0.6.0
 
 # Install Python packages used in the integration tests.
-RUN pip install flask httpbin gevent gunicorn crc32c
+RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 # Install Crc32c library.
 WORKDIR /var/tmp/build

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -53,7 +53,8 @@ pip install cmake_format==0.6.0
 Install the Python modules used in the integration tests:
 
 ```console
-pip install flask httpbin gevent gunicorn crc32c --user
+pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 ```
 
 Add the pip directory to your PATH:

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -29,7 +29,7 @@ import testbench_utils
 import time
 import sys
 from werkzeug import serving
-from werkzeug import wsgi
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 
 @httpbin.app.errorhandler(error_response.ErrorResponse)
@@ -830,7 +830,7 @@ def xmlapi_put_object(bucket_name, object_name):
 (IAM_HANDLER_PATH, iam_app) = gcs_iam.get_iam_app()
 
 
-application = wsgi.DispatcherMiddleware(
+application = DispatcherMiddleware(
     root, {
         '/httpbin': httpbin.app,
         GCS_HANDLER_PATH: gcs,


### PR DESCRIPTION
The builds broke when they picked up a new version of the Wekrzeug
module. In particular the changes around DispatcherMiddleware listed
here:

https://werkzeug.palletsprojects.com/en/master/changes/#version-0-15-0

I updated the testbench to use the new version, and then pinned the
builds to use that version, which should keep us from breaking in a
similar way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3377)
<!-- Reviewable:end -->
