### PR TITLE
fix: make options ctors work on all compilers

### DIFF
--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -247,6 +247,10 @@ TEST_F(ServiceAccountTest, UpdateHmacKeyPermanentFailure) {
       "UpdateHmacKey");
 }
 
+TEST(DefaultCtorsWork, Trivial) {
+  EXPECT_FALSE(OverrideDefaultProject().has_value());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -54,6 +54,8 @@ inline std::ostream& operator<<(std::ostream& os, ReadRangeData const& rhs) {
 struct ReadFromOffset
     : public internal::ComplexOption<ReadFromOffset, std::int64_t> {
   using ComplexOption::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  ReadFromOffset() : ComplexOption<ReadFromOffset, std::int64_t>() {}
   static char const* name() { return "read-offset"; }
 };
 
@@ -62,6 +64,8 @@ struct ReadFromOffset
  */
 struct ReadLast : public internal::ComplexOption<ReadLast, std::int64_t> {
   using ComplexOption::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  ReadLast() : ComplexOption<ReadLast, std::int64_t>() {}
   static char const* name() { return "read-last"; }
 };
 

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -54,8 +54,9 @@ inline std::ostream& operator<<(std::ostream& os, ReadRangeData const& rhs) {
 struct ReadFromOffset
     : public internal::ComplexOption<ReadFromOffset, std::int64_t> {
   using ComplexOption::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  ReadFromOffset() : ComplexOption<ReadFromOffset, std::int64_t>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  ReadFromOffset() = default;
   static char const* name() { return "read-offset"; }
 };
 
@@ -64,8 +65,9 @@ struct ReadFromOffset
  */
 struct ReadLast : public internal::ComplexOption<ReadLast, std::int64_t> {
   using ComplexOption::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  ReadLast() : ComplexOption<ReadLast, std::int64_t>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  ReadLast() = default;
   static char const* name() { return "read-last"; }
 };
 

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -34,8 +34,9 @@ inline namespace STORAGE_CLIENT_NS {
 struct MD5HashValue
     : public internal::ComplexOption<MD5HashValue, std::string> {
   using ComplexOption<MD5HashValue, std::string>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  MD5HashValue() : internal::ComplexOption<MD5HashValue, std::string>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  MD5HashValue() = default;
   static char const* name() { return "md5-hash-value"; }
 };
 
@@ -57,8 +58,9 @@ std::string ComputeMD5Hash(std::string const& payload);
  */
 struct DisableMD5Hash : public internal::ComplexOption<DisableMD5Hash, bool> {
   using ComplexOption<DisableMD5Hash, bool>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  DisableMD5Hash() : internal::ComplexOption<DisableMD5Hash, bool>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  DisableMD5Hash() = default;
   static char const* name() { return "disable-md5-hash"; }
 };
 
@@ -73,9 +75,9 @@ struct DisableMD5Hash : public internal::ComplexOption<DisableMD5Hash, bool> {
 struct Crc32cChecksumValue
     : public internal::ComplexOption<Crc32cChecksumValue, std::string> {
   using ComplexOption<Crc32cChecksumValue, std::string>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  Crc32cChecksumValue()
-      : internal::ComplexOption<Crc32cChecksumValue, std::string>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  Crc32cChecksumValue() = default;
   static char const* name() { return "crc32c-checksum"; }
 };
 
@@ -98,9 +100,9 @@ std::string ComputeCrc32cChecksum(std::string const& payload);
 struct DisableCrc32cChecksum
     : public internal::ComplexOption<DisableCrc32cChecksum, bool> {
   using ComplexOption<DisableCrc32cChecksum, bool>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  DisableCrc32cChecksum()
-      : internal::ComplexOption<DisableCrc32cChecksum, bool>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  DisableCrc32cChecksum() = default;
   static char const* name() { return "disable-crc32c-checksum"; }
 };
 

--- a/google/cloud/storage/hashing_options.h
+++ b/google/cloud/storage/hashing_options.h
@@ -34,6 +34,8 @@ inline namespace STORAGE_CLIENT_NS {
 struct MD5HashValue
     : public internal::ComplexOption<MD5HashValue, std::string> {
   using ComplexOption<MD5HashValue, std::string>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  MD5HashValue() : internal::ComplexOption<MD5HashValue, std::string>() {}
   static char const* name() { return "md5-hash-value"; }
 };
 
@@ -55,6 +57,8 @@ std::string ComputeMD5Hash(std::string const& payload);
  */
 struct DisableMD5Hash : public internal::ComplexOption<DisableMD5Hash, bool> {
   using ComplexOption<DisableMD5Hash, bool>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  DisableMD5Hash() : internal::ComplexOption<DisableMD5Hash, bool>() {}
   static char const* name() { return "disable-md5-hash"; }
 };
 
@@ -69,6 +73,9 @@ struct DisableMD5Hash : public internal::ComplexOption<DisableMD5Hash, bool> {
 struct Crc32cChecksumValue
     : public internal::ComplexOption<Crc32cChecksumValue, std::string> {
   using ComplexOption<Crc32cChecksumValue, std::string>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  Crc32cChecksumValue()
+      : internal::ComplexOption<Crc32cChecksumValue, std::string>() {}
   static char const* name() { return "crc32c-checksum"; }
 };
 
@@ -91,6 +98,9 @@ std::string ComputeCrc32cChecksum(std::string const& payload);
 struct DisableCrc32cChecksum
     : public internal::ComplexOption<DisableCrc32cChecksum, bool> {
   using ComplexOption<DisableCrc32cChecksum, bool>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  DisableCrc32cChecksum()
+      : internal::ComplexOption<DisableCrc32cChecksum, bool>() {}
   static char const* name() { return "disable-crc32c-checksum"; }
 };
 

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -899,6 +899,17 @@ TEST(ComposeObjectRequestTest, SimpleCompose) {
   EXPECT_THAT(actual, HasSubstr("\"ifGenerationMatch\":2"));
 }
 
+TEST(DefaultCtorsWork, Trivial) {
+  EXPECT_FALSE(ReadFromOffset().has_value());
+  EXPECT_FALSE(ReadLast().has_value());
+  EXPECT_FALSE(MD5HashValue().has_value());
+  EXPECT_FALSE(DisableMD5Hash().has_value());
+  EXPECT_FALSE(Crc32cChecksumValue().has_value());
+  EXPECT_FALSE(DisableCrc32cChecksum().has_value());
+  EXPECT_FALSE(WithObjectMetadata().has_value());
+  EXPECT_FALSE(UseResumableUploadSession().has_value());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/signed_url_requests_test.cc
+++ b/google/cloud/storage/internal/signed_url_requests_test.cc
@@ -438,6 +438,17 @@ UNSIGNED-PAYLOAD)""";
   EXPECT_THAT(os.str(), HasSubstr("/test-bucket/test-object/path/to/object"));
 }
 
+TEST(DefaultCtorsWork, Trivial) {
+  EXPECT_FALSE(ExpirationTime().has_value());
+  EXPECT_FALSE(AddExtensionHeaderOption().has_value());
+  EXPECT_FALSE(AddQueryParameterOption().has_value());
+  EXPECT_FALSE(SubResourceOption().has_value());
+  EXPECT_FALSE(SignedUrlTimestamp().has_value());
+  EXPECT_FALSE(SignedUrlDuration().has_value());
+  EXPECT_FALSE(SigningAccount().has_value());
+  EXPECT_FALSE(SigningAccountDelegates().has_value());
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -323,9 +323,9 @@ class ObjectMetadataPatchBuilder {
 struct WithObjectMetadata
     : public internal::ComplexOption<WithObjectMetadata, ObjectMetadata> {
   using ComplexOption<WithObjectMetadata, ObjectMetadata>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  WithObjectMetadata()
-      : internal::ComplexOption<WithObjectMetadata, ObjectMetadata>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  WithObjectMetadata() = default;
   static char const* name() { return "object-metadata"; }
 };
 

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -323,6 +323,9 @@ class ObjectMetadataPatchBuilder {
 struct WithObjectMetadata
     : public internal::ComplexOption<WithObjectMetadata, ObjectMetadata> {
   using ComplexOption<WithObjectMetadata, ObjectMetadata>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  WithObjectMetadata()
+      : internal::ComplexOption<WithObjectMetadata, ObjectMetadata>() {}
   static char const* name() { return "object-metadata"; }
 };
 

--- a/google/cloud/storage/override_default_project.h
+++ b/google/cloud/storage/override_default_project.h
@@ -33,6 +33,9 @@ inline namespace STORAGE_CLIENT_NS {
 struct OverrideDefaultProject
     : public internal::ComplexOption<OverrideDefaultProject, std::string> {
   using ComplexOption<OverrideDefaultProject, std::string>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  OverrideDefaultProject()
+      : internal::ComplexOption<OverrideDefaultProject, std::string>() {}
   static char const* name() { return "override_default_project"; }
 };
 

--- a/google/cloud/storage/override_default_project.h
+++ b/google/cloud/storage/override_default_project.h
@@ -33,9 +33,9 @@ inline namespace STORAGE_CLIENT_NS {
 struct OverrideDefaultProject
     : public internal::ComplexOption<OverrideDefaultProject, std::string> {
   using ComplexOption<OverrideDefaultProject, std::string>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  OverrideDefaultProject()
-      : internal::ComplexOption<OverrideDefaultProject, std::string>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  OverrideDefaultProject() = default;
   static char const* name() { return "override_default_project"; }
 };
 

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -33,6 +33,10 @@ struct ExpirationTime
                                      std::chrono::system_clock::time_point> {
   using ComplexOption<ExpirationTime,
                       std::chrono::system_clock::time_point>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  ExpirationTime()
+      : ComplexOption<ExpirationTime, std::chrono::system_clock::time_point>() {
+  }
   static char const* name() { return "expiration_time"; }
 };
 
@@ -44,6 +48,10 @@ struct AddExtensionHeaderOption
                                      std::pair<std::string, std::string>> {
   using ComplexOption<AddExtensionHeaderOption,
                       std::pair<std::string, std::string>>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  AddExtensionHeaderOption()
+      : ComplexOption<AddExtensionHeaderOption,
+                      std::pair<std::string, std::string>>() {}
   AddExtensionHeaderOption(std::string header, std::string value)
       : ComplexOption(std::make_pair(std::move(header), std::move(value))) {}
   static char const* name() { return "expiration_time"; }
@@ -62,6 +70,10 @@ struct AddQueryParameterOption
                                      std::pair<std::string, std::string>> {
   using ComplexOption<AddQueryParameterOption,
                       std::pair<std::string, std::string>>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  AddQueryParameterOption()
+      : ComplexOption<AddQueryParameterOption,
+                      std::pair<std::string, std::string>>() {}
   AddQueryParameterOption(std::string key, std::string value)
       : ComplexOption(std::make_pair(std::move(key), std::move(value))) {}
   AddQueryParameterOption(char const* key, std::string value)
@@ -103,6 +115,9 @@ inline AddQueryParameterOption WithResponseContentType(
 struct SubResourceOption
     : public internal::ComplexOption<SubResourceOption, std::string> {
   using ComplexOption<SubResourceOption, std::string>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  SubResourceOption()
+      : internal::ComplexOption<SubResourceOption, std::string>() {}
   static char const* name() { return "query-parameter"; }
 };
 
@@ -146,6 +161,10 @@ struct SignedUrlTimestamp
                                      std::chrono::system_clock::time_point> {
   using ComplexOption<SignedUrlTimestamp,
                       std::chrono::system_clock::time_point>::ComplexOption;
+  SignedUrlTimestamp()
+      : ComplexOption<SignedUrlTimestamp,
+                      std::chrono::system_clock::time_point>() {}
+  // g++ prior to version 7 has a bug which hides this ctor
   static char const* name() { return "x-good-date"; }
 };
 
@@ -155,6 +174,9 @@ struct SignedUrlTimestamp
 struct SignedUrlDuration
     : public internal::ComplexOption<SignedUrlDuration, std::chrono::seconds> {
   using ComplexOption<SignedUrlDuration, std::chrono::seconds>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  SignedUrlDuration()
+      : internal::ComplexOption<SignedUrlDuration, std::chrono::seconds>() {}
   static char const* name() { return "x-goog-expires"; }
 };
 
@@ -167,6 +189,8 @@ struct SignedUrlDuration
 struct SigningAccount
     : public internal::ComplexOption<SigningAccount, std::string> {
   using ComplexOption<SigningAccount, std::string>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  SigningAccount() : internal::ComplexOption<SigningAccount, std::string>() {}
   static char const* name() { return "signing-account"; }
 };
 
@@ -182,6 +206,9 @@ struct SigningAccountDelegates
                                      std::vector<std::string>> {
   using ComplexOption<SigningAccountDelegates,
                       std::vector<std::string>>::ComplexOption;
+  SigningAccountDelegates()
+      : ComplexOption<SigningAccountDelegates, std::vector<std::string>>() {}
+  // g++ prior to version 7 has a bug which hides this ctor
   static char const* name() { return "signing-account-delegates"; }
 };
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -33,10 +33,9 @@ struct ExpirationTime
                                      std::chrono::system_clock::time_point> {
   using ComplexOption<ExpirationTime,
                       std::chrono::system_clock::time_point>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  ExpirationTime()
-      : ComplexOption<ExpirationTime, std::chrono::system_clock::time_point>() {
-  }
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  ExpirationTime() = default;
   static char const* name() { return "expiration_time"; }
 };
 
@@ -48,10 +47,9 @@ struct AddExtensionHeaderOption
                                      std::pair<std::string, std::string>> {
   using ComplexOption<AddExtensionHeaderOption,
                       std::pair<std::string, std::string>>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  AddExtensionHeaderOption()
-      : ComplexOption<AddExtensionHeaderOption,
-                      std::pair<std::string, std::string>>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  AddExtensionHeaderOption() = default;
   AddExtensionHeaderOption(std::string header, std::string value)
       : ComplexOption(std::make_pair(std::move(header), std::move(value))) {}
   static char const* name() { return "expiration_time"; }
@@ -70,10 +68,9 @@ struct AddQueryParameterOption
                                      std::pair<std::string, std::string>> {
   using ComplexOption<AddQueryParameterOption,
                       std::pair<std::string, std::string>>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  AddQueryParameterOption()
-      : ComplexOption<AddQueryParameterOption,
-                      std::pair<std::string, std::string>>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  AddQueryParameterOption() = default;
   AddQueryParameterOption(std::string key, std::string value)
       : ComplexOption(std::make_pair(std::move(key), std::move(value))) {}
   AddQueryParameterOption(char const* key, std::string value)
@@ -115,9 +112,9 @@ inline AddQueryParameterOption WithResponseContentType(
 struct SubResourceOption
     : public internal::ComplexOption<SubResourceOption, std::string> {
   using ComplexOption<SubResourceOption, std::string>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  SubResourceOption()
-      : internal::ComplexOption<SubResourceOption, std::string>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  SubResourceOption() = default;
   static char const* name() { return "query-parameter"; }
 };
 
@@ -161,10 +158,9 @@ struct SignedUrlTimestamp
                                      std::chrono::system_clock::time_point> {
   using ComplexOption<SignedUrlTimestamp,
                       std::chrono::system_clock::time_point>::ComplexOption;
-  SignedUrlTimestamp()
-      : ComplexOption<SignedUrlTimestamp,
-                      std::chrono::system_clock::time_point>() {}
-  // g++ prior to version 7 has a bug which hides this ctor
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  SignedUrlTimestamp() = default;
   static char const* name() { return "x-good-date"; }
 };
 
@@ -174,9 +170,9 @@ struct SignedUrlTimestamp
 struct SignedUrlDuration
     : public internal::ComplexOption<SignedUrlDuration, std::chrono::seconds> {
   using ComplexOption<SignedUrlDuration, std::chrono::seconds>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  SignedUrlDuration()
-      : internal::ComplexOption<SignedUrlDuration, std::chrono::seconds>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  SignedUrlDuration() = default;
   static char const* name() { return "x-goog-expires"; }
 };
 
@@ -189,8 +185,9 @@ struct SignedUrlDuration
 struct SigningAccount
     : public internal::ComplexOption<SigningAccount, std::string> {
   using ComplexOption<SigningAccount, std::string>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  SigningAccount() : internal::ComplexOption<SigningAccount, std::string>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  SigningAccount() = default;
   static char const* name() { return "signing-account"; }
 };
 
@@ -206,9 +203,9 @@ struct SigningAccountDelegates
                                      std::vector<std::string>> {
   using ComplexOption<SigningAccountDelegates,
                       std::vector<std::string>>::ComplexOption;
-  SigningAccountDelegates()
-      : ComplexOption<SigningAccountDelegates, std::vector<std::string>>() {}
-  // g++ prior to version 7 has a bug which hides this ctor
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  SigningAccountDelegates() = default;
   static char const* name() { return "signing-account-delegates"; }
 };
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -36,9 +36,10 @@ inline namespace STORAGE_CLIENT_NS {
 struct UseResumableUploadSession
     : public internal::ComplexOption<UseResumableUploadSession, std::string> {
   using ComplexOption<UseResumableUploadSession, std::string>::ComplexOption;
-  // g++ prior to version 7 has a bug which hides this ctor
-  UseResumableUploadSession()
-      : ComplexOption<UseResumableUploadSession, std::string>() {}
+  // GCC <= 7.0 does not use the inherited default constructor, redeclare it
+  // explicitly
+  UseResumableUploadSession() = default;
+
   static char const* name() { return "resumable-upload"; }
 };
 

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -36,6 +36,9 @@ inline namespace STORAGE_CLIENT_NS {
 struct UseResumableUploadSession
     : public internal::ComplexOption<UseResumableUploadSession, std::string> {
   using ComplexOption<UseResumableUploadSession, std::string>::ComplexOption;
+  // g++ prior to version 7 has a bug which hides this ctor
+  UseResumableUploadSession()
+      : ComplexOption<UseResumableUploadSession, std::string>() {}
   static char const* name() { return "resumable-upload"; }
 };
 


### PR DESCRIPTION
g++ prior to version 7 hides inherited default constructors. They need
to be manually written. This is essential to dynamically generating
lists of options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3423)
<!-- Reviewable:end -->
