### PR TITLE
fix: actually use the ccache tarball

### DIFF
--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -99,6 +99,7 @@ readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/master/insta
 readonly CACHE_NAME="${DISTRO}.tar.gz"
 
 if cache_download_enabled; then
+  mkdir -p ci/kokoro/install/ccache-contents
   cache_download_tarball \
     "${CACHE_FOLDER}" "ci/kokoro/install/ccache-contents" "${CACHE_NAME}" || true
 fi
@@ -115,7 +116,6 @@ devtools_flags=(
   # upload it.
   "-t" "${INSTALL_IMAGE}:latest"
   "--build-arg" "NCPU=${NCPU}"
-  "--build-arg" "DISTRO=${DISTRO}"
   "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
 )
 
@@ -148,6 +148,7 @@ docker build -t "${INSTALL_RUN_IMAGE}" \
   "--cache-from=${INSTALL_IMAGE}:latest" \
   "--target=install" \
   "--build-arg" "NCPU=${NCPU}" \
+  "--build-arg" "DISTRO=${DISTRO}" \
   -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
 
 echo "================================================================"

--- a/ci/templates/kokoro/install/build.sh.in
+++ b/ci/templates/kokoro/install/build.sh.in
@@ -95,6 +95,7 @@ readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/@GOOGLE_CLOUD_CPP_REPOSITORY@
 readonly CACHE_NAME="${DISTRO}.tar.gz"
 
 if cache_download_enabled; then
+  mkdir -p ci/kokoro/install/ccache-contents
   cache_download_tarball \
     "${CACHE_FOLDER}" "ci/kokoro/install/ccache-contents" "${CACHE_NAME}" || true
 fi
@@ -111,7 +112,6 @@ devtools_flags=(
   # upload it.
   "-t" "${INSTALL_IMAGE}:latest"
   "--build-arg" "NCPU=${NCPU}"
-  "--build-arg" "DISTRO=${DISTRO}"
   "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
 )
 
@@ -144,6 +144,7 @@ docker build -t "${INSTALL_RUN_IMAGE}" \
   "--cache-from=${INSTALL_IMAGE}:latest" \
   "--target=install" \
   "--build-arg" "NCPU=${NCPU}" \
+  "--build-arg" "DISTRO=${DISTRO}" \
   -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
 
 echo "================================================================"


### PR DESCRIPTION
I made so many mistakes in these changes. In hindsight I should
have broken this down in a change to create the ccache tarball
(without using it), and then a change to use it. As it was my local
testing failed because:

- I expected the docker cache to not work as the devtools changed
  to include ccache, but then it did not work for other reasons too.
- I expected the local tests to fail (expect when I manually did the
  steps) because the cache tarballs had not been populated.

So all the testing was ad-hoc and did not catch the problems.

This time it will work, for realsies, really :fearful:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3921)
<!-- Reviewable:end -->
