### PR TITLE
chore: update compiler for sanitizer builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ build:ubsan --copt=-g
 build:ubsan --copt=-fsanitize=undefined
 build:ubsan --copt=-fno-omit-frame-pointer
 build:ubsan --linkopt=-fsanitize=undefined
-build:ubsan --linkopt=-lubsan
+build:ubsan --linkopt=-fsanitize-link-c++-runtime
 build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:suppressions=/v/bazel/ubsan_suppressions.txt
 
 # --config msan: Memory Sanitizer

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -18,7 +18,8 @@ FROM fedora:${DISTRO_VERSION}
 # Install the tools necessary to run Bazel and CMake Super builds.
 RUN dnf makecache && \
     dnf install -y clang clang-tools-extra cmake diffutils findutils \
-        gcc-c++ git libcxx-devel libcxxabi-devel make openssl-devel pkgconfig \
+        gcc-c++ git libcxx-devel libcxxabi-devel libubsan libubsan-static \
+        make openssl-devel pkgconfig \
         python3 python3-devel python3-pip tar unzip wget which zlib-devel
 
 # Install the Python modules needed to run the storage testbench

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -12,38 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=30
+ARG DISTRO_VERSION=31
 FROM fedora:${DISTRO_VERSION}
 
-RUN dnf makecache && dnf install -y \
-    autoconf \
-    automake \
-    c-ares-devel \
-    ccache \
-    clang \
-    clang-tools-extra \
-    cmake \
-    curl \
-    dia \
-    doxygen \
-    gcc-c++ \
-    git \
-    libcurl-devel \
-    libcxx-devel \
-    libcxxabi-devel \
-    libtool \
-    make \
-    ncurses-term \
-    openssl-devel \
-    pkgconfig \
-    python3 \
-    python3-devel \
-    shtool \
-    unzip \
-    wget \
-    which \
-    zlib-devel
+# Install the tools necessary to run Bazel and CMake Super builds.
+RUN dnf makecache && \
+    dnf install -y clang clang-tools-extra cmake diffutils findutils \
+        gcc-c++ git libcxx-devel libcxxabi-devel make openssl-devel pkgconfig \
+        python3 python3-devel python3-pip tar unzip wget which zlib-devel
 
+# Install the Python modules needed to run the storage testbench
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools
 RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -18,9 +18,9 @@ FROM fedora:${DISTRO_VERSION}
 # Install the tools necessary to run Bazel and CMake Super builds.
 RUN dnf makecache && \
     dnf install -y clang clang-tools-extra cmake diffutils findutils \
-        gcc-c++ git libcxx-devel libcxxabi-devel libubsan libubsan-static \
-        make openssl-devel pkgconfig \
-        python3 python3-devel python3-pip tar unzip wget which zlib-devel
+        gcc-c++ git libcxx-devel libcxxabi-devel libasan libubsan libtsan \
+        make openssl-devel pkgconfig python3 python3-devel python3-pip tar \
+        unzip wget which zlib-devel
 
 # Install the Python modules needed to run the storage testbench
 RUN pip3 install --upgrade pip

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -99,8 +99,8 @@ elif [[ "${BUILD_NAME}" = "asan" ]]; then
   # Compile with the AddressSanitizer enabled.
   export CC=clang
   export CXX=clang++
-  export DISTRO=ubuntu
-  export DISTRO_VERSION=18.04
+  export DISTRO=fedora
+  export DISTRO_VERSION=31
   export BAZEL_CONFIG="asan"
   RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
@@ -109,7 +109,7 @@ elif [[ "${BUILD_NAME}" = "msan" ]]; then
   export CC=clang
   export CXX=clang++
   export DISTRO=fedora-libcxx-msan
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   export BAZEL_CONFIG="msan"
   RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
@@ -117,18 +117,17 @@ elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   # Compile with the ThreadSanitizer enabled.
   export CC=clang
   export CXX=clang++
-  export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO=fedora
+  export DISTRO_VERSION=31
   export BAZEL_CONFIG="tsan"
-  # TODO(#3832) - fix bugs and enable
   # RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   # Compile with the UndefinedBehaviorSanitizer enabled.
   export CC=clang
   export CXX=clang++
-  export DISTRO=ubuntu
-  export DISTRO_VERSION=18.04
+  export DISTRO=fedora
+  export DISTRO_VERSION=31
   export BAZEL_CONFIG="ubsan"
   # TODO(#3832) - fix bugs and enable
   # RUN_INTEGRATION_TESTS=auto


### PR DESCRIPTION
With this change all the sanitizer builds will compile using Clang 9.0,
we have other builds to test older versions of Clang and GCC, it seems
that we should use a recent compiler for builds that helps us in
development.

This makes the work in #3832 a little bit easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3855)
<!-- Reviewable:end -->
