### PR TITLE
cleanup: restore dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# We do not need the git repository in docker images.
+.git/
+
+# We do not need the typical build directories in docker images.
+.idea/
+.build/
+_build/
+build-output/
+cmake-build-*/
+cmake-out/


### PR DESCRIPTION
Turns out we do need the top-level .dockerignore file. The
`ci/kokoro/install` builds use it. It is not a big deal in the CI
builds, where the ignored directories are mostly empty, but it is a
problem when testing those builds in a development workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3857)
<!-- Reviewable:end -->
