### PR TITLE
fix: remove CMake warnings loading modules

### DIFF
--- a/cmake/FindgRPC.cmake
+++ b/cmake/FindgRPC.cmake
@@ -68,7 +68,8 @@ find_package(Threads REQUIRED)
 # Load the module to find protobuf with proper targets. Do not use
 # `find_package()` because we (have to) install this module in non-standard
 # locations.
-include(${CMAKE_CURRENT_LIST_DIR}/FindProtobufWithTargets.cmake)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+find_package(ProtobufWithTargets)
 
 # The gRPC::grpc_cpp_plugin target is sometimes defined, but without a
 # IMPORTED_LOCATION


### PR DESCRIPTION
I noticed these with CMake-3.17.1, but may have been present before. We
cannot `include()` a module (aka package) from another because
`find_package_handle_standard_args()` generate warnings. Load the module
using `find_package()` works as expected.

Part of the work for #3892

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3906)
<!-- Reviewable:end -->
