### PR TITLE
test: reduce runtime of the "compose many" test

### DIFF
--- a/google/cloud/storage/tests/object_compose_many_integration_test.cc
+++ b/google/cloud/storage/tests/object_compose_many_integration_test.cc
@@ -45,7 +45,7 @@ TEST_F(ObjectComposeManyIntegrationTest, ComposeMany) {
 
   std::vector<ComposeSourceObject> source_objs;
   std::string expected;
-  for (int i = 0; i != 100; ++i) {
+  for (int i = 0; i != 33; ++i) {
     std::string const object_name = prefix + ".src-" + std::to_string(i);
     std::string content = std::to_string(i);
     expected += content;


### PR DESCRIPTION
See coryan's comment on #3873 recommending we reduce the number of
iterations from 100 to 33.

before:
```
//google/cloud/storage/tests:object_compose_many_integration_test        PASSED in 35.8s
```

after:
```
//google/cloud/storage/tests:object_compose_many_integration_test        PASSED in 14.4s
```

Part of #3854

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3875)
<!-- Reviewable:end -->
