### PR TITLE
ci: fix macos for older bash versions

### DIFF
--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -36,7 +36,7 @@ brew_env=()
 if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   brew_env+=("HOMEBREW_NO_AUTO_UPDATE=1")
 fi
-env "${brew_env[@]}" brew install libressl
+env ${brew_env[@]+"${brew_env[@]}"} brew install libressl
 
 echo "================================================================"
 echo "${COLOR_YELLOW}$(date -u): ccache stats${COLOR_RESET}"


### PR DESCRIPTION
Seems like the Kokoro machines have an older version of bash than my Laptop.

This should work with older versions too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3647)
<!-- Reviewable:end -->
