### PR TITLE
refactor: auto run storage_file_transfer_benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -35,13 +35,26 @@ cc_library(
 
 load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
 
-[cc_binary(
+# TODO(#3525) - remove this once the list is empty
+load(":storage_benchmark_programs_manual_run.bzl", "storage_benchmark_programs_manual_run")
+
+auto_run_tags = [
+    "integration-tests",
+    "storage-integration-tests",
+]
+
+manual_tags = [
+    "integration-tests",
+]
+
+[cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
+    tags = manual_tags if test in storage_benchmark_programs_manual_run else auto_run_tags,
     deps = [
         ":storage_benchmarks",
         "//google/cloud/storage:nlohmann_json",

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -38,14 +38,17 @@ if (BUILD_TESTING)
     include(CreateBazelConfig)
     create_bazel_config(storage_benchmarks YEAR 2019)
 
-    set(storage_benchmark_programs
+    set(storage_benchmarks_programs_manual_run
         # cmake-format: sort
-        storage_file_transfer_benchmark.cc
         storage_latency_benchmark.cc
         storage_parallel_uploads_benchmark.cc
         storage_shard_throughput_benchmark.cc
         storage_throughput_benchmark.cc
         storage_throughput_vs_cpu_benchmark.cc)
+    set(storage_benchmark_programs
+        # cmake-format: sort
+        ${storage_benchmarks_programs_manual_run}
+        storage_file_transfer_benchmark.cc)
 
     foreach (fname ${storage_benchmark_programs})
         string(REPLACE "/" "_" target ${fname})
@@ -62,10 +65,23 @@ if (BUILD_TESTING)
                     nlohmann_json
                     storage_common_options
                     google_cloud_cpp_common_options)
+        add_test(NAME ${target} COMMAND ${target})
+        set_tests_properties(
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;storage-integration-tests")
+    endforeach ()
+
+    # TODO(#3525) - remove this loop once the list is empty
+    foreach (fname ${storage_benchmarks_programs_manual_run})
+        string(REPLACE "/" "_" target ${fname})
+        string(REPLACE ".cc" "" target ${target})
+        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
     endforeach ()
 
     export_list_to_bazel("storage_benchmark_programs.bzl"
                          "storage_benchmark_programs" YEAR 2019)
+    export_list_to_bazel("storage_benchmark_programs_manual_run.bzl"
+                         "storage_benchmark_programs_manual_run" YEAR 2020)
 
     # List the unit tests, then setup the targets and dependencies.
     set(storage_benchmarks_unit_tests

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -38,7 +38,7 @@ if (BUILD_TESTING)
     include(CreateBazelConfig)
     create_bazel_config(storage_benchmarks YEAR 2019)
 
-    set(storage_benchmarks_programs_manual_run
+    set(storage_benchmark_programs_manual_run
         # cmake-format: sort
         storage_latency_benchmark.cc
         storage_parallel_uploads_benchmark.cc
@@ -47,7 +47,7 @@ if (BUILD_TESTING)
         storage_throughput_vs_cpu_benchmark.cc)
     set(storage_benchmark_programs
         # cmake-format: sort
-        ${storage_benchmarks_programs_manual_run}
+        ${storage_benchmark_programs_manual_run}
         storage_file_transfer_benchmark.cc)
 
     foreach (fname ${storage_benchmark_programs})
@@ -72,7 +72,7 @@ if (BUILD_TESTING)
     endforeach ()
 
     # TODO(#3525) - remove this loop once the list is empty
-    foreach (fname ${storage_benchmarks_programs_manual_run})
+    foreach (fname ${storage_benchmark_programs_manual_run})
         string(REPLACE "/" "_" target ${fname})
         string(REPLACE ".cc" "" target ${target})
         set_tests_properties(${target} PROPERTIES LABELS "integration-tests")

--- a/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
+++ b/google/cloud/storage/benchmarks/run_benchmarks_testbench.sh
@@ -16,7 +16,7 @@
 
 set -eu
 
-if [ -z "${PROJECT_ROOT+x}" ]; then
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(
     cd "$(dirname "$0")/../../../.."
     pwd
@@ -37,14 +37,6 @@ FAKE_REGION="fake-region-${RANDOM}-${RANDOM}"
 # them. We are not trying to validate the output is correct, or the performance
 # has not changed.
 export GOOGLE_CLOUD_PROJECT="fake-project-${RANDOM}-${RANDOM}"
-
-run_example_usage ./storage_file_transfer_benchmark \
-  --help --description
-run_example ./storage_file_transfer_benchmark \
-  "--project-id=${GOOGLE_CLOUD_PROJECT}" \
-  "--region=${FAKE_REGION}" \
-  --object-size=16KiB \
-  --duration=1s
 
 run_example ./storage_latency_benchmark \
   --duration=1 \

--- a/google/cloud/storage/benchmarks/storage_benchmark_programs_manual_run.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmark_programs_manual_run.bzl
@@ -17,4 +17,9 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_benchmark_programs_manual_run = [
+    "storage_latency_benchmark.cc",
+    "storage_parallel_uploads_benchmark.cc",
+    "storage_shard_throughput_benchmark.cc",
+    "storage_throughput_benchmark.cc",
+    "storage_throughput_vs_cpu_benchmark.cc",
 ]

--- a/google/cloud/storage/benchmarks/storage_benchmark_programs_manual_run.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmark_programs_manual_run.bzl
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,5 @@
 
 """Automatically generated unit tests list - DO NOT EDIT."""
 
-storage_benchmark_programs = [
-    "storage_latency_benchmark.cc",
-    "storage_parallel_uploads_benchmark.cc",
-    "storage_shard_throughput_benchmark.cc",
-    "storage_throughput_benchmark.cc",
-    "storage_throughput_vs_cpu_benchmark.cc",
-    "storage_file_transfer_benchmark.cc",
+storage_benchmark_programs_manual_run = [
 ]

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -272,7 +272,8 @@ google::cloud::StatusOr<Options> SelfTest() {
     if (!value.empty()) continue;
     std::ostringstream os;
     os << "The environment variable " << var << " is not set or empty";
-    throw std::runtime_error(std::move(os).str());
+    return google::cloud::Status(google::cloud::StatusCode::kUnknown,
+                                 std::move(os).str());
   }
   return ParseArgsDefault({
       "self-test",


### PR DESCRIPTION
Add a "self-test" to this benchmark that is automatically run as part of
the CI builds, without any need for supporting driver scripts.

Part of the work for #3525 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3877)
<!-- Reviewable:end -->
