### PR TITLE
ci: use CTest to drive Bigtable integration tests

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -64,7 +64,7 @@ echo "================================================================"
 echo "$(date -u): Compiling and running unit tests"
 echo "================================================================"
 "${BAZEL_BIN}" test \
-    "${bazel_args[@]}" \
+    "${bazel_args[@]}" "--test_tag_filters=-integration-tests" \
     -- //google/cloud/...:all
 
 echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -148,7 +148,7 @@ _EOF_
   fi
 fi
 
-ctest_args=("--output-on-failure")
+ctest_args=("--output-on-failure" "-j" "${NCPU}")
 if [[ -n "${RUNS_PER_TEST}" ]]; then
     ctest_args+=("--repeat-until-fail" "${RUNS_PER_TEST}")
 fi
@@ -163,11 +163,19 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     echo
     echo "${COLOR_YELLOW}Running unit tests $(date)${COLOR_RESET}"
     echo
-    (cd "${BINARY_DIR}" && ctest "${ctest_args[@]}")
+    (cd "${BINARY_DIR}" && ctest "-LE" "integration-tests" "${ctest_args[@]}")
 
     echo
     echo "${COLOR_YELLOW}Completed unit tests $(date)${COLOR_RESET}"
     echo
+  fi
+
+  if [[ "${RUN_INTEGRATION_TESTS:-}" != "no" ]]; then
+    echo
+    echo "${COLOR_YELLOW}Running integration tests via CTest $(date)${COLOR_RESET}"
+    echo
+    "${PROJECT_ROOT}/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh" \
+        "${BINARY_DIR}" "${ctest_args[@]}"
   fi
 
   if [[ "${RUN_INTEGRATION_TESTS:-}" != "no" ]]; then

--- a/google/cloud/bigtable/ci/run_integration_tests.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests.sh
@@ -23,36 +23,6 @@ source "${BINDIR}/../../../../ci/colors.sh"
 
 readonly BTDIR="google/cloud/bigtable"
 
-# TODO(#441) - fix the workaround below and use just this time:
-# (cd bigtable/tests && "${BINDIR}/../tests/run_integration_tests_emulator.sh")
-# Sometimes the integration tests manage to crash the Bigtable emulator.
-# Manually restarting the build clears up the problem, but that is just a waste
-# of everybody's time. Use a (short) timeout to run the test and try 3 times.
-set +e
-success=""
-readonly TIMEOUT_CMD="$(command -v timeout)"
-if [ -n "${TIMEOUT_CMD}" ]; then
-  timeout="${TIMEOUT_CMD} 300s"
-else
-  timeout="env"
-fi
-
-for attempt in 1 2 3; do
-  (cd "${BTDIR}/tests" && \
-   ${timeout} "${BINDIR}/../tests/run_integration_tests_emulator.sh")
-  if [ $? = 0 ]; then
-    success="yes"
-    break
-  fi
-  echo "${COLOR_YELLOW}Failure or timeout in integration test during " \
-      "attempt=${attempt} $(date)${COLOR_RESET}"
-done
-if [ "${success}" != "yes" ]; then
-  echo "Integration tests failed multiple times, aborting tests."
-  exit 1
-fi
-set -e
-
 if [ -d ${BTDIR}/examples ]; then
   (cd "${BTDIR}/examples" && "${BINDIR}/../examples/run_examples_emulator.sh")
 else

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -25,6 +25,9 @@ readonly BINARY_DIR
 shift
 ctest_args=("$@")
 
+# Configure run_emulators_utils.sh to find the instance admin emulator.
+export CBT_INSTANCE_ADMIN_EMULATOR_CMD="${BINARY_DIR}/google/cloud/bigtable/tests/instance_admin_emulator"
+
 CMDDIR="$(dirname "$0")"
 readonly CMDDIR
 PROJECT_ROOT="$(cd "${CMDDIR}/../../../.."; pwd)"
@@ -41,7 +44,6 @@ export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="it-${NONCE}"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="fake-region1-a"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="fake-region1-b"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="fake-sa@emulated-${NONCE}.iam.gserviceaccount.com"
-export CBT_INSTANCE_ADMIN_EMULATOR_CMD="${BINARY_DIR}/google/cloud/bigtable/tests/instance_admin_emulator"
 
 ctest "-L" "bigtable-integration-tests" "${ctest_args[@]}"
 exit_status=$?

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"
+  exit 1
+fi
+
+BINARY_DIR="$(cd "${1}"; pwd)"
+readonly BINARY_DIR
+shift
+ctest_args=("$@")
+
+CMDDIR="$(dirname "$0")"
+readonly CMDDIR
+PROJECT_ROOT="$(cd "${CMDDIR}/../../../.."; pwd)"
+readonly PROJECT_ROOT
+source "${PROJECT_ROOT}/google/cloud/bigtable/tools/run_emulator_utils.sh"
+
+cd "${BINARY_DIR}"
+start_emulators
+
+NONCE="$(date +%s)-${RANDOM}"
+readonly NONCE
+export GOOGLE_CLOUD_PROJECT="emulated-${NONCE}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="it-${NONCE}"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="fake-region1-a"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="fake-region1-b"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="fake-sa@emulated-${NONCE}.iam.gserviceaccount.com"
+export CBT_INSTANCE_ADMIN_EMULATOR_CMD="${BINARY_DIR}/google/cloud/bigtable/tests/instance_admin_emulator"
+
+ctest "-L" "bigtable-integration-tests" "${ctest_args[@]}"
+exit_status=$?
+
+kill_emulators
+trap '' EXIT
+
+exit "${exit_status}"

--- a/google/cloud/bigtable/tests/BUILD
+++ b/google/cloud/bigtable/tests/BUILD
@@ -21,9 +21,11 @@ load(
     "bigtable_client_integration_tests",
 )
 
-[cc_binary(
+[cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
+    timeout = "long",
     srcs = [test],
+    tags = ["integration-tests", "bigtable-integration-tests"],
     deps = [
         "//google/cloud/bigtable:bigtable_client",
         "//google/cloud/bigtable:bigtable_client_testing",

--- a/google/cloud/bigtable/tests/BUILD
+++ b/google/cloud/bigtable/tests/BUILD
@@ -25,7 +25,10 @@ load(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
-    tags = ["integration-tests", "bigtable-integration-tests"],
+    tags = [
+        "bigtable-integration-tests",
+        "integration-tests",
+    ],
     deps = [
         "//google/cloud/bigtable:bigtable_client",
         "//google/cloud/bigtable:bigtable_client_testing",

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -51,7 +51,9 @@ foreach (fname ${bigtable_client_integration_tests})
                 protobuf::libprotobuf
                 bigtable_common_options)
     add_test(NAME ${target} COMMAND ${target})
-    set_tests_properties(${target} PROPERTIES LABELS "integration-tests;bigtable-integration-tests")
+    set_tests_properties(
+        ${target} PROPERTIES LABELS
+                             "integration-tests;bigtable-integration-tests")
 endforeach ()
 
 add_executable(instance_admin_emulator instance_admin_emulator.cc)

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ foreach (fname ${bigtable_client_integration_tests})
                 gRPC::grpc
                 protobuf::libprotobuf
                 bigtable_common_options)
+    add_test(NAME ${target} COMMAND ${target})
+    set_tests_properties(${target} PROPERTIES LABELS "integration-tests;bigtable-integration-tests")
 endforeach ()
 
 add_executable(instance_admin_emulator instance_admin_emulator.cc)

--- a/super/CMakeLists.txt
+++ b/super/CMakeLists.txt
@@ -55,7 +55,8 @@ ExternalProject_Add(
                -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
-    TEST_COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    TEST_COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -LE
+                 integration-tests
     LOG_DOWNLOAD OFF
     LOG_CONFIGURE OFF
     LOG_BUILD OFF


### PR DESCRIPTION
For the CMake-based builds use CTest to run the Bigtable integration
tests. This allows us to parallelize the tests. This PR is a really
small improvement, we also need to parallelize the examples, and the
benchmark smoke test. But it serves as a good prototype.

I removed the workarounds for #441: I ran the test 100 times, with 4 cores
and the emulator no longer seems to crash. I will mark #441 as fixed separately.


Part of the work for #3489 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3502)
<!-- Reviewable:end -->
