### PR TITLE
ci: enable integration tests for asan+msan builds

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -18,8 +18,9 @@ FROM fedora:${DISTRO_VERSION}
 # Install the minimal packages needed to compile libcxx, install Bazel, and
 # then compile our code.
 RUN dnf makecache && \
-    dnf install -y clang clang-tools-extra cmake gcc-c++ git llvm-devel \
-        make ninja-build python3-lit tar unzip which wget xz
+    dnf install -y clang clang-tools-extra cmake findutils gcc-c++ git \
+        llvm-devel make ninja-build openssl-devel python3-lit tar unzip which \
+        wget xz
 
 WORKDIR /var/tmp/build
 RUN wget -q http://releases.llvm.org/8.0.0/libcxx-8.0.0.src.tar.xz
@@ -59,6 +60,12 @@ RUN cmake -Hlibcxx-8.0.0.src -B.build-libcxx -GNinja -Wno-dev \
 # we do not care about.
 RUN cmake --build .build-libcxx --target cxx
 RUN cmake --build .build-libcxx --target install-cxx
+
+# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
+# client.  They are used in the integration tests.
+COPY . /var/tmp/ci
+WORKDIR /var/tmp/downloads
+RUN /var/tmp/ci/install-cloud-sdk.sh
 
 # We need Bazel for this build.
 COPY . /var/tmp/ci

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -102,6 +102,7 @@ elif [[ "${BUILD_NAME}" = "asan" ]]; then
   export DISTRO=ubuntu
   export DISTRO_VERSION=18.04
   export BAZEL_CONFIG="asan"
+  RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "msan" ]]; then
   # Compile with the MemorySanitizer enabled.
@@ -110,6 +111,7 @@ elif [[ "${BUILD_NAME}" = "msan" ]]; then
   export DISTRO=fedora-libcxx-msan
   export DISTRO_VERSION=30
   export BAZEL_CONFIG="msan"
+  RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   # Compile with the ThreadSanitizer enabled.
@@ -118,6 +120,8 @@ elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   export DISTRO=fedora-install
   export DISTRO_VERSION=30
   export BAZEL_CONFIG="tsan"
+  # TODO(#3832) - fix bugs and enable
+  # RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   # Compile with the UndefinedBehaviorSanitizer enabled.
@@ -126,6 +130,8 @@ elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   export DISTRO=ubuntu
   export DISTRO_VERSION=18.04
   export BAZEL_CONFIG="ubsan"
+  # TODO(#3832) - fix bugs and enable
+  # RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="super"


### PR DESCRIPTION
This PR enables the integration tests on the AddressSanitizer and
MemorySanitizer builds. The tsan and ubsan builds need more work before
we can enable them.

I had to change the `curl.BUILD` file: as it was the integration tests could
not run on Fedora, `libcurl` needs to know where the certificate authority
bundles are located. The CMake and Makefile builds for it figure this out
automatically, but we use Bazel for the sanitizer builds, and the file had a
location hard-coded for Ubuntu.

Part of the work for #3832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3839)
<!-- Reviewable:end -->
