### PR TITLE
doc: update documentation scripts

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -542,7 +542,7 @@ if [[ "${BUILD_NAME}" == "publish-refdocs" ]]; then
   "${PROJECT_ROOT}/ci/kokoro/docker/publish-refdocs.sh"
   exit_status=$?
 else
-  "${PROJECT_ROOT}/ci/kokoro/docker/upload-docs.sh"
+  "${PROJECT_ROOT}/ci/kokoro/docker/upload-docs.sh" "${BRANCH}"
 fi
 
 "${PROJECT_ROOT}/ci/kokoro/docker/upload-coverage.sh" \

--- a/ci/kokoro/docker/publish-refdocs.sh
+++ b/ci/kokoro/docker/publish-refdocs.sh
@@ -88,6 +88,9 @@ upload_docs() {
   return 0
 }
 
+upload_docs "google-cloud-common" \
+  "${BUILD_OUTPUT}/google/cloud/cloud/html" "${BRANCH}" \
+  "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"
 upload_docs "google-cloud-bigtable" \
   "${BUILD_OUTPUT}/google/cloud/bigtable/html" "${BRANCH}" \
   "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -38,7 +38,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/pubsub/*"
     "*/google/cloud/grpc_utils/*"
     "*/google/cloud/*_test.cc")
-set(DOXYGEN_EXCLUDE_SYMBOL "internal")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/doc/common-main.dox
+++ b/google/cloud/doc/common-main.dox
@@ -1,0 +1,28 @@
+/*!
+@mainpage Common Components for the Google Cloud C++ Client Libraries
+
+# Overview
+
+This library contains common components shared by all the Google Cloud C++
+Client Libraries. Including:
+
+- [Status](@ref google::cloud::v1::Status) error codes and details from an
+  operation.
+- [StatusOr<T>](@ref google::cloud::v1::StatusOr) returns a value on success
+  and a `Status` on error.
+- [optional<T>](@ref google::cloud::v1::optional) a backport of `std::optional`
+  for C++11.
+- [future<T>](@ref google::cloud::v1::future) and
+  [promise<T>](@ref google::cloud::v1::promise) futures (a holder that will
+  receive a value asynchronously) and promises (the counterpart of a future,
+  where values are stored asynchronously). They satisfy the API for
+  `std::future` and `std::promise`, and add support for callbacks and
+  cancellation.
+
+@warning The symbols in the `google::cloud::internal` namespace are
+implementation details and subject to change and/or removal without notice.
+
+@warning The symbols in the `google::cloud::testing_util` namespace are
+implementation details and subject to change and/or removal without notice.
+
+*/


### PR DESCRIPTION
Fix the upload-refdocs.sh script to upload the common libraries.

The upload-docs.sh script has not uploaded anything to
googleapis.github.io in a few months. It seems that branch detection was
broken. I refactored the script to reuse the branch detection from
`build.sh` so we have only one place to fix in the future.

I added a landing page for the common libraries, nothing fancy, but
better than a blank page.

Fixes #3584 and fixes #3931 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3953)
<!-- Reviewable:end -->
