### PR TITLE
bug: express libcurl version in hex

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -149,7 +149,7 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
 
   handle_.FlushDebug(__func__);
   TRACE_STATE();
-  
+
 #if LIBCURL_VERSION_NUM >= 0x074500
   if (!curl_closed_ && paused_) {
 #else

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -149,8 +149,8 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
 
   handle_.FlushDebug(__func__);
   TRACE_STATE();
-
-#if LIBCURL_VERSION_NUM >= 0x076900
+  
+#if LIBCURL_VERSION_NUM >= 0x074500
   if (!curl_closed_ && paused_) {
 #else
   if (!curl_closed_) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3487)
<!-- Reviewable:end -->
