### PR TITLE
fix(Dockerfile): Some debian package manager tweaks

### DIFF
--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -14,8 +14,8 @@
 
 FROM ubuntu:bionic AS google-cloud-cpp-dependencies
 
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 
@@ -112,8 +112,8 @@ RUN cmake --build . --target install
 # - The final binaries, without any intermdiate object files.
 # - The run-time dependencies, without the build tool dependencies.
 FROM ubuntu:bionic
-RUN apt update && \
-    apt install -y ca-certificates libc-ares2 libcurl4 \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y ca-certificates libc-ares2 libcurl4 \
     libstdc++6 libssl1.1 zlib1g
 RUN /usr/sbin/update-ca-certificates
 

--- a/ci/benchmarks/Dockerfile
+++ b/ci/benchmarks/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:bionic AS google-cloud-cpp-dependencies
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 
 # #### crc32c
 
@@ -113,7 +113,7 @@ RUN cmake --build . --target install
 # - The run-time dependencies, without the build tool dependencies.
 FROM ubuntu:bionic
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y ca-certificates libc-ares2 libcurl4 \
+    apt-get --no-install-recommends install -y apt-utils ca-certificates apt-transport-https libc-ares2 libcurl4 \
     libstdc++6 libssl1.1 zlib1g
 RUN /usr/sbin/update-ca-certificates
 

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -15,8 +15,8 @@
 ARG DISTRO_VERSION=18.04
 FROM ubuntu:${DISTRO_VERSION}
 
-RUN apt update && \
-    apt install -y \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y \
         abi-compliance-checker \
         abi-dumper \
         automake \
@@ -49,7 +49,7 @@ RUN apt update && \
 # By default, Ubuntu 18.04 does not install the alternatives for clang-format
 # and clang-tidy, so we need to manually install those.
 RUN if grep -q 18.04 /etc/lsb-release; then \
-      apt update && apt install -y clang-tidy clang-format-7 clang-tools; \
+      apt-get update && apt-get --no-install-recommends install -y clang-tidy clang-format-7 clang-tools; \
       update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
       update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100; \
       update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100; \

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -44,7 +44,10 @@ RUN apt-get update && \
         tar \
         unzip \
         wget \
-        zlib1g-dev
+        zlib1g-dev \
+        apt-utils \
+        ca-certificates \
+        apt-transport-https
 
 # By default, Ubuntu 18.04 does not install the alternatives for clang-format
 # and clang-tidy, so we need to manually install those.

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -46,7 +46,10 @@ RUN apt-get update && \
         tar \
         unzip \
         wget \
-        zlib1g-dev
+        zlib1g-dev \
+        apt-utils \
+        ca-certificates \
+        apt-transport-https
 
 # By default, Ubuntu 18.04 does not install the alternatives for clang-format
 # and clang-tidy, so we need to manually install those.

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -16,8 +16,8 @@ ARG DISTRO_VERSION=18.04
 FROM ubuntu:${DISTRO_VERSION}
 ARG NCPU=4
 
-RUN apt update && \
-    apt install -y \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y \
         abi-compliance-checker \
         abi-dumper \
         automake \
@@ -51,7 +51,7 @@ RUN apt update && \
 # By default, Ubuntu 18.04 does not install the alternatives for clang-format
 # and clang-tidy, so we need to manually install those.
 RUN if grep -q 18.04 /etc/lsb-release; then \
-      apt update && apt install -y clang-tidy clang-format-7 clang-tools; \
+      apt-get update && apt-get --no-install-recommends install -y clang-tidy clang-format-7 clang-tools; \
       update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
       update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100; \
       update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100; \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -29,7 +29,8 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
-        libcurl4-openssl-dev libssl-dev make pkg-config tar wget zlib1g-dev
+        libcurl4-openssl-dev libssl-dev make pkg-config tar wget zlib1g-dev \
+        apt-utils ca-certificates apt-transport-https
 # ```
 
 # Debian 10 includes versions of gRPC and Protobuf that support the

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -27,8 +27,8 @@ ARG NCPU=4
 # Install the minimal development tools, libcurl, and OpenSSL:
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libcurl4-openssl-dev libssl-dev make pkg-config tar wget zlib1g-dev
 # ```
 
@@ -36,8 +36,8 @@ RUN apt update && \
 # Google Cloud Platform proto files. We simply install these pre-built versions:
 
 # ```bash
-RUN apt update && \
-    apt install -y libgrpc++-dev libprotobuf-dev libc-ares-dev \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y libgrpc++-dev libprotobuf-dev libc-ares-dev \
         protobuf-compiler protobuf-compiler-grpc
 # ```
 

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -37,7 +37,7 @@ ARG NCPU=4
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 # #### Protobuf

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -34,8 +34,8 @@ ARG NCPU=4
 # prevent you from compiling against openssl-1.1.0.
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -27,8 +27,8 @@ ARG NCPU=4
 # Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -30,7 +30,7 @@ ARG NCPU=4
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 # #### Protobuf

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -30,7 +30,7 @@ ARG NCPU=4
 RUN apt-get update && \
     apt-get --no-install-recommends install -y automake build-essential cmake git gcc g++ \
         libcurl4-openssl-dev libssl-dev libtool make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 # #### Protobuf

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -27,8 +27,8 @@ ARG NCPU=4
 # Install the minimal development tools, OpenSSL and libcurl:
 
 # ```bash
-RUN apt update && \
-    apt install -y automake build-essential cmake git gcc g++ \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y automake build-essential cmake git gcc g++ \
         libcurl4-openssl-dev libssl-dev libtool make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/kokoro/readme/Dockerfile.debian-buster
+++ b/ci/kokoro/readme/Dockerfile.debian-buster
@@ -26,8 +26,8 @@ FROM debian:${DISTRO_VERSION} AS devtools
 # First install the development tools.
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/kokoro/readme/Dockerfile.debian-buster
+++ b/ci/kokoro/readme/Dockerfile.debian-buster
@@ -29,7 +29,7 @@ FROM debian:${DISTRO_VERSION} AS devtools
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.debian-stretch
+++ b/ci/kokoro/readme/Dockerfile.debian-stretch
@@ -26,8 +26,8 @@ FROM debian:${DISTRO_VERSION} AS devtools
 # First install the development tools.
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/kokoro/readme/Dockerfile.debian-stretch
+++ b/ci/kokoro/readme/Dockerfile.debian-stretch
@@ -29,7 +29,7 @@ FROM debian:${DISTRO_VERSION} AS devtools
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-bionic
@@ -26,8 +26,8 @@ FROM ubuntu:${DISTRO_VERSION} AS devtools
 # Install the minimal development tools:
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/ci/kokoro/readme/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-bionic
@@ -29,7 +29,7 @@ FROM ubuntu:${DISTRO_VERSION} AS devtools
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-xenial
@@ -29,7 +29,7 @@ FROM ubuntu:${DISTRO_VERSION} AS devtools
 RUN apt-get update && \
     apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libcurl4-openssl-dev libssl-dev make \
-        pkg-config tar wget zlib1g-dev
+        pkg-config tar wget zlib1g-dev apt-utils ca-certificates apt-transport-https
 # ```
 
 ## [END README.md]

--- a/ci/kokoro/readme/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/readme/Dockerfile.ubuntu-xenial
@@ -26,8 +26,8 @@ FROM ubuntu:${DISTRO_VERSION} AS devtools
 # Install the minimal development tools:
 
 # ```bash
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 # ```

--- a/google/cloud/storage/tests/parallel_upload_regression/Dockerfile
+++ b/google/cloud/storage/tests/parallel_upload_regression/Dockerfile
@@ -15,8 +15,8 @@
 FROM ubuntu:bionic AS devtools
 
 # Install the typical development tools and some additions:
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 
@@ -42,8 +42,8 @@ RUN cmake \
 # Prepare the final image, this image is much smaller because only the required
 # dependencies are installed.
 FROM ubuntu:bionic
-RUN apt update && \
-    apt install -y libstdc++6 libc-ares2 libcurl4 zlib1g binutils \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y libstdc++6 libc-ares2 libcurl4 zlib1g binutils \
         ca-certificates tcpdump coreutils strace procps
 RUN /usr/sbin/update-ca-certificates
 

--- a/google/cloud/storage/tests/read_object_stall_regression/Dockerfile
+++ b/google/cloud/storage/tests/read_object_stall_regression/Dockerfile
@@ -15,8 +15,8 @@
 FROM ubuntu:bionic AS devtools
 
 # Install the typical development tools and some additions:
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
         pkg-config tar wget zlib1g-dev
 
@@ -42,8 +42,8 @@ RUN cmake \
 # Prepare the final image, this image is much smaller because only the required
 # dependencies are installed.
 FROM ubuntu:bionic
-RUN apt update && \
-    apt install -y libstdc++6 libc-ares2 libcurl4 zlib1g binutils \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y libstdc++6 libc-ares2 libcurl4 zlib1g binutils \
         ca-certificates tcpdump coreutils strace procps
 RUN /usr/sbin/update-ca-certificates
 

--- a/google/cloud/storage/tests/write_deadlock_regression/Dockerfile
+++ b/google/cloud/storage/tests/write_deadlock_regression/Dockerfile
@@ -15,8 +15,8 @@
 FROM ubuntu:bionic AS build
 
 # Install the typical development tools and some additions:
-RUN apt update && \
-    apt install -y build-essential cmake git gcc g++ cmake \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y build-essential cmake git gcc g++ cmake \
         libssl-dev make pkg-config tar wget zlib1g-dev
 
 WORKDIR /var/tmp/build
@@ -47,8 +47,8 @@ RUN cmake \
 # Prepare the final image, this image is much smaller because only the required
 # dependencies are installed.
 FROM ubuntu:bionic
-RUN apt update && \
-    apt install -y libstdc++6 zlib1g dsniff binutils ca-certificates
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y libstdc++6 zlib1g dsniff binutils ca-certificates
 RUN /usr/sbin/update-ca-certificates
 
 COPY --from=build \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

results in smaller image size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3417)
<!-- Reviewable:end -->
