### PR TITLE
fix: enable clang-tidy on all g/c/pubsub/ targets

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -157,6 +157,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
                     google_cloud_cpp_testing_grpc GTest::gmock_main
                     GTest::gmock GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
 
         # With googletest it is relatively easy to exceed the default number of
         # sections (~65,000) in a single .obj file. Add the /bigobj option to

--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -53,6 +53,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
             PRIVATE googleapis-c++::pubsub_client google_cloud_cpp_testing
                     GTest::gmock_main GTest::gmock GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
 
         # With googletest it is relatively easy to exceed the default number of
         # sections (~65,000) in a single .obj file. Add the /bigobj option to
@@ -87,6 +88,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         add_executable(${target} ${fname})
         target_link_libraries(${target} PRIVATE googleapis-c++::pubsub_client)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
 
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(

--- a/google/cloud/pubsub/samples/CMakeLists.txt
+++ b/google/cloud/pubsub/samples/CMakeLists.txt
@@ -32,12 +32,13 @@ function (pubsub_client_define_samples)
                    ${pubsub_client_unit_samples})
         google_cloud_cpp_test_name_to_target(target "${fname}")
         add_executable(${target} ${fname})
-        google_cloud_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
         target_link_libraries(
             ${target}
             PRIVATE googleapis-c++::pubsub_client google_cloud_cpp_testing
                     GTest::gmock_main GTest::gmock GTest::gtest)
+        google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()
 
     foreach (fname ${pubsub_client_integration_samples})

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -63,8 +63,8 @@ int constexpr VersionPatch() {
   return GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION_PATCH;
 }
 
-constexpr int kMaxPatchVersions = 100;
-constexpr int kMaxMinorVersions = 100;
+auto constexpr kMaxPatchVersions = 100;
+auto constexpr kMaxMinorVersions = 100;
 
 /// A single integer representing the Major/Minor/Patch version.
 int constexpr Version() {


### PR DESCRIPTION
I made a cosmetic change in `version.h` to force a rebuild, and I like
the new code better anyway.

Part of the work for #3958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3963)
<!-- Reviewable:end -->
