### PR TITLE
chore: upgrade to Python 3

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -36,15 +36,16 @@ RUN dnf makecache && dnf install -y \
     ncurses-term \
     openssl-devel \
     pkgconfig \
-    python \
+    python3 \
+    python3-devel \
     shtool \
     unzip \
     wget \
     which \
     zlib-devel
 
-RUN pip install --upgrade pip
-RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+RUN pip3 install --upgrade pip
+RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
     gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -40,15 +40,16 @@ RUN dnf makecache && dnf install -y \
     openssl-devel \
     pkgconfig \
     protobuf-compiler \
-    python \
+    python3 \
+    python3-devel \
     shtool \
     unzip \
     wget \
     which \
     zlib-devel
 
-RUN pip install --upgrade pip
-RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+RUN pip3 install --upgrade pip
+RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
     gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 WORKDIR /var/tmp/build

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -38,7 +38,8 @@ RUN apt update && \
         make \
         ninja-build \
         pkg-config \
-        python-pip \
+        python3 \
+        python3-pip \
         shellcheck \
         tar \
         unzip \
@@ -64,11 +65,11 @@ RUN chmod 755 /usr/bin/buildifier
 # Pin this to an specific version because the formatting changes when the
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
-RUN pip install --upgrade pip
-RUN pip install cmake_format==0.6.0
+RUN pip3 install --upgrade pip
+RUN pip3 install cmake_format==0.6.0
 
 # Install Python packages used in the integration tests.
-RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
     gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -40,7 +40,8 @@ RUN apt update && \
         make \
         ninja-build \
         pkg-config \
-        python-pip \
+        python3 \
+        python3-pip \
         shellcheck \
         tar \
         unzip \
@@ -66,11 +67,11 @@ RUN chmod 755 /usr/bin/buildifier
 # Pin this to an specific version because the formatting changes when the
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
-RUN pip install --upgrade pip
-RUN pip install cmake_format==0.6.0
+RUN pip3 install --upgrade pip
+RUN pip3 install cmake_format==0.6.0
 
 # Install Python packages used in the integration tests.
-RUN pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
     gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 # Install Crc32c library.

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -45,15 +45,15 @@ version is updated, and we do not want the builds to break just
 because some third party changed something.
 
 ```console
-sudo apt install -y python python-pip
-pip install --upgrade pip
-pip install cmake_format==0.6.0
+sudo apt install -y python3 python3-pip
+pip3 install --upgrade pip3
+pip3 install cmake_format==0.6.0
 ```
 
 Install the Python modules used in the integration tests:
 
 ```console
-pip install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
     gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 ```
 

--- a/google/cloud/storage/testbench/gcs_iam.py
+++ b/google/cloud/storage/testbench/gcs_iam.py
@@ -19,7 +19,6 @@ import error_response
 import flask
 import json
 
-
 IAM_HANDLER_PATH = '/iamapi'
 iam = flask.Flask(__name__)
 iam.debug = True
@@ -38,10 +37,10 @@ def sign_blob(service_account):
     except TypeError:
         raise error_response.ErrorResponse(
             'payload must be base64-encoded', status_code=400)
-    blob = 'signed: ' + blob
+    blob = b'signed: ' + blob
     response = {
         'keyId': 'fake-key-id-123',
-        'signedBlob': base64.b64encode(blob)
+        'signedBlob': base64.b64encode(blob).decode('utf-8')
     }
     return json.dumps(response)
 

--- a/google/cloud/storage/testbench/gcs_project.py
+++ b/google/cloud/storage/testbench/gcs_project.py
@@ -45,11 +45,11 @@ class ServiceAccount(object):
         timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)
         return self.keys.setdefault(key_id, {
             'kind': 'storage#hmacKeyCreate',
-            'secret': base64.b64encode(secret),
+            'secret': base64.b64encode(bytearray(secret, 'utf-8')).decode('utf-8'),
             'generator': 1,
             'metadata': {
                 'accessId': '%s:%s' % (self.email, key_id),
-                'etag': base64.b64encode('%d' % 1),
+                'etag': base64.b64encode(bytearray('%d' % 1, 'utf-8')).decode('utf-8'),
                 'id': key_id,
                 'kind': 'storage#hmacKey',
                 'projectId': project_id,
@@ -127,7 +127,7 @@ class ServiceAccount(object):
                 status_code=400)
         key['generator'] += 1
         metadata['state'] = state
-        metadata['etag'] = base64.b64encode('%d' % key['generator'])
+        metadata['etag'] = base64.b64encode(bytearray('%d' % key['generator'], 'utf-8')).decode('utf-8')
         now = time.gmtime(time.time())
         metadata['updated'] = time.strftime('%Y-%m-%dT%H:%M:%SZ', now)
         return metadata
@@ -193,7 +193,6 @@ class GcsProject(object):
 PROJECTS_HANDLER_PATH = '/storage/v1/projects'
 projects = flask.Flask(__name__)
 projects.debug = True
-
 
 VALID_PROJECTS = {}
 

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -380,7 +380,7 @@ def objects_list(bucket_name):
         if o.get_latest() is None:
             continue
         if all_versions:
-            for object_version in o.revisions.itervalues():
+            for object_version in o.revisions.values():
                 result['items'].append(object_version.metadata)
         else:
             result['items'].append(o.get_latest().metadata)
@@ -468,6 +468,7 @@ def objects_get_common(bucket_name, object_name, revision):
                 time.sleep(0.1)
                 chunk_end = min(r + chunk_size, len(response_payload))
                 yield response_payload[r:chunk_end]
+
         length = len(response_payload)
         content_range = 'bytes %d-%d/%d' % (begin, end - 1, length)
         headers = {
@@ -535,6 +536,7 @@ def objects_get_common(bucket_name, object_name, revision):
                     time.sleep(0.01)
                     chunk_end = min(r + chunk_size, len(response_payload))
                     yield response_payload[r:chunk_end]
+
             return flask.Response(streamer(), status=200, headers=headers)
         if instructions.endswith(u'/retry-1'):
             print("## Return error for retry 1")
@@ -603,7 +605,7 @@ def objects_compose(bucket_name, object_name):
             'The number of source components provided'
             ' (%d) exceeds the maximum (32)' % len(source_objects),
             status_code=400)
-    composed_media = ""
+    composed_media = b''
     for source_object in source_objects:
         source_object_name = source_object.get('name')
         if source_object_name is None:
@@ -825,10 +827,8 @@ def xmlapi_put_object(bucket_name, object_name):
 # Define the WSGI application to handle HMAC key requests
 (PROJECTS_HANDLER_PATH, projects_app) = gcs_project.get_projects_app()
 
-
 # Define the WSGI application to handle IAM requests
 (IAM_HANDLER_PATH, iam_app) = gcs_iam.get_iam_app()
-
 
 application = DispatcherMiddleware(
     root, {

--- a/google/cloud/storage/testbench/testbench_utils.py
+++ b/google/cloud/storage/testbench/testbench_utils.py
@@ -96,7 +96,7 @@ def filter_fields_from_response(fields, response):
     """Format the response as a JSON string, using any filtering included in
     the request.
 
-    :param fields:str the value of the `fields` parameter in the origina
+    :param fields:str the value of the `fields` parameter in the original
         request.
     :param response:dict a dictionary to be formatted as a JSON string.
     :return: the response formatted as a string.
@@ -138,9 +138,9 @@ def raise_csek_error(code=400):
                 "extendedHelp": link,
             }],
             "code":
-            code,
+                code,
             "message":
-            msg,
+                msg,
         }
     }
     raise error_response.ErrorResponse(json.dumps(error), status_code=code)
@@ -167,7 +167,7 @@ def validate_customer_encryption_headers(key_header_value, hash_header_value,
 
         h = hashlib.sha256()
         h.update(key)
-        expected = base64.standard_b64encode(h.digest())
+        expected = base64.standard_b64encode(h.digest()).decode('utf-8')
         if hash_header_value is None or expected != hash_header_value:
             raise_csek_error()
     except error_response.ErrorResponse:
@@ -206,7 +206,7 @@ def json_api_patch(original, patch, recurse_on=set({})):
     :rtype:dict
     """
     tmp = original.copy()
-    for key, value in patch.iteritems():
+    for key, value in patch.items():
         if value is None:
             tmp.pop(key, None)
         elif key not in recurse_on:
@@ -244,10 +244,10 @@ def corrupt_media(media):
     """
     # Deal with the boundary condition.
     if not media:
-        return str(random.sample("abcdefghijklmnopqrstuvwxyz", 1))
-    if media[0] == 'A':
-        return 'B' + media[1:]
-    return 'A' + media[1:]
+        return bytearray(random.sample("abcdefghijklmnopqrstuvwxyz", 1), 'utf-8')
+    if media[0] == b'A':
+        return b'B' + media[1:]
+    return b'A' + media[1:]
 
 
 # Define the collection of Buckets indexed by <bucket_name>


### PR DESCRIPTION
Python 2.7 went EOL on 2020-01-01. The builds are starting to fail
because some of our dependencies assume (with good reason I think)
they are working with Python 3.

Fixes #3056

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3402)
<!-- Reviewable:end -->
