### PR TITLE
refactor: split storage policy doc samples

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2788,7 +2788,7 @@ class Client {
    * `ExactMatch()`, `ContentLengthRange()`.
    *
    * @par Example
-   * @snippet storage_bucket_samples.cc create signed policy document
+   * @snippet storage_policy_doc_samples.cc create signed policy document
    *
    * @see
    * https://cloud.google.com/storage/docs/xml-api/post-object#policydocument
@@ -2829,7 +2829,7 @@ class Client {
    * `ExactMatch()`, `ContentLengthRange()`.
    *
    * @par Example
-   * @snippet storage_bucket_samples.cc create signed policy document v4
+   * @snippet storage_policy_doc_samples.cc create signed policy document v4
    *
    * @see
    * https://cloud.google.com/storage/docs/xml-api/post-object#policydocument

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -23,6 +23,7 @@ set(storage_autorun_examples
     # cmake-format: sort
     storage_bucket_acl_samples.cc
     storage_bucket_iam_samples.cc
+    storage_policy_doc_samples.cc
     storage_signed_url_v2_samples.cc
     storage_signed_url_v4_samples.cc
     storage_website_samples.cc)
@@ -97,7 +98,11 @@ foreach (fname ${storage_autorun_examples})
 endforeach ()
 
 # We just know that these tests need to be run against production.
-foreach (target storage_signed_url_v4_samples storage_signed_url_v2_samples)
+foreach (
+    target
+    # cmake-format: sort
+    storage_policy_doc_samples storage_signed_url_v2_samples
+    storage_signed_url_v4_samples)
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;integration-tests-no-emulator")

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -870,27 +870,6 @@ run_all_cmek_examples() {
 }
 
 ################################################
-# Run the examples to create signed policy documents.
-# Globals:
-#   COLOR_*: colorize output messages, defined in colors.sh
-#   EXIT_STATUS: control the final exit status for the program.
-# Arguments:
-#   None
-# Returns:
-#   None
-################################################
-run_signed_policy_document_examples() {
-  if [[ -n "${CLOUD_STORAGE_TESTBENCH_ENDPOINT:-}" ]]; then
-    echo "${COLOR_YELLOW}[  SKIPPED ]${COLOR_RESET}" \
-        " Signed policy document examples disabled when using the testbench."
-    return
-  fi
-
-  run_example ./storage_bucket_samples create-signed-policy-document
-  run_example ./storage_bucket_samples create-signed-policy-document-v4
-}
-
-################################################
 # Run all Object ACL examples.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
@@ -1072,7 +1051,6 @@ run_all_storage_examples() {
   run_event_based_hold_examples "${BUCKET_NAME}"
   run_temporary_hold_examples "${BUCKET_NAME}"
   run_object_versioning_examples
-  run_signed_policy_document_examples
   run_all_object_acl_examples "${BUCKET_NAME}"
   run_all_notification_examples "${TOPIC_NAME}"
   run_all_cmek_examples "${STORAGE_CMEK_KEY}"

--- a/google/cloud/storage/examples/storage_autorun_examples.bzl
+++ b/google/cloud/storage/examples/storage_autorun_examples.bzl
@@ -19,6 +19,7 @@
 storage_autorun_examples = [
     "storage_bucket_acl_samples.cc",
     "storage_bucket_iam_samples.cc",
+    "storage_policy_doc_samples.cc",
     "storage_signed_url_v2_samples.cc",
     "storage_signed_url_v4_samples.cc",
     "storage_website_samples.cc",

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -1421,74 +1421,6 @@ void SetCorsConfiguration(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, origin);
 }
 
-void CreateSignedPolicyDocument(google::cloud::storage::Client client,
-                                int& argc, char*[]) {
-  if (argc != 1) {
-    throw Usage{"create-signed-policy-document"};
-  }
-  //! [create signed policy document]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client) {
-    StatusOr<gcs::PolicyDocumentResult> signed_document =
-        client.CreateSignedPolicyDocument(gcs::PolicyDocument{
-            std::chrono::system_clock::now() + std::chrono::minutes(15),
-            {
-                gcs::PolicyDocumentCondition::StartsWith("key", ""),
-                gcs::PolicyDocumentCondition::ExactMatchObject(
-                    "acl", "bucket-owner-read"),
-                gcs::PolicyDocumentCondition::ExactMatchObject("bucket",
-                                                               "travel-maps"),
-                gcs::PolicyDocumentCondition::ExactMatch("Content-Type",
-                                                         "image/jpeg"),
-                gcs::PolicyDocumentCondition::ContentLengthRange(0, 1000000),
-            }});
-
-    if (!signed_document) {
-      throw std::runtime_error(signed_document.status().message());
-    }
-
-    std::cout << "The signed document is: " << *signed_document << "\n\n"
-              << "You can use this with an HTML form.\n";
-  }
-  //! [create signed policy document]
-  (std::move(client));
-}
-
-void CreateSignedPolicyDocumentV4(google::cloud::storage::Client client,
-                                  int& argc, char*[]) {
-  if (argc != 1) {
-    throw Usage{"create-signed-policy-document-v4"};
-  }
-  //! [create signed policy document v4]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client) {
-    StatusOr<gcs::PolicyDocumentV4Result> signed_document =
-        client.GenerateSignedPostPolicyV4(gcs::PolicyDocumentV4{
-            "travel-maps",
-            "scan_0001.jpg",
-            std::chrono::minutes(15),
-            std::chrono::system_clock::now(),
-            {
-                gcs::PolicyDocumentCondition::StartsWith("key", ""),
-                gcs::PolicyDocumentCondition::ExactMatchObject(
-                    "acl", "bucket-owner-read"),
-                gcs::PolicyDocumentCondition::ExactMatch("Content-Type",
-                                                         "image/jpeg"),
-                gcs::PolicyDocumentCondition::ContentLengthRange(0, 1000000),
-            }});
-
-    if (!signed_document) {
-      throw std::runtime_error(signed_document.status().message());
-    }
-
-    std::cout << "The signed document is: " << *signed_document << "\n\n"
-              << "You can use this with an HTML form.\n";
-  }
-  //! [create signed policy document v4]
-  (std::move(client));
-}
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -1551,8 +1483,6 @@ int main(int argc, char* argv[]) try {
       {"remove-retention-policy", RemoveRetentionPolicy},
       {"lock-retention-policy", LockRetentionPolicy},
       {"set-cors-configuration", SetCorsConfiguration},
-      {"create-signed-policy-document", CreateSignedPolicyDocument},
-      {"create-signed-policy-document-v4", CreateSignedPolicyDocumentV4},
   };
   for (auto&& kv : commands) {
     try {

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -1,0 +1,133 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/internal/getenv.h"
+#include <functional>
+#include <iostream>
+#include <sstream>
+
+namespace {
+
+using google::cloud::storage::examples::Commands;
+using google::cloud::storage::examples::CommandType;
+using google::cloud::storage::examples::Usage;
+
+void CreateSignedPolicyDocumentV2(google::cloud::storage::Client client,
+                                  std::vector<std::string> const& argv) {
+  //! [create signed policy document]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    StatusOr<gcs::PolicyDocumentResult> document =
+        client.CreateSignedPolicyDocument(gcs::PolicyDocument{
+            std::chrono::system_clock::now() + std::chrono::minutes(15),
+            {
+                gcs::PolicyDocumentCondition::StartsWith("key", ""),
+                gcs::PolicyDocumentCondition::ExactMatchObject(
+                    "acl", "bucket-owner-read"),
+                gcs::PolicyDocumentCondition::ExactMatchObject(
+                    "bucket", std::move(bucket_name)),
+                gcs::PolicyDocumentCondition::ExactMatch("Content-Type",
+                                                         "image/jpeg"),
+                gcs::PolicyDocumentCondition::ContentLengthRange(0, 1000000),
+            }});
+    if (!document) throw std::runtime_error(document.status().message());
+
+    std::cout << "The signed document is: " << *document << "\n\n"
+              << "You can use this with an HTML form.\n";
+  }
+  //! [create signed policy document]
+  (std::move(client), argv.at(0));
+}
+
+void CreateSignedPolicyDocumentV4(google::cloud::storage::Client client,
+                                  std::vector<std::string> const& argv) {
+  //! [create signed policy document v4]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    StatusOr<gcs::PolicyDocumentV4Result> document =
+        client.GenerateSignedPostPolicyV4(gcs::PolicyDocumentV4{
+            std::move(bucket_name),
+            "scan_0001.jpg",
+            std::chrono::minutes(15),
+            std::chrono::system_clock::now(),
+            {
+                gcs::PolicyDocumentCondition::StartsWith("key", ""),
+                gcs::PolicyDocumentCondition::ExactMatchObject(
+                    "acl", "bucket-owner-read"),
+                gcs::PolicyDocumentCondition::ExactMatch("Content-Type",
+                                                         "image/jpeg"),
+                gcs::PolicyDocumentCondition::ContentLengthRange(0, 1000000),
+            }});
+    if (!document) throw std::runtime_error(document.status().message());
+
+    std::cout << "The signed document is: " << *document << "\n\n"
+              << "You can use this with an HTML form.\n";
+  }
+  //! [create signed policy document v4]
+  (std::move(client), argv.at(0));
+}
+
+void RunAll(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::storage::examples;
+  namespace gcs = ::google::cloud::storage;
+
+  if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+  });
+  auto const project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const bucket_name =
+      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const object_name =
+      examples::MakeRandomObjectName(generator, "upload-object-");
+  auto client = gcs::Client::CreateDefaultClient().value();
+  std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
+            << std::endl;
+  auto bucket_metadata = client
+                             .CreateBucketForProject(bucket_name, project_id,
+                                                     gcs::BucketMetadata{})
+                             .value();
+
+  std::cout << "\nRunning the CreatedSignedPolicyDocumentV2() example"
+            << std::endl;
+  CreateSignedPolicyDocumentV2(client, {bucket_name});
+
+  std::cout << "\nRunning the CreatedSignedPolicyDocumentV4() example"
+            << std::endl;
+  CreateSignedPolicyDocumentV4(client, {bucket_name});
+
+  (void)client.DeleteBucket(bucket_name);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  namespace examples = ::google::cloud::storage::examples;
+  examples::Example example({
+      examples::CreateCommandEntry("create-signed-policy-document-v2",
+                                   {"<bucket-name>"},
+                                   CreateSignedPolicyDocumentV2),
+      examples::CreateCommandEntry("create-signed-policy-document-v4",
+                                   {"<bucket-name>"},
+                                   CreateSignedPolicyDocumentV4),
+      {"auto", RunAll},
+  });
+  return example.Run(argc, argv);
+}


### PR DESCRIPTION
This splits the storage policy doc samples to their own file, which is
automatically executed by CMake/Bazel.

Fixes #3667

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3709)
<!-- Reviewable:end -->
