### PR TITLE
ci: use separate service account to setup test environment

### DIFF
--- a/ci/kokoro/docker/coverage.cfg
+++ b/ci/kokoro/docker/coverage.cfg
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/google-cloud-cpp/codecov-io-upload-token"

--- a/ci/kokoro/docker/integration-nightly.cfg
+++ b/ci/kokoro/docker/integration-nightly.cfg
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/docker/integration-presubmit.cfg
+++ b/ci/kokoro/docker/integration-presubmit.cfg
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/docker/integration.cfg
+++ b/ci/kokoro/docker/integration.cfg
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -17,6 +17,7 @@ build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
 timeout_mins: 120
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/service-account.p12"
 


### PR DESCRIPTION
I also cleaned up a shellcheck warning.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3754)
<!-- Reviewable:end -->
