### PR TITLE
cleanup: remove repetitive code in storage examples

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -72,6 +72,8 @@ std::string RandomClusterId(std::string const& prefix,
 
 bool UsingEmulator();
 bool RunAdminIntegrationTests();
+
+// TODO(#3624) - refactor this function to -common
 void CheckEnvironmentVariablesAreSet(std::vector<std::string> const&);
 
 using TableAdminCommandType = std::function<void(

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -231,20 +231,16 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT",
+  });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  if (project_id.empty()) {
-    throw std::runtime_error("GOOGLE_CLOUD_PROJECT is not set or is empty");
-  }
   auto const service_account =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT")
           .value_or("");
-  if (service_account.empty()) {
-    throw std::runtime_error(
-        "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT is not set or is "
-        "empty");
-  }
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name =
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -236,11 +236,11 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const service_account =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT")
-          .value_or("");
+          .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name =
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -374,21 +374,16 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace gcs = ::google::cloud::storage;
 
   if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT",
+  });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  if (project_id.empty()) {
-    throw std::runtime_error("GOOGLE_CLOUD_PROJECT is not set or is empty");
-  }
   auto const service_account =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT")
           .value_or("");
-  if (service_account.empty()) {
-    throw std::runtime_error(
-        "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT is not set or is "
-        "empty");
-  }
-
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name =
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -379,11 +379,11 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const service_account =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT")
-          .value_or("");
+          .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name =
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -88,6 +88,20 @@ bool UsingTestbench() {
               .empty();
 }
 
+void CheckEnvironmentVariablesAreSet(std::vector<std::string> const& vars) {
+  for (auto const& var : vars) {
+    auto const value = google::cloud::internal::GetEnv(var.c_str());
+    if (!value) {
+      throw std::runtime_error("The " + var +
+                               " environment variable is not set");
+    }
+    if (value->empty()) {
+      throw std::runtime_error("The " + var +
+                               " environment variable has an empty value");
+    }
+  }
+}
+
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix) {
   // The total length of a bucket name must be <= 63 characters,

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -53,6 +53,10 @@ class Example {
 };
 
 bool UsingTestbench();
+
+// TODO(#3624) - refactor this function to -common
+void CheckEnvironmentVariablesAreSet(std::vector<std::string> const&);
+
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix);
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,

--- a/google/cloud/storage/examples/storage_examples_common_test.cc
+++ b/google/cloud/storage/examples/storage_examples_common_test.cc
@@ -138,6 +138,36 @@ TEST(StorageExamplesCommon, UsingTestbenchFalse) {
   EXPECT_FALSE(UsingTestbench());
 }
 
+TEST(StorageExamplesCommon, CheckEnvironmentVariablesNormal) {
+  google::cloud::testing_util::ScopedEnvironment test_a("TEST_A", "a");
+  google::cloud::testing_util::ScopedEnvironment test_b("TEST_B", "b");
+  EXPECT_NO_THROW(CheckEnvironmentVariablesAreSet({"TEST_A", "TEST_B"}));
+}
+
+TEST(StorageExamplesCommon, CheckEnvironmentVariablesNotSet) {
+  google::cloud::testing_util::ScopedEnvironment test_a("TEST_A", {});
+  EXPECT_THROW(
+      try {
+        CheckEnvironmentVariablesAreSet({"TEST_A"});
+      } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("TEST_A"));
+        throw;
+      },
+      std::runtime_error);
+}
+
+TEST(StorageExamplesCommon, CheckEnvironmentVariablesSetEmpty) {
+  google::cloud::testing_util::ScopedEnvironment test_a("TEST_A", "");
+  EXPECT_THROW(
+      try {
+        CheckEnvironmentVariablesAreSet({"TEST_A"});
+      } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("TEST_A"));
+        throw;
+      },
+      std::runtime_error);
+}
+
 TEST(StorageExamplesCommon, RandomBucket) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const actual_1 = MakeRandomBucketName(generator, "test-prefix-");

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -76,10 +76,10 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const bucket_name = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
-                               .value_or("");
+                               .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -71,19 +71,15 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace gcs = ::google::cloud::storage;
 
   if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
+  });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  if (project_id.empty()) {
-    throw std::runtime_error("GOOGLE_CLOUD_PROJECT is not set or is empty");
-  }
   auto const bucket_name = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
                                .value_or("");
-  if (bucket_name.empty()) {
-    throw std::runtime_error(
-        "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME is not set or is "
-        "empty");
-  }
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -76,10 +76,10 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const bucket_name = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
-                               .value_or("");
+                               .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -71,19 +71,15 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace gcs = ::google::cloud::storage;
 
   if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
+  });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  if (project_id.empty()) {
-    throw std::runtime_error("GOOGLE_CLOUD_PROJECT is not set or is empty");
-  }
   auto const bucket_name = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
                                .value_or("");
-  if (bucket_name.empty()) {
-    throw std::runtime_error(
-        "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME is not set or is "
-        "empty");
-  }
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -137,7 +137,7 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_PROJECT",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name =
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -129,16 +129,15 @@ void RemoveStaticWebsiteConfiguration(google::cloud::storage::Client client,
 }
 
 void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw Usage{"auto"};
-
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
+  if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+  });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  if (project_id.empty()) {
-    throw std::runtime_error("GOOGLE_CLOUD_PROJECT is not set or is empty");
-  }
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const bucket_name =
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");


### PR DESCRIPTION
The examples get their configuration from environment variables and
need to validate that these are set and have some value. That code was
getting repetitive, so copied the code from the Bigtable examples.
Eventually this should all make it to the `-common` library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3707)
<!-- Reviewable:end -->
