### PR TITLE
ci: compress cache tarball for Windows+Bazel

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -65,7 +65,7 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
         "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
         "downloading Bazel cache."
-    gsutil -q cp "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.tar" "${download_dir}"
+    gsutil -q cp "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.7z" "${download_dir}"
     if ($LastExitCode) {
         # Ignore errors, caching failures should not break the build.
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -73,6 +73,9 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "continue building without a cache"
     } else {
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "decompressing build cache."
+        7z x "${download_dir}/${CACHE_BASENAME}.7z" "-o${download_dir}" "-aoa" "-bso0" "-bsp0"
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "extracting build cache."
         $extract_flags=@(
@@ -215,6 +218,9 @@ if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     )
     Remove-Item "${download_dir}\${CACHE_BASENAME}.tar" -ErrorAction SilentlyContinue
     7z a "${download_dir}\${CACHE_BASENAME}.tar" "${bazel_root}" ${archive_flags}
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compressing cache tarball"
+    Remove-Item "${download_dir}\${CACHE_BASENAME}.7z" -ErrorAction SilentlyContinue
+    7z a "${download_dir}\${CACHE_BASENAME}.7z" "${download_dir}\${CACHE_BASENAME}.tar" -bso0 -bsp0
     if ($LastExitCode) {
         # Just report these errors and continue, caching failures should
         # not break the build.
@@ -225,8 +231,7 @@ if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
             "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "uploading Bazel cache."
-        gsutil -q cp "${download_dir}\${CACHE_BASENAME}.tar" `
-            "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.tar"
+        gsutil -q cp "${download_dir}\${CACHE_BASENAME}.7z" "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.7z"
         if ($LastExitCode) {
             # Just report these errors and continue, caching failures should
             # not break the build.


### PR DESCRIPTION
This reduces the size of the download from about 13GiB to about 1.7GiB,
which should save about 5 minutes for the download time, while the
decompression takes only about 20 seconds. The cost is in creating the
compressed tarball, but this only happens on continuous builds, i.e.,
the PRs only see the benefits.

Fixes #3516

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3891)
<!-- Reviewable:end -->
