### PR TITLE
fix: argument handling in table admin async example

### DIFF
--- a/google/cloud/bigtable/examples/table_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_async_snippets.cc
@@ -408,7 +408,7 @@ void AsyncTestIamPermissionsCommand(std::vector<std::string> argv) {
   }
   auto const project_id = argv[0];
   auto const instance_id = argv[1];
-  argv.erase(argv.begin(), argv.begin() + 1);
+  argv.erase(argv.begin(), argv.begin() + 2);
 
   google::cloud::CompletionQueue cq;
   std::thread th([&cq] { cq.Run(); });


### PR DESCRIPTION
One of the examples was not consuming its arguments correctly. Because
this only runs in the nightly build we did not catch the problem during
the PR. And I missed it during the review, of course.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3859)
<!-- Reviewable:end -->
