### PR TITLE
fix: output on test failure was empty

### DIFF
--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -670,7 +670,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
   EXPECT_LT(0, count) << "logs=" << [&backend] {
     std::string msg;
     for (auto const& l : backend->log_lines) {
-      if (msg.find(" POST ") == std::string::npos) continue;
+      if (l.find(" POST ") == std::string::npos) continue;
       msg += l;
       msg += "\n";
     }


### PR DESCRIPTION
This test was supposed to print the most interesting log lines when it
did not find the expected output, but it actually printed nothing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3853)
<!-- Reviewable:end -->
