### PR TITLE
cleanup: enable more clang-tidy warnings in tests

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -245,6 +245,7 @@ if (BUILD_TESTING)
             PRIVATE google_cloud_cpp_testing google_cloud_cpp_common
                     GTest::gmock_main GTest::gmock GTest::gtest
                     google_cloud_cpp_common_options)
+        google_cloud_cpp_add_clang_tidy(${target})
         if (MSVC)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
@@ -386,6 +387,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
                         gRPC::grpc++
                         gRPC::grpc
                         google_cloud_cpp_common_options)
+            google_cloud_cpp_add_clang_tidy(${target})
             if (MSVC)
                 target_compile_options(${target} PRIVATE "/bigobj")
             endif ()

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -35,7 +35,6 @@ class MockCompletionQueue : public internal::CompletionQueueImpl {
 namespace btadmin = ::google::bigtable::admin::v2;
 namespace btproto = ::google::bigtable::v2;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::StrictMock;
 
 class MockClient {

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -25,7 +25,6 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 
 using ::testing::ElementsAre;
-using ::testing::HasSubstr;
 using ::testing::StartsWith;
 
 /// Use these traits to test ConnectionOptions.

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -22,7 +22,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator""_ms;
+using testing_util::chrono_literals::operator"" _ms;
 using testing_util::ExpectFutureError;
 
 /// @test Verify that destructing a promise does not introduce race conditions.

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -22,7 +22,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using namespace testing_util::chrono_literals;
+using testing_util::chrono_literals::operator""_ms;
 using testing_util::ExpectFutureError;
 
 /// @test Verify that destructing a promise does not introduce race conditions.
@@ -53,6 +53,7 @@ TEST(FutureTestInt, DestroyInSignalingThread) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_3) {
   // TODO(coryan) - allocators are not supported for now.
   static_assert(!std::uses_allocator<promise<int>, std::allocator<int>>::value,
@@ -60,6 +61,7 @@ TEST(FutureTestInt, conform_30_6_5_3) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_4_default) {
   promise<int> p0;
   auto f0 = p0.get_future();
@@ -70,6 +72,7 @@ TEST(FutureTestInt, conform_30_6_5_4_default) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_5) {
   // promise<R> move constructor clears the shared state on the moved-from
   // promise.
@@ -81,10 +84,15 @@ TEST(FutureTestInt, conform_30_6_5_5) {
   ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
   f1.get();
 
-  ExpectFutureError([&] { p0.set_value(42); }, std::future_errc::no_state);
+  ExpectFutureError(
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_value(42);
+      },
+      std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_7) {
   // promise<R> destructor abandons the shared state, the associated future
   // becomes satisfied with an exception.
@@ -112,6 +120,7 @@ TEST(FutureTestInt, conform_30_6_5_7) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_8) {
   // promise<R> move assignment clears the shared state in the moved-from
   // promise.
@@ -124,10 +133,15 @@ TEST(FutureTestInt, conform_30_6_5_8) {
   ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
   f1.get();
 
-  ExpectFutureError([&] { p0.set_value(42); }, std::future_errc::no_state);
+  ExpectFutureError(
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_value(42);
+      },
+      std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_10) {
   // promise<R>::swap() actually swaps shared states.
   promise<int> p0;
@@ -147,6 +161,7 @@ TEST(FutureTestInt, conform_30_6_5_10) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_14_1) {
   // promise<R>::get_future() raises if future was already retrieved.
   promise<int> p0;
@@ -156,14 +171,18 @@ TEST(FutureTestInt, conform_30_6_5_14_1) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_14_2) {
   // promise<R>::get_future() raises if there is no shared state.
   promise<int> p0;
   promise<int> p1(std::move(p0));
-  ExpectFutureError([&] { p0.get_future(); }, std::future_errc::no_state);
+  ExpectFutureError([&]  // NOLINT(bugprone-use-after-move)
+                    { p0.get_future(); },
+                    std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_15) {
   // promise<R>::set_value() stores the value in the shared state and makes it
   // ready.
@@ -176,6 +195,7 @@ TEST(FutureTestInt, conform_30_6_5_15) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_16_1) {
   // promise<R>::set_value() raises if there is a value in the shared state.
   promise<int> p0;
@@ -185,14 +205,18 @@ TEST(FutureTestInt, conform_30_6_5_16_1) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_17_2) {
   // promise<R>::set_value() raises if there is no shared state.
   promise<int> p0;
   promise<int> p1(std::move(p0));
-  ExpectFutureError([&] { p0.set_value(42); }, std::future_errc::no_state);
+  ExpectFutureError([&]  // NOLINT(bugprone-use-after-move)
+                    { p0.set_value(42); },
+                    std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_18) {
   // promise<R>::set_exception() sets an exception and makes the shared state
   // ready.
@@ -216,6 +240,7 @@ TEST(FutureTestInt, conform_30_6_5_18) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_20_1_value) {
   // promise<R>::set_exception() raises if the shared state is already storing
   // a value.
@@ -230,6 +255,7 @@ TEST(FutureTestInt, conform_30_6_5_20_1_value) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_20_1_exception) {
   // promise<R>::set_exception() raises if the shared state is already storing
   // an exception.
@@ -244,20 +270,22 @@ TEST(FutureTestInt, conform_30_6_5_20_1_exception) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_20_2) {
   // promise<R>::set_exception() raises if the promise does not have a shared
   // state.
   promise<int> p0;
   promise<int> p1(std::move(p0));
   ExpectFutureError(
-      [&] {
-        p0.set_exception(  // NOLINT
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_exception(
             std::make_exception_ptr(std::runtime_error("testing")));
       },
       std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_3_a) {
   // Calling get() on a future with `valid() == false` is undefined, but the
   // implementation is encouraged to raise `future_error` with an error code
@@ -268,6 +296,7 @@ TEST(FutureTestInt, conform_30_6_6_3_a) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_3_b) {
   // Calling wait() on a future with `valid() == false` is undefined, but the
   // implementation is encouraged to raise `future_error` with an error code
@@ -278,6 +307,7 @@ TEST(FutureTestInt, conform_30_6_6_3_b) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_3_c) {
   // Calling wait_for() on a future with `valid() == false` is undefined, but
   // the implementation is encouraged to raise `future_error` with an error code
@@ -288,6 +318,7 @@ TEST(FutureTestInt, conform_30_6_6_3_c) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_3_d) {
   // Calling wait_until() on a future with `valid() == false` is undefined, but
   // the implementation is encouraged to raise `future_error` with an error code
@@ -300,6 +331,7 @@ TEST(FutureTestInt, conform_30_6_6_3_d) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_5) {
   // future<int>::future() constructs an empty future with no shared state.
   future<int> f;
@@ -307,6 +339,7 @@ TEST(FutureTestInt, conform_30_6_6_5) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_7) {
   // future<int> move constructor is `noexcept`.
   future<int> f0;
@@ -314,6 +347,7 @@ TEST(FutureTestInt, conform_30_6_6_7) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_8_a) {
   // future<int> move constructor transfers futures with valid state.
   promise<int> p;
@@ -321,22 +355,24 @@ TEST(FutureTestInt, conform_30_6_6_8_a) {
   EXPECT_TRUE(f0.valid());
 
   future<int> f1(std::move(f0));
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(f1.valid());
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_8_b) {
   // future<int> move constructor transfers futures with no state.
   future<int> f0;
   EXPECT_FALSE(f0.valid());
 
   future<int> f1(std::move(f0));
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(f1.valid());
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_9) {
   // future<int> destructor releases the shared state.
   promise<int> p;
@@ -347,6 +383,7 @@ TEST(FutureTestInt, conform_30_6_6_9) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_10) {
   // Move assignment is noexcept.
   promise<int> p;
@@ -358,6 +395,7 @@ TEST(FutureTestInt, conform_30_6_6_10) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_11_a) {
   // future<int> move assignment transfers futures with valid state.
   promise<int> p;
@@ -366,11 +404,12 @@ TEST(FutureTestInt, conform_30_6_6_11_a) {
 
   future<int> f1;
   f1 = std::move(f0);
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(f1.valid());
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_11_b) {
   // future<int> move assignment transfers futures with invalid state.
   future<int> f0;
@@ -378,7 +417,7 @@ TEST(FutureTestInt, conform_30_6_6_11_b) {
 
   future<int> f1;
   f1 = std::move(f0);
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(f1.valid());
 }
 
@@ -386,6 +425,7 @@ TEST(FutureTestInt, conform_30_6_6_11_b) {
 // not implementing yet.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_15) {
   // future<int>::get() only returns once the promise is satisfied.
   promise<int> p;
@@ -417,6 +457,7 @@ TEST(FutureTestInt, conform_30_6_6_15) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_16_3) {
   // future<int>::get() returns void.
   promise<int> p;
@@ -425,6 +466,7 @@ TEST(FutureTestInt, conform_30_6_6_16_3) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_17) {
   // future<int>::get() throws if an exception was set in the promise.
   promise<int> p;
@@ -446,6 +488,7 @@ TEST(FutureTestInt, conform_30_6_6_17) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_18_a) {
   // future<int>::get() releases the shared state.
   promise<int> p;
@@ -456,6 +499,7 @@ TEST(FutureTestInt, conform_30_6_6_18_a) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_18_b) {
   // future<int>::get() throws releases the shared state.
   promise<int> p;
@@ -474,6 +518,7 @@ TEST(FutureTestInt, conform_30_6_6_18_b) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_19_a) {
   // future<int>::valid() returns true when the future has a shared state.
   promise<int> p;
@@ -483,6 +528,7 @@ TEST(FutureTestInt, conform_30_6_6_19_a) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_19_b) {
   // future<int>::valid() returns false when the future has no shared state.
   future<int> const f;
@@ -491,6 +537,7 @@ TEST(FutureTestInt, conform_30_6_6_19_b) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_20) {
   // future<int>::wait() blocks until state is ready.
   promise<int> p;
@@ -519,6 +566,7 @@ TEST(FutureTestInt, conform_30_6_6_20) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_21) {
   // future<int>::wait_for() blocks until state is ready.
   promise<int> p;
@@ -551,6 +599,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
 // test needed.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_22_2) {
   // wait_for() returns std::future_status::ready if the future is ready.
   promise<int> p0;
@@ -563,6 +612,7 @@ TEST(FutureTestInt, conform_30_6_6_22_2) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_22_3) {
   // wait_for() returns std::future_status::timeout if the future is not ready.
   promise<int> p0;
@@ -578,6 +628,7 @@ TEST(FutureTestInt, conform_30_6_6_22_3) {
 // this is just giving implementors freedom.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_24) {
   // future<int>::wait_until() blocks until state is ready.
   promise<int> p;
@@ -610,6 +661,7 @@ TEST(FutureTestInt, conform_30_6_6_24) {
 // test needed.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_25_2) {
   // wait_until() returns std::future_status::ready if the future is ready.
   promise<int> p0;
@@ -623,6 +675,7 @@ TEST(FutureTestInt, conform_30_6_6_25_2) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_6_25_3) {
   // wait_until() returns std::future_status::timeout if the future is not
   // ready.
@@ -639,7 +692,7 @@ TEST(FutureTestInt, conform_30_6_6_25_3) {
 // this is just giving implementors freedom.
 
 /// @test Verify the behavior around cancellation.
-TEST(FutureTestInt, cancellation_without_satisfaction) {
+TEST(FutureTestInt, CancellationWithoutSatisfaction) {
   bool cancelled = false;
   promise<int> p0([&cancelled] { cancelled = true; });
   auto f0 = p0.get_future();
@@ -648,7 +701,7 @@ TEST(FutureTestInt, cancellation_without_satisfaction) {
 }
 
 /// @test Verify the case for cancel then satisfy.
-TEST(FutureTestInt, cancellation_and_satisfaction) {
+TEST(FutureTestInt, CancellationAndSatisfaction) {
   bool cancelled = false;
   promise<int> p0([&cancelled] { cancelled = true; });
   auto f0 = p0.get_future();
@@ -660,7 +713,7 @@ TEST(FutureTestInt, cancellation_and_satisfaction) {
 }
 
 /// @test Verify the cancellation fails on satisfied promise.
-TEST(FutureTestInt, cancellation_after_satisfaction) {
+TEST(FutureTestInt, CancellationAfterSatisfaction) {
   bool cancelled = false;
   promise<int> p0([&cancelled] { cancelled = true; });
   auto f0 = p0.get_future();

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -24,7 +24,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator""_ms;
+using testing_util::chrono_literals::operator"" _ms;
 using testing_util::ExpectFutureError;
 
 TEST(FutureTestInt, ThenSimple) {

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -24,7 +24,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using namespace testing_util::chrono_literals;
+using testing_util::chrono_literals::operator""_ms;
 using testing_util::ExpectFutureError;
 
 TEST(FutureTestInt, ThenSimple) {
@@ -193,6 +193,7 @@ TEST(FutureTestInt, CancelThroughContinuation) {
 // The test names match the section and paragraph from the TS.
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_2_a) {
   // future<T> should have an unwrapping constructor.
   promise<future<int>> p;
@@ -203,6 +204,7 @@ TEST(FutureTestInt, conform_2_3_2_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_3_a) {
   // A future<T> created via the unwrapping constructor becomes satisfied
   // when both become satisfied.
@@ -222,6 +224,7 @@ TEST(FutureTestInt, conform_2_3_3_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_3_b) {
   // A future<T> created via the unwrapping constructor becomes satisfied
   // when the wrapped future is satisfied by an exception.
@@ -249,6 +252,7 @@ TEST(FutureTestInt, conform_2_3_3_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_3_c) {
   // A future<T> created via the unwrapping constructor becomes satisfied
   // when the inner future is satisfied by an exception.
@@ -280,6 +284,7 @@ TEST(FutureTestInt, conform_2_3_3_c) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_3_d) {
   // A future<T> created via the unwrapping constructor becomes satisfied
   // when the inner future is invalid.
@@ -307,6 +312,7 @@ TEST(FutureTestInt, conform_2_3_3_d) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_4) {
   // future<T> should leaves the source invalid.
   promise<future<int>> p;
@@ -314,10 +320,11 @@ TEST(FutureTestInt, conform_2_3_4) {
 
   future<int> unwrapped(std::move(f));
   EXPECT_TRUE(unwrapped.valid());
-  EXPECT_FALSE(f.valid());
+  EXPECT_FALSE(f.valid());  // NOLINT(bugprone-use-after-move)
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_5) {
   // future<int>::then() is a template member function that takes callables.
   future<int> f;
@@ -328,7 +335,10 @@ TEST(FutureTestInt, conform_2_3_5) {
   EXPECT_TRUE(
       (std::is_same<future<void>, decltype(f.then(void_callable))>::value));
 
-  auto long_callable = [](future<int> f) -> long { return 2 * f.get(); };
+  auto long_callable =
+      [](future<int> f) -> long {  // NOLINT(google-runtime-int)
+    return 2 * f.get();
+  };
   EXPECT_TRUE(
       (std::is_same<future<long>, decltype(f.then(long_callable))>::value));
 
@@ -345,11 +355,12 @@ auto test_then(int)
 }
 
 template <typename T>
-auto test_then(long) -> std::false_type {
+auto test_then(long) -> std::false_type {  // NOLINT(google-runtime-int)
   return std::false_type{};
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_7) {
   // future<int>::then() requires callables that take future<int> as a
   // parameter.
@@ -368,6 +379,7 @@ TEST(FutureTestInt, conform_2_3_7) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_8_a) {
   // future<int>::then() creates a future with a valid shared state.
   promise<int> p;
@@ -378,6 +390,7 @@ TEST(FutureTestInt, conform_2_3_8_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_8_b) {
   // future<int>::then() calls the functor when the future becomes ready.
   promise<int> p;
@@ -393,6 +406,7 @@ TEST(FutureTestInt, conform_2_3_8_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_8_c) {
   // future<int>::then() calls the functor if the future was ready.
   promise<int> p;
@@ -406,6 +420,7 @@ TEST(FutureTestInt, conform_2_3_8_c) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_8_d) {
   // future<int>::then() propagates the value from the functor to the returned
   // future.
@@ -420,6 +435,7 @@ TEST(FutureTestInt, conform_2_3_8_d) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_8_e) {
   // future<int>::then() propagates exceptions raised by the functort to the
   // returned future.
@@ -446,6 +462,7 @@ TEST(FutureTestInt, conform_2_3_8_e) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_9_a) {
   // future<int>::then() returns a functor containing the type of the value
   // returned by the functor.
@@ -466,6 +483,7 @@ TEST(FutureTestInt, conform_2_3_9_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_9_b) {
   // future<int>::then() implicitly unwraps the future type when a functor
   // returns a future<>.
@@ -496,6 +514,7 @@ TEST(FutureTestInt, conform_2_3_9_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_9_c) {
   // future<int>::then() implicitly unwrapping captures the returned value.
   promise<int> p;
@@ -522,6 +541,7 @@ TEST(FutureTestInt, conform_2_3_9_c) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_9_d) {
   // future<int>::then() implicitly unwrapping captures exceptions.
   promise<int> p;
@@ -559,6 +579,7 @@ TEST(FutureTestInt, conform_2_3_9_d) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_9_e) {
   // future<int>::then() implicitly unwrapping raises on invalid future
   // returned by continuation.
@@ -594,6 +615,7 @@ TEST(FutureTestInt, conform_2_3_9_e) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_10) {
   // future<int>::then() invalidates the source future.
   promise<int> p;
@@ -609,6 +631,7 @@ TEST(FutureTestInt, conform_2_3_10) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_11_a) {
   // future<int>::is_ready() returns false for futures that are not ready.
   promise<int> p;
@@ -617,6 +640,7 @@ TEST(FutureTestInt, conform_2_3_11_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_11_b) {
   // future<int>::is_ready() returns true for futures that are ready.
   promise<int> p;
@@ -626,6 +650,7 @@ TEST(FutureTestInt, conform_2_3_11_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_2_3_11_c) {
   // future<int>::is_ready() raises for futures that are not valid.
   future<int> const f;
@@ -633,6 +658,7 @@ TEST(FutureTestInt, conform_2_3_11_c) {
 }
 
 /// @test Verify conformance with section 2.10 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestString, conform_2_10_4_2_a) {
   // When T is a simple value type we get back T.
   future<std::string> f = make_ready_future(std::string("42"));
@@ -642,6 +668,7 @@ TEST(FutureTestString, conform_2_10_4_2_a) {
 }
 
 /// @test Verify conformance with section 2.10 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestString, conform_2_10_4_2_b) {
   // When T is a reference we get std::decay<T>::type.
   std::string value("42");
@@ -653,6 +680,7 @@ TEST(FutureTestString, conform_2_10_4_2_b) {
 }
 
 //// @test Verify conformance with section 2.10 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestString, conform_2_10_4_2_c) {
 #if 1
   using V =
@@ -671,13 +699,15 @@ TEST(FutureTestString, conform_2_10_4_2_c) {
 
 class MockFunctor {
  public:
-  MockFunctor() : moved_from_() {}
-  MockFunctor(MockFunctor&& other) { other.moved_from_ = true; }
+  MockFunctor() = default;
+  MockFunctor(MockFunctor&& other) noexcept : moved_from_(other.moved_from_) {
+    other.moved_from_ = true;
+  }
   MockFunctor(MockFunctor const& other) = default;
 
   void operator()(future<int>) {}
 
-  bool moved_from_;
+  bool moved_from_{false};
 };
 
 TEST(FutureTestInt, RValueThenFunctorIsMoved) {
@@ -686,7 +716,7 @@ TEST(FutureTestInt, RValueThenFunctorIsMoved) {
   MockFunctor fun;
   fut.then(std::move(fun));
   promise.set_value(1);
-  EXPECT_TRUE(fun.moved_from_);
+  EXPECT_TRUE(fun.moved_from_);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(FutureTestInt, LValueThenFunctorIsCopied) {
@@ -700,13 +730,16 @@ TEST(FutureTestInt, LValueThenFunctorIsCopied) {
 
 class MockUnwrapFunctor {
  public:
-  MockUnwrapFunctor() : moved_from_() {}
-  MockUnwrapFunctor(MockUnwrapFunctor&& other) { other.moved_from_ = true; }
+  MockUnwrapFunctor() = default;
+  MockUnwrapFunctor(MockUnwrapFunctor&& other) noexcept
+      : moved_from_(other.moved_from_) {
+    other.moved_from_ = true;
+  }
   MockUnwrapFunctor(MockUnwrapFunctor const& other) = default;
 
   future<void> operator()(future<int>) { return make_ready_future(); }
 
-  bool moved_from_;
+  bool moved_from_{false};
 };
 
 TEST(FutureTestInt, RValueThenUnwrapFunctorIsMoved) {
@@ -715,7 +748,7 @@ TEST(FutureTestInt, RValueThenUnwrapFunctorIsMoved) {
   MockUnwrapFunctor fun;
   fut.then(std::move(fun));
   promise.set_value(1);
-  EXPECT_TRUE(fun.moved_from_);
+  EXPECT_TRUE(fun.moved_from_);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(FutureTestInt, LValueThenUnwrapFunctorIsCopied) {

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -22,7 +22,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using namespace testing_util::chrono_literals;
+using testing_util::chrono_literals::operator""_ms;
 using testing_util::ExpectFutureError;
 
 // Verify we are testing the types we think we should be testing.
@@ -60,6 +60,7 @@ TEST(FutureTestVoid, DestroyInSignalingThread) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_3) {
   // TODO(#1364) - allocators are not supported for now.
   static_assert(!std::uses_allocator<promise<void>, std::allocator<int>>::value,
@@ -67,6 +68,7 @@ TEST(FutureTestVoid, conform_30_6_5_3) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_4_default) {
   promise<void> p0;
   auto f0 = p0.get_future();
@@ -77,6 +79,7 @@ TEST(FutureTestVoid, conform_30_6_5_4_default) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_5) {
   // promise<R> move constructor clears the shared state on the moved-from
   // promise.
@@ -88,10 +91,15 @@ TEST(FutureTestVoid, conform_30_6_5_5) {
   ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
   f1.get();
 
-  ExpectFutureError([&] { p0.set_value(); }, std::future_errc::no_state);
+  ExpectFutureError(
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_value();
+      },
+      std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_7) {
   // promise<R> destructor abandons the shared state, the associated future
   // becomes satisfied with an exception.
@@ -119,6 +127,7 @@ TEST(FutureTestVoid, conform_30_6_5_7) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_8) {
   // promise<R> move assignment clears the shared state in the moved-from
   // promise.
@@ -130,10 +139,15 @@ TEST(FutureTestVoid, conform_30_6_5_8) {
   p1.set_value();
   ASSERT_EQ(std::future_status::ready, f1.wait_for(0_ms));
   f1.get();
-  ExpectFutureError([&] { p0.set_value(); }, std::future_errc::no_state);
+  ExpectFutureError(
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_value();
+      },
+      std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_10) {
   // promise<R>::swap() actually swaps shared states.
   promise<void> p0;
@@ -153,6 +167,7 @@ TEST(FutureTestVoid, conform_30_6_5_10) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_14_1) {
   // promise<R>::get_future() raises if future was already retrieved.
   promise<void> p0;
@@ -162,14 +177,20 @@ TEST(FutureTestVoid, conform_30_6_5_14_1) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_14_2) {
   // promise<R>::get_future() raises if there is no shared state.
   promise<void> p0;
   promise<void> p1(std::move(p0));
-  ExpectFutureError([&] { p0.set_value(); }, std::future_errc::no_state);
+  ExpectFutureError(
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_value();
+      },
+      std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_15) {
   // promise<R>::set_value() stores the value in the shared state and makes it
   // ready.
@@ -183,6 +204,7 @@ TEST(FutureTestVoid, conform_30_6_5_15) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_16_1) {
   // promise<R>::set_value() raises if there is a value in the shared state.
   promise<void> p0;
@@ -192,14 +214,20 @@ TEST(FutureTestVoid, conform_30_6_5_16_1) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_17_2) {
   // promise<R>::set_value() raises if there is no shared state.
   promise<void> p0;
   promise<void> p1(std::move(p0));
-  ExpectFutureError([&] { p0.set_value(); }, std::future_errc::no_state);
+  ExpectFutureError(
+      [&] {  // NOLINT(bugprone-use-after-move)
+        p0.set_value();
+      },
+      std::future_errc::no_state);
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_18) {
   // promise<R>::set_exception() sets an exception and makes the shared state
   // ready.
@@ -223,6 +251,7 @@ TEST(FutureTestVoid, conform_30_6_5_18) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_20_1_value) {
   // promise<R>::set_exception() raises if the shared state is already storing
   // a value.
@@ -237,6 +266,7 @@ TEST(FutureTestVoid, conform_30_6_5_20_1_value) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_20_1_exception) {
   // promise<R>::set_exception() raises if the shared state is already storing
   // an exception.
@@ -251,13 +281,14 @@ TEST(FutureTestVoid, conform_30_6_5_20_1_exception) {
 }
 
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_5_20_2) {
   // promise<R>::set_exception() raises if the promise does not have a shared
   // state.
   promise<void> p0;
   promise<void> p1(std::move(p0));
   ExpectFutureError(
-      [&] {
+      [&] {  // NOLINT(bugprone-use-after-move)
         p0.set_exception(
             std::make_exception_ptr(std::runtime_error("testing")));
       },
@@ -265,6 +296,7 @@ TEST(FutureTestVoid, conform_30_6_5_20_2) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_3_a) {
   // Calling get() on a future with `valid() == false` is undefined, but the
   // implementation is encouraged to raise `future_error` with an error code
@@ -275,6 +307,7 @@ TEST(FutureTestVoid, conform_30_6_6_3_a) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_3_b) {
   // Calling wait() on a future with `valid() == false` is undefined, but the
   // implementation is encouraged to raise `future_error` with an error code
@@ -285,6 +318,7 @@ TEST(FutureTestVoid, conform_30_6_6_3_b) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_3_c) {
   // Calling wait_for() on a future with `valid() == false` is undefined, but
   // the implementation is encouraged to raise `future_error` with an error code
@@ -295,6 +329,7 @@ TEST(FutureTestVoid, conform_30_6_6_3_c) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_3_d) {
   // Calling wait_until() on a future with `valid() == false` is undefined, but
   // the implementation is encouraged to raise `future_error` with an error code
@@ -307,6 +342,7 @@ TEST(FutureTestVoid, conform_30_6_6_3_d) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_5) {
   // future<void>::future() constructs an empty future with no shared state.
   future<void> f;
@@ -314,6 +350,7 @@ TEST(FutureTestVoid, conform_30_6_6_5) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_7) {
   // future<void> move constructor is `noexcept`.
   future<void> f0;
@@ -321,6 +358,7 @@ TEST(FutureTestVoid, conform_30_6_6_7) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_8_a) {
   // future<void> move constructor transfers futures with valid state.
   promise<void> p;
@@ -328,22 +366,24 @@ TEST(FutureTestVoid, conform_30_6_6_8_a) {
   EXPECT_TRUE(f0.valid());
 
   future<void> f1(std::move(f0));
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(f1.valid());
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_8_b) {
   // future<void> move constructor transfers futures with no state.
   future<void> f0;
   EXPECT_FALSE(f0.valid());
 
   future<void> f1(std::move(f0));
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(f1.valid());
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_9) {
   // future<void> destructor releases the shared state.
   promise<void> p;
@@ -354,6 +394,7 @@ TEST(FutureTestVoid, conform_30_6_6_9) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_10) {
   // Move assignment is noexcept.
   promise<void> p;
@@ -365,6 +406,7 @@ TEST(FutureTestVoid, conform_30_6_6_10) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_11_a) {
   // future<void> move assignment transfers futures with valid state.
   promise<void> p;
@@ -373,11 +415,12 @@ TEST(FutureTestVoid, conform_30_6_6_11_a) {
 
   future<void> f1;
   f1 = std::move(f0);
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(f1.valid());
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_11_b) {
   // future<void> move assignment transfers futures with invalid state.
   future<void> f0;
@@ -385,7 +428,7 @@ TEST(FutureTestVoid, conform_30_6_6_11_b) {
 
   future<void> f1;
   f1 = std::move(f0);
-  EXPECT_FALSE(f0.valid());
+  EXPECT_FALSE(f0.valid());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(f1.valid());
 }
 
@@ -393,6 +436,7 @@ TEST(FutureTestVoid, conform_30_6_6_11_b) {
 // not implementing yet.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_15) {
   // future<void>::get() only returns once the promise is satisfied.
   promise<void> p;
@@ -424,6 +468,7 @@ TEST(FutureTestVoid, conform_30_6_6_15) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_16_3) {
   // future<void>::get() returns void.
   promise<void> p;
@@ -432,6 +477,7 @@ TEST(FutureTestVoid, conform_30_6_6_16_3) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_17) {
   // future<void>::get() throws if an exception was set in the promise.
   promise<void> p;
@@ -453,6 +499,7 @@ TEST(FutureTestVoid, conform_30_6_6_17) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_18_a) {
   // future<void>::get() releases the shared state.
   promise<void> p;
@@ -463,6 +510,7 @@ TEST(FutureTestVoid, conform_30_6_6_18_a) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_18_b) {
   // future<void>::get() throws releases the shared state.
   promise<void> p;
@@ -481,6 +529,7 @@ TEST(FutureTestVoid, conform_30_6_6_18_b) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_19_a) {
   // future<void>::valid() returns true when the future has a shared state.
   promise<void> p;
@@ -490,6 +539,7 @@ TEST(FutureTestVoid, conform_30_6_6_19_a) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_19_b) {
   // future<void>::valid() returns false when the future has no shared state.
   future<void> const f;
@@ -498,6 +548,7 @@ TEST(FutureTestVoid, conform_30_6_6_19_b) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_20) {
   // future<void>::wait() blocks until state is ready.
   promise<void> p;
@@ -526,6 +577,7 @@ TEST(FutureTestVoid, conform_30_6_6_20) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_21) {
   // future<void>::wait_for() blocks until state is ready.
   promise<void> p;
@@ -558,6 +610,7 @@ TEST(FutureTestVoid, conform_30_6_6_21) {
 // test needed.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_22_2) {
   // wait_for() returns std::future_status::ready if the future is ready.
   promise<void> p0;
@@ -571,6 +624,7 @@ TEST(FutureTestVoid, conform_30_6_6_22_2) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_22_3) {
   // wait_for() returns std::future_status::timeout if the future is not ready.
   promise<void> p0;
@@ -586,6 +640,7 @@ TEST(FutureTestVoid, conform_30_6_6_22_3) {
 // this is just giving implementors freedom.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_24) {
   // future<void>::wait_until() blocks until state is ready.
   promise<void> p;
@@ -618,6 +673,7 @@ TEST(FutureTestVoid, conform_30_6_6_24) {
 // test needed.
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_25_2) {
   // wait_until() returns std::future_status::ready if the future is ready.
   promise<void> p0;
@@ -632,6 +688,7 @@ TEST(FutureTestVoid, conform_30_6_6_25_2) {
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_30_6_6_25_3) {
   // wait_until() returns std::future_status::timeout if the future is not
   // ready.
@@ -648,6 +705,7 @@ TEST(FutureTestVoid, conform_30_6_6_25_3) {
 // this is just giving implementors freedom.
 
 /// @test Verify the behavior around cancellation.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, cancellation_without_satisfaction) {
   bool cancelled = false;
   promise<void> p0([&cancelled] { cancelled = true; });
@@ -657,6 +715,7 @@ TEST(FutureTestVoid, cancellation_without_satisfaction) {
 }
 
 /// @test Verify the case for cancel then satisfy.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, cancellation_and_satisfaction) {
   bool cancelled = false;
   promise<void> p0([&cancelled] { cancelled = true; });
@@ -668,6 +727,7 @@ TEST(FutureTestVoid, cancellation_and_satisfaction) {
 }
 
 /// @test Verify the cancellation fails on satisfied promise.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, cancellation_after_satisfaction) {
   bool cancelled = false;
   promise<void> p0([&cancelled] { cancelled = true; });

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -22,7 +22,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator""_ms;
+using testing_util::chrono_literals::operator"" _ms;
 using testing_util::ExpectFutureError;
 
 // Verify we are testing the types we think we should be testing.

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -24,7 +24,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator""_ms;
+using testing_util::chrono_literals::operator"" _ms;
 using testing_util::ExpectFutureError;
 
 TEST(FutureTestVoid, ThenSimple) {

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -24,7 +24,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
-using namespace testing_util::chrono_literals;
+using testing_util::chrono_literals::operator""_ms;
 using testing_util::ExpectFutureError;
 
 TEST(FutureTestVoid, ThenSimple) {
@@ -180,6 +180,7 @@ TEST(FutureTestVoid, CancelThroughContinuation) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_2_a) {
   // future<void> should have an unwrapping constructor.
   promise<future<void>> p;
@@ -190,6 +191,7 @@ TEST(FutureTestVoid, conform_2_3_2_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_3_a) {
   // A future<void> created via the unwrapping constructor becomes satisfied
   // when both become satisfied.
@@ -209,6 +211,7 @@ TEST(FutureTestVoid, conform_2_3_3_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_3_b) {
   // A future<void> created via the unwrapping constructor becomes satisfied
   // when the wrapped future is satisfied by an exception.
@@ -236,6 +239,7 @@ TEST(FutureTestVoid, conform_2_3_3_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_3_c) {
   // A future<void> created via the unwrapping constructor becomes satisfied
   // when the inner future is satisfied by an exception.
@@ -270,6 +274,7 @@ TEST(FutureTestVoid, conform_2_3_3_c) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_3_d) {
   // A future<void> created via the unwrapping constructor becomes satisfied
   // when the inner future is invalid.
@@ -298,6 +303,7 @@ TEST(FutureTestVoid, conform_2_3_3_d) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_4) {
   // future<void> should leaves the source invalid.
   promise<future<void>> p;
@@ -305,10 +311,11 @@ TEST(FutureTestVoid, conform_2_3_4) {
 
   future<void> unwrapped(std::move(f));
   EXPECT_TRUE(unwrapped.valid());
-  EXPECT_FALSE(f.valid());
+  EXPECT_FALSE(f.valid());  // NOLINT(bugprone-use-after-move)
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_5) {
   // future<void>::then() is a template member function that takes callables.
   future<void> f;
@@ -335,11 +342,12 @@ auto test_then(int)
 }
 
 template <typename T>
-auto test_then(long) -> std::false_type {
+auto test_then(long) -> std::false_type {  // NOLINT(google-runtime-int)
   return std::false_type{};
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_7) {
   // future<void>::then() requires callables that take future<void> as a
   // parameter.
@@ -358,6 +366,7 @@ TEST(FutureTestVoid, conform_2_3_7) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_8_a) {
   // future<void>::then() creates a future with a valid shared state.
   promise<void> p;
@@ -368,6 +377,7 @@ TEST(FutureTestVoid, conform_2_3_8_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_8_b) {
   // future<void>::then() calls the functor when the future becomes ready.
   promise<void> p;
@@ -383,6 +393,7 @@ TEST(FutureTestVoid, conform_2_3_8_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_8_c) {
   // future<void>::then() calls the functor if the future was ready.
   promise<void> p;
@@ -396,6 +407,7 @@ TEST(FutureTestVoid, conform_2_3_8_c) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_8_d) {
   // future<void>::then() propagates the value from the functor to the returned
   // future.
@@ -410,6 +422,7 @@ TEST(FutureTestVoid, conform_2_3_8_d) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_8_e) {
   // future<void>::then() propagates exceptions raised by the functor to the
   // returned future.
@@ -437,6 +450,7 @@ TEST(FutureTestVoid, conform_2_3_8_e) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_9_a) {
   // future<void>::then() returns a functor containing the type of the value
   // returned by the functor.
@@ -457,6 +471,7 @@ TEST(FutureTestVoid, conform_2_3_9_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_9_b) {
   // future<void>::then() implicitly unwraps the future type when a functor
   // returns a future<>.
@@ -487,6 +502,7 @@ TEST(FutureTestVoid, conform_2_3_9_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_9_c) {
   // future<void>::then() implicitly unwrapping captures the returned value.
   promise<void> p;
@@ -513,6 +529,7 @@ TEST(FutureTestVoid, conform_2_3_9_c) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_9_d) {
   // future<void>::then() implicitly unwrapping captures exceptions.
   promise<void> p;
@@ -551,6 +568,7 @@ TEST(FutureTestVoid, conform_2_3_9_d) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_9_e) {
   // future<void>::then() implicitly unwrapping raises on invalid future
   // returned by continuation.
@@ -586,6 +604,7 @@ TEST(FutureTestVoid, conform_2_3_9_e) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_10) {
   // future<void>::then() invalidates the source future.
   promise<void> p;
@@ -602,6 +621,7 @@ TEST(FutureTestVoid, conform_2_3_10) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_11_a) {
   // future<void>::is_ready() returns false for futures that are not ready.
   promise<void> p;
@@ -610,6 +630,7 @@ TEST(FutureTestVoid, conform_2_3_11_a) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_11_b) {
   // future<void>::is_ready() returns true for futures that are ready.
   promise<void> p;
@@ -619,6 +640,7 @@ TEST(FutureTestVoid, conform_2_3_11_b) {
 }
 
 /// @test Verify conformance with section 2.3 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_3_11_c) {
   // future<void>::is_ready() raises for futures that are not valid.
   future<void> const f;
@@ -626,6 +648,7 @@ TEST(FutureTestVoid, conform_2_3_11_c) {
 }
 
 /// @test Verify conformance with section 2.10 of the Concurrency TS.
+// NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestVoid, conform_2_10_4) {
   future<void> f = make_ready_future();
   EXPECT_TRUE(f.valid());
@@ -636,13 +659,15 @@ TEST(FutureTestVoid, conform_2_10_4) {
 
 class MockFunctor {
  public:
-  MockFunctor() : moved_from_() {}
-  MockFunctor(MockFunctor&& other) { other.moved_from_ = true; }
+  MockFunctor() = default;
+  MockFunctor(MockFunctor&& other) noexcept : moved_from_(other.moved_from_) {
+    other.moved_from_ = true;
+  }
   MockFunctor(MockFunctor const& other) = default;
 
   void operator()(future<void>) {}
 
-  bool moved_from_;
+  bool moved_from_{false};
 };
 
 TEST(FutureTestVoid, RValueThenFunctorIsMoved) {
@@ -651,7 +676,7 @@ TEST(FutureTestVoid, RValueThenFunctorIsMoved) {
   MockFunctor fun;
   fut.then(std::move(fun));
   promise.set_value();
-  EXPECT_TRUE(fun.moved_from_);
+  EXPECT_TRUE(fun.moved_from_);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(FutureTestVoid, LValueThenFunctorIsCopied) {
@@ -665,13 +690,16 @@ TEST(FutureTestVoid, LValueThenFunctorIsCopied) {
 
 class MockUnwrapFunctor {
  public:
-  MockUnwrapFunctor() : moved_from_() {}
-  MockUnwrapFunctor(MockUnwrapFunctor&& other) { other.moved_from_ = true; }
+  MockUnwrapFunctor() = default;
+  MockUnwrapFunctor(MockUnwrapFunctor&& other) noexcept
+      : moved_from_(other.moved_from_) {
+    other.moved_from_ = true;
+  }
   MockUnwrapFunctor(MockUnwrapFunctor const& other) = default;
 
   future<void> operator()(future<void>) { return make_ready_future(); }
 
-  bool moved_from_;
+  bool moved_from_{false};
 };
 
 TEST(FutureTestVoid, RValueThenUnwrapFunctorIsMoved) {
@@ -680,7 +708,7 @@ TEST(FutureTestVoid, RValueThenUnwrapFunctorIsMoved) {
   MockUnwrapFunctor fun;
   fut.then(std::move(fun));
   promise.set_value();
-  EXPECT_TRUE(fun.moved_from_);
+  EXPECT_TRUE(fun.moved_from_);  // NOLINT(bugprone-use-after-move)
 }
 
 TEST(FutureTestVoid, LValueThenUnwrapFunctorIsCopied) {

--- a/google/cloud/iam_bindings_test.cc
+++ b/google/cloud/iam_bindings_test.cc
@@ -169,7 +169,7 @@ TEST(IamBindingsTest, RemoveMembersTestIamBindingParam) {
   auto temp_binding = iam_bindings.bindings();
   bool has_removed_member = false;
 
-  for (auto it : temp_binding[role]) {
+  for (auto const& it : temp_binding[role]) {
     if (it == *member_list.begin()) {
       has_removed_member = true;
       break;

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -32,7 +32,7 @@ namespace {
 namespace btadmin = ::google::bigtable::admin::v2;
 using ::google::cloud::testing_util::MockAsyncResponseReader;
 using ::google::cloud::testing_util::MockCompletionQueue;
-using ::google::cloud::testing_util::chrono_literals::operator""_us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -32,6 +32,7 @@ namespace {
 namespace btadmin = ::google::bigtable::admin::v2;
 using ::google::cloud::testing_util::MockAsyncResponseReader;
 using ::google::cloud::testing_util::MockCompletionQueue;
+using ::google::cloud::testing_util::chrono_literals::operator""_us;
 using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Invoke;
@@ -81,8 +82,6 @@ using RpcExponentialBackoffPolicy =
     google::cloud::internal::ExponentialBackoffPolicy;
 
 TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   MockStub mock;
 
   using ReaderType = MockAsyncResponseReader<btadmin::Table>;
@@ -135,8 +134,6 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
 }
 
 TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   MockStub mock;
 
   using ReaderType = MockAsyncResponseReader<google::protobuf::Empty>;
@@ -184,8 +181,6 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
 }
 
 TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   MockStub mock;
 
   using ReaderType = MockAsyncResponseReader<btadmin::Table>;
@@ -237,8 +232,6 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
 }
 
 TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   MockStub mock;
 
   using ReaderType = MockAsyncResponseReader<btadmin::Table>;
@@ -319,8 +312,6 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
 }
 
 TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   MockStub mock;
 
   using ReaderType = MockAsyncResponseReader<google::protobuf::Empty>;

--- a/google/cloud/internal/backoff_policy_test.cc
+++ b/google/cloud/internal/backoff_policy_test.cc
@@ -98,7 +98,8 @@ TEST(ExponentialBackoffPolicy, Randomness) {
   // The type used to represent a duration varies by platform, better to use
   // the alias guaranteed by the standard than trying to guess the type or
   // use a lot of casts.
-  std::vector<std::chrono::milliseconds::rep> output1, output2;
+  std::vector<std::chrono::milliseconds::rep> output1;
+  std::vector<std::chrono::milliseconds::rep> output2;
 
   auto delay = test_object1.OnCompletion();
   EXPECT_LE(ms(10), delay);

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -26,11 +26,10 @@ namespace internal {
 namespace {
 
 using ::testing::HasSubstr;
+using testing_util::chrono_literals::operator""_us;
 using testing_util::ExpectFutureError;
 using testing_util::NoDefaultConstructor;
 using testing_util::Observable;
-
-using namespace google::cloud::testing_util::chrono_literals;
 
 TEST(FutureImplBaseTest, Basic) {
   future_shared_state_base shared_state;
@@ -110,7 +109,7 @@ TEST(FutureImplBaseTest, AbandonReady) {
 
 // @test Verify that we can create continuations.
 TEST(ContinuationVoidTest, Constructor) {
-  auto functor = [](std::shared_ptr<future_shared_state<void>>) {};
+  auto functor = [](std::shared_ptr<future_shared_state<void>> const&) {};
 
   using tested_type = continuation<decltype(functor), void>;
 
@@ -125,10 +124,11 @@ TEST(ContinuationVoidTest, Constructor) {
 /// continuation.
 TEST(ContinuationVoidTest, SetExceptionCallsContinuation) {
   bool called = false;
-  auto functor = [&called](std::shared_ptr<future_shared_state<void>> state) {
-    called = true;
-    state->get();
-  };
+  auto functor =
+      [&called](std::shared_ptr<future_shared_state<void>> const& state) {
+        called = true;
+        state->get();
+      };
 
   auto input = std::make_shared<future_shared_state<void>>();
   std::shared_ptr<future_shared_state<void>> output =
@@ -157,10 +157,11 @@ TEST(ContinuationVoidTest, SetExceptionCallsContinuation) {
 /// continuation.
 TEST(ContinuationVoidTest, SetValueCallsContinuation) {
   bool called = false;
-  auto functor = [&called](std::shared_ptr<future_shared_state<void>> state) {
-    called = true;
-    state->get();
-  };
+  auto functor =
+      [&called](std::shared_ptr<future_shared_state<void>> const& state) {
+        called = true;
+        state->get();
+      };
 
   auto input = std::make_shared<future_shared_state<void>>();
   std::shared_ptr<future_shared_state<void>> output =
@@ -175,7 +176,7 @@ TEST(ContinuationVoidTest, SetValueCallsContinuation) {
 
 class TestContinuation : public continuation_base {
  public:
-  TestContinuation(int* r) : execute_counter(r) {}
+  explicit TestContinuation(int* r) : execute_counter(r) {}
   void execute() override { (*execute_counter)++; }
 
   int* execute_counter;
@@ -453,7 +454,7 @@ TEST(FutureImplInt, SetContinuationAlreadySatisfied) {
 
 // @test Verify that we can create continuations.
 TEST(ContinuationIntTest, Constructor) {
-  auto functor = [](std::shared_ptr<future_shared_state<int>>) {};
+  auto functor = [](std::shared_ptr<future_shared_state<int>> const&) {};
 
   using tested_type = continuation<decltype(functor), int>;
 
@@ -468,10 +469,11 @@ TEST(ContinuationIntTest, Constructor) {
 /// continuation.
 TEST(ContinuationIntTest, SetExceptionCallsContinuation) {
   bool called = false;
-  auto functor = [&called](std::shared_ptr<future_shared_state<int>> state) {
-    called = true;
-    return 2 * state->get();
-  };
+  auto functor =
+      [&called](std::shared_ptr<future_shared_state<int>> const& state) {
+        called = true;
+        return 2 * state->get();
+      };
 
   auto input = std::make_shared<future_shared_state<int>>();
   std::shared_ptr<future_shared_state<int>> output =
@@ -500,10 +502,11 @@ TEST(ContinuationIntTest, SetExceptionCallsContinuation) {
 /// continuation.
 TEST(ContinuationIntTest, SetValueCallsContinuation) {
   bool called = false;
-  auto functor = [&called](std::shared_ptr<future_shared_state<int>> state) {
-    called = true;
-    return 2 * state->get();
-  };
+  auto functor =
+      [&called](std::shared_ptr<future_shared_state<int>> const& state) {
+        called = true;
+        return 2 * state->get();
+      };
 
   auto input = std::make_shared<future_shared_state<int>>();
   std::shared_ptr<future_shared_state<int>> output =

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -26,7 +26,7 @@ namespace internal {
 namespace {
 
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator""_us;
+using testing_util::chrono_literals::operator"" _us;
 using testing_util::ExpectFutureError;
 using testing_util::NoDefaultConstructor;
 using testing_util::Observable;

--- a/google/cloud/internal/invoke_result_test.cc
+++ b/google/cloud/internal/invoke_result_test.cc
@@ -20,15 +20,16 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
+
 TEST(ResultOfTest, Lambda) {
   // This test mostly uses static assertions because the result_of classes are
   // largely meta-functions.
 
-  auto l = [](long, int) -> int { return 7; };
+  auto l = [](long, int) -> int { return 7; };  // NOLINT(google-runtime-int)
 
   using F = decltype(l);
 
-  using R = invoke_result<F, long, int>::type;
+  using R = invoke_result<F, long, int>::type;  // NOLINT(google-runtime-int)
 
   static_assert(std::is_same<R, int>::value,
                 "expected `int` in invoke_result_t<>");

--- a/google/cloud/internal/random_test.cc
+++ b/google/cloud/internal/random_test.cc
@@ -17,15 +17,13 @@
 #include <future>
 #include <vector>
 
-using namespace google::cloud::internal;
-
 TEST(Random, Basic) {
   // This is not a statistical test for PRNG, basically we want to make
   // sure that MakeDefaultPRNG uses different seeds, or at least creates
   // different series:
   auto gen_string = []() {
-    auto g = MakeDefaultPRNG();
-    return Sample(g, 32, "0123456789abcdefghijklm");
+    auto g = google::cloud::internal::MakeDefaultPRNG();
+    return google::cloud::internal::Sample(g, 32, "0123456789abcdefghijklm");
   };
   std::string s0 = gen_string();
   std::string s1 = gen_string();
@@ -50,7 +48,7 @@ TEST(Random, Threads) {
   std::generate_n(workers.begin(), workers.size(), [&] {
     return std::async(std::launch::async, [&] {
       for (auto i = 0; i != kIterations; ++i) {
-        auto g = MakeDefaultPRNG();
+        auto g = google::cloud::internal::MakeDefaultPRNG();
         (void)g();
       }
       return kIterations;

--- a/google/cloud/internal/throw_delegate_test.cc
+++ b/google/cloud/internal/throw_delegate_test.cc
@@ -22,37 +22,37 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
-std::string const cmsg("testing with std::string const&");
+std::string const kCmsg("testing with std::string const&");
 char const* msg = "testing with char const*";
 using ::testing::HasSubstr;
 
 TEST(ThrowDelegateTest, InvalidArgument) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(ThrowInvalidArgument(msg), std::invalid_argument);
-  EXPECT_THROW(ThrowInvalidArgument(cmsg), std::invalid_argument);
+  EXPECT_THROW(ThrowInvalidArgument(kCmsg), std::invalid_argument);
 #else
   EXPECT_DEATH_IF_SUPPORTED(ThrowInvalidArgument(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(ThrowInvalidArgument(cmsg), cmsg);
+  EXPECT_DEATH_IF_SUPPORTED(ThrowInvalidArgument(kCmsg), kCmsg);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ThrowDelegateTest, RangeError) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(ThrowRangeError(msg), std::range_error);
-  EXPECT_THROW(ThrowRangeError(cmsg), std::range_error);
+  EXPECT_THROW(ThrowRangeError(kCmsg), std::range_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(ThrowRangeError(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(ThrowRangeError(cmsg), cmsg);
+  EXPECT_DEATH_IF_SUPPORTED(ThrowRangeError(kCmsg), kCmsg);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ThrowDelegateTest, RuntimeError) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(ThrowRuntimeError(msg), std::runtime_error);
-  EXPECT_THROW(ThrowRuntimeError(cmsg), std::runtime_error);
+  EXPECT_THROW(ThrowRuntimeError(kCmsg), std::runtime_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(ThrowRuntimeError(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(ThrowRuntimeError(cmsg), cmsg);
+  EXPECT_DEATH_IF_SUPPORTED(ThrowRuntimeError(kCmsg), kCmsg);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
@@ -68,25 +68,25 @@ TEST(ThrowDelegateTest, SystemError) {
       std::system_error);
 
   EXPECT_THROW(
-      try { ThrowSystemError(ec, cmsg); } catch (std::system_error const& ex) {
+      try { ThrowSystemError(ec, kCmsg); } catch (std::system_error const& ex) {
         EXPECT_EQ(ec, ex.code());
-        EXPECT_THAT(ex.what(), HasSubstr(cmsg));
+        EXPECT_THAT(ex.what(), HasSubstr(kCmsg));
         throw;
       },
       std::system_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(ThrowSystemError(ec, msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(ThrowSystemError(ec, cmsg), cmsg);
+  EXPECT_DEATH_IF_SUPPORTED(ThrowSystemError(ec, kCmsg), kCmsg);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 
 TEST(ThrowDelegateTest, LogicError) {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   EXPECT_THROW(ThrowLogicError(msg), std::logic_error);
-  EXPECT_THROW(ThrowLogicError(cmsg), std::logic_error);
+  EXPECT_THROW(ThrowLogicError(kCmsg), std::logic_error);
 #else
   EXPECT_DEATH_IF_SUPPORTED(ThrowLogicError(msg), msg);
-  EXPECT_DEATH_IF_SUPPORTED(ThrowLogicError(cmsg), cmsg);
+  EXPECT_DEATH_IF_SUPPORTED(ThrowLogicError(kCmsg), kCmsg);
 #endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 }
 

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -73,6 +73,7 @@ class MockLogBackend : public LogBackend {
 TEST(LogSinkTest, BackendAddRemove) {
   LogSink sink;
   EXPECT_TRUE(sink.empty());
+  // NOLINTNEXTLINE(google-runtime-int)
   long id = sink.AddBackend(std::make_shared<MockLogBackend>());
   EXPECT_FALSE(sink.empty());
   sink.RemoveBackend(id);
@@ -92,7 +93,7 @@ TEST(LogSinkTest, LogEnabled) {
   LogSink sink;
   auto backend = std::make_shared<MockLogBackend>();
   EXPECT_CALL(*backend, ProcessWithOwnership(_))
-      .WillOnce(Invoke([](LogRecord lr) {
+      .WillOnce(Invoke([](LogRecord const& lr) {
         EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
         EXPECT_EQ("test message", lr.message);
       }));
@@ -122,7 +123,7 @@ TEST(LogSinkTest, LogEnabledMultipleBackends) {
 TEST(LogSinkTest, LogDefaultInstance) {
   auto backend = std::make_shared<MockLogBackend>();
   EXPECT_CALL(*backend, ProcessWithOwnership(_))
-      .WillOnce(Invoke([](LogRecord lr) {
+      .WillOnce(Invoke([](LogRecord const& lr) {
         EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
         EXPECT_EQ("test message", lr.message);
       }));

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -78,11 +78,11 @@ TEST(OptionalTest, MoveCopy) {
   EXPECT_EQ("foo", copy->str());
   // The spec requires moved-from optionals to have a value, but the value
   // is whatever is left after moving out from the 'T' parameter:
-  EXPECT_TRUE(other.has_value());
+  EXPECT_TRUE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ("moved-out", other->str());
 }
 
-TEST(OptionalTest, MoveAssignment_NoValue_NoValue) {
+TEST(OptionalTest, MoveAssignmentNoValueNoValue) {
   OptionalObservable other;
   OptionalObservable assigned;
   EXPECT_FALSE(other.has_value());
@@ -90,7 +90,7 @@ TEST(OptionalTest, MoveAssignment_NoValue_NoValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_FALSE(other.has_value());
+  EXPECT_FALSE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.has_value());
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
@@ -99,7 +99,7 @@ TEST(OptionalTest, MoveAssignment_NoValue_NoValue) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, MoveAssignment_NoValue_Value) {
+TEST(OptionalTest, MoveAssignmentNoValueValue) {
   OptionalObservable other(Observable("foo"));
   OptionalObservable assigned;
   EXPECT_TRUE(other.has_value());
@@ -107,7 +107,7 @@ TEST(OptionalTest, MoveAssignment_NoValue_Value) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_TRUE(other.has_value());
+  EXPECT_TRUE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
@@ -118,7 +118,7 @@ TEST(OptionalTest, MoveAssignment_NoValue_Value) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, MoveAssignment_NoValue_T) {
+TEST(OptionalTest, MoveAssignmentNoValueT) {
   Observable other("foo");
   OptionalObservable assigned;
   EXPECT_FALSE(assigned.has_value());
@@ -127,7 +127,7 @@ TEST(OptionalTest, MoveAssignment_NoValue_T) {
   assigned = std::move(other);
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
-  EXPECT_EQ("moved-out", other.str());
+  EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
   EXPECT_EQ(0, Observable::copy_assignment);
@@ -135,7 +135,7 @@ TEST(OptionalTest, MoveAssignment_NoValue_T) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, MoveAssignment_Value_NoValue) {
+TEST(OptionalTest, MoveAssignmentValueNoValue) {
   OptionalObservable other;
   OptionalObservable assigned(Observable("bar"));
   EXPECT_FALSE(other.has_value());
@@ -143,7 +143,7 @@ TEST(OptionalTest, MoveAssignment_Value_NoValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_FALSE(other.has_value());
+  EXPECT_FALSE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.has_value());
   EXPECT_EQ(1, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
@@ -152,7 +152,7 @@ TEST(OptionalTest, MoveAssignment_Value_NoValue) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, MoveAssignment_Value_Value) {
+TEST(OptionalTest, MoveAssignmentValueValue) {
   OptionalObservable other(Observable("foo"));
   OptionalObservable assigned(Observable("bar"));
   EXPECT_TRUE(other.has_value());
@@ -160,7 +160,7 @@ TEST(OptionalTest, MoveAssignment_Value_Value) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_TRUE(other.has_value());
+  EXPECT_TRUE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(1, Observable::move_assignment);
@@ -171,7 +171,7 @@ TEST(OptionalTest, MoveAssignment_Value_Value) {
   EXPECT_EQ("moved-out", other->str());
 }
 
-TEST(OptionalTest, MoveAssignment_Value_T) {
+TEST(OptionalTest, MoveAssignmentValueT) {
   Observable other("foo");
   OptionalObservable assigned(Observable("bar"));
   EXPECT_TRUE(assigned.has_value());
@@ -185,10 +185,10 @@ TEST(OptionalTest, MoveAssignment_Value_T) {
   EXPECT_EQ(0, Observable::move_constructor);
   EXPECT_EQ(0, Observable::copy_constructor);
   EXPECT_EQ("foo", assigned->str());
-  EXPECT_EQ("moved-out", other.str());
+  EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
 }
 
-TEST(OptionalTest, CopyAssign_Lvalue) {
+TEST(OptionalTest, CopyAssignLvalue) {
   Observable::reset_counters();
   Observable original("foo");
   OptionalObservable other(original);
@@ -198,7 +198,7 @@ TEST(OptionalTest, CopyAssign_Lvalue) {
   EXPECT_EQ(1, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, CopyAssignment_NoValue_NoValue) {
+TEST(OptionalTest, CopyAssignmentNoValueNoValue) {
   OptionalObservable other;
   OptionalObservable assigned;
   EXPECT_FALSE(other.has_value());
@@ -215,7 +215,7 @@ TEST(OptionalTest, CopyAssignment_NoValue_NoValue) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, CopyAssignment_NoValue_Value) {
+TEST(OptionalTest, CopyAssignmentNoValueValue) {
   OptionalObservable other(Observable("foo"));
   OptionalObservable assigned;
   EXPECT_TRUE(other.has_value());
@@ -234,7 +234,7 @@ TEST(OptionalTest, CopyAssignment_NoValue_Value) {
   EXPECT_EQ(1, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, CopyAssignment_NoValue_T) {
+TEST(OptionalTest, CopyAssignmentNoValueT) {
   Observable other("foo");
   OptionalObservable assigned;
   EXPECT_FALSE(assigned.has_value());
@@ -251,7 +251,7 @@ TEST(OptionalTest, CopyAssignment_NoValue_T) {
   EXPECT_EQ(1, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, CopyAssignment_Value_NoValue) {
+TEST(OptionalTest, CopyAssignmentValueNoValue) {
   OptionalObservable other;
   OptionalObservable assigned(Observable("bar"));
   EXPECT_FALSE(other.has_value());
@@ -268,7 +268,7 @@ TEST(OptionalTest, CopyAssignment_Value_NoValue) {
   EXPECT_EQ(0, Observable::copy_constructor);
 }
 
-TEST(OptionalTest, CopyAssignment_Value_Value) {
+TEST(OptionalTest, CopyAssignmentValueValue) {
   OptionalObservable other(Observable("foo"));
   OptionalObservable assigned(Observable("bar"));
   EXPECT_TRUE(other.has_value());
@@ -287,7 +287,7 @@ TEST(OptionalTest, CopyAssignment_Value_Value) {
   EXPECT_EQ("foo", other->str());
 }
 
-TEST(OptionalTest, CopyAssignment_Value_T) {
+TEST(OptionalTest, CopyAssignmentValueT) {
   Observable other("foo");
   OptionalObservable assigned(Observable("bar"));
   EXPECT_TRUE(assigned.has_value());
@@ -313,7 +313,7 @@ TEST(OptionalTest, MoveValue) {
   EXPECT_EQ("foo", observed.str());
   // The optional should still have a value, but its value should have been
   // moved out.
-  EXPECT_TRUE(other.has_value());
+  EXPECT_TRUE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ("moved-out", other->str());
 }
 
@@ -325,7 +325,7 @@ TEST(OptionalTest, MoveValueOr) {
   EXPECT_EQ("foo", observed.str());
   // The optional should still have a value, but its value should have been
   // moved out.
-  EXPECT_TRUE(other.has_value());
+  EXPECT_TRUE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ("moved-out", other->str());
 }
 
@@ -344,6 +344,7 @@ struct ExplicitlyConvertible {
 };
 
 struct ImplicitlyConvertible {
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator std::string() const { return "implicit-conversion"; }
 };
 
@@ -389,6 +390,7 @@ TEST(OptionalTest, OptionalBoolCopy) {
   // This test previously broke on gcc 4.8 because optional's converting
   // constructor was being chosen instead of its copy constructor.
   optional<bool> opt_b(false);
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   optional<bool> copy(opt_b);
   EXPECT_EQ(copy, opt_b);
 }

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -217,12 +217,12 @@ TEST(StatusOrObservableTest, MoveCopy) {
   EXPECT_EQ(1, Observable::move_constructor);
   EXPECT_STATUS_OK(copy);
   EXPECT_EQ("foo", copy->str());
-  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ("moved-out", other->str());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, MoveAssignment_NoValue_NoValue) {
+TEST(StatusOrObservableTest, MoveAssignmentNoValueNoValue) {
   StatusOr<Observable> other;
   StatusOr<Observable> assigned;
   EXPECT_FALSE(other.ok());
@@ -230,7 +230,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_NoValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_FALSE(other.ok());
+  EXPECT_FALSE(other.ok());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.ok());
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
@@ -240,7 +240,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_NoValue) {
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, MoveAssignment_NoValue_Value) {
+TEST(StatusOrObservableTest, MoveAssignmentNoValueValue) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned;
   EXPECT_STATUS_OK(other);
@@ -248,7 +248,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_Value) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
@@ -260,7 +260,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_Value) {
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, MoveAssignment_NoValue_T) {
+TEST(StatusOrObservableTest, MoveAssignmentNoValueT) {
   Observable other("foo");
   StatusOr<Observable> assigned;
   EXPECT_FALSE(assigned.ok());
@@ -269,7 +269,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_T) {
   assigned = std::move(other);
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
-  EXPECT_EQ("moved-out", other.str());
+  EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
   EXPECT_EQ(0, Observable::copy_assignment);
@@ -278,7 +278,7 @@ TEST(StatusOrObservableTest, MoveAssignment_NoValue_T) {
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, MoveAssignment_Value_NoValue) {
+TEST(StatusOrObservableTest, MoveAssignmentValueNoValue) {
   StatusOr<Observable> other;
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_FALSE(other.ok());
@@ -286,7 +286,7 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_NoValue) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_FALSE(other.ok());
+  EXPECT_FALSE(other.ok());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.ok());
   EXPECT_EQ(1, Observable::destructor);
   EXPECT_EQ(0, Observable::move_assignment);
@@ -296,7 +296,7 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_NoValue) {
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, MoveAssignment_Value_Value) {
+TEST(StatusOrObservableTest, MoveAssignmentValueValue) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_STATUS_OK(other);
@@ -304,7 +304,7 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_Value) {
 
   Observable::reset_counters();
   assigned = std::move(other);
-  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ(0, Observable::destructor);
   EXPECT_EQ(1, Observable::move_assignment);
@@ -316,7 +316,7 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_Value) {
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, MoveAssignment_Value_T) {
+TEST(StatusOrObservableTest, MoveAssignmentValueT) {
   Observable other("foo");
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_STATUS_OK(assigned);
@@ -330,11 +330,11 @@ TEST(StatusOrObservableTest, MoveAssignment_Value_T) {
   EXPECT_EQ(0, Observable::move_constructor);
   EXPECT_EQ(0, Observable::copy_constructor);
   EXPECT_EQ("foo", assigned->str());
-  EXPECT_EQ("moved-out", other.str());
+  EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, CopyAssignment_NoValue_NoValue) {
+TEST(StatusOrObservableTest, CopyAssignmentNoValueNoValue) {
   StatusOr<Observable> other;
   StatusOr<Observable> assigned;
   EXPECT_FALSE(other.ok());
@@ -352,7 +352,7 @@ TEST(StatusOrObservableTest, CopyAssignment_NoValue_NoValue) {
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, CopyAssignment_NoValue_Value) {
+TEST(StatusOrObservableTest, CopyAssignmentNoValueValue) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned;
   EXPECT_STATUS_OK(other);
@@ -372,7 +372,7 @@ TEST(StatusOrObservableTest, CopyAssignment_NoValue_Value) {
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, CopyAssignment_NoValue_T) {
+TEST(StatusOrObservableTest, CopyAssignmentNoValueT) {
   Observable other("foo");
   StatusOr<Observable> assigned;
   EXPECT_FALSE(assigned.ok());
@@ -390,7 +390,7 @@ TEST(StatusOrObservableTest, CopyAssignment_NoValue_T) {
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, CopyAssignment_Value_NoValue) {
+TEST(StatusOrObservableTest, CopyAssignmentValueNoValue) {
   StatusOr<Observable> other;
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_FALSE(other.ok());
@@ -408,7 +408,7 @@ TEST(StatusOrObservableTest, CopyAssignment_Value_NoValue) {
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, CopyAssignment_Value_Value) {
+TEST(StatusOrObservableTest, CopyAssignmentValueValue) {
   StatusOr<Observable> other(Observable("foo"));
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_STATUS_OK(other);
@@ -428,7 +428,7 @@ TEST(StatusOrObservableTest, CopyAssignment_Value_Value) {
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
-TEST(StatusOrObservableTest, CopyAssignment_Value_T) {
+TEST(StatusOrObservableTest, CopyAssignmentValueT) {
   Observable other("foo");
   StatusOr<Observable> assigned(Observable("bar"));
   EXPECT_STATUS_OK(assigned);
@@ -452,7 +452,7 @@ TEST(StatusOrObservableTest, MoveValue) {
   Observable::reset_counters();
   auto observed = std::move(other).value();
   EXPECT_EQ("foo", observed.str());
-  EXPECT_STATUS_OK(other);
+  EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_EQ("moved-out", other->str());
 }
 

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -21,7 +21,6 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
-using ::testing::HasSubstr;
 
 TEST(Status, StatusCodeToString) {
   EXPECT_EQ("OK", StatusCodeToString(StatusCode::kOk));

--- a/google/cloud/terminate_handler_test.cc
+++ b/google/cloud/terminate_handler_test.cc
@@ -16,13 +16,16 @@
 #include <gtest/gtest.h>
 #include <iostream>
 
-using namespace google::cloud;
+using ::google::cloud::GetTerminateHandler;
+using ::google::cloud::SetTerminateHandler;
+using ::google::cloud::Terminate;
+using ::google::cloud::TerminateHandler;
 
 namespace {
-const std::string handler_msg = "Custom handler invoked. Extra description: ";
+const std::string kHandlerMsg = "Custom handler invoked. Extra description: ";
 
 void CustomHandler(const char* msg) {
-  std::cerr << handler_msg << msg << "\n";
+  std::cerr << kHandlerMsg << msg << "\n";
   abort();
 }
 
@@ -51,7 +54,7 @@ TEST(TerminateHandler, OldHandlerIsReturned) {
 
 TEST(TerminateHandler, TerminateTerminates) {
   SetTerminateHandler(&CustomHandler);
-  EXPECT_DEATH_IF_SUPPORTED(Terminate("details"), handler_msg + "details");
+  EXPECT_DEATH_IF_SUPPORTED(Terminate("details"), kHandlerMsg + "details");
 }
 
 TEST(TerminateHandler, NoAbortAborts) {


### PR DESCRIPTION
For `google_cloud_cpp_common_unit_tests` and `google_cloud_cpp_grpc_utils_unit_tests`.

Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4001)
<!-- Reviewable:end -->
