### PR TITLE
cleanup: add varargs support to `CreateCommandEntry`

### DIFF
--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -251,16 +251,11 @@ void NativeRemoveBucketConditionalIamBinding(
    argv.at(4));
 }
 
-void TestBucketIamPermissions(std::vector<std::string> argv) {
-  if (argv.size() < 2) {
-    throw Usage{
-        "test-bucket-iam-permissions <bucket_name> <permission>"
-        " [permission ...]"};
-  }
-  auto bucket_name = argv[0];
-  argv.erase(argv.begin());
-  std::vector<std::string> permissions = std::move(argv);
-  auto client = google::cloud::storage::Client::CreateDefaultClient().value();
+void TestBucketIamPermissions(google::cloud::storage::Client client,
+                              std::vector<std::string> const& argv) {
+  auto it = argv.cbegin();
+  auto bucket_name = *it++;
+  std::vector<std::string> permissions(it, argv.cend());
 
   //! [test bucket iam permissions]
   namespace gcs = google::cloud::storage;
@@ -416,7 +411,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nRunning TestBucketIamPermissions() example" << std::endl;
   TestBucketIamPermissions(
-      {bucket_name, "storage.objects.list", "storage.objects.delete"});
+      client, {bucket_name, "storage.objects.list", "storage.objects.delete"});
 
   std::cout << "\nRunning NativeGetBucketIamPolicy() example" << std::endl;
   NativeGetBucketIamPolicy(client, {bucket_name});
@@ -490,8 +485,8 @@ int main(int argc, char* argv[]) {
                  NativeRemoveBucketConditionalIamBinding),
       make_entry("native-remove-bucket-iam-member", {},
                  NativeRemoveBucketIamMember),
-      // Cannot use make_entry(), it parses a variable number of arguments
-      {"test-bucket-iam-permissions", TestBucketIamPermissions},
+      make_entry("test-bucket-iam-permissions",
+                 {"<permission>", "[permission...]"}, TestBucketIamPermissions),
       make_entry("set-bucket-public-iam", {}, SetBucketPublicIam),
       make_entry("native-set-bucket-public-iam", {}, NativeSetBucketPublicIam),
       {"auto", RunAll},

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -132,9 +132,13 @@ std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
 Commands::value_type CreateCommandEntry(
     std::string const& name, std::vector<std::string> const& arg_names,
     ClientCommand const& command) {
+  bool allow_varargs =
+      !arg_names.empty() &&
+      arg_names[arg_names.size() - 1].find("...") != std::string::npos;
   auto adapter = [=](std::vector<std::string> argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
-        argv.size() != arg_names.size()) {
+        (allow_varargs ? argv.size() < (arg_names.size() - 1)
+                       : argv.size() != arg_names.size())) {
       std::ostringstream os;
       os << name;
       for (auto& a : arg_names) {

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -133,8 +133,7 @@ Commands::value_type CreateCommandEntry(
     std::string const& name, std::vector<std::string> const& arg_names,
     ClientCommand const& command) {
   bool allow_varargs =
-      !arg_names.empty() &&
-      arg_names[arg_names.size() - 1].find("...") != std::string::npos;
+      !arg_names.empty() && arg_names.back().find("...") != std::string::npos;
   auto adapter = [=](std::vector<std::string> argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         (allow_varargs ? argv.size() < (arg_names.size() - 1)

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -64,6 +64,9 @@ std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
 
 using ClientCommand = std::function<void(google::cloud::storage::Client,
                                          std::vector<std::string> argv)>;
+
+// If the last value of `arg_names` contains `...` it represents a variable
+// number (0 or more) of arguments.
 Commands::value_type CreateCommandEntry(
     std::string const& name, std::vector<std::string> const& arg_names,
     ClientCommand const& command);


### PR DESCRIPTION
It saves a little bit of boilerplate and avoids a special case where the
commands are defined.

I also made `storage_bucket_iam_samples` use it (more uses are in other
to-be-converted samples).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3795)
<!-- Reviewable:end -->
