### PR TITLE
refactor: run lifecycle management examples without scripts

### DIFF
--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ set(storage_examples
     storage_bucket_samples.cc
     storage_default_object_acl_samples.cc
     storage_event_based_hold_samples.cc
+    storage_lifecycle_management_samples.cc
     storage_notification_samples.cc
     storage_object_acl_samples.cc
     storage_object_cmek_samples.cc

--- a/google/cloud/storage/examples/run_examples_utils.sh
+++ b/google/cloud/storage/examples/run_examples_utils.sh
@@ -25,33 +25,6 @@ fi
 source "${PROJECT_ROOT}/ci/define-example-runner.sh"
 
 ################################################
-# Run all examples showing how to use lifecycle policies.
-# Globals:
-#   COLOR_*: colorize output messages, defined in colors.sh
-#   EXIT_STATUS: control the final exit status for the program.
-#   PROJECT_ID: the Google Cloud Project used for the test.
-# Arguments:
-#   None
-# Returns:
-#   None
-################################################
-run_lifecycle_management_examples() {
-  local bucket_name="cloud-cpp-test-bucket-${RANDOM}-${RANDOM}-${RANDOM}"
-
-  run_example ./storage_bucket_samples create-bucket-for-project \
-    "${bucket_name}" "${PROJECT_ID}"
-  run_example ./storage_bucket_samples enable-bucket-lifecycle-management \
-    "${bucket_name}"
-  run_example ./storage_bucket_samples get-bucket-lifecycle-management \
-    "${bucket_name}"
-  run_example ./storage_bucket_samples disable-bucket-lifecycle-management \
-    "${bucket_name}"
-  run_example ./storage_bucket_samples get-bucket-lifecycle-management \
-    "${bucket_name}"
-  run_example ./storage_bucket_samples delete-bucket "${bucket_name}"
-}
-
-################################################
 # Run all the examples.
 # Globals:
 #   PROJECT_ID: the id of a GCP project, do not use a project number.
@@ -70,7 +43,6 @@ run_all_storage_examples() {
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET}" \
     " Running Google Cloud Storage Examples"
   EMULATOR_LOG="testbench.log"
-  run_lifecycle_management_examples
   echo "${COLOR_GREEN}[ ======== ]${COLOR_RESET}" \
     " Google Cloud Storage Examples Finished"
   exit "${EXIT_STATUS}"

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -517,99 +517,6 @@ void RemoveBucketLabel(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1));
 }
 
-void GetBucketLifecycleManagement(google::cloud::storage::Client client,
-                                  std::vector<std::string> const& argv) {
-  // [START storage_view_lifecycle_management_configuration]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> updated_metadata =
-        client.GetBucketMetadata(bucket_name);
-
-    if (!updated_metadata) {
-      throw std::runtime_error(updated_metadata.status().message());
-    }
-
-    if (!updated_metadata->has_lifecycle() ||
-        updated_metadata->lifecycle().rule.empty()) {
-      std::cout << "Bucket lifecycle management is not enabled for bucket "
-                << updated_metadata->name() << ".\n";
-      return;
-    }
-    std::cout << "Bucket lifecycle management is enabled for bucket "
-              << updated_metadata->name() << ".\n";
-    std::cout << "The bucket lifecycle rules are";
-    for (auto const& kv : updated_metadata->lifecycle().rule) {
-      std::cout << "\n " << kv.condition() << ", " << kv.action();
-    }
-    std::cout << "\n";
-  }
-  // [END storage_view_lifecycle_management_configuration]
-  (std::move(client), argv.at(0));
-}
-
-void EnableBucketLifecycleManagement(google::cloud::storage::Client client,
-                                     std::vector<std::string> const& argv) {
-  //! [enable_bucket_lifecycle_management]
-  // [START storage_enable_bucket_lifecycle_management]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
-    gcs::BucketLifecycle bucket_lifecycle_rules = gcs::BucketLifecycle{
-        {gcs::LifecycleRule(gcs::LifecycleRule::ConditionConjunction(
-                                gcs::LifecycleRule::MaxAge(30),
-                                gcs::LifecycleRule::IsLive(true)),
-                            gcs::LifecycleRule::Delete())}};
-
-    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name,
-        gcs::BucketMetadataPatchBuilder().SetLifecycle(bucket_lifecycle_rules));
-
-    if (!updated_metadata) {
-      throw std::runtime_error(updated_metadata.status().message());
-    }
-
-    if (!updated_metadata->has_lifecycle() ||
-        updated_metadata->lifecycle().rule.empty()) {
-      std::cout << "Bucket lifecycle management is not enabled for bucket "
-                << updated_metadata->name() << ".\n";
-      return;
-    }
-    std::cout << "Successfully enabled bucket lifecycle management for bucket "
-              << updated_metadata->name() << ".\n";
-    std::cout << "The bucket lifecycle rules are";
-    for (auto const& kv : updated_metadata->lifecycle().rule) {
-      std::cout << "\n " << kv.condition() << ", " << kv.action();
-    }
-    std::cout << "\n";
-  }
-  // [END storage_enable_bucket_lifecycle_management]
-  //! [storage_enable_bucket_lifecycle_management]
-  (std::move(client), argv.at(0));
-}
-
-void DisableBucketLifecycleManagement(google::cloud::storage::Client client,
-                                      std::vector<std::string> const& argv) {
-  //! [disable_bucket_lifecycle_management]
-  // [START storage_disable_bucket_lifecycle_management]
-  namespace gcs = google::cloud::storage;
-  using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
-    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().ResetLifecycle());
-
-    if (!updated_metadata) {
-      throw std::runtime_error(updated_metadata.status().message());
-    }
-
-    std::cout << "Successfully disabled bucket lifecycle management for bucket "
-              << updated_metadata->name() << ".\n";
-  }
-  // [END storage_disable_bucket_lifecycle_management]
-  //! [storage_disable_bucket_lifecycle_management]
-  (std::move(client), argv.at(0));
-}
-
 void RunAll(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::storage::examples;
   namespace gcs = ::google::cloud::storage;
@@ -746,12 +653,6 @@ int main(int argc, char* argv[]) {
                  AddBucketLabel),
       make_entry("get-bucket-labels", {}, GetBucketLabels),
       make_entry("remove-bucket-label", {"<label-key>"}, RemoveBucketLabel),
-      make_entry("get-bucket-lifecycle-management", {},
-                 GetBucketLifecycleManagement),
-      make_entry("enable-bucket-lifecycle-management", {},
-                 EnableBucketLifecycleManagement),
-      make_entry("disable-bucket-lifecycle-management", {},
-                 DisableBucketLifecycleManagement),
       {"auto", RunAll},
   });
   return example.Run(argc, argv);

--- a/google/cloud/storage/examples/storage_examples.bzl
+++ b/google/cloud/storage/examples/storage_examples.bzl
@@ -25,6 +25,7 @@ storage_examples = [
     "storage_bucket_samples.cc",
     "storage_default_object_acl_samples.cc",
     "storage_event_based_hold_samples.cc",
+    "storage_lifecycle_management_samples.cc",
     "storage_notification_samples.cc",
     "storage_object_acl_samples.cc",
     "storage_object_cmek_samples.cc",

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -1,0 +1,176 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/internal/getenv.h"
+#include <functional>
+#include <iostream>
+#include <map>
+#include <sstream>
+
+namespace {
+
+void GetBucketLifecycleManagement(google::cloud::storage::Client client,
+                                  std::vector<std::string> const& argv) {
+  // [START storage_view_lifecycle_management_configuration]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    StatusOr<gcs::BucketMetadata> updated_metadata =
+        client.GetBucketMetadata(bucket_name);
+
+    if (!updated_metadata) {
+      throw std::runtime_error(updated_metadata.status().message());
+    }
+
+    if (!updated_metadata->has_lifecycle() ||
+        updated_metadata->lifecycle().rule.empty()) {
+      std::cout << "Bucket lifecycle management is not enabled for bucket "
+                << updated_metadata->name() << ".\n";
+      return;
+    }
+    std::cout << "Bucket lifecycle management is enabled for bucket "
+              << updated_metadata->name() << ".\n";
+    std::cout << "The bucket lifecycle rules are";
+    for (auto const& kv : updated_metadata->lifecycle().rule) {
+      std::cout << "\n " << kv.condition() << ", " << kv.action();
+    }
+    std::cout << "\n";
+  }
+  // [END storage_view_lifecycle_management_configuration]
+  (std::move(client), argv.at(0));
+}
+
+void EnableBucketLifecycleManagement(google::cloud::storage::Client client,
+                                     std::vector<std::string> const& argv) {
+  //! [enable_bucket_lifecycle_management]
+  // [START storage_enable_bucket_lifecycle_management]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    gcs::BucketLifecycle bucket_lifecycle_rules = gcs::BucketLifecycle{
+        {gcs::LifecycleRule(gcs::LifecycleRule::ConditionConjunction(
+                                gcs::LifecycleRule::MaxAge(30),
+                                gcs::LifecycleRule::IsLive(true)),
+                            gcs::LifecycleRule::Delete())}};
+
+    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetLifecycle(bucket_lifecycle_rules));
+
+    if (!updated_metadata) {
+      throw std::runtime_error(updated_metadata.status().message());
+    }
+
+    if (!updated_metadata->has_lifecycle() ||
+        updated_metadata->lifecycle().rule.empty()) {
+      std::cout << "Bucket lifecycle management is not enabled for bucket "
+                << updated_metadata->name() << ".\n";
+      return;
+    }
+    std::cout << "Successfully enabled bucket lifecycle management for bucket "
+              << updated_metadata->name() << ".\n";
+    std::cout << "The bucket lifecycle rules are";
+    for (auto const& kv : updated_metadata->lifecycle().rule) {
+      std::cout << "\n " << kv.condition() << ", " << kv.action();
+    }
+    std::cout << "\n";
+  }
+  // [END storage_enable_bucket_lifecycle_management]
+  //! [storage_enable_bucket_lifecycle_management]
+  (std::move(client), argv.at(0));
+}
+
+void DisableBucketLifecycleManagement(google::cloud::storage::Client client,
+                                      std::vector<std::string> const& argv) {
+  //! [disable_bucket_lifecycle_management]
+  // [START storage_disable_bucket_lifecycle_management]
+  namespace gcs = google::cloud::storage;
+  using ::google::cloud::StatusOr;
+  [](gcs::Client client, std::string bucket_name) {
+    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
+        bucket_name, gcs::BucketMetadataPatchBuilder().ResetLifecycle());
+
+    if (!updated_metadata) {
+      throw std::runtime_error(updated_metadata.status().message());
+    }
+
+    std::cout << "Successfully disabled bucket lifecycle management for bucket "
+              << updated_metadata->name() << ".\n";
+  }
+  // [END storage_disable_bucket_lifecycle_management]
+  //! [storage_disable_bucket_lifecycle_management]
+  (std::move(client), argv.at(0));
+}
+
+void RunAll(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::storage::examples;
+  namespace gcs = ::google::cloud::storage;
+
+  if (!argv.empty()) throw examples::Usage{"auto"};
+  examples::CheckEnvironmentVariablesAreSet({
+      "GOOGLE_CLOUD_PROJECT",
+  });
+  auto const project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const bucket_name =
+      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto client = gcs::Client::CreateDefaultClient().value();
+
+  std::cout << "\nCreating bucket to run the examples" << std::endl;
+  (void)client.CreateBucketForProject(bucket_name, project_id,
+                                      gcs::BucketMetadata());
+
+  std::cout << "\nRunning EnableBucketLifecycleManagement() example"
+            << std::endl;
+  EnableBucketLifecycleManagement(client, {bucket_name});
+
+  std::cout << "\nRunning GetBucketLifecycleManagement() example" << std::endl;
+  GetBucketLifecycleManagement(client, {bucket_name});
+
+  std::cout << "\nRunning DisableBucketLifecycleManagement() example"
+            << std::endl;
+  DisableBucketLifecycleManagement(client, {bucket_name});
+
+  std::cout << "\nRunning GetBucketLifecycleManagement() example" << std::endl;
+  GetBucketLifecycleManagement(client, {bucket_name});
+
+  std::cout << "\nCleaning up" << std::endl;
+  (void)client.DeleteBucket(bucket_name);
+}
+
+}  // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  namespace examples = ::google::cloud::storage::examples;
+  auto make_entry = [](std::string const& name,
+                       std::vector<std::string> arg_names,
+                       examples::ClientCommand const& cmd) {
+    arg_names.insert(arg_names.begin(), "<bucket-name>");
+    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+  };
+
+  google::cloud::storage::examples::Example example({
+      make_entry("get-bucket-lifecycle-management", {},
+                 GetBucketLifecycleManagement),
+      make_entry("enable-bucket-lifecycle-management", {},
+                 EnableBucketLifecycleManagement),
+      make_entry("disable-bucket-lifecycle-management", {},
+                 DisableBucketLifecycleManagement),
+      {"auto", RunAll},
+  });
+  return example.Run(argc, argv);
+}


### PR DESCRIPTION
Fixes #3654

Note: after I merge the other outstanding PRs, `run_examples_utils.sh`
will be a no-op and can be removed - I'll do that separately for
clarity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3837)
<!-- Reviewable:end -->
