### PR TITLE
test: move ubsan tests to cmake

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,16 +41,6 @@ build:tsan --copt=-fno-omit-frame-pointer
 build:tsan --linkopt=-fsanitize=thread
 build:tsan --action_env=TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1
 
-# --config ubsan: Undefined Behavior Sanitizer
-build:ubsan --strip=never
-build:ubsan --copt=-Og
-build:ubsan --copt=-g
-build:ubsan --copt=-fsanitize=undefined
-build:ubsan --copt=-fno-omit-frame-pointer
-build:ubsan --linkopt=-fsanitize=undefined
-build:ubsan --linkopt=-lubsan
-build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
-
 # --config msan: Memory Sanitizer
 build:msan --strip=never
 build:msan --copt=-Og

--- a/.ubsan_suppressions.txt
+++ b/.ubsan_suppressions.txt
@@ -1,0 +1,1 @@
+bounds:random.tcc

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -123,6 +123,13 @@ if [[ "${BUILD_TYPE}" == "Coverage" ]]; then
 fi
 readonly TEST_JOB_COUNT
 
+if [[ "${BUILD_TYPE}" == "UBSan" ]]; then
+  # Make sure that tests which don't pass UBSan produce a meaningful error.
+  ABS_SOURCE_DIR=$( cd "${SOURCE_DIR}" ; pwd)
+  readonly UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:suppressions=${ABS_SOURCE_DIR}/.ubsan_suppressions.txt
+  export UBSAN_OPTIONS
+fi
+
 ctest_args=("--output-on-failure" "-j" "${TEST_JOB_COUNT}")
 if [[ -n "${RUNS_PER_TEST}" ]]; then
     ctest_args+=("--repeat-until-fail" "${RUNS_PER_TEST}")

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -121,12 +121,12 @@ elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   # Compile with the UndefinedBehaviorSanitizer enabled.
+  export DISTRO=fedora-install
+  export DISTRO_VERSION=31
   export CC=clang
   export CXX=clang++
-  export DISTRO=ubuntu
-  export DISTRO_VERSION=18.04
-  export BAZEL_CONFIG="ubsan"
-  in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
+  export BUILD_TYPE=UBSan
+  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="super"
   export BUILD_TYPE=Release

--- a/cmake/EnableUBSan.cmake
+++ b/cmake/EnableUBSan.cmake
@@ -1,0 +1,48 @@
+# ~~~
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# For the Clang compiler families, enable a UBSan build type.
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # UBSan build type
+    set(CMAKE_CXX_FLAGS_UBSAN
+        "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer"
+        CACHE STRING "Flags used by the C++ compiler during UBSan builds."
+              FORCE)
+
+    # A bit of a hack: we should not assume the C compiler also supports these
+    # flags
+    set(CMAKE_C_FLAGS_UBSAN
+        "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer"
+        CACHE STRING "Flags used by the C compiler during UBSan builds." FORCE)
+    set(CMAKE_EXE_LINKER_FLAGS_UBSAN
+        "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=undefined"
+        CACHE STRING "Flags used for linking binaries during UBSan builds."
+              FORCE)
+    set(CMAKE_SHARED_LINKER_FLAGS_UBSAN
+        "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined"
+        CACHE STRING
+              "Flags used by the shared libraries linker during UBSan builds."
+              FORCE)
+    mark_as_advanced(
+        CMAKE_CXX_FLAGS_UBSAN CMAKE_C_FLAGS_UBSAN CMAKE_EXE_LINKER_FLAGS_UBSAN
+        CMAKE_SHARED_LINKER_FLAGS_UBSAN)
+    set(CMAKE_BUILD_TYPE
+        "${CMAKE_BUILD_TYPE}"
+        CACHE
+            STRING
+            "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel Coverage UBSan."
+            FORCE)
+endif ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -33,6 +33,9 @@ endif ()
 # If possible, enable a code coverage build type.
 include(EnableCoverage)
 
+# If possible, enable a UBSan build type.
+include(EnableUBSan)
+
 # Include support for clang-tidy if available
 include(EnableClangTidy)
 


### PR DESCRIPTION
Issue #3687 has shown that ubsan needs an update. The failure generated
by it couldn't be suppressed. bazel couldn't be used with newer versions
of clang  ecause of https://github.com/bazelbuild/bazel/issues/11122, so
the only option was to move ubsan to cmake and workaround the bazel bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3780)
<!-- Reviewable:end -->
