### PR TITLE
fix: copy .clang-format from -spanner

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,8 +9,11 @@ PointerAlignment: Left
 
 IncludeBlocks: Merge
 IncludeCategories:
-- Regex: '^\"google/cloud/'
+# Matches common headers first, but sorts them after project includes
+- Regex: '^\"google/cloud/(internal/|grpc_utils/|testing_util/|[^/]+\.h)'
   Priority: 1500
+- Regex: '^\"google/cloud/'  # project includes should sort first
+  Priority: 500
 - Regex: '^\"'
   Priority: 1000
 - Regex: '^<grpc/'
@@ -21,3 +24,13 @@ IncludeCategories:
   Priority: 4000
 - Regex: '^<[^/]*>'
   Priority: 5000
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+- Language: TextProto
+  Delimiters:
+  - 'pb'
+  - 'proto'
+  BasedOnStyle: Google
+
+CommentPragmas: '(@copydoc)'

--- a/google/cloud/bigtable/cluster_list_responses.h
+++ b/google/cloud/bigtable/cluster_list_responses.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLUSTER_LIST_RESPONSES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLUSTER_LIST_RESPONSES_H
 
-#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_list_responses.h
+++ b/google/cloud/bigtable/instance_list_responses.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_LIST_RESPONSES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_LIST_RESPONSES_H
 
-#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_BENCHMARK_UTILS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_BENCHMARK_UTILS_H
 
-#include "google/cloud/internal/random.h"
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/random_names.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/optional.h"
 #include <chrono>
 #include <functional>
 #include <sstream>

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "google/cloud/storage/client.h"
 #include <fstream>
 #include <future>
 #include <iomanip>

--- a/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_latency_benchmark.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "google/cloud/storage/client.h"
 #include <future>
 #include <iomanip>
 #include <sstream>

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/parallel_upload.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "google/cloud/storage/client.h"
-#include "google/cloud/storage/parallel_upload.h"
 #include "google/cloud/terminate_handler.h"
 #include <cstdio>
 #include <future>

--- a/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/benchmarks/bounded_queue.h"
+#include "google/cloud/storage/client.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "google/cloud/storage/benchmarks/bounded_queue.h"
-#include "google/cloud/storage/client.h"
 #include <future>
 #include <iomanip>
 #include <sstream>

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "google/cloud/storage/client.h"
 #include <future>
 #include <iomanip>
 #include <sstream>

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "google/cloud/storage/client.h"
 #include <future>
 #include <iomanip>
 #include <sstream>

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_ACCESS_CONTROL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_ACCESS_CONTROL_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/access_control_common.h"
 #include "google/cloud/storage/internal/patch_builder.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "google/cloud/storage/bucket_metadata.h"
-#include "google/cloud/internal/format_time_point.h"
-#include "google/cloud/internal/ios_flags_saver.h"
-#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
+#include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/internal/ios_flags_saver.h"
+#include "google/cloud/status.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -15,13 +15,13 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BUCKET_METADATA_H
 
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/bucket_access_control.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/patch_builder.h"
 #include "google/cloud/storage/lifecycle_rule.h"
 #include "google/cloud/storage/object_access_control.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include <map>
 #include <tuple>
 #include <utility>

--- a/google/cloud/storage/bucket_metadata_test.cc
+++ b/google/cloud/storage/bucket_metadata_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/bucket_metadata.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/storage_class.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
-#include "google/cloud/internal/filesystem.h"
-#include "google/cloud/internal/make_unique.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/internal/curl_handle.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/internal/filesystem.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/log.h"
 #include <openssl/md5.h>
 #include <fstream>
 #include <thread>

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -15,10 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H
 
-#include "google/cloud/internal/disjunction.h"
-#include "google/cloud/internal/throw_delegate.h"
-#include "google/cloud/status.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/hmac_key_metadata.h"
 #include "google/cloud/storage/internal/logging_client.h"
 #include "google/cloud/storage/internal/parameter_pack_validation.h"
@@ -37,6 +33,10 @@
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/upload_options.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/disjunction.h"
+#include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
 #include <type_traits>
 
 namespace google {

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client_options.h"
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include <cstdlib>
 #include <set>
 #include <sstream>

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/format_time_point.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/internal/make_unique.h"
 #include <gmock/gmock.h>
 #include <functional>
 #include <iostream>

--- a/google/cloud/storage/hashing_options.cc
+++ b/google/cloud/storage/hashing_options.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/hashing_options.h"
-#include "google/cloud/internal/big_endian.h"
 #include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/internal/big_endian.h"
 #include <crc32c/crc32c.h>
 #include <openssl/md5.h>
 #include <cstring>

--- a/google/cloud/storage/hmac_key_metadata.h
+++ b/google/cloud/storage/hmac_key_metadata.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_HMAC_KEY_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_HMAC_KEY_METADATA_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <chrono>
 #include <iosfwd>
 #include <string>

--- a/google/cloud/storage/hmac_key_metadata_test.cc
+++ b/google/cloud/storage/hmac_key_metadata_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/hmac_key_metadata.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/storage/internal/hmac_key_requests.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/iam_policy.h
+++ b/google/cloud/storage/iam_policy.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_IAM_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_IAM_POLICY_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_CONTROL_COMMON_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_CONTROL_COMMON_H
 
-#include "google/cloud/optional.h"
-#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
+#include "google/cloud/status.h"
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/bucket_requests.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <sstream>
 
 namespace google {

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -15,13 +15,13 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_BUCKET_REQUESTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_BUCKET_REQUESTS_H
 
-#include "google/cloud/iam_policy.h"
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/iam_policy.h"
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/iam_policy.h"
 #include <iosfwd>
 
 namespace google {

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMMON_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMMON_METADATA_H
 
-#include "google/cloud/optional.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
+#include "google/cloud/status_or.h"
 #include <chrono>
 #include <map>
 #include <utility>

--- a/google/cloud/storage/internal/complex_option.h
+++ b/google/cloud/storage/internal/complex_option.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPLEX_OPTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPLEX_OPTION_H
 
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include <iostream>
 
 namespace google {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_client.h"
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/curl_resumable_upload_session.h"
 #include "google/cloud/storage/internal/generate_message_boundary.h"
 #include "google/cloud/storage/internal/object_streambuf.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/terminate_handler.h"
 #include <sstream>
 

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_CLIENT_H
 
-#include "google/cloud/internal/random.h"
 #include "google/cloud/storage/internal/curl_handle_factory.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/random.h"
 #include <mutex>
 
 namespace google {

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_client.h"
-#include "google/cloud/internal/make_unique.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/iam_policy.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 #include <memory>

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_download_request.h"
-#include "google/cloud/internal/throw_delegate.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
 #include "google/cloud/storage/internal/curl_wrappers.h"
+#include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/log.h"
 #include <curl/multi.h>
 #include <algorithm>
 #include <cstring>

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_handle.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
+#include "google/cloud/log.h"
 #include <string.h>  // NOLINT
 #ifdef _WIN32
 #include <winsock.h>

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_HANDLE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_HANDLE_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/internal/curl_wrappers.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <curl/curl.h>
 
 namespace google {

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_request_builder.h"
-#include "google/cloud/internal/build_info.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/build_info.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_wrappers.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
+#include "google/cloud/log.h"
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
 #include <algorithm>

--- a/google/cloud/storage/internal/generate_message_boundary.h
+++ b/google/cloud/storage/internal/generate_message_boundary.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERATE_MESSAGE_BOUNDARY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERATE_MESSAGE_BOUNDARY_H
 
-#include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/invoke_result.h"
 #include <string>
 
 namespace google {

--- a/google/cloud/storage/internal/hash_validator.cc
+++ b/google/cloud/storage/internal/hash_validator.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hash_validator.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/internal/hash_validator_impl.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/internal/make_unique.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_validator_impl.cc
+++ b/google/cloud/storage/internal/hash_validator_impl.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hash_validator_impl.h"
-#include "google/cloud/internal/big_endian.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/internal/big_endian.h"
 #include <crc32c/crc32c.h>
 
 namespace google {

--- a/google/cloud/storage/internal/hash_validator_test.cc
+++ b/google/cloud/storage/internal/hash_validator_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hash_validator.h"
-#include "google/cloud/internal/make_unique.h"
-#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/hash_validator_impl.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/status.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HTTP_RESPONSE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HTTP_RESPONSE_H
 
-#include "google/cloud/status.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status.h"
 #include <iosfwd>
 #include <map>
 #include <string>

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/logging_client.h"
-#include "google/cloud/internal/make_unique.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/logging_resumable_upload_session.h"
 #include "google/cloud/storage/internal/raw_client_wrapper_utils.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/log.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/logging_client.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/logging_resumable_upload_session.h"
+#include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_READ_SOURCE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_READ_SOURCE_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <string>
 
 namespace google {

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/object_streambuf.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/object_stream.h"
+#include "google/cloud/log.h"
 #include <cstring>
 
 namespace google {

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_STREAMBUF_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_OBJECT_STREAMBUF_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/internal/object_read_source.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <iostream>
 #include <map>
 #include <memory>

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/object_streambuf.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/internal/parameter_pack_validation.h
+++ b/google/cloud/storage/internal/parameter_pack_validation.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PARAMETER_PACK_VALIDATION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PARAMETER_PACK_VALIDATION_H
 
-#include "google/cloud/internal/disjunction.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/disjunction.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_PATCH_BUILDER_H
 
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include <iostream>
 #include <string>
 #include <vector>

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/policy_document_request.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/openssl_util.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <sstream>
 
 namespace google {

--- a/google/cloud/storage/internal/range_from_pagination.h
+++ b/google/cloud/storage/internal/range_from_pagination.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RANGE_FROM_PAGINATION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RANGE_FROM_PAGINATION_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <functional>
 #include <iterator>
 #include <string>

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -15,8 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RAW_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RAW_CLIENT_H
 
-#include "google/cloud/status.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
@@ -37,6 +35,8 @@
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/service_account.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_RESUMABLE_UPLOAD_SESSION_H
 
-#include "google/cloud/optional.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
+#include "google/cloud/status_or.h"
 #include <cstdint>
 #include <iosfwd>
 #include <string>

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/retry_client.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/internal/raw_client_wrapper_utils.h"
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include "google/cloud/storage/internal/retry_resumable_upload_session.h"
+#include "google/cloud/internal/make_unique.h"
 #include <sstream>
 #include <thread>
 

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/retry_resumable_upload_session.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/internal/service_account_requests.h
+++ b/google/cloud/storage/internal/service_account_requests.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_SERVICE_ACCOUNT_REQUESTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_SERVICE_ACCOUNT_REQUESTS_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/service_account.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/status_or.h"
 #include <iosfwd>
 
 namespace google {

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_SIGN_BLOB_REQUESTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_SIGN_BLOB_REQUESTS_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/generic_request.h"
+#include "google/cloud/status_or.h"
 #include <string>
 #include <vector>
 

--- a/google/cloud/storage/internal/signed_url_requests.cc
+++ b/google/cloud/storage/internal/signed_url_requests.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/signed_url_requests.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/storage/internal/curl_handle.h"
 #include "google/cloud/storage/internal/sha256_hash.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <algorithm>
 #include <cctype>
 #include <sstream>

--- a/google/cloud/storage/internal/tuple_filter.h
+++ b/google/cloud/storage/internal/tuple_filter.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_TUPLE_FILTER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_TUPLE_FILTER_H
 
+#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/disjunction.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/tuple.h"
 #include "google/cloud/internal/utility.h"
-#include "google/cloud/storage/version.h"
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIFECYCLE_RULE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIFECYCLE_RULE_H
 
+#include "google/cloud/storage/storage_class.h"
+#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
-#include "google/cloud/storage/storage_class.h"
-#include "google/cloud/storage/version.h"
 #include <chrono>
 #include <iosfwd>
 #include <utility>

--- a/google/cloud/storage/list_hmac_keys_reader.h
+++ b/google/cloud/storage/list_hmac_keys_reader.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIST_HMAC_KEYS_READER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIST_HMAC_KEYS_READER_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/hmac_key_requests.h"
 #include "google/cloud/storage/internal/range_from_pagination.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <iterator>
 
 namespace google {

--- a/google/cloud/storage/list_objects_reader.h
+++ b/google/cloud/storage/list_objects_reader.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIST_OBJECTS_READER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_LIST_OBJECTS_READER_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/internal/range_from_pagination.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <iterator>
 
 namespace google {

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_NOTIFICATION_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_NOTIFICATION_METADATA_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 #include <map>
 #include <string>
 #include <vector>

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -15,13 +15,13 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_AUTHORIZED_USER_CREDENTIALS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_AUTHORIZED_USER_CREDENTIALS_H
 
-#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status.h"
 #include <iostream>
 #include <mutex>
 

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/testing/mock_fake_clock.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstring>

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -15,8 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_COMPUTE_ENGINE_CREDENTIALS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_COMPUTE_ENGINE_CREDENTIALS_H
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/status.h"
 #include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/openssl_util.h"
@@ -24,6 +22,8 @@
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/status.h"
 #include <ctime>
 #include <mutex>
 #include <set>

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/testing/mock_fake_clock.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <chrono>

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_CREDENTIALS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_CREDENTIALS_H
 
-#include "google/cloud/status.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/signed_url_options.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
 #include <chrono>
 
 namespace google {

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
-#include "google/cloud/internal/filesystem.h"
-#include "google/cloud/internal/make_unique.h"
-#include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/internal/filesystem.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/internal/throw_delegate.h"
 #include <fstream>
 #include <iterator>
 #include <memory>

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_GOOGLE_CREDENTIALS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_GOOGLE_CREDENTIALS_H
 
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include <memory>
 #include <set>
 

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/google_credentials.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/internal/compute_engine_util.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/storage/oauth2/authorized_user_credentials.h"
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
 #include "google/cloud/storage/oauth2/google_application_default_credentials_file.h"
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_REFRESHING_CREDENTIALS_WRAPPER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_REFRESHING_CREDENTIALS_WRAPPER_H
 
+#include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "google/cloud/storage/version.h"
 #include <chrono>
 #include <string>
 #include <utility>

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -15,7 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_SERVICE_ACCOUNT_CREDENTIALS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OAUTH2_SERVICE_ACCOUNT_CREDENTIALS_H
 
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/internal/sha256_hash.h"
@@ -23,6 +22,7 @@
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include <condition_variable>
 #include <ctime>
 #include <iostream>

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
-#include "google/cloud/internal/random.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/credential_constants.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/mock_fake_clock.h"
 #include "google/cloud/storage/testing/mock_http_request.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <chrono>

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -15,11 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_ACCESS_CONTROL_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_ACCESS_CONTROL_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/access_control_common.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/patch_builder.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_metadata.h"
-#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
+#include "google/cloud/internal/format_time_point.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_METADATA_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_METADATA_H
 
-#include "google/cloud/optional.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/internal/common_metadata.h"
 #include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/object_access_control.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
+#include "google/cloud/status_or.h"
 #include <map>
 
 namespace google {

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_metadata.h"
-#include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_rewriter.h"
-#include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/internal/throw_delegate.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_REWRITER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OBJECT_REWRITER_H
 
-#include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/invoke_result.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_stream.cc
+++ b/google/cloud/storage/object_stream.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_stream.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/log.h"
 #include <sstream>
 #include <thread>
 

--- a/google/cloud/storage/object_stream_test.cc
+++ b/google/cloud/storage/object_stream_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/object_stream.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/internal/make_unique.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -15,14 +15,14 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_PARALLEL_UPLOAD_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_PARALLEL_UPLOAD_H
 
-#include "google/cloud/future.h"
-#include "google/cloud/internal/filesystem.h"
-#include "google/cloud/internal/make_unique.h"
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/tuple_filter.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/future.h"
+#include "google/cloud/internal/filesystem.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/status_or.h"
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>

--- a/google/cloud/storage/policy_document_test.cc
+++ b/google/cloud/storage/policy_document_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/policy_document.h"
-#include "google/cloud/internal/format_time_point.h"
-#include "google/cloud/internal/parse_rfc3339.h"
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/internal/policy_document_request.h"
+#include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/internal/parse_rfc3339.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/retry_policy.h
+++ b/google/cloud/storage/retry_policy.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_RETRY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_RETRY_POLICY_H
 
+#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/backoff_policy.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/status.h"
-#include "google/cloud/storage/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/service_account.h
+++ b/google/cloud/storage/service_account.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_SERVICE_ACCOUNT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_SERVICE_ACCOUNT_H
 
-#include "google/cloud/status_or.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/storage_client_options_test.cc
+++ b/google/cloud/storage/storage_client_options_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/storage_version_test.cc
+++ b/google/cloud/storage/storage_version_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/build_info.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/build_info.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_STORAGE_INTEGRATION_TEST_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_STORAGE_INTEGRATION_TEST_H
 
-#include "google/cloud/internal/random.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/well_known_headers.h"
+#include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/list_objects_reader.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdlib>

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdlib>

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/optional.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/terminate_handler.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <fstream>

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/tests/object_file_multi_threaded_test.cc
+++ b/google/cloud/storage/tests/object_file_multi_threaded_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <cstdio>

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/client.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/scoped_environment.h"

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/parallel_upload.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/storage/testing/temp_file.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/client.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/scoped_environment.h"

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <thread>

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/object_streambuf.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
-#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/internal/signed_url_requests.h"
 #include "google/cloud/storage/list_objects_reader.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/terminate_handler.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/init_google_mock.h"

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/curl_request_builder.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/list_objects_reader.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <fstream>

--- a/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/client.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <thread>

--- a/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/client.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <thread>

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
-#include "google/cloud/storage/client.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <future>

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_HEADERS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_HEADERS_H
 
+#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/optional.h"
-#include "google/cloud/storage/version.h"
 #include <algorithm>
 #include <cstdint>
 #include <iostream>

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_PARAMETERS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_WELL_KNOWN_PARAMETERS_H
 
+#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/ios_flags_saver.h"
 #include "google/cloud/optional.h"
-#include "google/cloud/storage/version.h"
 #include <cstdint>
 #include <iomanip>
 #include <string>


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/3596

We want all of our repos to use the same `.clang-format` file. This
copies the one from -spanner. This change results in lots of changes to
GCS code because previously GCS was sorting the "common" includes before
the includes in "storage". Bigtable did the Right Thing in most cases
because "b" sorts near the beginning of the alphabet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3597)
<!-- Reviewable:end -->
