### PR TITLE
feat: adds benchmark dep to bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,4 +2,6 @@ ci/
 cmake-out/
 cmake-build-debug/
 cmake-build-release/
-google/cloud/**/quickstart/
+google/cloud/bigtable/quickstart/
+google/cloud/spanner/quickstart/
+google/cloud/storage/quickstart/

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -48,6 +48,17 @@ def google_cloud_cpp_deps():
             sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
         )
 
+    # Load a version of benchmark that we know works.
+    if "com_google_benchmark" not in native.existing_rules():
+        http_archive(
+            name = "com_google_benchmark",
+            strip_prefix = "benchmark-1.5.0",
+            urls = [
+                "https://github.com/google/benchmark/archive/v1.5.0.tar.gz",
+            ],
+            sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",
+        )
+
     # Load the googleapis dependency.
     if "com_google_googleapis" not in native.existing_rules():
         http_archive(


### PR DESCRIPTION
Also fixes the patterns in the `.bazelignore` file, which does
not understand globs at all. Only file paths, so we need to explicitly
list all of our quickstart/ directories that need to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4012)
<!-- Reviewable:end -->
