### PR TITLE
feat: enable integration tests for tsan and ubsan builds

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -120,7 +120,7 @@ elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   export DISTRO=fedora
   export DISTRO_VERSION=31
   export BAZEL_CONFIG="tsan"
-  # RUN_INTEGRATION_TESTS=auto
+  RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   # Compile with the UndefinedBehaviorSanitizer enabled.
@@ -129,8 +129,7 @@ elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   export DISTRO=fedora
   export DISTRO_VERSION=31
   export BAZEL_CONFIG="ubsan"
-  # TODO(#3832) - fix bugs and enable
-  # RUN_INTEGRATION_TESTS=auto
+  RUN_INTEGRATION_TESTS=auto
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="super"


### PR DESCRIPTION
This enables the integration tests for the ThreadSanitizer and
UndefinedBehaviorSanitiser builds. To summarize the changes precending
this one:

- We removed the use of CURL_SHARE, a feature to share the connection
cache and other resources, because libcurl has outstanding issues with
this feature.
- We upgraded libcurl to 7.69.1 for the Bazel and CMake Super builds,
this was nice, but did not fix any problems.
- Two of the tests actually had errors detected by ThreadSanitizer, but
this was only in the test code.
- We upgrade the sanitizer builds to use clang-9.0, which could be
useful in the future.

Fixes #3832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3861)
<!-- Reviewable:end -->
