### PR TITLE
cleanup: refactor version() and version_string()

### DIFF
--- a/google/cloud/bigquery/version.cc
+++ b/google/cloud/bigquery/version.cc
@@ -18,15 +18,7 @@ namespace google {
 namespace cloud {
 namespace bigquery {
 inline namespace BIGQUERY_CLIENT_NS {
-std::string VersionString() {
-  static std::string const kVersion = []() {
-    std::ostringstream os;
-    os << "v" << VersionMajor() << "." << VersionMinor() << "."
-       << VersionPatch();
-    return os.str();
-  }();
-  return kVersion;
-}
+std::string VersionString() { return ::google::cloud::version_string(); }
 
 }  // namespace BIGQUERY_CLIENT_NS
 }  // namespace bigquery

--- a/google/cloud/bigquery/version.h
+++ b/google/cloud/bigquery/version.h
@@ -44,7 +44,13 @@ int constexpr VersionPatch() { return BIGQUERY_CLIENT_VERSION_PATCH; }
 // Returns a single integer representing the major, minor, and patch
 // version.
 int constexpr Version() {
-  return 100 * (100 * VersionMajor() + VersionMinor()) + VersionPatch();
+  static_assert(::google::cloud::version_major() == VersionMajor(),
+                "Mismatched major version");
+  static_assert(::google::cloud::version_minor() == VersionMinor(),
+                "Mismatched minor version");
+  static_assert(::google::cloud::version_patch() == VersionPatch(),
+                "Mismatched patch version");
+  return ::google::cloud::version();
 }
 
 // Returns the version as a string in the form `MAJOR.MINOR.PATCH`.

--- a/google/cloud/bigtable/version.cc
+++ b/google/cloud/bigtable/version.cc
@@ -20,20 +20,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
-// NOLINTNEXTLINE(readability-identifier-naming)
-std::string version_string() {
-  static std::string const kVersion = [] {
-    std::ostringstream os;
-    os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch();
-    auto metadata = google::cloud::internal::build_metadata();
-    if (!metadata.empty()) {
-      os << "+" << metadata;
-    }
-    return os.str();
-  }();
-  return kVersion;
-}
+std::string version_string() { return ::google::cloud::version_string(); }
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -65,7 +65,13 @@ int constexpr version_patch() { return BIGTABLE_CLIENT_VERSION_PATCH; }
 
 /// A single integer representing the Major/Minor/Patch version.
 int constexpr version() {
-  return 100 * (100 * version_major() + version_minor()) + version_patch();
+  static_assert(::google::cloud::version_major() == version_major(),
+                "Mismatched major version");
+  static_assert(::google::cloud::version_minor() == version_minor(),
+                "Mismatched minor version");
+  static_assert(::google::cloud::version_patch() == version_patch(),
+                "Mismatched patch version");
+  return ::google::cloud::version();
 }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.

--- a/google/cloud/pubsub/version.cc
+++ b/google/cloud/pubsub/version.cc
@@ -20,19 +20,7 @@ namespace google {
 namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
-std::string VersionString() {
-  static std::string const kVersion = [] {
-    std::ostringstream os;
-    os << "v" << VersionMajor() << "." << VersionMinor() << "."
-       << VersionPatch();
-    auto metadata = ::google::cloud::internal::build_metadata();
-    if (!metadata.empty()) {
-      os << "+" << metadata;
-    }
-    return os.str();
-  }();
-  return kVersion;
-}
+std::string VersionString() { return ::google::cloud::version_string(); }
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
 }  // namespace cloud

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -63,14 +63,15 @@ int constexpr VersionPatch() {
   return GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION_PATCH;
 }
 
-auto constexpr kMaxPatchVersions = 100;
-auto constexpr kMaxMinorVersions = 100;
-
 /// A single integer representing the Major/Minor/Patch version.
 int constexpr Version() {
-  return kMaxPatchVersions *
-             (kMaxMinorVersions * VersionMajor() + VersionMinor()) +
-         VersionPatch();
+  static_assert(::google::cloud::version_major() == VersionMajor(),
+                "Mismatched major version");
+  static_assert(::google::cloud::version_minor() == VersionMinor(),
+                "Mismatched minor version");
+  static_assert(::google::cloud::version_patch() == VersionPatch(),
+                "Mismatched patch version");
+  return ::google::cloud::version();
 }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.

--- a/google/cloud/spanner/version.cc
+++ b/google/cloud/spanner/version.cc
@@ -20,19 +20,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-std::string VersionString() {
-  static std::string const kVersion = [] {
-    std::ostringstream os;
-    os << "v" << VersionMajor() << "." << VersionMinor() << "."
-       << VersionPatch();
-    auto metadata = google::cloud::internal::build_metadata();
-    if (!metadata.empty()) {
-      os << "+" << metadata;
-    }
-    return os.str();
-  }();
-  return kVersion;
-}
+std::string VersionString() { return ::google::cloud::version_string(); }
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/version.h
+++ b/google/cloud/spanner/version.h
@@ -59,7 +59,13 @@ int constexpr VersionPatch() { return SPANNER_CLIENT_VERSION_PATCH; }
 
 /// A single integer representing the Major/Minor/Patch version.
 int constexpr Version() {
-  return 100 * (100 * VersionMajor() + VersionMinor()) + VersionPatch();
+  static_assert(::google::cloud::version_major() == VersionMajor(),
+                "Mismatched major version");
+  static_assert(::google::cloud::version_minor() == VersionMinor(),
+                "Mismatched minor version");
+  static_assert(::google::cloud::version_patch() == VersionPatch(),
+                "Mismatched patch version");
+  return ::google::cloud::version();
 }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.

--- a/google/cloud/storage/version.cc
+++ b/google/cloud/storage/version.cc
@@ -22,22 +22,8 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
-// NOLINTNEXTLINE(readability-identifier-naming)
-std::string version_string() {
-  static std::string const kVersion = [] {
-    std::ostringstream os;
-    os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch();
-    auto metadata = google::cloud::internal::build_metadata();
-    if (!metadata.empty()) {
-      os << "+" << metadata;
-    }
-    return os.str();
-  }();
-  return kVersion;
-}
+std::string version_string() { return ::google::cloud::version_string(); }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 std::string x_goog_api_client() {
   static std::string const kXGoogApiClient = [] {
     std::ostringstream os;

--- a/google/cloud/storage/version.h
+++ b/google/cloud/storage/version.h
@@ -65,7 +65,13 @@ int constexpr version_patch() { return STORAGE_CLIENT_VERSION_PATCH; }
 
 /// Returns a single integer representing the Major/Minor/Patch version.
 int constexpr version() {
-  return 100 * (100 * version_major() + version_minor()) + version_patch();
+  static_assert(::google::cloud::version_major() == version_major(),
+                "Mismatched major version");
+  static_assert(::google::cloud::version_minor() == version_minor(),
+                "Mismatched minor version");
+  static_assert(::google::cloud::version_patch() == version_patch(),
+                "Mismatched patch version");
+  return ::google::cloud::version();
 }
 
 /// Returns the version as a string, in MAJOR.MINOR.PATCH+gitrev format.

--- a/google/cloud/version.cc
+++ b/google/cloud/version.cc
@@ -19,7 +19,6 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-// NOLINTNEXTLINE(readability-identifier-naming)
 std::string version_string() {
   static std::string const kVersion = [] {
     std::ostringstream os;

--- a/google/cloud/version.h
+++ b/google/cloud/version.h
@@ -64,9 +64,20 @@ int constexpr version_minor() { return GOOGLE_CLOUD_CPP_VERSION_MINOR; }
  */
 int constexpr version_patch() { return GOOGLE_CLOUD_CPP_VERSION_PATCH; }
 
+namespace internal {
+auto constexpr kMaxMinorVersions = 100;
+auto constexpr kMaxPatchVersions = 100;
+}  // namespace internal
+
 /// A single integer representing the Major/Minor/Patch version.
 int constexpr version() {
-  return 100 * (100 * version_major() + version_minor()) + version_patch();
+  static_assert(version_minor() < internal::kMaxMinorVersions,
+                "version_minor() should be < kMaxMinorVersions");
+  static_assert(version_patch() < internal::kMaxPatchVersions,
+                "version_minor() should be < kMaxPatchVersions");
+  return internal::kMaxPatchVersions *
+             (internal::kMaxMinorVersions * version_major() + version_minor()) +
+         version_patch();
 }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.

--- a/google/cloud/version.h
+++ b/google/cloud/version.h
@@ -74,7 +74,7 @@ int constexpr version() {
   static_assert(version_minor() < internal::kMaxMinorVersions,
                 "version_minor() should be < kMaxMinorVersions");
   static_assert(version_patch() < internal::kMaxPatchVersions,
-                "version_minor() should be < kMaxPatchVersions");
+                "version_patch() should be < kMaxPatchVersions");
   return internal::kMaxPatchVersions *
              (internal::kMaxMinorVersions * version_major() + version_minor()) +
          version_patch();


### PR DESCRIPTION
We had multiple implementations of the version() and version_string()
functions, one on each library. This refactors the implementations to
use only the one from `google::cloud::`. I do not think we should remove
these functions, while rarely used they are part of the public API, and
we should avoid breaking changes when we can.

In the case of bigquery/ and pubsub/ we probably can remove the
functions, and I propose doing so in a followup PR.

Part of the work for #3712

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4062)
<!-- Reviewable:end -->
