### PR TITLE
ci: speed up clang-tidy builds

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -120,36 +120,26 @@ ${CMAKE_COMMAND} \
 echo
 log_yellow "Finished CMake config"
 
-log_green "DEBUG DEBUG DEBUG =============================================="
-ls -l "${BINARY_DIR}"
-log_green "DEBUG DEBUG DEBUG =============================================="
-echo
-echo "BRANCH = ${BRANCH}"
-echo
-log_green "DEBUG DEBUG DEBUG =============================================="
-echo
-echo "git diff"
-git diff --name-only "${BRANCH}"
-echo "git diff"
-git diff --name-only master
-log_green "DEBUG DEBUG DEBUG =============================================="
-echo
 if [[ "${CLANG_TIDY:-}" == "yes" ]]; then
   if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" || \
     "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GIT_ON_BORG" ]]; then
     # For presubmit builds we only run clang-tidy in the files that have changed
     # w.r.t. the target branch.
+    echo
+    log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
     git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" | grep -E '\.(cc|h)$' |
       xargs -d '\n' -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
   elif [[ "${KOKORO_JOB_TYPE:-}" == "CONTINUOUS_INTEGRATION" ]]; then
     # For continuous integration builds we run clang-tidy on all the files,
     # regardless of whether they have changed or not.
+    echo
+    log_yellow "Running clang-tidy on a continuous build, all files are tested."
     git ls-files -z | grep -zE '\.(cc|h)$' |
       xargs -0 -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
   fi
 fi
-log_green "DEBUG DEBUG DEBUG =============================================="
 
+echo
 echo "================================================================"
 log_yellow "started build"
 ${CMAKE_COMMAND} --build "${BINARY_DIR}" -- -j "${NCPU}"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -131,7 +131,7 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
     grep -E '\.(cc|h)$' |
-    xargs -d '\n' -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
+    xargs -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
 fi
 
 echo

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -73,7 +73,12 @@ if [[ "${BUILD_TESTING:-}" == "no" ]]; then
 fi
 
 if [[ "${CLANG_TIDY:-}" = "yes" ]]; then
-  cmake_extra_flags+=("-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes")
+  cmake_extra_flags+=("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
+  # Only on interactive builds we run clang-tidy as part of the build. On CI
+  # builds this is too slow, and we run clang-tidy separately (see below).
+  if [[ -z "${KOKORO_JOB_TYPE:-}" ]]; then
+    cmake_extra_flags+=("-DGOOGLE_CLOUD_CPP_CLANG_TIDY=ON")
+  fi
 fi
 
 if [[ "${GOOGLE_CLOUD_CPP_CXX_STANDARD:-}" != "" ]]; then
@@ -114,6 +119,36 @@ ${CMAKE_COMMAND} \
   "-B${BINARY_DIR}"
 echo
 log_yellow "Finished CMake config"
+
+log_green "DEBUG DEBUG DEBUG =============================================="
+ls -l "${BINARY_DIR}"
+log_green "DEBUG DEBUG DEBUG =============================================="
+echo
+echo "BRANCH = ${BRANCH}"
+echo
+log_green "DEBUG DEBUG DEBUG =============================================="
+echo
+echo "git diff"
+git diff --name-only "${BRANCH}"
+echo "git diff"
+git diff --name-only master
+log_green "DEBUG DEBUG DEBUG =============================================="
+echo
+if [[ "${CLANG_TIDY:-}" == "yes" ]]; then
+  if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" || \
+    "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GIT_ON_BORG" ]]; then
+    # For presubmit builds we only run clang-tidy in the files that have changed
+    # w.r.t. the target branch.
+    git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" | grep -E '\.(cc|h)$' |
+      xargs -d '\n' -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
+  elif [[ "${KOKORO_JOB_TYPE:-}" == "CONTINUOUS_INTEGRATION" ]]; then
+    # For continuous integration builds we run clang-tidy on all the files,
+    # regardless of whether they have changed or not.
+    git ls-files -z | grep -zE '\.(cc|h)$' |
+      xargs -0 -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
+  fi
+fi
+log_green "DEBUG DEBUG DEBUG =============================================="
 
 echo "================================================================"
 log_yellow "started build"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -74,9 +74,11 @@ fi
 
 if [[ "${CLANG_TIDY:-}" = "yes" ]]; then
   cmake_extra_flags+=("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
-  # Only on interactive builds we run clang-tidy as part of the build. On CI
-  # builds this is too slow, and we run clang-tidy separately (see below).
-  if [[ -z "${KOKORO_JOB_TYPE:-}" ]]; then
+  # On pre-submit builds we run clang-tidy on only the changed files (see below)
+  # in other cases (interactive builds, continuous builds) we run clang-tidy as
+  # part of the regular build.
+  if [[ "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB" && \
+    "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GIT_ON_BORG" ]]; then
     cmake_extra_flags+=("-DGOOGLE_CLOUD_CPP_CLANG_TIDY=ON")
   fi
 fi
@@ -120,23 +122,16 @@ ${CMAKE_COMMAND} \
 echo
 log_yellow "Finished CMake config"
 
-if [[ "${CLANG_TIDY:-}" == "yes" ]]; then
-  if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" || \
-    "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GIT_ON_BORG" ]]; then
-    # For presubmit builds we only run clang-tidy in the files that have changed
-    # w.r.t. the target branch.
-    echo
-    log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
-    git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" | grep -E '\.(cc|h)$' |
-      xargs -d '\n' -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
-  elif [[ "${KOKORO_JOB_TYPE:-}" == "CONTINUOUS_INTEGRATION" ]]; then
-    # For continuous integration builds we run clang-tidy on all the files,
-    # regardless of whether they have changed or not.
-    echo
-    log_yellow "Running clang-tidy on a continuous build, all files are tested."
-    git ls-files -z | grep -zE '\.(cc|h)$' |
-      xargs -0 -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
-  fi
+if [[ "${CLANG_TIDY:-}" == "yes" && (\
+  "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" || \
+  "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GIT_ON_BORG") ]]; then
+  # For presubmit builds we only run clang-tidy in the files that have changed
+  # w.r.t. the target branch.
+  echo
+  log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
+  git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
+    grep -E '\.(cc|h)$' |
+    xargs -d '\n' -r -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
 fi
 
 echo

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -342,8 +342,8 @@ BRANCH="$(git branch --all --no-color --contains "$(git rev-parse HEAD)" |
   grep -v 'HEAD' | tail -1 || exit 0)"
 # Enable extglob if not enabled
 shopt -q extglob || shopt -s extglob
-BRANCH="${BRANCH##*( )}"
-BRANCH="${BRANCH%%*( )}"
+BRANCH="${BRANCH##* }"
+BRANCH="${BRANCH%%* }"
 BRANCH="${BRANCH##remotes/origin/}"
 BRANCH="${BRANCH##remotes/upstream/}"
 export BRANCH
@@ -496,6 +496,14 @@ docker_flags=(
   # No need to preserve the container.
   "--rm"
 )
+
+if [[ -n "${KOKORO_JOB_TYPE:-}" ]]; then
+  docker_flags+=("--env" "KOKORO_JOB_TYPE=${KOKORO_JOB_TYPE:-}")
+fi
+
+if [[ -n "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-}" ]]; then
+  docker_flags+=("--env" "KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH=${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-}")
+fi
 
 # When running on Travis the build gets a tty, and docker can produce nicer
 # output in that case, but on Kokoro the script does not get a tty, and Docker

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -60,7 +60,7 @@ class ClientIntegrationTest : public spanner_testing::DatabaseIntegrationTest {
 
   static void TearDownTestSuite() {
     client_ = nullptr;
-    spanner_testing::DatabaseIntegrationTest::TearDownTestCase();
+    spanner_testing::DatabaseIntegrationTest::TearDownTestSuite();
   }
 
  protected:

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -80,7 +80,7 @@ class DataTypeIntegrationTest
 
   static void TearDownTestSuite() {
     client_ = nullptr;
-    spanner_testing::DatabaseIntegrationTest::TearDownTestCase();
+    spanner_testing::DatabaseIntegrationTest::TearDownTestSuite();
   }
 
  protected:

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -107,7 +107,7 @@ void InsertObject(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
-// TEST-DEBUG-coryan(performance-unnecessary-value-param)
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void InsertObjectStrictIdempotency(google::cloud::storage::Client,
                                    std::vector<std::string> const& argv) {
   //! [insert object strict idempotency]

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -107,7 +107,7 @@ void InsertObject(google::cloud::storage::Client client,
   (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
+// TEST-DEBUG-coryan(performance-unnecessary-value-param)
 void InsertObjectStrictIdempotency(google::cloud::storage::Client,
                                    std::vector<std::string> const& argv) {
   //! [insert object strict idempotency]


### PR DESCRIPTION
This change minimizes the time spent on clang-tidy for PR builds.

On interactive builds and continuous builds the `clang-tidy` build works
as before: CMake calls `clang-tidy` for whatever TU it rebuilds, and so
(for the most part) only changed files run `clang-tidy`. Changes in
headers, of course, trigger a lot more `clang-tidy` work, but that might
be necessary.

On PR builds only the files changed w.r.t. to the target branch run through
`clang-tidy`. In some cases that might cause more files that necessary to
be examined, e.g. if the PR was based on an older version of `master`.
And in some it will cause fewer files, notably with header changes that
could affect the `clang-tidy` results.

The build times are about 8m with a warm cache.

Fixes #4057 

Here is an example of a PR build detecting an error:

https://source.cloud.google.com/results/invocations/0442c761-38e3-409c-9cfb-fb77e52bebe8/targets



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4068)
<!-- Reviewable:end -->
