### PR TITLE
doc: update packaging docs with missing distros

### DIFF
--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -205,7 +205,9 @@ these dependencies.
 - [Ubuntu (20.04 - Bionic Beaver)](#ubuntu-2004---focal-fossa)
 - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804---bionic-beaver)
 - [Ubuntu (16.04 - Xenial Xerus)](#ubuntu-1604---xenial-xerus)
+- [Debian (Buster)](#debian-buster)
 - [Debian (Stretch)](#debian-stretch)
+- [CentOS 8](#centos-8)
 - [CentOS 7](#centos-7)
 END_OF_PREAMBLE
 
@@ -236,8 +238,16 @@ echo "### Ubuntu (16.04 - Xenial Xerus)"
 "${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.ubuntu-xenial"
 
 echo
+echo "### Debian (Buster)"
+"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.debian-buster"
+
+echo
 echo "### Debian (Stretch)"
 "${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.debian-stretch"
+
+echo
+echo "### CentOS (8)"
+"${BINDIR}/extract-install.sh" "${DOCKERFILES_DIR}/Dockerfile.centos-8"
 
 echo
 echo "### CentOS (7)"

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -184,7 +184,9 @@ these dependencies.
 - [Ubuntu (20.04 - Bionic Beaver)](#ubuntu-2004---focal-fossa)
 - [Ubuntu (18.04 - Bionic Beaver)](#ubuntu-1804---bionic-beaver)
 - [Ubuntu (16.04 - Xenial Xerus)](#ubuntu-1604---xenial-xerus)
+- [Debian (Buster)](#debian-buster)
 - [Debian (Stretch)](#debian-stretch)
+- [CentOS 8](#centos-8)
 - [CentOS 7](#centos-7)
 
 ### Fedora (30)
@@ -980,6 +982,112 @@ sudo cmake --build . --target install
 ```
 
 
+### Debian (Buster)
+
+Install the minimal development tools, libcurl, and OpenSSL:
+
+```bash
+sudo apt-get update && \
+sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
+        automake build-essential ca-certificates cmake git gcc g++ cmake \
+        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
+        pkg-config tar wget zlib1g-dev
+```
+
+Debian 10 includes versions of gRPC and Protobuf that support the
+Google Cloud Platform proto files. We simply install these pre-built versions:
+
+```bash
+sudo apt-get update && \
+sudo apt-get --no-install-recommends install -y libgrpc++-dev libprotobuf-dev libc-ares-dev \
+        protobuf-compiler protobuf-compiler-grpc
+```
+
+#### crc32c
+
+The project depends on the Crc32c library, we need to compile this from
+source:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
+    tar -xf 1.1.0.tar.gz && \
+    cd crc32c-1.1.0 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DCRC32C_BUILD_TESTS=OFF \
+        -DCRC32C_BUILD_BENCHMARKS=OFF \
+        -DCRC32C_USE_GLOG=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### googleapis
+
+We need a recent version of the Google Cloud Platform proto C++ libraries:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz && \
+    tar -xf v0.8.0.tar.gz && \
+    cd cpp-cmakefiles-0.8.0 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### googletest
+
+We need a recent version of GoogleTest to compile the unit and integration
+tests.
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### google-cloud-cpp-common
+
+The project also depends on google-cloud-cpp-common, the libraries shared by
+all the Google Cloud C++ client libraries:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz && \
+    tar -xf v0.25.0.tar.gz && \
+    cd google-cloud-cpp-common-0.25.0 && \
+    cmake -H. -Bcmake-out \
+        -DBUILD_TESTING=OFF \
+        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### Compile and install the main project
+
+We can now compile, test, and install `google-cloud-cpp`.
+
+```bash
+cd $HOME/project
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
+sudo cmake --build . --target install
+```
+
+
 ### Debian (Stretch)
 
 First install the development tools and libcurl.
@@ -1023,6 +1131,149 @@ sudo ldconfig
 
 To install gRPC we first need to configure pkg-config to find the version of
 Protobuf we just installed in `/usr/local`:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
+    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
+    make -j ${NCPU:-4} && \
+sudo make install && \
+sudo ldconfig
+```
+
+#### crc32c
+
+The project depends on the Crc32c library, we need to compile this from
+source:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
+    tar -xf 1.1.0.tar.gz && \
+    cd crc32c-1.1.0 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DCRC32C_BUILD_TESTS=OFF \
+        -DCRC32C_BUILD_BENCHMARKS=OFF \
+        -DCRC32C_USE_GLOG=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### googleapis
+
+We need a recent version of the Google Cloud Platform proto C++ libraries:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.8.0.tar.gz && \
+    tar -xf v0.8.0.tar.gz && \
+    cd cpp-cmakefiles-0.8.0 && \
+    cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### googletest
+
+We need a recent version of GoogleTest to compile the unit and integration
+tests.
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
+    tar -xf release-1.10.0.tar.gz && \
+    cd googletest-release-1.10.0 && \
+    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### google-cloud-cpp-common
+
+The project also depends on google-cloud-cpp-common, the libraries shared by
+all the Google Cloud C++ client libraries:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.25.0.tar.gz && \
+    tar -xf v0.25.0.tar.gz && \
+    cd google-cloud-cpp-common-0.25.0 && \
+    cmake -H. -Bcmake-out \
+        -DBUILD_TESTING=OFF \
+        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### Compile and install the main project
+
+We can now compile, test, and install `google-cloud-cpp`.
+
+```bash
+cd $HOME/project
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
+ctest -LE integration-tests --output-on-failure
+sudo cmake --build . --target install
+```
+
+
+### CentOS (8)
+
+Install the minimal development tools, libcurl, OpenSSL, and the c-ares
+library (required by gRPC):
+
+```bash
+sudo dnf makecache && \
+sudo dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+        zlib-devel libcurl-devel c-ares-devel tar wget which
+```
+
+The following steps will install libraries and tools in `/usr/local`. By
+default CentOS-8 does not search for shared libraries in these directories,
+there are multiple ways to solve this problem, the following steps are one
+solution:
+
+```bash
+(echo "/usr/local/lib" ; echo "/usr/local/lib64") | \
+sudo tee /etc/ld.so.conf.d/usrlocal.conf
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig
+export PATH=/usr/local/bin:${PATH}
+```
+
+#### Protobuf
+
+We need to install a version of Protobuf that is recent enough to support the
+Google Cloud Platform proto files:
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
+    tar -xf v3.11.3.tar.gz && \
+    cd protobuf-3.11.3/cmake && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
+#### gRPC
+
+We also need a version of gRPC that is recent enough to support the Google
+Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads


### PR DESCRIPTION
There were two distros that we tested, but did not include in our
packaging docs: CentOS:8 and Debian:Buster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3913)
<!-- Reviewable:end -->
