### PR TITLE
feat: support query parameters in v4 signed URLs

### DIFF
--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -135,7 +135,8 @@ void V4SignUrlRequest::AddMissingRequiredHeaders() {
 std::string V4SignUrlRequest::CanonicalQueryString(
     std::string const& client_id) const {
   CurlHandle curl;
-  auto parameters = CanonicalQueryParameters(client_id);
+  // Query parameters.
+  auto parameters = AllQueryParameters(client_id);
   return QueryStringFromParameters(curl, parameters);
 }
 
@@ -155,10 +156,7 @@ std::string V4SignUrlRequest::CanonicalRequest(
   os << "\n";
 
   // Query parameters.
-  auto parameters = common_request_.query_parameters();
-  auto canonical_parameters = CanonicalQueryParameters(client_id);
-  // No .merge() until C++17, blegh.
-  parameters.insert(canonical_parameters.begin(), canonical_parameters.end());
+  auto parameters = AllQueryParameters(client_id);
   os << QueryStringFromParameters(curl, parameters) << "\n";
 
   // Headers
@@ -204,6 +202,17 @@ V4SignUrlRequest::CanonicalQueryParameters(std::string const& client_id) const {
       {"X-Goog-Expires", std::to_string(expires_.count())},
       {"X-Goog-SignedHeaders", SignedHeaders()},
   };
+}
+
+std::multimap<std::string, std::string> V4SignUrlRequest::AllQueryParameters(
+    std::string const& client_id) const {
+  CurlHandle curl;
+  // Query parameters.
+  auto parameters = common_request_.query_parameters();
+  auto canonical_parameters = CanonicalQueryParameters(client_id);
+  // No .merge() until C++17, blegh.
+  parameters.insert(canonical_parameters.begin(), canonical_parameters.end());
+  return parameters;
 }
 
 std::string V4SignUrlRequest::SignedHeaders() const {

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -293,6 +293,9 @@ class V4SignUrlRequest {
   std::multimap<std::string, std::string> CanonicalQueryParameters(
       std::string const& client_id) const;
 
+  std::multimap<std::string, std::string> AllQueryParameters(
+      std::string const& client_id) const;
+
   std::string SignedHeaders() const;
 
   SignUrlRequestCommon common_request_;

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -291,7 +291,8 @@ TEST(V4SignedUrlRequests, CanonicalQueryStringMultiHeader) {
       "&X-Goog-Credential=fake-client-id"
       "%2F20190201%2Fauto%2Fstorage%2Fgoog4_request"
       "&X-Goog-Date=20190201T090000Z"
-      "&X-Goog-Expires=10&X-Goog-SignedHeaders=content-type%3Bhost";
+      "&X-Goog-Expires=10&X-Goog-SignedHeaders=content-type%3Bhost"
+      "&generation=7&userProject=test-project";
   std::string actual = request.CanonicalQueryString("fake-client-id");
   EXPECT_EQ(expected, actual);
 }


### PR DESCRIPTION
This fixes #3344.

The test had to be reworked a bit because otherwise we'd have to put `if`s for every feasible combination of numbers of headers and parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3422)
<!-- Reviewable:end -->
