### PR TITLE
fix: speed up cmake-format with in-place edit

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -60,10 +60,7 @@ replace_original_if_changed() {
 find . \( "${ignore[@]}" \) -prune -o \
        \( -name 'CMakeLists.txt' -o -name '*.cmake' \) \
        -print0 |
-  while IFS= read -r -d $'\0' file; do
-    cmake-format "${file}" >"${file}.tmp"
-    replace_original_if_changed "${file}" "${file}.tmp"
-  done
+  xargs -0 cmake-format -i
 
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly


### PR DESCRIPTION
In #3431 (March 4, 2020) we updated `cmake_format` from 0.6.0 to 0.6.8.
I _think_ that update "fixed" the problem w/ cmake_format that caused it
to change the timestamp on files even when it did not change them.
Therefore, I think we could change the `cmake_format` code in
`check-style.sh` to use something like `find ... | xargs -0 cmake_format
-i`, which would likely speed it up too.

Sadly, this change doesn't improve the speed very much. Maybe 11 sec ->
8 sec. It turns out that cmake-format itself is just really slow. But
this incantation is a bit simpler and matches how we do clang-format, so
it's probably worth the change anyway.

Fixes: #3794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3805)
<!-- Reviewable:end -->
