### PR TITLE
test: ensure sure tests clean up objects they create

### DIFF
--- a/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
+++ b/google/cloud/storage/tests/object_list_objects_versions_integration_test.cc
@@ -104,6 +104,7 @@ TEST_F(ObjectListObjectsVersionsIntegrationTest, ListObjectsVersions) {
     EXPECT_EQ(3, std::count(actual.begin(), actual.end(), name))
         << "Expected to find 3 copies of " << name << " in the object list:\n"
         << produce_joined_list();
+    EXPECT_STATUS_OK(client->DeleteObject(bucket_name_, name));
   }
 }
 


### PR DESCRIPTION
In the "Compose Many" test I use `TearDown` in case there are any
`ASSERT`s that terminate the test early.  We don't have that issue
in the "List" test but it might be worth considering a more generic
cleanup mechanism for all tests.

I ran all of the integration tests against my own bucket and verified
no files were left over.

Fixes #3872

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3879)
<!-- Reviewable:end -->
