### PR TITLE
cleanup(ci): simplify integration tests configuration

### DIFF
--- a/ci/etc/kokoro/install/run-installed-programs.sh
+++ b/ci/etc/kokoro/install/run-installed-programs.sh
@@ -17,7 +17,7 @@ CONFIG_DIRECTORY="${KOKORO_GFILE_DIR:-/dev/shm}"
 readonly CONFIG_DIRECTORY
 if [[ -r "${CONFIG_DIRECTORY}/service-account.json" && \
       -r "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh" ]]; then
-  source "${CONFIG_DIRECTORY}/test-configuration.sh"
+  source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
 
   run_args=(
     # Remove the container after running

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -52,7 +52,7 @@ fi
 
 declare -A quickstart_args=()
 
-if [[ -r "/c/test-configuration.sh" ]]; then
+if [[ -r "/c/service-account.json" ]]; then
   # shellcheck disable=SC1091
   source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
   # TODO(#3604) - figure out how to run pass arguments safely
@@ -81,7 +81,7 @@ build_service() {
     log_normal "compiling quickstart program for ${service}"
     "${BAZEL_BIN}" build  "${bazel_args[@]}" -- ...
 
-    if [[ -r "/c/test-configuration.sh" ]]; then
+    if [[ -r "/c/service-account.json" ]]; then
       log_normal "running quickstart program for ${service}"
       env "${run_vars[@]}" "${BAZEL_BIN}" run "${bazel_args[@]}" \
           "--spawn_strategy=local" \

--- a/ci/kokoro/docker/integration-nightly.cfg
+++ b/ci/kokoro/docker/integration-nightly.cfg
@@ -15,5 +15,4 @@
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/docker/integration-presubmit.cfg
+++ b/ci/kokoro/docker/integration-presubmit.cfg
@@ -15,5 +15,4 @@
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/docker/integration.cfg
+++ b/ci/kokoro/docker/integration.cfg
@@ -15,5 +15,4 @@
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/install/common.cfg
+++ b/ci/kokoro/install/common.cfg
@@ -19,4 +19,3 @@ timeout_mins: 120
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"

--- a/ci/kokoro/macos/common.cfg
+++ b/ci/kokoro/macos/common.cfg
@@ -16,5 +16,4 @@ build_file: "google-cloud-cpp/ci/kokoro/macos/build.sh"
 timeout_mins: 60
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/test-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"


### PR DESCRIPTION
Remove uses of the external configuration for integration tests, and
always use the configuration in `ci/etc/`. In some cases we were using
the presence of `${KOKORO_GFILE_DIR}/test-configuration.sh` as a marker
to indicate that the integration tests were configured. We now use the
service account credentials for that purpose, which are needed in any
case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3752)
<!-- Reviewable:end -->
