### PR TITLE
refactor: PredefinedAcl knows proper header names

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -225,6 +225,7 @@ add_library(
     version_info.h
     well_known_headers.cc
     well_known_headers.h
+    well_known_parameters.cc
     well_known_parameters.h)
 target_link_libraries(
     storage_client
@@ -394,7 +395,8 @@ if (BUILD_TESTING)
         storage_client_options_test.cc
         storage_iam_policy_test.cc
         storage_version_test.cc
-        well_known_headers_test.cc)
+        well_known_headers_test.cc
+        well_known_parameters_test.cc)
 
     foreach (fname ${storage_client_unit_tests})
         string(REPLACE "/" "_" target ${fname})

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -53,22 +53,6 @@ std::shared_ptr<CurlHandleFactory> CreateHandleFactory(
       options.connection_pool_size(), options.channel_options());
 }
 
-std::string XmlMapPredefinedAcl(std::string const& acl) {
-  static std::map<std::string, std::string> mapping{
-      {"authenticatedRead", "authenticated-read"},
-      {"bucketOwnerFullControl", "bucket-owner-full-control"},
-      {"bucketOwnerRead", "bucket-owner-read"},
-      {"private", "private"},
-      {"projectPrivate", "project-private"},
-      {"publicRead", "public-read"},
-  };
-  auto loc = mapping.find(acl);
-  if (loc == mapping.end()) {
-    return acl;
-  }
-  return loc->second;
-}
-
 std::string UrlEscapeString(std::string const& value) {
   CurlHandle handle;
   return std::string(handle.MakeEscapedString(value).get());
@@ -1300,9 +1284,8 @@ StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaXml(
                       ComputeCrc32cChecksum(request.contents()));
   }
   if (request.HasOption<PredefinedAcl>()) {
-    builder.AddHeader(
-        "x-goog-acl: " +
-        XmlMapPredefinedAcl(request.GetOption<PredefinedAcl>().value()));
+    builder.AddHeader("x-goog-acl: " +
+                      request.GetOption<PredefinedAcl>().HeaderName());
   }
   builder.AddOption(request.GetOption<UserProject>());
 

--- a/google/cloud/storage/storage_client.bzl
+++ b/google/cloud/storage/storage_client.bzl
@@ -176,4 +176,5 @@ storage_client_srcs = [
     "service_account.cc",
     "version.cc",
     "well_known_headers.cc",
+    "well_known_parameters.cc",
 ]

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -100,4 +100,5 @@ storage_client_unit_tests = [
     "storage_iam_policy_test.cc",
     "storage_version_test.cc",
     "well_known_headers_test.cc",
+    "well_known_parameters_test.cc",
 ]

--- a/google/cloud/storage/well_known_parameters.cc
+++ b/google/cloud/storage/well_known_parameters.cc
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/well_known_parameters.h"
+#include <map>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+std::string PredefinedAcl::HeaderName() const {
+  static std::map<std::string, std::string> mapping{
+      {"authenticatedRead", "authenticated-read"},
+      {"bucketOwnerFullControl", "bucket-owner-full-control"},
+      {"bucketOwnerRead", "bucket-owner-read"},
+      {"private", "private"},
+      {"projectPrivate", "project-private"},
+      {"publicRead", "public-read"},
+  };
+  auto loc = mapping.find(value());
+  if (loc == mapping.end()) {
+    return value();
+  }
+  return loc->second;
+}
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -333,6 +333,8 @@ struct PredefinedAcl
   static PredefinedAcl PublicReadWrite() {
     return PredefinedAcl("publicReadWrite");
   }
+
+  std::string HeaderName() const;
 };
 
 /**

--- a/google/cloud/storage/well_known_parameters_test.cc
+++ b/google/cloud/storage/well_known_parameters_test.cc
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/well_known_parameters.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+TEST(PredefinedAclHeaderNameTest, Simple) {
+  EXPECT_EQ("authenticated-read",
+            PredefinedAcl::AuthenticatedRead().HeaderName());
+  EXPECT_EQ("bucket-owner-full-control",
+            PredefinedAcl::BucketOwnerFullControl().HeaderName());
+  EXPECT_EQ("bucket-owner-read", PredefinedAcl::BucketOwnerRead().HeaderName());
+  EXPECT_EQ("private", PredefinedAcl::Private().HeaderName());
+  EXPECT_EQ("project-private", PredefinedAcl::ProjectPrivate().HeaderName());
+  EXPECT_EQ("public-read", PredefinedAcl::PublicRead().HeaderName());
+  EXPECT_EQ("SomeCustom", PredefinedAcl("SomeCustom").HeaderName());
+}
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is needed for #3635.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3639)
<!-- Reviewable:end -->
