### PR TITLE
cleanup: cleanup the firestore documentation and deps

### DIFF
--- a/google/cloud/firestore/BUILD
+++ b/google/cloud/firestore/BUILD
@@ -22,9 +22,7 @@ cc_library(
     name = "firestore_client",
     srcs = firestore_client_srcs,
     hdrs = firestore_client_hdrs,
-    deps = [
-        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
-    ],
+    deps = [],
 )
 
 load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")
@@ -38,8 +36,6 @@ load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")
     }),
     deps = [
         ":firestore_client",
-        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gmock_main",
     ],
 ) for test in firestore_client_unit_tests]

--- a/google/cloud/firestore/BUILD
+++ b/google/cloud/firestore/BUILD
@@ -36,6 +36,6 @@ load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")
     }),
     deps = [
         ":firestore_client",
-        "@com_google_googletest//:gmock_main",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for test in firestore_client_unit_tests]

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -48,10 +48,7 @@ include(CreateBazelConfig)
 
 # the client library
 add_library(firestore_client field_path.cc field_path.h)
-target_link_libraries(
-    firestore_client
-    PUBLIC google_cloud_cpp_common
-    PRIVATE firestore_common_options)
+target_link_libraries(firestore_client PRIVATE firestore_common_options)
 target_include_directories(
     firestore_client
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -86,14 +83,8 @@ if (BUILD_TESTING)
         string(REPLACE ".cc" "" target ${target})
         add_executable(${target} ${fname})
         target_link_libraries(
-            ${target}
-            PRIVATE firestore_client
-                    google_cloud_cpp_testing
-                    google_cloud_cpp_common
-                    GTest::gmock_main
-                    GTest::gmock
-                    GTest::gtest
-                    firestore_common_options)
+            ${target} PRIVATE firestore_client GTest::gmock_main GTest::gmock
+                              GTest::gtest firestore_common_options)
         if (MSVC)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()

--- a/google/cloud/firestore/README.md
+++ b/google/cloud/firestore/README.md
@@ -1,4 +1,4 @@
-# Google Cloud Firestore
+# :construction: Google Cloud Firestore
 
 [![Documentation][doxygen-shield]][doxygen-link]
 
@@ -6,27 +6,9 @@
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-firestore/latest/
 
 This directory contains community contributions to use Google Cloud Firestore
-from C++. It should be considered work in progress, it is not supported by
-Google.
+from C++. It should be considered work in progress, **it is not supported by
+Google**.
 
 ## Status
 
-This library support Google Cloud Firestore at the
-[Experimental](../README.md#versioning) quality level.
-
-## Documentation
-
-Full documentation is available [online][doxygen-link].
-
-## Release Notes
-
-### v1.13.0 - 2020-05
-
-* All libraries in this repository will receive the same version number. The
-  bump to 1.x for this library should not be considered an indication of
-  completeness or suitability for production for the Google Cloud Firestore C++
-  library.
-
-### v0.0.1 - 2018-05
-
-* This release implements FieldPath class for Google Cloud Firestore.
+This library is *experimental* and has no specific support guarantees.


### PR DESCRIPTION
Cleans up the README.md to make it clearer that this library is not GA
and has no specific support guarantees. Also cleans up the build a bit
since it doesn't actually depend on -common.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3717)
<!-- Reviewable:end -->
