### PR TITLE
fix: typo in function name

### DIFF
--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -140,8 +140,7 @@ class ClientOptions {
   ClientOptions& SetUploadBufferSize(std::size_t size);
 
   std::string const& user_agent_prefix() const { return user_agent_prefix_; }
-  ClientOptions& add_user_agent_prefix(std::string const& v) {
-    std::string prefix = v;
+  ClientOptions& add_user_agent_prefix(std::string prefix) {
     if (!user_agent_prefix_.empty()) {
       prefix += '/';
       prefix += user_agent_prefix_;
@@ -149,7 +148,7 @@ class ClientOptions {
     user_agent_prefix_ = std::move(prefix);
     return *this;
   }
-  // Backward-compatibility typo.
+  /// @deprecated use `add_user_agent_prefix()` instead.
   ClientOptions& add_user_agent_prefx(std::string const& v) {
     return add_user_agent_prefix(v);
   }

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -140,7 +140,7 @@ class ClientOptions {
   ClientOptions& SetUploadBufferSize(std::size_t size);
 
   std::string const& user_agent_prefix() const { return user_agent_prefix_; }
-  ClientOptions& add_user_agent_prefx(std::string const& v) {
+  ClientOptions& add_user_agent_prefix(std::string const& v) {
     std::string prefix = v;
     if (!user_agent_prefix_.empty()) {
       prefix += '/';
@@ -148,6 +148,10 @@ class ClientOptions {
     }
     user_agent_prefix_ = std::move(prefix);
     return *this;
+  }
+  // Backward-compatibility typo.
+  ClientOptions& add_user_agent_prefx(std::string const& v) {
+    return add_user_agent_prefix(v);
   }
 
   std::size_t maximum_simple_upload_size() const {
@@ -217,7 +221,6 @@ class ClientOptions {
  private:
   void SetupFromEnvironment();
 
- private:
   std::shared_ptr<oauth2::Credentials> credentials_;
   std::string endpoint_;
   std::string iam_endpoint_;

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -138,9 +138,9 @@ TEST_F(ClientOptionsTest, SetUploadBufferSize) {
 TEST_F(ClientOptionsTest, UserAgentPrefix) {
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   EXPECT_EQ("", options.user_agent_prefix());
-  options.add_user_agent_prefx("foo-1.0");
+  options.add_user_agent_prefix("foo-1.0");
   EXPECT_EQ("foo-1.0", options.user_agent_prefix());
-  options.add_user_agent_prefx("bar-2.2");
+  options.add_user_agent_prefix("bar-2.2");
   EXPECT_EQ("bar-2.2/foo-1.0", options.user_agent_prefix());
 }
 

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -185,7 +185,7 @@ TEST(CurlRequestTest, UserAgent) {
       storage::internal::GetDefaultCurlHandleFactory());
   auto options =
       ClientOptions(std::make_shared<storage::oauth2::AnonymousCredentials>())
-          .add_user_agent_prefx("test-user-agent-prefix");
+          .add_user_agent_prefix("test-user-agent-prefix");
   builder.ApplyClientOptions(options);
   builder.AddHeader("Accept: application/json");
   builder.AddHeader("charsets: utf-8");


### PR DESCRIPTION
I left the old function name there (marked `@deprecated`) so as to not break the API for users. I also changed the signature of the new function to accept the argument by-value, since a copy was always being made anyway -- this may reduce the total number of copies in some cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3991)
<!-- Reviewable:end -->
