### PR TITLE
ci: use the right distro version in builds

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -248,6 +248,7 @@ docker_build_flags=(
   # upload it.
   "-t" "${IMAGE}:latest"
   "--build-arg" "NCPU=${NCPU}"
+  "--build-arg" "DISTRO_VERSION=${DISTRO_VERSION}"
   "-f" "ci/kokoro/docker/Dockerfile.${DISTRO}"
 )
 


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3484)
<!-- Reviewable:end -->
