### PR TITLE
perf: parallelize slow formatting steps

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -51,12 +51,13 @@ replace_original_if_changed() {
 # Apply cmake_format to all the CMake list files.
 #     https://github.com/cheshirekow/cmake_format
 git ls-files -z | grep -zE '((^|/)CMakeLists\.txt|\.cmake)$' |
-  xargs -0 cmake-format -i
+  xargs -P "${NCPU}" -n 1 -0 cmake-format -i
 
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly
 # different formatting output (sigh).
-git ls-files -z | grep -zE '\.(cc|h)$' | xargs -0 clang-format -i
+git ls-files -z | grep -zE '\.(cc|h)$' |
+  xargs -P "${NCPU}" -n 50 -0 clang-format -i
 
 # Apply buildifier to fix the BUILD and .bzl formatting rules.
 #    https://github.com/bazelbuild/buildtools/tree/master/buildifier


### PR DESCRIPTION
With the more C++ and CMake files being added, the check-style step is
getting slower. The cmake-format step is the slowest, and was taking
about 45 seconds on my laptop. clang-format was taking about 23 seconds.

This change parallelizes the executions of these steps with `xargs -P`.
The parallelism and number of arguments values were determined
experimentally on my machine.

With this change, the cmake-format step is about 11 seconds, and the
clang-format step is about 4 seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3912)
<!-- Reviewable:end -->
