### PR TITLE
fix: use github team as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # is the same as .gitignore.
 
 # The owners for all files in the repo, sorted alphabetically.
-* @coryan @devbww @devjgm @mr-salty @scotthart
+* @googleapis/cloud-cxx-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # request containing files matching the given path. The syntax for file paths
 # is the same as .gitignore.
 
-# The owners for all files in the repo, sorted alphabetically.
+# The owners for all files in the repo.
 * @googleapis/cloud-cxx-owners


### PR DESCRIPTION
This will make it easier for us to load balance PRs and stuff, and I think it will give us more options. I'm not sure of all the details, but I think it's worth a try.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/3998)
<!-- Reviewable:end -->
