### PR TITLE
fix: deflake by increasing some timeouts

### DIFF
--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -181,7 +181,7 @@ TEST(ConnectionOptionsTest, CustomBackgroundThreads) {
 
   // Verify we can create our own threads to drain the completion queue.
   std::thread t([&cq] { cq.Run(); });
-  EXPECT_EQ(std::future_status::ready, background_thread_id.wait_for(ms(100)));
+  EXPECT_EQ(std::future_status::ready, background_thread_id.wait_for(ms(500)));
 
   cq.Shutdown();
   t.join();

--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -39,10 +39,10 @@ TEST(CustomerSuppliedBackgroundThreads, LifecycleNoShutdown) {
   EXPECT_NE(std::future_status::ready, has_shutdown.wait_for(ms(2)));
 
   auto expired = cq.MakeRelativeTimer(ms(0));
-  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(100)));
+  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(500)));
 
   cq.Shutdown();
-  EXPECT_EQ(std::future_status::ready, has_shutdown.wait_for(ms(100)));
+  EXPECT_EQ(std::future_status::ready, has_shutdown.wait_for(ms(500)));
 
   t.join();
 }
@@ -62,7 +62,7 @@ TEST(CustomerSuppliedBackgroundThreads, SharesCompletionQueue) {
         return std::this_thread::get_id();
       });
   std::thread t([&cq] { cq.Run(); });
-  EXPECT_EQ(std::future_status::ready, id.wait_for(ms(100)));
+  EXPECT_EQ(std::future_status::ready, id.wait_for(ms(500)));
   EXPECT_EQ(t.get_id(), id.get());
 
   cq.Shutdown();
@@ -76,7 +76,7 @@ TEST(AutomaticallyCreatedBackgroundThreads, IsActive) {
   using ms = std::chrono::milliseconds;
 
   auto expired = actual.cq().MakeRelativeTimer(ms(0));
-  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(100)));
+  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(500)));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/3962

This PR increases some `wait_for` timeouts in an attempt to minimize test flakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3971)
<!-- Reviewable:end -->
