### PR TITLE
fix: restore CBT variable setting

### DIFF
--- a/ci/kokoro/ubuntu/build.sh
+++ b/ci/kokoro/ubuntu/build.sh
@@ -84,6 +84,7 @@ sha256sum google-cloud-sdk-282.0.0-linux-x86_64.tar.gz | \
     grep -q '^db2fd176a998381ef937bd9f9e83b16eadff864111255d771976d654c961fc95 '
 tar x -C "${HOME}" -f google-cloud-sdk-282.0.0-linux-x86_64.tar.gz
 "${HOME}/google-cloud-sdk/bin/gcloud" --quiet components install cbt
+export CBT="${HOME}/google-cloud-sdk/bin/cbt"
 
 echo "================================================================"
 echo "Setup environment for integration tests $(date)"


### PR DESCRIPTION
I accidentally removed this on #3416, and the variable is only used in
the nightly builds, so it passed all the tests until that night.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3436)
<!-- Reviewable:end -->
