### PR TITLE
refactor: simplify googleapis.BUILD rules

### DIFF
--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -32,11 +32,7 @@ cc_library(
 cc_proto_library(
     name = "bigtableadmin_cc_proto",
     deps = ["//google/bigtable/admin/v2:admin_proto"],
-)
-
-cc_proto_library(
-    name = "bigtable_cc_proto",
-    deps = ["//google/bigtable/v2:bigtable_proto"],
+    visibility = [ "//visibility:private"],
 )
 
 cc_grpc_library(
@@ -45,37 +41,19 @@ cc_grpc_library(
         "//google/bigtable/admin/v2:admin_proto",
     ],
     grpc_only = True,
-    use_external = True,
-    well_known_protos = True,
     deps = [
         ":bigtableadmin_cc_proto",
         "//google/longrunning:longrunning_cc_grpc",
-        "@com_github_grpc_grpc//:grpc++",
     ],
-)
-
-cc_grpc_library(
-    name = "bigtable_cc_grpc",
-    srcs = ["//google/bigtable/v2:bigtable_proto"],
-    grpc_only = True,
-    use_external = True,
-    well_known_protos = True,
-    deps = [
-        ":bigtable_cc_proto",
-        "@com_github_grpc_grpc//:grpc++",
-    ],
+    visibility = [ "//visibility:private"],
 )
 
 cc_library(
     name = "bigtable_protos",
-    includes = [
-        ".",
-    ],
+    # Do not sort: grpc++ must come last
     deps = [
-        ":bigtable_cc_grpc",
-        ":bigtable_cc_proto",
         ":bigtableadmin_cc_grpc",
-        ":bigtableadmin_cc_proto",
+        "//google/bigtable/v2:bigtable_cc_grpc",
         "//google/rpc:error_details_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
     ],

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -31,8 +31,8 @@ cc_library(
 
 cc_proto_library(
     name = "bigtableadmin_cc_proto",
+    visibility = ["//visibility:private"],
     deps = ["//google/bigtable/admin/v2:admin_proto"],
-    visibility = [ "//visibility:private"],
 )
 
 cc_grpc_library(
@@ -41,11 +41,11 @@ cc_grpc_library(
         "//google/bigtable/admin/v2:admin_proto",
     ],
     grpc_only = True,
+    visibility = ["//visibility:private"],
     deps = [
         ":bigtableadmin_cc_proto",
         "//google/longrunning:longrunning_cc_grpc",
     ],
-    visibility = [ "//visibility:private"],
 )
 
 cc_library(


### PR DESCRIPTION
This PR simplifies the `googleapis.BUILD` rules by using the canonical
rules that are defined in the googleapis repo if/when they exist,
and explicitly using a `# Do not sort` comment to make it clear that the
`grpc++` target must come last.

This also removes some bazel rule attributes that weren't needed, in an
effort to simplify a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3774)
<!-- Reviewable:end -->
