### PR TITLE
ci: actually use Bazel 2.0

### DIFF
--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -29,15 +29,5 @@ cd github\google-cloud-cpp
 powershell -exec bypass ci\kokoro\windows\build.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-@REM Kokoro rsyncs all the files in the %KOKORO_ARTIFACTS_DIR%, which takes a
-@REM long time. The recommended workaround is to remove all the files that are
-@REM not interesting artifacts.
-if defined KOKORO_ARTIFACTS_DIR (
-  @echo %date% %time% "Cleanup Kokoro artifacts directory"
-  cd "%KOKORO_ARTIFACTS_DIR%"
-  powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item -Recurse -Force}"
-  if %errorlevel% neq 0 exit /b %errorlevel%
-)
-
 @echo DONE "============================================="
 @echo %date% %time%

--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -16,7 +16,7 @@ REM Install Bazel using Chocolatey.
 choco install -y bazel --version 2.0.0
 
 REM Change PATH to use chocolatey's version of Bazel
-set PATH=C:\ProgramData\chocolatey\bin:%PATH%
+set PATH=C:\ProgramData\chocolatey\bin%PATH%
 bazel version
 
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.

--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -16,7 +16,7 @@ REM Install Bazel using Chocolatey.
 choco install -y bazel --version 2.0.0
 
 REM Change PATH to use chocolatey's version of Bazel
-set PATH=C:\ProgramData\chocolatey\bin%PATH%
+set PATH=C:\ProgramData\chocolatey\bin;%PATH%
 bazel version
 
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.

--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -15,11 +15,13 @@
 REM Install Bazel using Chocolatey.
 choco install -y bazel --version 2.0.0
 
+REM Change PATH to use chocolatey's version of Bazel
+set PATH=C:\ProgramData\chocolatey\bin:%PATH%
+bazel version
+
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-REM Change PATH to use chocolatey's version of Bazel
-set PATH=C:\ProgramData\chocolatey\bin:%PATH%
 
 REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%

--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -18,6 +18,9 @@ choco install -y bazel --version 2.0.0
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 
+REM Change PATH to use chocolatey's version of Bazel
+set PATH=C:\ProgramData\chocolatey\bin:%PATH%
+
 REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%
 cd github\google-cloud-cpp

--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -22,7 +22,6 @@ bazel version
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-
 REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%
 cd github\google-cloud-cpp


### PR DESCRIPTION
We installed Bazel 2.0, but the script was still picking up 0.24.1 from
somewhere. Changing the PATH should fix this.

Part of the work for googleapis/google-cloud-cpp-common#231 and googleapis/google-cloud-cpp-common#227

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3469)
<!-- Reviewable:end -->
