### PR TITLE
ci: actually update the vcpkg cache

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -120,7 +120,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
     ($env:KOKORO_JOB_TYPE -eq "GITHUB_PULL_REQUEST")
 $HasBuildCache = (Test-Path env:BUILD_CACHE)
-if (-not $IsPR -and $HasBuildCache) {
+if ((-not $IsPR) -and $HasBuildCache) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
       "zip vcpkg cache for upload."
     7z a vcpkg-installed.zip installed\ -bsp0

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -118,8 +118,9 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 # Do not update the vcpkg cache on PRs, it might dirty the cache for any
 # PRs running in parallel, and it is a waste of time in most cases.
 $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
-    ($env:KOKORO_JOB_TYPE = "GITHUB_PULL_REQUEST")
-if (-not $IsPR -and (Test-Path env:BUILD_CACHE)) {
+    ($env:KOKORO_JOB_TYPE -eq "GITHUB_PULL_REQUEST")
+$HasBuildCache = (Test-Path env:BUILD_CACHE)
+if (-not $IsPR -and $HasBuildCache) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
       "zip vcpkg cache for upload."
     7z a vcpkg-installed.zip installed\ -bsp0
@@ -137,4 +138,7 @@ if (-not $IsPR -and (Test-Path env:BUILD_CACHE)) {
                 "continue despite upload failure with code ${LastExitCode}".
         }
     }
+} else {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+      "vcpkg not updated IsPR == $IsPR, HasBuildCache == $HasBuildCache."
 }


### PR DESCRIPTION
I disabled the vcpkg cache upload for continuous builds too, that
was a mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3619)
<!-- Reviewable:end -->
