### PR TITLE
chore: upgrade libcurl to v7.69.1

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -121,10 +121,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_github_curl_curl",
             urls = [
-                "https://curl.haxx.se/download/curl-7.65.3.tar.gz",
+                "https://curl.haxx.se/download/curl-7.69.1.tar.gz",
             ],
-            strip_prefix = "curl-7.65.3",
-            sha256 = "4376ac72b95572fb6c4fbffefb97c7ea0dd083e1974c0e44cd7e49396f454839",
+            strip_prefix = "curl-7.69.1",
+            sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:curl.BUILD",
         )
 

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -493,7 +493,9 @@ TEST_F(ObjectIntegrationTest, PlentyClientsSerially) {
 
   // Create a iostream to read the object back.
   auto num_fds_before_test = GetNumOpenFiles();
+#ifdef __linux__
   std::size_t delta = 0;
+#endif  // __linux__
   for (int i = 0; i != 100; ++i) {
     auto read_client = MakeIntegrationTestClient();
     ASSERT_STATUS_OK(read_client);

--- a/super/external/curl.cmake
+++ b/super/external/curl.cmake
@@ -22,9 +22,9 @@ if (NOT TARGET curl-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_CURL_URL
-        "https://curl.haxx.se/download/curl-7.65.3.tar.gz")
+        "https://curl.haxx.se/download/curl-7.69.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_CURL_SHA256
-        "4376ac72b95572fb6c4fbffefb97c7ea0dd083e1974c0e44cd7e49396f454839")
+        "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
We have not updated this in a while, and there are important bug fixes
in newer versions. I would prefer not to chase these bugs if they
manifest in our builds. Note that in some platforms we build against the
version installed on the platform, which can be much older.

One of the test had hard-coded assumptions about the number of file
descriptors created by a `storage::Client`. The number depends on the
version of libcurl used under the hood. Where possible I just changed
the test to make no such assumptions, we are looking for file descriptor
leaks in this test, we do not really care how many are created.

I think this will make some of the work in #3832 a little easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3851)
<!-- Reviewable:end -->
