### PR TITLE
fix: make it easier to manually build on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
+# and there is (AFAIK) no way to "inherit" their definitions.
+#   [1]: https://github.com/bazelbuild/bazel/issues/4341
+build --copt=-DGRPC_BAZEL_BUILD
+
 # Clang Sanitizers, use with (for example):
 #
 # --client_env=CXX=clang++ --client_env=CC=clang --config asan


### PR DESCRIPTION
I am doing more builds on macOS and find myself forgetting to add
the magic flags needed by gRPC on that platform (and harmless in other
platforms).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3493)
<!-- Reviewable:end -->
