### PR TITLE
feat: add top-level BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,3 +19,17 @@ licenses(["notice"])  # Apache 2.0
 exports_files([
     "LICENSE",
 ])
+
+cc_library(
+    name = "bigtable_client",
+    deps = [
+        "//google/cloud/bigtable:bigtable_client",
+    ],
+)
+
+cc_library(
+    name = "storage_client",
+    deps = [
+        "//google/cloud/storage:storage_client",
+    ],
+)

--- a/google/cloud/bigtable/BUILD
+++ b/google/cloud/bigtable/BUILD
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
+# required to use the top-level BUILD file rather than reaching down into this
+# one.
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
+# required to use the top-level BUILD file rather than reaching down into this
+# one.
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0


### PR DESCRIPTION
Fixes: #3532

The goal is to get bazel users to *only* use these top-level BUILD
targets. This target is shorter and easier to type, and customers need
not rely on the directory structure that we choose to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3702)
<!-- Reviewable:end -->
