### PR TITLE
fix: storage_client_mock_samples is a unit test

### DIFF
--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -36,6 +36,7 @@ load(":storage_examples_unit_tests.bzl", "storage_examples_unit_tests")
     deps = [
         ":storage_examples_common",
         "//google/cloud/storage:storage_client",
+        "//google/cloud/storage:storage_client_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -45,8 +45,9 @@ set(storage_examples
     storage_bucket_samples.cc storage_object_acl_samples.cc
     storage_object_samples.cc)
 
-set(storage_examples_unit_tests # cmake-format: sort
-                                storage_examples_common_test.cc)
+set(storage_examples_unit_tests
+    # cmake-format: sort
+    storage_client_mock_samples.cc storage_examples_common_test.cc)
 
 include(CreateBazelConfig)
 export_list_to_bazel("storage_autorun_examples.bzl" "storage_autorun_examples")

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -25,7 +25,6 @@
 namespace {
 
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -95,35 +94,33 @@ TEST(StorageMockingSamples, MockWriteObject) {
   gcs::ObjectMetadata expected_metadata;
 
   EXPECT_CALL(*mock, CreateResumableSession(_))
-      .WillOnce(
-          Invoke([&expected_metadata](
-                     gcs::internal::ResumableUploadRequest const& request) {
-            EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
-            auto* mock_result = new gcs::testing::MockResumableUploadSession;
-            using gcs::internal::ResumableUploadResponse;
-            EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
-            EXPECT_CALL(*mock_result, next_expected_byte())
-                .WillRepeatedly(Return(0));
-            EXPECT_CALL(*mock_result, UploadChunk(_))
-                .WillRepeatedly(Return(
-                    google::cloud::make_status_or(ResumableUploadResponse{
-                        "fake-url",
-                        0,
-                        {},
-                        ResumableUploadResponse::kInProgress,
-                        {}})));
-            EXPECT_CALL(*mock_result, UploadFinalChunk(_, _))
-                .WillRepeatedly(Return(google::cloud::make_status_or(
-                    ResumableUploadResponse{"fake-url",
-                                            0,
-                                            expected_metadata,
-                                            ResumableUploadResponse::kDone,
-                                            {}})));
+      .WillOnce([&expected_metadata](
+                    gcs::internal::ResumableUploadRequest const& request) {
+        EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
+        auto* mock_result = new gcs::testing::MockResumableUploadSession;
+        using gcs::internal::ResumableUploadResponse;
+        EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mock_result, next_expected_byte())
+            .WillRepeatedly(Return(0));
+        EXPECT_CALL(*mock_result, UploadChunk(_))
+            .WillRepeatedly(Return(google::cloud::make_status_or(
+                ResumableUploadResponse{"fake-url",
+                                        0,
+                                        {},
+                                        ResumableUploadResponse::kInProgress,
+                                        {}})));
+        EXPECT_CALL(*mock_result, UploadFinalChunk(_, _))
+            .WillRepeatedly(Return(google::cloud::make_status_or(
+                ResumableUploadResponse{"fake-url",
+                                        0,
+                                        expected_metadata,
+                                        ResumableUploadResponse::kDone,
+                                        {}})));
 
-            std::unique_ptr<gcs::internal::ResumableUploadSession> result(
-                mock_result);
-            return google::cloud::make_status_or(std::move(result));
-          }));
+        std::unique_ptr<gcs::internal::ResumableUploadSession> result(
+            mock_result);
+        return google::cloud::make_status_or(std::move(result));
+      });
 
   auto stream = client.WriteObject("mock-bucket-name", "mock-object-name");
   stream << "Hello World!";
@@ -147,23 +144,21 @@ TEST(StorageMockingSamples, MockReadObjectFailure) {
 
   std::string text = "this is a mock http response";
   EXPECT_CALL(*mock, ReadObject(_))
-      .WillOnce(
-          Invoke([](gcs::internal::ReadObjectRangeRequest const& request) {
-            EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
-            auto* mock_source = new gcs::testing::MockObjectReadSource;
-            EXPECT_CALL(*mock_source, IsOpen())
-                .WillOnce(Return(true))
-                .WillRepeatedly(Return(false));
-            EXPECT_CALL(*mock_source, Read(_, _))
-                .WillOnce(Return(google::cloud::Status(
-                    google::cloud::StatusCode::kInvalidArgument,
-                    "Invalid Argument")));
+      .WillOnce([](gcs::internal::ReadObjectRangeRequest const& request) {
+        EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
+        auto* mock_source = new gcs::testing::MockObjectReadSource;
+        EXPECT_CALL(*mock_source, IsOpen())
+            .WillOnce(Return(true))
+            .WillRepeatedly(Return(false));
+        EXPECT_CALL(*mock_source, Read(_, _))
+            .WillOnce(Return(google::cloud::Status(
+                google::cloud::StatusCode::kInvalidArgument,
+                "Invalid Argument")));
 
-            std::unique_ptr<gcs::internal::ObjectReadSource> result(
-                mock_source);
+        std::unique_ptr<gcs::internal::ObjectReadSource> result(mock_source);
 
-            return google::cloud::make_status_or(std::move(result));
-          }));
+        return google::cloud::make_status_or(std::move(result));
+      });
 
   gcs::ObjectReadStream stream =
       client.ReadObject("mock-bucket-name", "mock-object-name");
@@ -186,27 +181,26 @@ TEST(StorageMockingSamples, MockWriteObjectFailure) {
   gcs::Client client(mock);
 
   EXPECT_CALL(*mock, CreateResumableSession(_))
-      .WillOnce(
-          Invoke([](gcs::internal::ResumableUploadRequest const& request) {
-            EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
-            auto* mock_result = new gcs::testing::MockResumableUploadSession;
-            using gcs::internal::ResumableUploadResponse;
-            EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
-            EXPECT_CALL(*mock_result, next_expected_byte())
-                .WillRepeatedly(Return(0));
-            EXPECT_CALL(*mock_result, UploadChunk(_))
-                .WillRepeatedly(Return(google::cloud::Status(
-                    google::cloud::StatusCode::kInvalidArgument,
-                    "Invalid Argument")));
-            EXPECT_CALL(*mock_result, UploadFinalChunk(_, _))
-                .WillRepeatedly(Return(google::cloud::Status(
-                    google::cloud::StatusCode::kInvalidArgument,
-                    "Invalid Argument")));
+      .WillOnce([](gcs::internal::ResumableUploadRequest const& request) {
+        EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
+        auto* mock_result = new gcs::testing::MockResumableUploadSession;
+        using gcs::internal::ResumableUploadResponse;
+        EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
+        EXPECT_CALL(*mock_result, next_expected_byte())
+            .WillRepeatedly(Return(0));
+        EXPECT_CALL(*mock_result, UploadChunk(_))
+            .WillRepeatedly(Return(google::cloud::Status(
+                google::cloud::StatusCode::kInvalidArgument,
+                "Invalid Argument")));
+        EXPECT_CALL(*mock_result, UploadFinalChunk(_, _))
+            .WillRepeatedly(Return(google::cloud::Status(
+                google::cloud::StatusCode::kInvalidArgument,
+                "Invalid Argument")));
 
-            std::unique_ptr<gcs::internal::ResumableUploadSession> result(
-                mock_result);
-            return google::cloud::make_status_or(std::move(result));
-          }));
+        std::unique_ptr<gcs::internal::ResumableUploadSession> result(
+            mock_result);
+        return google::cloud::make_status_or(std::move(result));
+      });
 
   auto stream = client.WriteObject("mock-bucket-name", "mock-object-name");
   stream << "Hello World!";

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
-#include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/mock_client.h"
@@ -25,72 +24,63 @@
 
 namespace {
 
-using google::cloud::storage::examples::Usage;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnRef;
 
-void MockReadObject(std::vector<std::string> argv) {
-  if (argv.size() != 3) {
-    throw Usage{"mock-read-object <bucket-name> <object-name>"};
-  }
-  auto bucket_name = argv[0];
-  auto object_name = argv[1];
-
-  //! [mock successful readobject]
+//! [mock successful readobject]
+TEST(StorageMockingSamples, MockReadObject) {
   namespace gcs = google::cloud::storage;
+
   gcs::ClientOptions client_options =
       gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
   EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(testing::ReturnRef(client_options));
+      .WillRepeatedly(ReturnRef(client_options));
 
   gcs::Client client(mock);
 
-  std::string text = "this is a mock http response";
-  using ::testing::_;
+  std::string const text = "this is a mock http response";
+  std::size_t offset = 0;
+  // Simulate a Read() call in the MockObjectReadSource object created below
+  auto simulate_read = [&text, &offset](char* buf, std::size_t n) {
+    auto const l = (std::min)(n, text.size() - offset);
+    std::memcpy(buf, text.data() + offset, l);
+    offset += l;
+    return gcs::internal::ReadSourceResult{
+        l, gcs::internal::HttpResponse{200, {}, {}}};
+  };
   EXPECT_CALL(*mock, ReadObject(_))
-      .WillOnce(testing::Invoke(
-          [&text](gcs::internal::ReadObjectRangeRequest const& request) {
-            std::cout << "\nReading from bucket : " << request.bucket_name()
-                      << std::endl;
-            auto* mock_source = new gcs::testing::MockObjectReadSource;
-            EXPECT_CALL(*mock_source, IsOpen())
-                .WillOnce(testing::Return(true))
-                .WillRepeatedly(testing::Return(false));
-            EXPECT_CALL(*mock_source, Read(_, _))
-                .WillOnce(testing::Return(gcs::internal::ReadSourceResult{
-                    text.length(),
-                    gcs::internal::HttpResponse{200, text, {}}}));
+      .WillOnce([simulate_read](
+                    gcs::internal::ReadObjectRangeRequest const& request) {
+        EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
+        std::unique_ptr<gcs::testing::MockObjectReadSource> mock_source(
+            new gcs::testing::MockObjectReadSource);
+        EXPECT_CALL(*mock_source, IsOpen())
+            .WillOnce(Return(true))
+            .WillRepeatedly(Return(false));
+        EXPECT_CALL(*mock_source, Read(_, _)).WillRepeatedly(simulate_read);
 
-            std::unique_ptr<gcs::internal::ObjectReadSource> result(
-                mock_source);
+        return google::cloud::make_status_or(
+            std::unique_ptr<gcs::internal::ObjectReadSource>(
+                std::move(mock_source)));
+      });
 
-            return google::cloud::make_status_or(std::move(result));
-          }));
-
-  gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
+  gcs::ObjectReadStream stream =
+      client.ReadObject("mock-bucket-name", "mock-object-name");
 
   // Reading the payload of http response stored in stream
-  int count = 0;
-  std::string line;
-  while (std::getline(stream, line, '\n')) {
-    std::cout << "Reading line : " << line << std::endl;
-    ++count;
-  }
-
-  std::cout << "The object has " << count << " line(s)\n";
+  std::string actual{std::istreambuf_iterator<char>(stream), {}};
+  EXPECT_EQ(actual, text);
   stream.Close();
-  //! [mock successful readobject]
 }
+//! [mock successful readobject]
 
-void MockWriteObject(std::vector<std::string> argv) {
-  if (argv.size() != 3) {
-    throw Usage{"mock-write-object <bucket-name> <object-name>"};
-  }
-  auto bucket_name = argv[0];
-  auto object_name = argv[1];
-
-  //! [mock successful writeobject]
+//! [mock successful writeobject]
+TEST(StorageMockingSamples, MockWriteObject) {
   namespace gcs = google::cloud::storage;
   gcs::ClientOptions client_options =
       gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
@@ -98,20 +88,17 @@ void MockWriteObject(std::vector<std::string> argv) {
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
   EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(testing::ReturnRef(client_options));
+      .WillRepeatedly(ReturnRef(client_options));
 
   gcs::Client client(mock);
 
   gcs::ObjectMetadata expected_metadata;
 
-  using ::testing::_;
-  using ::testing::Return;
   EXPECT_CALL(*mock, CreateResumableSession(_))
-      .WillOnce(testing::Invoke(
-          [&expected_metadata](
-              gcs::internal::ResumableUploadRequest const& request) {
-            std::cout << "Writing to bucket : " << request.bucket_name()
-                      << std::endl;
+      .WillOnce(
+          Invoke([&expected_metadata](
+                     gcs::internal::ResumableUploadRequest const& request) {
+            EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
             auto* mock_result = new gcs::testing::MockResumableUploadSession;
             using gcs::internal::ResumableUploadResponse;
             EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
@@ -138,59 +125,37 @@ void MockWriteObject(std::vector<std::string> argv) {
             return google::cloud::make_status_or(std::move(result));
           }));
 
-  auto stream = client.WriteObject(bucket_name, object_name);
+  auto stream = client.WriteObject("mock-bucket-name", "mock-object-name");
   stream << "Hello World!";
   stream.Close();
   //! [mock successful writeobject]
 }
 
-void MockReadObjectFailure(std::vector<std::string> argv) {
-  if (argv.size() != 3) {
-    throw Usage{"mock-read-object-failure <bucket-name> <object-name>"};
-  }
-  auto bucket_name = argv[0];
-  auto object_name = argv[1];
-
-  //! [mock failed readobject]
+//! [mock failed readobject]
+TEST(StorageMockingSamples, MockReadObjectFailure) {
   namespace gcs = google::cloud::storage;
+
   gcs::ClientOptions client_options =
       gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
 
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
   EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(testing::ReturnRef(client_options));
+      .WillRepeatedly(ReturnRef(client_options));
 
   gcs::Client client(mock);
 
   std::string text = "this is a mock http response";
-  using ::testing::_;
   EXPECT_CALL(*mock, ReadObject(_))
-      .WillOnce(testing::Invoke(
-          [](gcs::internal::ReadObjectRangeRequest const& request) {
-            std::cout << "\nReading from bucket : " << request.bucket_name()
-                      << std::endl;
+      .WillOnce(
+          Invoke([](gcs::internal::ReadObjectRangeRequest const& request) {
+            EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
             auto* mock_source = new gcs::testing::MockObjectReadSource;
             EXPECT_CALL(*mock_source, IsOpen())
-                .WillOnce(testing::Return(true))
-                .WillRepeatedly(testing::Return(false));
+                .WillOnce(Return(true))
+                .WillRepeatedly(Return(false));
             EXPECT_CALL(*mock_source, Read(_, _))
-                .WillOnce(testing::Return(google::cloud::Status(
-                    google::cloud::StatusCode::kInvalidArgument,
-                    "Invalid Argument")));
-
-            std::unique_ptr<gcs::internal::ObjectReadSource> result(
-                mock_source);
-
-            return google::cloud::make_status_or(std::move(result));
-          }))
-      .WillOnce(testing::Invoke(
-          [](gcs::internal::ReadObjectRangeRequest const& request) {
-            std::cout << "\nRetry reading from bucket : "
-                      << request.bucket_name() << std::endl;
-            auto* mock_source = new gcs::testing::MockObjectReadSource;
-            EXPECT_CALL(*mock_source, Read(_, _))
-                .WillOnce(testing::Return(google::cloud::Status(
+                .WillOnce(Return(google::cloud::Status(
                     google::cloud::StatusCode::kInvalidArgument,
                     "Invalid Argument")));
 
@@ -200,25 +165,15 @@ void MockReadObjectFailure(std::vector<std::string> argv) {
             return google::cloud::make_status_or(std::move(result));
           }));
 
-  gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
-
-  if (stream.bad()) {
-    std::cerr << "\nError reading from stream... status=" << stream.status()
-              << std::endl;
-  }
+  gcs::ObjectReadStream stream =
+      client.ReadObject("mock-bucket-name", "mock-object-name");
+  EXPECT_TRUE(stream.bad());
   stream.Close();
-
-  //! [mock failed readobject]
 }
+//! [mock failed readobject]
 
-void MockWriteObjectFailure(std::vector<std::string> argv) {
-  if (argv.size() != 3) {
-    throw Usage{"mock-read-object-failure <bucket-name> <object-name>"};
-  }
-  auto bucket_name = argv[0];
-  auto object_name = argv[1];
-
-  //! [mock failed writeobject]
+//! [mock failed writeobject]
+TEST(StorageMockingSamples, MockWriteObjectFailure) {
   namespace gcs = google::cloud::storage;
   gcs::ClientOptions client_options =
       gcs::ClientOptions(gcs::oauth2::CreateAnonymousCredentials());
@@ -226,17 +181,14 @@ void MockWriteObjectFailure(std::vector<std::string> argv) {
   std::shared_ptr<gcs::testing::MockClient> mock =
       std::make_shared<gcs::testing::MockClient>();
   EXPECT_CALL(*mock, client_options())
-      .WillRepeatedly(testing::ReturnRef(client_options));
+      .WillRepeatedly(ReturnRef(client_options));
 
   gcs::Client client(mock);
 
-  using ::testing::_;
-  using ::testing::Return;
   EXPECT_CALL(*mock, CreateResumableSession(_))
-      .WillOnce(testing::Invoke(
-          [](gcs::internal::ResumableUploadRequest const& request) {
-            std::cout << "Writing to bucket : " << request.bucket_name()
-                      << std::endl;
+      .WillOnce(
+          Invoke([](gcs::internal::ResumableUploadRequest const& request) {
+            EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
             auto* mock_result = new gcs::testing::MockResumableUploadSession;
             using gcs::internal::ResumableUploadResponse;
             EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
@@ -256,44 +208,12 @@ void MockWriteObjectFailure(std::vector<std::string> argv) {
             return google::cloud::make_status_or(std::move(result));
           }));
 
-  auto stream = client.WriteObject(bucket_name, object_name);
+  auto stream = client.WriteObject("mock-bucket-name", "mock-object-name");
   stream << "Hello World!";
   stream.Close();
 
-  if (stream.bad()) {
-    std::cerr << "Error writing to stream... status="
-              << stream.metadata().status() << std::endl;
-  }
-
-  //! [mock failed writeobject]
+  EXPECT_TRUE(stream.bad());
 }
-
-void RunAll(std::vector<std::string> const& argv) {
-  if (!argv.empty()) throw Usage{"auto"};
-
-  std::cout << "\nRunning the MockReadObject() example" << std::endl;
-  MockReadObject({"test-bucket-name", "test-object-name"});
-
-  std::cout << "\nRunning the MockWriteObject() example" << std::endl;
-  MockWriteObject({"test-bucket-name", "test-object-name"});
-
-  std::cout << "\nRunning the MockReadObjectFailure() example" << std::endl;
-  MockReadObjectFailure({"test-bucket-name", "test-object-name"});
-
-  std::cout << "\nRunning the MockWriteObjectFailure() example" << std::endl;
-  MockWriteObjectFailure({"test-bucket-name", "test-object-name"});
-}
+//! [mock failed writeobject]
 
 }  // anonymous namespace
-
-int main(int argc, char* argv[]) {
-  namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
-      {"mock-read-object", MockReadObject},
-      {"mock-write-object", MockWriteObject},
-      {"mock-read-object-failure", MockReadObjectFailure},
-      {"mock-write-object-failure", MockWriteObjectFailure},
-      {"auto", RunAll},
-  });
-  return example.Run(argc, argv);
-}

--- a/google/cloud/storage/examples/storage_examples_unit_tests.bzl
+++ b/google/cloud/storage/examples/storage_examples_unit_tests.bzl
@@ -17,5 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_examples_unit_tests = [
+    "storage_client_mock_samples.cc",
     "storage_examples_common_test.cc",
 ]


### PR DESCRIPTION
We do extract code from this to show users how to write their own mocks,
but the easiest way to run this program is to turn it into an actual
unit test.

In the process of getting this to run I discovered that some of the
examples were wrong, with the incorrect number of expectations and/or
incomplete implementation for the mocked functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3791)
<!-- Reviewable:end -->
