### PR TITLE
ci: ignore errors on build cleanup

### DIFF
--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -122,7 +122,7 @@ if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
             -Exclude test.xml,sponge_log.xml,build.bat `
             -ErrorAction SilentlyContinue `
             -Path "${env:KOKORO_ARTIFACTS_DIR}" | `
-            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue    
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
     } catch {
         Write-Host "$(Get-Date -Format o) error cleaning up KOKORO_ARTIFACTS DIR, ignored"
     }

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -116,13 +116,18 @@ $BuildExitCode = $LastExitCode
 # Remove most things from the artifacts directory. Kokoro copies these files
 # *very* slowly on Windows, and then ignores most of them :shrug:
 if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
-    Set-Location "$env:KOKORO_ARTIFACTS_DIR"
-    Get-ChildItem -Recurse -File `
-        -Exclude test.xml,sponge_log.xml,build.bat `
-        -ErrorAction SilentlyContinue | `
-        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    try {
+        $ErrorActionPreference = "SilentlyContinue"
+        Get-ChildItem -Recurse -File `
+            -Exclude test.xml,sponge_log.xml,build.bat `
+            -ErrorAction SilentlyContinue `
+            -Path "${env:KOKORO_ARTIFACTS_DIR}" | `
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue    
+    } catch {
+        Write-Host "$(Get-Date -Format o) error cleaning up KOKORO_ARTIFACTS DIR, ignored"
+    }
 }
 
 if ($BuildExitCode) {
-    throw "Build failed with exit code $LastExitCode"
+    throw "Build failed with exit code ${BuildExitCode}"
 }


### PR DESCRIPTION
After the build runs we cleanup the ${env:KOKORO_ARTIFACTS_DIR}
directory (if present).  This is not supposed to break the build, but at
least once it did. With this change we put a try/catch to ignore all
errors for realsies.

Fixes #3803 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4017)
<!-- Reviewable:end -->
