### PR TITLE
fix: speed up clang-format in check-style

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -68,11 +68,8 @@ find . \( "${ignore[@]}" \) -prune -o \
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly
 # different formatting output (sigh).
-find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 |
-  while IFS= read -r -d $'\0' file; do
-    clang-format "${file}" >"${file}.tmp"
-    replace_original_if_changed "${file}" "${file}.tmp"
-  done
+find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 | \
+  xargs -0 clang-format -i
 
 # Apply several transformations that cannot be enforced by clang-format:
 #     - Replace any #include for grpc++/* with grpcpp/*. The paths with grpc++

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -50,14 +50,6 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
-# By default, Ubuntu 18.04 does not install the alternatives for clang-format
-# and clang-tidy, so we need to manually install those.
-RUN if grep -q 18.04 /etc/lsb-release; then \
-      apt-get update && apt-get --no-install-recommends install -y clang-tidy clang-format-7 clang-tools; \
-      update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
-      update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100; \
-    fi
-
 # Install the the buildifier tool, which does not compile with the default
 # golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
 RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -24,7 +24,6 @@ RUN apt-get update && \
         build-essential \
         ccache \
         clang \
-        clang-format-7 \
         cmake \
         curl \
         ctags \


### PR DESCRIPTION
Changes this loop back to using `clang-format -i`. This used to cause a
problem when we were using clang-format-7, in that it would update every
file's timestamp even if no edits were made. However, since #3458
(2020-03-10), we're now using fedora with clang-format-9, and this
problem no longer exists. So we can go back to the faster `clang-format
-i`.

This PR reduces the "clang-format" step in the check-style.sh script
from about 30 seconds to about 4.

I also removed the clang-format-7 packages from the Dockerfiles that
don't use it, because it was just confusing to see a version being
installed that we don't use.

Part of https://github.com/googleapis/google-cloud-cpp/issues/3794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3802)
<!-- Reviewable:end -->
