### PR TITLE
cleanup: simplify quickstart CMakeLists.txt files

### DIFF
--- a/ci/kokoro/windows/build-quickstart-cmake.ps1
+++ b/ci/kokoro/windows/build-quickstart-cmake.ps1
@@ -67,6 +67,7 @@ ForEach($library in ("bigtable", "storage")) {
     $cmake_flags += "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET"
     $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"
     $cmake_flags += "-DCMAKE_CXX_COMPILER=cl.exe"
+    $cmake_flags += "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW"
 
     # Configure CMake and create the build directory.
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Configuring CMake with $cmake_flags"

--- a/google/cloud/bigtable/quickstart/CMakeLists.txt
+++ b/google/cloud/bigtable/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Cloud Bigtable C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-bigtable-quickstart CXX C)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/google/cloud/bigtable/quickstart/CMakeLists.txt
+++ b/google/cloud/bigtable/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Cloud Bigtable C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(google-cloud-cpp-bigtable-quickstart CXX C)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -24,18 +24,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Threads REQUIRED)
 find_package(bigtable_client REQUIRED)
 
-# ~~~
-#  https://gitlab.kitware.com/cmake/community/wikis/FAQ#how-can-i-build-my-msvc-application-with-a-static-runtime
-# ~~~
-if (MSVC AND VCPKG_TARGET_TRIPLET MATCHES "-static$")
-    foreach (flag_var
-             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-             CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        if (${flag_var} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endif ()
-    endforeach (flag_var)
-    unset(flag_var)
+# MSVC requires some additional code to select the correct runtime library
+if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else ()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif ()
 
 # Once the bigtable_client package is found, define new targets.

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -108,6 +108,10 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
+To correctly configure the MSVC runtime you should change the CMake minimum
+required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
+CMake configuration step.
+
 gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 

--- a/google/cloud/storage/quickstart/CMakeLists.txt
+++ b/google/cloud/storage/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Google Cloud Storage C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 project(google-cloud-cpp-storage-quickstart CXX C)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/google/cloud/storage/quickstart/CMakeLists.txt
+++ b/google/cloud/storage/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Google Cloud Storage C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(google-cloud-cpp-storage-quickstart CXX C)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -24,18 +24,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(CURL REQUIRED)
 find_package(storage_client REQUIRED)
 
-# ~~~
-#  https://gitlab.kitware.com/cmake/community/wikis/FAQ#how-can-i-build-my-msvc-application-with-a-static-runtime
-# ~~~
-if (MSVC AND VCPKG_TARGET_TRIPLET MATCHES "-static$")
-    foreach (flag_var
-             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-             CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-        if (${flag_var} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-        endif ()
-    endforeach (flag_var)
-    unset(flag_var)
+# MSVC requires some additional code to select the correct runtime library
+if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+else ()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif ()
 
 # Once the packages are found, define the targets.

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -78,6 +78,14 @@ https://cloud.google.com/docs/authentication/production
    .build/quickstart [GCP PROJECT] [BUCKET NAME]
    ```
 
+## Platform Specific Notes
+
+### Windows
+
+To correctly configure the MSVC runtime you should change the CMake minimum
+required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
+CMake configuration step.
+
 [bazel-install]: https://docs.bazel.build/versions/master/install.html
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake


### PR DESCRIPTION
Require CMake >= 3.15 for the quickstart examples, with that version we
can write slightly cleaner code to pick the MSVC runtime.

Fixes #3729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3979)
<!-- Reviewable:end -->
