### PR TITLE
chore: bigtable, storage quickstarts use top-level build targets

### DIFF
--- a/google/cloud/bigtable/quickstart/BUILD
+++ b/google/cloud/bigtable/quickstart/BUILD
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/bigtable:bigtable_client",
+        "@com_github_googleapis_google_cloud_cpp//:bigtable_client",
     ],
 )

--- a/google/cloud/storage/quickstart/BUILD
+++ b/google/cloud/storage/quickstart/BUILD
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/storage:storage_client",
+        "@com_github_googleapis_google_cloud_cpp//:storage_client",
     ],
 )


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/3703

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4050)
<!-- Reviewable:end -->
