### PR TITLE
refactor: split CORS examples to its own program

### DIFF
--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(storage_examples_common storage_client
 set(storage_autorun_examples
     # cmake-format: sort
     storage_bucket_acl_samples.cc
+    storage_bucket_cors_samples.cc
     storage_bucket_default_kms_key_samples.cc
     storage_bucket_iam_samples.cc
     storage_object_cmek_samples.cc

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -907,30 +907,6 @@ run_all_notification_examples() {
 }
 
 ################################################
-# Run the examples showing how to use cors configuration.
-# Globals:
-#   COLOR_*: colorize output messages, defined in colors.sh
-#   EXIT_STATUS: control the final exit status for the program.
-# Arguments:
-#   None
-# Returns:
-#   None
-################################################
-run_cors_configuration_examples() {
-  # Create the bucket to avoid changing the configuration for "${BUCKET_NAME}"
-  local bucket_name="cloud-cpp-test-bucket-${RANDOM}-${RANDOM}-${RANDOM}"
-
-  run_example ./storage_bucket_samples create-bucket-for-project \
-      "${bucket_name}" "${PROJECT_ID}"
-
-  run_example ./storage_bucket_samples set-cors-configuration \
-      "${bucket_name}" "http://origin1.example.com"
-
-  run_example ./storage_bucket_samples delete-bucket \
-      "${bucket_name}"
-}
-
-################################################
 # Run mocking client examples.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
@@ -997,7 +973,6 @@ run_all_storage_examples() {
   run_all_object_acl_examples "${BUCKET_NAME}"
   run_all_notification_examples "${TOPIC_NAME}"
   run_all_service_account_examples
-  run_cors_configuration_examples
   run_mocking_client_examples "test-bucket-name" "test-object-name"
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET}" \
       " Google Cloud Storage Examples Finished"

--- a/google/cloud/storage/examples/storage_autorun_examples.bzl
+++ b/google/cloud/storage/examples/storage_autorun_examples.bzl
@@ -18,6 +18,7 @@
 
 storage_autorun_examples = [
     "storage_bucket_acl_samples.cc",
+    "storage_bucket_cors_samples.cc",
     "storage_bucket_default_kms_key_samples.cc",
     "storage_bucket_iam_samples.cc",
     "storage_object_cmek_samples.cc",

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/internal/getenv.h"
+#include <functional>
+#include <iostream>
+#include <map>
+
+namespace {
+
+using google::cloud::storage::examples::Usage;
+
+void SetCorsConfiguration(google::cloud::storage::Client client,
+                          std::vector<std::string> const& argv) {
+  //! [cors configuration] [START storage_cors_configuration]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name, std::string origin) {
+    StatusOr<gcs::BucketMetadata> original =
+        client.GetBucketMetadata(bucket_name);
+
+    if (!original) throw std::runtime_error(original.status().message());
+    std::vector<gcs::CorsEntry> cors_configuration;
+    cors_configuration.emplace_back(
+        gcs::CorsEntry{3600, {"GET"}, {origin}, {"Content-Type"}});
+
+    StatusOr<gcs::BucketMetadata> patched_metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetCors(cors_configuration),
+        gcs::IfMetagenerationMatch(original->metageneration()));
+
+    if (!patched_metadata) {
+      throw std::runtime_error(patched_metadata.status().message());
+    }
+
+    if (patched_metadata->cors().empty()) {
+      std::cout << "Cors configuration is not set for bucket "
+                << patched_metadata->name() << "\n";
+      return;
+    }
+
+    std::cout << "Cors configuration successfully set for bucket "
+              << patched_metadata->name() << "\nNew cors configuration: ";
+    for (auto const& cors_entry : patched_metadata->cors()) {
+      std::cout << "\n  " << cors_entry << "\n";
+    }
+  }
+  //! [cors configuration] [END storage_cors_configuration]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
+void RunAll(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::storage::examples;
+  namespace gcs = ::google::cloud::storage;
+
+  if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+  });
+  auto const project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const bucket_name =
+      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto client = gcs::Client::CreateDefaultClient().value();
+
+  std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
+            << std::endl;
+  auto bucket_metadata = client
+                             .CreateBucketForProject(bucket_name, project_id,
+                                                     gcs::BucketMetadata{})
+                             .value();
+
+  std::cout << "\nRunning the SetCorsConfiguration() example" << std::endl;
+  SetCorsConfiguration(client, {bucket_name, "http://origin1.example.com"});
+
+  (void)client.DeleteBucket(bucket_name);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  namespace examples = ::google::cloud::storage::examples;
+  google::cloud::storage::examples::Example example({
+      examples::CreateCommandEntry("set-cors-configuration",
+                                   {"<bucket-name>", "<config>"},
+                                   SetCorsConfiguration),
+      {"auto", RunAll},
+  });
+  return example.Run(argc, argv);
+}

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -1289,50 +1289,6 @@ void LockRetentionPolicy(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name);
 }
 
-void SetCorsConfiguration(google::cloud::storage::Client client, int& argc,
-                          char* argv[]) {
-  if (argc != 3) {
-    throw Usage{"set-cors-configuration <bucket-name> <origin>"};
-  }
-  auto bucket_name = ConsumeArg(argc, argv);
-  auto origin = ConsumeArg(argc, argv);
-  //! [cors configuration] [START storage_cors_configuration]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string origin) {
-    StatusOr<gcs::BucketMetadata> original =
-        client.GetBucketMetadata(bucket_name);
-
-    if (!original) throw std::runtime_error(original.status().message());
-    std::vector<gcs::CorsEntry> cors_configuration;
-    cors_configuration.emplace_back(
-        gcs::CorsEntry{3600, {"GET"}, {origin}, {"Content-Type"}});
-
-    StatusOr<gcs::BucketMetadata> patched_metadata = client.PatchBucket(
-        bucket_name,
-        gcs::BucketMetadataPatchBuilder().SetCors(cors_configuration),
-        gcs::IfMetagenerationMatch(original->metageneration()));
-
-    if (!patched_metadata) {
-      throw std::runtime_error(patched_metadata.status().message());
-    }
-
-    if (patched_metadata->cors().empty()) {
-      std::cout << "Cors configuration is not set for bucket "
-                << patched_metadata->name() << "\n";
-      return;
-    }
-
-    std::cout << "Cors configuration successfully set for bucket "
-              << patched_metadata->name() << "\nNew cors configuration: ";
-    for (auto const& cors_entry : patched_metadata->cors()) {
-      std::cout << "\n  " << cors_entry;
-    }
-  }
-  //! [cors configuration] [END storage_cors_configuration]
-  (std::move(client), bucket_name, origin);
-}
-
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) try {
@@ -1391,7 +1347,6 @@ int main(int argc, char* argv[]) try {
       {"set-retention-policy", SetRetentionPolicy},
       {"remove-retention-policy", RemoveRetentionPolicy},
       {"lock-retention-policy", LockRetentionPolicy},
-      {"set-cors-configuration", SetCorsConfiguration},
   };
   for (auto&& kv : commands) {
     try {


### PR DESCRIPTION
This program is executed automatically by CMake/Bazel without any
additional scripts.

Fixes #3672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3720)
<!-- Reviewable:end -->
