### PR TITLE
ci: improve error handling for Windows+Bazel caching

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -145,6 +145,7 @@ if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "
 # Shutdown the Bazel server to release any locks
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel server"
 bazel $common_flags shutdown
+bazel shutdown
 
 if ((-not $IsPR) -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
@@ -159,16 +160,16 @@ if ((-not $IsPR) -and $CacheConfigured -and $Has7z) {
         "-spf",
         # Exclude directories named "install"
         "-xr!install",
-        # Suppress errors
-        "-bse0",
-        # Suppress progress
-        "-bsp0",
         # Suppress standard logging
-        "-bso0"
+        "-bso0",
+        # Suppress progress
+        "-bsp0"
     )
+    Remove-Item "${download_dir}\${CACHE_BASENAME}.tar" -ErrorAction SilentlyContinue
     7z a "${download_dir}\${CACHE_BASENAME}.tar" "${bazel_root}" ${archive_flags}
     if ($LastExitCode) {
-        # Ignore errors, caching failures should not break the build.
+        # Just report these errors and continue, caching failures should
+        # not break the build.
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "zipping cache contents failed with exit code ${LastExitCode}."
     } else {
@@ -179,6 +180,8 @@ if ((-not $IsPR) -and $CacheConfigured -and $Has7z) {
         gsutil -q cp "${download_dir}\${CACHE_BASENAME}.tar" `
             "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.tar"
         if ($LastExitCode) {
+            # Just report these errors and continue, caching failures should
+            # not break the build.
             Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
                 "uploading cache failed exit code ${LastExitCode}."
             Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -168,8 +168,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
-if (#TODO(coryan) - DO NOT MERGE (-not $IsPR) -and
-    $CacheConfigured -and $Has7z) {
+if ((-not $IsPR) -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -180,6 +180,8 @@ if (#TODO(coryan) - DO NOT MERGE (-not $IsPR) -and
         "-snl",
         # Preserve full path
         "-spf",
+        # Exclude directories named "install"
+        "-xr!install",
         # Suppress standard logging
         "-bso0",
         # Suppress progress


### PR DESCRIPTION
Remove any .tar files before trying to create them, because 7z fails
if they do exist.
Report more details about upload failures for better troubleshooting.
Shutdown each bazel invocation or we cannot tarball the Bazel cache.

Part of the work for #3534 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3727)
<!-- Reviewable:end -->
