### PR TITLE
fix: add top-level BUILD target for :spanner_client

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,13 @@ cc_library(
 )
 
 cc_library(
+    name = "spanner_client",
+    deps = [
+        "//google/cloud/spanner:spanner_client",
+    ],
+)
+
+cc_library(
     name = "storage_client",
     deps = [
         "//google/cloud/storage:storage_client",


### PR DESCRIPTION
This target is the one recommend users use, and it's the one we use in
our spanner/quickstart/.

Part of https://github.com/googleapis/google-cloud-cpp/issues/3703

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4048)
<!-- Reviewable:end -->
