### PR TITLE
ci: PRs should not update the vcpkg cache

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -35,7 +35,7 @@ if (Test-Path env:RUNNING_CI) {
     if (Test-Path "vcpkg") {
         Remove-Item -LiteralPath "vcpkg" -Force -Recurse
     }
-    git clone --depth 10 https://github.com/Microsoft/vcpkg.git
+    git clone --quiet --depth 10 https://github.com/Microsoft/vcpkg.git
     if ($LastExitCode) {
       throw "vcpkg git setup failed with exit code $LastExitCode"
     }

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -48,18 +48,25 @@ Set-Location vcpkg
 # If BUILD_CACHE is set (which typically is on Kokoro builds), try
 # to download and extract the build cache.
 if (Test-Path env:BUILD_CACHE) {
-    gcloud auth activate-service-account --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
-    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Downloading build cache."
-    gsutil cp $env:BUILD_CACHE vcpkg-installed.zip
+    gcloud auth activate-service-account `
+        --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+        "downloading build cache."
+    gsutil -q cp $env:BUILD_CACHE vcpkg-installed.zip
     if ($LastExitCode) {
         # Ignore errors, caching failures should not break the build.
         Write-Host "gsutil download failed with exit code $LastExitCode"
-    }
-    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Extracting build cache."
-    7z x vcpkg-installed.zip -aoa
-    if ($LastExitCode) {
-        # Ignore errors, caching failures should not break the build.
-        Write-Host "extracting build cache failed with exit code $LastExitCode"
+    } else {
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "extracting build cache."
+        7z x vcpkg-installed.zip -aoa -bsp0
+        if ($LastExitCode) {
+            # Ignore errors, caching failures should not break the build.
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+                "extracting build cache failed with exit code ${LastExitCode}."
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+                "build will continue without a cache."
+        }
     }
 }
 
@@ -108,18 +115,26 @@ foreach ($pkg in $packages) {
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 .\vcpkg.exe list
 
-if (Test-Path env:BUILD_CACHE) {
-    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Create cache zip file."
-    7z a vcpkg-installed.zip installed\
+# Do not update the vcpkg cache on PRs, it might dirty the cache for any
+# PRs running in parallel, and it is a waste of time in most cases.
+$IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
+    ($env:KOKORO_JOB_TYPE = "GITHUB_PULL_REQUEST")
+if (-not $IsPR -and (Test-Path env:BUILD_CACHE)) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+      "zip vcpkg cache for upload."
+    7z a vcpkg-installed.zip installed\ -bsp0
     if ($LastExitCode) {
         # Ignore errors, caching failures should not break the build.
-        Write-Host "zip build cache failed with exit code $LastExitCode"
-    }
-
-    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Upload cache zip file."
-    gsutil cp vcpkg-installed.zip $env:BUILD_CACHE
-    if ($LastExitCode) {
-        # Ignore errors, caching failures should not break the build.
-        Write-Host "gsutil upload failed with exit code $LastExitCode"
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "zip failed with exit code ${LastExitCode}."
+    } else {
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "upload zip with vcpkg cache."
+        gsutil -q cp vcpkg-installed.zip "${env:BUILD_CACHE}"
+        if ($LastExitCode) {
+            # Ignore errors, caching failures should not break the build.
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+                "continue despite upload failure with code ${LastExitCode}".
+        }
     }
 }

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -13,11 +13,15 @@
 @REM limitations under the License.
 
 REM Install Bazel using Chocolatey.
-choco install -y bazel --version 2.0.0
+choco install --no-progress -y bazel --version 2.0.0
 
 REM Change PATH to use chocolatey's version of Bazel
 set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+
+@REM capture the version for troubleshooting
 bazel version
+@REM shutdown afterwards otherwise the server locks files
+bazel shutdown
 
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
We should not update the vcpkg cache in a PR as this may dirty the
cache for other PRs and it is a waste of time in most builds.
I also cleaned up the log to avoid progress meters.

Part of the work for #3489 and for googleapis/google-cloud-cpp-common#249

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3513)
<!-- Reviewable:end -->
