### PR TITLE
test: rework some logic for counting open files

### DIFF
--- a/google/cloud/storage/testing/object_integration_test.cc
+++ b/google/cloud/storage/testing/object_integration_test.cc
@@ -37,7 +37,7 @@ StatusOr<std::size_t> GetNumEntries(std::string const& path) {
                                              "\": " + strerror(errno));
   }
   int count = 0;
-  while (struct dirent* entry = readdir(dir)) {
+  while (readdir(dir)) {
     ++count;
   }
   closedir(dir);

--- a/google/cloud/storage/testing/object_integration_test.cc
+++ b/google/cloud/storage/testing/object_integration_test.cc
@@ -31,17 +31,17 @@ namespace {
 
 StatusOr<std::size_t> GetNumEntries(std::string const& path) {
 #ifdef __unix__
-  dirent** namelist;
-  int res = scandir(path.c_str(), &namelist, nullptr, alphasort);
-  if (res < 0) {
+  DIR* dir = opendir(path.c_str());
+  if (dir == nullptr) {
     return Status(StatusCode::kInternal, "Failed to open directory \"" + path +
                                              "\": " + strerror(errno));
   }
-  for (int i = 0; i < res; ++i) {
-    free(namelist[i]);
+  int count = 0;
+  while (struct dirent* entry = readdir(dir)) {
+    ++count;
   }
-  free(namelist);
-  return res;
+  closedir(dir);
+  return count;
 #else   // __unix__
   return Status(StatusCode::kUnimplemented,
                 "Can't check #entries in " + path +
@@ -59,7 +59,7 @@ StatusOr<std::size_t> ObjectIntegrationTest::GetNumOpenFiles() {
   if (*res < 3) {
     return Status(StatusCode::kInternal,
                   "Expected at least three entries in /proc/self/fd: ., .., "
-                  "and the directory itself, found " +
+                  "and /proc/self/fd itself, found " +
                       std::to_string(*res));
   }
   return *res - 3;

--- a/google/cloud/storage/testing/object_integration_test.cc
+++ b/google/cloud/storage/testing/object_integration_test.cc
@@ -36,7 +36,7 @@ StatusOr<std::size_t> GetNumEntries(std::string const& path) {
     return Status(StatusCode::kInternal, "Failed to open directory \"" + path +
                                              "\": " + strerror(errno));
   }
-  int count = 0;
+  std::size_t count = 0;
   while (readdir(dir)) {
     ++count;
   }
@@ -53,9 +53,7 @@ StatusOr<std::size_t> GetNumEntries(std::string const& path) {
 
 StatusOr<std::size_t> ObjectIntegrationTest::GetNumOpenFiles() {
   auto res = GetNumEntries("/proc/self/fd");
-  if (!res) {
-    return res;
-  }
+  if (!res) return res;
   if (*res < 3) {
     return Status(StatusCode::kInternal,
                   "Expected at least three entries in /proc/self/fd: ., .., "


### PR DESCRIPTION
addresses devbww's comments on #3873

* use `opendir()` instead of `scandir()` to read the directory
* I do think eliding 3 entries makes sense since opening `/proc/self/fd`
  is a side effect of taking the measurement. I updated the comment.
* contained the #ifdef to one place, which I think makes it easier to
  read. The test still fails if we can't get the count on linux, and it
  will also fail as a reminder to update it if we find a way to get
  the count on non-linux.

part of #3854

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3876)
<!-- Reviewable:end -->
