### PR TITLE
ci: update builds to use g-c-cpp-common v0.23.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -247,9 +247,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
@@ -357,9 +357,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
@@ -516,9 +516,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
@@ -648,9 +648,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
@@ -795,9 +795,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
@@ -934,9 +934,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
@@ -1098,9 +1098,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -41,11 +41,11 @@ def google_cloud_cpp_deps():
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
-            strip_prefix = "google-cloud-cpp-common-0.22.1",
+            strip_prefix = "google-cloud-cpp-common-0.23.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz",
             ],
-            sha256 = "43108ffa0c66fc871e1787c30c5aa6ecac593e6e19fc1190470ba2436756c4a2",
+            sha256 = "5079dfa6a1d735a9da52769fc0619030cef3f82a1f30a2a66f7825f9c148b24e",
         )
 
     # Load a version of googletest that we know works.

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -88,9 +88,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 
 # Download and compile google-cloud-cpp-common from source too.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd /var/tmp/build/google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd /var/tmp/build/google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
       -DBUILD_SHARED_LIBS=YES \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -156,9 +156,9 @@ RUN ldconfig
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz
-RUN tar -xf v0.22.1.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.22.1
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz
+RUN tar -xf v0.23.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.23.0
 # Compile without the tests because we are testing google-cloud-cpp, not the
 # base libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -161,9 +161,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -140,9 +140,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -103,9 +103,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -136,9 +136,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -109,9 +109,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -156,9 +156,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -107,9 +107,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -129,9 +129,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -144,9 +144,9 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz && \
-    tar -xf v0.22.1.tar.gz && \
-    cd google-cloud-cpp-common-0.22.1 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out \
         -DBUILD_TESTING=OFF \
         -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \

--- a/ci/kokoro/windows/vcpkg-ports/google-cloud-cpp-common/CONTROL
+++ b/ci/kokoro/windows/vcpkg-ports/google-cloud-cpp-common/CONTROL
@@ -1,5 +1,5 @@
 Source: google-cloud-cpp-common
-Version: 0.21.0
+Version: 0.23.0
 Build-Depends: grpc, googleapis
 Description: Base C++ Libraries for Google Cloud Platform APIs
 Homepage: https://github.com/googleapis/google-cloud-cpp-common

--- a/ci/kokoro/windows/vcpkg-ports/google-cloud-cpp-common/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-ports/google-cloud-cpp-common/portfile.cmake
@@ -8,9 +8,9 @@ vcpkg_from_github(
     REPO
     googleapis/google-cloud-cpp-common
     REF
-    v0.21.0
+    v0.23.0
     SHA512
-    a339c6f57ac539f1c45f2fb92311e5d48e29a4406a1e0cfda2f1dc18e8c6db345588ad0bebd2c23531e572982d4429ee73b4f0c3df1ba8028d4100d9b12ecaa1
+    76b610b8d345f49c101b7de885287df6289f5f4349c59b5c38683fc299c5cbdb7b763700cdc3e75460802bf2da36f1b75e8ff5e660a622451d23523f34e5a001
     HEAD_REF
     master)
 

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -23,10 +23,10 @@ if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.22.1.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz"
     )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "43108ffa0c66fc871e1787c30c5aa6ecac593e6e19fc1190470ba2436756c4a2")
+        "5079dfa6a1d735a9da52769fc0619030cef3f82a1f30a2a66f7825f9c148b24e")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#248

----
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3482)
<!-- Reviewable:end -->
