### PR TITLE
feat(storage): policy doc example with form

### DIFF
--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -90,8 +90,8 @@ void CreatePolicyDocumentFormV4(google::cloud::storage::Client client,
   [](gcs::Client client, std::string bucket_name, std::string object_name) {
     auto document = client.GenerateSignedPostPolicyV4(
         gcs::PolicyDocumentV4{
-            std::move(bucket_name),
-            std::move(object_name),
+            bucket_name,
+            object_name,
             /*expiration=*/std::chrono::minutes(10),
         },
         gcs::AddExtensionFieldOption("x-goog-meta-test", "data"));
@@ -101,16 +101,20 @@ void CreatePolicyDocumentFormV4(google::cloud::storage::Client client,
     std::ostringstream os;
     os << "<form action='" << document->url << "' method='POST'"
        << " enctype='multipart/form-data'>\n"
-       << "  <input name='access_id' value='" << document->access_id
+       << "  <input name='key' value='" << object_name
        << "' type='hidden' />\n"
        << "  <input name='policy' value='" << document->policy
        << "' type='hidden' />\n"
+       << "  <input name='x-goog-algorithm' value='"
+       << document->signing_algorithm << "' type='hidden' />\n"
+       << "  <input name='x-goog-credential' value='" << document->access_id
+       << "' type='hidden' />\n"
+       << "  <input name='x-goog-date' value='" << gcs::FormatDateForForm(*document)
+       << "' type='hidden' />\n"
        << "  <input name='signature' value='" << document->signature
        << "' type='hidden' />\n"
-       << "  <input name='signing_algorithm' value='"
-       << document->signing_algorithm << "' type='hidden' />\n"
-       << "  <input type='file' name='file' /><br />\n"
        << "  <input type='submit' value='Upload File' name='submit' /><br />\n"
+       << "  <input type='file' name='file' /><br />\n"
        << "</form>";
 
     std::cout << "A sample HTML form:\n" << os.str() << "\n";

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -101,16 +101,15 @@ void CreatePolicyDocumentFormV4(google::cloud::storage::Client client,
     std::ostringstream os;
     os << "<form action='" << document->url << "' method='POST'"
        << " enctype='multipart/form-data'>\n"
-       << "  <input name='key' value='" << object_name
-       << "' type='hidden' />\n"
+       << "  <input name='key' value='" << object_name << "' type='hidden' />\n"
        << "  <input name='policy' value='" << document->policy
        << "' type='hidden' />\n"
        << "  <input name='x-goog-algorithm' value='"
        << document->signing_algorithm << "' type='hidden' />\n"
        << "  <input name='x-goog-credential' value='" << document->access_id
        << "' type='hidden' />\n"
-       << "  <input name='x-goog-date' value='" << gcs::FormatDateForForm(*document)
-       << "' type='hidden' />\n"
+       << "  <input name='x-goog-date' value='"
+       << gcs::FormatDateForForm(*document) << "' type='hidden' />\n"
        << "  <input name='signature' value='" << document->signature
        << "' type='hidden' />\n"
        << "  <input type='submit' value='Upload File' name='submit' /><br />\n"

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -82,6 +82,43 @@ void CreateSignedPolicyDocumentV4(google::cloud::storage::Client client,
   (std::move(client), argv.at(0));
 }
 
+void CreatePolicyDocumentFormV4(google::cloud::storage::Client client,
+                                std::vector<std::string> const& argv) {
+  // [START storage_generate_signed_post_policy_v4]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+    auto document = client.GenerateSignedPostPolicyV4(
+        gcs::PolicyDocumentV4{
+            std::move(bucket_name),
+            std::move(object_name),
+            /*expiration=*/std::chrono::minutes(10),
+        },
+        gcs::AddExtensionFieldOption("x-goog-meta-test", "data"));
+    if (!document) throw std::runtime_error(document.status().message());
+
+    // Create the HTML form for the computed policy.
+    std::ostringstream os;
+    os << "<form action='" << document->url << "' method='POST'"
+       << " enctype='multipart/form-data'>\n"
+       << "  <input name='access_id' value='" << document->access_id
+       << "' type='hidden' />\n"
+       << "  <input name='policy' value='" << document->policy
+       << "' type='hidden' />\n"
+       << "  <input name='signature' value='" << document->signature
+       << "' type='hidden' />\n"
+       << "  <input name='signing_algorithm' value='"
+       << document->signing_algorithm << "' type='hidden' />\n"
+       << "  <input type='file' name='file' /><br />\n"
+       << "  <input type='submit' value='Upload File' name='submit' /><br />\n"
+       << "</form>";
+
+    std::cout << "A sample HTML form:\n" << os.str() << "\n";
+  }
+  // [END storage_generate_signed_post_policy_v4]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
@@ -113,6 +150,10 @@ void RunAll(std::vector<std::string> const& argv) {
             << std::endl;
   CreateSignedPolicyDocumentV4(client, {bucket_name});
 
+  std::cout << "\nRunning the CreatePolicyDocumentFormV4() example"
+            << std::endl;
+  CreatePolicyDocumentFormV4(client, {bucket_name, object_name});
+
   (void)client.DeleteBucket(bucket_name);
 }
 
@@ -127,6 +168,9 @@ int main(int argc, char* argv[]) {
       examples::CreateCommandEntry("create-signed-policy-document-v4",
                                    {"<bucket-name>"},
                                    CreateSignedPolicyDocumentV4),
+      examples::CreateCommandEntry("create-policy-document-form-v4",
+                                   {"<bucket-name>", "<object-name>"},
+                                   CreatePolicyDocumentFormV4),
       {"auto", RunAll},
   });
   return example.Run(argc, argv);

--- a/google/cloud/storage/policy_document.cc
+++ b/google/cloud/storage/policy_document.cc
@@ -77,6 +77,11 @@ std::ostream& operator<<(std::ostream& os, PolicyDocumentResult const& rhs) {
             << "}";
 }
 
+std::string FormatDateForForm(PolicyDocumentV4Result const&) {
+  return google::cloud::internal::FormatV4SignedUrlTimestamp(
+      std::chrono::system_clock::now()).substr(0, 8);
+}
+
 std::ostream& operator<<(std::ostream& os, PolicyDocumentV4Result const& rhs) {
   return os << "PolicyDocumentV4Result={"
             << "url=" << rhs.url << ", access_id=" << rhs.access_id

--- a/google/cloud/storage/policy_document.cc
+++ b/google/cloud/storage/policy_document.cc
@@ -78,8 +78,13 @@ std::ostream& operator<<(std::ostream& os, PolicyDocumentResult const& rhs) {
 }
 
 std::string FormatDateForForm(PolicyDocumentV4Result const&) {
+  // The V4 signed URL format for timestamps and the format for dates in the V4
+  // policy docs are fortunately the same, so we can just call the existing
+  // function and truncate the sub-day parts.
+  auto constexpr kDateLength = sizeof("YYYYMMDD");
   return google::cloud::internal::FormatV4SignedUrlTimestamp(
-      std::chrono::system_clock::now()).substr(0, 8);
+             std::chrono::system_clock::now())
+      .substr(0, kDateLength);
 }
 
 std::ostream& operator<<(std::ostream& os, PolicyDocumentV4Result const& rhs) {

--- a/google/cloud/storage/policy_document.h
+++ b/google/cloud/storage/policy_document.h
@@ -196,7 +196,11 @@ struct PolicyDocumentV4Result {
   std::string signing_algorithm;
 };
 
+/// Format the current date in the format expected by a POST form
+std::string FormatDateForForm(PolicyDocumentV4Result const&);
+
 std::ostream& operator<<(std::ostream& os, PolicyDocumentV4Result const& rhs);
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
Implement an example that actually generates the text for a HTML form
associated with a signed policy document.

Fixes #3642

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3715)
<!-- Reviewable:end -->
