### PR TITLE
ci: run all quickstarts in install builds

### DIFF
--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -41,10 +41,6 @@ _EOF_
   done
 ) || true # read always exit with error
 
-echo =====
-echo ${QUICKSTART_FRAGMENT} | tr '\003' '\n'
-echo =====
-
 BUILD_AND_TEST_PROJECT_FRAGMENT=$(
   replace_fragments \
     "INSTALL_CRC32C_FROM_SOURCE" \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -198,16 +198,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -177,16 +177,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -140,16 +140,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -173,16 +173,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -146,16 +146,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -193,16 +193,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -144,16 +144,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -166,16 +166,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -181,16 +181,16 @@ WORKDIR /home/build/bigtable-make
 COPY google/cloud/bigtable/quickstart /home/build/bigtable-make
 RUN make
 
-WORKDIR /home/build/bigtable-cmake
-COPY google/cloud/bigtable/quickstart /home/build/bigtable-cmake
-RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
-RUN cmake --build /i/bigtable -- -j ${NCPU:-4}
-
 WORKDIR /home/build/storage-make
 COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
-WORKDIR /home/build/storage-cmake
-COPY google/cloud/storage/quickstart /home/build/storage-cmake
+WORKDIR /home/build/quickstart-cmake/bigtable
+COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
+RUN cmake --build /i/bigtable
+
+WORKDIR /home/build/quickstart-cmake/storage
+COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
-RUN cmake --build /i/storage -- -j ${NCPU:-4}
+RUN cmake --build /i/storage


### PR DESCRIPTION
With this change the ci/kokoro/install builds will automatically pickup
new `quickstart` libraries. Or at least, will automatically pick them up
when they are regenerated.

Fixes #3544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3843)
<!-- Reviewable:end -->
