### PR TITLE
cleanup: enforce formatting in more Bazel files

### DIFF
--- a/bazel/crc32c.BUILD
+++ b/bazel/crc32c.BUILD
@@ -103,9 +103,9 @@ cc_library(
     name = "crc32c",
     srcs = crc32c_SRCS + crc32c_sse42_SRCS + crc32c_arm64_SRCS,
     hdrs = crc32c_HDRS + ["crc32c/crc32c_config.h"],
-    deps = [],
-    includes = ["include"],
     copts = sse42_copts,
+    includes = ["include"],
+    deps = [],
 )
 
 crc32c_test_sources = [

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 package(default_visibility = ["//visibility:public"])
+
 licenses(["notice"])  # Apache 2.0
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
@@ -23,8 +24,8 @@ cc_library(
         ".",
     ],
     deps = [
+        "//google/rpc:status_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
-        "//google/rpc:status_cc_proto"
     ],
 )
 
@@ -71,11 +72,11 @@ cc_library(
         ".",
     ],
     deps = [
-        "@com_github_grpc_grpc//:grpc++",
         ":bigtable_cc_grpc",
         ":bigtable_cc_proto",
         ":bigtableadmin_cc_grpc",
         ":bigtableadmin_cc_proto",
-        "//google/rpc:error_details_cc_proto"
+        "//google/rpc:error_details_cc_proto",
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -95,7 +95,8 @@ find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 |
 # Apply buildifier to fix the BUILD and .bzl formatting rules.
 #    https://github.com/bazelbuild/buildtools/tree/master/buildifier
 find . \( "${ignore[@]}" \) -prune -o \
-       \( -name BUILD -o -name '*.bzl' \) \
+       \( -name WORKSPACE -o -name BUILD \
+          -o -name '*.BUILD' -o -name '*.bzl' \) \
        -print0 |
   xargs -0 buildifier -mode=fix
 


### PR DESCRIPTION
We were missing WORKSPACE and *.BUILD files from the formatting step.

Fixes #3602

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3607)
<!-- Reviewable:end -->
