### PR TITLE
feat: use -prune flag to find

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -572,7 +572,7 @@ if [[ "${RUNNING_CI:-}" == "yes" ]] && [[ -n "${KOKORO_ARTIFACTS_DIR:-}" ]]; the
   # the build completes. Removing the cmake-out/ dir shaves minutes off this
   # process. This is safe as long as we don't wish to save any build artifacts.
   echo "${COLOR_YELLOW}$(date -u): cleaning up artifacts.${COLOR_RESET}"
-  find "${KOKORO_ARTIFACTS_DIR}" -name cmake-out -type d -print0 \
+  find "${KOKORO_ARTIFACTS_DIR}" -name cmake-out -type d -prune -print0 \
     | xargs -0 -t rm -rf
 else
   echo "${COLOR_YELLOW}$(date -u): Not a CI build; " \


### PR DESCRIPTION
When cleaning up the artifacts dir, we want to remove the top-level
`cmake-out` directory, but once we find it, we can stop descending into
it since we're going to delete the whole thing. This change is in
response to a comment that @devbww made to the original PR
https://github.com/googleapis/google-cloud-cpp/pull/3637

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3694)
<!-- Reviewable:end -->
