### PR TITLE
ci: avoid slow brew updates in PRs

### DIFF
--- a/ci/kokoro/macos/bazel.cfg
+++ b/ci/kokoro/macos/bazel.cfg
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout_mins: 180

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -31,7 +31,12 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 
 echo "================================================================"
 echo "${COLOR_YELLOW}$(date -u): Update or install dependencies.${COLOR_RESET}"
-brew install libressl
+
+brew_env=()
+if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
+  brew_env+=("HOMEBREW_NO_AUTO_UPDATE=1")
+fi
+env "${brew_env[@]}" brew install libressl
 
 echo "================================================================"
 echo "${COLOR_YELLOW}$(date -u): ccache stats${COLOR_RESET}"

--- a/ci/kokoro/macos/cmake-super.cfg
+++ b/ci/kokoro/macos/cmake-super.cfg
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout_mins: 180

--- a/ci/kokoro/macos/common.cfg
+++ b/ci/kokoro/macos/common.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
-timeout_mins: 240
+timeout_mins: 60
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"

--- a/ci/kokoro/macos/common.cfg
+++ b/ci/kokoro/macos/common.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
-timeout_mins: 120
+timeout_mins: 240
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"


### PR DESCRIPTION
We use homebrew to install some of our dependencies (LibreSSL).
Homebrew automatically updates its list of packages when you install
something, which can be really slow. We disable this on pull requests
to keep those snappy. Also increase the timeout for continuous builds
because the continuous builds that are forced to do a homebrew
update can take more than two hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3644)
<!-- Reviewable:end -->
