### PR TITLE
cleanup: remove unused CMake code

### DIFF
--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -23,58 +23,6 @@ set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples)
 
 include(GoogleCloudCppCommon)
 
-# Define a function to fetch the current git revision. Using a function creates
-# a new scope, so the CMake variables do not leak to the global namespace.
-function (google_cloud_cpp_bigquery_initialize_git_head var)
-    set(result "unknown")
-    # If we cannot find a `.git` directory do not even try to guess the git
-    # revision.
-    if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
-        # We need `git` to find the revision.
-        find_program(GOOGLE_CLOUD_CPP_BIGQUERY_GIT_PROGRAM NAMES git)
-        mark_as_advanced(GOOGLE_CLOUD_CPP_BIGQUERY_GIT_PROGRAM)
-        if (GOOGLE_CLOUD_CPP_BIGQUERY_GIT_PROGRAM)
-            # Run `git rev-parse --short HEAD` and capture the output in a
-            # variable.
-            execute_process(
-                COMMAND "${GOOGLE_CLOUD_CPP_BIGQUERY_GIT_PROGRAM}" rev-parse
-                        --short HEAD
-                OUTPUT_VARIABLE GIT_HEAD_LOG
-                ERROR_VARIABLE GIT_HEAD_LOG)
-            string(REPLACE "\n" "" result "${GIT_HEAD_LOG}")
-        endif ()
-    endif ()
-    set(${var}
-        "${result}"
-        PARENT_SCOPE)
-endfunction ()
-
-# Capture the compiler version and the git revision into variables, then
-# generate a config file with the values.
-if (NOT "${GOOGLE_CLOUD_CPP_BIGQUERY_BUILD_METADATA}" STREQUAL "")
-    # The build metadata flag is already defined, do not re-compute the
-    # initialization value. This works both when the user supplies
-    # -DGOOGLE_CLOUD_CPP_BIGQUERY_METADATA=value in the command line, and when
-    # GOOGLE_CLOUD_CPP_BIGQUERY_METADATA has a cached value
-    set(GOOGLE_CLOUD_CPP_BIGQUERY_GIT_HEAD "unused")
-else ()
-    google_cloud_cpp_bigquery_initialize_git_head(
-        GOOGLE_CLOUD_CPP_BIGQUERY_GIT_HEAD)
-endif ()
-
-# Define a CMake configuration option to set the build metadata. By default this
-# is initialized from `git rev-parse --short HEAD`, but the developer (or the
-# script building via CMake) can override the value.
-set(GOOGLE_CLOUD_CPP_BIGQUERY_BUILD_METADATA
-    "${GOOGLE_CLOUD_CPP_BIGQUERY_GIT_HEAD}"
-    CACHE STRING "Append build metadata to the library version number")
-# This option is rarely needed. Mark it as "advanced" to remove it from the
-# default CMake UIs.
-mark_as_advanced(GOOGLE_CLOUD_CPP_BIGQUERY_BUILD_METADATA)
-
-message(STATUS "google-cloud-cpp-bigquery build metadata set to"
-               " ${GOOGLE_CLOUD_CPP_BIGQUERY_BUILD_METADATA}")
-
 configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(
     bigquery_client

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -23,58 +23,6 @@ set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples)
 
 include(GoogleCloudCppCommon)
 
-# Define a function to fetch the current git revision. Using a function creates
-# a new scope, so the CMake variables do not leak to the global namespace.
-function (google_cloud_cpp_pubsub_initialize_git_head var)
-    set(result "unknown")
-    # If we cannot find a `.git` directory do not even try to guess the git
-    # revision.
-    if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
-        # We need `git` to find the revision.
-        find_program(GOOGLE_CLOUD_CPP_PUBSUB_GIT_PROGRAM NAMES git)
-        mark_as_advanced(GOOGLE_CLOUD_CPP_PUBSUB_GIT_PROGRAM)
-        if (GOOGLE_CLOUD_CPP_PUBSUB_GIT_PROGRAM)
-            # Run `git rev-parse --short HEAD` and capture the output in a
-            # variable.
-            execute_process(
-                COMMAND "${GOOGLE_CLOUD_CPP_PUBSUB_GIT_PROGRAM}" rev-parse
-                        --short HEAD
-                OUTPUT_VARIABLE GIT_HEAD_LOG
-                ERROR_VARIABLE GIT_HEAD_LOG)
-            string(REPLACE "\n" "" result "${GIT_HEAD_LOG}")
-        endif ()
-    endif ()
-    set(${var}
-        "${result}"
-        PARENT_SCOPE)
-endfunction ()
-
-# Capture the compiler version and the git revision into variables, then
-# generate a config file with the values.
-if (NOT "${GOOGLE_CLOUD_CPP_PUBSUB_BUILD_METADATA}" STREQUAL "")
-    # The build metadata flag is already defined, do not re-compute the
-    # initialization value. This works both when the user supplies
-    # -DGOOGLE_CLOUD_CPP_PUBSUB_METADATA=value in the command line, and when
-    # GOOGLE_CLOUD_CPP_PUBSUB_METADATA has a cached value
-    set(GOOGLE_CLOUD_CPP_PUBSUB_GIT_HEAD "unused")
-else ()
-    google_cloud_cpp_pubsub_initialize_git_head(
-        GOOGLE_CLOUD_CPP_PUBSUB_GIT_HEAD)
-endif ()
-
-# Define a CMake configuration option to set the build metadata. By default this
-# is initialized from `git rev-parse --short HEAD`, but the developer (or the
-# script building via CMake) can override the value.
-set(GOOGLE_CLOUD_CPP_PUBSUB_BUILD_METADATA
-    "${GOOGLE_CLOUD_CPP_PUBSUB_GIT_HEAD}"
-    CACHE STRING "Append build metadata to the library version number")
-# This option is rarely needed. Mark it as "advanced" to remove it from the
-# default CMake UIs.
-mark_as_advanced(GOOGLE_CLOUD_CPP_PUBSUB_BUILD_METADATA)
-
-message(STATUS "google-cloud-cpp-pubsub build metadata set to"
-               " ${GOOGLE_CLOUD_CPP_PUBSUB_BUILD_METADATA}")
-
 configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(
     pubsub_client # cmake-format: sort


### PR DESCRIPTION
Both bigquery/ and pubsub/ captured the git revision into a CMake
variable, but this is no longer needed as the build information is
shared with the common libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3966)
<!-- Reviewable:end -->
