### PR TITLE
ci: coverage build runs some tests against production

### DIFF
--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Common configuration parameters.
+#
+export GOOGLE_CLOUD_PROJECT="cloud-cpp-testing-resources"
+
+# Cloud Bigtable configuration parameters
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="test-instance"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="us-west2-b"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="us-west2-c"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="bigtable-test-iam-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+
+# Cloud Storage configuration parameters
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="cloud-cpp-testing-bucket"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME="cloud-cpp-testing-regional"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID="us-central1"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_LOCATION="${GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID}"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT="storage-test-iam-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT="hmac-keys-test-service-account@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT="kokoro-agent@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY="projects/${GOOGLE_CLOUD_PROJECT}/locations/us/keyRings/gcs-testing-us-kr/cryptoKeys/integration-tests-key"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME="projects/${GOOGLE_CLOUD_PROJECT}/topics/gcs-changes"
+
+# Cloud Spanner configuration parameters
+export GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID="test-instance"
+export GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT="spanner-iam-test-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+
+# Cloud Pub/Sub only needs GOOGLE_CLOUD_PROJECT
+
+
+#
+# TODO(#3523 #3524) - remove these legacy variables
+#
+
+export PROJECT_ID=${GOOGLE_CLOUD_PROJECT}
+
+export INSTANCE_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID}
+export ZONE_A=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A}
+export ZONE_B=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B}
+
+export BUCKET_NAME="${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}"
+export DESTINATION_BUCKET_NAME="${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}"
+export STORAGE_REGION_ID="${GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID}"
+export LOCATION=${STORAGE_REGION_ID}
+export SERVICE_ACCOUNT="${GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT}"
+export HMAC_SERVICE_ACCOUNT="${GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT}"
+export SIGNING_SERVICE_ACCOUNT="${GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT}"
+export STORAGE_CMEK_KEY="${GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY}"
+export TOPIC_NAME="${GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME}"
+
+export GOOGLE_CLOUD_CPP_SPANNER_INSTANCE="${GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}"
+export GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA="${GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT}"

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -76,7 +76,7 @@ echo "================================================================"
     "${bazel_args[@]}" \
     -- //google/cloud/...:all
 
-readonly INTEGRATION_TESTS_CONFIG="/c/test-configuration.sh"
+readonly INTEGRATION_TESTS_CONFIG="${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
 readonly TEST_KEY_FILE_JSON="/c/service-account.json"
 readonly TEST_KEY_FILE_P12="/c/service-account.p12"
 readonly GOOGLE_APPLICATION_CREDENTIALS="/c/service-account.json"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -186,16 +186,17 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
   readonly GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON="/c/service-account.json"
   readonly GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12="/c/service-account.p12"
   readonly GOOGLE_APPLICATION_CREDENTIALS="/c/service-account.json"
+
   if [[ # yes: always try to run the integration tests
-        "${RUN_INTEGRATION_TESTS}" == "yes" || \
-        # auto: only try to run integration tests if the config files are present
-        ( "${RUN_INTEGRATION_TESTS}" == "auto" && \
-          -r "${INTEGRATION_TESTS_CONFIG}" && \
-          -r "${GOOGLE_APPLICATION_CREDENTIALS}" && \
-          -r "${GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON}" && \
-          -r "${GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12}" ) ]] && \
-      # super builds cannot run the integration tests
-      [[ "${SOURCE_DIR}" != "super" ]]; then
+        ( ("${RUN_INTEGRATION_TESTS}" == "yes" ) ||
+          # auto: only try to run integration tests if the config files are present
+          ( "${RUN_INTEGRATION_TESTS}" == "auto" &&
+            -r "${INTEGRATION_TESTS_CONFIG}" &&
+            -r "${GOOGLE_APPLICATION_CREDENTIALS}" &&
+            -r "${GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON}" &&
+            -r "${GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12}" ) ) &&
+        # super builds cannot run the integration tests
+        ( "${SOURCE_DIR}" != "super" ) ]]; then
     echo "================================================================"
     echo "${COLOR_YELLOW}$(date -u): Running the integration tests against" \
         "production${COLOR_RESET}"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -182,6 +182,43 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
         "${BINARY_DIR}" "${ctest_args[@]}"
   fi
 
+  readonly INTEGRATION_TESTS_CONFIG="${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
+  readonly GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON="/c/service-account.json"
+  readonly GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12="/c/service-account.p12"
+  readonly GOOGLE_APPLICATION_CREDENTIALS="/c/service-account.json"
+  if [[ # yes: always try to run the integration tests
+        "${RUN_INTEGRATION_TESTS}" == "yes" || \
+        # auto: only try to run integration tests if the config files are present
+        ( "${RUN_INTEGRATION_TESTS}" == "auto" && \
+          -r "${INTEGRATION_TESTS_CONFIG}" && \
+          -r "${GOOGLE_APPLICATION_CREDENTIALS}" && \
+          -r "${GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON}" && \
+          -r "${GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12}" ) ]] && \
+      # super builds cannot run the integration tests
+      [[ "${SOURCE_DIR}" != "super" ]]; then
+    echo "================================================================"
+    echo "${COLOR_YELLOW}$(date -u): Running the integration tests against" \
+        "production${COLOR_RESET}"
+
+    # shellcheck disable=SC1091
+    source "${INTEGRATION_TESTS_CONFIG}"
+    export GOOGLE_APPLICATION_CREDENTIALS
+    export GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON
+    export GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12
+    export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
+
+    # Since we already run multiple integration tests against the emulator we
+    # only need to run the tests here that cannot use the emulator. Some libraries
+    # will tag all their tests as "integration-tests-no-emulator", that is fine
+    # too. As long as we do not repeat all the tests we are winning.
+    env -C "${BINARY_DIR}" ctest \
+        -L integration-tests-no-emulator "${ctest_args[@]}"
+
+    echo "================================================================"
+    echo "${COLOR_YELLOW}$(date -u): Completed the integration tests against" \
+        "production${COLOR_RESET}"
+  fi
+
   if [[ "${RUN_INTEGRATION_TESTS:-}" != "no" ]]; then
     echo
     echo "${COLOR_YELLOW}$(date -u): Running integration tests${COLOR_RESET}"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -22,6 +22,11 @@ export DISTRO=ubuntu-install
 export DISTRO_VERSION=18.04
 export CMAKE_SOURCE_DIR="."
 
+# By default we run the integration tests *if* all the configuration files
+# are present. This makes it convenient to run locally, where sometimes we
+# do not have the configuration files and we would rather skip some tests.
+RUN_INTEGRATION_TESTS="auto"
+
 in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 
 if [[ $# -ge 1 ]]; then

--- a/ci/kokoro/docker/coverage-presubmit.cfg
+++ b/ci/kokoro/docker/coverage-presubmit.cfg
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp/codecov-io-upload-token"

--- a/ci/kokoro/docker/coverage.cfg
+++ b/ci/kokoro/docker/coverage.cfg
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp/codecov-io-upload-token"

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -75,7 +75,7 @@ if (BUILD_TESTING)
     endforeach ()
 endif ()
 
-# TODO(#3524) - merge these loops when `storage_examples` is empty.
+# TODO(#3524) - merge these two loops when `storage_examples` is empty.
 foreach (fname ${storage_examples} ${storage_autorun_examples})
     string(REPLACE "/" "_" target ${fname})
     string(REPLACE ".cc" "" target ${target})
@@ -93,4 +93,11 @@ foreach (fname ${storage_autorun_examples})
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;storage-integration-tests")
+endforeach ()
+
+# We just know that these tests need to be run against production.
+foreach (target storage_signed_url_v4_samples storage_signed_url_v2_samples)
+    set_tests_properties(
+        ${target} PROPERTIES LABELS
+                             "integration-tests;integration-tests-no-emulator")
 endforeach ()

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -65,11 +65,8 @@ foreach (fname ${storage_client_integration_tests})
 endforeach ()
 
 # We just know that these tests need to be run against production.
-foreach (
-    target
-    # cmake-format: sort
-    error_injection_integration_test key_file_integration_test
-    signed_url_integration_test)
+foreach (target # cmake-format: sort
+                key_file_integration_test signed_url_integration_test)
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;integration-tests-no-emulator")

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -64,6 +64,17 @@ foreach (fname ${storage_client_integration_tests})
                              "integration-tests;storage-integration-tests")
 endforeach ()
 
+# We just know that these tests need to be run against production.
+foreach (
+    target
+    # cmake-format: sort
+    error_injection_integration_test key_file_integration_test
+    signed_url_integration_test)
+    set_tests_properties(
+        ${target} PROPERTIES LABELS
+                             "integration-tests;integration-tests-no-emulator")
+endforeach ()
+
 target_link_libraries(error_injection_integration_test PRIVATE ${CMAKE_DL_LIBS})
 
 include(CreateBazelConfig)

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -301,11 +301,9 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cStreamingWriteJSON) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadXML) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -347,11 +345,9 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadXML) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -393,11 +389,9 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
 /// @test Verify that CRC32C checksum mismatches are reported when using
 /// .read().
 TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -431,11 +425,9 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
 /// @test Verify that CRC32C checksum mismatches are reported when using
 /// .read().
 TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -470,11 +462,9 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
 /// @test Verify that CRC32C checksum mismatches are reported by default on
 /// downloads.
 TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingWriteJSON) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -212,10 +212,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFile) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
-  if (UsingTestbench()) {
-    // The testbench does not support binary payloads.
-    return;
-  }
+  // The testbench does not support binary payloads.
+  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -413,11 +413,9 @@ TEST_F(ObjectHashIntegrationTest, DisableHashesStreamingWriteJSON) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -457,11 +455,9 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -502,11 +498,9 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
 
 /// @test Verify that MD5 hash mismatches are reported when using .read().
 TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -539,11 +533,9 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
 
 /// @test Verify that MD5 hash mismatches are reported when using .read().
 TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -577,11 +569,9 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
 
 /// @test Verify that MD5 hash mismatches are reported by default on downloads.
 TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingWriteJSON) {
-  if (!UsingTestbench()) {
-    // This test is disabled when not using the testbench as it relies on the
-    // testbench to inject faults.
-    return;
-  }
+  // This test is disabled when not using the testbench as it relies on the
+  // testbench to inject faults.
+  if (!UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -321,7 +321,7 @@ TEST_F(ObjectIntegrationTest, ListObjectsVersions) {
 }
 
 TEST_F(ObjectIntegrationTest, ListObjectsDelimiter) {
-  if (UsingTestbench()) return;
+  if (UsingTestbench()) GTEST_SKIP();
 
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -641,9 +641,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureUploadFile) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
-  if (!UsingTestbench()) {
-    return;
-  }
+  if (!UsingTestbench()) GTEST_SKIP();
 
   auto options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(options);
@@ -676,9 +674,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
-  if (!UsingTestbench()) {
-    return;
-  }
+  if (!UsingTestbench()) GTEST_SKIP();
 
   auto options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(options);
@@ -717,9 +713,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, StreamingReadInternalError) {
-  if (!UsingTestbench()) {
-    return;
-  }
+  if (!UsingTestbench()) GTEST_SKIP();
 
   auto options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(options);

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -328,7 +328,7 @@ TEST_F(ObjectResumableWriteIntegrationTest, WithXUploadContentLengthRandom) {
 }
 
 TEST_F(ObjectResumableWriteIntegrationTest, WithInvalidXUploadContentLength) {
-  if (UsingTestbench()) return;
+  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -49,10 +49,8 @@ class SignedUrlIntegrationTest
 };
 
 TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
-  if (UsingTestbench()) {
-    // The testbench does not implement signed URLs.
-    return;
-  }
+  // The testbench does not implement signed URLs.
+  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -84,10 +82,8 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlGet) {
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
-  if (UsingTestbench()) {
-    // The testbench does not implement signed URLs.
-    return;
-  }
+  // The testbench does not implement signed URLs.
+  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -119,10 +115,8 @@ TEST_F(SignedUrlIntegrationTest, CreateV2SignedUrlPut) {
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
-  if (UsingTestbench()) {
-    // The testbench does not implement signed URLs.
-    return;
-  }
+  // The testbench does not implement signed URLs.
+  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -154,10 +148,8 @@ TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlGet) {
 }
 
 TEST_F(SignedUrlIntegrationTest, CreateV4SignedUrlPut) {
-  if (UsingTestbench()) {
-    // The testbench does not implement signed URLs.
-    return;
-  }
+  // The testbench does not implement signed URLs.
+  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
The main goal in this change is to run some tests that can *only*
run in production during the code coverage builds. This is important
because we have no visibility into their coverage, and it will be
even more important when we import `-spanner` which only
runs integration tests against production.

Move the configuration parameters for integration tests to git.
Easier to track and change them if they are part of the code, and
there are no secrets in this configuration.

More importantly, soon we will want to run all kinds of tests against
production in this build, e.g., the Cloud Spanner and Cloud Pub/Sub
tests.

To make it easier to identify which tests are skipping production 
and/or the emulator I used the GTEST_SKIP() annotations more
consistently.

Fixes #3547 and fixes #3542.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3648)
<!-- Reviewable:end -->
