### PR TITLE
cleanup: avoid tput warnings in CI builds

### DIFF
--- a/ci/colors.sh
+++ b/ci/colors.sh
@@ -16,8 +16,8 @@
 # Prefer the log_* functions, such as log_yellow, instead of directly using
 # these variables. The functions don't require the caller to remember to reset
 # the terminal.
-if [[ -z "${COLOR_RESET+x}" && -n "${TERM:-}" ]]; then
-  if type tput >/dev/null 2>&1; then
+if [[ -z "${COLOR_RESET+x}" ]]; then
+  if command -v tput >/dev/null && [[ -n "${TERM:-}" ]]; then
     readonly COLOR_RED="$(tput setaf 1)"
     readonly COLOR_GREEN="$(tput setaf 2)"
     readonly COLOR_YELLOW="$(tput setaf 3)"

--- a/ci/colors.sh
+++ b/ci/colors.sh
@@ -16,7 +16,7 @@
 # Prefer the log_* functions, such as log_yellow, instead of directly using
 # these variables. The functions don't require the caller to remember to reset
 # the terminal.
-if [ -z "${COLOR_RESET+x}" ]; then
+if [[ -z "${COLOR_RESET+x}" && -n "${TERM:-}" ]]; then
   if type tput >/dev/null 2>&1; then
     readonly COLOR_RED="$(tput setaf 1)"
     readonly COLOR_GREEN="$(tput setaf 2)"


### PR DESCRIPTION
When building in Kokoro it seems that TERM is not set and `tput` outputs
some warnings. This change avoids calling `tput` in that case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3801)
<!-- Reviewable:end -->
