### PR TITLE
feat: outputs timing for check-style blocks

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -26,11 +26,18 @@ fi
 readonly BINDIR="$(dirname "$0")"
 source "${BINDIR}/colors.sh"
 
-problems=""
-if ! find google/cloud -name '*.h' -print0 |
-  xargs -0 awk -f "${BINDIR}/check-include-guards.gawk"; then
-  problems="${problems} include-guards"
-fi
+# This controls the output format from bash's `time` command, which we use
+# below to time blocks of the script. A newline is automatically included.
+readonly TIMEFORMAT="... %R seconds"
+
+printf "%-30s" "Running check-include-guards:"
+time {
+  problems=""
+  if ! find google/cloud -name '*.h' -print0 |
+    xargs -0 awk -f "${BINDIR}/check-include-guards.gawk"; then
+    problems="${problems} include-guards"
+  fi
+}
 
 replace_original_if_changed() {
   if [[ $# != 2 ]]; then
@@ -50,66 +57,90 @@ replace_original_if_changed() {
 
 # Apply cmake_format to all the CMake list files.
 #     https://github.com/cheshirekow/cmake_format
-git ls-files -z | grep -zE '((^|/)CMakeLists\.txt|\.cmake)$' |
-  xargs -P "${NCPU}" -n 1 -0 cmake-format -i
+printf "%-30s" "Running cmake-format:"
+time {
+  git ls-files -z | grep -zE '((^|/)CMakeLists\.txt|\.cmake)$' |
+    xargs -P "${NCPU}" -n 1 -0 cmake-format -i
+}
 
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly
 # different formatting output (sigh).
-git ls-files -z | grep -zE '\.(cc|h)$' |
-  xargs -P "${NCPU}" -n 50 -0 clang-format -i
+printf "%-30s" "Running clang-format:"
+time {
+  git ls-files -z | grep -zE '\.(cc|h)$' |
+    xargs -P "${NCPU}" -n 50 -0 clang-format -i
+}
 
 # Apply buildifier to fix the BUILD and .bzl formatting rules.
 #    https://github.com/bazelbuild/buildtools/tree/master/buildifier
-git ls-files -z | grep -zE '\.(BUILD|bzl)$' | xargs -0 buildifier -mode=fix
-git ls-files -z | grep -zE '(^|/)(BUILD|WORKSPACE)$' |
-  xargs -0 buildifier -mode=fix
+printf "%-30s" "Running buildifier:"
+time {
+  git ls-files -z | grep -zE '\.(BUILD|bzl)$' | xargs -0 buildifier -mode=fix
+  git ls-files -z | grep -zE '(^|/)(BUILD|WORKSPACE)$' |
+    xargs -0 buildifier -mode=fix
+}
 
 # Apply psf/black to format Python files.
 #    https://pypi.org/project/black/
-git ls-files -z | grep -z '\.py$' | xargs -0 python3 -m black --quiet
+printf "%-30s" "Running black:"
+time {
+  git ls-files -z | grep -z '\.py$' | xargs -0 python3 -m black --quiet
+}
 
 # Apply shfmt to format all shell scripts
-git ls-files -z | grep -z '\.sh$' | xargs -0 shfmt -w -i 2
+printf "%-30s" "Running shfmt:"
+time {
+  git ls-files -z | grep -z '\.sh$' | xargs -0 shfmt -w -i 2
+}
 
 # Apply shellcheck(1) to emit warnings for common scripting mistakes.
-if ! git ls-files -z | grep -z '\.sh$' |
-  xargs -0 shellcheck \
-    --exclude=SC1090 \
-    --exclude=SC2034 \
-    --exclude=SC2153 \
-    --exclude=SC2181; then
-  problems="${problems} shellcheck"
-fi
+printf "%-30s" "Running shellcheck:"
+time {
+  if ! git ls-files -z | grep -z '\.sh$' |
+    xargs -0 shellcheck \
+      --exclude=SC1090 \
+      --exclude=SC2034 \
+      --exclude=SC2153 \
+      --exclude=SC2181; then
+    problems="${problems} shellcheck"
+  fi
+}
 
 # Apply several transformations that cannot be enforced by clang-format:
 #     - Replace any #include for grpc++/* with grpcpp/*. The paths with grpc++
 #       are obsoleted by the gRPC team, so we should not use them in our code.
 #     - Replace grpc::<BLAH> with grpc::StatusCode::<BLAH>, the aliases in the
 #       `grpc::` namespace do not exist inside google.
-git ls-files -z | grep -zE '\.(cc|h)$' |
-  while IFS= read -r -d $'\0' file; do
-    # We used to run run `sed -i` to apply these changes, but that touches the
-    # files even if there are no changes applied, forcing a rebuild each time.
-    # So we first apply the change to a temporary file, and replace the original
-    # only if something changed.
-    sed -e 's/grpc::\([A-Z][A-Z_][A-Z_]*\)/grpc::StatusCode::\1/g' \
-      -e 's;#include <grpc\\+\\+/grpc\+\+.h>;#include <grpcpp/grpcpp.h>;' \
-      -e 's;#include <grpc\\+\\+/;#include <grpcpp/;' \
-      "${file}" >"${file}.tmp"
-    replace_original_if_changed "${file}" "${file}.tmp"
-  done
+printf "%-30s" "Running include fixes:"
+time {
+  git ls-files -z | grep -zE '\.(cc|h)$' |
+    while IFS= read -r -d $'\0' file; do
+      # We used to run run `sed -i` to apply these changes, but that touches the
+      # files even if there are no changes applied, forcing a rebuild each time.
+      # So we first apply the change to a temporary file, and replace the original
+      # only if something changed.
+      sed -e 's/grpc::\([A-Z][A-Z_][A-Z_]*\)/grpc::StatusCode::\1/g' \
+        -e 's;#include <grpc\\+\\+/grpc\+\+.h>;#include <grpcpp/grpcpp.h>;' \
+        -e 's;#include <grpc\\+\\+/;#include <grpcpp/;' \
+        "${file}" >"${file}.tmp"
+      replace_original_if_changed "${file}" "${file}.tmp"
+    done
+}
 
 # Apply transformations to fix whitespace formatting in files not handled by
 # clang-format(1) above.  For now we simply remove trailing blanks.  Note that
 # we do not expand TABs (they currently only appear in Makefiles and Makefile
 # snippets).
-git ls-files -z | grep -zv '\.gz$' |
-  while IFS= read -r -d $'\0' file; do
-    sed -e 's/[[:blank:]][[:blank:]]*$//' \
-      "${file}" >"${file}.tmp"
-    replace_original_if_changed "${file}" "${file}.tmp"
-  done
+printf "%-30s" "Running whitespace fixes:"
+time {
+  git ls-files -z | grep -zv '\.gz$' |
+    while IFS= read -r -d $'\0' file; do
+      sed -e 's/[[:blank:]][[:blank:]]*$//' \
+        "${file}" >"${file}.tmp"
+      replace_original_if_changed "${file}" "${file}.tmp"
+    done
+}
 
 # Report any differences created by running the formatting tools.
 if ! git diff --ignore-submodules=all --color --exit-code .; then

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -30,9 +30,9 @@ source "${BINDIR}/colors.sh"
 # below to time blocks of the script. A newline is automatically included.
 readonly TIMEFORMAT="... %R seconds"
 
+problems=""
 printf "%-30s" "Running check-include-guards:"
 time {
-  problems=""
   if ! find google/cloud -name '*.h' -print0 |
     xargs -0 awk -f "${BINDIR}/check-include-guards.gawk"; then
     problems="${problems} include-guards"


### PR DESCRIPTION
The "Verifying formatting" step is sometimes slow-ish, and when we run
clang-tidy from the command line, it would be nice to see what it's
doing. This PR adds timing output to each section of the check-style
script so the user can see what it's doing, and we'll know if a section
all of a sudden gets slow and can be optimized. The output looks like:

```
2020-05-05T18:41:32Z: Verify formatting
Running check-include-guards: ... 0.045 seconds
Running cmake-format:         ... 3.607 seconds
Running clang-format:         ... 1.981 seconds
Running buildifier:           ... 0.041 seconds
Running black:                ... 0.148 seconds
Running shfmt:                ... 0.024 seconds
Running shellcheck:           ... 1.237 seconds
Running include fixes:        ... 1.876 seconds
Running whitespace fixes:     ... 2.632 seconds
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4011)
<!-- Reviewable:end -->
