### PR TITLE
ci: fix clang-tidy PR builds for storage/*

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -129,6 +129,7 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   # w.r.t. the target branch.
   echo
   log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
+  ${CMAKE_COMMAND} --build "${BINARY_DIR}" --target nlohmann_json_project
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
     grep -E '\.(cc|h)$' |
     xargs -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"


### PR DESCRIPTION
When compiling PR builds we run `clang-tidy` before compiling the code,
this skips the step to download and patch the lohmann json header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4078)
<!-- Reviewable:end -->
