### PR TITLE
fix(cmake): typo in find protobuf-config.cmake

### DIFF
--- a/cmake/FindProtobufWithTargets.cmake
+++ b/cmake/FindProtobufWithTargets.cmake
@@ -83,7 +83,7 @@ find_package(Threads REQUIRED)
 # where protobuf was compiled and installed with `CMake`. Note that on Linux
 # this *must* be all lowercase ``protobuf``, while on Windows it does not
 # matter.
-find_package(protobuf CONFIG QUIET)
+find_package(Protobuf CONFIG QUIET)
 
 if (protobuf_DEBUG)
     message(STATUS "[ ${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE} ] "


### PR DESCRIPTION
Hi,

I have cmake 3.17.0 and protobuf manually installed from gRPC 1.27.3

protobuf-config.cmake is located here : /usr/local/lib/cmake/protobuf

But it can't be found by CMake without this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3685)
<!-- Reviewable:end -->
