### PR TITLE
refactor: run storage public object samples without scripts

### DIFF
--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -27,6 +27,7 @@ set(storage_autorun_examples
     storage_bucket_iam_samples.cc
     storage_object_cmek_samples.cc
     storage_policy_doc_samples.cc
+    storage_public_object_samples.cc
     storage_signed_url_v2_samples.cc
     storage_signed_url_v4_samples.cc
     storage_website_samples.cc)

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -692,31 +692,6 @@ run_all_object_rewrite_examples() {
 }
 
 ################################################
-# Run the example showing how to make objects public.
-# Globals:
-#   COLOR_*: colorize output messages, defined in colors.sh
-#   EXIT_STATUS: control the final exit status for the program.
-# Arguments:
-#   bucket_name: the name of the bucket to run the examples against.
-# Returns:
-#   None
-################################################
-run_all_public_object_examples() {
-  local bucket_name=$1
-  shift
-
-  local object_name="object-${RANDOM}-${RANDOM}.txt"
-  run_example ./storage_object_samples insert-object \
-      "${bucket_name}" "${object_name}" "a-string-to-serve-as-object-media"
-  run_example ./storage_object_samples make-object-public \
-      "${bucket_name}" "${object_name}"
-  run_example ./storage_object_samples read-object-unauthenticated \
-      "${bucket_name}" "${object_name}"
-  run_example ./storage_object_samples delete-object \
-      "${bucket_name}" "${object_name}"
-}
-
-################################################
 # Run the examples showing how to use event based holds.
 # Globals:
 #   COLOR_*: colorize output messages, defined in colors.sh
@@ -966,7 +941,6 @@ run_all_storage_examples() {
   run_resumable_file_upload_examples "${BUCKET_NAME}"
   run_resumable_write_object_examples "${BUCKET_NAME}"
   run_all_object_rewrite_examples "${BUCKET_NAME}" "${DESTINATION_BUCKET_NAME}"
-  run_all_public_object_examples "${BUCKET_NAME}"
   run_event_based_hold_examples "${BUCKET_NAME}"
   run_temporary_hold_examples "${BUCKET_NAME}"
   run_object_versioning_examples

--- a/google/cloud/storage/examples/storage_autorun_examples.bzl
+++ b/google/cloud/storage/examples/storage_autorun_examples.bzl
@@ -23,6 +23,7 @@ storage_autorun_examples = [
     "storage_bucket_iam_samples.cc",
     "storage_object_cmek_samples.cc",
     "storage_policy_doc_samples.cc",
+    "storage_public_object_samples.cc",
     "storage_signed_url_v2_samples.cc",
     "storage_signed_url_v4_samples.cc",
     "storage_website_samples.cc",

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -872,29 +872,6 @@ void PatchObjectContentType(google::cloud::storage::Client client, int& argc,
   (std::move(client), bucket_name, object_name, content_type);
 }
 
-void MakeObjectPublic(google::cloud::storage::Client client, int& argc,
-                      char* argv[]) {
-  if (argc != 3) {
-    throw Usage{"make-object-public <bucket-name> <object-name>"};
-  }
-  auto bucket_name = ConsumeArg(argc, argv);
-  auto object_name = ConsumeArg(argc, argv);
-  //! [make object public] [START storage_make_public]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
-    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
-        bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
-        gcs::PredefinedAcl::PublicRead());
-
-    if (!updated) throw std::runtime_error(updated.status().message());
-    std::cout << "Object updated. The full metadata after the update is: "
-              << *updated << "\n";
-  }
-  //! [make object public] [END storage_make_public]
-  (std::move(client), bucket_name, object_name);
-}
-
 void GenerateEncryptionKey(google::cloud::storage::Client, int& argc, char*[]) {
   if (argc != 1) {
     throw Usage{"generate-encryption-key"};
@@ -937,33 +914,6 @@ void GenerateEncryptionKey(google::cloud::storage::Client, int& argc, char*[]) {
   std::cout << "Base64 encoded key = " << data.key << "\n"
             << "Base64 encoded SHA256 of key = " << data.sha256 << "\n";
   //! [generate encryption key] [END storage_generate_encryption_key]
-}
-
-void ReadObjectUnauthenticated(google::cloud::storage::Client, int& argc,
-                               char* argv[]) {
-  if (argc != 3) {
-    throw Usage{"read-object-unauthenticated <bucket-name> <object-name>"};
-  }
-  auto bucket_name = ConsumeArg(argc, argv);
-  auto object_name = ConsumeArg(argc, argv);
-  //! [download_public_file] [START storage_download_public_file]
-  namespace gcs = google::cloud::storage;
-  [](std::string bucket_name, std::string object_name) {
-    // Create a client that does not authenticate with the server.
-    gcs::Client client{gcs::oauth2::CreateAnonymousCredentials()};
-
-    // Read an object, the object must have been made public.
-    gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
-
-    int count = 0;
-    std::string line;
-    while (std::getline(stream, line, '\n')) {
-      ++count;
-    }
-    std::cout << "The object has " << count << " lines\n";
-  }
-  //! [download_public_file] [END storage_download_public_file]
-  (bucket_name, object_name);
 }
 
 void WriteEncryptedObject(google::cloud::storage::Client client, int& argc,
@@ -1560,8 +1510,6 @@ int main(int argc, char* argv[]) try {
       {"update-object-metadata", UpdateObjectMetadata},
       {"patch-object-delete-metadata", PatchObjectDeleteMetadata},
       {"patch-object-content-type", PatchObjectContentType},
-      {"make-object-public", MakeObjectPublic},
-      {"read-object-unauthenticated", ReadObjectUnauthenticated},
       {"generate-encryption-key", GenerateEncryptionKey},
       {"write-encrypted-object", WriteEncryptedObject},
       {"read-encrypted-object", ReadEncryptedObject},

--- a/google/cloud/storage/examples/storage_public_object_samples.cc
+++ b/google/cloud/storage/examples/storage_public_object_samples.cc
@@ -1,0 +1,115 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/internal/getenv.h"
+#include <functional>
+#include <iostream>
+#include <map>
+
+namespace {
+
+using google::cloud::storage::examples::Usage;
+
+void MakeObjectPublic(google::cloud::storage::Client client,
+                      std::vector<std::string> const& argv) {
+  //! [make object public] [START storage_make_public]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+    StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
+        bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
+        gcs::PredefinedAcl::PublicRead());
+
+    if (!updated) throw std::runtime_error(updated.status().message());
+    std::cout << "Object updated. The full metadata after the update is: "
+              << *updated << "\n";
+  }
+  //! [make object public] [END storage_make_public]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
+void ReadObjectUnauthenticated(std::vector<std::string> const& argv) {
+  if (argv.size() != 2) {
+    throw Usage{"read-object-unauthenticated <bucket-name> <object-name>"};
+  }
+  //! [download_public_file] [START storage_download_public_file]
+  namespace gcs = google::cloud::storage;
+  [](std::string bucket_name, std::string object_name) {
+    // Create a client that does not authenticate with the server.
+    gcs::Client client{gcs::oauth2::CreateAnonymousCredentials()};
+
+    // Read an object, the object must have been made public.
+    gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
+
+    int count = 0;
+    std::string line;
+    while (std::getline(stream, line, '\n')) {
+      ++count;
+    }
+    std::cout << "The object has " << count << " lines\n";
+  }
+  //! [download_public_file] [END storage_download_public_file]
+  (argv.at(0), argv.at(1));
+}
+
+void RunAll(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::storage::examples;
+  namespace gcs = ::google::cloud::storage;
+
+  if (!argv.empty()) throw Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
+  });
+  auto const project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto const bucket_name = google::cloud::internal::GetEnv(
+                               "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
+                               .value();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const object_name =
+      examples::MakeRandomObjectName(generator, "public-object-") + ".txt";
+  auto client = gcs::Client::CreateDefaultClient().value();
+
+  auto const text = R"""(A bit of text to store in the test object.
+The actual contents are not interesting.
+)""";
+  std::cout << "\nCreating object to run the example (" << object_name << ")"
+            << std::endl;
+  auto meta = client.InsertObject(bucket_name, object_name, text).value();
+
+  std::cout << "\nRunning the MakeObjectPublic() example" << std::endl;
+  MakeObjectPublic(client, {bucket_name, object_name});
+
+  std::cout << "\nRunning the ReadObjectUnathenticated() example" << std::endl;
+  ReadObjectUnauthenticated({bucket_name, object_name});
+
+  (void)client.DeleteObject(bucket_name, object_name);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  namespace examples = ::google::cloud::storage::examples;
+  google::cloud::storage::examples::Example example({
+      examples::CreateCommandEntry("set-cors-configuration",
+                                   {"<bucket-name>", "<object-name>"},
+                                   MakeObjectPublic),
+      {"remove-cors-configuration", ReadObjectUnauthenticated},
+      {"auto", RunAll},
+  });
+  return example.Run(argc, argv);
+}


### PR DESCRIPTION
Use CMake/Bazel to drive the storage public object examples.

Fixes #3662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3738)
<!-- Reviewable:end -->
