### PR TITLE
fix: run clang-tidy on the code for library targes

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -172,6 +172,7 @@ target_link_libraries(
     google_cloud_cpp_common
     PUBLIC Threads::Threads
     PRIVATE google_cloud_cpp_common_options)
+google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 target_include_directories(
     google_cloud_cpp_common
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -197,7 +198,6 @@ set_target_properties(
 
 include(CreateBazelConfig)
 create_bazel_config(google_cloud_cpp_common YEAR 2018)
-google_cloud_cpp_add_clang_tidy(google_cloud_cpp_common)
 
 add_subdirectory(testing_util)
 
@@ -336,6 +336,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
         PUBLIC googleapis-c++::rpc_status_protos google_cloud_cpp_common
                gRPC::grpc++ gRPC::grpc
         PRIVATE google_cloud_cpp_common_options)
+    google_cloud_cpp_add_clang_tidy(google_cloud_cpp_grpc_utils)
     target_include_directories(
         google_cloud_cpp_grpc_utils
         PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -350,7 +351,6 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
 
     include(CreateBazelConfig)
     create_bazel_config(google_cloud_cpp_grpc_utils YEAR 2019)
-    google_cloud_cpp_add_clang_tidy(google_cloud_cpp_grpc_utils)
 
     if (BUILD_TESTING)
         # List the unit tests, then setup the targets and dependencies.

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -106,13 +106,13 @@ target_include_directories(
 target_link_libraries(
     bigquery_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
                            googleapis-c++::cloud_bigquery_protos)
+google_cloud_cpp_add_common_options(bigquery_client)
+google_cloud_cpp_add_clang_tidy(bigquery_client)
 set_target_properties(
     bigquery_client PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"
                                SOVERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}")
 target_compile_options(bigquery_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-
-google_cloud_cpp_add_common_options(bigquery_client)
 
 add_library(googleapis-c++::bigquery_client ALIAS bigquery_client)
 
@@ -137,6 +137,8 @@ function (bigquery_client_define_tests)
         bigquery_client_testing
         PUBLIC googleapis-c++::bigquery_client google_cloud_cpp_testing
                GTest::gmock_main GTest::gmock GTest::gtest)
+    google_cloud_cpp_add_common_options(bigquery_client_testing)
+    google_cloud_cpp_add_clang_tidy(bigquery_client_testing)
     create_bazel_config(bigquery_client_testing YEAR "2019")
     target_include_directories(
         bigquery_client_testing

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -177,6 +177,8 @@ target_link_libraries(
     PUBLIC bigtable_protos google_cloud_cpp_common google_cloud_cpp_grpc_utils
            gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
     PRIVATE bigtable_common_options)
+google_cloud_cpp_add_common_options(bigtable_client)
+google_cloud_cpp_add_clang_tidy(bigtable_client)
 target_include_directories(
     bigtable_client
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -194,7 +196,6 @@ add_library(bigtable::client ALIAS bigtable_client)
 
 include(CreateBazelConfig)
 create_bazel_config(bigtable_client)
-google_cloud_cpp_add_clang_tidy(bigtable_client)
 
 if (BUILD_TESTING)
     add_library(
@@ -232,6 +233,8 @@ if (BUILD_TESTING)
                gRPC::grpc
                protobuf::libprotobuf
         PRIVATE bigtable_common_options)
+    google_cloud_cpp_add_common_options(bigtable_client_testing)
+    google_cloud_cpp_add_clang_tidy(bigtable_client_testing)
 
     create_bazel_config(bigtable_client_testing)
 

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -37,8 +37,7 @@ void EmbeddedServerTestFixture::SetUp() {
   StartServer();
 
   grpc::ChannelArguments channel_arguments;
-  static std::string const user_agent_prefix = ClientOptions::UserAgentPrefix();
-  channel_arguments.SetUserAgentPrefix(user_agent_prefix);
+  channel_arguments.SetUserAgentPrefix(ClientOptions::UserAgentPrefix());
 
   std::shared_ptr<grpc::Channel> data_channel =
       server_->InProcessChannel(channel_arguments);

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -20,8 +20,6 @@
 #include <algorithm>
 #include <cctype>
 
-namespace btadmin = ::google::bigtable::admin::v2;
-
 namespace google {
 namespace cloud {
 namespace bigtable {
@@ -69,12 +67,16 @@ void TableTestEnvironment::SetUp() {
   std::string const family2 = "family2";
   std::string const family3 = "family3";
   std::string const family4 = "family4";
-  bigtable::TableConfig table_config =
-      bigtable::TableConfig({{family1, bigtable::GcRule::MaxNumVersions(10)},
-                             {family2, bigtable::GcRule::MaxNumVersions(10)},
-                             {family3, bigtable::GcRule::MaxNumVersions(10)},
-                             {family4, bigtable::GcRule::MaxNumVersions(10)}},
-                            {});
+  auto constexpr kTestMaxVersions = 10;
+  auto const test_gc_rule = bigtable::GcRule::MaxNumVersions(kTestMaxVersions);
+  bigtable::TableConfig table_config = bigtable::TableConfig(
+      {
+          {family1, test_gc_rule},
+          {family2, test_gc_rule},
+          {family3, test_gc_rule},
+          {family4, test_gc_rule},
+      },
+      {});
 
   table_id_ = RandomTableId();
   ASSERT_STATUS_OK(table_admin.CreateTable(table_id_, table_config));
@@ -99,11 +101,11 @@ std::string TableTestEnvironment::CreateRandomId(std::string const& prefix,
 std::string TableTestEnvironment::RandomTableId() {
   // This value was discovered by trial and error, it is not documented in the
   // proto files.
-  constexpr int kMaxTableIdLength = 50;
-  static char const prefix[] = "table-";
-  static_assert(kMaxTableIdLength > sizeof(prefix), "prefix is too long");
-  constexpr int sample_count = kMaxTableIdLength - sizeof(prefix) + 1;
-  return CreateRandomId(prefix, sample_count);
+  auto constexpr kMaxTableIdLength = 50;
+  static char const kPrefix[] = "table-";  // NOLINT(modernize-avoid-c-arrays)
+  static_assert(kMaxTableIdLength > sizeof(kPrefix), "prefix is too long");
+  auto constexpr kSampleCount = kMaxTableIdLength - sizeof(kPrefix) + 1;
+  return CreateRandomId(kPrefix, kSampleCount);
 }
 
 std::string TableTestEnvironment::RandomInstanceId() {
@@ -115,12 +117,12 @@ std::string TableTestEnvironment::RandomInstanceId() {
   // returned values, these fields have their limits (e.g. 30 for cluster id)
   // so need to keep some reserve.
   constexpr int kReserveForSuffix = 10;
-  static char const prefix[] = "inst-";
-  static_assert((kMaxInstanceIdLength - kReserveForSuffix) > sizeof(prefix),
+  static char const kPrefix[] = "inst-";  // NOLINT(modernize-avoid-c-arrays)
+  static_assert((kMaxInstanceIdLength - kReserveForSuffix) > sizeof(kPrefix),
                 "prefix is too long");
-  constexpr int sample_count =
-      (kMaxInstanceIdLength - kReserveForSuffix) - sizeof(prefix) + 1;
-  return CreateRandomId(prefix, sample_count);
+  auto constexpr kSampleCount =
+      (kMaxInstanceIdLength - kReserveForSuffix) - sizeof(kPrefix) + 1;
+  return CreateRandomId(kPrefix, kSampleCount);
 }
 
 void TableIntegrationTest::SetUp() {
@@ -189,7 +191,7 @@ std::vector<bigtable::Cell> TableIntegrationTest::ReadRows(
 }
 
 std::vector<bigtable::Cell> TableIntegrationTest::ReadRows(
-    std::string table_name, bigtable::Filter filter) {
+    std::string const& table_name, bigtable::Filter filter) {
   bigtable::Table table(data_client_, table_name);
   return ReadRows(table, std::move(filter));
 }
@@ -224,7 +226,9 @@ void TableIntegrationTest::CreateCells(
     bigtable::Table& table, std::vector<bigtable::Cell> const& cells) {
   std::map<RowKeyType, bigtable::SingleRowMutation> mutations;
   for (auto const& cell : cells) {
-    using namespace std::chrono;
+    using std::chrono::duration_cast;
+    using std::chrono::microseconds;
+    using std::chrono::milliseconds;
     auto key = cell.row_key();
     auto inserted = mutations.emplace(key, bigtable::SingleRowMutation(key));
     inserted.first->second.emplace_back(bigtable::SetCell(
@@ -254,11 +258,10 @@ std::vector<bigtable::Cell> TableIntegrationTest::GetCellsIgnoringTimestamp(
   std::vector<bigtable::Cell> return_cells;
   std::transform(cells.begin(), cells.end(), std::back_inserter(return_cells),
                  [](Cell& cell) {
-                   bigtable::Cell newCell(
+                   return bigtable::Cell(
                        std::move(cell.row_key()), std::move(cell.family_name()),
                        std::move(cell.column_qualifier()), 0,
                        std::move(cell.value()), std::move(cell.labels()));
-                   return newCell;
                  });
 
   return return_cells;

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -89,22 +89,23 @@ class TableIntegrationTest : public ::testing::Test {
   bigtable::Table GetTable();
 
   /// Return all the cells in @p table that pass @p filter.
-  std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
-                                       bigtable::Filter filter);
+  static std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
+                                              bigtable::Filter filter);
 
   /// Return all the cells in @p table that pass @p filter.
-  std::vector<bigtable::Cell> ReadRows(std::string table_name,
+  std::vector<bigtable::Cell> ReadRows(std::string const& table_name,
                                        bigtable::Filter filter);
 
-  std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
-                                       std::int64_t rows_limit,
-                                       bigtable::Filter filter);
+  static std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
+                                              std::int64_t rows_limit,
+                                              bigtable::Filter filter);
 
-  std::vector<bigtable::Cell> MoveCellsFromReader(bigtable::RowReader& reader);
+  static std::vector<bigtable::Cell> MoveCellsFromReader(
+      bigtable::RowReader& reader);
 
   /// Return all the cells in @p table that pass @p filter.
-  void CreateCells(bigtable::Table& table,
-                   std::vector<bigtable::Cell> const& cells);
+  static void CreateCells(bigtable::Table& table,
+                          std::vector<bigtable::Cell> const& cells);
 
   /**
    * Return @p cells with all timestamps set to a fixed value.
@@ -112,15 +113,15 @@ class TableIntegrationTest : public ::testing::Test {
    * This is useful to compare sets of cells but ignoring their timestamp
    * values.
    */
-  std::vector<bigtable::Cell> GetCellsIgnoringTimestamp(
+  static std::vector<bigtable::Cell> GetCellsIgnoringTimestamp(
       std::vector<bigtable::Cell> cells);
 
   /**
    * Compare two sets of cells.
    * Unordered because ReadRows does not guarantee a particular order.
    */
-  void CheckEqualUnordered(std::vector<bigtable::Cell> expected,
-                           std::vector<bigtable::Cell> actual);
+  static void CheckEqualUnordered(std::vector<bigtable::Cell> expected,
+                                  std::vector<bigtable::Cell> actual);
 
   /**
    * Generate a random table id.
@@ -129,7 +130,7 @@ class TableIntegrationTest : public ::testing::Test {
    * Bigtable instance.  To avoid conflicts and minimize coordination between
    * the tests, we run each test with a randomly selected table name.
    */
-  std::string RandomTableId();
+  static std::string RandomTableId();
 
   /// Some tests cannot run on the emulator.
   bool UsingCloudBigtableEmulator() const {

--- a/google/cloud/bigtable/testing/validate_metadata.cc
+++ b/google/cloud/bigtable/testing/validate_metadata.cc
@@ -147,7 +147,7 @@ StatusOr<std::map<std::string, std::string> > ExtractMDFromContext(
 }
 
 /// A poorman's check if a value matches a glob used in URL patterns.
-bool ValueMatchesPattern(std::string val, std::string pattern) {
+bool ValueMatchesPattern(std::string const& val, std::string const& pattern) {
   std::string regexified_pattern =
       regex_replace(pattern, std::regex("\\*"), std::string("[^/]+"));
   return std::regex_match(val, std::regex(regexified_pattern));
@@ -245,11 +245,11 @@ Status IsContextMDValid(grpc::ClientContext& context,
                     "Expected param \"" + param + "\" not found in metadata");
     }
     if (!ValueMatchesPattern(found_it->second, expected_pattern)) {
-      return Status(StatusCode::kInvalidArgument,
-                    "Expected param \"" + param +
-                        "\" found, but its value (\"" + found_it->second +
-                        "\") does not satisfy the pattern (\"" +
-                        expected_pattern + "\").");
+      std::ostringstream os;
+      os << "Expected param \"" << param << "\" found, but its value (\""
+         << found_it->second << "\") does not satisfy the pattern (\""
+         << expected_pattern << "\").";
+      return Status(StatusCode::kInvalidArgument, std::move(os).str());
     }
   }
   return Status();

--- a/google/cloud/bigtable/testing/validate_metadata.cc
+++ b/google/cloud/bigtable/testing/validate_metadata.cc
@@ -24,6 +24,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 #include <regex>
+#include <sstream>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -47,6 +47,8 @@ include(CreateBazelConfig)
 # the client library
 add_library(firestore_client field_path.cc field_path.h)
 target_link_libraries(firestore_client PRIVATE firestore_common_options)
+google_cloud_cpp_add_common_options(firestore_client)
+google_cloud_cpp_add_clang_tidy(firestore_client)
 target_include_directories(
     firestore_client
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -112,12 +112,12 @@ target_include_directories(
 target_link_libraries(
     pubsub_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
                          googleapis-c++::pubsub_protos)
+google_cloud_cpp_add_common_options(pubsub_client)
+google_cloud_cpp_add_clang_tidy(pubsub_client)
 set_target_properties(
     pubsub_client PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"
                              SOVERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}")
 target_compile_options(pubsub_client PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-
-google_cloud_cpp_add_common_options(pubsub_client)
 
 add_library(googleapis-c++::pubsub_client ALIAS pubsub_client)
 

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -232,6 +232,8 @@ target_link_libraries(
            OpenSSL::Crypto
            ZLIB::ZLIB
     PRIVATE storage_common_options)
+google_cloud_cpp_add_common_options(storage_client)
+google_cloud_cpp_add_clang_tidy(storage_client)
 target_include_directories(
     storage_client
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -270,7 +272,6 @@ set_target_properties(
         SOVERSION ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
 
 create_bazel_config(storage_client)
-google_cloud_cpp_add_clang_tidy(storage_client)
 
 if (BUILD_TESTING)
     add_library(
@@ -294,6 +295,8 @@ if (BUILD_TESTING)
         PUBLIC storage_client nlohmann_json GTest::gmock_main GTest::gmock
                GTest::gtest
         PRIVATE storage_common_options)
+    google_cloud_cpp_add_common_options(storage_client_testing)
+    google_cloud_cpp_add_clang_tidy(storage_client_testing)
     target_include_directories(
         storage_client_testing
         PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -43,10 +43,10 @@ using ::testing::StrEq;
 class AuthorizedUserCredentialsTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    MockHttpRequestBuilder::mock =
+    MockHttpRequestBuilder::mock_ =
         std::make_shared<MockHttpRequestBuilder::Impl>();
   }
-  void TearDown() override { MockHttpRequestBuilder::mock.reset(); }
+  void TearDown() override { MockHttpRequestBuilder::mock_.reset(); }
 };
 
 /// @test Verify that we can create credentials from a JWT string.
@@ -67,7 +67,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
         return HttpResponse{200, response, {}};
       }));
 
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder,
               Constructor(StrEq("https://oauth2.googleapis.com/token")))
       .Times(1);
@@ -121,7 +121,7 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
       .WillOnce(Return(HttpResponse{200, r2, {}}));
 
   // Now setup the builder to return those responses.
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
     MockHttpRequest request;
     request.mock = mock_request;
@@ -162,7 +162,7 @@ TEST_F(AuthorizedUserCredentialsTest, FailedRefresh) {
       .WillOnce(Return(HttpResponse{400, "", {}}));
 
   // Now setup the builder to return those responses.
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
     MockHttpRequest request;
     request.mock = mock_request;

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -47,10 +47,10 @@ using ::testing::UnorderedElementsAre;
 class ComputeEngineCredentialsTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    MockHttpRequestBuilder::mock =
+    MockHttpRequestBuilder::mock_ =
         std::make_shared<MockHttpRequestBuilder::Impl>();
   }
-  void TearDown() override { MockHttpRequestBuilder::mock.reset(); }
+  void TearDown() override { MockHttpRequestBuilder::mock_.reset(); }
 };
 
 /// @test Verify that we can create and refresh ComputeEngineCredentials.
@@ -76,7 +76,7 @@ TEST_F(ComputeEngineCredentialsTest,
   EXPECT_CALL(*second_mock_req_impl, MakeRequest(_))
       .WillOnce(Return(HttpResponse{200, token_info_resp, {}}));
 
-  auto mock_req_builder = MockHttpRequestBuilder::mock;
+  auto mock_req_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_req_builder, BuildRequest())
       .WillOnce(Invoke([first_mock_req_impl] {
         MockHttpRequest mock_request;
@@ -231,7 +231,7 @@ TEST_F(ComputeEngineCredentialsTest, FailedRetrieveServiceAccountInfo) {
       // Parse with an invalid metadata response.
       .WillOnce(Return(HttpResponse{1, svc_acct_info_resp, {}}));
 
-  auto mock_req_builder = MockHttpRequestBuilder::mock;
+  auto mock_req_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_req_builder, BuildRequest())
       .Times(3)
       .WillRepeatedly(Invoke([first_mock_req_impl] {
@@ -297,7 +297,7 @@ TEST_F(ComputeEngineCredentialsTest, FailedRefresh) {
       .WillOnce(Return(HttpResponse{200, svc_acct_info_resp, {}}))
       .WillOnce(Return(HttpResponse{1, token_info_resp, {}}));
 
-  auto mock_req_builder = MockHttpRequestBuilder::mock;
+  auto mock_req_builder = MockHttpRequestBuilder::mock_;
   auto mock_matcher = Invoke([mock_req] {
     MockHttpRequest mock_request;
     mock_request.mock = mock_req;
@@ -369,7 +369,7 @@ TEST_F(ComputeEngineCredentialsTest, AccountEmail) {
   EXPECT_CALL(*first_mock_req_impl, MakeRequest(_))
       .WillOnce(Return(HttpResponse{200, svc_acct_info_resp, {}}));
 
-  auto mock_req_builder = MockHttpRequestBuilder::mock;
+  auto mock_req_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_req_builder, BuildRequest())
       .WillOnce(Invoke([first_mock_req_impl] {
         MockHttpRequest mock_request;

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -83,11 +83,11 @@ constexpr char kSubjectForGrant[] = "user@foo.bar";
 class ServiceAccountCredentialsTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    MockHttpRequestBuilder::mock =
+    MockHttpRequestBuilder::mock_ =
         std::make_shared<MockHttpRequestBuilder::Impl>();
     FakeClock::reset_clock(kFixedJwtTimestamp);
   }
-  void TearDown() override { MockHttpRequestBuilder::mock.reset(); }
+  void TearDown() override { MockHttpRequestBuilder::mock_.reset(); }
 
   std::string CreateRandomFileName() {
     // When running on the internal Google CI systems we cannot write to the
@@ -118,7 +118,7 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
         return HttpResponse{200, response, {}};
       }));
 
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
     MockHttpRequest result;
     result.mock = mock_request;
@@ -189,7 +189,7 @@ TEST_F(ServiceAccountCredentialsTest,
       .WillOnce(Return(HttpResponse{200, r2, {}}));
 
   // Now setup the builder to return those responses.
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
     MockHttpRequest request;
     request.mock = mock_request;
@@ -396,7 +396,7 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
       .WillOnce(Invoke(make_request_assertion(clock_value_1)))
       .WillOnce(Invoke(make_request_assertion(clock_value_2)));
 
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
     MockHttpRequest result;
     result.mock = mock_request;
@@ -440,7 +440,7 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
 
 /// @test Verify that we can create sign blobs using a service account.
 TEST_F(ServiceAccountCredentialsTest, SignBlob) {
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   std::string expected_header =
       "Content-Type: application/x-www-form-urlencoded";
   EXPECT_CALL(*mock_builder, AddHeader(StrEq(expected_header)));
@@ -494,7 +494,7 @@ x-goog-meta-foo:bar,baz
 
 /// @test Verify that signing blobs fails with invalid e-mail.
 TEST_F(ServiceAccountCredentialsTest, SignBlobFailure) {
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   std::string expected_header =
       "Content-Type: application/x-www-form-urlencoded";
   EXPECT_CALL(*mock_builder, AddHeader(StrEq(expected_header)));
@@ -530,7 +530,7 @@ TEST_F(ServiceAccountCredentialsTest, SignBlobFailure) {
 
 /// @test Verify that we can get the client id from a service account.
 TEST_F(ServiceAccountCredentialsTest, ClientId) {
-  auto mock_builder = MockHttpRequestBuilder::mock;
+  auto mock_builder = MockHttpRequestBuilder::mock_;
   std::string expected_header =
       "Content-Type: application/x-www-form-urlencoded";
   EXPECT_CALL(*mock_builder, AddHeader(StrEq(expected_header)));

--- a/google/cloud/storage/testing/mock_http_request.cc
+++ b/google/cloud/storage/testing/mock_http_request.cc
@@ -18,7 +18,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 namespace testing {
-std::shared_ptr<MockHttpRequestBuilder::Impl> MockHttpRequestBuilder::mock;
+std::shared_ptr<MockHttpRequestBuilder::Impl> MockHttpRequestBuilder::mock_;
 
 }  // namespace testing
 }  // namespace storage

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -63,7 +63,7 @@ class MockHttpRequestBuilder {
  public:
   explicit MockHttpRequestBuilder(
       std::string url, std::shared_ptr<internal::CurlHandleFactory>) {
-    mock->Constructor(std::move(url));
+    mock_->Constructor(std::move(url));
   }
 
   using RequestType = MockHttpRequest;
@@ -72,7 +72,7 @@ class MockHttpRequestBuilder {
   void AddWellKnownParameter(
       internal::WellKnownParameter<P, std::string> const& p) {
     if (p.has_value()) {
-      mock->AddQueryParameter(p.parameter_name(), p.value());
+      mock_->AddQueryParameter(p.parameter_name(), p.value());
     }
   }
 
@@ -80,7 +80,7 @@ class MockHttpRequestBuilder {
   void AddWellKnownParameter(
       internal::WellKnownParameter<P, std::int64_t> const& p) {
     if (p.has_value()) {
-      mock->AddQueryParameter(p.parameter_name(), std::to_string(p.value()));
+      mock_->AddQueryParameter(p.parameter_name(), std::to_string(p.value()));
     }
   }
 
@@ -89,29 +89,29 @@ class MockHttpRequestBuilder {
     if (!p.has_value()) {
       return;
     }
-    mock->AddQueryParameter(p.parameter_name(), p.value() ? "true" : "false");
+    mock_->AddQueryParameter(p.parameter_name(), p.value() ? "true" : "false");
   }
 
-  MockHttpRequest BuildRequest() { return mock->BuildRequest(); }
+  MockHttpRequest BuildRequest() { return mock_->BuildRequest(); }
 
   void AddUserAgentPrefix(std::string const& prefix) {
-    mock->AddUserAgentPrefix(prefix);
+    mock_->AddUserAgentPrefix(prefix);
   }
 
-  void AddHeader(std::string const& header) { mock->AddHeader(header); }
+  void AddHeader(std::string const& header) { mock_->AddHeader(header); }
 
   void AddQueryParameter(std::string const& key, std::string const& value) {
-    mock->AddQueryParameter(key, value);
+    mock_->AddQueryParameter(key, value);
   }
 
-  void SetMethod(std::string const& method) { mock->SetMethod(method); }
+  void SetMethod(std::string const& method) { mock_->SetMethod(method); }
 
-  void SetDebugLogging(bool enable) { mock->SetDebugLogging(enable); }
+  void SetDebugLogging(bool enable) { mock_->SetDebugLogging(enable); }
 
-  std::string UserAgentSuffix() { return mock->UserAgentSuffix(); }
+  std::string UserAgentSuffix() { return mock_->UserAgentSuffix(); }
 
   std::unique_ptr<char[]> MakeEscapedString(std::string const& tmp) {
-    return mock->MakeEscapedString(tmp);
+    return mock_->MakeEscapedString(tmp);
   }
 
   struct Impl {
@@ -128,7 +128,7 @@ class MockHttpRequestBuilder {
                  std::unique_ptr<char[]>(std::string const&));
   };
 
-  static std::shared_ptr<Impl> mock;
+  static std::shared_ptr<Impl> mock_;
 };
 
 }  // namespace testing

--- a/google/cloud/storage/testing/random_names.cc
+++ b/google/cloud/storage/testing/random_names.cc
@@ -31,14 +31,21 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
 }
 
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
-  return google::cloud::internal::Sample(gen, 128,
+  // GCS accepts object name up to 1024 characters, but 128 seems long enough to
+  // avoid collisions.
+  auto constexpr kObjectNameLength = 128;
+  return google::cloud::internal::Sample(gen, kObjectNameLength,
                                          "abcdefghijklmnopqrstuvwxyz"
                                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                          "0123456789");
 }
 
 std::string MakeRandomFileName(google::cloud::internal::DefaultPRNG& gen) {
-  return google::cloud::internal::Sample(gen, 28,
+  // All the operating systems we support handle filenames with 28 characters,
+  // they may support much longer names in fact, but 28 is good enough for our
+  // purposes.
+  auto constexpr kFilenameLength = 28;
+  return google::cloud::internal::Sample(gen, kFilenameLength,
                                          "abcdefghijklmnopqrstuvwxyz"
                                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                          "0123456789") +

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/storage/testing/random_names.h"
 #include "google/cloud/internal/getenv.h"
 
 namespace google {
@@ -68,16 +69,21 @@ std::unique_ptr<RetryPolicy> StorageIntegrationTest::TestRetryPolicy() {
       .clone();
 }
 
+std::string StorageIntegrationTest::MakeRandomBucketName() {
+  // The total length of this bucket name must be <= 63 characters,
+  char constexpr kPrefix[] = "gcs-cpp-test-bucket-";  // NOLINT
+  auto constexpr kMaxBucketNameLength = 63;
+  static_assert(kMaxBucketNameLength > sizeof(kPrefix),
+                "The bucket prefix is too long");
+  return storage::testing::MakeRandomBucketName(generator_, kPrefix);
+}
+
 std::string StorageIntegrationTest::MakeRandomObjectName() {
-  // GCS accepts object name up to 1024 characters, but 128 seems long enough to
-  // avoid collisions.
-  auto constexpr kObjectNameLength = 128;
-  return "ob-" +
-         google::cloud::internal::Sample(generator_, kObjectNameLength,
-                                         "abcdefghijklmnopqrstuvwxyz"
-                                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                         "012456789") +
-         ".txt";
+  return "ob-" + storage::testing::MakeRandomObjectName(generator_) + ".txt";
+}
+
+std::string StorageIntegrationTest::MakeRandomFilename() {
+  return storage::testing::MakeRandomFileName(generator_);
 }
 
 std::string StorageIntegrationTest::LoremIpsum() {
@@ -100,17 +106,6 @@ EncryptionKeyData StorageIntegrationTest::MakeEncryptionKeyData() {
   // them. Google Cloud Storage does not save customer-supplied keys, and if
   // lost the encrypted data cannot be decrypted.
   return CreateKeyFromGenerator(generator_);
-}
-
-std::string StorageIntegrationTest::MakeRandomBucketName() {
-  // The total length of this bucket name must be <= 63 characters,
-  auto constexpr kPrefix = "gcs-cpp-test-bucket-";
-  auto constexpr kMaxBucketNameLength = 63;
-  auto const max_random_characters =
-      kMaxBucketNameLength - std::strlen(kPrefix);
-  return kPrefix + google::cloud::internal::Sample(
-                       generator_, static_cast<int>(max_random_characters),
-                       "abcdefghijklmnopqrstuvwxyz012456789");
 }
 
 bool StorageIntegrationTest::UsingTestbench() {

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -58,9 +58,8 @@ std::unique_ptr<BackoffPolicy> StorageIntegrationTest::TestBackoffPolicy() {
 
   auto constexpr kMaximumBackoffDelay = std::chrono::minutes(5);
   auto constexpr kBackoffScalingFactor = 2.0;
-  return ExponentialBackoffPolicy(initial_delay,
-                                  /*maximum_delay=*/kMaximumBackoffDelay,
-                                  /*scaling=*/kBackoffScalingFactor)
+  return ExponentialBackoffPolicy(initial_delay, kMaximumBackoffDelay,
+                                  kBackoffScalingFactor)
       .clone();
 }
 

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -31,18 +31,18 @@ namespace testing {
  */
 class StorageIntegrationTest : public ::testing::Test {
  protected:
-  google::cloud::StatusOr<google::cloud::storage::Client>
+  static google::cloud::StatusOr<google::cloud::storage::Client>
   MakeIntegrationTestClient();
 
-  google::cloud::StatusOr<google::cloud::storage::Client>
+  static google::cloud::StatusOr<google::cloud::storage::Client>
   MakeIntegrationTestClient(std::unique_ptr<RetryPolicy> retry_policy);
 
-  std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
-  std::unique_ptr<RetryPolicy> TestRetryPolicy();
+  static std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
+  static std::unique_ptr<RetryPolicy> TestRetryPolicy();
 
   std::string MakeRandomObjectName();
 
-  std::string LoremIpsum() const;
+  static std::string LoremIpsum();
 
   EncryptionKeyData MakeEncryptionKeyData();
 
@@ -57,7 +57,7 @@ class StorageIntegrationTest : public ::testing::Test {
 
   std::string MakeRandomData(std::size_t desired_size);
 
-  bool UsingTestbench() const;
+  static bool UsingTestbench();
 
   google::cloud::internal::DefaultPRNG generator_ =
       google::cloud::internal::MakeDefaultPRNG();

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -40,13 +40,13 @@ class StorageIntegrationTest : public ::testing::Test {
   static std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
   static std::unique_ptr<RetryPolicy> TestRetryPolicy();
 
+  std::string MakeRandomBucketName();
   std::string MakeRandomObjectName();
+  std::string MakeRandomFilename();
 
   static std::string LoremIpsum();
 
   EncryptionKeyData MakeEncryptionKeyData();
-
-  std::string MakeRandomBucketName();
 
   static constexpr int kDefaultRandomLineCount = 1000;
   static constexpr int kDefaultLineSize = 200;

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -50,7 +50,7 @@ TEST_F(ObjectFileIntegrationTest, XmlDownloadFile) {
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
 
   // We will construct the expected response while streaming the data up.
   std::ostringstream expected;
@@ -84,7 +84,7 @@ TEST_F(ObjectFileIntegrationTest, JsonDownloadFile) {
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
 
   // We will construct the expected response while streaming the data up.
   std::ostringstream expected;
@@ -118,7 +118,7 @@ TEST_F(ObjectFileIntegrationTest, DownloadFileFailure) {
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
 
   auto status = client->DownloadToFile(bucket_name_, object_name, file_name);
   EXPECT_FALSE(status.ok());

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -136,7 +136,7 @@ TEST_F(ObjectFileIntegrationTest, DownloadFileCannotOpenFile) {
   ASSERT_STATUS_OK(meta);
 
   // Create an invalid path for the destination object.
-  auto file_name = MakeRandomObjectName() + "/" + MakeRandomObjectName();
+  auto file_name = MakeRandomFilename() + "/" + MakeRandomFilename();
 
   auto status = client->DownloadToFile(bucket_name_, object_name, file_name);
   EXPECT_FALSE(status.ok());
@@ -181,7 +181,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFile) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -217,7 +217,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // Create a file with the contents to upload.
@@ -259,7 +259,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileEmpty) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // Create a file with the contents to upload.
@@ -288,7 +288,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileMissingFileFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   StatusOr<ObjectMetadata> meta = client->UploadFile(
@@ -302,7 +302,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileUploadFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // Create the file.
@@ -333,7 +333,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   ASSERT_NE(-1, mkfifo(file_name.c_str(), 0777));
@@ -372,7 +372,7 @@ TEST_F(ObjectFileIntegrationTest, XmlUploadFile) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -418,7 +418,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableBySize) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -457,7 +457,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableByOption) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -498,7 +498,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableQuantum) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -538,7 +538,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableNonQuantum) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto object_name = MakeRandomObjectName();
 
   // We will construct the expected response while streaming the data up.
@@ -577,7 +577,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileResumableUploadFailure) {
   auto client_options = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(client_options);
   Client client(client_options->set_maximum_simple_upload_size(0));
-  auto file_name = ::testing::TempDir() + MakeRandomObjectName();
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
   auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
 

--- a/google/cloud/storage/tests/object_file_multi_threaded_test.cc
+++ b/google/cloud/storage/tests/object_file_multi_threaded_test.cc
@@ -56,8 +56,10 @@ class ObjectFileMultiThreadedTest
 
   std::vector<std::string> CreateObjectNames() {
     std::vector<std::string> object_names(object_count_);
+    // Use MakeRandomFilename() because the same name is used for
+    // the destination file.
     std::generate_n(object_names.begin(), object_names.size(),
-                    [this] { return MakeRandomObjectName(); });
+                    [this] { return MakeRandomFilename(); });
     return object_names;
   }
 

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -54,7 +54,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
 
   // Construct a large object, or at least large enough that it is not
   // downloaded in the first chunk.
@@ -612,7 +612,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureDownloadFile) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
 
   Status status = client.DownloadToFile(bucket_name_, object_name, file_name);
   EXPECT_FALSE(status.ok());
@@ -627,7 +627,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureUploadFile) {
                 LimitedErrorCountRetryPolicy(2)};
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
+  auto file_name = MakeRandomFilename();
 
   std::ofstream(file_name, std::ios::binary) << LoremIpsum();
 

--- a/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
@@ -49,7 +49,6 @@ TEST_F(SlowReaderChunkIntegrationTest, LongPauses) {
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
 
   // Construct an object too large to fit in the first chunk.
   auto const read_size = 1024 * 1024L;

--- a/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
@@ -49,7 +49,6 @@ TEST_F(SlowReaderStreamIntegrationTest, LongPauses) {
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();
-  auto file_name = MakeRandomObjectName();
 
   // Construct an object too large to fit in the first chunk.
   auto const read_size = 1024 * 1024L;


### PR DESCRIPTION
That is, the code that gets compiled into `.a` files that our customers would
link, and including test support libraries. The code for tests and examples
will need additional work (and lots of it).

Fixed the existing (but unreported) clang-tidy warnings.

Part of the work for #3958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3960)
<!-- Reviewable:end -->
