### PR TITLE
fix: use docker cache in ci/kokoro/instal builds

### DIFF
--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -55,8 +55,18 @@ if [[ -z "${PROJECT_ROOT+x}" ]]; then
     pwd
   )"
 fi
-GCLOUD=gcloud
+
+# ATTENTION: The gcr-configuration.sh script MUST be sourced first if present.
+echo "================================================================"
+log_normal "Load Google Container Registry configuration parameters."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+# ATTENTION: The gcr-configuration.sh script MUST be sourced before this file.
 source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
+
+GCLOUD=gcloud
 source "${PROJECT_ROOT}/ci/colors.sh"
 source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
 source "${PROJECT_ROOT}/ci/kokoro/cache-functions.sh"
@@ -64,13 +74,6 @@ source "${PROJECT_ROOT}/ci/kokoro/cache-functions.sh"
 echo "================================================================"
 log_yellow "Change working directory to project root."
 cd "${PROJECT_ROOT}"
-
-echo "================================================================"
-log_normal "Load Google Container Registry configuration parameters."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
 
 echo "================================================================"
 log_normal "Building with ${NCPU} cores on ${PWD}."

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -55,6 +55,7 @@ if [[ -z "${PROJECT_ROOT+x}" ]]; then
     pwd
   )"
 fi
+source "${PROJECT_ROOT}/ci/colors.sh"
 
 # ATTENTION: The gcr-configuration.sh script MUST be sourced first if present.
 echo "================================================================"
@@ -67,7 +68,6 @@ fi
 source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
 
 GCLOUD=gcloud
-source "${PROJECT_ROOT}/ci/colors.sh"
 source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
 source "${PROJECT_ROOT}/ci/kokoro/cache-functions.sh"
 


### PR DESCRIPTION
Ooops, I disabled the Docker cache when I enabled the ccache. The former is more important.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3917)
<!-- Reviewable:end -->
