### PR TITLE
fix: fix flake after python 3 changes

### DIFF
--- a/google/cloud/storage/testbench/testbench_utils.py
+++ b/google/cloud/storage/testbench/testbench_utils.py
@@ -238,16 +238,14 @@ def extract_media(request):
 def corrupt_media(media):
     """Return a randomly modified version of a string.
 
-    :param media:str a string (typically some object media) to be modified.
+    :param media:bytes a string (typically some object media) to be modified.
     :return: a string that is slightly different than media.
     :rtype: str
     """
     # Deal with the boundary condition.
     if not media:
         return bytearray(random.sample("abcdefghijklmnopqrstuvwxyz", 1), 'utf-8')
-    if media[0] == b'A':
-        return b'B' + media[1:]
-    return b'A' + media[1:]
+    return b'B' + media[1:] if media[0:1] == b'A' else b'A' + media[1:]
 
 
 # Define the collection of Buckets indexed by <bucket_name>


### PR DESCRIPTION
I introduced a flake when making the changes for Python 3: strings,
even binary strings, are never equal to single characters.

Fixes #3403

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3404)
<!-- Reviewable:end -->
