### PR TITLE
feat: helper functions for bigtable async examples

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -294,7 +294,64 @@ Commands::value_type MakeCommandEntry(std::string const& name,
     argv.erase(argv.begin(), argv.begin() + common.size());
     command(std::move(table), cq, std::move(argv));
   };
-  return examples::Commands::value_type{name, std::move(adapter)};
+  return Commands::value_type{name, std::move(adapter)};
+}
+
+Commands::value_type MakeCommandEntry(
+    std::string const& name, std::vector<std::string> const& args,
+    InstanceAdminAsyncCommandType const& command) {
+  auto adapter = [=](std::vector<std::string> argv) {
+    std::vector<std::string> const common{"<project-id>"};
+    if (argv.size() != common.size() + args.size()) {
+      std::ostringstream os;
+      os << name;
+      for (auto const& a : common) {
+        os << " " << a;
+      }
+      for (auto const& a : args) {
+        os << " " << a;
+      }
+      throw Usage{std::move(os).str()};
+    }
+    google::cloud::bigtable::InstanceAdmin admin(
+        google::cloud::bigtable::CreateDefaultInstanceAdminClient(
+            argv[0], google::cloud::bigtable::ClientOptions()));
+    google::cloud::CompletionQueue cq;
+    std::thread t([&cq] { cq.Run(); });
+    AutoShutdownCQ shutdown(cq, std::move(t));
+    argv.erase(argv.begin(), argv.begin() + common.size());
+    command(std::move(admin), cq, std::move(argv));
+  };
+  return Commands::value_type{name, std::move(adapter)};
+}
+
+Commands::value_type MakeCommandEntry(
+    std::string const& name, std::vector<std::string> const& args,
+    TableAdminAsyncCommandType const& command) {
+  auto adapter = [=](std::vector<std::string> argv) {
+    std::vector<std::string> const common{"<project-id>", "<instance-id>"};
+    if (argv.size() != common.size() + args.size()) {
+      std::ostringstream os;
+      os << name;
+      for (auto const& a : common) {
+        os << " " << a;
+      }
+      for (auto const& a : args) {
+        os << " " << a;
+      }
+      throw Usage{std::move(os).str()};
+    }
+    google::cloud::bigtable::TableAdmin admin(
+        google::cloud::bigtable::CreateDefaultAdminClient(
+            argv[0], google::cloud::bigtable::ClientOptions()),
+        argv[1]);
+    google::cloud::CompletionQueue cq;
+    std::thread t([&cq] { cq.Run(); });
+    AutoShutdownCQ shutdown(cq, std::move(t));
+    argv.erase(argv.begin(), argv.begin() + common.size());
+    command(std::move(admin), cq, std::move(argv));
+  };
+  return Commands::value_type{name, std::move(adapter)};
 }
 
 }  // namespace examples

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -116,6 +116,22 @@ Commands::value_type MakeCommandEntry(std::string const& name,
                                       std::vector<std::string> const& args,
                                       TableAsyncCommandType const& command);
 
+using InstanceAdminAsyncCommandType = std::function<void(
+    google::cloud::bigtable::InstanceAdmin, google::cloud::CompletionQueue,
+    std::vector<std::string>)>;
+
+Commands::value_type MakeCommandEntry(
+    std::string const& name, std::vector<std::string> const& args,
+    InstanceAdminAsyncCommandType const& command);
+
+using TableAdminAsyncCommandType = std::function<void(
+    google::cloud::bigtable::TableAdmin, google::cloud::CompletionQueue,
+    std::vector<std::string>)>;
+
+Commands::value_type MakeCommandEntry(
+    std::string const& name, std::vector<std::string> const& args,
+    TableAdminAsyncCommandType const& command);
+
 }  // namespace examples
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
@@ -409,6 +409,67 @@ TEST(BigtableExamplesCommon, MakeTableAsyncCommandEntry) {
   EXPECT_EQ(1, call_count);
 }
 
+TEST(BigtableExamplesCommon, MakeInstanceAdminAsyncCommandEntry) {
+  // Pretend we are using the emulator to avoid loading the default
+  // credentials from $HOME, which do not exist when running with Bazel.
+  google::cloud::testing_util::ScopedEnvironment emulator(
+      "BIGTABLE_EMULATOR_HOST", "localhost:9090");
+
+  int call_count = 0;
+  auto command = [&call_count](bigtable::InstanceAdmin const&,
+                               CompletionQueue const&,
+                               std::vector<std::string> const& argv) {
+    ++call_count;
+    ASSERT_EQ(2, argv.size());
+    EXPECT_EQ("a", argv[0]);
+    EXPECT_EQ("b", argv[1]);
+  };
+  auto const actual = MakeCommandEntry("command-name", {"foo", "bar"}, command);
+  EXPECT_EQ("command-name", actual.first);
+  EXPECT_THROW(
+      try { actual.second({}); } catch (Usage const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("command-name"));
+        EXPECT_THAT(ex.what(), HasSubstr("foo"));
+        EXPECT_THAT(ex.what(), HasSubstr("bar"));
+        throw;
+      },
+      Usage);
+
+  ASSERT_NO_FATAL_FAILURE(actual.second({"unused-project", "a", "b"}));
+  EXPECT_EQ(1, call_count);
+}
+
+TEST(BigtableExamplesCommon, MakeTableAdminAsyncCommandEntry) {
+  // Pretend we are using the emulator to avoid loading the default
+  // credentials from $HOME, which do not exist when running with Bazel.
+  google::cloud::testing_util::ScopedEnvironment emulator(
+      "BIGTABLE_EMULATOR_HOST", "localhost:9090");
+
+  int call_count = 0;
+  auto command = [&call_count](bigtable::TableAdmin const&,
+                               CompletionQueue const&,
+                               std::vector<std::string> const& argv) {
+    ++call_count;
+    ASSERT_EQ(2, argv.size());
+    EXPECT_EQ("a", argv[0]);
+    EXPECT_EQ("b", argv[1]);
+  };
+  auto const actual = MakeCommandEntry("command-name", {"foo", "bar"}, command);
+  EXPECT_EQ("command-name", actual.first);
+  EXPECT_THROW(
+      try { actual.second({}); } catch (Usage const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("command-name"));
+        EXPECT_THAT(ex.what(), HasSubstr("foo"));
+        EXPECT_THAT(ex.what(), HasSubstr("bar"));
+        throw;
+      },
+      Usage);
+
+  ASSERT_NO_FATAL_FAILURE(
+      actual.second({"unused-project", "unused-instance", "a", "b"}));
+  EXPECT_EQ(1, call_count);
+}
+
 }  // namespace examples
 }  // namespace bigtable
 }  // namespace cloud


### PR DESCRIPTION
The Bigtable instance admin and table admin async examples will
benefit from a function to adapt an example of the form:

```C++
void F(
  bigtable::TableAdmin, CompletionQueue cq,
  std::vector<std::string> argv)
```

to something that just takes `std::vector<std::string>` as its only
argument. This PR creates two helper functions to create such adapters.

Part of the work for #3676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3721)
<!-- Reviewable:end -->
