### PR TITLE
ci: disable cache upload/download for non-CI builds

### DIFF
--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -46,7 +46,7 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
+if [[ "${RUNNING_CI:-}" != "yes" ]] ||
   [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
   [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -46,7 +46,8 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
+if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
+  [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
   [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
   log_normal "Cache not downloaded as this is not a PR build."

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -46,9 +46,9 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${RUNNING_CI:-}" != "yes" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
-  [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" ]]; then
+if [[ "${RUNNING_CI:-}" != "yes" || (\
+  "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" && \
+  "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB") ]]; then
   echo "================================================================"
   log_normal "Cache not downloaded as this is not a PR build."
   exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -42,8 +42,7 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${RUNNING_CI:-}" != "yes" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
+if [[ "${RUNNING_CI:-}" != "yes" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
   echo "================================================================"
   log_normal "Cache not updated as this is not a CI build or it is a PR build."
   exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -42,9 +42,8 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
+if [[ "${RUNNING_CI:-}" != "yes" ]] ||
+  [[ "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
   echo "================================================================"
   log_normal "Cache not updated as this is not a CI build or it is a PR build."
   exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -42,10 +42,11 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] ||
+if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
+  [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] ||
   [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
-  log_normal "Cache not updated as this is a PR build."
+  log_normal "Cache not updated as this is not a CI build or it is a PR build."
   exit 0
 fi
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -37,6 +37,13 @@ elif [[ -n "${KOKORO_JOB_NAME:-}" ]]; then
   # name.
   BUILD_NAME="$(basename "${KOKORO_JOB_NAME}" "-presubmit")"
   export BUILD_NAME
+
+  # This is passed into the environment of the remaining scripts to tell them if
+  # they are running as part of a CI build rather than just a human invocation
+  # of "build.sh <build-name>". This allows scripts to be strict when run in a
+  # CI, but a little more friendly when run by a human.
+  RUNNING_CI="yes"
+  export RUNNING_CI
 else
   echo "Aborting build as the build name is not defined."
   echo "If you are invoking this script via the command line use:"

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -48,7 +48,8 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
+if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
+  [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
   [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
   log_normal "Cache not downloaded as this is not a PR build."

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -48,7 +48,7 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
+if [[ "${RUNNING_CI:-}" != "yes" ]] ||
   [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
   [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -48,9 +48,9 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${RUNNING_CI:-}" != "yes" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" ]] &&
-  [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" ]]; then
+if [[ "${RUNNING_CI:-}" != "yes" || (\
+  "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" && \
+  "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB") ]]; then
   echo "================================================================"
   log_normal "Cache not downloaded as this is not a PR build."
   exit 0

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -46,10 +46,11 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] ||
+if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
+  [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] ||
   [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
-  log_normal "Cache not updated as this is a PR build."
+  log_normal "Cache not updated as this is not a CI build or it is a PR build."
   exit 0
 fi
 

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -46,9 +46,8 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ -z "${KOKORO_JOB_TYPE:-}" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
+if [[ "${RUNNING_CI:-}" != "yes" ]] ||
+  [[ "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
   echo "================================================================"
   log_normal "Cache not updated as this is not a CI build or it is a PR build."
   exit 0

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -46,8 +46,7 @@ if [[ ! -f "${KEYFILE}" ]]; then
   exit 0
 fi
 
-if [[ "${RUNNING_CI:-}" != "yes" ]] ||
-  [[ "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
+if [[ "${RUNNING_CI:-}" != "yes" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
   echo "================================================================"
   log_normal "Cache not updated as this is not a CI build or it is a PR build."
   exit 0

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -40,6 +40,7 @@ $CACHE_FOLDER="${CACHE_BUCKET}/build-cache/${GOOGLE_CLOUD_CPP_REPOSITORY}/${BRAN
 # support those well.
 $CACHE_BASENAME="cache-windows-bazel"
 
+$IsCI = (Test-Path env:KOKORO_JOB_TYPE)
 $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
     ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
 $CacheConfigured = (Test-Path env:KOKORO_GFILE_DIR) -and `
@@ -56,7 +57,7 @@ if (Test-Path env:TEMP) {
 } elseif (-not $download_dir) {
     Make-Item -Type "Directory" ${download_dir}
 }
-if ($IsPR -and $CacheConfigured -and $Has7z) {
+if ($IsCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     gcloud auth activate-service-account --key-file `
         "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -191,7 +192,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
-if ((-not $IsPR) -and $CacheConfigured -and $Has7z) {
+if ($IsCI -and (-not $IsPR) -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -40,7 +40,10 @@ $CACHE_FOLDER="${CACHE_BUCKET}/build-cache/${GOOGLE_CLOUD_CPP_REPOSITORY}/${BRAN
 # support those well.
 $CACHE_BASENAME="cache-windows-bazel"
 
-$IsCI = (Test-Path env:KOKORO_JOB_TYPE)
+$RunningCI = (Test-Path env:RUNNING_CI) -and `
+    ($env:RUNNING_CI -eq "yes")
+$IsCI = (Test-Path env:KOKORO_JOB_TYPE) -and `
+    ($env:KOKORO_JOB_TYPE -eq "CONTINUOUS_INTEGRATION")
 $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
     ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
 $CacheConfigured = (Test-Path env:KOKORO_GFILE_DIR) -and `
@@ -57,7 +60,7 @@ if (Test-Path env:TEMP) {
 } elseif (-not $download_dir) {
     Make-Item -Type "Directory" ${download_dir}
 }
-if ($IsCI -and $IsPR -and $CacheConfigured -and $Has7z) {
+if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     gcloud auth activate-service-account --key-file `
         "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -192,7 +195,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
-if ($IsCI -and (-not $IsPR) -and $CacheConfigured -and $Has7z) {
+if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -119,10 +119,11 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 
 # Do not update the vcpkg cache on PRs, it might dirty the cache for any
 # PRs running in parallel, and it is a waste of time in most cases.
+$IsCI = (Test-Path env:KOKORO_JOB_TYPE)
 $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
     ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
 $HasBuildCache = (Test-Path env:BUILD_CACHE)
-if ((-not $IsPR) -and $HasBuildCache) {
+if ($IsCI -and (-not $IsPR) -and $HasBuildCache) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
       "zip vcpkg cache for upload."
     7z a vcpkg-installed.zip installed\ -bsp0
@@ -142,5 +143,6 @@ if ((-not $IsPR) -and $HasBuildCache) {
     }
 } else {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
-      "vcpkg not updated IsPR == $IsPR, HasBuildCache == $HasBuildCache."
+      "vcpkg not updated IsCI = $IsCI, IsPR = $IsPR, " `
+      "HasBuildCache = $HasBuildCache."
 }

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -24,6 +24,14 @@ if (-not (Test-Path env:VCPKG_TRIPLET)) {
     throw "Aborting build because the VCPKG_TRIPLET environment variable is not set."
 }
 
+$RunningCI = (Test-Path env:RUNNING_CI) -and `
+    ($env:RUNNING_CI -eq "yes")
+$IsCI = (Test-Path env:KOKORO_JOB_TYPE) -and `
+    ($env:KOKORO_JOB_TYPE -eq "CONTINUOUS_INTEGRATION")
+$IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
+    ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
+$HasBuildCache = (Test-Path env:BUILD_CACHE)
+
 $project_root = (Get-Item -Path ".\" -Verbose).FullName
 $vcpkg_dir = "cmake-out\vcpkg"
 $packages = @("zlib", "openssl",
@@ -43,7 +51,7 @@ if ($args.count -ge 1) {
 # multiple times while debugging vcpkg installs.  It also works on Kokoro
 # where we cache the vcpkg installation, but it might be empty on the first
 # build.
-if ((Test-Path env:RUNNING_CI) -and (Test-Path "${vcpkg_dir}")) {
+if ($RunningCI -and (Test-Path "${vcpkg_dir}")) {
     Remove-Item -LiteralPath "${vcpkg_dir}" -Force -Recurse
 }
 if (-not (Test-Path ${vcpkg_dir})) {
@@ -63,7 +71,7 @@ Set-Location "${vcpkg_dir}"
 
 # If BUILD_CACHE is set (which typically is on Kokoro builds), try
 # to download and extract the build cache.
-if ((Test-Path env:BUILD_CACHE) -and (Test-Path env:KOKORO_GFILE_DIR)) {
+if ($RunningCI -and $IsPR -and $HasBuildCache) {
     gcloud auth activate-service-account `
         --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -119,11 +127,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 
 # Do not update the vcpkg cache on PRs, it might dirty the cache for any
 # PRs running in parallel, and it is a waste of time in most cases.
-$IsCI = (Test-Path env:KOKORO_JOB_TYPE)
-$IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
-    ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
-$HasBuildCache = (Test-Path env:BUILD_CACHE)
-if ($IsCI -and (-not $IsPR) -and $HasBuildCache) {
+if ($RunningCI -and $IsCI -and $HasBuildCache) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
       "zip vcpkg cache for upload."
     7z a vcpkg-installed.zip installed\ -bsp0

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -57,7 +57,7 @@ if (Test-Path env:TEMP) {
 } elseif (-not $download_dir) {
     Make-Item -Type "Directory" ${download_dir}
 }
-if ($IsPR -and $CacheConfigured -and $Has7z) {
+if ($IsCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     gcloud auth activate-service-account --key-file `
         "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -168,7 +168,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
-if ((-not $IsPR) -and $CacheConfigured -and $Has7z) {
+if ($IsCI -and (-not $IsPR) -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -40,6 +40,10 @@ $CACHE_FOLDER="${CACHE_BUCKET}/build-cache/${GOOGLE_CLOUD_CPP_REPOSITORY}/${BRAN
 # support those well.
 $CACHE_BASENAME="cache-windows-quickstart-bazel"
 
+$RunningCI = (Test-Path env:RUNNING_CI) -and `
+    ($env:RUNNING_CI -eq "yes")
+$IsCI = (Test-Path env:KOKORO_JOB_TYPE) -and `
+    ($env:KOKORO_JOB_TYPE -eq "CONTINUOUS_INTEGRATION")
 $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
     ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
 $CacheConfigured = (Test-Path env:KOKORO_GFILE_DIR) -and `
@@ -57,7 +61,7 @@ if (Test-Path env:TEMP) {
 } elseif (-not $download_dir) {
     Make-Item -Type "Directory" ${download_dir}
 }
-if ($IsCI -and $IsPR -and $CacheConfigured -and $Has7z) {
+if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     gcloud auth activate-service-account --key-file `
         "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -168,7 +172,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
-if ($IsCI -and (-not $IsPR) -and $CacheConfigured -and $Has7z) {
+if ($RUnningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).


### PR DESCRIPTION
These scripts are used to run the builds locally, on a developer
workstations. With these changes the cache is not downloaded or
downloaded unless KOKORO_JOB_TYPE is configured, which hopefully
developers only will set when they mean to simulate the CI environment
and they understand the consequences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3889)
<!-- Reviewable:end -->
