### PR TITLE
cleanup: remove arguments in bigtable integration tests

### DIFF
--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -29,14 +29,32 @@ namespace testing {
 
 std::string TableTestEnvironment::project_id_;
 std::string TableTestEnvironment::instance_id_;
-std::string TableTestEnvironment::cluster_id_;
-std::string TableTestEnvironment::zone_;
-std::string TableTestEnvironment::replication_zone_;
+std::string TableTestEnvironment::zone_a_;
+std::string TableTestEnvironment::zone_b_;
 google::cloud::internal::DefaultPRNG TableTestEnvironment::generator_;
 std::string TableTestEnvironment::table_id_;
 bool TableTestEnvironment::using_cloud_bigtable_emulator_;
 
+TableTestEnvironment::TableTestEnvironment() {
+  project_id_ =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  instance_id_ = google::cloud::internal::GetEnv(
+                     "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
+                     .value_or("");
+  zone_a_ =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A")
+          .value_or("");
+  zone_b_ =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B")
+          .value_or("");
+}
+
 void TableTestEnvironment::SetUp() {
+  ASSERT_FALSE(project_id_.empty());
+  ASSERT_FALSE(instance_id_.empty());
+  ASSERT_FALSE(zone_a_.empty());
+  ASSERT_FALSE(zone_b_.empty());
+
   using_cloud_bigtable_emulator_ =
       google::cloud::internal::GetEnv("BIGTABLE_EMULATOR_HOST").has_value();
 

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -31,34 +31,15 @@ namespace testing {
 /// Store the project and instance captured from the command-line arguments.
 class TableTestEnvironment : public ::testing::Environment {
  public:
-  TableTestEnvironment(std::string project, std::string instance) {
-    project_id_ = std::move(project);
-    instance_id_ = std::move(instance);
-  }
-
-  TableTestEnvironment(std::string project, std::string instance,
-                       std::string cluster) {
-    project_id_ = std::move(project);
-    instance_id_ = std::move(instance);
-    cluster_id_ = std::move(cluster);
-  }
-
-  TableTestEnvironment(std::string project, std::string instance,
-                       std::string zone, std::string replication_zone) {
-    project_id_ = std::move(project);
-    instance_id_ = std::move(instance);
-    zone_ = std::move(zone);
-    replication_zone_ = std::move(replication_zone);
-  }
+  TableTestEnvironment();
 
   void SetUp() override;
   void TearDown() override;
 
   static std::string const& project_id() { return project_id_; }
   static std::string const& instance_id() { return instance_id_; }
-  static std::string const& cluster_id() { return cluster_id_; }
-  static std::string const& zone() { return zone_; }
-  static std::string const& replication_zone() { return replication_zone_; }
+  static std::string const& zone_a() { return zone_a_; }
+  static std::string const& zone_b() { return zone_b_; }
 
   /**
    * Generate a random string for instance, cluster, or table identifiers.
@@ -86,9 +67,8 @@ class TableTestEnvironment : public ::testing::Environment {
  private:
   static std::string project_id_;
   static std::string instance_id_;
-  static std::string cluster_id_;
-  static std::string zone_;
-  static std::string replication_zone_;
+  static std::string zone_a_;
+  static std::string zone_b_;
 
   static google::cloud::internal::DefaultPRNG generator_;
 

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -270,11 +270,11 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncCheckConsistencyIntegrationTest) {
 
   // Replication needs at least two clusters
   auto cluster_config_1 =
-      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone(),
+      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_a(),
                               3, bigtable::ClusterConfig::HDD);
-  auto cluster_config_2 = bigtable::ClusterConfig(
-      bigtable::testing::TableTestEnvironment::replication_zone(), 3,
-      bigtable::ClusterConfig::HDD);
+  auto cluster_config_2 =
+      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_b(),
+                              3, bigtable::ClusterConfig::HDD);
   bigtable::InstanceConfig config(
       id, display_name,
       {{id + "-c1", cluster_config_1}, {id + "-c2", cluster_config_2}});
@@ -361,24 +361,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncCheckConsistencyIntegrationTest) {
 
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  // Make sure the arguments are valid.
-  if (argc != 5) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(argv[0]).find_last_of('/');
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project_id> <instance_id> <zone> <replication_zone>\n";
-    return 1;
-  }
-
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-  std::string const zone = argv[3];
-  std::string const replication_zone = argv[4];
-
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment(
-          project_id, instance_id, zone, replication_zone));
-
+      new google::cloud::bigtable::testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -249,11 +249,11 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
   // than 30 characters.
   auto display_name = ("IT " + id).substr(0, 30);
   auto cluster_config_1 =
-      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone(),
+      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_a(),
                               3, bigtable::ClusterConfig::HDD);
-  auto cluster_config_2 = bigtable::ClusterConfig(
-      bigtable::testing::TableTestEnvironment::replication_zone(), 3,
-      bigtable::ClusterConfig::HDD);
+  auto cluster_config_2 =
+      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_b(),
+                              3, bigtable::ClusterConfig::HDD);
   bigtable::InstanceConfig config(
       id, display_name,
       {{id + "-c1", cluster_config_1}, {id + "-c2", cluster_config_2}});
@@ -311,25 +311,7 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  // Check for arguments validity
-  if (argc != 5) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(cmd).find_last_of('/');
-    // Show Usage if invalid no of arguments
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << "<project_id> <instance_id> <zone> <replication_zone>\n";
-    return 1;
-  }
-
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-  std::string const zone = argv[3];
-  std::string const replication_zone = argv[4];
-
   (void)::testing::AddGlobalTestEnvironment(
-      new bigtable::testing::TableTestEnvironment(project_id, instance_id, zone,
-                                                  replication_zone));
-
+      new bigtable::testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -333,22 +333,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowTest) {
 
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  // Make sure the arguments are valid.
-  if (argc != 3) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(argv[0]).find_last_of('/');
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project> <instance>\n";
-    return 1;
-  }
-
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment(project_id,
-                                                                 instance_id));
+      new google::cloud::bigtable::testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -41,21 +41,8 @@ class DataIntegrationTest : public bigtable::testing::TableIntegrationTest {
 
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  // Make sure the arguments are valid.
-  if (argc != 3) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(argv[0]).find_last_of('/');
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project> <instance>\n";
-    return 1;
-  }
-
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-
   (void)::testing::AddGlobalTestEnvironment(
-      new ::bigtable::testing::TableTestEnvironment(project_id, instance_id));
+      new ::bigtable::testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -58,20 +58,8 @@ class FilterIntegrationTest : public bigtable::testing::TableIntegrationTest {
 
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  // Make sure the arguments are valid.
-  if (argc != 3) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(argv[0]).find_last_of("/");
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project> <instance>\n";
-    return 1;
-  }
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-
   (void)::testing::AddGlobalTestEnvironment(
-      new ::bigtable::testing::TableTestEnvironment(project_id, instance_id));
+      new ::bigtable::testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/status_or.h"
@@ -28,23 +29,37 @@ using testing::HasSubstr;
 
 namespace {
 
-// Initialized in main() below.
-char const* flag_project_id;
-char const* flag_zone_a;
-char const* flag_zone_b;
-char const* flag_service_account;
-
 class InstanceAdminAsyncFutureIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    project_id_ =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+    ASSERT_FALSE(project_id_.empty());
+    zone_a_ =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A")
+            .value_or("");
+    ASSERT_FALSE(zone_a_.empty());
+    zone_b_ =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B")
+            .value_or("");
+    ASSERT_FALSE(zone_b_.empty());
+    service_account_ = google::cloud::internal::GetEnv(
+                           "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT")
+                           .value_or("");
+    ASSERT_FALSE(service_account_.empty());
+
     auto instance_admin_client = bigtable::CreateDefaultInstanceAdminClient(
-        flag_project_id, bigtable::ClientOptions());
+        project_id_, bigtable::ClientOptions());
     instance_admin_ =
         google::cloud::internal::make_unique<bigtable::InstanceAdmin>(
             instance_admin_client);
   }
 
  protected:
+  std::string project_id_;
+  std::string zone_a_;
+  std::string zone_b_;
+  std::string service_account_;
   std::unique_ptr<bigtable::InstanceAdmin> instance_admin_;
   google::cloud::internal::DefaultPRNG generator_ =
       google::cloud::internal::MakeDefaultPRNG();
@@ -129,7 +144,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
       << " generated at random.";
 
   // create instance
-  auto config = IntegrationTestConfig(instance_id, flag_zone_a);
+  auto config = IntegrationTestConfig(instance_id, zone_a_);
   auto instance = instance_admin_->AsyncCreateInstance(cq, config).get();
   ASSERT_STATUS_OK(instance);
 
@@ -189,7 +204,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
 
   // create instance prerequisites for cluster operations
   auto instance_config = IntegrationTestConfig(
-      instance_id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
+      instance_id, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_details =
       instance_admin_->AsyncCreateInstance(cq, instance_config).get();
   ASSERT_STATUS_OK(instance_details);
@@ -207,7 +222,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest,
                                               cluster_id));
   // create cluster
   auto cluster_config =
-      bigtable::ClusterConfig(flag_zone_b, 3, bigtable::ClusterConfig::HDD);
+      bigtable::ClusterConfig(zone_b_, 3, bigtable::ClusterConfig::HDD);
   auto cluster =
       instance_admin_
           ->AsyncCreateCluster(cq, cluster_config, instance_id, cluster_id)
@@ -287,9 +302,9 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAllClustersTest) {
   std::thread pool([&cq] { cq.Run(); });
 
   auto instance_config1 = IntegrationTestConfig(
-      id1, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
+      id1, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_config2 = IntegrationTestConfig(
-      id2, flag_zone_b, bigtable::InstanceConfig::PRODUCTION, 3);
+      id2, zone_b_, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance1_future =
       instance_admin_->AsyncCreateInstance(cq, instance_config1);
   auto instance2_future =
@@ -337,7 +352,7 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   std::thread pool([&cq] { cq.Run(); });
 
   auto instance_config = IntegrationTestConfig(
-      instance_id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
+      instance_id, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3);
   auto future = instance_admin_->AsyncCreateInstance(cq, instance_config);
   auto actual = future.get();
   ASSERT_STATUS_OK(actual);
@@ -446,14 +461,13 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, SetGetTestIamAPIsTest) {
 
   // create instance prerequisites for cluster operations
   auto instance_config = IntegrationTestConfig(
-      id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
+      id, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_details =
       instance_admin_->CreateInstance(instance_config).get();
   ASSERT_STATUS_OK(instance_details);
 
   auto iam_bindings = google::cloud::IamBindings(
-      "roles/bigtable.reader",
-      {"serviceAccount:" + std::string(flag_service_account)});
+      "roles/bigtable.reader", {"serviceAccount:" + service_account_});
 
   auto initial_policy =
       instance_admin_->AsyncSetIamPolicy(cq, id, iam_bindings).get();
@@ -489,14 +503,13 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, SetGetTestIamNativeAPIsTest) {
 
   // create instance prerequisites for cluster operations
   auto instance_config = IntegrationTestConfig(
-      id, flag_zone_a, bigtable::InstanceConfig::PRODUCTION, 3);
+      id, zone_a_, bigtable::InstanceConfig::PRODUCTION, 3);
   auto instance_details =
       instance_admin_->CreateInstance(instance_config).get();
   ASSERT_STATUS_OK(instance_details);
 
   auto iam_policy = bigtable::IamPolicy({bigtable::IamBinding(
-      "roles/bigtable.reader",
-      {"serviceAccount:" + std::string(flag_service_account)})});
+      "roles/bigtable.reader", {"serviceAccount:" + service_account_})});
 
   auto initial_policy =
       instance_admin_->AsyncSetIamPolicy(cq, id, iam_policy).get();
@@ -520,24 +533,4 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, SetGetTestIamNativeAPIsTest) {
 
   cq.Shutdown();
   pool.join();
-}
-
-int main(int argc, char* argv[]) {
-  google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  if (argc != 5) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(cmd).find_last_of('/');
-    // Show usage if number of arguments is invalid.
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1) << " <project_id>"
-              << " <zone-a> <zone-b> <service-account>\n";
-    return 1;
-  }
-
-  flag_project_id = argv[1];
-  flag_zone_a = argv[2];
-  flag_zone_b = argv[3];
-  flag_service_account = argv[4];
-
-  return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -444,20 +444,8 @@ TEST_F(MutationIntegrationTest, DeleteFromRowTest) {
 
 int main(int argc, char* argv[]) {
   google::cloud::testing_util::InitGoogleMock(argc, argv);
-
-  // Make sure the arguments are valid.
-  if (argc != 3) {
-    std::string const cmd = argv[0];
-    auto last_slash = std::string(argv[0]).find_last_of("/");
-    std::cerr << "Usage: " << cmd.substr(last_slash + 1)
-              << " <project> <instance>\n";
-    return 1;
-  }
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-
   (void)::testing::AddGlobalTestEnvironment(
-      new ::bigtable::testing::TableTestEnvironment(project_id, instance_id));
+      new ::bigtable::testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/run_admin_integration_tests_production.sh
+++ b/google/cloud/bigtable/tests/run_admin_integration_tests_production.sh
@@ -21,30 +21,30 @@ set -eu
 # The following environment variables must be defined before calling this
 # script:
 #
-# - PROJECT_ID: the id (typically the string form) of a valid GCP project.
-# - ZONE_A: the name of a valid GCP zone supporting Cloud Bigtable.
-# - ZONE_B: the name of a valid GCP zone supporting Cloud Bigtable, should be
+# - GOOGLE_CLOUD_PROJECT: the id (typically the string form) of a valid GCP
+#   project.
+# - GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A: the name of a valid GCP zone
+#   supporting Cloud Bigtable.
+# - GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B: the name of a valid GCP zone
+#   supporting Cloud Bigtable, should be
 #   different from ZONE_A and should be in the same region.
-# - INSTANCE_ID: the ID of an existing Cloud Bigtable instance in ZONE_A.
-# - SERVICE_ACCOUNT: a valid service account to test IAM operations.
+# - GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID: the ID of an existing Cloud
+#   Bigtable instance in ZONE_A.
+# - GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT: a valid service account to
+#   test IAM operations.
 #
 
 echo
 echo "Running bigtable::InstanceAdmin integration test."
-./instance_admin_integration_test \
-    "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}" "${SERVICE_ACCOUNT}"
-
+./instance_admin_integration_test
 echo
 echo "Running bigtable::InstanceAdmin async with futures integration test."
-./instance_admin_async_future_integration_test \
-    "${PROJECT_ID}" "${ZONE_A}" "${ZONE_B}" "${SERVICE_ACCOUNT}"
+./instance_admin_async_future_integration_test
 
 echo
 echo "Running bigtable::TableAdmin integration test."
-./admin_integration_test \
-    "${PROJECT_ID}" "${INSTANCE_ID}" "${ZONE_A}" "${ZONE_B}"
+./admin_integration_test
 
 echo
 echo "Running TableAdmin async with futures integration test."
-./admin_async_future_integration_test \
-    "${PROJECT_ID}" "${INSTANCE_ID}"  "${ZONE_A}" "${ZONE_B}"
+./admin_async_future_integration_test

--- a/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
+++ b/google/cloud/bigtable/tests/run_integration_tests_emulator.sh
@@ -26,11 +26,11 @@ start_emulators
 # Use a unique project name to allow multiple runs of the test with
 # an externally launched emulator.
 readonly NONCE="${RANDOM}-${RANDOM}"
-export PROJECT_ID="emulated-${NONCE}"
-export INSTANCE_ID="it-${NONCE}"
-export ZONE_A="fake-region1-a"
-export ZONE_B="fake-region1-b"
-export SERVICE_ACCOUNT="fake-sa@${PROJECT_ID}.iam.gserviceaccount.com"
+export GOOGLE_CLOUD_PROJECT="emulated-${NONCE}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="it-${NONCE}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="fake-region1-a"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="fake-region1-b"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="fake-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 
 # We run the same tests we run in production, just with different settings.
 "${BINDIR}/run_integration_tests_production.sh"

--- a/google/cloud/bigtable/tests/run_integration_tests_production.sh
+++ b/google/cloud/bigtable/tests/run_integration_tests_production.sh
@@ -20,16 +20,16 @@ set -eu
 # PROJECT_ID and INSTANCE_ID.
 echo
 echo "Running bigtable::Table integration test."
-./data_integration_test "${PROJECT_ID}" "${INSTANCE_ID}"
+./data_integration_test
 
 echo
 echo "Running bigtable::Filters integration tests."
-./filters_integration_test "${PROJECT_ID}" "${INSTANCE_ID}"
+./filters_integration_test
 
 echo
 echo "Running Mutation (e.g. DeleteFromColumn, SetCell) integration tests."
-./mutations_integration_test "${PROJECT_ID}" "${INSTANCE_ID}"
+./mutations_integration_test
 
 echo
 echo "Running Table::Async* integration test."
-./data_async_future_integration_test "${PROJECT_ID}" "${INSTANCE_ID}"
+./data_async_future_integration_test


### PR DESCRIPTION
We want to use Bazel and CTest to run the integration tests, one of the
first steps is to have these tests receive any parameters through
environment variables. Neither Bazel nor CTest support passing
additional arguments to the tests through the command-line.

Part of the work for #3489

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3490)
<!-- Reviewable:end -->
