### PR TITLE
cleanup: fix inconsistencies in the examples

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
+++ b/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc
@@ -19,6 +19,7 @@
 #include <sstream>
 
 namespace {
+
 using google::cloud::bigtable::examples::Usage;
 
 void AccessToken(std::vector<std::string> argv) {
@@ -116,9 +117,9 @@ void GCECredentials(std::vector<std::string> argv) {
 }
 
 void RunAll(std::vector<std::string> argv) {
-  if (!argv.empty()) throw Usage{"auto"};
-
   namespace examples = ::google::cloud::bigtable::examples;
+
+  if (!argv.empty()) throw Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -25,8 +25,6 @@ namespace cbt = google::cloud::bigtable;
 
 namespace {
 
-using google::cloud::bigtable::examples::CleanupOldTables;
-using google::cloud::bigtable::examples::RandomTableId;
 using google::cloud::bigtable::examples::Usage;
 
 void HelloWorldAppProfile(std::vector<std::string> argv) {
@@ -103,9 +101,9 @@ void HelloWorldAppProfile(std::vector<std::string> argv) {
 }
 
 void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::bigtable::examples::Usage{"auto"};
-
   namespace examples = ::google::cloud::bigtable::examples;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
   if (!examples::RunAdminIntegrationTests()) return;
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
@@ -121,10 +119,10 @@ void RunAll(std::vector<std::string> const& argv) {
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),
       instance_id);
 
-  CleanupOldTables("hw-app-profile-tbl-", admin);
+  examples::CleanupOldTables("hw-app-profile-tbl-", admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto table_id = RandomTableId("hw-app-profile-tbl-", generator);
+  auto table_id = examples::RandomTableId("hw-app-profile-tbl-", generator);
   auto schema = admin.CreateTable(
       table_id,
       cbt::TableConfig({{"fam", cbt::GcRule::MaxNumVersions(10)}}, {}));

--- a/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
@@ -23,8 +23,7 @@
 #include <iostream>
 
 namespace {
-using google::cloud::bigtable::examples::CleanupOldTables;
-using google::cloud::bigtable::examples::RandomTableId;
+
 using google::cloud::bigtable::examples::Usage;
 
 void HelloWorldTableAdmin(std::vector<std::string> const& argv) {
@@ -136,10 +135,10 @@ void RunAll(std::vector<std::string> const& argv) {
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),
       instance_id);
 
-  CleanupOldTables("hw-admin-tbl-", admin);
+  examples::CleanupOldTables("hw-admin-tbl-", admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto table_id = RandomTableId("hw-admin-tbl-", generator);
+  auto table_id = examples::RandomTableId("hw-admin-tbl-", generator);
 
   std::cout << "\nRunning the HelloWorldTableAdmin() example" << std::endl;
   HelloWorldTableAdmin({project_id, instance_id, table_id});

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! [bigtable includes]
-#include "google/cloud/bigtable/instance_admin.h"
-//! [bigtable includes]
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/internal/getenv.h"
 
 namespace {
 
-using google::cloud::bigtable::examples::RandomTableId;
 using google::cloud::bigtable::examples::Usage;
 
 void CreateInstance(google::cloud::bigtable::InstanceAdmin instance_admin,

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! [bigtable includes]
-#include "google/cloud/bigtable/table.h"
-//! [bigtable includes]
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/bigtable/table.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include <sstream>
 
 namespace {
-
-using google::cloud::bigtable::examples::CleanupOldTables;
-using google::cloud::bigtable::examples::RandomTableId;
-using google::cloud::bigtable::examples::Usage;
 
 void AsyncApply(google::cloud::bigtable::Table table,
                 google::cloud::bigtable::CompletionQueue cq,
@@ -293,8 +287,9 @@ void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
 
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::bigtable::examples;
+  namespace cbt = google::cloud::bigtable;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
@@ -305,7 +300,6 @@ void RunAll(std::vector<std::string> const& argv) {
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
                                .value();
 
-  namespace cbt = google::cloud::bigtable;
   cbt::TableAdmin admin(
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),
       instance_id);
@@ -313,7 +307,7 @@ void RunAll(std::vector<std::string> const& argv) {
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  CleanupOldTables("data-async-", admin);
+  examples::CleanupOldTables("data-async-", admin);
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -24,8 +24,6 @@
 
 namespace {
 
-using google::cloud::bigtable::examples::CleanupOldTables;
-using google::cloud::bigtable::examples::RandomTableId;
 using google::cloud::bigtable::examples::Usage;
 
 void Apply(google::cloud::bigtable::Table table,
@@ -923,8 +921,10 @@ std::string DefaultTablePrefix() { return "tbl-data-"; }
 
 void RunMutateExamples(google::cloud::bigtable::TableAdmin admin,
                        google::cloud::internal::DefaultPRNG& generator) {
+  namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = google::cloud::bigtable;
-  auto table_id = RandomTableId(DefaultTablePrefix(), generator);
+
+  auto table_id = examples::RandomTableId(DefaultTablePrefix(), generator);
   auto schema = admin.CreateTable(
       table_id,
       cbt::TableConfig({{"fam", cbt::GcRule::MaxNumVersions(10)}}, {}));
@@ -948,8 +948,10 @@ void RunMutateExamples(google::cloud::bigtable::TableAdmin admin,
 
 void RunWriteExamples(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::internal::DefaultPRNG& generator) {
+  namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = google::cloud::bigtable;
-  auto table_id = RandomTableId("mobile-time-series-", generator);
+
+  auto table_id = examples::RandomTableId("mobile-time-series-", generator);
   auto schema = admin.CreateTable(
       table_id, cbt::TableConfig(
                     {{"stats_summary", cbt::GcRule::MaxNumVersions(11)}}, {}));
@@ -979,8 +981,10 @@ void RunWriteExamples(google::cloud::bigtable::TableAdmin admin,
 
 void RunDataExamples(google::cloud::bigtable::TableAdmin admin,
                      google::cloud::internal::DefaultPRNG& generator) {
+  namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = google::cloud::bigtable;
-  auto table_id = RandomTableId(DefaultTablePrefix(), generator);
+
+  auto table_id = examples::RandomTableId(DefaultTablePrefix(), generator);
   std::cout << "Creating table " << table_id << std::endl;
   auto schema = admin.CreateTable(
       table_id,
@@ -1115,9 +1119,10 @@ void RunDataExamples(google::cloud::bigtable::TableAdmin admin,
 }
 
 void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw google::cloud::bigtable::examples::Usage{"auto"};
-
   namespace examples = ::google::cloud::bigtable::examples;
+  namespace cbt = google::cloud::bigtable;
+
+  if (!argv.empty()) throw google::cloud::bigtable::examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
@@ -1128,7 +1133,6 @@ void RunAll(std::vector<std::string> const& argv) {
                                "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID")
                                .value();
 
-  namespace cbt = google::cloud::bigtable;
   cbt::TableAdmin admin(
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),
       instance_id);
@@ -1136,8 +1140,8 @@ void RunAll(std::vector<std::string> const& argv) {
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  CleanupOldTables(DefaultTablePrefix(), admin);
-  CleanupOldTables("mobile-time-series-", admin);
+  examples::CleanupOldTables(DefaultTablePrefix(), admin);
+  examples::CleanupOldTables("mobile-time-series-", admin);
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! [bigtable includes]
+#include "google/cloud/bigtable/examples/bigtable_examples_common.h"
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/bigtable/instance_admin_client.h"
-//! [bigtable includes]
-#include "google/cloud/bigtable/examples/bigtable_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include <sstream>

--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -14,11 +14,8 @@
 
 //! [all code]
 
-//! [bigtable includes]
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
-//! [bigtable includes]
-
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/stats/stdout/stdout_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"

--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
 #include <google/protobuf/text_format.h>
 #include <algorithm>

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -13,18 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
-//! [bigtable includes]
-#include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
-//! [bigtable includes]
 #include "google/cloud/internal/getenv.h"
 #include <sstream>
 
 namespace {
-
-using google::cloud::bigtable::examples::CleanupOldTables;
-using google::cloud::bigtable::examples::RandomTableId;
-using google::cloud::bigtable::examples::Usage;
 
 void CreateTable(google::cloud::bigtable::TableAdmin admin,
                  std::vector<std::string> const& argv) {
@@ -509,7 +502,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::bigtable::examples;
   namespace cbt = google::cloud::bigtable;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID",
@@ -529,7 +522,7 @@ void RunAll(std::vector<std::string> const& argv) {
   // remove stale tables after 48 hours.
   std::cout << "\nCleaning up old tables" << std::endl;
   std::string const prefix = "table-admin-snippets-";
-  CleanupOldTables(prefix, admin);
+  examples::CleanupOldTables(prefix, admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   // This table is actually created and used to test the positive case (e.g.

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -18,13 +18,8 @@
 #include <functional>
 #include <iostream>
 #include <map>
-#include <sstream>
 
 namespace {
-
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
 
 void ListBucketAcl(google::cloud::storage::Client client,
                    std::vector<std::string> const& argv) {
@@ -226,11 +221,10 @@ void RemoveBucketOwner(google::cloud::storage::Client client,
 }
 
 void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw Usage{"auto"};
-
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT",

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -21,8 +21,6 @@
 
 namespace {
 
-using google::cloud::storage::examples::Usage;
-
 void SetCorsConfiguration(google::cloud::storage::Client client,
                           std::vector<std::string> const& argv) {
   //! [cors configuration] [START storage_cors_configuration]
@@ -88,7 +86,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
   });

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -17,13 +17,8 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
 
 namespace {
-
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
 
 void AddBucketDefaultKmsKey(google::cloud::storage::Client client,
                             std::vector<std::string> const& argv) {
@@ -96,11 +91,10 @@ void RemoveBucketDefaultKmsKey(google::cloud::storage::Client client,
 }
 
 void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw Usage{"auto"};
-
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY",

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -15,12 +15,10 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
-#include <functional>
 #include <iostream>
 
 namespace {
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
+
 using google::cloud::storage::examples::Usage;
 
 void GetBucketIamPolicy(google::cloud::storage::Client client,

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -21,8 +21,6 @@
 
 namespace {
 
-using google::cloud::storage::examples::Usage;
-
 void GetBilling(google::cloud::storage::Client client,
                 std::vector<std::string> const& argv) {
   //! [get billing] [START storage_get_requester_pays_status]
@@ -172,7 +170,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
   });

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -19,8 +19,6 @@
 
 namespace {
 
-using google::cloud::storage::examples::Usage;
-
 void ListNotifications(google::cloud::storage::Client client,
                        std::vector<std::string> const& argv) {
   //! [list notifications] [START storage_list_bucket_notifications]
@@ -111,7 +109,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME",

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -21,10 +21,6 @@
 
 namespace {
 
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
-
 void WriteObjectWithKmsKey(google::cloud::storage::Client client,
                            std::vector<std::string> const& argv) {
   //! [write object with kms key] [START storage_upload_with_kms_key]
@@ -93,11 +89,10 @@ void GetObjectKmsKey(google::cloud::storage::Client client,
 }
 
 void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw Usage{"auto"};
-
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY",

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -15,15 +15,10 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
-#include <functional>
 #include <iostream>
 #include <sstream>
 
 namespace {
-
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
 
 void CreateSignedPolicyDocumentV2(google::cloud::storage::Client client,
                                   std::vector<std::string> const& argv) {
@@ -126,7 +121,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
   });

--- a/google/cloud/storage/examples/storage_public_object_samples.cc
+++ b/google/cloud/storage/examples/storage_public_object_samples.cc
@@ -69,7 +69,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -19,8 +19,6 @@
 
 namespace {
 
-using google::cloud::storage::examples::Usage;
-
 void GetServiceAccount(google::cloud::storage::Client client,
                        std::vector<std::string> const&) {
   //! [START storage_get_service_account] [get service account]
@@ -235,7 +233,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT",

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -15,14 +15,9 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
-#include <functional>
 #include <iostream>
 
 namespace {
-
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
 
 void CreateGetSignedUrlV2(google::cloud::storage::Client client,
                           std::vector<std::string> const& argv) {
@@ -70,7 +65,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -15,16 +15,9 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
-#include <functional>
 #include <iostream>
-#include <map>
-#include <sstream>
 
 namespace {
-
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
 
 void CreateGetSignedUrlV4(google::cloud::storage::Client client,
                           std::vector<std::string> const& argv) {
@@ -70,7 +63,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -15,15 +15,9 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
-#include <functional>
 #include <iostream>
-#include <map>
-#include <sstream>
 
 namespace {
-using google::cloud::storage::examples::Commands;
-using google::cloud::storage::examples::CommandType;
-using google::cloud::storage::examples::Usage;
 
 void GetStaticWebsiteConfiguration(google::cloud::storage::Client client,
                                    std::vector<std::string> const& argv) {
@@ -132,7 +126,7 @@ void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
 
-  if (!argv.empty()) throw Usage{"auto"};
+  if (!argv.empty()) throw examples::Usage{"auto"};
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
   });


### PR DESCRIPTION
Put any namespace aliases before the executable code. Removed unnecessary
using-declarations. Removed unused doxygen tags. Removed unnecessary
include directives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3750)
<!-- Reviewable:end -->
