### PR TITLE
cleanup: use `.value()` to read validated env variables

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
+++ b/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
@@ -127,16 +127,15 @@ void RunAll(std::vector<std::string> argv) {
   });
 
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const instance_id = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
-                               .value_or("");
+                               .value();
   auto const access_token = google::cloud::internal::GetEnv(
                                 "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ACCESS_TOKEN")
-                                .value_or("");
+                                .value();
   auto const credentials_file =
-      google::cloud::internal::GetEnv("GOOGLE_APPLICATION_CREDENTIALS")
-          .value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_APPLICATION_CREDENTIALS").value();
 
   AccessToken({project_id, instance_id, access_token});
   JWTAccessToken({project_id, instance_id, credentials_file});

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -112,10 +112,10 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const instance_id = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
-                               .value_or("");
+                               .value();
 
   cbt::TableAdmin admin(
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),

--- a/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
@@ -127,10 +127,10 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const instance_id = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
-                               .value_or("");
+                               .value();
 
   cbt::TableAdmin admin(
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -738,17 +738,17 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const service_account =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT")
-          .value_or("");
+          .value();
   auto const zone_a =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A")
-          .value_or("");
+          .value();
   auto const zone_b =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B")
-          .value_or("");
+          .value();
 
   cbt::InstanceAdmin admin(
       cbt::CreateDefaultInstanceAdminClient(project_id, cbt::ClientOptions{}));

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -1123,10 +1123,10 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const instance_id = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
-                               .value_or("");
+                               .value();
 
   namespace cbt = google::cloud::bigtable;
   cbt::TableAdmin admin(

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -515,10 +515,10 @@ void RunAll(std::vector<std::string> const& argv) {
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
   });
   auto const project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const instance_id = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
-                               .value_or("");
+                               .value();
 
   cbt::TableAdmin admin(
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),


### PR DESCRIPTION
As @devbww pointed out in #3707 , once we validate an
environment variable using `.value_or("")` is redundant. Use just
`.value()` it is cleaner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3708)
<!-- Reviewable:end -->
