### PR TITLE
cleanup: prefer CURL_AT_LEAST_VERSION()

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -270,9 +270,9 @@ CurlClient::CurlClient(ClientOptions options)
   curl_share_setopt(share_.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
   curl_share_setopt(share_.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
   curl_share_setopt(share_.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
-#if LIBCURL_VERSION_NUM >= 0x076100
+#if CURL_AT_LEAST_VERSION(7, 61, 0)
   curl_share_setopt(share_.get(), CURLSHOPT_SHARE, CURL_LOCK_DATA_PSL);
-#endif  // LIBCURL_VERSION_NUM
+#endif  // libcurl >= 7.61.0
 
   CurlInitializeOnce(options);
 }
@@ -1185,11 +1185,11 @@ void CurlClient::LockShared(curl_lock_data data) {
     case CURL_LOCK_DATA_CONNECT:
       mu_connect_.lock();
       return;
-#if LIBCURL_VERSION_NUM >= 0x076100
+#if CURL_AT_LEAST_VERSION(7, 61, 0)
     case CURL_LOCK_DATA_PSL:
       mu_psl_.lock();
       return;
-#endif  // LIBCURL_VERSION_NUM
+#endif  // libcurl >= 7.61.0
     default:
       // We use a default because different versions of libcurl have different
       // values in the `curl_lock_data` enum.
@@ -1214,11 +1214,11 @@ void CurlClient::UnlockShared(curl_lock_data data) {
     case CURL_LOCK_DATA_CONNECT:
       mu_connect_.unlock();
       return;
-#if LIBCURL_VERSION_NUM >= 0x076100
+#if CURL_AT_LEAST_VERSION(7, 61, 0)
     case CURL_LOCK_DATA_PSL:
       mu_psl_.unlock();
       return;
-#endif  // LIBCURL_VERSION_NUM
+#endif  // libcurl >= 7.61.0
     default:
       // We use a default because different versions of libcurl have different
       // values in the `curl_lock_data` enum.

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -150,11 +150,11 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
   handle_.FlushDebug(__func__);
   TRACE_STATE();
 
-#if LIBCURL_VERSION_NUM >= 0x074500
+#if CURL_AT_LEAST_VERSION(7, 69, 0)
   if (!curl_closed_ && paused_) {
 #else
   if (!curl_closed_) {
-#endif  // LIBCURL_VERSION_NUM
+#endif  // libcurl >= 7.69.0
     auto status = handle_.EasyPause(CURLPAUSE_RECV_CONT);
     if (!status.ok()) {
       TRACE_STATE() << ", status=" << status;

--- a/google/cloud/storage/internal/curl_wrappers.h
+++ b/google/cloud/storage/internal/curl_wrappers.h
@@ -32,7 +32,7 @@ namespace internal {
 
 #ifndef CURL_AT_LEAST_VERSION
 #define CURL_AT_LEAST_VERSION(Ma, Mi, Pa) \
-  (LIBCURL_VERSION_NUM >= ((((Ma) << 8) | ((Mi) << 8)) | (Pa)))
+  (LIBCURL_VERSION_NUM >= ((((Ma) << 16) | ((Mi) << 8)) | (Pa)))
 #endif  // CURL_AT_LEAST_VERSION
 
 /// Hold a CURL* handle and automatically clean it up.

--- a/google/cloud/storage/internal/curl_wrappers.h
+++ b/google/cloud/storage/internal/curl_wrappers.h
@@ -29,6 +29,12 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+
+#ifndef CURL_AT_LEAST_VERSION
+#define CURL_AT_LEAST_VERSION(Ma, Mi, Pa) \
+  (LIBCURL_VERSION_NUM >= ((((Ma) << 8) | ((Mi) << 8)) | (Pa)))
+#endif  // CURL_AT_LEAST_VERSION
+
 /// Hold a CURL* handle and automatically clean it up.
 using CurlPtr = std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>;
 

--- a/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
@@ -39,7 +39,7 @@ TEST(CurlWrappers, SigpipeHandlerDisabledTest) {
 
 #if !defined(SIGPIPE)
   return;  // nothing to do
-#elif CURL_AT_LEAST_VERSION(7, 29, 0)
+#elif CURL_AT_LEAST_VERSION(7, 30, 0)
   // libcurl <= 7.29.0 installs its own signal handler for SIGPIPE during
   // curl_global_init(). Unfortunately 7.29.0 is the default on CentOS-7, and
   // the tests here fails. We simply skip the test with this ancient library.

--- a/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
@@ -39,7 +39,7 @@ TEST(CurlWrappers, SigpipeHandlerDisabledTest) {
 
 #if !defined(SIGPIPE)
   return;  // nothing to do
-#elif LIBCURL_VERSION_NUM > 0x072900
+#elif CURL_AT_LEAST_VERSION(7, 29, 0)
   // libcurl <= 7.29.0 installs its own signal handler for SIGPIPE during
   // curl_global_init(). Unfortunately 7.29.0 is the default on CentOS-7, and
   // the tests here fails. We simply skip the test with this ancient library.


### PR DESCRIPTION
This macro is (I think) more readable than using the hexadecimal
representation of version numbers, and it caught a couple of places
where I (at least I think it was me) used the wrong version number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3856)
<!-- Reviewable:end -->
