### PR TITLE
cleanup: use std::vector::at in examples

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
+++ b/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
@@ -47,7 +47,7 @@ void AccessToken(std::vector<std::string> argv) {
     if (!tables) throw std::runtime_error(tables.status().message());
   }
   //! [test access token]
-  (argv[0], argv[1], argv[2]);
+  (argv.at(0), argv.at(1), argv.at(2));
 }
 
 void JWTAccessToken(std::vector<std::string> argv) {
@@ -86,7 +86,7 @@ void JWTAccessToken(std::vector<std::string> argv) {
     if (!tables) throw std::runtime_error(tables.status().message());
   }
   //! [test jwt access token]
-  (argv[0], argv[1], argv[2]);
+  (argv.at(0), argv.at(1), argv.at(2));
 }
 
 void GCECredentials(std::vector<std::string> argv) {
@@ -112,7 +112,7 @@ void GCECredentials(std::vector<std::string> argv) {
     if (!tables) throw std::runtime_error(tables.status().message());
   }
   //! [test gce credentials]
-  (argv[0], argv[1]);
+  (argv.at(0), argv.at(1));
 }
 
 void RunAll(std::vector<std::string> argv) {

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -67,7 +67,7 @@ void ApplyRelaxedIdempotency(google::cloud::bigtable::Table table,
     if (!status.ok()) throw std::runtime_error(status.message());
   }
   //! [apply relaxed idempotency]
-  (table.project_id(), table.instance_id(), table.table_id(), argv[0]);
+  (table.project_id(), table.instance_id(), table.table_id(), argv.at(0));
 }
 
 void ApplyCustomRetry(google::cloud::bigtable::Table table,
@@ -86,7 +86,7 @@ void ApplyCustomRetry(google::cloud::bigtable::Table table,
     if (!status.ok()) throw std::runtime_error(status.message());
   }
   //! [apply custom retry]
-  (table.project_id(), table.instance_id(), table.table_id(), argv[0]);
+  (table.project_id(), table.instance_id(), table.table_id(), argv.at(0));
 }
 
 void BulkApply(google::cloud::bigtable::Table table,
@@ -162,7 +162,7 @@ void ReadRow(google::cloud::bigtable::Table table,
     }
   }
   //! [read row] [END bigtable_read_error]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void ReadRows(google::cloud::bigtable::Table table,
@@ -286,7 +286,7 @@ void ReadRowSetPrefix(google::cloud::bigtable::Table table,
     }
   }
   //! [read rowset prefix] [END bigtable_read_prefix]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void ReadPrefixList(google::cloud::bigtable::Table table,
@@ -332,12 +332,12 @@ void ReadMultipleRanges(std::vector<std::string> argv) {
 
   std::vector<std::pair<std::string, std::string>> ranges;
   while (!argv.empty()) {
-    auto begin = argv[0];
+    auto begin = argv.at(0);
     argv.erase(argv.begin());
     if (argv.empty()) {
       throw Usage{"read-multiple-ranges - error: mismatched [begin,end) pair"};
     }
-    auto end = argv[0];
+    auto end = argv.at(0);
     argv.erase(argv.begin());
     ranges.emplace_back(std::make_pair(begin, end));
   }
@@ -396,7 +396,7 @@ void CheckAndMutate(google::cloud::bigtable::Table table,
     }
   }
   //! [check and mutate]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void CheckAndMutateNotPresent(google::cloud::bigtable::Table table,
@@ -424,7 +424,7 @@ void CheckAndMutateNotPresent(google::cloud::bigtable::Table table,
     }
   }
   //! [check and mutate not present]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void ReadModifyWrite(google::cloud::bigtable::Table table,
@@ -441,7 +441,7 @@ void ReadModifyWrite(google::cloud::bigtable::Table table,
     std::cout << row->row_key() << "\n";
   }
   //! [read modify write]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void SampleRows(google::cloud::bigtable::Table table,
@@ -472,7 +472,7 @@ void DeleteAllCells(google::cloud::bigtable::Table table,
     if (!status.ok()) throw std::runtime_error(status.message());
   }
   //! [delete all cells]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void DeleteFamilyCells(google::cloud::bigtable::Table table,
@@ -487,7 +487,7 @@ void DeleteFamilyCells(google::cloud::bigtable::Table table,
     if (!status.ok()) throw std::runtime_error(status.message());
   }
   //! [delete family cells]
-  (std::move(table), argv[0], argv[1]);
+  (std::move(table), argv.at(0), argv.at(1));
 }
 
 void DeleteSelectiveFamilyCells(google::cloud::bigtable::Table table,
@@ -503,7 +503,7 @@ void DeleteSelectiveFamilyCells(google::cloud::bigtable::Table table,
     if (!status.ok()) throw std::runtime_error(status.message());
   }
   //! [delete selective family cells]
-  (std::move(table), argv[0], argv[1], argv[2]);
+  (std::move(table), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void RowExists(google::cloud::bigtable::Table table,
@@ -527,7 +527,7 @@ void RowExists(google::cloud::bigtable::Table table,
     std::cout << "Row exists.\n";
   }
   //! [row exists]
-  (std::move(table), argv[0]);
+  (std::move(table), argv.at(0));
 }
 
 void MutateDeleteColumns(std::vector<std::string> argv) {
@@ -545,7 +545,7 @@ void MutateDeleteColumns(std::vector<std::string> argv) {
       argv[2]);
   argv.erase(argv.begin(), argv.begin() + 3);
 
-  auto key = argv[0];
+  auto key = argv.at(0);
   argv.erase(argv.begin());
   std::vector<std::pair<std::string, std::string>> columns;
   for (auto arg : argv) {
@@ -641,7 +641,7 @@ void MutateInsertUpdateRows(google::cloud::bigtable::Table table,
     return InsertOrUpdate{family, column, value};
   };
 
-  auto key = argv[0];
+  auto key = argv.at(0);
   argv.erase(argv.begin());
   std::vector<InsertOrUpdate> mutations;
   for (auto& a : argv) {
@@ -711,7 +711,7 @@ void RenameColumn(google::cloud::bigtable::Table table,
     std::cout << "Row successfully updated\n";
   }
   // [END bigtable_mutate_mix_match]
-  (std::move(table), argv[0], argv[1], argv[2], argv[3]);
+  (std::move(table), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
 // This command just generates data suitable for other examples to run. This

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -42,7 +42,7 @@ void ListBucketAcl(google::cloud::storage::Client client,
     }
   }
   //! [list bucket acl] [END storage_print_bucket_acl]
-  (std::move(client), argv[0]);
+  (std::move(client), argv.at(0));
 }
 
 void CreateBucketAcl(google::cloud::storage::Client client,
@@ -62,7 +62,7 @@ void CreateBucketAcl(google::cloud::storage::Client client,
               << "Full attributes: " << *bucket_acl << "\n";
   }
   //! [create bucket acl]
-  (std::move(client), argv[0], argv[1], argv[2]);
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void DeleteBucketAcl(google::cloud::storage::Client client,
@@ -77,7 +77,7 @@ void DeleteBucketAcl(google::cloud::storage::Client client,
               << bucket_name << "\n";
   }
   //! [delete bucket acl]
-  (std::move(client), argv[0], argv[1]);
+  (std::move(client), argv.at(0), argv.at(1));
 }
 
 void GetBucketAcl(google::cloud::storage::Client client,
@@ -94,7 +94,7 @@ void GetBucketAcl(google::cloud::storage::Client client,
               << acl->bucket() << " is " << *acl << "\n";
   }
   //! [get bucket acl] [END storage_print_bucket_acl_for_user]
-  (std::move(client), argv[0], argv[1]);
+  (std::move(client), argv.at(0), argv.at(1));
 }
 
 void UpdateBucketAcl(google::cloud::storage::Client client,
@@ -116,7 +116,7 @@ void UpdateBucketAcl(google::cloud::storage::Client client,
               << " is " << *updated_acl << "\n";
   }
   //! [update bucket acl]
-  (std::move(client), argv[0], argv[1], argv[2]);
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void PatchBucketAcl(google::cloud::storage::Client client,
@@ -144,7 +144,7 @@ void PatchBucketAcl(google::cloud::storage::Client client,
               << patched_acl->bucket() << " is now " << *patched_acl << "\n";
   }
   //! [patch bucket acl]
-  (std::move(client), argv[0], argv[1], argv[2]);
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void PatchBucketAclNoRead(google::cloud::storage::Client client,
@@ -163,7 +163,7 @@ void PatchBucketAclNoRead(google::cloud::storage::Client client,
               << patched_acl->bucket() << " is now " << *patched_acl << "\n";
   }
   //! [patch bucket acl no-read]
-  (std::move(client), argv[0], argv[1], argv[2]);
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void AddBucketOwner(google::cloud::storage::Client client,
@@ -182,7 +182,7 @@ void AddBucketOwner(google::cloud::storage::Client client,
               << patched_acl->bucket() << " is now " << *patched_acl << "\n";
   }
   //! [add bucket owner] [END storage_add_bucket_owner]
-  (std::move(client), argv[0], argv[1]);
+  (std::move(client), argv.at(0), argv.at(1));
 }
 
 void RemoveBucketOwner(google::cloud::storage::Client client,
@@ -222,7 +222,7 @@ void RemoveBucketOwner(google::cloud::storage::Client client,
               << bucket_name << "\n";
   }
   //! [remove bucket owner] [END storage_remove_bucket_owner]
-  (std::move(client), argv[0], argv[1]);
+  (std::move(client), argv.at(0), argv.at(1));
 }
 
 void RunAll(std::vector<std::string> const& argv) {

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -53,7 +53,7 @@ void GetStaticWebsiteConfiguration(google::cloud::storage::Client client,
   }
   // [END storage_print_bucket_website_configuration]
   //! [print bucket website configuration]
-  (std::move(client), argv[0]);
+  (std::move(client), argv.at(0));
 }
 
 void SetStaticWebsiteConfiguration(google::cloud::storage::Client client,
@@ -92,7 +92,7 @@ void SetStaticWebsiteConfiguration(google::cloud::storage::Client client,
   }
   // [END storage_define_bucket_website_configuration]
   //! [define bucket website configuration]
-  (std::move(client), argv[0], argv[1], argv[2]);
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void RemoveStaticWebsiteConfiguration(google::cloud::storage::Client client,
@@ -125,7 +125,7 @@ void RemoveStaticWebsiteConfiguration(google::cloud::storage::Client client,
               << " application has modified the bucket concurrently.\n";
   }
   //! [remove bucket website configuration]
-  (std::move(client), argv[0]);
+  (std::move(client), argv.at(0));
 }
 
 void RunAll(std::vector<std::string> const& argv) {


### PR DESCRIPTION
The `RunAll()` function in the examples calls example functions directly,
bypassing the size validation for `argv`. When we are developing (or
changing) these functions the crashes from passing the wrong number of
arguments are fairly obscure. Using `std::vector::at` makes it easier to
debug the problems, and as this is not performance critical code, it
seems like a better tradeoff to use that accessor over `operator[]`.

Fixes #3696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3700)
<!-- Reviewable:end -->
