### PR TITLE
fix: bigtable's random_mutation_test missing from build

### DIFF
--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -43,7 +43,7 @@ if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
     set(bigtable_benchmarks_unit_tests
         bigtable_benchmark_test.cc embedded_server_test.cc
-        format_duration_test.cc setup_test.cc)
+        format_duration_test.cc random_mutation_test.cc setup_test.cc)
     export_list_to_bazel("bigtable_benchmarks_unit_tests.bzl"
                          "bigtable_benchmarks_unit_tests" YEAR 2020)
 

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmarks_unit_tests.bzl
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmarks_unit_tests.bzl
@@ -20,5 +20,6 @@ bigtable_benchmarks_unit_tests = [
     "bigtable_benchmark_test.cc",
     "embedded_server_test.cc",
     "format_duration_test.cc",
+    "random_mutation_test.cc",
     "setup_test.cc",
 ]

--- a/google/cloud/bigtable/benchmarks/random_mutation_test.cc
+++ b/google/cloud/bigtable/benchmarks/random_mutation_test.cc
@@ -16,8 +16,11 @@
 #include "google/cloud/bigtable/benchmarks/constants.h"
 #include <gmock/gmock.h>
 
-using namespace bigtable::benchmarks;
-
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+namespace {
 TEST(BenchmarksRandomMutation, RandomValue) {
   auto g = google::cloud::internal::MakeDefaultPRNG();
   std::string val = MakeRandomValue(g);
@@ -36,3 +39,9 @@ TEST(BenchmarksRandomMutation, RandomMutation) {
   EXPECT_EQ(0, m.set_cell().timestamp_micros());
   EXPECT_EQ(static_cast<std::size_t>(kFieldSize), m.set_cell().value().size());
 }
+
+}  // namespace
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Fixes #4052 . Thanks to @devjgm for noticing this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4058)
<!-- Reviewable:end -->
