### PR TITLE
fix: CI script for Windows+Bazel used of env vars

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -143,6 +143,10 @@ if (Integration-Tests-Enabled) {
         'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
          "${env:KOKORO_GFILE_DIR}/roots.pem")
     ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
+    $enable_bigtable_admin_integration_tests="no"
+    if (Test-Path env:ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS) {
+        $enable_bigtable_admin_integration_tests=${env:ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS}
+    }
 
     $integration_flags=@(
         # Common configuration
@@ -156,7 +160,7 @@ if (Integration-Tests-Enabled) {
         "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A=${env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A}",
         "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B=${env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B}",
         "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT=${env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT}",
-        "--test_env=ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS=${env:ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS:-no}",
+        "--test_env=ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS=${enable_bigtable_admin_integration_tests}",
 
         # Storage
         "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME=${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}",


### PR DESCRIPTION
I used a shell-ism in PowerShell, i.e. ${FOO:-no}, which is not a thing
in PowerShell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3886)
<!-- Reviewable:end -->
