### PR TITLE
ci: use emulator for the spanner integration tests

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu-install
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-install
@@ -16,6 +16,7 @@ ARG DISTRO_VERSION=18.04
 FROM ubuntu:${DISTRO_VERSION}
 ARG NCPU=4
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y \
         abi-compliance-checker \
@@ -43,6 +44,7 @@ RUN apt-get update && \
         python3 \
         python3-pip \
         tar \
+        tzdata \
         unzip \
         wget \
         zlib1g-dev \

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -201,7 +201,7 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
       "${BINARY_DIR}" "${ctest_args[@]}"
 
     echo
-    io::log_yellow "running storage integration tests via CTest+Emulator"
+    io::log_yellow "running spanner integration tests via CTest+Emulator"
     echo
     "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
       "${BINARY_DIR}" "${ctest_args[@]}"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -193,10 +193,17 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
       exit 1
     fi
     set -e
+
     echo
-    io::log_yellow "running storage integration tests via CTest [${attempt}]"
+    io::log_yellow "running storage integration tests via CTest+Emulator"
     echo
     "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+      "${BINARY_DIR}" "${ctest_args[@]}"
+
+    echo
+    io::log_yellow "running storage integration tests via CTest+Emulator"
+    echo
+    "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
       "${BINARY_DIR}" "${ctest_args[@]}"
   fi
 

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -446,6 +446,9 @@ docker_flags=(
   "--env" "CBT=/usr/local/google-cloud-sdk/bin/cbt"
   "--env" "CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator"
 
+  # Configure the location of the Cloud SDK.
+  "--env" "CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk"
+
   # Let the Docker image script know what kind of terminal we are using, that
   # produces properly colorized error messages.
   "--env" "TERM=${TERM:-dumb}"

--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -89,16 +89,13 @@ function (spanner_client_define_benchmarks)
         # To automatically smoke-test the benchmarks as part of the CI build we
         # label them as tests.
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-tests;spanner-integration-tests;integration-tests-no-emulator"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;spanner-integration-tests")
     endforeach ()
 endfunction ()
 
 # Only define the benchmarks if testing is enabled. Package maintainers may not
-# want to build all the benchmarks everytime they create a new package or when
+# want to build all the benchmarks every time they create a new package or when
 # the package is installed from source.
 if (BUILD_TESTING)
     spanner_client_define_benchmarks()

--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -55,9 +55,17 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
 
   config.project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  config.instance_id = google::cloud::internal::GetEnv(
-                           "GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID")
-                           .value_or("");
+  auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
+  if (!emulator.has_value()) {
+    // When using the emulator it is easier to create an instance each time, and
+    // PickRandomInstance() will do that for us. While we do not want to
+    // benchmark the emulator, we do want to smoke test the benchmarks
+    // themselves, and running them against the emulator is the faster way to do
+    // so.
+    config.instance_id = google::cloud::internal::GetEnv(
+                             "GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID")
+                             .value_or("");
+  }
 
   struct Flag {
     std::string flag_name;

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -183,14 +183,6 @@ int main(int argc, char* argv[]) {
       std::cout << "# Re-using existing database\n";
       database_created = false;
     } else {
-      auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
-      if (emulator.has_value() &&
-          db.status().code() == google::cloud::StatusCode::kNotFound) {
-        // The emulator probably doesn't have the instance, and we don't care
-        // to create it as benchmarking the emulator is a non-goal. So, just
-        // succeed quietly.
-        return 0;
-      }
       std::cerr << "Error creating database: " << db.status() << "\n";
       return 1;
     }

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -120,14 +120,6 @@ int main(int argc, char* argv[]) {
       std::cout << "# Re-using existing database\n";
       database_created = false;
     } else {
-      auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
-      if (emulator.has_value() &&
-          db.status().code() == google::cloud::StatusCode::kNotFound) {
-        // The emulator probably doesn't have the instance, and we don't care
-        // to create it as benchmarking the emulator is a non-goal. So, just
-        // succeed quietly.
-        return 0;
-      }
       std::cerr << "Error creating database: " << db.status() << "\n";
       return 1;
     }

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -112,6 +112,7 @@ function start_emulator() {
 # production. Easier to maintain just one copy.
 source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
+export RUN_SLOW_INTEGRATION_TESTS="instance"
 
 cd "${BINARY_DIR}"
 start_emulator

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"
+  exit 1
+fi
+
+BINARY_DIR="$(
+  cd "${1}"
+  pwd
+)"
+readonly BINARY_DIR
+shift
+ctest_args=("$@")
+
+CMDDIR="$(dirname "$0")"
+readonly CMDDIR
+PROJECT_ROOT="$(
+  cd "${CMDDIR}/../../../.."
+  pwd
+)"
+readonly PROJECT_ROOT
+
+SPANNER_EMULATOR_PID=0
+if [[ -z "${CLOUD_SDK_LOCATION:-}" ]]; then
+  echo 1>&2 "You must set CLOUD_SDK_LOCATION to find the emulator"
+  exit 1
+fi
+
+# We cannot use `gcloud beta emulators spanner start` because there is no way
+# to kill the emulator at the end using that command.
+readonly SPANNER_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/cloud_spanner_emulator/emulator_main"
+if [[ ! -x "${SPANNER_EMULATOR_CMD}" ]]; then
+  echo 1>&2 "The spanner emulator does not seem to be installed, aborting"
+  exit 1
+fi
+
+function kill_emulator() {
+  echo -n "Killing Spanner Emulator [${SPANNER_EMULATOR_PID}] "
+  kill "${SPANNER_EMULATOR_PID}" || echo -n "-"
+  wait "${SPANNER_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
+  echo -n "."
+  echo " done."
+}
+
+################################################
+# Wait until the port number is printed in the log file for one of the
+# emulators
+# Globals:
+#   None
+# Arguments:
+#   logfile: the name of the logfile to wait on.
+# Returns:
+#   None
+################################################
+wait_for_port() {
+  local -r logfile="$1"
+  shift
+
+  local emulator_port="0"
+  local -r expected=' : Server address: '
+  for attempt in $(seq 1 8); do
+    if grep -q "${expected}" "${logfile}"; then
+      # The port number is whatever is after the last ':'. Note that on IPv6
+      # there may be multiple ':' characters, and recall that regular
+      # expressions are greedy. If grep has multiple matches this breaks,
+      # which is Okay because then the emulator is exhibiting unexpected
+      # behavior.
+      emulator_port=$(grep "${expected}" "${logfile}" | sed 's/^.*://')
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "${emulator_port}" = "0" ]]; then
+    echo "Cannot determine Cloud Spanner emulator port." >&2
+    kill_emulator
+    exit 1
+  fi
+
+  echo "${emulator_port}"
+}
+
+function start_emulator() {
+  echo "Launching Cloud Spanner emulator in the background"
+  trap kill_emulator EXIT
+
+  # The tests typically run in a Docker container, where the ports are largely
+  # free; when using in manual tests, you can set EMULATOR_PORT.
+  "${SPANNER_EMULATOR_CMD}" --host_port localhost:0 >emulator.log 2>&1 </dev/null &
+  SPANNER_EMULATOR_PID=$!
+  local -r emulator_port="$(wait_for_port emulator.log)"
+  export SPANNER_EMULATOR_HOST="localhost:${emulator_port}"
+}
+
+# Use the same configuration parameters as we use for testing against
+# production. Easier to maintain just one copy.
+source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
+export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
+
+cd "${BINARY_DIR}"
+start_emulator
+
+ctest -L "spanner-integration-tests" "${ctest_args[@]}"
+exit_status=$?
+
+kill_emulator
+trap '' EXIT
+
+exit "${exit_status}"

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -109,7 +109,7 @@ function start_emulator() {
 
 # Use the same configuration parameters as we use for testing against
 # production. Easier to maintain just one copy.
-source "${PROJECT_ROOT}/ci/etc/integration-tests-config.sh"
+source module "etc/integration-tests-config.sh"
 export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export RUN_SLOW_INTEGRATION_TESTS="instance"
 

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -59,11 +59,8 @@ function (spanner_client_define_integration_tests)
         endif ()
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-tests;spanner-integration-tests;integration-tests-no-emulator"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;spanner-integration-tests")
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
 

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -591,6 +591,7 @@ TEST_F(ClientIntegrationTest, PartitionRead) {
   auto read_partitions =
       client_->PartitionRead(ro_transaction, "Singers", KeySet::All(),
                              {"SingerId", "FirstName", "LastName"});
+  if (EmulatorUnimplemented(read_partitions.status())) GTEST_SKIP();
   ASSERT_STATUS_OK(read_partitions);
 
   std::vector<std::string> serialized_partitions;

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 std::int64_t flag_table_size = 10 * 1000 * 1000;
 std::int64_t flag_maximum_read_size = 10 * 1000;
-std::chrono::seconds flag_duration(30);
+std::chrono::seconds flag_duration(5);
 int flag_threads = 0;  // 0 means use the threads_per_core setting.
 int flag_threads_per_core = 4;
 

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -44,11 +44,8 @@ function (spanner_client_define_samples)
     foreach (fname ${spanner_client_integration_samples})
         google_cloud_cpp_set_target_name(target "spanner" "${fname}")
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-tests;spanner-integration-tests;integration-tests-no-emulator"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;spanner-integration-tests")
     endforeach ()
 endfunction ()
 


### PR DESCRIPTION
For CMake builds we use the emulator to run the spanner integration
tests. The main motivation is the `coverage` test, which needs to
serialize the tests and runs very slowly against production. Other
builds run fine against the emulator or against production, but testing
locally is usually faster.

The drop in code coverage (0.22%) can be fixed with via #4080, but I think
we should leave that to a future PR.


Fixes #4023

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4077)
<!-- Reviewable:end -->
