### PR TITLE
ci: use functions to get quickstart arguments

### DIFF
--- a/ci/etc/quickstart-config.sh
+++ b/ci/etc/quickstart-config.sh
@@ -13,11 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+quickstart_libraries() {
+  echo "bigtable"
+  echo "storage"
+}
+
 # TODO(#3798) - figure out a better way to represent the argument lists
 # We would like to declare an associate array of arrays, but not sure how to
 # do that. This works because all the variables below are "words", without
 # spaces, but it would be nice to have something more robust.
-declare -A -r quickstart_args=(
-  ["storage"]="${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}"
-  ["bigtable"]="${GOOGLE_CLOUD_PROJECT} ${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID} quickstart"
-)
+quickstart_arguments() {
+  local -r library="$1"
+  case "${library}" in
+    "bigtable")
+        echo "${GOOGLE_CLOUD_PROJECT}"
+        echo "${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID}"
+        echo "quickstart"
+        return 0
+        ;;
+    "storage")
+        echo "${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}"
+        return 0
+        ;;
+    *)
+        echo "Unknown argument list for ${library}'s quickstart"
+  esac
+  return 1
+}

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -76,17 +76,16 @@ build_service() {
 
     if [[ -r "/c/kokoro-run-key.json" ]]; then
       log_normal "running quickstart program for ${service}"
-      # We want the word splitting for $quickstart_args
-      # shellcheck disable=SC2086
+      args=($(quickstart_arguments "${service}"))
       env "${run_vars[@]}" "${BAZEL_BIN}" run "${bazel_args[@]}" \
           "--spawn_strategy=local" \
-          :quickstart -- ${quickstart_args["${service}"]}
+          :quickstart -- "${args[@]}"
     fi
   )
 }
 
 errors=""
-for service in "${!quickstart_args[@]}"; do
+for service in $(quickstart_libraries); do
   if ! build_service "${service}"; then
     errors="${errors} ${service}"
   fi

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -74,7 +74,7 @@ readonly run_quickstart
 echo "================================================================"
 cd "${PROJECT_ROOT}"
 
-for library in "${!quickstart_args[@]}"; do
+for library in $(quickstart_libraries); do
   echo "================================================================"
   cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
   for repeat in 1 2 3; do
@@ -93,11 +93,10 @@ for library in "${!quickstart_args[@]}"; do
   if [[ "${run_quickstart}" == "true" ]]; then
     echo "================================================================"
     log_yellow "Running ${library}'s quickstart."
-    # We want the word splitting for $quickstart_args
-    # shellcheck disable=SC2086
+    args=($(quickstart_arguments "${service}"))
     env "GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_FILE}" \
       "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=${CONFIG_DIR}/roots.pem" \
       "${BAZEL_BIN}" run "${bazel_args[@]}" "--spawn_strategy=local" \
-      :quickstart -- ${quickstart_args[$library]}
+      :quickstart -- "${args[@]}"
   fi
 done

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -68,7 +68,7 @@ cmake_flags=(
   "-DCMAKE_TOOLCHAIN_FILE=${PROJECT_ROOT}/${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
 )
 
-for library in "${!quickstart_args[@]}"; do
+for library in $(quickstart_libraries); do
   echo "================================================================"
   log_yellow "Configure CMake for ${library}'s quickstart."
   cd "${PROJECT_ROOT}"
@@ -84,10 +84,9 @@ for library in "${!quickstart_args[@]}"; do
     echo "================================================================"
     log_yellow "Running ${library}'s quickstart."
     cd "${binary_dir}"
-    # We want the word splitting for $quickstart_args
-    # shellcheck disable=SC2086
+    args=($(quickstart_arguments "${service}"))
     env "GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_FILE}" \
       "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=${CONFIG_DIR}/roots.pem" \
-      ./quickstart ${quickstart_args[$library]}
+      ./quickstart "${args[@]}"
   fi
 done

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -57,6 +57,10 @@ echo "================================================================"
 log_yellow "change working directory to project root."
 cd "${PROJECT_ROOT}"
 
+echo
+log_yellow "DEBUG DEBUG BASH_VERSION=${BASH_VERSION}"
+log_yellow "DEBUG DEBUG BASH_VERSINFO=" "${BASH_VERSINFO[@]}"
+
 NCPU="$(sysctl -n hw.logicalcpu)"
 readonly NCPU
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -57,10 +57,6 @@ echo "================================================================"
 log_yellow "change working directory to project root."
 cd "${PROJECT_ROOT}"
 
-echo
-log_yellow "DEBUG DEBUG BASH_VERSION=${BASH_VERSION}"
-log_yellow "DEBUG DEBUG BASH_VERSINFO=" "${BASH_VERSINFO[@]}"
-
 NCPU="$(sysctl -n hw.logicalcpu)"
 readonly NCPU
 

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -66,7 +66,7 @@ if [[ -x "${BAZEL_BIN}" ]]; then
   maybe_dirs+=("$("${BAZEL_BIN}" info output_base)")
   "${BAZEL_BIN}" shutdown
 
-  for library in "${!quickstart_args[@]}"; do
+  for library in $(quickstart_libraries); do
     cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
     maybe_dirs+=("$("${BAZEL_BIN}" info repository_cache)")
     maybe_dirs+=("$("${BAZEL_BIN}" info output_base)")


### PR DESCRIPTION
Kokoro+macOS runs bash==3.2.x, which does not support
associative arrays, so we need to use functions to get the
quickstart arguments and the list of libraries with a quickstart
program.

Part of the work for #3730 and #3731

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3800)
<!-- Reviewable:end -->
