### PR TITLE
ci: use ccache in ci/kokoro/install builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ github-io-staging/
 .vsbuild/
 .vscode/
 
+# Ignore staging files for the ci/kokoro/install builds
+ci/kokoro/install/ccache-contents/
+
 google/cloud/storage/testbench/__pycache__/
 google/cloud/storage/testbench/*.pyc

--- a/ci/.dockerignore
+++ b/ci/.dockerignore
@@ -8,3 +8,6 @@
 *
 !*.*
 !etc
+
+# Ignore staging files for the kokoro/install builds
+kokoro/install/ccache-contents/

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -104,7 +104,6 @@ RUN mkdir -p /h/.ccache; \
       tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
       ccache --show-stats; \
       ccache --zero-stats; \
-      false; \
     fi; \
     true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -98,13 +98,15 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+      false; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -126,11 +126,9 @@ COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
 @QUICKSTART_FRAGMENT@
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]
-
 _EOF_
 )

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -85,6 +85,7 @@ BUILD_AND_TEST_PROJECT_FRAGMENT=$(
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -99,8 +100,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -37,7 +37,6 @@ WORKDIR /home/build/quickstart-cmake/${library}
 COPY google/cloud/${library}/quickstart /home/build/quickstart-cmake/${library}
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/${library}
 RUN cmake --build /i/${library}
-
 _EOF_
   done
 ) || true # read always exit with error
@@ -127,7 +126,6 @@ COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
 @QUICKSTART_FRAGMENT@
-
 ## [START IGNORED]
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -94,6 +94,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -115,5 +127,12 @@ COPY google/cloud/storage/quickstart /home/build/storage-make
 RUN make
 
 @QUICKSTART_FRAGMENT@
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]
+
 _EOF_
 )

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -63,7 +63,7 @@ cache_upload_enabled() {
     return 1
   fi
 
-  if [[ "${RUNNING_CI:-}" != "TODO(coryan)" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
+  if [[ "${RUNNING_CI:-}" != "yes" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
     echo "================================================================"
     log_normal "Cache not updated as this is not a CI build or it is a PR build."
     return 1

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -35,7 +35,7 @@ cache_download_enabled() {
 
 cache_gcloud_cleanup() {
   revoke_service_account_keyfile "${CACHE_KEYFILE}" || true
-  delete_gcloud_config
+  delete_gcloud_config || true
 }
 
 cache_download_tarball() {

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -43,7 +43,7 @@ cache_download_tarball() {
   local -r DESTINATION="$2"
   local -r FILENAME="$3"
 
-  trap cache_gcloud_cleanup EXIT
+  trap cache_gcloud_cleanup RETURN
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"
 
@@ -77,7 +77,7 @@ cache_upload_tarball() {
   echo "================================================================"
   log_normal "Uploading build cache ${FILENAME} to ${GCS_FOLDER}"
 
-  trap cache_gcloud_cleanup EXIT
+  trap cache_gcloud_cleanup RETURN
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "DEBUG DEBUG DEBUG $0"
+
+readonly CACHE_KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
+
+cache_download_enabled() {
+  if [[ ! -f "${CACHE_KEYFILE}" ]]; then
+    echo "================================================================"
+    log_normal "Service account for cache access is not configured."
+    log_normal "No attempt will be made to download the cache, exit with success."
+    return 1
+  fi
+
+  if [[ "${RUNNING_CI:-}" != "yes" || (\
+    "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" && \
+    "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB") ]]; then
+    echo "================================================================"
+    log_normal "Cache not downloaded as this is not a PR build."
+    return 1
+  fi
+  return 0
+}
+
+cache_gcloud_cleanup() {
+  revoke_service_account_keyfile "${CACHE_KEYFILE}" || true
+  delete_gcloud_config
+}
+
+cache_download_tarball() {
+  local -r GCS_FOLDER="$1"
+  local -r DESTINATION="$2"
+  local -r FILENAME="$3"
+
+  trap cache_gcloud_cleanup EXIT
+  create_gcloud_config
+  activate_service_account_keyfile "${CACHE_KEYFILE}"
+
+  echo "================================================================"
+  log_normal "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
+  env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
+    gsutil -q cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
+}
+
+cache_upload_enabled() {
+  if [[ ! -f "${CACHE_KEYFILE}" ]]; then
+    echo "================================================================"
+    log_normal "Service account for cache access is not configured."
+    log_normal "No attempt will be made to upload the cache, exit with success."
+    return 1
+  fi
+
+  if [[ "${RUNNING_CI:-}" != "TODO(coryan)" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
+    echo "================================================================"
+    log_normal "Cache not updated as this is not a CI build or it is a PR build."
+    return 1
+  fi
+  return 0
+}
+
+cache_upload_tarball() {
+  local -r SOURCE_DIRECTORY="$1"
+  local -r FILENAME="$2"
+  local -r GCS_FOLDER="$3"
+
+  echo "================================================================"
+  log_normal "Uploading build cache ${FILENAME} to ${GCS_FOLDER}"
+
+  trap cache_gcloud_cleanup EXIT
+  create_gcloud_config
+  activate_service_account_keyfile "${CACHE_KEYFILE}"
+  env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
+    gsutil -q cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
+
+  log_normal "Upload completed"
+}

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "DEBUG DEBUG DEBUG $0"
-
 readonly CACHE_KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
 
 cache_download_enabled() {

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -34,17 +34,7 @@ readonly CACHE_FOLDER="$1"
 readonly CACHE_NAME="$2"
 readonly HOME_DIR="$3"
 
-readonly KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
-if [[ ! -f "${KEYFILE}" ]]; then
-  echo "================================================================"
-  log_normal "Service account for cache access is not configured."
-  log_normal "No attempt will be made to upload the cache, exit with success."
-  exit 0
-fi
-
-if [[ "${RUNNING_CI:-}" != "yes" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
-  echo "================================================================"
-  log_normal "Cache not updated as this is not a CI build or it is a PR build."
+if ! cache_upload_enabled; then
   exit 0
 fi
 
@@ -70,21 +60,6 @@ echo "================================================================"
 log_normal "Preparing cache tarball for ${CACHE_NAME}"
 tar -zcf "${HOME_DIR}/${CACHE_NAME}.tar.gz" "${dirs[@]}"
 
-echo "================================================================"
-log_normal "Uploading build cache ${CACHE_NAME} to ${CACHE_FOLDER}"
-
-trap cleanup EXIT
-cleanup() {
-  revoke_service_account_keyfile "${KEYFILE}" || true
-  delete_gcloud_config
-}
-
-create_gcloud_config
-activate_service_account_keyfile "${KEYFILE}"
-env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-  gsutil -q cp "${HOME_DIR}/${CACHE_NAME}.tar.gz" "gs://${CACHE_FOLDER}/"
-
-echo "================================================================"
-log_normal "Upload completed"
+cache_upload_tarball "${HOME_DIR}" "${CACHE_NAME}.tar.gz" "${CACHE_FOLDER}"
 
 exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -29,6 +29,7 @@ fi
 GCLOUD=gcloud
 source "${PROJECT_ROOT}/ci/colors.sh"
 source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
+source "${PROJECT_ROOT}/ci/kokoro/cache-functions.sh"
 
 readonly CACHE_FOLDER="$1"
 readonly CACHE_NAME="$2"

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -185,13 +185,15 @@ COPY . /home/build/project
 ## [START IGNORED]
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/centos-7.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/centos-7.tar.gz -C /h || true; \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
     fi
-ENV CCACHE_DIR=/h/.ccache
-## [END IGNORED}
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -216,8 +218,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -34,7 +34,7 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN yum install -y centos-release-scl yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
-    yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
+    yum install -y automake ccache cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest
 # ```
@@ -182,6 +182,16 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/centos-7.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/centos-7.tar.gz -C /h || true; \
+    fi
+ENV CCACHE_DIR=/h/.ccache
+## [END IGNORED}
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -174,6 +174,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -188,8 +189,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -187,13 +187,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -223,8 +223,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -202,8 +202,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -29,6 +29,8 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
+    dnf install -y epel-release && \
+    dnf makecache && \
     dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -155,6 +155,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -169,8 +170,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -168,13 +168,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -29,7 +29,7 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+    dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel libcurl-devel c-ares-devel tar wget which
 # ```
 
@@ -161,6 +161,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -185,8 +197,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -165,8 +165,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -129,13 +129,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -29,7 +29,7 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ca-certificates cmake git gcc g++ cmake \
+        automake build-essential ca-certificates ccache cmake git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 # ```
@@ -124,6 +124,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -148,8 +160,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -116,6 +116,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -130,8 +131,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -198,8 +198,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -162,13 +162,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -149,6 +149,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -163,8 +164,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -36,9 +36,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake libc-ares-dev \
-        libc-ares2 libcurl4-openssl-dev libssl1.0-dev make m4 pkg-config tar \
-        wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make m4 \
+        pkg-config tar wget zlib1g-dev
 # ```
 
 # #### Protobuf
@@ -157,6 +157,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -181,8 +193,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -133,13 +133,14 @@ COPY . /home/build/project
 ## [START IGNORED]
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
     if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
       tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
       ccache --show-stats || true; \
+      ccache --zero-stats || true; \
     fi
-ENV CCACHE_DIR=/h/.ccache
 ## [END IGNORED}
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
@@ -174,4 +175,4 @@ RUN cmake --build /i/storage
 ## [START IGNORED]
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
-RUN ccache --show-stats || true
+RUN ccache --show-stats --zero-stats || true

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -122,6 +122,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -136,8 +137,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -166,7 +166,6 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -135,13 +135,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -28,7 +28,7 @@ ARG NCPU=4
 
 # ```bash
 RUN dnf makecache && \
-    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+    dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel
 # ```
 
@@ -130,6 +130,17 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+    fi
+ENV CCACHE_DIR=/h/.ccache
+## [END IGNORED}
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -159,3 +170,8 @@ WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats || true

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -171,8 +171,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -141,7 +141,7 @@ RUN mkdir -p /h/.ccache && \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi
-## [END IGNORED}
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -176,3 +176,4 @@ RUN cmake --build /i/storage
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -31,8 +31,8 @@ ARG NCPU=4
 
 # ```bash
 RUN zypper refresh && \
-    zypper install --allow-downgrade -y automake cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel libtool make tar wget which
+    zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
+        gzip libcurl-devel libopenssl-devel libtool make tar wget which
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. openSUSE
@@ -177,6 +177,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -201,8 +213,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -218,8 +218,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -182,13 +182,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -169,6 +169,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -183,8 +184,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -133,13 +133,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -28,7 +28,7 @@ ARG NCPU=4
 
 # ```bash
 RUN zypper refresh && \
-    zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+    zypper install --allow-downgrade -y ccache cmake gcc gcc-c++ git gzip \
         libcurl-devel libopenssl-devel make tar wget zlib-devel
 # ```
 
@@ -128,6 +128,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -152,8 +164,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -120,6 +120,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -134,8 +135,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -169,8 +169,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -191,8 +191,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -29,7 +29,7 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 # ```
@@ -150,6 +150,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -174,8 +186,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -142,6 +142,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -156,8 +157,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -155,13 +155,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -156,13 +156,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -192,8 +192,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -143,6 +143,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -157,8 +158,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -30,7 +30,7 @@ ARG NCPU=4
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 # ```
@@ -151,6 +151,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -175,8 +187,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -170,13 +170,14 @@ COPY . /home/build/project
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 ENV CCACHE_DIR=/h/.ccache
-RUN mkdir -p /h/.ccache && \
-    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+RUN mkdir -p /h/.ccache; \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf"; \
     if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
-      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
-      ccache --show-stats || true; \
-      ccache --zero-stats || true; \
-    fi
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h; \
+      ccache --show-stats; \
+      ccache --zero-stats; \
+    fi; \
+    true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -157,6 +157,7 @@ RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.
 
 FROM devtools AS install
 ARG NCPU=4
+ARG DISTRO="distro-name"
 
 # #### Compile and install the main project
 
@@ -171,8 +172,8 @@ COPY . /home/build/project
 ENV CCACHE_DIR=/h/.ccache
 RUN mkdir -p /h/.ccache && \
     echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
-    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
-      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+    if [ -r "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" ]; then \
+      tar -xf "ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" -C /h || true; \
       ccache --show-stats || true; \
       ccache --zero-stats || true; \
     fi

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -206,8 +206,7 @@ COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
 
-## [START IGNORED]
+
 # This is just here to speed up the pre-submit builds and should not be part
 # of the instructions on how to compile the code.
 RUN ccache --show-stats --zero-stats || true
-## [END IGNORED]

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -29,7 +29,7 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libcurl4-openssl-dev libssl-dev libtool m4 make \
         pkg-config tar wget zlib1g-dev
 # ```
@@ -165,6 +165,18 @@ ARG NCPU=4
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+ENV CCACHE_DIR=/h/.ccache
+RUN mkdir -p /h/.ccache && \
+    echo "max_size = 4.0G" >"/h/.ccache/ccache.conf" && \
+    if [ -r ci/kokoro/install/ccache-contents/fedora.tar.gz ]; then \
+      tar -xf ci/kokoro/install/ccache-contents/fedora.tar.gz -C /h || true; \
+      ccache --show-stats || true; \
+      ccache --zero-stats || true; \
+    fi
+## [END IGNORED]
 RUN cmake -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 WORKDIR /home/build/project/cmake-out
@@ -189,8 +201,13 @@ WORKDIR /home/build/quickstart-cmake/bigtable
 COPY google/cloud/bigtable/quickstart /home/build/quickstart-cmake/bigtable
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/bigtable
 RUN cmake --build /i/bigtable
-
 WORKDIR /home/build/quickstart-cmake/storage
 COPY google/cloud/storage/quickstart /home/build/quickstart-cmake/storage
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i/storage
 RUN cmake --build /i/storage
+
+## [START IGNORED]
+# This is just here to speed up the pre-submit builds and should not be part
+# of the instructions on how to compile the code.
+RUN ccache --show-stats --zero-stats || true
+## [END IGNORED]

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -161,7 +161,7 @@ fi
 echo "================================================================"
 log_normal "Preparing and uploading ccache tarball."
 mkdir -p ci/kokoro/install/ccache-contents
-docker run --rm --volume $PWD:/v \
+docker run --rm --volume "$PWD:/v" \
   --workdir /h \
   "${INSTALL_RUN_IMAGE}:latest" \
   tar -zcf "/v/ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" .ccache

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -92,7 +92,7 @@ if docker pull "${INSTALL_IMAGE}:latest"; then
 fi
 
 readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
-readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/master/install/"
+readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/master/install"
 readonly CACHE_NAME="${DISTRO}.tar.gz"
 
 if cache_download_enabled; then

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -112,6 +112,7 @@ devtools_flags=(
   # upload it.
   "-t" "${INSTALL_IMAGE}:latest"
   "--build-arg" "NCPU=${NCPU}"
+  "--build-arg" "DISTRO=${DISTRO}"
   "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
 )
 

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -78,10 +78,10 @@ log_normal "Building with ${NCPU} cores on ${PWD}."
 echo "================================================================"
 log_normal "Setup Google Container Registry access."
 if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
-  "${GCLOUD}" auth activate-service-account --key-file \
+  gcloud auth activate-service-account --key-file \
     "${KOKORO_GFILE_DIR}/gcr-service-account.json"
 fi
-"${GCLOUD}" auth configure-docker
+gcloud auth configure-docker
 
 echo "================================================================"
 log_normal "Download existing image (if available) for ${DISTRO}."

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -78,10 +78,10 @@ log_normal "Building with ${NCPU} cores on ${PWD}."
 echo "================================================================"
 log_normal "Setup Google Container Registry access."
 if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
-  gcloud auth activate-service-account --key-file \
+  "${GCLOUD}" auth activate-service-account --key-file \
     "${KOKORO_GFILE_DIR}/gcr-service-account.json"
 fi
-gcloud auth configure-docker
+"${GCLOUD}" auth configure-docker
 
 echo "================================================================"
 log_normal "Download existing image (if available) for ${DISTRO}."

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -97,7 +97,7 @@ readonly CACHE_NAME="${DISTRO}.tar.gz"
 
 if cache_download_enabled; then
   cache_download_tarball \
-    "${CACHE_FOLDER}" "ci/kokoro/install/ccache-contents" "${CACHE_NAME}"
+    "${CACHE_FOLDER}" "ci/kokoro/install/ccache-contents" "${CACHE_NAME}" || true
 fi
 
 echo "================================================================"

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -162,10 +162,10 @@ echo "================================================================"
 log_normal "Preparing and uploading ccache tarball."
 mkdir -p ci/kokoro/install/ccache-contents
 docker run --rm --volume $PWD:/v \
-    --workdir /h \
-    "${INSTALL_RUN_IMAGE}:latest" \
-    tar -zcf "/v/ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" .ccache
+  --workdir /h \
+  "${INSTALL_RUN_IMAGE}:latest" \
+  tar -zcf "/v/ci/kokoro/install/ccache-contents/${DISTRO}.tar.gz" .ccache
 cache_upload_tarball "ci/kokoro/install/ccache-contents" "${DISTRO}.tar.gz" \
-    "${CACHE_FOLDER}"
+  "${CACHE_FOLDER}"
 
 exit 0

--- a/ci/kokoro/install/common.cfg
+++ b/ci/kokoro/install/common.cfg
@@ -19,3 +19,4 @@ timeout_mins: 120
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -32,6 +32,7 @@ readonly KOKORO_GFILE_DIR
 
 source "${PROJECT_ROOT}/ci/colors.sh"
 source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
+source "${PROJECT_ROOT}/ci/kokoro/cache-functions.sh"
 source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
 source "${PROJECT_ROOT}/ci/etc/quickstart-config.sh"
 

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -27,6 +27,9 @@ if [[ -z "${PROJECT_ROOT+x}" ]]; then
   )"
 fi
 GCLOUD=gcloud
+KOKORO_GFILE_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
+readonly KOKORO_GFILE_DIR
+
 source "${PROJECT_ROOT}/ci/colors.sh"
 source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
 source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
@@ -35,20 +38,7 @@ source "${PROJECT_ROOT}/ci/etc/quickstart-config.sh"
 readonly CACHE_FOLDER="$1"
 readonly CACHE_NAME="$2"
 
-KOKORO_GFILE_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
-readonly KOKORO_GFILE_DIR
-
-readonly KEYFILE="${KOKORO_GFILE_DIR}/build-results-service-account.json"
-if [[ ! -f "${KEYFILE}" ]]; then
-  echo "================================================================"
-  log_normal "Service account for cache access is not configured."
-  log_normal "No attempt will be made to upload the cache, exit with success."
-  exit 0
-fi
-
-if [[ "${RUNNING_CI:-}" != "yes" || "${KOKORO_JOB_TYPE:-}" != "CONTINUOUS_INTEGRATION" ]]; then
-  echo "================================================================"
-  log_normal "Cache not updated as this is not a CI build or it is a PR build."
+if ! cache_upload_enabled; then
   exit 0
 fi
 
@@ -89,21 +79,6 @@ echo "================================================================"
 log_normal "Preparing cache tarball for ${CACHE_NAME}"
 tar -C / -zcf "${UPLOAD}/${CACHE_NAME}.tar.gz" "${dirs[@]}"
 
-echo "================================================================"
-log_normal "Uploading build cache ${CACHE_NAME} to ${CACHE_FOLDER}"
-
-trap cleanup EXIT
-cleanup() {
-  revoke_service_account_keyfile "${KEYFILE}" || true
-  delete_gcloud_config
-}
-
-create_gcloud_config
-activate_service_account_keyfile "${KEYFILE}"
-env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-  gsutil -q cp "${UPLOAD}/${CACHE_NAME}.tar.gz" "gs://${CACHE_FOLDER}/"
-
-echo "================================================================"
-log_normal "Upload completed"
+cache_upload_tarball "${UPLOAD}" "${CACHE_NAME}.tar.gz" "${CACHE_FOLDER}"
 
 exit 0

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -195,7 +195,7 @@ Install the minimal development tools:
 
 ```bash
 sudo dnf makecache && \
-sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel
 ```
 
@@ -293,13 +293,6 @@ We can now compile, test, and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
-```
-
 
 ### openSUSE (Tumbleweed)
 
@@ -1382,7 +1375,7 @@ sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch
 sudo yum install -y centos-release-scl yum-utils
 sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
 sudo yum makecache && \
-sudo yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
+sudo yum install -y automake ccache cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
 sudo ln -sf /usr/bin/cmake3 /usr/bin/cmake && sudo ln -sf /usr/bin/ctest3 /usr/bin/ctest
 ```
@@ -1526,10 +1519,3 @@ We can now compile, test, and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
-cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
-```
-

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -293,6 +293,13 @@ We can now compile, test, and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/project
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
+sudo cmake --build . --target install
+```
+
 
 ### openSUSE (Tumbleweed)
 
@@ -300,7 +307,7 @@ Install the minimal development tools, libcurl and OpenSSL:
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install --allow-downgrade -y cmake gcc gcc-c++ git gzip \
+sudo zypper install --allow-downgrade -y ccache cmake gcc gcc-c++ git gzip \
         libcurl-devel libopenssl-devel make tar wget zlib-devel
 ```
 
@@ -413,8 +420,8 @@ workstation or build server.
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install --allow-downgrade -y automake cmake gcc gcc-c++ git gzip \
-        libcurl-devel libopenssl-devel libtool make tar wget which
+sudo zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
+        gzip libcurl-devel libopenssl-devel libtool make tar wget which
 ```
 
 The following steps will install libraries and tools in `/usr/local`. openSUSE
@@ -703,7 +710,7 @@ Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 ```
@@ -835,7 +842,7 @@ Install the minimal development tools, OpenSSL and libcurl:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libcurl4-openssl-dev libssl-dev libtool m4 make \
         pkg-config tar wget zlib1g-dev
 ```
@@ -1095,9 +1102,9 @@ prevent you from compiling against openssl-1.1.0.
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake libc-ares-dev \
-        libc-ares2 libcurl4-openssl-dev libssl1.0-dev make m4 pkg-config tar \
-        wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl1.0-dev make m4 \
+        pkg-config tar wget zlib1g-dev
 ```
 
 #### Protobuf
@@ -1519,3 +1526,10 @@ We can now compile, test, and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/project
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
+sudo cmake --build . --target install
+```
+

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -578,7 +578,7 @@ Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential cmake ca-certificates git gcc g++ cmake \
+        automake build-essential ccache cmake ca-certificates git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 ```

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -989,7 +989,7 @@ Install the minimal development tools, libcurl, and OpenSSL:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ca-certificates cmake git gcc g++ cmake \
+        automake build-essential ca-certificates ccache cmake git gcc g++ \
         libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
         pkg-config tar wget zlib1g-dev
 ```
@@ -1234,7 +1234,9 @@ library (required by gRPC):
 
 ```bash
 sudo dnf makecache && \
-sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+sudo dnf install -y epel-release && \
+sudo dnf makecache && \
+sudo dnf install -y ccache cmake gcc-c++ git make openssl-devel pkgconfig \
         zlib-devel libcurl-devel c-ares-devel tar wget which
 ```
 


### PR DESCRIPTION
On Pull-Request builds, and if available, download the
ccache tarball and store them in `ci/kokoro/install/ccache-contents`.
The Dockerfile then extracts this tarball in `/h/.ccache` and configures
ccache to use that directory.

At the end of a successful build update the tarball. If the build is a CI
build then upload the tarball to the GCS folder.

Fixes #3521 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3894)
<!-- Reviewable:end -->
