### PR TITLE
ci: speed up the PR builds for Windows+CMake

### DIFF
--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -96,7 +96,9 @@ $BuildExitCode = $LastExitCode
 # *very* slowly on Windows, and then ignores most of them :shrug:
 if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
     Set-Location "$env:KOKORO_ARTIFACTS_DIR"    
-    Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | `
+    Get-ChildItem -Recurse -File `
+        -Exclude test.xml,sponge_log.xml,build.bat `
+        -ErrorAction SilentlyContinue | `
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -96,7 +96,8 @@ $BuildExitCode = $LastExitCode
 # *very* slowly on Windows, and then ignores most of them :shrug:
 if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
     Set-Location "$env:KOKORO_ARTIFACTS_DIR"    
-    Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item -Recurse -Force
+    Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | `
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 if ($BuildExitCode) {

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -61,7 +61,13 @@ if (Test-Path env:KOKORO_GFILE_DIR) {
     }
 }
 
-if ($BuildName -eq "cmake") {
+if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
+    $env:CONFIG = "Debug"
+    $env:GENERATOR = "Ninja"
+    $env:VCPKG_TRIPLET = "x64-windows-static"
+    $DependencyScript = "build-cmake-dependencies.ps1"
+    $BuildScript = "build-cmake.ps1"
+} elseif ($BuildName -eq "cmake-release") {
     $env:CONFIG = "Release"
     $env:GENERATOR = "Ninja"
     $env:VCPKG_TRIPLET = "x64-windows-static"

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -92,6 +92,13 @@ powershell -exec bypass "${ScriptLocation}/${BuildScript}"
 # even if the build fails.
 $BuildExitCode = $LastExitCode
 
+# Remove most things from the artifacts directory. Kokoro copies these files
+# *very* slowly on Windows, and then ignores most of them :shrug:
+if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
+    Set-Location "$env:KOKORO_ARTIFACTS_DIR"    
+    Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item -Recurse -Force
+}
+
 if ($BuildExitCode) {
     throw "Build failed with exit code $LastExitCode"
 }

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -95,7 +95,7 @@ $BuildExitCode = $LastExitCode
 # Remove most things from the artifacts directory. Kokoro copies these files
 # *very* slowly on Windows, and then ignores most of them :shrug:
 if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
-    Set-Location "$env:KOKORO_ARTIFACTS_DIR"    
+    Set-Location "$env:KOKORO_ARTIFACTS_DIR"
     Get-ChildItem -Recurse -File `
         -Exclude test.xml,sponge_log.xml,build.bat `
         -ErrorAction SilentlyContinue | `


### PR DESCRIPTION
Use a Debug build for faster PR builds, a future change will enable
a Release build for post-submit builds. Also parallelize the unit
tests it saves maybe 30 seconds, but I will take it. Prepare the
ground work for running the integration tests for this build too.

Part of the work for #3489

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3509)
<!-- Reviewable:end -->
