### PR TITLE
feat(3444): content-length to failure case `return-broken-stream`

### DIFF
--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -461,7 +461,7 @@ def objects_get_common(bucket_name, object_name, revision):
     if instructions == 'return-broken-stream':
         def streamer():
             chunk_size = 64 * 1024
-            for r in range(0, len(response_payload) / 2, chunk_size):
+            for r in range(0, len(response_payload), chunk_size):
                 if r > 1024 * 1024:
                     print("\n\n###### EXIT to simulate crash\n")
                     sys.exit(1)
@@ -473,6 +473,7 @@ def objects_get_common(bucket_name, object_name, revision):
         content_range = 'bytes %d-%d/%d' % (begin, end - 1, length)
         headers = {
             'Content-Range': content_range,
+            'Content-Length': length,
             'x-goog-hash': revision.x_goog_hash_header(),
             'x-goog-generation': revision.generation
         }


### PR DESCRIPTION
1. Adding Content-Length to response to give client expectations of payload length.
1. I didn't find ` / 2` necessary and removed it.

Fixes: #3444

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3445)
<!-- Reviewable:end -->
