### PR TITLE
fix: build for Windows+CMake

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -37,10 +37,9 @@ $vcpkg_dir = "cmake-out\vcpkg"
 $packages = @("zlib", "openssl",
               "protobuf", "c-ares",
               "grpc", "gtest", "crc32c", "curl",
-              "googleapis", "google-cloud-cpp-common[test]")
+              "googleapis")
 $vcpkg_flags=@(
-    "--triplet", "${env:VCPKG_TRIPLET}",
-    "--overlay-ports=${project_root}/ci/kokoro/windows/vcpkg-ports")
+    "--triplet", "${env:VCPKG_TRIPLET}")
 if ($args.count -ge 1) {
     $vcpkg_dir, $packages = $args
     $vcpkg_flags=("--triplet", "${env:VCPKG_TRIPLET}")


### PR DESCRIPTION
We do not have a pre-submit build for this, and the CI build is failing.
I think for a large change like importing `google-cloud-cpp-common` I
should have (and we all should in the future) run the CI build manually.

In any case, we removed the vcpkg ports directory because we no longer
need it, but the build still refers to it. We also installed `-common` via
vcpkg, but we do not need that either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3944)
<!-- Reviewable:end -->
