### PR TITLE
fix!: use correct type for generation numbers

### DIFF
--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -42,8 +42,8 @@ struct CustomerEncryption {
 /// Defines one of the source objects for a compose operation.
 struct ComposeSourceObject {
   std::string object_name;
-  google::cloud::optional<long> generation;
-  google::cloud::optional<long> if_generation_match;
+  google::cloud::optional<std::int64_t> generation;
+  google::cloud::optional<std::int64_t> if_generation_match;
 };
 
 std::ostream& operator<<(std::ostream& os, ComposeSourceObject const& r);


### PR DESCRIPTION
**BREAKING CHANGE:** This changes the type of two fields from
`google::cloud::optional<long>` to
`google::cloud::optional<std::int64_t>`. With MSVC this is not a
backwards compatible change (storing the result of `.value()` into a
`long` now loses precision). However, on that platform the fields were
not usable, they could not store the values that are typically generated
by the production environment. We apologize to any customers affected by
this change, but we think it is unlikely that anybody used the field on
that platform or we would have heard of the bug earlier.

Part of the work for #3540

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3870)
<!-- Reviewable:end -->
