### PR TITLE
ci: another iteration on quickstart builds for macOS

### DIFF
--- a/ci/etc/quickstart-config.sh
+++ b/ci/etc/quickstart-config.sh
@@ -18,10 +18,6 @@ quickstart_libraries() {
   echo "storage"
 }
 
-# TODO(#3798) - figure out a better way to represent the argument lists
-# We would like to declare an associate array of arrays, but not sure how to
-# do that. This works because all the variables below are "words", without
-# spaces, but it would be nice to have something more robust.
 quickstart_arguments() {
   local -r library="$1"
   case "${library}" in

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -62,7 +62,8 @@ fi
 build_quickstart() {
   local -r library="$1"
 
-  cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
+  pushd "${PROJECT_ROOT}/google/cloud/${library}/quickstart" >/dev/null
+  trap "popd >/dev/null" RETURN
   log_normal "capture bazel version"
   ${BAZEL_BIN} version
   log_normal "fetch dependencies for ${library}'s quickstart"

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -59,43 +59,52 @@ if [[ -r "/c/kokoro-run-key.json" ]]; then
   )
 fi
 
-build_service() {
-  local -r service="$1"
+build_quickstart() {
+  local -r library="$1"
 
-  echo "================================================================"
-  log_yellow "building ${service}"
-  ( cd "google/cloud/${service}/quickstart";
-    log_normal "capture bazel version"
-    ${BAZEL_BIN} version
-    log_normal "fetch dependencies for ${service}'s quickstart"
-    "${PROJECT_ROOT}/ci/retry-command.sh" \
-        "${BAZEL_BIN}" fetch -- ...
+  cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
+  log_normal "capture bazel version"
+  ${BAZEL_BIN} version
+  log_normal "fetch dependencies for ${library}'s quickstart"
+  "${PROJECT_ROOT}/ci/retry-command.sh" \
+      "${BAZEL_BIN}" fetch -- ...
+
+  echo
+  log_yellow "Compiling ${library}'s quickstart"
+  "${BAZEL_BIN}" build  "${bazel_args[@]}" -- ...
+
+  if [[ -r "/c/kokoro-run-key.json" ]]; then
     echo
-    log_normal "compiling quickstart program for ${service}"
-    "${BAZEL_BIN}" build  "${bazel_args[@]}" -- ...
-
-    if [[ -r "/c/kokoro-run-key.json" ]]; then
-      log_normal "running quickstart program for ${service}"
-      args=($(quickstart_arguments "${service}"))
-      env "${run_vars[@]}" "${BAZEL_BIN}" run "${bazel_args[@]}" \
-          "--spawn_strategy=local" \
-          :quickstart -- "${args[@]}"
-    fi
-  )
+    log_yellow "Running ${library}'s quickstart."
+    args=()
+    while IFS="" read -r line; do
+      args+=("${line}")
+    done < <(quickstart_arguments "${library}")
+    env "${run_vars[@]}" "${BAZEL_BIN}" run "${bazel_args[@]}" \
+        "--spawn_strategy=local" \
+        :quickstart -- "${args[@]}"
+  fi
 }
 
 errors=""
-for service in $(quickstart_libraries); do
-  if ! build_service "${service}"; then
-    errors="${errors} ${service}"
+for library in $(quickstart_libraries); do
+  echo
+  echo "================================================================"
+  log_yellow "Building ${library}'s quickstart"
+  if ! build_quickstart "${library}"; then
+    log_red "Building ${library}'s quickstart failed"
+    errors="${errors} ${library}"
+  else
+    log_green "Building ${library}'s quickstart was successful"
   fi
 done
 
 echo "================================================================"
 if [[ -z "${errors}" ]]; then
-  log_green "Build finished"
+  log_green "All quickstart builds were successful"
 else
   log_red "Build failed for ${errors}"
+  exit 1
 fi
 
 exit 0

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -77,7 +77,8 @@ cd "${PROJECT_ROOT}"
 build_quickstart() {
   local -r library="$1"
 
-  cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
+  pushd "${PROJECT_ROOT}/google/cloud/${library}/quickstart" >/dev/null
+  trap "popd >/dev/null" RETURN
   log_normal "capture bazel version"
   ${BAZEL_BIN} version
   for repeat in 1 2 3; do

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -76,7 +76,6 @@ build_quickstart() {
 
   echo
   log_yellow "Configure CMake for ${library}'s quickstart."
-  cd "${PROJECT_ROOT}"
   source_dir="google/cloud/${library}/quickstart"
   binary_dir="cmake-out/quickstart-${library}"
   cmake "-H${source_dir}" "-B${binary_dir}" "${cmake_flags[@]}"
@@ -88,14 +87,13 @@ build_quickstart() {
   if [[ "${run_quickstart}" == "true" ]]; then
     echo
     log_yellow "Running ${library}'s quickstart."
-    cd "${binary_dir}"
     args=()
     while IFS="" read -r line; do
       args+=("${line}")
     done < <(quickstart_arguments "${library}")
     env "GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_FILE}" \
       "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=${CONFIG_DIR}/roots.pem" \
-      ./quickstart "${args[@]}"
+      "${binary_dir}/quickstart" "${args[@]}"
   fi
 }
 


### PR DESCRIPTION
Made the quickstart builds for Linux and macOS more similar, fixed a
number of shellcheck warnings, incidentally fixing #3798. Also made the
output more legible (I think). Also made sure all quickstarts are built,
even if some of them fail.

Fixes #3798 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3806)
<!-- Reviewable:end -->
