### PR TITLE
feat: make throughput benchmark more flexible

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -244,6 +244,33 @@ ProgressReporter::GetAccumulatedProgress() const {
   return progress_;
 }
 
+std::string FormatSize(std::uintmax_t size) {
+  struct {
+    std::uintmax_t limit;
+    std::uintmax_t resolution;
+    char const* name;
+  } ranges[] = {
+      {kKiB, 1, "B"},
+      {kMiB, kKiB, "KiB"},
+      {kGiB, kMiB, "MiB"},
+      {kTiB, kGiB, "GiB"},
+  };
+  auto resolution = kTiB;
+  char const* name = "TiB";
+  for (auto const& r : ranges) {
+    if (size < r.limit) {
+      resolution = r.resolution;
+      name = r.name;
+      break;
+    }
+  }
+  std::ostringstream os;
+  os.setf(std::ios::fixed);
+  os.precision(1);
+  os << static_cast<double>(size) / resolution << name;
+  return os.str();
+}
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/random_names.h"
 #include <chrono>
 #include <functional>
+#include <sstream>
 #include <string>
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 #include <sys/resource.h>
@@ -122,6 +123,34 @@ class ProgressReporter {
   std::chrono::steady_clock::time_point start_;
   std::vector<TimePoint> progress_;
 };
+
+template <typename Integer>
+std::string FormatSize(Integer size) {
+  struct {
+    std::int64_t limit;
+    std::int64_t resolution;
+    char const* name;
+  } ranges[] = {
+      {kKiB, 1, "B"},
+      {kMiB, kKiB, "KiB"},
+      {kGiB, kMiB, "MiB"},
+      {kTiB, kGiB, "GiB"},
+  };
+  auto resolution = kTiB;
+  char const* name = "TiB";
+  for (auto const& r : ranges) {
+    if (size < r.limit) {
+      resolution = r.resolution;
+      name = r.name;
+      break;
+    }
+  }
+  std::ostringstream os;
+  os.setf(std::ios::fixed);
+  os.precision(1);
+  os << static_cast<double>(size) / resolution << name;
+  return os.str();
+}
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -124,33 +124,7 @@ class ProgressReporter {
   std::vector<TimePoint> progress_;
 };
 
-template <typename Integer>
-std::string FormatSize(Integer size) {
-  struct {
-    std::int64_t limit;
-    std::int64_t resolution;
-    char const* name;
-  } ranges[] = {
-      {kKiB, 1, "B"},
-      {kMiB, kKiB, "KiB"},
-      {kGiB, kMiB, "MiB"},
-      {kTiB, kGiB, "GiB"},
-  };
-  auto resolution = kTiB;
-  char const* name = "TiB";
-  for (auto const& r : ranges) {
-    if (size < r.limit) {
-      resolution = r.resolution;
-      name = r.name;
-      break;
-    }
-  }
-  std::ostringstream os;
-  os.setf(std::ios::fixed);
-  os.precision(1);
-  os << static_cast<double>(size) / resolution << name;
-  return os.str();
-}
+std::string FormatSize(std::uintmax_t size);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/benchmark_utils_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils_test.cc
@@ -38,6 +38,17 @@ TEST(ProgressReporterTest, Trivial) {
   EXPECT_LE(3000, res[2].elapsed.count());
 }
 
+TEST(FormatSize, Basic) {
+  EXPECT_EQ("1023.0B", FormatSize(1023));
+  EXPECT_EQ("1.0KiB", FormatSize(kKiB));
+  EXPECT_EQ("1.1KiB", FormatSize(kKiB + 100));
+  EXPECT_EQ("1.0MiB", FormatSize(kMiB));
+  EXPECT_EQ("1.0GiB", FormatSize(kGiB));
+  EXPECT_EQ("1.1GiB", FormatSize(kGiB + 128 * kMiB));
+  EXPECT_EQ("1.0TiB", FormatSize(kTiB));
+  EXPECT_EQ("2.0TiB", FormatSize(2 * kTiB));
+}
+
 }  // namespace
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -66,17 +66,45 @@ run_example ./storage_shard_throughput_benchmark \
 
 run_example ./storage_throughput_benchmark --help
 run_example ./storage_throughput_benchmark --description
+readonly THROUGHPUT_BUCKET_NAME="bm-bucket-${RANDOME}"
 run_example ./storage_throughput_benchmark \
       --duration=1 \
       --object-count=8 \
-      --object-size=10MiB \
-      --region="${FAKE_REGION}"
+      --object-size=128KiB \
+      --chunk-size=64KiB \
+      --minimum-read-size=2KiB \
+      --maximum-read-size=4KiB \
+      --thread-count=1 \
+      --enable-connection-pool=true \
+      --enable-xml-api=true \
+      --region="${FAKE_REGION}" \
+      "--bucket-name=${THROUGHPUT_BUCKET_NAME}" \
+      --create-bucket=true \
+      --delete-bucket=false \
+      --create-objects=true \
+      --upload-objects=true \
+      --download-objects=true \
+      --minimum-sample-count=1 \
+      --maximum-sample-count=2
 run_example ./storage_throughput_benchmark \
-      --enable-xml-api=false \
       --duration=1 \
       --object-count=8 \
-      --object-size=10MiB \
-      --region="${FAKE_REGION}"
+      --object-size=128KiB \
+      --chunk-size=64KiB \
+      --minimum-read-size=2KiB \
+      --maximum-read-size=4KiB \
+      --thread-count=1 \
+      --enable-connection-pool=true \
+      --enable-xml-api=true \
+      --region="${FAKE_REGION}" \
+      "--bucket-name=${THROUGHPUT_BUCKET_NAME}" \
+      --create-bucket=false \
+      --delete-bucket=true \
+      --create-objects=false \
+      --upload-objects=false \
+      --download-objects=false \
+      --minimum-sample-count=1 \
+      --maximum-sample-count=2
 
 run_example_usage ./storage_throughput_vs_cpu_benchmark \
       --help --description

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -64,17 +64,19 @@ run_example ./storage_shard_throughput_benchmark \
       --iteration-size=2 \
       --iteration-count=2
 
+run_example ./storage_throughput_benchmark --help
+run_example ./storage_throughput_benchmark --description
 run_example ./storage_throughput_benchmark \
       --duration=1 \
       --object-count=8 \
       --object-size=10MiB \
-      "${FAKE_REGION}"
+      --region="${FAKE_REGION}"
 run_example ./storage_throughput_benchmark \
       --enable-xml-api=false \
       --duration=1 \
       --object-count=8 \
       --object-size=10MiB \
-      "${FAKE_REGION}"
+      --region="${FAKE_REGION}"
 
 run_example_usage ./storage_throughput_vs_cpu_benchmark \
       --help --description

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -66,7 +66,7 @@ run_example ./storage_shard_throughput_benchmark \
 
 run_example ./storage_throughput_benchmark --help
 run_example ./storage_throughput_benchmark --description
-readonly THROUGHPUT_BUCKET_NAME="bm-bucket-${RANDOME}"
+readonly THROUGHPUT_BUCKET_NAME="bm-bucket-${RANDOM}"
 run_example ./storage_throughput_benchmark \
       --duration=1 \
       --object-count=8 \

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -77,7 +77,7 @@ run_example ./storage_throughput_benchmark \
       --thread-count=1 \
       --enable-connection-pool=true \
       --enable-xml-api=true \
-      --region="${FAKE_REGION}" \
+      "--region=${FAKE_REGION}" \
       "--bucket-name=${THROUGHPUT_BUCKET_NAME}" \
       --create-bucket=true \
       --delete-bucket=false \
@@ -96,7 +96,7 @@ run_example ./storage_throughput_benchmark \
       --thread-count=1 \
       --enable-connection-pool=true \
       --enable-xml-api=true \
-      --region="${FAKE_REGION}" \
+      "--region=${FAKE_REGION}" \
       "--bucket-name=${THROUGHPUT_BUCKET_NAME}" \
       --create-bucket=false \
       --delete-bucket=true \

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -66,13 +66,23 @@ this program.
 struct Options {
   std::string project_id;
   std::string region;
+  std::string bucket_name;
   std::chrono::seconds duration = std::chrono::seconds(60);
+  long minimum_sample_count = 0;
+  long maximum_sample_count = std::numeric_limits<long>::max();
   long object_count = 1000;
   int thread_count = 1;
   std::int64_t object_size = 250 * gcs_bm::kMiB;
   std::int64_t chunk_size = 32 * gcs_bm::kMiB;
+  std::int64_t minimum_read_size = 0;
+  std::int64_t maximum_read_size = 0;
   bool enable_connection_pool = true;
   bool enable_xml_api = true;
+  bool create_bucket = true;
+  bool delete_bucket = true;
+  bool create_objects = true;
+  bool upload_objects = true;
+  bool download_objects = true;
 };
 
 enum class OpType { OP_READ, OP_WRITE, OP_CREATE };
@@ -81,7 +91,7 @@ struct IterationResult {
   OpType op;
   ApiName api;
   std::size_t bytes;
-  std::chrono::milliseconds elapsed;
+  std::chrono::microseconds elapsed;
 };
 using TestResult = std::vector<IterationResult>;
 
@@ -91,14 +101,15 @@ void PrintResult(TestResult const& result);
 
 std::vector<std::string> CreateAllObjects(
     gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
-    std::string const& bucket_name, Options const& options);
+    Options const& options);
+std::vector<std::string> GetObjectNames(
+    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    Options const& options);
 
-void RunTest(gcs::Client client, std::string const& bucket_name,
-             Options const& options,
+void RunTest(gcs::Client client, Options const& options,
              std::vector<std::string> const& object_names);
 
-void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
-                      Options const& options,
+void DeleteAllObjects(gcs::Client client, Options const& options,
                       std::vector<std::string> const& object_names);
 
 google::cloud::StatusOr<Options> ParseArgs(int argc, char* argv[]);
@@ -130,19 +141,29 @@ int main(int argc, char* argv[]) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
-  auto bucket_name =
-      gcs_bm::MakeRandomBucketName(generator, "gcs-cpp-throughput-bm-");
-  auto meta =
-      client
-          .CreateBucket(bucket_name,
-                        gcs::BucketMetadata()
-                            .set_storage_class(gcs::storage_class::Standard())
-                            .set_location(options->region),
-                        gcs::PredefinedAcl("private"),
-                        gcs::PredefinedDefaultObjectAcl("projectPrivate"),
-                        gcs::Projection("full"))
-          .value();
-  std::cout << "# Running test on bucket: " << meta.name() << "\n";
+  if (options->bucket_name.empty()) {
+    options->bucket_name =
+        gcs_bm::MakeRandomBucketName(generator, "gcs-cpp-throughput-bm-");
+  }
+  if (options->create_bucket) {
+    std::cout << "# Creating bucket to run the test, region: "
+              << options->region << "\n";
+    auto meta =
+        client
+            .CreateBucket(options->bucket_name,
+                          gcs::BucketMetadata()
+                              .set_storage_class(gcs::storage_class::Standard())
+                              .set_location(options->region),
+                          gcs::PredefinedAcl("private"),
+                          gcs::PredefinedDefaultObjectAcl("projectPrivate"),
+                          gcs::Projection("full"))
+            .value();
+    std::cout << "# Running test on bucket: " << options->bucket_name
+              << "\n# Bucket Region: " << meta.location()
+              << "\n# Bucket Location Type: " << meta.location_type()
+              << "\n# Bucket Storage Class: " << meta.storage_class() << "\n";
+  }
+
   std::string notes = google::cloud::storage::version_string() + ";" +
                       google::cloud::internal::compiler() + ";" +
                       google::cloud::internal::compiler_flags();
@@ -152,24 +173,44 @@ int main(int argc, char* argv[]) {
             << google::cloud::internal::FormatRfc3339(
                    std::chrono::system_clock::now())
             << "\n# Region: " << options->region
+            << "\n# Bucket Name: " << options->bucket_name
+            << "\n# Test Duration: " << options->duration.count() << "s"
+            << "\n# Minimum Sample Count: " << options->minimum_sample_count
+            << "\n# Maximum Sample Count: " << options->maximum_sample_count
             << "\n# Object Count: " << options->object_count
-            << "\n# Object Size: " << options->object_size
-            << "\n# Object Size (MiB): " << options->object_size / gcs_bm::kMiB
             << "\n# Thread Count: " << options->thread_count
+            << "\n# Object Size: " << gcs_bm::FormatSize(options->object_size)
+            << "\n# Chunk Size: " << gcs_bm::FormatSize(options->chunk_size)
+            << "\n# Minimum Read Size: "
+            << gcs_bm::FormatSize(options->minimum_read_size)
+            << "\n# Maximum Read Size: "
+            << gcs_bm::FormatSize(options->maximum_read_size) << std::boolalpha
             << "\n# Enable connection pool: " << options->enable_connection_pool
             << "\n# Enable XML API: " << options->enable_xml_api
-            << "\n# Build info: " << notes << std::endl;
+            << "\n# Create Bucket: " << options->create_bucket
+            << "\n# Delete Bucket: " << options->delete_bucket
+            << "\n# Create Objects: " << options->create_objects
+            << "\n# Upload Objects: " << options->upload_objects
+            << "\n# Download Objects: " << options->download_objects
+            << "\n# Build info: " << notes
+            << "\n# OpType,ApiName,Bytes,ElapsedTime(us)" << std::endl;
 
-  std::vector<std::string> object_names =
-      CreateAllObjects(client, generator, bucket_name, *options);
-  RunTest(client, bucket_name, *options, object_names);
-  DeleteAllObjects(client, bucket_name, *options, object_names);
+  std::vector<std::string> object_names;
+  if (options->create_objects) {
+    object_names = CreateAllObjects(client, generator, *options);
+  } else {
+    object_names = GetObjectNames(client, generator, *options);
+  }
+  RunTest(client, *options, object_names);
 
-  std::cout << "# Deleting " << bucket_name << "\n";
-  auto status = client.DeleteBucket(bucket_name);
-  if (!status.ok()) {
-    std::cerr << "# Error deleting bucket, status=" << status << "\n";
-    return 1;
+  if (options->delete_bucket) {
+    DeleteAllObjects(client, *options, object_names);
+    std::cout << "# Deleting " << options->bucket_name << "\n";
+    auto status = client.DeleteBucket(options->bucket_name);
+    if (!status.ok()) {
+      std::cerr << "# Error deleting bucket, status=" << status << "\n";
+      return 1;
+    }
   }
 
   return 0;
@@ -205,21 +246,22 @@ void PrintResult(TestResult const& result) {
   }
 }
 
-TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
-                       std::string const& object_name,
+TestResult WriteCommon(gcs::Client client, std::string const& object_name,
                        std::string const& data_chunk, Options const& options,
                        OpType op_type, ApiName api) {
-  using std::chrono::milliseconds;
+  using std::chrono::microseconds;
   auto start = std::chrono::steady_clock::now();
 
   TestResult result;
 
   gcs::ObjectWriteStream stream = client.WriteObject(
-      bucket_name, object_name,
+      options.bucket_name, object_name,
       api == ApiName::API_JSON ? gcs::Fields{} : gcs::Fields{""});
   for (std::int64_t size = 0; size < options.object_size;
        size += data_chunk.size()) {
-    stream.write(data_chunk.data(), data_chunk.size());
+    auto const n = (std::min<std::streamsize>)(data_chunk.size(),
+                                               options.object_size - size);
+    stream.write(data_chunk.data(), n);
     if (stream.bad()) break;
   }
 
@@ -232,54 +274,50 @@ TestResult WriteCommon(gcs::Client client, std::string const& bucket_name,
     std::cerr << status.status().message() << "\n";
     auto elapsed = std::chrono::steady_clock::now() - start;
     result.emplace_back(IterationResult{
-        op_type, api, 0, std::chrono::duration_cast<milliseconds>(elapsed)});
+        op_type, api, 0, std::chrono::duration_cast<microseconds>(elapsed)});
   } else {
     auto elapsed = std::chrono::steady_clock::now() - start;
     result.emplace_back(IterationResult{
         op_type, api, static_cast<std::size_t>(options.object_size),
-        std::chrono::duration_cast<milliseconds>(elapsed)});
+        std::chrono::duration_cast<microseconds>(elapsed)});
   }
   return result;
 }
 
-TestResult CreateOnce(gcs::Client client, std::string const& bucket_name,
-                      std::string const& object_name,
+TestResult CreateOnce(gcs::Client client, std::string const& object_name,
                       std::string const& data_chunk, Options const& options) {
-  return WriteCommon(client, bucket_name, object_name, data_chunk, options,
+  return WriteCommon(client, object_name, data_chunk, options,
                      OpType::OP_CREATE, ApiName::API_XML);
 }
 
-TestResult WriteOnce(gcs::Client client, std::string const& bucket_name,
-                     std::string const& object_name,
+TestResult WriteOnce(gcs::Client client, std::string const& object_name,
                      std::string const& data_chunk, Options const& options,
                      ApiName api) {
-  return WriteCommon(client, bucket_name, object_name, data_chunk, options,
-                     OpType::OP_WRITE, api);
+  return WriteCommon(client, object_name, data_chunk, options, OpType::OP_WRITE,
+                     api);
 }
 
-TestResult ReadOnce(gcs::Client client, std::string const& bucket_name,
-                    std::string const& object_name, Options const& options,
-                    ApiName api) {
-  using std::chrono::milliseconds;
+TestResult ReadOnce(gcs::Client client, std::string const& object_name,
+                    Options const& options, ApiName api, gcs::ReadRange range) {
+  using std::chrono::microseconds;
   auto start = std::chrono::steady_clock::now();
   TestResult result;
 
   gcs::ObjectReadStream stream =
-      client.ReadObject(bucket_name, object_name,
+      client.ReadObject(options.bucket_name, object_name,
                         api == ApiName::API_JSON ? gcs::IfGenerationNotMatch{0}
-                                                 : gcs::IfGenerationNotMatch{});
+                                                 : gcs::IfGenerationNotMatch{},
+                        std::move(range));
   std::size_t total_size = 0;
   std::vector<char> buffer(options.chunk_size);
-  while (stream.read(buffer.data(), buffer.size())) {
-    if (stream.gcount() == 0) {
-      continue;
-    }
+  do {
+    stream.read(buffer.data(), buffer.size());
     total_size += stream.gcount();
-  }
+  } while (stream.good());
   auto elapsed = std::chrono::steady_clock::now() - start;
   result.emplace_back(
       IterationResult{OpType::OP_READ, api, total_size,
-                      std::chrono::duration_cast<milliseconds>(elapsed)});
+                      std::chrono::duration_cast<microseconds>(elapsed)});
   return result;
 }
 
@@ -296,15 +334,15 @@ std::string CreateChunk(google::cloud::internal::DefaultPRNG& generator,
   return chunk;
 }
 
-TestResult CreateGroup(gcs::Client client, std::string const& bucket_name,
-                       Options const& options, std::vector<std::string> group) {
+TestResult CreateGroup(gcs::Client client, Options const& options,
+                       std::vector<std::string> group) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
   auto const chunk = CreateChunk(generator, options.chunk_size);
   TestResult result;
   for (auto const& object_name : group) {
-    auto tmp = CreateOnce(client, bucket_name, object_name, chunk, options);
+    auto tmp = CreateOnce(client, object_name, chunk, options);
     result.insert(result.end(), tmp.begin(), tmp.end());
   }
   return result;
@@ -312,7 +350,7 @@ TestResult CreateGroup(gcs::Client client, std::string const& bucket_name,
 
 std::vector<std::string> CreateAllObjects(
     gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
-    std::string const& bucket_name, Options const& options) {
+    Options const& options) {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;
 
@@ -337,13 +375,13 @@ std::vector<std::string> CreateAllObjects(
     group.push_back(o);
     if (group.size() >= max_group_size) {
       tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
-                                    bucket_name, options, std::move(group)));
+                                    options, std::move(group)));
       group = {};  // after a move, must assign to guarantee it is valid.
     }
   }
   if (!group.empty()) {
     tasks.emplace_back(std::async(std::launch::async, &CreateGroup, client,
-                                  bucket_name, options, std::move(group)));
+                                  options, std::move(group)));
     group = {};  // after a move, must assign to guarantee it is valid.
   }
   // Wait for the threads to finish.
@@ -356,8 +394,22 @@ std::vector<std::string> CreateAllObjects(
   return object_names;
 }
 
-TestResult RunTestThread(gcs::Client client, std::string const& bucket_name,
-                         Options const& options,
+std::vector<std::string> GetObjectNames(gcs::Client client,
+                                        google::cloud::internal::DefaultPRNG&,
+                                        Options const& options) {
+  std::vector<std::string> object_names;
+  object_names.reserve(options.object_count);
+  for (auto const& o : client.ListObjects(options.bucket_name)) {
+    if (!o) break;
+    object_names.push_back(o->name());
+    if (object_names.size() > static_cast<std::size_t>(options.object_count)) {
+      break;
+    }
+  }
+  return object_names;
+}
+
+TestResult RunTestThread(gcs::Client client, Options const& options,
                          std::vector<std::string> const& object_names) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
@@ -366,7 +418,9 @@ TestResult RunTestThread(gcs::Client client, std::string const& bucket_name,
 
   std::uniform_int_distribution<std::size_t> object_number_gen(
       0, object_names.size() - 1);
-  std::uniform_int_distribution<int> action_gen(0, 99);
+  std::uniform_int_distribution<std::int64_t> range_gen(
+      options.minimum_read_size, options.maximum_read_size);
+  std::bernoulli_distribution action_gen;
   std::uniform_int_distribution<int> api_gen(0, 1);
   if (!options.enable_xml_api) {
     api_gen = std::uniform_int_distribution<int>(0, 0);
@@ -374,30 +428,39 @@ TestResult RunTestThread(gcs::Client client, std::string const& bucket_name,
 
   TestResult result;
   result.reserve(static_cast<std::size_t>(options.duration.count()));
-  auto deadline = std::chrono::system_clock::now() + options.duration;
-  while (std::chrono::system_clock::now() < deadline) {
+  auto deadline = std::chrono::steady_clock::now() + options.duration;
+  long iteration_count = 0;
+  for (auto start = std::chrono::steady_clock::now();
+       iteration_count < options.maximum_sample_count &&
+       (iteration_count < options.minimum_sample_count || start < deadline);
+       start = std::chrono::steady_clock::now(), ++iteration_count) {
     auto const& object_name = object_names.at(object_number_gen(generator));
     auto const api =
         api_gen(generator) == 0 ? ApiName::API_JSON : ApiName::API_XML;
-    if (action_gen(generator) < 50) {
-      TestResult tmp =
-          WriteOnce(client, bucket_name, object_name, chunk, options, api);
+    if (action_gen(generator) && options.upload_objects) {
+      TestResult tmp = WriteOnce(client, object_name, chunk, options, api);
       result.insert(result.end(), tmp.begin(), tmp.end());
-    } else {
-      TestResult tmp = ReadOnce(client, bucket_name, object_name, options, api);
+      continue;
+    }
+    if (options.download_objects) {
+      auto range = gcs::ReadRange();
+      if (options.maximum_read_size != 0) {
+        range = gcs::ReadRange(0, range_gen(generator));
+      }
+      TestResult tmp =
+          ReadOnce(client, object_name, options, api, std::move(range));
       result.insert(result.end(), tmp.begin(), tmp.end());
     }
   }
   return result;
 }
 
-void RunTest(gcs::Client client, std::string const& bucket_name,
-             Options const& options,
+void RunTest(gcs::Client client, Options const& options,
              std::vector<std::string> const& object_names) {
   std::vector<std::future<TestResult>> tasks;
   for (int i = 0; i != options.thread_count; ++i) {
     tasks.emplace_back(std::async(std::launch::async, &RunTestThread, client,
-                                  bucket_name, options, object_names));
+                                  options, object_names));
   }
 
   for (auto& t : tasks) {
@@ -405,8 +468,8 @@ void RunTest(gcs::Client client, std::string const& bucket_name,
   }
 }
 
-google::cloud::Status DeleteGroup(gcs::Client client,
-                                  std::vector<gcs::ObjectMetadata> group) {
+google::cloud::Status DeleteGroup(
+    gcs::Client client, std::vector<gcs::ObjectMetadata> const& group) {
   google::cloud::Status last_error;
   for (auto const& o : group) {
     auto status = client.DeleteObject(o.bucket(), o.name(),
@@ -416,8 +479,8 @@ google::cloud::Status DeleteGroup(gcs::Client client,
   return last_error;
 }
 
-void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
-                      Options const& options, std::vector<std::string> const&) {
+void DeleteAllObjects(gcs::Client client, Options const& options,
+                      std::vector<std::string> const&) {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;
 
@@ -428,7 +491,7 @@ void DeleteAllObjects(gcs::Client client, std::string const& bucket_name,
   auto start = std::chrono::steady_clock::now();
   std::vector<std::future<google::cloud::Status>> tasks;
   std::vector<gcs::ObjectMetadata> group;
-  for (auto&& o : client.ListObjects(bucket_name, gcs::Versions(true))) {
+  for (auto& o : client.ListObjects(options.bucket_name, gcs::Versions(true))) {
     group.emplace_back(std::move(o).value());
     if (group.size() >= static_cast<std::size_t>(max_group_size)) {
       tasks.emplace_back(std::async(std::launch::async, &DeleteGroup, client,
@@ -481,6 +544,15 @@ google::cloud::StatusOr<Options> ParseArgs(int argc, char* argv[]) {
        [&options](std::string const& val) {
          options.chunk_size = gcs_bm::ParseSize(val);
        }},
+      {"--minimum-read-size", "minimum read size",
+       [&options](std::string const& val) {
+         options.minimum_read_size = gcs_bm::ParseSize(val);
+       }},
+      {"--maximum-read-size",
+       "maximum read size, set to 0 to read the full object each time",
+       [&options](std::string const& val) {
+         options.maximum_read_size = gcs_bm::ParseSize(val);
+       }},
       {"--thread-count", "set the number of threads in the benchmark",
        [&options](std::string const& val) {
          options.thread_count = std::stoi(val);
@@ -496,32 +568,76 @@ google::cloud::StatusOr<Options> ParseArgs(int argc, char* argv[]) {
        }},
       {"--project-id", "use the given project id for the benchmark",
        [&options](std::string const& val) { options.project_id = val; }},
-      {"--region", "use the given region for the benchmark",
+      {"--region", "use this region if the benchmark creates a bucket",
        [&options](std::string const& val) { options.region = val; }},
+      {"--bucket-name", "use an existing bucket to run the benchmark",
+       [&options](std::string const& val) { options.bucket_name = val; }},
+      {"--create-bucket", "create a new bucket for the benchmark",
+       [&options](std::string const& val) {
+         options.create_bucket = gcs_bm::ParseBoolean(val).value_or(true);
+       }},
+      {"--delete-bucket", "delete the bucket after running the benchmark",
+       [&options](std::string const& val) {
+         options.delete_bucket = gcs_bm::ParseBoolean(val).value_or(true);
+       }},
+      {"--create-objects", "run the benchmark that creates new objects",
+       [&options](std::string const& val) {
+         options.create_objects = gcs_bm::ParseBoolean(val).value_or(true);
+       }},
+      {"--upload-objects", "run the benchmark that uploads objects",
+       [&options](std::string const& val) {
+         options.upload_objects = gcs_bm::ParseBoolean(val).value_or(true);
+       }},
+      {"--download-objects", "run the benchmark that downloads objects",
+       [&options](std::string const& val) {
+         options.download_objects = gcs_bm::ParseBoolean(val).value_or(true);
+       }},
+      {"--minimum-sample-count",
+       "continue the test until at least this number of samples are obtained",
+       [&options](std::string const& val) {
+         options.minimum_sample_count = std::stol(val);
+       }},
+      {"--maximum-sample-count",
+       "stop the test when this number of samples are obtained",
+       [&options](std::string const& val) {
+         options.maximum_sample_count = std::stol(val);
+       }},
   };
   auto usage = gcs_bm::BuildUsage(desc, argv[0]);
 
   auto unparsed = gcs_bm::OptionsParse(desc, {argv, argv + argc});
   if (wants_help) {
     std::cout << usage << "\n";
+    std::exit(0);
   }
 
   if (wants_description) {
     std::cout << kDescription << "\n";
+    std::exit(0);
   }
 
-  if (unparsed.size() > 2) {
+  if (unparsed.size() > 1) {
     std::ostringstream os;
-    os << "Unknown arguments or options\n" << usage << "\n";
+    os << "Unknown arguments or options:";
+    for (std::size_t i = 1; i != unparsed.size(); ++i) {
+      os << " " << unparsed[i];
+    }
+    os << "\n" << usage << "\n";
     return google::cloud::Status{google::cloud::StatusCode::kInvalidArgument,
                                  std::move(os).str()};
   }
-  if (unparsed.size() == 2) {
-    options.region = unparsed[1];
-  }
-  if (options.region.empty()) {
+  if (options.region.empty() && options.bucket_name.empty()) {
     std::ostringstream os;
-    os << "Missing value for --region option" << usage << "\n";
+    os << "Both --region and --bucket-name options were missing, you must set"
+       << " at least one of them:\n"
+       << usage << "\n";
+    return google::cloud::Status{google::cloud::StatusCode::kInvalidArgument,
+                                 std::move(os).str()};
+  }
+  if (options.minimum_sample_count > options.maximum_sample_count) {
+    std::ostringstream os;
+    os << "Invalid range for sample range [" << options.minimum_sample_count
+       << ',' << options.maximum_sample_count << "]";
     return google::cloud::Status{google::cloud::StatusCode::kInvalidArgument,
                                  std::move(os).str()};
   }

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -402,7 +402,7 @@ std::vector<std::string> GetObjectNames(gcs::Client client,
   for (auto const& o : client.ListObjects(options.bucket_name)) {
     if (!o) break;
     object_names.push_back(o->name());
-    if (object_names.size() > static_cast<std::size_t>(options.object_count)) {
+    if (object_names.size() >= static_cast<std::size_t>(options.object_count)) {
       break;
     }
   }


### PR DESCRIPTION
Add configuration options to run the throughput benchmark with an
existing bucket and/or with existing objects. This can speed up the
benchmark and can help when using very large objects in the benchmark.

Add configuration options to read a randomly-sized range of the object,
this is helpful to show that the download time is largely linear with
the object size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3401)
<!-- Reviewable:end -->
