### PR TITLE
refactor: auto run the bigtable benchmarks

### DIFF
--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -70,54 +70,28 @@ if (BUILD_TESTING)
     endforeach ()
 endif ()
 
-# Benchmark Table::ReadRows().
-add_executable(scan_throughput_benchmark scan_throughput_benchmark.cc)
-target_link_libraries(
-    scan_throughput_benchmark
-    PRIVATE bigtable_benchmark_common
-            bigtable_client
-            bigtable_protos
-            bigtable_common_options
-            google_cloud_cpp_grpc_utils
-            gRPC::grpc++
-            gRPC::grpc
-            protobuf::libprotobuf)
-
-# Benchmark for Table::Apply() and Table::ReadRow().
-add_executable(apply_read_latency_benchmark apply_read_latency_benchmark.cc)
-target_link_libraries(
-    apply_read_latency_benchmark
-    PRIVATE bigtable_benchmark_common
-            bigtable_client
-            bigtable_protos
-            bigtable_common_options
-            google_cloud_cpp_grpc_utils
-            gRPC::grpc++
-            gRPC::grpc
-            protobuf::libprotobuf)
-
-# A benchmark for ReadRow() comparing sync vs. async throughput.
-add_executable(read_sync_vs_async_benchmark read_sync_vs_async_benchmark.cc)
-target_link_libraries(
-    read_sync_vs_async_benchmark
-    PRIVATE bigtable_benchmark_common
-            bigtable_client
-            bigtable_protos
-            bigtable_common_options
-            google_cloud_cpp_grpc_utils
-            gRPC::grpc++
-            gRPC::grpc
-            protobuf::libprotobuf)
-
-# A benchmark to measure performance of long running programs.
-add_executable(endurance_benchmark endurance_benchmark.cc)
-target_link_libraries(
-    endurance_benchmark
-    PRIVATE bigtable_benchmark_common
-            bigtable_client
-            bigtable_protos
-            bigtable_common_options
-            google_cloud_cpp_grpc_utils
-            gRPC::grpc++
-            gRPC::grpc
-            protobuf::libprotobuf)
+set(storage_benchmark_programs
+    # cmake-format: sort
+    apply_read_latency_benchmark.cc endurance_benchmark.cc
+    read_sync_vs_async_benchmark.cc scan_throughput_benchmark.cc)
+foreach (fname ${storage_benchmark_programs})
+    string(REPLACE "/" "_" target ${fname})
+    string(REPLACE ".cc" "" target ${target})
+    add_executable(${target} ${fname})
+    target_link_libraries(
+        ${target}
+        PRIVATE bigtable_benchmark_common
+                bigtable_client
+                bigtable_protos
+                bigtable_common_options
+                google_cloud_cpp_grpc_utils
+                gRPC::grpc++
+                gRPC::grpc
+                protobuf::libprotobuf)
+    if (BUILD_TESTING)
+        add_test(NAME ${target} COMMAND ${target})
+        set_tests_properties(
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;bigtable-integration-tests")
+    endif ()
+endforeach ()

--- a/google/cloud/bigtable/ci/run_integration_tests.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests.sh
@@ -23,26 +23,4 @@ source "${BINDIR}/../../../../ci/colors.sh"
 
 readonly BTDIR="google/cloud/bigtable"
 
-# To improve coverage (and avoid bitrot), run the Bigtable benchmarks using the
-# embedded server.  The performance in the Travis and AppVeyor CI builds is not
-# consistent enough to use the results, but we want to detect crashes and ensure
-# the code at least is able to run as soon as possible.
-log="$(mktemp -t "bigtable_benchmarks.XXXXXX")"
-for benchmark in endurance apply_read_latency scan_throughput; do
-  if [ ! -x "${BTDIR}/benchmarks/${benchmark}_benchmark" ]; then
-    echo "${COLOR_YELLOW}[ SKIPPED  ]${COLOR_RESET} ${benchmark} benchmark"
-    continue
-  fi
-  echo "${COLOR_GREEN}[ RUN      ]${COLOR_RESET} ${benchmark}"
-  "${BTDIR}/benchmarks/${benchmark}_benchmark" unused unused unused 1 5 1000 true >"${log}" 2>&1 </dev/null
-  if [ $? = 0 ]; then
-    echo "${COLOR_GREEN}[       OK ]${COLOR_RESET} ${benchmark} benchmark"
-  else
-    echo "${COLOR_RED}[    ERROR ]${COLOR_RESET} ${benchmark} benchmark"
-    echo
-    echo "================ [begin ${log}] ================"
-    cat "${log}"
-    echo "================ [end ${log}] ================"
-  fi
-done
-/bin/rm -f "${log}"
+# TODO(#3526) - remove this file and call sites when dust settles


### PR DESCRIPTION
With this change all the bigtable benchmarks automatically run, without
the need of additional support scripts. Note that these benchmarks (and
their unit tests) are not compiled with Bazel, so they will not be
present in many builds. That is a matter for a separate bug and PR.

The support scripts will be removed in a future PR once we merge the
analogous changes for google/cloud/storage

Fixes #3526

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3882)
<!-- Reviewable:end -->
