### PR TITLE
ci: fix cache refresh for quickstart-bazel build

### DIFF
--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -176,7 +176,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
-if ($RUnningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
+if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).
@@ -198,7 +198,7 @@ if ($RUnningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     7z a "${download_dir}\${CACHE_BASENAME}.tar" "${bazel_root}" ${archive_flags}
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compressing cache tarball"
     Remove-Item "${download_dir}\${CACHE_BASENAME}.7z" -ErrorAction SilentlyContinue
-    7z a "${download_dir}\${CACHE_BAZENAME}.7z" "${download_dir}\${CACHE_BAZENAME}.7z" -bso0 -bsp0
+    7z a "${download_dir}\${CACHE_BASENAME}.7z" "${download_dir}\${CACHE_BASENAME}.tar" -bso0 -bsp0
     if ($LastExitCode) {
         # Just report these errors and continue, caching failures should
         # not break the build.


### PR DESCRIPTION
There were several mistakes in the build script preventing it from
uploading the cache on continuous builds. These go untected because
errors uploading and/or downloading the cache are intentionally
non-fatal.

Fixes #4061

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4064)
<!-- Reviewable:end -->
