### PR TITLE
cleanup: enable clang-tidy for `storage/examples`

### DIFF
--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -81,6 +81,7 @@ if (BUILD_TESTING)
                     GTest::gtest
                     storage_common_options)
         add_test(NAME ${target} COMMAND ${target})
+        google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()
 endif ()
 
@@ -96,6 +97,7 @@ foreach (fname ${storage_examples})
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;storage-integration-tests")
+    google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()
 
 # We just know that these tests need to be run against production.
@@ -107,4 +109,5 @@ foreach (
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;integration-tests-no-emulator")
+    google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -26,7 +26,7 @@ void ListBucketAcl(google::cloud::storage::Client client,
   //! [list bucket acl] [START storage_print_bucket_acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<std::vector<gcs::BucketAccessControl>> items =
         client.ListBucketAcl(bucket_name);
 
@@ -45,8 +45,8 @@ void CreateBucketAcl(google::cloud::storage::Client client,
   //! [create bucket acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::BucketAccessControl> bucket_acl =
         client.CreateBucketAcl(bucket_name, entity, role);
 
@@ -64,7 +64,8 @@ void DeleteBucketAcl(google::cloud::storage::Client client,
                      std::vector<std::string> const& argv) {
   //! [delete bucket acl]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity) {
     google::cloud::Status status = client.DeleteBucketAcl(bucket_name, entity);
 
     if (!status.ok()) throw std::runtime_error(status.message());
@@ -80,7 +81,8 @@ void GetBucketAcl(google::cloud::storage::Client client,
   //! [get bucket acl] [START storage_print_bucket_acl_for_user]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity) {
     StatusOr<gcs::BucketAccessControl> acl =
         client.GetBucketAcl(bucket_name, entity);
 
@@ -97,8 +99,8 @@ void UpdateBucketAcl(google::cloud::storage::Client client,
   //! [update bucket acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     gcs::BucketAccessControl desired_acl =
         gcs::BucketAccessControl().set_entity(entity).set_role(role);
 
@@ -119,8 +121,8 @@ void PatchBucketAcl(google::cloud::storage::Client client,
   //! [patch bucket acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::BucketAccessControl> original_acl =
         client.GetBucketAcl(bucket_name, entity);
 
@@ -147,8 +149,8 @@ void PatchBucketAclNoRead(google::cloud::storage::Client client,
   //! [patch bucket acl no-read]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::BucketAccessControl> patched_acl = client.PatchBucketAcl(
         bucket_name, entity,
         gcs::BucketAccessControlPatchBuilder().set_role(role));
@@ -166,7 +168,8 @@ void AddBucketOwner(google::cloud::storage::Client client,
   //! [add bucket owner] [START storage_add_bucket_owner]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity) {
     StatusOr<gcs::BucketAccessControl> patched_acl =
         client.PatchBucketAcl(bucket_name, entity,
                               gcs::BucketAccessControlPatchBuilder().set_role(
@@ -185,7 +188,8 @@ void RemoveBucketOwner(google::cloud::storage::Client client,
   //! [remove bucket owner] [START storage_remove_bucket_owner]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity) {
     StatusOr<gcs::BucketMetadata> original_metadata =
         client.GetBucketMetadata(bucket_name, gcs::Projection::Full());
 
@@ -290,7 +294,7 @@ int main(int argc, char* argv[]) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("list-bucket-acl", {}, ListBucketAcl),
       make_entry("create-bucket-acl", {"<entity>", "<role>"}, CreateBucketAcl),
       make_entry("delete-bucket-acl", {"<entity>"}, DeleteBucketAcl),

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -26,7 +26,8 @@ void SetCorsConfiguration(google::cloud::storage::Client client,
   //! [cors configuration] [START storage_cors_configuration]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string origin) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& origin) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -65,7 +66,7 @@ void RemoveCorsConfiguration(google::cloud::storage::Client client,
   // [START storage_remove_cors_configuration]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
     if (!original) throw std::runtime_error(original.status().message());
@@ -117,7 +118,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry("set-cors-configuration",
                                    {"<bucket-name>", "<config>"},
                                    SetCorsConfiguration),

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -25,7 +25,8 @@ void AddBucketDefaultKmsKey(google::cloud::storage::Client client,
   //! [add bucket kms key] [START storage_set_bucket_default_kms_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string key_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& key_name) {
     StatusOr<gcs::BucketMetadata> updated = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().SetEncryption(
                          gcs::BucketEncryption{key_name}));
@@ -53,7 +54,7 @@ void GetBucketDefaultKmsKey(google::cloud::storage::Client client,
   //! [get bucket default kms key] [START storage_bucket_get_default_kms_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> metadata =
         client.GetBucketMetadata(bucket_name);
     if (!metadata) throw std::runtime_error(metadata.status().message());
@@ -77,7 +78,7 @@ void RemoveBucketDefaultKmsKey(google::cloud::storage::Client client,
   // [START storage_bucket_delete_default_kms_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> updated = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetEncryption());
     if (!updated) throw std::runtime_error(updated.status().message());
@@ -143,7 +144,7 @@ int main(int argc, char* argv[]) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("add-bucket-default-kms-key", {"<kms-key-name>"},
                  AddBucketDefaultKmsKey),
       make_entry("get-bucket-default-kms-key", {}, GetBucketDefaultKmsKey),

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -26,7 +26,7 @@ void GetBucketIamPolicy(google::cloud::storage::Client client,
   //! [get bucket iam policy]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
 
@@ -43,7 +43,7 @@ void NativeGetBucketIamPolicy(google::cloud::storage::Client client,
   //! [native get bucket iam policy] [START storage_view_bucket_iam_members]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     auto policy = client.GetNativeBucketIamPolicy(
         bucket_name, gcs::RequestedPolicyVersion(3));
 
@@ -60,8 +60,8 @@ void AddBucketIamMember(google::cloud::storage::Client client,
   //! [add bucket iam member]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string role,
-     std::string member) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& role, std::string const& member) {
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
 
@@ -85,8 +85,8 @@ void NativeAddBucketIamMember(google::cloud::storage::Client client,
   //! [native add bucket iam member] [START storage_add_bucket_iam_member]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string role,
-     std::string member) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& role, std::string const& member) {
     auto policy = client.GetNativeBucketIamPolicy(
         bucket_name, gcs::RequestedPolicyVersion(3));
 
@@ -120,9 +120,11 @@ void NativeAddBucketConditionalIamBinding(
   //! [native add bucket conditional iam binding]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string role,
-     std::string member, std::string condition_title,
-     std::string condition_description, std::string condition_expression) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& role, std::string const& member,
+     std::string const& condition_title,
+     std::string const& condition_description,
+     std::string const& condition_expression) {
     auto policy = client.GetNativeBucketIamPolicy(
         bucket_name, gcs::RequestedPolicyVersion(3));
     if (!policy) throw std::runtime_error(policy.status().message());
@@ -157,8 +159,8 @@ void RemoveBucketIamMember(google::cloud::storage::Client client,
   //! [remove bucket iam member]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string role,
-     std::string member) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& role, std::string const& member) {
     StatusOr<google::cloud::IamPolicy> policy =
         client.GetBucketIamPolicy(bucket_name);
     if (!policy) throw std::runtime_error(policy.status().message());
@@ -180,8 +182,8 @@ void NativeRemoveBucketIamMember(google::cloud::storage::Client client,
   //! [native remove bucket iam member] [START storage_remove_bucket_iam_member]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string role,
-     std::string member) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& role, std::string const& member) {
     auto policy = client.GetNativeBucketIamPolicy(
         bucket_name, gcs::RequestedPolicyVersion(3));
     if (!policy) throw std::runtime_error(policy.status().message());
@@ -217,9 +219,10 @@ void NativeRemoveBucketConditionalIamBinding(
   //! [native remove bucket conditional iam binding]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string role,
-     std::string condition_title, std::string condition_description,
-     std::string condition_expression) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& role, std::string const& condition_title,
+     std::string const& condition_description,
+     std::string const& condition_expression) {
     auto policy = client.GetNativeBucketIamPolicy(
         bucket_name, gcs::RequestedPolicyVersion(3));
     if (!policy) throw std::runtime_error(policy.status().message());
@@ -260,8 +263,8 @@ void TestBucketIamPermissions(google::cloud::storage::Client client,
   //! [test bucket iam permissions]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name,
-     std::vector<std::string> permissions) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::vector<std::string> const& permissions) {
     StatusOr<std::vector<std::string>> actual_permissions =
         client.TestBucketIamPermissions(bucket_name, permissions);
 
@@ -290,7 +293,7 @@ void SetBucketPublicIam(google::cloud::storage::Client client,
   // [START storage_set_bucket_public_iam]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<google::cloud::IamPolicy> current_policy =
         client.GetBucketIamPolicy(bucket_name);
 
@@ -340,7 +343,7 @@ void NativeSetBucketPublicIam(google::cloud::storage::Client client,
   // [START native storage_set_bucket_public_iam]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     auto current_policy = client.GetNativeBucketIamPolicy(
         bucket_name, gcs::RequestedPolicyVersion(3));
 
@@ -466,7 +469,7 @@ int main(int argc, char* argv[]) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("get-bucket-iam-policy", {}, GetBucketIamPolicy),
       make_entry("native-get-bucket-iam-policy", {}, NativeGetBucketIamPolicy),
       make_entry("add-bucket-iam-member", {"<role>", "<member>"},

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -26,7 +26,8 @@ void GetBilling(google::cloud::storage::Client client,
   //! [get billing] [START storage_get_requester_pays_status]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string user_project) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& user_project) {
     StatusOr<gcs::BucketMetadata> metadata =
         client.GetBucketMetadata(bucket_name, gcs::UserProject(user_project));
     if (!metadata) throw std::runtime_error(metadata.status().message());
@@ -58,7 +59,7 @@ void EnableRequesterPays(google::cloud::storage::Client client,
   //! [enable requester pays] [START storage_enable_requester_pays]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> metadata = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetBilling(gcs::BucketBilling{true}));
@@ -84,7 +85,8 @@ void DisableRequesterPays(google::cloud::storage::Client client,
   //! [disable requester pays] [START storage_disable_requester_pays]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string billed_project) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& billed_project) {
     StatusOr<gcs::BucketMetadata> metadata = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetBilling(gcs::BucketBilling{false}),
@@ -111,8 +113,8 @@ void WriteObjectRequesterPays(google::cloud::storage::Client client,
   //! [write object requester pays]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string billed_project) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& billed_project) {
     gcs::ObjectWriteStream stream = client.WriteObject(
         bucket_name, object_name, gcs::UserProject(billed_project));
     for (int lineno = 0; lineno != 10; ++lineno) {
@@ -137,8 +139,8 @@ void ReadObjectRequesterPays(google::cloud::storage::Client client,
   //! [read object requester pays]
   // [START storage_download_file_requester_pays]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string billed_project) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& billed_project) {
     gcs::ObjectReadStream stream = client.ReadObject(
         bucket_name, object_name, gcs::UserProject(billed_project));
 
@@ -156,8 +158,8 @@ void DeleteObjectRequesterPays(google::cloud::storage::Client client,
                                std::vector<std::string> const& argv) {
   //! [delete object requester pays]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string billed_project) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& billed_project) {
     google::cloud::Status status = client.DeleteObject(
         bucket_name, object_name, gcs::UserProject(billed_project));
     if (!status.ok()) throw std::runtime_error(status.message());
@@ -221,7 +223,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry(
           "get-billing", {"<bucket-name>", "<user-project>"}, GetBilling),
       examples::CreateCommandEntry("enable-requester-pays", {"<bucket-name>"},

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -51,7 +51,7 @@ void ListBucketsForProject(google::cloud::storage::Client client,
                            std::vector<std::string> const& argv) {
   //! [list buckets for project]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string project_id) {
+  [](gcs::Client client, std::string const& project_id) {
     int count = 0;
     for (auto&& bucket_metadata : client.ListBucketsForProject(project_id)) {
       if (!bucket_metadata) {
@@ -75,7 +75,7 @@ void CreateBucket(google::cloud::storage::Client client,
   //! [create bucket] [START storage_create_bucket]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.CreateBucket(bucket_name, gcs::BucketMetadata());
 
@@ -95,7 +95,8 @@ void CreateBucketForProject(google::cloud::storage::Client client,
   //! [create bucket for project]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string project_id) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& project_id) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.CreateBucketForProject(bucket_name, project_id,
                                       gcs::BucketMetadata());
@@ -119,8 +120,8 @@ void CreateBucketWithStorageClassLocation(
   // [START storage_create_bucket_class_location]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string storage_class,
-     std::string location) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& storage_class, std::string const& location) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.CreateBucket(bucket_name, gcs::BucketMetadata()
                                              .set_storage_class(storage_class)
@@ -144,7 +145,7 @@ void GetBucketMetadata(google::cloud::storage::Client client,
   // [START storage_get_bucket_metadata]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -164,7 +165,7 @@ void DeleteBucket(google::cloud::storage::Client client,
                   std::vector<std::string> const& argv) {
   //! [delete bucket] [START storage_delete_bucket]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     google::cloud::Status status = client.DeleteBucket(bucket_name);
 
     if (!status.ok()) throw std::runtime_error(status.message());
@@ -179,7 +180,8 @@ void ChangeDefaultStorageClass(google::cloud::storage::Client client,
   //! [update bucket]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string storage_class) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& storage_class) {
     StatusOr<gcs::BucketMetadata> meta = client.GetBucketMetadata(bucket_name);
 
     if (!meta) throw std::runtime_error(meta.status().message());
@@ -204,7 +206,8 @@ void PatchBucketStorageClass(google::cloud::storage::Client client,
   //! [patch bucket storage class] [START storage_change_default_storage_class]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string storage_class) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& storage_class) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -229,7 +232,8 @@ void PatchBucketStorageClassWithBuilder(google::cloud::storage::Client client,
   //! [patch bucket storage class with builder]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string storage_class) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& storage_class) {
     StatusOr<gcs::BucketMetadata> patched = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetStorageClass(storage_class));
@@ -248,7 +252,7 @@ void GetBucketClassAndLocation(google::cloud::storage::Client client,
   // [START storage_get_bucket_class_and_location]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -271,7 +275,7 @@ void EnableBucketPolicyOnly(google::cloud::storage::Client client,
   // [START storage_enable_bucket_policy_only]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     gcs::BucketIamConfiguration configuration;
     configuration.bucket_policy_only = gcs::BucketPolicyOnly{true, {}};
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
@@ -296,7 +300,7 @@ void DisableBucketPolicyOnly(google::cloud::storage::Client client,
   // [START storage_disable_bucket_policy_only]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     gcs::BucketIamConfiguration configuration;
     configuration.bucket_policy_only = gcs::BucketPolicyOnly{false, {}};
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
@@ -321,7 +325,7 @@ void GetBucketPolicyOnly(google::cloud::storage::Client client,
   // [START storage_get_bucket_policy_only]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -353,7 +357,7 @@ void EnableUniformBucketLevelAccess(google::cloud::storage::Client client,
   // [START storage_enable_uniform_bucket_level_access]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     gcs::BucketIamConfiguration configuration;
     configuration.uniform_bucket_level_access =
         gcs::UniformBucketLevelAccess{true, {}};
@@ -379,7 +383,7 @@ void DisableUniformBucketLevelAccess(google::cloud::storage::Client client,
   // [START storage_disable_uniform_bucket_level_access]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     gcs::BucketIamConfiguration configuration;
     configuration.uniform_bucket_level_access =
         gcs::UniformBucketLevelAccess{false, {}};
@@ -405,7 +409,7 @@ void GetUniformBucketLevelAccess(google::cloud::storage::Client client,
   // [START storage_get_uniform_bucket_level_access]
   namespace gcs = google::cloud::storage;
   using google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -438,8 +442,8 @@ void AddBucketLabel(google::cloud::storage::Client client,
   //! [add bucket label] [START storage_add_bucket_label]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string label_key,
-     std::string label_value) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& label_key, std::string const& label_value) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name,
         gcs::BucketMetadataPatchBuilder().SetLabel(label_key, label_value));
@@ -465,7 +469,7 @@ void GetBucketLabels(google::cloud::storage::Client client,
   //! [get bucket labels] [START storage_get_bucket_labels]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name, gcs::Fields("labels"));
 
@@ -493,7 +497,8 @@ void RemoveBucketLabel(google::cloud::storage::Client client,
   //! [remove bucket label] [START storage_remove_bucket_label]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string label_key) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& label_key) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetLabel(label_key));
 
@@ -620,7 +625,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry("list-buckets", {}, ListBuckets),
       examples::CreateCommandEntry("list-buckets-for-project", {"<project-id>"},
                                    ListBucketsForProject),

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -27,7 +27,7 @@ void ListDefaultObjectAcl(google::cloud::storage::Client client,
   //! [list default object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<std::vector<gcs::ObjectAccessControl>> items =
         client.ListDefaultObjectAcl(bucket_name);
 
@@ -46,8 +46,8 @@ void CreateDefaultObjectAcl(google::cloud::storage::Client client,
   //! [create default object acl] [START storage_add_bucket_default_owner]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> default_object_acl =
         client.CreateDefaultObjectAcl(bucket_name, entity, role);
 
@@ -70,7 +70,8 @@ void GetDefaultObjectAcl(google::cloud::storage::Client client,
   //! [get default object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity) {
     StatusOr<gcs::ObjectAccessControl> acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
 
@@ -87,8 +88,8 @@ void UpdateDefaultObjectAcl(google::cloud::storage::Client client,
   //! [update default object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
 
@@ -118,8 +119,8 @@ void PatchDefaultObjectAcl(google::cloud::storage::Client client,
   //! [patch default object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetDefaultObjectAcl(bucket_name, entity);
 
@@ -148,8 +149,8 @@ void PatchDefaultObjectAclNoRead(google::cloud::storage::Client client,
   //! [patch default object acl no-read]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string entity,
-     std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity, std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> patched_acl =
         client.PatchDefaultObjectAcl(
             bucket_name, entity,
@@ -168,7 +169,8 @@ void DeleteDefaultObjectAcl(google::cloud::storage::Client client,
                             std::vector<std::string> const& argv) {
   //! [delete default object acl] [START storage_remove_bucket_default_owner]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& entity) {
     google::cloud::Status status =
         client.DeleteDefaultObjectAcl(bucket_name, entity);
 
@@ -245,7 +247,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("list-default-object-acl", {}, ListDefaultObjectAcl),
       make_entry("create-default-object-acl", {"<entity>", "<role>"},
                  CreateDefaultObjectAcl),

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -28,7 +28,7 @@ void GetDefaultEventBasedHold(google::cloud::storage::Client client,
   // [START storage_get_default_event_based_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -53,7 +53,7 @@ void EnableDefaultEventBasedHold(google::cloud::storage::Client client,
   // [START storage_enable_default_event_based_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -84,7 +84,7 @@ void DisableDefaultEventBasedHold(google::cloud::storage::Client client,
   // [START storage_disable_default_event_based_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("get-default-event-based-hold", {}, GetDefaultEventBasedHold),
       make_entry("enable-default-event-based-hold", {},
                  EnableDefaultEventBasedHold),

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -134,7 +134,7 @@ Commands::value_type CreateCommandEntry(
     ClientCommand const& command) {
   bool allow_varargs =
       !arg_names.empty() && arg_names.back().find("...") != std::string::npos;
-  auto adapter = [=](std::vector<std::string> argv) {
+  auto adapter = [=](std::vector<std::string> const& argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         (allow_varargs ? argv.size() < (arg_names.size() - 1)
                        : argv.size() != arg_names.size())) {

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -63,7 +63,7 @@ std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix);
 
 using ClientCommand = std::function<void(google::cloud::storage::Client,
-                                         std::vector<std::string> argv)>;
+                                         std::vector<std::string> const& argv)>;
 
 // If the last value of `arg_names` contains `...` it represents a variable
 // number (0 or more) of arguments.

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -27,7 +27,7 @@ void GetBucketLifecycleManagement(google::cloud::storage::Client client,
   // [START storage_view_lifecycle_management_configuration]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> updated_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -59,7 +59,7 @@ void EnableBucketLifecycleManagement(google::cloud::storage::Client client,
   // [START storage_enable_bucket_lifecycle_management]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     gcs::BucketLifecycle bucket_lifecycle_rules = gcs::BucketLifecycle{
         {gcs::LifecycleRule(gcs::LifecycleRule::ConditionConjunction(
                                 gcs::LifecycleRule::MaxAge(30),
@@ -99,7 +99,7 @@ void DisableBucketLifecycleManagement(google::cloud::storage::Client client,
   // [START storage_disable_bucket_lifecycle_management]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
         bucket_name, gcs::BucketMetadataPatchBuilder().ResetLifecycle());
 
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("get-bucket-lifecycle-management", {},
                  GetBucketLifecycleManagement),
       make_entry("enable-bucket-lifecycle-management", {},

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -24,7 +24,7 @@ void ListNotifications(google::cloud::storage::Client client,
   //! [list notifications] [START storage_list_bucket_notifications]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<std::vector<gcs::NotificationMetadata>> items =
         client.ListNotifications(bucket_name);
     if (!items) throw std::runtime_error(items.status().message());
@@ -43,7 +43,8 @@ void CreateNotification(google::cloud::storage::Client client,
   //! [create notification] [START storage_create_bucket_notifications]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string topic_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& topic_name) {
     StatusOr<gcs::NotificationMetadata> notification =
         client.CreateNotification(bucket_name, topic_name,
                                   gcs::payload_format::JsonApiV1(),
@@ -67,7 +68,8 @@ void GetNotification(google::cloud::storage::Client client,
   //! [get notification] [START storage_print_pubsub_bucket_notification]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string notification_id) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& notification_id) {
     StatusOr<gcs::NotificationMetadata> notification =
         client.GetNotification(bucket_name, notification_id);
     if (!notification) {
@@ -93,7 +95,8 @@ void DeleteNotification(google::cloud::storage::Client client,
                         std::vector<std::string> const& argv) {
   //! [delete notification] [START storage_delete_bucket_notification]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string notification_id) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& notification_id) {
     google::cloud::Status status =
         client.DeleteNotification(bucket_name, notification_id);
     if (!status.ok()) throw std::runtime_error(status.message());
@@ -178,7 +181,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry("list-notifications", {"<bucket-name>"},
                                    ListNotifications),
       examples::CreateCommandEntry("create-notification",

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -27,7 +27,8 @@ void ListObjectAcl(google::cloud::storage::Client client,
   //! [list object acl] [START storage_print_file_acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<std::vector<gcs::ObjectAccessControl>> items =
         client.ListObjectAcl(bucket_name, object_name);
 
@@ -47,8 +48,9 @@ void CreateObjectAcl(google::cloud::storage::Client client,
   //! [create object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity, std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity,
+     std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> object_acl =
         client.CreateObjectAcl(bucket_name, object_name, entity, role);
 
@@ -65,8 +67,8 @@ void DeleteObjectAcl(google::cloud::storage::Client client,
                      std::vector<std::string> const& argv) {
   //! [delete object acl]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity) {
     google::cloud::Status status =
         client.DeleteObjectAcl(bucket_name, object_name, entity);
 
@@ -83,8 +85,8 @@ void GetObjectAcl(google::cloud::storage::Client client,
   //! [print file acl for user] [START storage_print_file_acl_for_user]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity) {
     StatusOr<gcs::ObjectAccessControl> acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
 
@@ -102,8 +104,9 @@ void UpdateObjectAcl(google::cloud::storage::Client client,
   //! [update object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity, std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity,
+     std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> current_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
 
@@ -127,8 +130,9 @@ void PatchObjectAcl(google::cloud::storage::Client client,
   //! [patch object acl]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity, std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity,
+     std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> original_acl =
         client.GetObjectAcl(bucket_name, object_name, entity);
 
@@ -156,8 +160,9 @@ void PatchObjectAclNoRead(google::cloud::storage::Client client,
   //! [patch object acl no-read]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity, std::string role) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity,
+     std::string const& role) {
     StatusOr<gcs::ObjectAccessControl> patched_acl = client.PatchObjectAcl(
         bucket_name, object_name, entity,
         gcs::ObjectAccessControlPatchBuilder().set_role(role));
@@ -176,8 +181,8 @@ void AddObjectOwner(google::cloud::storage::Client client,
   //! [add file owner] [START storage_add_file_owner]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity) {
     StatusOr<gcs::ObjectAccessControl> patched_acl =
         client.CreateObjectAcl(bucket_name, object_name, entity,
                                gcs::ObjectAccessControl::ROLE_OWNER());
@@ -196,8 +201,8 @@ void RemoveObjectOwner(google::cloud::storage::Client client,
   //! [remove file owner] [START storage_remove_file_owner]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string entity) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& entity) {
     StatusOr<gcs::ObjectMetadata> original_metadata = client.GetObjectMetadata(
         bucket_name, object_name, gcs::Projection::Full());
 
@@ -314,7 +319,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("list-object-acl", {"<object-name>"}, ListObjectAcl),
       make_entry("create-object-acl", {"<object-name>", "<entity>", "<role>"},
                  CreateObjectAcl),

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -26,8 +26,8 @@ void WriteObjectWithKmsKey(google::cloud::storage::Client client,
   //! [write object with kms key] [START storage_upload_with_kms_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string kms_key_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& kms_key_name) {
     gcs::ObjectWriteStream stream = client.WriteObject(
         bucket_name, object_name, gcs::KmsKeyName(kms_key_name));
 
@@ -54,8 +54,9 @@ void ObjectCsekToCmek(google::cloud::storage::Client client,
   //! [object csek to cmek] [START storage_object_csek_to_cmek]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string old_csek_key_base64, std::string new_cmek_key_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& old_csek_key_base64,
+     std::string const& new_cmek_key_name) {
     StatusOr<gcs::ObjectMetadata> metadata = client.RewriteObjectBlocking(
         bucket_name, object_name, bucket_name, object_name,
         gcs::SourceEncryptionKey::FromBase64Key(old_csek_key_base64),
@@ -76,7 +77,8 @@ void GetObjectKmsKey(google::cloud::storage::Client client,
   //! [get object kms key] [START storage_object_get_kms_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> metadata =
         client.GetObjectMetadata(bucket_name, object_name);
     if (!metadata) throw std::runtime_error(metadata.status().message());
@@ -166,7 +168,7 @@ int main(int argc, char* argv[]) {
     arg_names.insert(arg_names.begin(), {"<bucket-name>", "<object-name>"});
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("write-object-with-kms-key", {"<kms-key-name>"},
                  WriteObjectWithKmsKey),
       make_entry(

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -49,7 +49,7 @@ std::string GenerateEncryptionKey() {
       (GeneratorType::word_size / std::numeric_limits<unsigned int>::digits);
 
   // Capture the entropy bits into a vector.
-  std::vector<unsigned long> entropy(kRequiredEntropyWords);
+  std::vector<std::uint64_t> entropy(kRequiredEntropyWords);
   std::generate(entropy.begin(), entropy.end(), [&rd] { return rd(); });
 
   // Create the PRNG with the fetched entropy.
@@ -81,8 +81,8 @@ void WriteEncryptedObject(google::cloud::storage::Client client,
   //! [insert encrypted object] [START storage_upload_encrypted_file]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string base64_aes256_key) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& base64_aes256_key) {
     StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
         bucket_name, object_name, "top secret",
         gcs::EncryptionKey::FromBase64Key(base64_aes256_key));
@@ -103,8 +103,8 @@ void ReadEncryptedObject(google::cloud::storage::Client client,
                          std::vector<std::string> const& argv) {
   //! [read encrypted object] [START storage_download_encrypted_file]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string base64_aes256_key) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& base64_aes256_key) {
     gcs::ObjectReadStream stream =
         client.ReadObject(bucket_name, object_name,
                           gcs::EncryptionKey::FromBase64Key(base64_aes256_key));
@@ -130,9 +130,10 @@ void ComposeObjectFromEncryptedObjects(google::cloud::storage::Client client,
   //! [compose object csek]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name,
-     std::string destination_object_name, std::string base64_aes256_key,
-     std::vector<gcs::ComposeSourceObject> compose_objects) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& destination_object_name,
+     std::string const& base64_aes256_key,
+     std::vector<gcs::ComposeSourceObject> const& compose_objects) {
     StatusOr<gcs::ObjectMetadata> composed_object = client.ComposeObject(
         bucket_name, compose_objects, destination_object_name,
         gcs::EncryptionKey::FromBase64Key(base64_aes256_key));
@@ -155,9 +156,11 @@ void CopyEncryptedObject(google::cloud::storage::Client client,
   //! [copy encrypted object]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name, std::string key_base64) {
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name,
+     std::string const& key_base64) {
     StatusOr<gcs::ObjectMetadata> new_copy_meta = client.CopyObject(
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name, gcs::EncryptionKey::FromBase64Key(key_base64));
@@ -182,8 +185,9 @@ void RotateEncryptionKey(google::cloud::storage::Client client,
   //! [rotate encryption key] [START storage_rotate_encryption_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string old_key_base64, std::string new_key_base64) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& old_key_base64,
+     std::string const& new_key_base64) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.RewriteObjectBlocking(
             bucket_name, object_name, bucket_name, object_name,
@@ -277,7 +281,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       {"generate-encryption-key", GenerateEncryptionKeyCommand},
       make_entry("write-encrypted-object", {"<base64-encoded-aes256-key>"},
                  WriteEncryptedObject),

--- a/google/cloud/storage/examples/storage_object_file_transfer_samples.cc
+++ b/google/cloud/storage/examples/storage_object_file_transfer_samples.cc
@@ -27,8 +27,8 @@ void UploadFile(google::cloud::storage::Client client,
   //! [upload file] [START storage_upload_file]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string file_name, std::string bucket_name,
-     std::string object_name) {
+  [](gcs::Client client, std::string const& file_name,
+     std::string const& bucket_name, std::string const& object_name) {
     // Note that the client library automatically computes a hash on the
     // client-side to verify data integrity during transmission.
     StatusOr<gcs::ObjectMetadata> metadata = client.UploadFile(
@@ -48,8 +48,8 @@ void UploadFileResumable(google::cloud::storage::Client client,
   //! [upload file resumable]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string file_name, std::string bucket_name,
-     std::string object_name) {
+  [](gcs::Client client, std::string const& file_name,
+     std::string const& bucket_name, std::string const& object_name) {
     // Note that the client library automatically computes a hash on the
     // client-side to verify data integrity during transmission.
     StatusOr<gcs::ObjectMetadata> metadata = client.UploadFile(
@@ -70,14 +70,14 @@ void ParallelUploadFile(google::cloud::storage::Client client,
   //! [parallel upload file]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string file_name, std::string bucket_name,
-     std::string object_name) {
+  [](gcs::Client client, std::string const& file_name,
+     std::string const& bucket_name, std::string const& object_name) {
     // Pick a unique random prefix for the temporary objects created by the
     // parallel upload.
     auto prefix = gcs::CreateRandomPrefixName("");
 
-    auto metadata = gcs::ParallelUploadFile(client, file_name, bucket_name,
-                                            object_name, prefix, false);
+    auto metadata = gcs::ParallelUploadFile(
+        std::move(client), file_name, bucket_name, object_name, prefix, false);
     if (!metadata) throw std::runtime_error(metadata.status().message());
 
     std::cout << "Uploaded " << file_name << " to object " << metadata->name()
@@ -92,8 +92,8 @@ void DownloadFile(google::cloud::storage::Client client,
                   std::vector<std::string> const& argv) {
   //! [download file]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string file_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& file_name) {
     google::cloud::Status status =
         client.DownloadToFile(bucket_name, object_name, file_name);
     if (!status.ok()) throw std::runtime_error(status.message());
@@ -181,7 +181,7 @@ culpa qui officia deserunt mollit anim id est laborum.
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry(
           "upload-file", {"<filename>", "<bucket-name>", "<object-name>"},
           UploadFile),

--- a/google/cloud/storage/examples/storage_object_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_object_hold_samples.cc
@@ -24,7 +24,8 @@ void SetObjectEventBasedHold(google::cloud::storage::Client client,
   //! [set event based hold] [START storage_set_event_based_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
     if (!original) throw std::runtime_error(original.status().message());
@@ -48,7 +49,8 @@ void ReleaseObjectEventBasedHold(google::cloud::storage::Client client,
   //! [release event based hold] [START storage_release_event_based_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
     if (!original) throw std::runtime_error(original.status().message());
@@ -72,7 +74,8 @@ void SetObjectTemporaryHold(google::cloud::storage::Client client,
   //! [set temporary hold] [START storage_set_temporary_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
     if (!original) throw std::runtime_error(original.status().message());
@@ -96,7 +99,8 @@ void ReleaseObjectTemporaryHold(google::cloud::storage::Client client,
   //! [release temporary hold] [START storage_release_temporary_hold]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
 
@@ -178,7 +182,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(
         name, {"<bucket-name>", "<object-name>"}, cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("set-event-based-hold", SetObjectEventBasedHold),
       make_entry("release-event-based-hold", ReleaseObjectEventBasedHold),
       make_entry("set-temporary-hold", SetObjectTemporaryHold),

--- a/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
+++ b/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
@@ -30,7 +30,8 @@ void StartResumableUpload(google::cloud::storage::Client client,
                           std::vector<std::string> const& argv) {
   //! [start resumable upload]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     gcs::ObjectWriteStream stream = client.WriteObject(
         bucket_name, object_name, gcs::NewResumableUploadSession());
     std::cout << "Created resumable upload: " << stream.resumable_session_id()
@@ -51,8 +52,8 @@ void ResumeResumableUpload(google::cloud::storage::Client client,
   //! [resume resumable upload]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string session_id) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& session_id) {
     // Restore a resumable upload stream, the library automatically queries the
     // state of the upload and discovers the next expected byte.
     gcs::ObjectWriteStream stream =
@@ -137,7 +138,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("start-resumable-upload", {}, StartResumableUpload),
       make_entry("resume-resumable-upload", {"<session-id>"},
                  ResumeResumableUpload),

--- a/google/cloud/storage/examples/storage_object_rewrite_samples.cc
+++ b/google/cloud/storage/examples/storage_object_rewrite_samples.cc
@@ -26,9 +26,10 @@ void RewriteObject(google::cloud::storage::Client client,
   //! [rewrite object]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name) {
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name) {
     StatusOr<gcs::ObjectMetadata> metadata = client.RewriteObjectBlocking(
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name);
@@ -46,9 +47,10 @@ void RewriteObjectNonBlocking(google::cloud::storage::Client client,
   //! [rewrite object non blocking]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name) {
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name) {
     gcs::ObjectRewriter rewriter =
         client.RewriteObject(source_bucket_name, source_object_name,
                              destination_bucket_name, destination_object_name);
@@ -74,9 +76,10 @@ void RewriteObjectToken(google::cloud::storage::Client client,
   //! [rewrite object token]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name) {
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name) {
     gcs::ObjectRewriter rewriter = client.RewriteObject(
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name, gcs::MaxBytesRewrittenPerCall(1024 * 1024));
@@ -100,9 +103,11 @@ void RewriteObjectResume(google::cloud::storage::Client client,
   //! [rewrite object resume]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name, std::string rewrite_token) {
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name,
+     std::string const& rewrite_token) {
     gcs::ObjectRewriter rewriter = client.ResumeRewriteObject(
         source_bucket_name, source_object_name, destination_bucket_name,
         destination_object_name, rewrite_token,
@@ -130,8 +135,8 @@ void RenameObject(google::cloud::storage::Client client,
   //! [rename object] [START storage_move_file]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string old_object_name,
-     std::string new_object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& old_object_name, std::string const& new_object_name) {
     StatusOr<gcs::ObjectMetadata> metadata = client.RewriteObjectBlocking(
         bucket_name, old_object_name, bucket_name, new_object_name);
     if (!metadata) throw std::runtime_error(metadata.status().message());
@@ -256,7 +261,7 @@ int main(int argc, char* argv[]) {
          "<destination-bucket-name>", "<destination-object-name>"});
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("rewrite-object", {}, RewriteObject),
       make_entry("rewrite-object-non-blocking", {}, RewriteObjectNonBlocking),
       make_entry("rewrite-object-token", {}, RewriteObjectToken),

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -31,7 +31,7 @@ void ListObjects(google::cloud::storage::Client client,
                  std::vector<std::string> const& argv) {
   //! [list objects] [START storage_list_files]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     for (auto&& object_metadata : client.ListObjects(bucket_name)) {
       if (!object_metadata) {
         throw std::runtime_error(object_metadata.status().message());
@@ -49,7 +49,8 @@ void ListObjectsWithPrefix(google::cloud::storage::Client client,
                            std::vector<std::string> const& argv) {
   //! [list objects with prefix] [START storage_list_files_with_prefix]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string bucket_prefix) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& bucket_prefix) {
     for (auto&& object_metadata :
          client.ListObjects(bucket_name, gcs::Prefix(bucket_prefix))) {
       if (!object_metadata) {
@@ -68,7 +69,7 @@ void ListVersionedObjects(google::cloud::storage::Client client,
                           std::vector<std::string> const& argv) {
   //! [list versioned objects] [START storage_list_file_archived_generations]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     for (auto&& object_metadata :
          client.ListObjects(bucket_name, gcs::Versions{true})) {
       if (!object_metadata) {
@@ -89,8 +90,8 @@ void InsertObject(google::cloud::storage::Client client,
   //! [insert object]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string contents) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& contents) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.InsertObject(bucket_name, object_name, std::move(contents));
 
@@ -106,12 +107,14 @@ void InsertObject(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void InsertObjectStrictIdempotency(google::cloud::storage::Client,
                                    std::vector<std::string> const& argv) {
   //! [insert object strict idempotency]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](std::string bucket_name, std::string object_name, std::string contents) {
+  [](std::string const& bucket_name, std::string const& object_name,
+     std::string const& contents) {
     // Create a client that only retries idempotent operations, the default is
     // to retry all operations.
     StatusOr<gcs::ClientOptions> options =
@@ -135,12 +138,14 @@ void InsertObjectStrictIdempotency(google::cloud::storage::Client,
   (argv.at(0), argv.at(1), argv.at(2));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void InsertObjectModifiedRetry(google::cloud::storage::Client,
                                std::vector<std::string> const& argv) {
   //! [insert object modified retry]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](std::string bucket_name, std::string object_name, std::string contents) {
+  [](std::string const& bucket_name, std::string const& object_name,
+     std::string const& contents) {
     // Create a client that only gives up on the third error. The default policy
     // is to retry for several minutes.
     StatusOr<gcs::ClientOptions> options =
@@ -170,8 +175,9 @@ void InsertObjectMultipart(google::cloud::storage::Client client,
   //! [insert object multipart]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string content_type, std::string contents) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& content_type,
+     std::string const& contents) {
     // Setting the object metadata (via the `gcs::WithObjectMadata` option)
     // requires a multipart upload, the library prefers simple uploads unless
     // required as in this case.
@@ -199,9 +205,10 @@ void CopyObject(google::cloud::storage::Client client,
   //! [copy object] [START storage_copy_file]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name) {
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name) {
     StatusOr<gcs::ObjectMetadata> new_copy_meta =
         client.CopyObject(source_bucket_name, source_object_name,
                           destination_bucket_name, destination_object_name);
@@ -225,7 +232,8 @@ void GetObjectMetadata(google::cloud::storage::Client client,
   //! [get object metadata] [START storage_get_metadata]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.GetObjectMetadata(bucket_name, object_name);
 
@@ -245,7 +253,8 @@ void ReadObject(google::cloud::storage::Client client,
                 std::vector<std::string> const& argv) {
   //! [read object] [START storage_download_file]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     gcs::ObjectReadStream stream = client.ReadObject(bucket_name, object_name);
 
     int count = 0;
@@ -264,8 +273,8 @@ void ReadObjectRange(google::cloud::storage::Client client,
                      std::vector<std::string> const& argv) {
   //! [read object range] [START storage_download_byte_range]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::int64_t start, std::int64_t end) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::int64_t start, std::int64_t end) {
     gcs::ObjectReadStream stream =
         client.ReadObject(bucket_name, object_name, gcs::ReadRange(start, end));
 
@@ -287,7 +296,8 @@ void DeleteObject(google::cloud::storage::Client client,
                   std::vector<std::string> const& argv) {
   //! [delete object] [START storage_delete_file]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     google::cloud::Status status =
         client.DeleteObject(bucket_name, object_name);
 
@@ -304,8 +314,8 @@ void WriteObject(google::cloud::storage::Client client,
   //! [write object] [START storage_stream_file_upload]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     long desired_line_count) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, int desired_line_count) {
     std::string const text = "Lorem ipsum dolor sit amet";
     gcs::ObjectWriteStream stream =
         client.WriteObject(bucket_name, object_name);
@@ -325,7 +335,7 @@ void WriteObject(google::cloud::storage::Client client,
               << "\nFull metadata: " << *metadata << "\n";
   }
   //! [write object] [END storage_stream_file_upload]
-  (std::move(client), argv.at(0), argv.at(1), std::stol(argv.at(2)));
+  (std::move(client), argv.at(0), argv.at(1), std::stoi(argv.at(2)));
 }
 
 void UpdateObjectMetadata(google::cloud::storage::Client client,
@@ -333,8 +343,9 @@ void UpdateObjectMetadata(google::cloud::storage::Client client,
   //! [update object metadata] [START storage_set_metadata]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string key, std::string value) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& key,
+     std::string const& value) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.GetObjectMetadata(bucket_name, object_name);
 
@@ -362,8 +373,8 @@ void PatchObjectDeleteMetadata(google::cloud::storage::Client client,
   //! [patch object delete metadata]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string key) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& key) {
     StatusOr<gcs::ObjectMetadata> original =
         client.GetObjectMetadata(bucket_name, object_name);
 
@@ -387,8 +398,8 @@ void PatchObjectContentType(google::cloud::storage::Client client,
   //! [patch object content type]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string content_type) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& content_type) {
     StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name,
         gcs::ObjectMetadataPatchBuilder().SetContentType(content_type));
@@ -401,6 +412,7 @@ void PatchObjectContentType(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ComposeObject(google::cloud::storage::Client client,
                    std::vector<std::string> const& argv) {
   auto it = argv.cbegin();
@@ -414,9 +426,9 @@ void ComposeObject(google::cloud::storage::Client client,
   //! [compose object] [START storage_compose_file]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name,
-     std::string destination_object_name,
-     std::vector<gcs::ComposeSourceObject> compose_objects) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& destination_object_name,
+     std::vector<gcs::ComposeSourceObject> const& compose_objects) {
     StatusOr<gcs::ObjectMetadata> composed_object = client.ComposeObject(
         bucket_name, compose_objects, destination_object_name);
 
@@ -446,9 +458,9 @@ void ComposeObjectFromMany(google::cloud::storage::Client client,
   //! [compose object from many] [START storage_compose_file_from_many]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name,
-     std::string destination_object_name,
-     std::vector<gcs::ComposeSourceObject> compose_objects) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& destination_object_name,
+     std::vector<gcs::ComposeSourceObject> const& compose_objects) {
     std::string prefix = gcs::CreateRandomPrefixName(".tmpfiles");
     StatusOr<gcs::ObjectMetadata> composed_object =
         ComposeMany(client, bucket_name, compose_objects, prefix,
@@ -476,8 +488,8 @@ void ChangeObjectStorageClass(google::cloud::storage::Client client,
   // [START storage_change_file_storage_class]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::string storage_class) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::string const& storage_class) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
         client.RewriteObjectBlocking(
             bucket_name, object_name, bucket_name, object_name,
@@ -626,7 +638,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("list-objects", {}, ListObjects),
       make_entry("list-objects-with-prefix", {"<prefix>"},
                  ListObjectsWithPrefix),

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -412,7 +412,6 @@ void PatchObjectContentType(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ComposeObject(google::cloud::storage::Client client,
                    std::vector<std::string> const& argv) {
   auto it = argv.cbegin();

--- a/google/cloud/storage/examples/storage_object_versioning_samples.cc
+++ b/google/cloud/storage/examples/storage_object_versioning_samples.cc
@@ -26,7 +26,7 @@ void GetObjectVersioning(google::cloud::storage::Client client,
   //! [START storage_view_versioning_status]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> metadata =
         client.GetBucketMetadata(bucket_name);
     if (!metadata) throw std::runtime_error(metadata.status().message());
@@ -49,7 +49,7 @@ void EnableObjectVersioning(google::cloud::storage::Client client,
   //! [enable versioning] [START storage_enable_versioning]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
     if (!original) throw std::runtime_error(original.status().message());
@@ -79,7 +79,7 @@ void DisableObjectVersioning(google::cloud::storage::Client client,
   //! [START storage_disable_versioning]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
     if (!original) throw std::runtime_error(original.status().message());
@@ -109,9 +109,10 @@ void CopyVersionedObject(google::cloud::storage::Client client,
   // [START storage_copy_file_archived_generation]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string source_bucket_name,
-     std::string source_object_name, std::string destination_bucket_name,
-     std::string destination_object_name,
+  [](gcs::Client client, std::string const& source_bucket_name,
+     std::string const& source_object_name,
+     std::string const& destination_bucket_name,
+     std::string const& destination_object_name,
      std::int64_t source_object_generation) {
     StatusOr<gcs::ObjectMetadata> copy =
         client.CopyObject(source_bucket_name, source_object_name,
@@ -135,8 +136,8 @@ void DeleteVersionedObject(google::cloud::storage::Client client,
   //! [delete versioned object]
   // [START storage_delete_file_archived_generation]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string bucket_name, std::string object_name,
-     std::int64_t object_generation) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name, std::int64_t object_generation) {
     google::cloud::Status status = client.DeleteObject(
         bucket_name, object_name, gcs::Generation{object_generation});
     if (!status.ok()) throw std::runtime_error(status.message());
@@ -222,7 +223,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry("get-object-versioning", {"<bucket-name>"},
                                    GetObjectVersioning),
       examples::CreateCommandEntry("enable-object-versioning",

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -25,7 +25,7 @@ void CreateSignedPolicyDocumentV2(google::cloud::storage::Client client,
   //! [create signed policy document]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::PolicyDocumentResult> document =
         client.CreateSignedPolicyDocument(gcs::PolicyDocument{
             std::chrono::system_clock::now() + std::chrono::minutes(15),
@@ -53,7 +53,7 @@ void CreateSignedPolicyDocumentV4(google::cloud::storage::Client client,
   //! [create signed policy document v4]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::PolicyDocumentV4Result> document =
         client.GenerateSignedPostPolicyV4(gcs::PolicyDocumentV4{
             std::move(bucket_name),
@@ -82,7 +82,8 @@ void CreatePolicyDocumentFormV4(google::cloud::storage::Client client,
   // [START storage_generate_signed_post_policy_v4]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     auto document = client.GenerateSignedPostPolicyV4(
         gcs::PolicyDocumentV4{
             bucket_name,

--- a/google/cloud/storage/examples/storage_public_object_samples.cc
+++ b/google/cloud/storage/examples/storage_public_object_samples.cc
@@ -28,7 +28,8 @@ void MakeObjectPublic(google::cloud::storage::Client client,
   //! [make object public] [START storage_make_public]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<gcs::ObjectMetadata> updated = client.PatchObject(
         bucket_name, object_name, gcs::ObjectMetadataPatchBuilder(),
         gcs::PredefinedAcl::PublicRead());
@@ -47,7 +48,7 @@ void ReadObjectUnauthenticated(std::vector<std::string> const& argv) {
   }
   //! [download_public_file] [START storage_download_public_file]
   namespace gcs = google::cloud::storage;
-  [](std::string bucket_name, std::string object_name) {
+  [](std::string const& bucket_name, std::string const& object_name) {
     // Create a client that does not authenticate with the server.
     gcs::Client client{gcs::oauth2::CreateAnonymousCredentials()};
 
@@ -104,7 +105,7 @@ The actual contents are not interesting.
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry("set-cors-configuration",
                                    {"<bucket-name>", "<object-name>"},
                                    MakeObjectPublic),

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -77,7 +77,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       {"storage-quickstart", StorageQuickstartCommand},
       {"auto", RunAll},
   });

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -28,7 +28,7 @@ void GetRetentionPolicy(google::cloud::storage::Client client,
   // [START storage_get_retention_policy]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -57,7 +57,8 @@ void SetRetentionPolicy(google::cloud::storage::Client client,
   // [START storage_set_retention_policy]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::chrono::seconds period) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::chrono::seconds period) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -92,7 +93,7 @@ void RemoveRetentionPolicy(google::cloud::storage::Client client,
   // [START storage_remove_retention_policy]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -128,7 +129,7 @@ void LockRetentionPolicy(google::cloud::storage::Client client,
   // [START storage_lock_retention_policy]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -209,7 +210,7 @@ int main(int argc, char* argv[]) {
     return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
   };
 
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("get-retention-policy", {}, GetRetentionPolicy),
       make_entry("set-retention-policy", {"<period>"}, SetRetentionPolicy),
       make_entry("remove-retention-policy", {}, RemoveRetentionPolicy),

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -39,7 +39,7 @@ void GetServiceAccountForProject(google::cloud::storage::Client client,
   //! [get service account for project]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string project_id) {
+  [](gcs::Client client, std::string const& project_id) {
     StatusOr<gcs::ServiceAccount> account =
         client.GetServiceAccountForProject(project_id);
     if (!account) throw std::runtime_error(account.status().message());
@@ -79,7 +79,7 @@ void ListHmacKeysWithServiceAccount(google::cloud::storage::Client client,
   //! [list hmac keys service account]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string service_account) {
+  [](gcs::Client client, std::string const& service_account) {
     int count = 0;
     gcs::ListHmacKeysReader hmac_keys_list =
         client.ListHmacKeys(gcs::ServiceAccountFilter(service_account));
@@ -104,7 +104,7 @@ void CreateHmacKey(google::cloud::storage::Client client,
   //! [create hmac key] [START storage_create_hmac_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string service_account_email) {
+  [](gcs::Client client, std::string const& service_account_email) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> key_info =
         client.CreateHmacKey(service_account_email);
     if (!key_info) throw std::runtime_error(key_info.status().message());
@@ -122,8 +122,8 @@ void CreateHmacKeyForProject(google::cloud::storage::Client client,
   //! [create hmac key project]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string project_id,
-     std::string service_account_email) {
+  [](gcs::Client client, std::string const& project_id,
+     std::string const& service_account_email) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> hmac_key_details =
         client.CreateHmacKey(service_account_email,
                              gcs::OverrideDefaultProject(project_id));
@@ -144,7 +144,7 @@ void DeleteHmacKey(google::cloud::storage::Client client,
                    std::vector<std::string> const& argv) {
   //! [delete hmac key] [START storage_delete_hmac_key]
   namespace gcs = google::cloud::storage;
-  [](gcs::Client client, std::string access_id) {
+  [](gcs::Client client, std::string const& access_id) {
     google::cloud::Status status = client.DeleteHmacKey(access_id);
     if (!status.ok()) throw std::runtime_error(status.message());
 
@@ -160,7 +160,7 @@ void GetHmacKey(google::cloud::storage::Client client,
   //! [get hmac key] [START storage_get_hmac_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string access_id) {
+  [](gcs::Client client, std::string const& access_id) {
     StatusOr<gcs::HmacKeyMetadata> hmac_key = client.GetHmacKey(access_id);
     if (!hmac_key) throw std::runtime_error(hmac_key.status().message());
 
@@ -175,7 +175,8 @@ void UpdateHmacKey(google::cloud::storage::Client client,
   //! [update hmac key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string access_id, std::string state) {
+  [](gcs::Client client, std::string const& access_id,
+     std::string const& state) {
     StatusOr<gcs::HmacKeyMetadata> updated = client.UpdateHmacKey(
         access_id, gcs::HmacKeyMetadata().set_state(std::move(state)));
     if (!updated) throw std::runtime_error(updated.status().message());
@@ -191,7 +192,7 @@ void ActivateHmacKey(google::cloud::storage::Client client,
   //! [START storage_activate_hmac_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string access_id) {
+  [](gcs::Client client, std::string const& access_id) {
     StatusOr<gcs::HmacKeyMetadata> updated = client.UpdateHmacKey(
         access_id,
         gcs::HmacKeyMetadata().set_state(gcs::HmacKeyMetadata::state_active()));
@@ -213,7 +214,7 @@ void DeactivateHmacKey(google::cloud::storage::Client client,
   //! [START storage_deactivate_hmac_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string access_id) {
+  [](gcs::Client client, std::string const& access_id) {
     StatusOr<gcs::HmacKeyMetadata> updated = client.UpdateHmacKey(
         access_id, gcs::HmacKeyMetadata().set_state(
                        gcs::HmacKeyMetadata::state_inactive()));
@@ -307,7 +308,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
 int main(int argc, char* argv[]) {
   namespace examples = ::google::cloud::storage::examples;
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       examples::CreateCommandEntry("get-service-account", {},
                                    GetServiceAccount),
       examples::CreateCommandEntry("get-service-account-for-project",

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -24,7 +24,8 @@ void CreateGetSignedUrlV2(google::cloud::storage::Client client,
   //! [sign url v2] [START storage_generate_signed_url_v2]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<std::string> signed_url = client.CreateV2SignedUrl(
         "GET", std::move(bucket_name), std::move(object_name),
         gcs::ExpirationTime(std::chrono::system_clock::now() +
@@ -44,7 +45,8 @@ void CreatePutSignedUrlV2(google::cloud::storage::Client client,
   //! [create put signed url v2]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<std::string> signed_url = client.CreateV2SignedUrl(
         "PUT", std::move(bucket_name), std::move(object_name),
         gcs::ExpirationTime(std::chrono::system_clock::now() +

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -24,7 +24,8 @@ void CreateGetSignedUrlV4(google::cloud::storage::Client client,
   //! [sign url v4] [START storage_generate_signed_url_v4]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
         "GET", std::move(bucket_name), std::move(object_name),
         gcs::SignedUrlDuration(std::chrono::minutes(15)));
@@ -43,7 +44,8 @@ void CreatePutSignedUrlV4(google::cloud::storage::Client client,
   //! [create put signed url v4] [START storage_generate_upload_signed_url_v4]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string object_name) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& object_name) {
     StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
         "PUT", std::move(bucket_name), std::move(object_name),
         gcs::SignedUrlDuration(std::chrono::minutes(15)),

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -25,7 +25,7 @@ void GetStaticWebsiteConfiguration(google::cloud::storage::Client client,
   // [START storage_print_bucket_website_configuration]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.GetBucketMetadata(bucket_name);
 
@@ -56,8 +56,8 @@ void SetStaticWebsiteConfiguration(google::cloud::storage::Client client,
   // [START storage_define_bucket_website_configuration]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name, std::string main_page_suffix,
-     std::string not_found_page) {
+  [](gcs::Client client, std::string const& bucket_name,
+     std::string const& main_page_suffix, std::string const& not_found_page) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -94,7 +94,7 @@ void RemoveStaticWebsiteConfiguration(google::cloud::storage::Client client,
   //! [remove bucket website configuration]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string bucket_name) {
+  [](gcs::Client client, std::string const& bucket_name) {
     StatusOr<gcs::BucketMetadata> original =
         client.GetBucketMetadata(bucket_name);
 
@@ -167,7 +167,7 @@ int main(int argc, char* argv[]) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
     return examples::CreateCommandEntry(name, arg_names, cmd);
   };
-  google::cloud::storage::examples::Example example({
+  examples::Example example({
       make_entry("get-static-website-configuration", {},
                  GetStaticWebsiteConfiguration),
       make_entry("set-static-website-configuration",


### PR DESCRIPTION
part of #3958 (also see my comment there about whether we actually want
to do this).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3984)
<!-- Reviewable:end -->
