### PR TITLE
refactor: same config for emulator vs. production tests

### DIFF
--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -38,6 +38,7 @@ source "${PROJECT_ROOT}/google/cloud/bigtable/tools/run_emulator_utils.sh"
 # production. Easier to maintain just one copy.
 source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
+export ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS="yes"
 
 cd "${BINARY_DIR}"
 start_emulators

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -34,18 +34,13 @@ PROJECT_ROOT="$(cd "${CMDDIR}/../../../.."; pwd)"
 readonly PROJECT_ROOT
 source "${PROJECT_ROOT}/google/cloud/bigtable/tools/run_emulator_utils.sh"
 
+# Use the same configuration parameters as we use for testing against
+# production. Easier to maintain just one copy.
+source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
+export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
+
 cd "${BINARY_DIR}"
 start_emulators
-
-NONCE="$(date +%s)-${RANDOM}"
-readonly NONCE
-export GOOGLE_CLOUD_PROJECT="emulated-${NONCE}"
-export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="it-${NONCE}"
-export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="fake-region1-a"
-export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="fake-region1-b"
-export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="fake-sa@emulated-${NONCE}.iam.gserviceaccount.com"
-export ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS="yes"
-export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 
 ctest -L "bigtable-integration-tests" "${ctest_args[@]}"
 exit_status=$?

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -32,19 +32,13 @@ PROJECT_ROOT="$(cd "${CMDDIR}/../../../.."; pwd)"
 readonly PROJECT_ROOT
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 
-NONCE="$(date +%s)-${RANDOM}"
-readonly NONCE
-# Create most likely unique names for the project and bucket so multiple tests
-# can use the same testbench.
-export GOOGLE_CLOUD_PROJECT="fake-project-${NONCE}"
-export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="fake-bucket-${NONCE}"
-export GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID="fake-region-${NONCE}"
-export GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME="projects/${GOOGLE_CLOUD_PROJECT}/topics/fake-topic-${NONCE}"
-export GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT="fake-service-account@example.com"
+# Use the same configuration parameters as we use for testing against
+# production. Easier to maintain just one copy.
+source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
+export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT="fake-service-account@example.com"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE="${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME="${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
-export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 
 cd "${BINARY_DIR}"
 start_testbench


### PR DESCRIPTION
Use the same configuration file for the integration tests against the
emulator vs. production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3697)
<!-- Reviewable:end -->
