### PR TITLE
feat: add explicit ctor to PolicyDocumentV4

### DIFF
--- a/google/cloud/storage/policy_document.h
+++ b/google/cloud/storage/policy_document.h
@@ -143,6 +143,17 @@ std::ostream& operator<<(std::ostream& os, PolicyDocument const& rhs);
  * for general information on policy documents in Google Cloud Storage.
  */
 struct PolicyDocumentV4 {
+  PolicyDocumentV4() = default;
+  PolicyDocumentV4(std::string bucket, std::string object,
+                   std::chrono::seconds expiration,
+                   std::chrono::system_clock::time_point timestamp,
+                   std::vector<PolicyDocumentCondition> conditions = {})
+      : bucket(std::move(bucket)),
+        object(std::move(object)),
+        expiration(std::move(expiration)),
+        timestamp(std::move(timestamp)),
+        conditions(std::move(conditions)) {}
+
   std::string bucket;
   std::string object;
   std::chrono::seconds expiration;

--- a/google/cloud/storage/policy_document_test.cc
+++ b/google/cloud/storage/policy_document_test.cc
@@ -197,6 +197,17 @@ TEST(PolicyDocumentTests, PolicyDocumentV4ResultStreaming) {
                 ", policy=test-policy, signature=test-sig, "
                 "signing_algorithm=test-alg}");
 }
+
+/// @test Verify that PolicyDocumentV4 ctor works.
+TEST(PolicyDocumentTests, PolicyDocumentV4Ctor) {
+  auto const now = std::chrono::system_clock::now();
+  PolicyDocumentV4 doc("bucket", "object", std::chrono::seconds(42), now);
+  EXPECT_EQ("bucket", doc.bucket);
+  EXPECT_EQ("object", doc.object);
+  EXPECT_EQ(42, doc.expiration.count());
+  EXPECT_EQ(now, doc.timestamp);
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This is to allow users to create `PolicyDocumentV4` without specifying
an empty initializer list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3688)
<!-- Reviewable:end -->
