### PR TITLE
cleanup: enable clang-tidy in pubsub headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,7 @@ Checks: >
 WarningsAsErrors: "*"
 
 # TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/pubbsub/.*"
+HeaderFilterRegex: "google/cloud/pubsub/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,8 +48,8 @@ Checks: >
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"
 
-# TODO(#205) - Enable clang-tidy checks in our headers.
-#    HeaderFilterRegex: "google/cloud/.*"
+# TODO(#3920) - Enable clang-tidy checks in our headers.
+HeaderFilterRegex: "google/cloud/pubbsub/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }


### PR DESCRIPTION
clang-tidy does not scan headers by default, you have to enable a
regular expression for it. As we import projects where the headers do
pass the clang-tidy checks, we should enable the checks for that
particular project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3948)
<!-- Reviewable:end -->
