### PR TITLE
feat: update to new version of googleapis protos

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -64,10 +64,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/bf839ae632e0f263a729569e44be4b38b1c85f9c.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/fea22b1d9f27f86ef355c1d0dba00e0791a08a19.tar.gz",
             ],
-            strip_prefix = "googleapis-bf839ae632e0f263a729569e44be4b38b1c85f9c",
-            sha256 = "874a4ad1f65c346a8a73c91e78cca0d49e5da3be5a7e58a05d6b2c74bc331ac6",
+            strip_prefix = "googleapis-fea22b1d9f27f86ef355c1d0dba00e0791a08a19",
+            sha256 = "957ef432cdedbace1621bb023e6d8637ecbaa78856b3fc6e299f9b277ae990ff",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -34,27 +34,7 @@ cc_library(
     # Do not sort: grpc++ must come last
     deps = [
         "@com_google_googleapis//google/cloud/bigquery/storage/v1beta1:storage_cc_grpc",
-        "@com_google_googleapis//google/cloud/bigquery/storage/v1beta1:storage_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
-    ],
-)
-
-cc_proto_library(
-    name = "bigtableadmin_cc_proto",
-    visibility = ["//visibility:private"],
-    deps = ["//google/bigtable/admin/v2:admin_proto"],
-)
-
-cc_grpc_library(
-    name = "bigtableadmin_cc_grpc",
-    srcs = [
-        "//google/bigtable/admin/v2:admin_proto",
-    ],
-    grpc_only = True,
-    visibility = ["//visibility:private"],
-    deps = [
-        ":bigtableadmin_cc_proto",
-        "//google/longrunning:longrunning_cc_grpc",
     ],
 )
 
@@ -62,9 +42,8 @@ cc_library(
     name = "bigtable_protos",
     # Do not sort: grpc++ must come last
     deps = [
-        ":bigtableadmin_cc_grpc",
+        "//google/bigtable/admin/v2:admin_cc_grpc",
         "//google/bigtable/v2:bigtable_cc_grpc",
-        "//google/rpc:error_details_cc_proto",
         "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/google/cloud/bigtable/BUILD
+++ b/google/cloud/bigtable/BUILD
@@ -29,6 +29,8 @@ cc_library(
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_grpc_utils",
         "@com_google_googleapis//:bigtable_protos",
+        "@com_google_googleapis//google/longrunning:longrunning_cc_grpc",
+        "@com_google_googleapis//google/rpc:error_details_cc_proto",
     ],
 )
 


### PR DESCRIPTION
With this version, we can now use the googleapis-provided BUILD files
for the Bigtable Admin V2 protos, so we don't need to define our own. I
also move the unnecessary proto deps out of the `googleapis.BUILD` file
to make the targets in there look more consistent -- they only exist so
that we can explicitly sort the `grpc++` target *after* the grpc proto
rules that depend on it (this is working around a grpc issue).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3779)
<!-- Reviewable:end -->
