### PR TITLE
ci: enforce shell formatting with shfmt

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -120,6 +120,10 @@ if ! find . \( "${ignore[@]}" \) -prune -o \
   problems="${problems} shellcheck"
 fi
 
+# Apply shfmt to format all shell scripts
+find . \( "${ignore[@]}" \) -prune -o \
+  -iname '*.sh' -print0 | xargs -0 shfmt -w -i 2
+
 # Apply transformations to fix whitespace formatting in files not handled by
 # clang-format(1) above.  For now we simply remove trailing blanks.  Note that
 # we do not expand TABs (they currently only appear in Makefiles and Makefile

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -42,6 +42,12 @@ RUN pip3 install cmake_format==0.6.8
 # Install black to automatically format the Python files.
 RUN pip3 install black==19.3b0
 
+# Install shfmt to automatically format the Shell scripts.
+RUN curl -L -o /usr/local/bin/shfmt \
+    "https://github.com/mvdan/sh/releases/download/v3.1.0/shfmt_v3.1.0_linux_amd64" && \
+    chmod 755 /usr/local/bin/shfmt
+
+# Install the Python modules needed to run the storage testbench
 RUN dnf makecache && dnf install -y python3-devel
 RUN pip3 install setuptools
 RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \


### PR DESCRIPTION
Runs as part of the `clang-tidy` build, like all the other formatting
checks.

Part of the work for googleapis/google-cloud-cpp-common#102

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3831)
<!-- Reviewable:end -->
