### PR TITLE
fix: crash for bigtable's scan_throughput_benchmark

### DIFF
--- a/google/cloud/bigtable/benchmarks/setup.cc
+++ b/google/cloud/bigtable/benchmarks/setup.cc
@@ -112,7 +112,8 @@ google::cloud::StatusOr<BenchmarkSetup> MakeBenchmarkSetup(
     setup_data.app_profile_id = "default";
     setup_data.thread_count = 1;
     setup_data.test_duration = std::chrono::seconds(1);
-    setup_data.table_size = 1000;
+    // Must be > 10,000 or scan_throughput_benchmark crashes on Windows
+    setup_data.table_size = 11000;
     return BenchmarkSetup{setup_data};
   }
 


### PR DESCRIPTION
On Windows+CMake+Debug builds the C++ library has a few more assertions,
and it crashed when we passed invalid ranges to the random number
generators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3905)
<!-- Reviewable:end -->
