### PR TITLE
fix: build problems on MSVC x86

### DIFF
--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -1,0 +1,36 @@
+@REM Copyright 2020 Google LLC
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+
+REM Install Bazel using Chocolatey.
+choco install --no-progress -y bazel --version 2.0.0
+
+REM Change PATH to use chocolatey's version of Bazel
+set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+
+@REM capture the version for troubleshooting
+bazel version
+@REM shutdown afterwards otherwise the server locks files
+bazel shutdown
+
+REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
+call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+
+REM The remaining of the build script is implemented in PowerShell.
+echo %date% %time%
+cd github\google-cloud-cpp
+powershell -exec bypass ci\kokoro\windows\build.ps1
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+@echo DONE "============================================="
+@echo %date% %time%

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -61,6 +61,20 @@ if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
     $env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/master/vcpkg/Release/x64-windows-static/cmake.zip"
     $DependencyScript = "build-cmake-dependencies.ps1"
     $BuildScript = "build-cmake.ps1"
+} elseif ($BuildName -eq "cmake-debug-x86") {
+    $env:CONFIG = "Debug"
+    $env:GENERATOR = "Ninja"
+    $env:VCPKG_TRIPLET = "x86-windows-static"
+    $env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/master/vcpkg/Release/x86-windows-static/cmake-debug.zip"
+    $DependencyScript = "build-cmake-dependencies.ps1"
+    $BuildScript = "build-cmake.ps1"
+} elseif ($BuildName -eq "cmake-release-x86") {
+    $env:CONFIG = "Release"
+    $env:GENERATOR = "Ninja"
+    $env:VCPKG_TRIPLET = "x86-windows-static"
+    $env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/master/vcpkg/Release/x86-windows-static/cmake-release.zip"
+    $DependencyScript = "build-cmake-dependencies.ps1"
+    $BuildScript = "build-cmake.ps1"
 } elseif ($BuildName -eq "bazel") {
     $DependencyScript = "build-bazel-dependencies.ps1"
     $BuildScript = "build-bazel.ps1"

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -966,9 +966,10 @@ std::vector<std::uintmax_t> ComputeParallelFileUploadSplitPoints(
                                .value();
 
   std::size_t const wanted_num_streams =
-      (std::max<std::size_t>)(1,
-                              (std::min<std::size_t>)(max_streams,
-                                         div_ceil(file_size, min_stream_size)));
+      (std::max<std::size_t>)(1, (std::min<std::size_t>)(max_streams,
+                                                         div_ceil(
+                                                             file_size,
+                                                             min_stream_size)));
 
   std::uintmax_t const stream_size =
       (std::max<std::uintmax_t>)(1, div_ceil(file_size, wanted_num_streams));

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -967,7 +967,7 @@ std::vector<std::uintmax_t> ComputeParallelFileUploadSplitPoints(
 
   std::size_t const wanted_num_streams =
       (std::max<std::size_t>)(1,
-                              (std::min)(max_streams,
+                              (std::min<std::size_t>)(max_streams,
                                          div_ceil(file_size, min_stream_size)));
 
   std::uintmax_t const stream_size =


### PR DESCRIPTION
I also added support scripts to compile with MSVC+x86 on Windows.
I am not sure we would enable CI builds for that platform, but it is
nice to be able to manually run the full build.

Fixes #3797

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3916)
<!-- Reviewable:end -->
