### PR TITLE
chore: removes ubsan suppressions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,7 +49,7 @@ build:ubsan --copt=-fsanitize=undefined
 build:ubsan --copt=-fno-omit-frame-pointer
 build:ubsan --linkopt=-fsanitize=undefined
 build:ubsan --linkopt=-fsanitize-link-c++-runtime
-build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:suppressions=/v/bazel/ubsan_suppressions.txt
+build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
 # --config msan: Memory Sanitizer
 build:msan --strip=never

--- a/bazel/ubsan_suppressions.txt
+++ b/bazel/ubsan_suppressions.txt
@@ -1,2 +1,0 @@
-vptr:codecvt.h
-vptr:locale_conv.h


### PR DESCRIPTION
I don't think these suppressions are needed anymore since we're now
including `--linkopt=-fsanitize-link-c++-runtime`. But we'll see what
all the builds say.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3922)
<!-- Reviewable:end -->
