### PR TITLE
ci: fix quickstart build for Windows+CMake

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -43,7 +43,7 @@ if ($args.count -ge 1) {
 # multiple times while debugging vcpkg installs.  It also works on Kokoro
 # where we cache the vcpkg installation, but it might be empty on the first
 # build.
-if (Test-Path env:RUNNING_CI) {
+if ((Test-Path env:RUNNING_CI) -and (Test-Path "${vcpkg_dir}")) {
     Remove-Item -LiteralPath "${vcpkg_dir}" -Force -Recurse
 }
 if (-not (Test-Path ${vcpkg_dir})) {


### PR DESCRIPTION
I did not test the case where the build is running under the CI system
well enough. I think I got it right this time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3739)
<!-- Reviewable:end -->
