### PR TITLE
feat: adds Feature Request and Internal Cleanup templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'type: feature request'
+assignees: ''
+
+---
+
+**What component of `google-cloud-cpp` is this feature request for?**
+For example, is this related to bigtable (i.e., something in `google/cloud/bigtable`), or GCS (i.e., something in `google/cloud/storage`)?
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/internal-cleanup.md
+++ b/.github/ISSUE_TEMPLATE/internal-cleanup.md
@@ -1,0 +1,10 @@
+---
+name: Internal Cleanup
+about: This template is for project developers to track internal cleanups
+title: ''
+labels: 'type: cleanup'
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
Adds two more custom issue templates that might make it easier for us to file issues correctly. One benefit of these templates is they default set the labels correctly.

/cc @mr-salty who added the feature request template to `-spanner` and which I copied from here.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3947)
<!-- Reviewable:end -->
