### PR TITLE
cleanup: fixing misleading duration names usage

### DIFF
--- a/google/cloud/internal/parse_rfc3339.cc
+++ b/google/cloud/internal/parse_rfc3339.cc
@@ -38,9 +38,9 @@ bool IsLeapYear(int year) {
 auto constexpr kMonthsInYear = 12;
 auto constexpr kHoursInDay = 24;
 auto constexpr kMinutesInHour =
-    std::chrono::seconds(std::chrono::minutes(1)).count();
-auto constexpr kSecondsInMinute =
     std::chrono::minutes(std::chrono::hours(1)).count();
+auto constexpr kSecondsInMinute =
+    std::chrono::seconds(std::chrono::minutes(1)).count();
 
 std::chrono::system_clock::time_point ParseDateTime(
     char const*& buffer, std::string const& timestamp) {


### PR DESCRIPTION
Hello.
Nothing special, just found incorrect (but working fine since both are 60) duration usage in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4079)
<!-- Reviewable:end -->
