### PR TITLE
cleanup: enable clang-tidy for `storage/tests`

### DIFF
--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ foreach (fname ${storage_client_integration_tests})
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;storage-integration-tests")
+    google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()
 
 # We just know that these tests need to be run against production.

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -25,7 +25,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 
@@ -426,7 +425,7 @@ TEST_F(BucketIntegrationTest, GetMetadataFields) {
   EXPECT_TRUE(metadata->kind().empty());
 }
 
-TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
+TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatchSuccess) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -443,7 +442,7 @@ TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationMatch_Success) {
   EXPECT_EQ(*metadata2, *metadata);
 }
 
-TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatch_Failure) {
+TEST_F(BucketIntegrationTest, GetMetadataIfMetagenerationNotMatchFailure) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -27,8 +27,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::testing::HasSubstr;
-
 std::string HttpBinEndpoint() {
   return google::cloud::internal::GetEnv("HTTPBIN_ENDPOINT")
       .value_or("https://nghttp2.org/httpbin");

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -202,7 +202,7 @@ TEST(CurlRequestTest, UserAgent) {
 }
 
 /// @test Verify that the Projection parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_Projection) {
+TEST(CurlRequestTest, WellKnownQueryParametersProjection) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -225,7 +225,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Projection) {
 }
 
 /// @test Verify that the UserProject parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_UserProject) {
+TEST(CurlRequestTest, WellKnownQueryParametersUserProject) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -248,7 +248,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_UserProject) {
 }
 
 /// @test Verify that the IfGenerationMatch parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationMatch) {
+TEST(CurlRequestTest, WellKnownQueryParametersIfGenerationMatch) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -271,7 +271,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationMatch) {
 }
 
 /// @test Verify that the IfGenerationNotMatch parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationNotMatch) {
+TEST(CurlRequestTest, WellKnownQueryParametersIfGenerationNotMatch) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -294,7 +294,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfGenerationNotMatch) {
 }
 
 /// @test Verify that the IfMetagenerationMatch parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationMatch) {
+TEST(CurlRequestTest, WellKnownQueryParametersIfMetagenerationMatch) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -317,7 +317,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationMatch) {
 }
 
 /// @test Verify that the IfMetagenerationNotMatch parameter is included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationNotMatch) {
+TEST(CurlRequestTest, WellKnownQueryParametersIfMetagenerationNotMatch) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -340,7 +340,7 @@ TEST(CurlRequestTest, WellKnownQueryParameters_IfMetagenerationNotMatch) {
 }
 
 /// @test Verify that the well-known query parameters are included if set.
-TEST(CurlRequestTest, WellKnownQueryParameters_Multiple) {
+TEST(CurlRequestTest, WellKnownQueryParametersMultiple) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/get",
       storage::internal::GetDefaultCurlHandleFactory());
@@ -366,7 +366,9 @@ TEST(CurlRequestTest, WellKnownQueryParameters_Multiple) {
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:
-  void Process(google::cloud::LogRecord const& lr) { ProcessWithOwnership(lr); }
+  void Process(google::cloud::LogRecord const& lr) override {
+    ProcessWithOwnership(lr);
+  }
   MOCK_METHOD1(ProcessWithOwnership, void(google::cloud::LogRecord));
 };
 
@@ -381,10 +383,11 @@ TEST(CurlRequestTest, Logging) {
 
   std::string log_messages;
   EXPECT_CALL(*mock_logger, ProcessWithOwnership(_))
-      .WillRepeatedly(Invoke([&log_messages](google::cloud::LogRecord lr) {
-        log_messages += lr.message;
-        log_messages += "\n";
-      }));
+      .WillRepeatedly(
+          Invoke([&log_messages](google::cloud::LogRecord const& lr) {
+            log_messages += lr.message;
+            log_messages += "\n";
+          }));
 
   {
     storage::internal::CurlRequestBuilder request(

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -366,9 +366,10 @@ TEST(CurlRequestTest, WellKnownQueryParametersMultiple) {
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:
-  void Process(google::cloud::LogRecord const& lr) override {
-    ProcessWithOwnership(lr);
-  }
+  // TODO(#3983) clang-tidy and clang-3.8 conflict about annotating
+  // `Process` as `override`. See the issue for details.
+  // NOLINTNEXTLINE(modernize-use-override)
+  void Process(google::cloud::LogRecord const& lr) { ProcessWithOwnership(lr); }
   MOCK_METHOD1(ProcessWithOwnership, void(google::cloud::LogRecord));
 };
 

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -366,11 +366,11 @@ TEST(CurlRequestTest, WellKnownQueryParametersMultiple) {
 
 class MockLogBackend : public google::cloud::LogBackend {
  public:
-  // TODO(#3983) clang-tidy and clang-3.8 conflict about annotating
-  // `Process` as `override`. See the issue for details.
-  // NOLINTNEXTLINE(modernize-use-override)
-  void Process(google::cloud::LogRecord const& lr) { ProcessWithOwnership(lr); }
-  MOCK_METHOD1(ProcessWithOwnership, void(google::cloud::LogRecord));
+  void Process(google::cloud::LogRecord const& lr) override {
+    ProcessWithOwnership(lr);
+  }
+  MOCK_METHOD(void, ProcessWithOwnership, (google::cloud::LogRecord),
+              (override));
 };
 
 /// @test Verify that CurlRequest logs when requested.

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -25,8 +25,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::testing::HasSubstr;
-
 class CurlResumableUploadIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -26,8 +26,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::testing::HasSubstr;
-
 class CurlSignBlobIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -251,7 +251,8 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
   // Create the object, but only if it does not exist already.
   auto os = client.WriteObject(bucket_name_, object_name, IfGenerationMatch(0),
                                NewResumableUploadSession());
-  WriteRandomLines(os, expected, 80, opts->download_buffer_size() * 3 / 80);
+  WriteRandomLines(os, expected, 80,
+                   static_cast<int>(opts->download_buffer_size()) * 3 / 80);
   os.Close();
   EXPECT_TRUE(os);
   EXPECT_TRUE(os.metadata().ok());
@@ -287,7 +288,8 @@ TEST_F(ErrorInjectionIntegrationTest, InjectSendErrorOnRead) {
                                NewResumableUploadSession());
   os.exceptions(std::ios_base::badbit);
 
-  WriteRandomLines(os, expected, 80, opts->download_buffer_size() * 3 / 80);
+  WriteRandomLines(os, expected, 80,
+                   static_cast<int>(opts->download_buffer_size()) * 3 / 80);
   os.Close();
   EXPECT_TRUE(os);
   EXPECT_TRUE(os.metadata().ok());

--- a/google/cloud/storage/tests/key_file_integration_test.cc
+++ b/google/cloud/storage/tests/key_file_integration_test.cc
@@ -26,7 +26,6 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::HasSubstr;
 
 class KeyFileIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest,

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -26,8 +26,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::CountMatchingEntities;
-using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 class ObjectChecksumIntegrationTest
@@ -388,7 +386,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedCrc32cStreamingReadJSON) {
 
 /// @test Verify that CRC32C checksum mismatches are reported when using
 /// .read().
-TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
+TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadXMLRead) {
   // This test is disabled when not using the testbench as it relies on the
   // testbench to inject faults.
   if (!UsingTestbench()) GTEST_SKIP();
@@ -424,7 +422,7 @@ TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
 
 /// @test Verify that CRC32C checksum mismatches are reported when using
 /// .read().
-TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
+TEST_F(ObjectChecksumIntegrationTest, MismatchedMD5StreamingReadJSONRead) {
   // This test is disabled when not using the testbench as it relies on the
   // testbench to inject faults.
   if (!UsingTestbench()) GTEST_SKIP();

--- a/google/cloud/storage/tests/object_file_multi_threaded_test.cc
+++ b/google/cloud/storage/tests/object_file_multi_threaded_test.cc
@@ -29,8 +29,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::testing::HasSubstr;
-
 auto const kObjectSize = 16 * 1024;
 
 class ObjectFileMultiThreadedTest
@@ -47,11 +45,11 @@ class ObjectFileMultiThreadedTest
   }
 
   static int ThreadCount() {
-    static int const count = [] {
+    static int const kCount = [] {
       auto c = static_cast<int>(std::thread::hardware_concurrency());
       return c == 0 ? 4 : 4 * c;
     }();
-    return count;
+    return kCount;
   }
 
   std::vector<std::string> CreateObjectNames() {

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -29,8 +29,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::CountMatchingEntities;
-using ::google::cloud::storage::testing::TestPermanentFailure;
 using ::testing::HasSubstr;
 
 class ObjectHashIntegrationTest
@@ -497,7 +495,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON) {
 }
 
 /// @test Verify that MD5 hash mismatches are reported when using .read().
-TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
+TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXMLRead) {
   // This test is disabled when not using the testbench as it relies on the
   // testbench to inject faults.
   if (!UsingTestbench()) GTEST_SKIP();
@@ -532,7 +530,7 @@ TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadXML_Read) {
 }
 
 /// @test Verify that MD5 hash mismatches are reported when using .read().
-TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSON_Read) {
+TEST_F(ObjectHashIntegrationTest, MismatchedMD5StreamingReadJSONRead) {
   // This test is disabled when not using the testbench as it relies on the
   // testbench to inject faults.
   if (!UsingTestbench()) GTEST_SKIP();

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -30,8 +30,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::CountMatchingEntities;
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::HasSubstr;
 
 class ObjectInsertIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest,
@@ -59,21 +57,20 @@ class ObjectInsertIntegrationTest
     ASSERT_FALSE(bucket_name_.empty());
   }
 
-  std::string GetLinesWith(
-      google::cloud::testing_util::CaptureLogLinesBackend const& backend,
-      std::string const& text) {
-    std::string msg;
-    for (auto const& l : backend.log_lines) {
-      if (l.find(text) == std::string::npos) continue;
-      msg += l;
-      msg += "\n";
-    }
-    return msg;
-  }
-
   ::google::cloud::testing_util::ScopedEnvironment application_credentials_;
   std::string bucket_name_;
 };
+
+std::string GetLinesWith(testing_util::CaptureLogLinesBackend const& backend,
+                         std::string const& text) {
+  std::string msg;
+  for (auto const& l : backend.log_lines) {
+    if (l.find(text) == std::string::npos) continue;
+    msg += l;
+    msg += "\n";
+  }
+  return msg;
+}
 
 TEST_P(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   StatusOr<Client> client = MakeIntegrationTestClient();

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -542,11 +542,11 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailureNoex) {
 }
 
 TEST_F(ObjectIntegrationTest, ListObjectsFailure) {
-  auto bucket_name_ = MakeRandomBucketName();
+  auto bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  ListObjectsReader reader = client->ListObjects(bucket_name_, Versions(true));
+  ListObjectsReader reader = client->ListObjects(bucket_name, Versions(true));
 
   // This operation should fail because the bucket does not exist.
   TestPermanentFailure([&] {

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -33,8 +33,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::testing::HasSubstr;
-
 class ObjectMediaIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
@@ -58,9 +56,9 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
 
   // Construct a large object, or at least large enough that it is not
   // downloaded in the first chunk.
-  long const lines = 4 * 1024 * 1024 / 128;
+  std::size_t constexpr kLines = 4 * 1024 * 1024 / 128;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
+  for (std::size_t i = 0; i != kLines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -97,10 +95,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
   // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
-  long const chunk = 16 * 1024L;
-  long const lines = 4 * chunk / 128;
+  std::size_t constexpr kChunk = 16 * 1024L;
+  std::size_t constexpr kLines = 4 * kChunk / 128;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
+  for (std::size_t i = 0; i != kLines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -117,11 +115,11 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name,
-                                   ReadRange(1 * chunk, 2 * chunk),
+                                   ReadRange(1 * kChunk, 2 * kChunk),
                                    IfGenerationNotMatch(0));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(1 * chunk, actual.size());
-  EXPECT_EQ(large_text.substr(1 * chunk, 1 * chunk), actual);
+  EXPECT_EQ(1 * kChunk, actual.size());
+  EXPECT_EQ(large_text.substr(1 * kChunk, 1 * kChunk), actual);
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -138,10 +136,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
   // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
-  long const chunk = 16 * 1024L;
-  long const lines = 4 * chunk / 128;
+  std::size_t constexpr kChunk = 16 * 1024L;
+  std::size_t constexpr kLines = 4 * kChunk / 128;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
+  for (std::size_t i = 0; i != kLines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -158,10 +156,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
 
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name,
-                                   ReadRange(1 * chunk, 2 * chunk));
+                                   ReadRange(1 * kChunk, 2 * kChunk));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(1 * chunk, actual.size());
-  EXPECT_EQ(large_text.substr(1 * chunk, 1 * chunk), actual);
+  EXPECT_EQ(1 * kChunk, actual.size());
+  EXPECT_EQ(large_text.substr(1 * kChunk, 1 * kChunk), actual);
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -178,10 +176,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
   // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
-  long const chunk = 16 * 1024L;
-  long const lines = 4 * chunk / 128;
+  std::size_t constexpr kChunk = 16 * 1024L;
+  std::size_t constexpr kLines = 4 * kChunk / 128;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
+  for (std::size_t i = 0; i != kLines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -198,11 +196,11 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
 
   // Create an iostream to read the object back.
   auto stream =
-      client->ReadObject(bucket_name_, object_name, ReadFromOffset(2 * chunk),
+      client->ReadObject(bucket_name_, object_name, ReadFromOffset(2 * kChunk),
                          IfGenerationNotMatch(0));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(2 * chunk, actual.size());
-  EXPECT_EQ(large_text.substr(2 * chunk), actual);
+  EXPECT_EQ(2 * kChunk, actual.size());
+  EXPECT_EQ(large_text.substr(2 * kChunk), actual);
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -219,10 +217,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
   // This produces a 64 KiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
-  long const chunk = 16 * 1024L;
-  long const lines = 4 * chunk / 128;
+  std::size_t constexpr kChunk = 16 * 1024L;
+  std::size_t constexpr kLines = 4 * kChunk / 128;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
+  for (std::size_t i = 0; i != kLines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -239,10 +237,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
 
   // Create an iostream to read the object back.
   auto stream =
-      client->ReadObject(bucket_name_, object_name, ReadFromOffset(2 * chunk));
+      client->ReadObject(bucket_name_, object_name, ReadFromOffset(2 * kChunk));
   std::string actual(std::istreambuf_iterator<char>{stream}, {});
-  EXPECT_EQ(2 * chunk, actual.size());
-  EXPECT_EQ(large_text.substr(2 * chunk), actual);
+  EXPECT_EQ(2 * kChunk, actual.size());
+  EXPECT_EQ(large_text.substr(2 * kChunk), actual);
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -259,10 +257,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
   // This produces a 4 MiB text object. Normally applications should download
   // much larger chunks from GCS, but it is really hard to figure out what is
   // broken when the error messages are in the MiB ranges.
-  auto const object_size = 4 * 1024 * 1024LL;
-  auto const lines = object_size / 128;
+  auto constexpr kObjectSize = 4 * 1024 * 1024LL;
+  auto constexpr kLines = kObjectSize / 128;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
+  for (std::size_t i = 0; i != kLines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -284,15 +282,14 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
   // it is unlikely that any application would actually read like this,
   // nevertheless the library should work in this case.
   std::string actual;
-  actual.reserve(object_size);
-  auto const maximum_chunk_size = 256 * 1024L;
-  auto const minimum_chunk_size = 16;
-  std::vector<char> buffer(maximum_chunk_size);
-  std::uniform_int_distribution<int> chunk_size_generator(0,
-                                                          maximum_chunk_size);
+  actual.reserve(kObjectSize);
+  auto constexpr kMaximumChunkSize = 256 * 1024L;
+  auto constexpr kMinimumChunkSize = 16;
+  std::vector<char> buffer(kMaximumChunkSize);
+  std::uniform_int_distribution<int> chunk_size_generator(0, kMaximumChunkSize);
   do {
     auto size = chunk_size_generator(generator_);
-    if (size < minimum_chunk_size) {
+    if (size < kMinimumChunkSize) {
       std::string line;
       if (std::getline(stream, line)) {
         actual.append(line);
@@ -304,7 +301,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
     }
   } while (stream);
 
-  EXPECT_EQ(object_size, actual.size());
+  EXPECT_EQ(kObjectSize, actual.size());
   EXPECT_EQ(large_text, actual);
 
   auto status = client->DeleteObject(bucket_name_, object_name);
@@ -322,20 +319,20 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
   // multiple of 128KiB.
   auto constexpr kKiB = 1024L;
   auto constexpr kMiB = 1024L * kKiB;
-  auto constexpr object_size = 3 * kMiB + 129 * kKiB;
-  auto constexpr line_size = 128;
-  auto constexpr lines = object_size / line_size;
+  auto constexpr kObjectSize = 3 * kMiB + 129 * kKiB;
+  auto constexpr kLineSize = 128;
+  auto constexpr kLines = kObjectSize / kLineSize;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
-    auto line = google::cloud::internal::Sample(generator_, line_size - 1,
+  for (std::size_t i = 0; i != kLines; ++i) {
+    auto line = google::cloud::internal::Sample(generator_, kLineSize - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                 "012456789");
     large_text += line + "\n";
   }
-  static_assert(object_size % line_size == 0,
+  static_assert(kObjectSize % kLineSize == 0,
                 "Object must be multiple of line size");
-  EXPECT_EQ(object_size, large_text.size());
+  EXPECT_EQ(kObjectSize, large_text.size());
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
@@ -354,7 +351,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
   EXPECT_TRUE(stream.eof());
   EXPECT_TRUE(stream.fail());
   EXPECT_FALSE(stream.bad());
-  EXPECT_EQ(object_size - 3 * kMiB, stream.gcount());
+  EXPECT_EQ(kObjectSize - 3 * kMiB, stream.gcount());
   std::string actual(buffer.data(), stream.gcount());
   EXPECT_EQ(large_text.substr(3 * kMiB), actual);
 
@@ -379,10 +376,10 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
   //
   // However, the library reads 128 KiB as soon as the stream is created, so
   // we need to create an object that has just a little over 128 KiB:
-  const int initial_read_size = 128 * 1024;
-  const int trailer_size = 512;
-  int const unread_bytes = 16;
-  std::string contents = MakeRandomData(initial_read_size + trailer_size);
+  int constexpr kInitialReadSize = 128 * 1024;
+  int constexpr kTrailerSize = 512;
+  int constexpr kUnreadBytes = 16;
+  std::string contents = MakeRandomData(kInitialReadSize + kTrailerSize);
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, contents, IfGenerationMatch(0));
@@ -393,7 +390,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
 
   // Read most of the data, but leave some in the spill buffer, this `is testing
   // for a regression of #3051.
-  std::vector<char> buffer(contents.size() - unread_bytes);
+  std::vector<char> buffer(contents.size() - kUnreadBytes);
   stream.read(buffer.data(), buffer.size());
   EXPECT_FALSE(stream.eof());
   EXPECT_FALSE(stream.fail());
@@ -413,7 +410,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
 }
 
 /// @test Read the last chunk of an object by setting ReadLasst option.
-TEST_F(ObjectMediaIntegrationTest, ReadLastChunk_ReadLast) {
+TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -423,20 +420,20 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk_ReadLast) {
   // multiple of 128KiB.
   auto constexpr kKiB = 1024L;
   auto constexpr kMiB = 1024L * kKiB;
-  auto constexpr object_size = 3 * kMiB + 129 * kKiB;
-  auto constexpr line_size = 128;
-  auto constexpr lines = object_size / line_size;
+  auto constexpr kObjectSize = 3 * kMiB + 129 * kKiB;
+  auto constexpr kLineSize = 128;
+  auto constexpr kLines = kObjectSize / kLineSize;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
-    auto line = google::cloud::internal::Sample(generator_, line_size - 1,
+  for (std::size_t i = 0; i != kLines; ++i) {
+    auto line = google::cloud::internal::Sample(generator_, kLineSize - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                 "012456789");
     large_text += line + "\n";
   }
-  static_assert(object_size % line_size == 0,
+  static_assert(kObjectSize % kLineSize == 0,
                 "Object must be multiple of line size");
-  EXPECT_EQ(object_size, large_text.size());
+  EXPECT_EQ(kObjectSize, large_text.size());
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
@@ -457,7 +454,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk_ReadLast) {
   EXPECT_FALSE(stream.bad());
   EXPECT_EQ(129 * kKiB, stream.gcount());
   std::string actual(buffer.data(), stream.gcount());
-  EXPECT_EQ(large_text.substr(object_size - 129 * kKiB), actual);
+  EXPECT_EQ(large_text.substr(kObjectSize - 129 * kKiB), actual);
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -473,20 +470,20 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
   // This produces a 3.25 MiB text object.
   auto constexpr kKiB = 1024L;
   auto constexpr kMiB = 1024L * kKiB;
-  auto constexpr object_size = 3 * kMiB + 129 * kKiB;
-  auto constexpr line_size = 128;
-  auto constexpr lines = object_size / line_size;
+  auto constexpr kObjectSize = 3 * kMiB + 129 * kKiB;
+  auto constexpr kLineSize = 128;
+  auto constexpr kLines = kObjectSize / kLineSize;
   std::string large_text;
-  for (long i = 0; i != lines; ++i) {
-    auto line = google::cloud::internal::Sample(generator_, line_size - 1,
+  for (std::size_t i = 0; i != kLines; ++i) {
+    auto line = google::cloud::internal::Sample(generator_, kLineSize - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                                 "012456789");
     large_text += line + "\n";
   }
-  static_assert(object_size % line_size == 0,
+  static_assert(kObjectSize % kLineSize == 0,
                 "Object must be multiple of line size");
-  EXPECT_EQ(object_size, large_text.size());
+  EXPECT_EQ(kObjectSize, large_text.size());
 
   StatusOr<ObjectMetadata> source_meta = client->InsertObject(
       bucket_name_, object_name, large_text, IfGenerationMatch(0));
@@ -521,7 +518,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
   EXPECT_TRUE(stream.eof());
   EXPECT_TRUE(stream.fail());
   EXPECT_FALSE(stream.bad());
-  EXPECT_EQ(object_size - 3 * kMiB, stream.gcount());
+  EXPECT_EQ(kObjectSize - 3 * kMiB, stream.gcount());
   std::string actual(buffer.data(), stream.gcount());
   auto expected = large_text.substr(3 * kMiB);
   EXPECT_EQ(expected.size(), actual.size());
@@ -652,8 +649,8 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
   auto object_name = MakeRandomObjectName();
 
   // Construct an object large enough to not be downloaded in the first chunk.
-  auto const object_size = 512 * 1024L;
-  auto large_text = MakeRandomData(object_size);
+  auto constexpr kObjectSize = 512 * 1024L;
+  auto large_text = MakeRandomData(kObjectSize);
 
   // Create an object with the contents to download.
   StatusOr<ObjectMetadata> source_meta = client.InsertObject(
@@ -664,8 +661,8 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeout) {
       bucket_name_, object_name,
       CustomHeader("x-goog-testbench-instructions", "stall-always"));
 
-  std::vector<char> buffer(object_size);
-  stream.read(buffer.data(), object_size);
+  std::vector<char> buffer(kObjectSize);
+  stream.read(buffer.data(), kObjectSize);
   EXPECT_TRUE(stream.bad());
   EXPECT_FALSE(stream.status().ok());
 
@@ -685,9 +682,9 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
   auto object_name = MakeRandomObjectName();
 
   // Construct an object large enough to not be downloaded in the first chunk.
-  auto const object_size = 512 * 1024L;
-  auto large_text = MakeRandomData(object_size);
-  EXPECT_EQ(object_size, large_text.size());
+  auto constexpr kObjectSize = 512 * 1024L;
+  auto large_text = MakeRandomData(kObjectSize);
+  EXPECT_EQ(kObjectSize, large_text.size());
 
   // Create an object with the contents to download.
   StatusOr<ObjectMetadata> source_meta = client.InsertObject(
@@ -698,11 +695,11 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadTimeoutContinues) {
       bucket_name_, object_name,
       CustomHeader("x-goog-testbench-instructions", "stall-at-256KiB"));
 
-  std::vector<char> buffer(object_size);
-  stream.read(buffer.data(), object_size);
+  std::vector<char> buffer(kObjectSize);
+  stream.read(buffer.data(), kObjectSize);
   EXPECT_STATUS_OK(stream.status());
-  EXPECT_EQ(object_size, stream.gcount());
-  stream.read(buffer.data(), object_size);
+  EXPECT_EQ(kObjectSize, stream.gcount());
+  stream.read(buffer.data(), kObjectSize);
 
   EXPECT_TRUE(stream.eof());
   EXPECT_EQ(0, stream.gcount());

--- a/google/cloud/storage/tests/object_parallel_upload_integration_test.cc
+++ b/google/cloud/storage/tests/object_parallel_upload_integration_test.cc
@@ -34,9 +34,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::UnorderedElementsAre;
-
 using ObjectParallelUploadIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 

--- a/google/cloud/storage/tests/object_plenty_clients_serially_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_serially_integration_test.cc
@@ -34,9 +34,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::UnorderedElementsAre;
-
 using ObjectPlentyClientsSeriallyIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 

--- a/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
+++ b/google/cloud/storage/tests/object_plenty_clients_simultaneously_integration_test.cc
@@ -34,9 +34,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::UnorderedElementsAre;
-
 using ObjectPlentyClientsSimultaneouslyIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 

--- a/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
@@ -34,9 +34,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::UnorderedElementsAre;
-
 using ObjectResumableParallelUploadIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -29,8 +29,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::CountMatchingEntities;
-using ::google::cloud::storage::testing::TestPermanentFailure;
-using ::testing::HasSubstr;
 
 class ObjectRewriteIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -392,8 +390,8 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
   auto source_name = MakeRandomObjectName();
 
   std::string large_text;
-  long const lines = 8 * 1024 * 1024 / 128;
-  for (long i = 0; i != lines; ++i) {
+  std::size_t const lines = 8 * 1024 * 1024 / 128;
+  for (std::size_t i = 0; i != lines; ++i) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -28,8 +28,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::testing::HasSubstr;
-
 class ObjectWriteStreambufIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:

--- a/google/cloud/storage/tests/service_account_integration_test.cc
+++ b/google/cloud/storage/tests/service_account_integration_test.cc
@@ -24,8 +24,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::testing::HasSubstr;
-
 class ServiceAccountIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -321,7 +321,11 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace cloud
 }  // namespace google
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[])
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+    try
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+{
   auto conformance_tests_file =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME")
@@ -459,7 +463,10 @@ int main(int argc, char* argv[]) try {
   ::testing::InitGoogleMock(&argc, argv);
 
   return RUN_ALL_TESTS();
-} catch (std::exception const& ex) {
+}
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
   return 1;
 }
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -321,7 +321,7 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace cloud
 }  // namespace google
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[]) try {
   auto conformance_tests_file =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME")
@@ -459,4 +459,7 @@ int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
 
   return RUN_ALL_TESTS();
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
+  return 1;
 }

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -321,11 +321,7 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace cloud
 }  // namespace google
 
-int main(int argc, char* argv[])
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-    try
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-{
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   auto conformance_tests_file =
       google::cloud::internal::GetEnv(
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME")
@@ -464,9 +460,3 @@ int main(int argc, char* argv[])
 
   return RUN_ALL_TESTS();
 }
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-catch (std::exception const& ex) {
-  std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
-  return 1;
-}
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -27,7 +27,6 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
-using ::testing::HasSubstr;
 
 class SignedUrlIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {

--- a/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_chunk_integration_test.cc
@@ -27,8 +27,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::testing::HasSubstr;
-
 class SlowReaderChunkIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
@@ -77,7 +75,7 @@ TEST_F(SlowReaderChunkIntegrationTest, LongPauses) {
   auto const period_increment = std::chrono::seconds(UsingTestbench() ? 5 : 60);
   auto const max_slow_reader_period = std::chrono::minutes(10);
   std::vector<char> buffer;
-  long const size = 1024 * 1024;
+  std::size_t const size = 1024 * 1024;
   buffer.resize(size);
   stream.read(buffer.data(), size);
   EXPECT_STATUS_OK(stream.status());

--- a/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
+++ b/google/cloud/storage/tests/slow_reader_stream_integration_test.cc
@@ -27,8 +27,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
-using ::testing::HasSubstr;
-
 class SlowReaderStreamIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:


### PR DESCRIPTION
part of #3958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3982)
<!-- Reviewable:end -->
