### PR TITLE
feat: support x-goog-content-sha256 for V4 signed URLs

### DIFF
--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -118,7 +118,7 @@ std::string TrimHeaderValue(std::string const& value) {
   std::string tmp = value;
   // Heasder values need to be normalized for spaces, whitespaces and tabs
   std::replace_if(tmp.begin(), tmp.end(),
-                  [&](char c) { return std::isspace(c); }, ' ');
+                  [](char c) { return std::isspace(c); }, ' ');
   tmp.erase(0, tmp.find_first_not_of(' '));
   tmp = tmp.substr(0, tmp.find_last_not_of(' ') + 1);
   auto end = std::unique(tmp.begin(), tmp.end(),
@@ -233,12 +233,9 @@ std::string V4SignUrlRequest::PayloadHashValue() const {
   auto it =
       std::find_if(common_request_.extension_headers().begin(),
                    common_request_.extension_headers().end(),
-                   [&](const std::pair<const std::string, std::string>& entry) {
-                     if (entry.first == "x-goog-content-sha256" ||
-                         entry.first == "x-amz-content-sha256") {
-                       return true;
-                     };
-                     return false;
+                   [](const std::pair<const std::string, std::string>& entry) {
+                     return entry.first == "x-goog-content-sha256" ||
+                            entry.first == "x-amz-content-sha256";
                    });
   if (it != common_request_.extension_headers().end()) {
     return it->second;

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -116,6 +116,9 @@ std::string QueryStringFromParameters(
 
 std::string TrimHeaderValue(std::string const& value) {
   std::string tmp = value;
+  // Heasder values need to be normalized for spaces, whitespaces and tabs
+  std::replace_if(tmp.begin(), tmp.end(),
+                  [&](char c) { return std::isspace(c); }, ' ');
   tmp.erase(0, tmp.find_first_not_of(' '));
   tmp = tmp.substr(0, tmp.find_last_not_of(' ') + 1);
   auto end = std::unique(tmp.begin(), tmp.end(),
@@ -163,7 +166,7 @@ std::string V4SignUrlRequest::CanonicalRequest(
   for (auto&& kv : common_request_.extension_headers()) {
     os << kv.first << ":" << TrimHeaderValue(kv.second) << "\n";
   }
-  os << "\n" << SignedHeaders() << "\nUNSIGNED-PAYLOAD";
+  os << "\n" << SignedHeaders() << "\n" << PayloadHashValue();
 
   return std::move(os).str();
 }
@@ -224,6 +227,23 @@ std::string V4SignUrlRequest::SignedHeaders() const {
     sep = ";";
   }
   return result;
+}
+
+std::string V4SignUrlRequest::PayloadHashValue() const {
+  auto it =
+      std::find_if(common_request_.extension_headers().begin(),
+                   common_request_.extension_headers().end(),
+                   [&](const std::pair<const std::string, std::string>& entry) {
+                     if (entry.first == "x-goog-content-sha256" ||
+                         entry.first == "x-amz-content-sha256") {
+                       return true;
+                     };
+                     return false;
+                   });
+  if (it != common_request_.extension_headers().end()) {
+    return it->second;
+  }
+  return "UNSIGNED-PAYLOAD";
 }
 
 std::ostream& operator<<(std::ostream& os, V4SignUrlRequest const& r) {

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -298,6 +298,8 @@ class V4SignUrlRequest {
 
   std::string SignedHeaders() const;
 
+  std::string PayloadHashValue() const;
+
   SignUrlRequestCommon common_request_;
   std::chrono::system_clock::time_point timestamp_;
   std::chrono::seconds expires_;

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -191,19 +191,16 @@ int main(int argc, char* argv[]) {
 
   // The implementation is not yet completed and these tests still fail, so skip
   // them so far.
-  std::set<std::string> nonconformant_tests{
-      "HTTPBucketBoundDomainSupport",
-      "HTTPSBucketBoundDomainSupport",
-      "Headersshouldbetrimmed",
-      "ListObjects",
-      "POSTPolicyACLmatching",
-      "POSTPolicyCacheControlFileHeader",
-      "POSTPolicySimple",
-      "POSTPolicySuccessWithRedirect",
-      "POSTPolicySuccessWithStatus",
-      "POSTPolicyWithinContentRange",
-      "SignedPayloadInsteadofUNSIGNEDPAYLOAD",
-      "VirtualHostedStyle"};
+  std::set<std::string> nonconformant_tests{"HTTPBucketBoundDomainSupport",
+                                            "HTTPSBucketBoundDomainSupport",
+                                            "ListObjects",
+                                            "POSTPolicyACLmatching",
+                                            "POSTPolicyCacheControlFileHeader",
+                                            "POSTPolicySimple",
+                                            "POSTPolicySuccessWithRedirect",
+                                            "POSTPolicySuccessWithStatus",
+                                            "POSTPolicyWithinContentRange",
+                                            "VirtualHostedStyle"};
 
   auto json = google::cloud::storage::internal::nl::json::parse(ifstr);
   if (json.is_discarded()) {


### PR DESCRIPTION
Adds support for x-goog-content-sha256 and x-amz-content-sha256 headers. Part of the work for #3329.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3435)
<!-- Reviewable:end -->
