### PR TITLE
refactor: ci scripts now use log_<color> functions

### DIFF
--- a/ci/colors.sh
+++ b/ci/colors.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Prefer the log_* functions, such as log_yellow, instead of directly using
+# these variables. The functions don't require the caller to remember to reset
+# the terminal.
 if [ -z "${COLOR_RESET+x}" ]; then
   if type tput >/dev/null 2>&1; then
     readonly COLOR_RED="$(tput setaf 1)"
@@ -26,3 +29,30 @@ if [ -z "${COLOR_RESET+x}" ]; then
     readonly COLOR_RESET=""
   fi
 fi
+
+# Logs a message using the given color. The first argument must be one of the
+# COLOR_* variables defined above, such as "${COLOR_YELLOW}". The remaining
+# arguments will be logged in the given color. The log message will also have
+# an RFC-3339 timestamp prepended (in UTC).
+function log_color_impl() {
+  local color="$1"
+  shift
+  local timestamp
+  timestamp="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
+  echo "${color}${timestamp}: " "$@" "${COLOR_RESET}"
+}
+
+# Logs the given message in green with a timestamp.
+function log_green() {
+  log_color_impl "${COLOR_GREEN}" "$@"
+}
+
+# Logs the given message in yellow with a timestamp.
+function log_yellow() {
+  log_color_impl "${COLOR_YELLOW}" "$@"
+}
+
+# Logs the given message in red with a timestamp.
+function log_red() {
+  log_color_impl "${COLOR_RED}" "$@"
+}

--- a/ci/colors.sh
+++ b/ci/colors.sh
@@ -39,7 +39,12 @@ function log_color_impl() {
   shift
   local timestamp
   timestamp="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
-  echo "${color}${timestamp}: " "$@" "${COLOR_RESET}"
+  echo "${color}${timestamp}:" "$@" "${COLOR_RESET}"
+}
+
+# Logs the given message with normal coloring and a timestamp.
+function log_normal() {
+  log_color_impl "${COLOR_RESET}" "$@"
 }
 
 # Logs the given message in green with a timestamp.

--- a/ci/kokoro/docker/build-in-docker-bazel-dependency.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel-dependency.sh
@@ -38,7 +38,7 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 # ci/Dockerfile.* build scripts.
 
 echo
-echo "${COLOR_YELLOW}$(date -u): compiling quickstart programs${COLOR_RESET}"
+log_yellow "compiling quickstart programs"
 echo
 
 readonly BAZEL_BIN="/usr/local/bin/bazel"
@@ -70,7 +70,7 @@ build_service() {
   local -r service="$1"
 
   echo "================================================================"
-  echo "${COLOR_YELLOW}$(date -u): building ${service}${COLOR_RESET}"
+  log_yellow "building ${service}"
   ( cd "google/cloud/${service}/quickstart";
     echo "$(date -u): capture bazel version"
     ${BAZEL_BIN} version
@@ -85,7 +85,7 @@ build_service() {
       echo "$(date -u): running quickstart program for ${service}"
       env "${run_vars[@]}" "${BAZEL_BIN}" run "${bazel_args[@]}" \
           "--spawn_strategy=local" \
-          :quickstart -- ${quickstart_args["${service}"]}
+          :quickstart -- "${quickstart_args["${service}"]}"
     fi
   )
 }
@@ -99,9 +99,9 @@ done
 
 echo "================================================================"
 if [[ -z "${errors}" ]]; then
-  echo "${COLOR_GREEN}$(date -u): Build finished${COLOR_RESET}"
+  log_green "Build finished"
 else
-  echo "${COLOR_GREEN}$(date -u): Build failed for ${errors}${COLOR_RESET}"
+  log_red "Build failed for ${errors}"
 fi
 
 exit 0

--- a/ci/kokoro/docker/build-in-docker-bazel-dependency.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel-dependency.sh
@@ -42,7 +42,7 @@ log_yellow "compiling quickstart programs"
 echo
 
 readonly BAZEL_BIN="/usr/local/bin/bazel"
-echo "$(date -u): ising Bazel in ${BAZEL_BIN}"
+log_normal "Using Bazel in ${BAZEL_BIN}"
 
 run_vars=()
 bazel_args=("--test_output=errors" "--verbose_failures=true" "--keep_going")
@@ -72,17 +72,17 @@ build_service() {
   echo "================================================================"
   log_yellow "building ${service}"
   ( cd "google/cloud/${service}/quickstart";
-    echo "$(date -u): capture bazel version"
+    log_normal "capture bazel version"
     ${BAZEL_BIN} version
-    echo "$(date -u): fetch dependencies to avoid flaky builds"
+    log_normal "fetch dependencies to avoid flaky builds"
     "${PROJECT_ROOT}/ci/retry-command.sh" \
         "${BAZEL_BIN}" fetch -- ...
     echo
-    echo "$(date -u): compiling quickstart program for ${service}"
+    log_normal "compiling quickstart program for ${service}"
     "${BAZEL_BIN}" build  "${bazel_args[@]}" -- ...
 
     if [[ -r "/c/test-configuration.sh" ]]; then
-      echo "$(date -u): running quickstart program for ${service}"
+      log_normal "running quickstart program for ${service}"
       env "${run_vars[@]}" "${BAZEL_BIN}" run "${bazel_args[@]}" \
           "--spawn_strategy=local" \
           :quickstart -- "${quickstart_args["${service}"]}"

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -36,7 +36,7 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 # ci/Dockerfile.* build scripts.
 
 echo
-echo "${COLOR_YELLOW}$(date -u): Starting docker build with ${NCPU} cores${COLOR_RESET}"
+log_yellow "Starting docker build with ${NCPU} cores"
 echo
 
 echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -41,7 +41,7 @@ echo
 
 echo "================================================================"
 readonly BAZEL_BIN="/usr/local/bin/bazel"
-echo "$(date -u): Using Bazel in ${BAZEL_BIN}"
+log_normal "Using Bazel in ${BAZEL_BIN}"
 "${BAZEL_BIN}" version
 echo "================================================================"
 
@@ -55,20 +55,20 @@ if [[ -n "${BAZEL_CONFIG}" ]]; then
 fi
 
 echo "================================================================"
-echo "$(date -u): Fetching dependencies"
+log_normal "Fetching dependencies"
 echo "================================================================"
 "${PROJECT_ROOT}/ci/retry-command.sh" \
     "${BAZEL_BIN}" fetch -- //google/cloud/...:all
 
 echo "================================================================"
-echo "$(date -u): Compiling and running unit tests"
+log_normal "Compiling and running unit tests"
 echo "================================================================"
 "${BAZEL_BIN}" test \
     "${bazel_args[@]}" "--test_tag_filters=-integration-tests" \
     -- //google/cloud/...:all
 
 echo "================================================================"
-echo "$(date -u): Compiling all the code, including integration tests"
+log_normal "Compiling all the code, including integration tests"
 echo "================================================================"
 # Then build everything else (integration tests, examples, etc). So we can run
 # them next.
@@ -89,7 +89,7 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
         -r "${TEST_KEY_FILE_P12}" && \
         -r "${GOOGLE_APPLICATION_CREDENTIALS}" ) ]]; then
   echo "================================================================"
-  echo "$(date -u): Running the integration tests"
+  log_normal "Running the integration tests"
   echo "================================================================"
 
   # shellcheck disable=SC1091
@@ -170,7 +170,7 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
   if [[ "${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS:-}" = "yes" ]]; then
     echo
     echo "================================================================"
-    echo "$(date -u): Running Google Cloud Bigtable Admin Examples"
+    log_normal "Running Google Cloud Bigtable Admin Examples"
     echo "================================================================"
     (cd "${BAZEL_BIN_DIR}/google/cloud/bigtable/examples" && \
        "${PROJECT_ROOT}/google/cloud/bigtable/examples/run_admin_examples_production.sh")
@@ -178,14 +178,14 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
 
   echo
   echo "================================================================"
-  echo "$(date -u): Running Google Cloud Bigtable Examples"
+  log_normal "Running Google Cloud Bigtable Examples"
   echo "================================================================"
   (cd "${BAZEL_BIN_DIR}/google/cloud/bigtable/examples" && \
       "${PROJECT_ROOT}/google/cloud/bigtable/examples/run_examples_production.sh")
 
   echo
   echo "================================================================"
-  echo "$(date -u): Create service account to run the storage HMAC tests."
+  log_normal "Create service account to run the storage HMAC tests."
   echo "================================================================"
   # Recall that each evaluation of ${RANDOM} produces a different value.
   HMAC_SERVICE_ACCOUNT_NAME="hmac-sa-$(date +%s)-${RANDOM}"
@@ -196,7 +196,7 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
       "${GOOGLE_APPLICATION_CREDENTIALS}"
   "${GCLOUD}" --quiet iam service-accounts create "--project=${PROJECT_ID}" \
       "${HMAC_SERVICE_ACCOUNT_NAME}"
-  echo "$(date -u): Grant service account permissions to create HMAC keys."
+  log_normal "Grant service account permissions to create HMAC keys."
   "${GCLOUD}" --quiet projects add-iam-policy-binding "${PROJECT_ID}" \
       --member "serviceAccount:${HMAC_SERVICE_ACCOUNT}" \
       --role roles/iam.serviceAccountTokenCreator >/dev/null
@@ -205,7 +205,7 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
 
   echo
   echo "================================================================"
-  echo "$(date -u): Running Google Cloud Storage Examples"
+  log_normal "Running Google Cloud Storage Examples"
   echo "================================================================"
   set +e
   echo "Running Google Cloud Storage Examples"
@@ -216,27 +216,27 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
 
   echo
   echo "================================================================"
-  echo "$(date -u): Delete service account to used in the storage HMAC tests."
+  log_normal "Delete service account to used in the storage HMAC tests."
   echo "================================================================"
   "${GCLOUD}" --quiet auth activate-service-account --key-file \
       "${GOOGLE_APPLICATION_CREDENTIALS}"
   "${GCLOUD}" --quiet projects remove-iam-policy-binding "${PROJECT_ID}" \
       --member "serviceAccount:${HMAC_SERVICE_ACCOUNT}" \
       --role roles/iam.serviceAccountTokenCreator >/dev/null
-  echo "$(date -u): Revoke service account permissions to create HMAC keys."
+  log_normal "Revoke service account permissions to create HMAC keys."
   "${GCLOUD}" --quiet iam service-accounts delete --quiet \
       "${HMAC_SERVICE_ACCOUNT}" >/dev/null
   # Deactivate the recently activated service account to prevent accidents.
   "${GCLOUD}" --quiet auth revoke "${GOOGLE_APPLICATION_CREDENTIALS_ACCOUNT}"
 
   if [[ "${storage_examples_status}" != 0 ]]; then
-    echo "$(date -u): Error in storage examples."
+    log_red "Error in storage examples."
     exit 1
   fi
 fi
 
 echo "================================================================"
-echo "$(date -u): Build finished successfully"
+log_normal "Build finished successfully"
 echo "================================================================"
 
 exit 0

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -565,9 +565,9 @@ fi
 echo
 echo "================================================================"
 if [[ ${exit_status} -eq 0 ]]; then
-  log_green "$(date -u): Build script finished successfully."
+  log_green "Build script finished successfully."
 else
-  log_red "$(date -u): Build script failed with status ${exit_status}"
+  log_red "Build script failed with status ${exit_status}"
 fi
 
 exit ${exit_status}

--- a/ci/kokoro/docker/check-abi.sh
+++ b/ci/kokoro/docker/check-abi.sh
@@ -30,8 +30,7 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 
 if [[ "${CHECK_ABI:-}" != "yes" ]]; then
   echo
-  echo "${COLOR_YELLOW}Skipping ABI check as it is disabled for this build." \
-      "${COLOR_RESET}"
+  log_yellow "Skipping ABI check as it is disabled for this build."
   exit 0
 fi
 
@@ -40,7 +39,7 @@ check_library() {
   local return_status=0
 
   echo
-  echo "${COLOR_YELLOW}Checking ABI for ${library} library.${COLOR_RESET}"
+  log_yellow "Checking ABI for ${library} library."
   libdir="$(pkg-config "${library}" --variable=libdir)"
   includedir="$(pkg-config "${library}" --variable=includedir)"
   new_dump_file="${library}.actual.abi.dump"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -25,7 +25,7 @@ readonly PROJECT_ROOT="$1"
 source "${PROJECT_ROOT}/ci/colors.sh"
 echo
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): update or install Bazel.${COLOR_RESET}"
+log_yellow "update or install Bazel."
 
 # macOS does not have sha256sum by default, but `shasum -a 256` does the same
 # thing:
@@ -58,24 +58,23 @@ fi
 echo
 echo "================================================================"
 for repeat in 1 2 3; do
-  echo "${COLOR_YELLOW}$(date -u): Fetch bazel dependencies" \
-      "[${repeat}/3].${COLOR_RESET}"
+  log_yellow "Fetch bazel dependencies [${repeat}/3]."
   if "${BAZEL_BIN}" fetch -- //google/cloud/...; then
     break;
   else
-    echo "${COLOR_YELLOW}$(date -u): bazel fetch failed with $?${COLOR_RESET}"
+    log_yellow "bazel fetch failed with $?"
   fi
 done
 
 echo
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): build and run unit tests.${COLOR_RESET}"
+log_yellow "build and run unit tests."
 "${BAZEL_BIN}" test \
     "${bazel_args[@]}" "--test_tag_filters=-integration-tests" \
     -- //google/cloud/...:all
 
 echo
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): build all targets.${COLOR_RESET}"
+log_yellow "build all targets."
 "${BAZEL_BIN}" build \
     "${bazel_args[@]}" -- //google/cloud/...:all

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -37,7 +37,7 @@ mkdir -p "cmake-out/download"
 echo
 echo "================================================================"
 readonly BAZEL_BIN="$HOME/bin/bazel"
-echo "$(date -u): using Bazel in ${BAZEL_BIN}"
+log_normal "Using Bazel in ${BAZEL_BIN}"
 "${BAZEL_BIN}" version
 "${BAZEL_BIN}" shutdown
 

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -30,7 +30,7 @@ readonly NCPU
 source "${PROJECT_ROOT}/ci/colors.sh"
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): Update or install dependencies.${COLOR_RESET}"
+log_yellow "Update or install dependencies."
 
 brew_env=()
 if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
@@ -39,7 +39,7 @@ fi
 env ${brew_env[@]+"${brew_env[@]}"} brew install libressl
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): ccache stats${COLOR_RESET}"
+log_yellow "ccache stats"
 ccache --show-stats
 ccache --zero-stats
 
@@ -52,11 +52,11 @@ cmake_flags=(
 )
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): Configure CMake.${COLOR_RESET}"
+log_yellow "Configure CMake."
 cmake "-H${SOURCE_DIR}" "-B${BINARY_DIR}" "${cmake_flags[@]}"
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): Compiling with ${NCPU} cpus.${COLOR_RESET}"
+log_yellow "Compiling with ${NCPU} cpus."
 cmake --build "${BINARY_DIR}" -- -j "${NCPU}"
 
 # When user a super-build the tests are hidden in a subdirectory. We can tell
@@ -65,7 +65,7 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
   # If the file is not present, then this is a super build, which automatically
   # run the tests anyway, no need to run them again.
   echo "================================================================"
-  echo "${COLOR_YELLOW}$(date -u): Running unit tests.${COLOR_RESET}"
+  log_yellow "Running unit tests."
   (cd "${BINARY_DIR}"; ctest \
       -LE integration-tests \
       --output-on-failure -j "${NCPU}")
@@ -73,12 +73,12 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
 fi
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): ccache stats${COLOR_RESET}"
+log_yellow "ccache stats"
 ccache --show-stats
 ccache --zero-stats
 
 echo "================================================================"
-echo "${COLOR_GREEN}$(date -u): Build finished sucessfully${COLOR_RESET}"
+log_green "Build finished sucessfully"
 echo "================================================================"
 
 exit 0

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -54,8 +54,7 @@ source "${PROJECT_ROOT}/ci/colors.sh"
 source "${PROJECT_ROOT}/ci/etc/repo-config.sh"
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): change working directory to project root."\
-    "${COLOR_RESET}"
+log_yellow "change working directory to project root."
 cd "${PROJECT_ROOT}"
 
 NCPU="$(sysctl -n hw.logicalcpu)"
@@ -65,8 +64,7 @@ KOKORO_GFILE_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly KOKORO_GFILE_DIR
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): building with ${NCPU} cores on ${PWD}."\
-    "${COLOR_RESET}"
+log_yellow "building with ${NCPU} cores on ${PWD}."
 
 script_flags=("${PROJECT_ROOT}")
 
@@ -76,8 +74,7 @@ elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   driver_script="ci/kokoro/macos/build-cmake.sh"
   script_flags+=("super" "cmake-out/macos")
 else
-  echo "${COLOR_RED}$(date -u): unknown BUILD_NAME (${BUILD_NAME})."\
-      "${COLOR_RESET}"
+  log_red "unknown BUILD_NAME (${BUILD_NAME})."
   exit 1
 fi
 
@@ -85,8 +82,7 @@ fi
 # find the credentials, even if you do not use them. Some of the unit tests do
 # exactly that.
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): define GOOGLE_APPLICATION_CREDENTIALS."\
-    "${COLOR_RESET}"
+log_yellow "define GOOGLE_APPLICATION_CREDENTIALS."
 export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
 
 # Download the gRPC `roots.pem` file. On macOS gRPC does not use the native
@@ -96,7 +92,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/service-account.json"
 # But it was closed without being merged, and there are open bugs:
 #    https://github.com/grpc/grpc/issues/16571
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): getting roots.pem for gRPC.${COLOR_RESET}"
+log_yellow "getting roots.pem for gRPC."
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${KOKORO_GFILE_DIR}/roots.pem"
 rm -f "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
 wget -O "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
@@ -105,8 +101,7 @@ wget -O "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
 BRANCH="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
 readonly BRANCH
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): detected the branch name:"\
-    "${BRANCH}.${COLOR_RESET}"
+log_yellow "detected the branch name: ${BRANCH}."
 
 CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
 readonly CACHE_BUCKET
@@ -120,13 +115,13 @@ readonly CACHE_NAME
       "${CACHE_FOLDER}" "${CACHE_NAME}" || true
 
 echo "================================================================"
-echo "${COLOR_YELLOW}$(date -u): starting build script.${COLOR_RESET}"
+log_yellow "starting build script."
 
 if "${driver_script}" "${script_flags[@]}"; then
-  echo "${COLOR_GREEN}$(date -u): build script was successful.${COLOR_RESET}"
+  log_green "build script was successful."
   exit_status=0
 else
-  echo "${COLOR_RED}$(date -u): build script reported errors.${COLOR_RESET}"
+  log_red "build script reported errors."
   exit_status=1
 fi
 


### PR DESCRIPTION
This shortens the log statements, gives them all the same timestamp
prefix, and removes the need to remember to reset the terminal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3704)
<!-- Reviewable:end -->
