### PR TITLE
ci: use new script with new configs

### DIFF
--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
+build_file: "google-cloud-cpp/ci/kokoro/windows/build-new.bat"
 timeout_mins: 120
 
 env_vars {


### PR DESCRIPTION
I need to point the new Kokoro configs to the new scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3467)
<!-- Reviewable:end -->
