### PR TITLE
refactor: simplify *-install Dockerfiles

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -69,7 +69,7 @@ RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
 # Install googleapis, remove the downloaded files and the temporary artifacts
 # after a successful build to keep the image smaller (and with fewer layers)
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz && \
+RUN curl -sSL https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DBUILD_SHARED_LIBS=YES \
@@ -79,7 +79,7 @@ RUN curl -sSL https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz
     cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -94,7 +94,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 
 # Download and compile google-cloud-cpp-common from source too.
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz && \
+RUN curl -sSL https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
     cmake -H. -Bcmake-out \
       -DBUILD_SHARED_LIBS=YES \

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -56,9 +56,8 @@ RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
 # Install googletest, remove the downloaded files and the temporary artifacts
 # after a successful build to keep the image smaller (and with fewer layers)
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd /var/tmp/build/googletest-release-1.10.0 && \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
@@ -70,9 +69,8 @@ RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz &
 # Install googleapis, remove the downloaded files and the temporary artifacts
 # after a successful build to keep the image smaller (and with fewer layers)
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz && \
-    tar -xf v0.8.0.tar.gz && \
-    cd /var/tmp/build/cpp-cmakefiles-0.8.0 && \
+RUN curl -sSL https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz && \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DBUILD_SHARED_LIBS=YES \
       -H. -Bcmake-out && \
@@ -81,9 +79,8 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz &
     cd /var/tmp && rm -fr build
 
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd /var/tmp/build/crc32c-1.1.0 && \
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -97,9 +94,8 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 
 # Download and compile google-cloud-cpp-common from source too.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz && \
-    tar -xf v0.25.0.tar.gz && \
-    cd /var/tmp/build/google-cloud-cpp-common-0.25.0 && \
+RUN curl -sSL https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz && \
+    tar -xzf - --strip-components=1 && \
     cmake -H. -Bcmake-out \
       -DBUILD_SHARED_LIBS=YES \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -79,7 +79,7 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.0.6.tar.gz | \
 #   as the dependent (gRPC or google-cloud-cpp) works.
 WORKDIR /var/tmp/build
 RUN curl -sSL https://github.com/google/protobuf/archive/v3.11.3.tar.gz | \
-    tar -xzf - --strip-components=1 && \
+    tar -xzf - --strip-components=1
 WORKDIR cmake
 RUN for build_type in "Debug" "Release"; do \
     cmake \

--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -57,18 +57,18 @@ RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
 
 # Install Crc32c library.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
-RUN tar -xf 1.0.6.tar.gz
-WORKDIR /var/tmp/build/crc32c-1.0.6
-RUN cmake \
+RUN curl -sSL https://github.com/google/crc32c/archive/1.0.6.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
       -DCRC32C_BUILD_TESTS=OFF \
       -DCRC32C_BUILD_BENCHMARKS=OFF \
       -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out/crc32c
-RUN cmake --build cmake-out/crc32c --target install -- -j ${NCPU}
-RUN ldconfig
+      -H. -Bcmake-out && \
+    cmake --build cmake-out --target install -- -j ${NCPU} && \
+    ldconfig && \
+    cd /var/tmp && rm -fr build
 
 # Install protobuf using CMake. Some distributions include protobuf, but gRPC
 # requires 3.4.x or newer, and many of those distribution use older versions.
@@ -78,9 +78,9 @@ RUN ldconfig
 # - When using CMake, only the version compiled with the same CMAKE_BUILD_TYPE
 #   as the dependent (gRPC or google-cloud-cpp) works.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz
-RUN tar -xf v3.11.3.tar.gz
-WORKDIR /var/tmp/build/protobuf-3.11.3/cmake
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.11.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+WORKDIR cmake
 RUN for build_type in "Debug" "Release"; do \
     cmake \
         -DCMAKE_BUILD_TYPE="${build_type}" \
@@ -90,6 +90,7 @@ RUN for build_type in "Debug" "Release"; do \
     cmake --build cmake-out-${build_type} --target install -- -j ${NCPU}; \
   done
 RUN ldconfig
+RUN cd /var/tmp && rm -fr build
 
 # Many distributions include c-ares, but they do not include the CMake support
 # files for the library, so manually install it.  c-ares requires two install
@@ -97,26 +98,25 @@ RUN ldconfig
 # and (2) the Makefile-based build does not install CMake config files.
 WORKDIR /var/tmp/build
 RUN apt-get remove -y libc-ares-dev libc-ares2
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz
-RUN tar -xf cares-1_14_0.tar.gz
-WORKDIR /var/tmp/build/c-ares-cares-1_14_0
-RUN cmake \
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out
-RUN cmake --build cmake-out --target install -- -j ${NCPU}
+      -H. -Bcmake-out && \
+    cmake --build cmake-out --target install -- -j ${NCPU}
 RUN ./buildconf
 RUN ./configure
 RUN install -m 644 -D -t /usr/local/lib/pkgconfig libcares.pc
 RUN ldconfig
+RUN cd /var/tmp && rm -fr build
 
 # Install gRPC. Note that we use the system's zlib and ssl libraries.
 # For similar reasons to c-ares (see above), we need two install steps.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz
-RUN tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz
-WORKDIR /var/tmp/build/grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b
-RUN cmake \
+RUN curl -sSL https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
       -DgRPC_BUILD_TESTS=OFF \
@@ -124,16 +124,16 @@ RUN cmake \
       -DgRPC_SSL_PROVIDER=package \
       -DgRPC_CARES_PROVIDER=package \
       -DgRPC_PROTOBUF_PROVIDER=package \
-      -H. -Bcmake-out/grpc
-RUN cmake --build cmake-out/grpc --target install -- -j ${NCPU}
+      -H. -Bcmake-out/grpc && \
+    cmake --build cmake-out/grpc --target install -- -j ${NCPU}
 RUN make install-pkg-config_c install-pkg-config_cxx install-certs
 RUN ldconfig
+RUN cd /var/tmp && rm -fr build
 
 # Install googleapis.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz && \
-    tar -xf v0.8.0.tar.gz && \
-    cd /var/tmp/build/cpp-cmakefiles-0.8.0 && \
+RUN curl -sSL https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DBUILD_SHARED_LIBS=YES \
       -H. -Bcmake-out && \
@@ -143,21 +143,20 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz &
 
 # Install googletest.
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-RUN tar -xf release-1.10.0.tar.gz
-WORKDIR /var/tmp/build/googletest-release-1.10.0
-RUN cmake \
+RUN curl -sSL https://github.com/google/googletest/archive/release-1.10.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_SHARED_LIBS=yes \
-      -H. -Bcmake-out/googletest
-RUN cmake --build cmake-out/googletest --target install -- -j ${NCPU}
-RUN ldconfig
+      -H. -Bcmake-out/googletest && \
+    cmake --build cmake-out/googletest --target install -- -j ${NCPU} && \
+    ldconfig && \
+    cd /var/tmp && rm -fr build
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz && \
-    tar -xf v0.25.0.tar.gz && \
-    cd /var/tmp/build/google-cloud-cpp-common-0.25.0 && \
+RUN curl -sSL https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -H. -Bcmake-out \
       -DBUILD_SHARED_LIBS=YES \
       -DBUILD_TESTING=OFF \


### PR DESCRIPTION
Reduces the duplication of version numbers in these files, which will
make it easier to update versions. The solution employed here is to
use `curl ... | tar -xzf - --strip-components=1` directly into the
`/var/tmp/build` directory. We'll do the build directly from there, then
remove `/var/tmp/build` after each build step. This makes it so the only
place each library's version is specified is in the curl URL.

Fixes https://github.com/googleapis/google-cloud-cpp/issues/3788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3850)
<!-- Reviewable:end -->
