### PR TITLE
cleanup: enable clang-tidy for `firestore`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks: >
 WarningsAsErrors: "*"
 
 # TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/(bigquery|pubsub|spanner)/.*"
+HeaderFilterRegex: "google/cloud/(bigquery|firestore|pubsub|spanner)/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -85,6 +85,7 @@ if (BUILD_TESTING)
         target_link_libraries(
             ${target} PRIVATE firestore_client GTest::gmock_main GTest::gmock
                               GTest::gtest firestore_common_options)
+        google_cloud_cpp_add_clang_tidy(${target})
         if (MSVC)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()

--- a/google/cloud/firestore/field_path.h
+++ b/google/cloud/firestore/field_path.h
@@ -117,7 +117,7 @@ class FieldPath {
    * @param string A const string to write to.
    * @return The vector of string after splitting via delimiter
    */
-  static std::vector<std::string> Split(std::string const string);
+  static std::vector<std::string> Split(std::string string);
 
   /**
    * Replace all occurences of @p find in @p string with @p replace.


### PR DESCRIPTION
Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4002)
<!-- Reviewable:end -->
