### PR TITLE
cleanup: removes dead code from build scripts

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -56,7 +56,6 @@ RUN if grep -q 18.04 /etc/lsb-release; then \
       apt-get update && apt-get --no-install-recommends install -y clang-tidy clang-format-7 clang-tools; \
       update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
       update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100; \
-      update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100; \
     fi
 
 # Install the the buildifier tool, which does not compile with the default

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -110,14 +110,6 @@ ${CMAKE_COMMAND} \
 echo
 echo "${COLOR_YELLOW}$(date -u): Finished CMake config${COLOR_RESET}"
 
-# CMake can generate dependency graphs, which are useful to understand and
-# troubleshoot dependencies.
-if [[ "${CREATE_GRAPHVIZ:-}" == "yes" ]]; then
-  ${CMAKE_COMMAND} \
-      --graphviz="${BINARY_DIR}/graphviz/google-cloud-cpp" \
-      --build "${BINARY_DIR}"
-fi
-
 echo "================================================================"
 echo "${COLOR_YELLOW}$(date -u): started build${COLOR_RESET}"
 ${CMAKE_COMMAND} --build "${BINARY_DIR}" -- -j "${NCPU}"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -204,13 +204,6 @@ elif [[ "${BUILD_NAME}" = "check-abi" ]] || [[ "${BUILD_NAME}" = "update-abi" ]]
   if [[ "${BUILD_NAME}" = "update-abi" ]]; then
     export UPDATE_ABI=yes
   fi
-elif [[ "${BUILD_NAME}" = "scan-build" ]]; then
-  # Compile using Clang's static analyzer. Use fedora because it has recent
-  # versions of the toolchain.
-  export BUILD_TYPE=Debug
-  export CC=clang
-  export CXX=clang++
-  export SCAN_BUILD=yes
 elif [[ "${BUILD_NAME}" = "cxx17" ]]; then
   export GOOGLE_CLOUD_CPP_CXX_STANDARD=17
   export TEST_INSTALL=yes
@@ -413,10 +406,6 @@ docker_flags=(
 
     # If set, enable the Ninja generator with CMake.
     "--env" "USE_NINJA=${USE_NINJA:-}"
-
-    # If set, use Clang's static analyzer. Currently there is no build that
-    # uses this feature, it may have rotten.
-    "--env" "SCAN_BUILD=${SCAN_BUILD:-}"
 
     # If set, run the check-abi.sh script.
     "--env" "CHECK_ABI=${CHECK_ABI:-}"

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -29,7 +29,6 @@ code style rules:
 sudo apt install -y clang-6.0 clang-tidy clang-format-7 clang-tools
 sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100
 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100
-sudo update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-6.0 100
 ```
 
 Install buildifier tool, which we use to format `BUILD` files:


### PR DESCRIPTION
- Deletes the `scan-build` stuff.
- Deletes the `CREATE_GRAPHVIZ` stuff, which I don't think was accessible/used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3628)
<!-- Reviewable:end -->
