### PR TITLE
cleanup: enable clang-tidy for `bigtable/tests`

### DIFF
--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ foreach (fname ${bigtable_client_integration_tests})
     set_tests_properties(
         ${target} PROPERTIES LABELS
                              "integration-tests;bigtable-integration-tests")
+    google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()
 
 add_executable(instance_admin_emulator instance_admin_emulator.cc)
@@ -65,6 +66,7 @@ target_link_libraries(
             gRPC::grpc
             protobuf::libprotobuf
             bigtable_common_options)
+google_cloud_cpp_add_clang_tidy(instance_admin_emulator)
 
 # We just know that these tests need to be run against production.
 set(bigtable_integration_tests_production # cmake-format: sort

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -26,7 +26,6 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 namespace btadmin = google::bigtable::admin::v2;
 namespace bigtable = google::cloud::bigtable;
-using namespace google::cloud::testing_util::chrono_literals;
 
 class AdminAsyncFutureIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
@@ -34,7 +33,7 @@ class AdminAsyncFutureIntegrationTest
   std::shared_ptr<AdminClient> admin_client_;
   std::unique_ptr<TableAdmin> table_admin_;
 
-  void SetUp() {
+  void SetUp() override {
     if (google::cloud::internal::GetEnv(
             "ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
             .value_or("") != "yes") {
@@ -47,8 +46,6 @@ class AdminAsyncFutureIntegrationTest
     table_admin_ = google::cloud::internal::make_unique<TableAdmin>(
         admin_client_, bigtable::testing::TableTestEnvironment::instance_id());
   }
-
-  void TearDown() {}
 
   int CountMatchingTables(std::string const& table_id,
                           std::vector<btadmin::Table> const& tables) {
@@ -251,8 +248,6 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncDropAllRowsTest) {
 /// @test Verify that `bigtable::TableAdmin` AsyncCheckConsistency works as
 /// expected.
 TEST_F(AdminAsyncFutureIntegrationTest, AsyncCheckConsistencyIntegrationTest) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   std::string id = bigtable::testing::TableTestEnvironment::RandomInstanceId();
   std::string const table_id = RandomTableId();
 

--- a/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
@@ -26,7 +26,6 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 namespace btadmin = google::bigtable::admin::v2;
 namespace bigtable = google::cloud::bigtable;
-using namespace google::cloud::testing_util::chrono_literals;
 
 class AdminIAMPolicyIntegrationTest
     : public bigtable::testing::TableIntegrationTest {
@@ -35,7 +34,7 @@ class AdminIAMPolicyIntegrationTest
   std::unique_ptr<TableAdmin> table_admin_;
   std::string service_account_;
 
-  void SetUp() {
+  void SetUp() override {
     service_account_ = google::cloud::internal::GetEnv(
                            "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT")
                            .value_or("");
@@ -47,8 +46,6 @@ class AdminIAMPolicyIntegrationTest
     table_admin_ = google::cloud::internal::make_unique<TableAdmin>(
         admin_client_, bigtable::testing::TableTestEnvironment::instance_id());
   }
-
-  void TearDown() {}
 
   int CountMatchingTables(std::string const& table_id,
                           std::vector<btadmin::Table> const& tables) {
@@ -63,8 +60,6 @@ class AdminIAMPolicyIntegrationTest
 };
 
 TEST_F(AdminIAMPolicyIntegrationTest, AsyncSetGetTestIamAPIsTest) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   std::string const table_id = RandomTableId();
 
   auto iam_policy = bigtable::IamPolicy({bigtable::IamBinding(

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -31,7 +31,7 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
  protected:
   std::unique_ptr<bigtable::TableAdmin> table_admin_;
 
-  void SetUp() {
+  void SetUp() override {
     if (google::cloud::internal::GetEnv(
             "ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS")
             .value_or("") != "yes") {
@@ -46,8 +46,6 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
     table_admin_ = google::cloud::internal::make_unique<bigtable::TableAdmin>(
         admin_client, bigtable::testing::TableTestEnvironment::instance_id());
   }
-
-  void TearDown() {}
 
   int CountMatchingTables(std::string const& table_id,
                           std::vector<btadmin::Table> const& tables) {
@@ -71,8 +69,8 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(previous_table_list);
 
-  int const TABLE_COUNT = 5;
-  for (int index = 0; index < TABLE_COUNT; ++index) {
+  int constexpr kTableCount = 5;
+  for (int index = 0; index < kTableCount; ++index) {
     std::string table_id = RandomTableId();
     auto previous_count = CountMatchingTables(table_id, *previous_table_list);
     ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
@@ -231,8 +229,6 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTable) {
 /// @test Verify that `bigtable::TableAdmin` WaitForConsistencyCheck works as
 /// expected.
 TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
-  using namespace google::cloud::testing_util::chrono_literals;
-
   // WaitForConsistencyCheck() only makes sense on a replicated table, we need
   // to create an instance with at least 2 clusters to test it.
   auto project_id = bigtable::testing::TableTestEnvironment::project_id();

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -277,7 +277,6 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
       cq,
       [&actual](Row const& row) {
         auto const& cells = row.cells();
-        actual.reserve(actual.size() + cells.size());
         actual.insert(actual.end(), cells.begin(), cells.end());
         return make_ready_future(true);
       },

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -21,20 +21,17 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
-class DataAsyncFutureIntegrationTest
-    : public bigtable::testing::TableIntegrationTest {
- protected:
-  std::string const family = "family1";
-};
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using DataAsyncFutureIntegrationTest = bigtable::testing::TableIntegrationTest;
 
-using namespace google::cloud::testing_util::chrono_literals;
+std::string const kFamily = "family1";
 
 TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   auto table = GetTable();
 
   std::string const row_key = "key-000010";
-  std::vector<bigtable::Cell> created{{row_key, family, "cc1", 1000, "v1000"},
-                                      {row_key, family, "cc2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> created{{row_key, kFamily, "cc1", 1000, "v1000"},
+                                      {row_key, kFamily, "cc2", 2000, "v2000"}};
   SingleRowMutation mut(row_key);
   for (auto const& c : created) {
     mut.emplace_back(SetCell(
@@ -56,8 +53,9 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   EXPECT_TRUE(status.ok());
 
   // Validate that the newly created cells are actually in the server.
-  std::vector<bigtable::Cell> expected{{row_key, family, "cc1", 1000, "v1000"},
-                                       {row_key, family, "cc2", 2000, "v2000"}};
+  std::vector<bigtable::Cell> expected{
+      {row_key, kFamily, "cc1", 1000, "v1000"},
+      {row_key, kFamily, "cc2", 2000, "v2000"}};
 
   auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
 
@@ -74,11 +72,11 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncBulkApply) {
   std::string const row_key2 = "key-000020";
   std::map<std::string, std::vector<bigtable::Cell>> created{
       {row_key1,
-       {{row_key1, family, "cc1", 1000, "vv10"},
-        {row_key1, family, "cc2", 2000, "vv20"}}},
+       {{row_key1, kFamily, "cc1", 1000, "vv10"},
+        {row_key1, kFamily, "cc2", 2000, "vv20"}}},
       {row_key2,
-       {{row_key2, family, "cc1", 3000, "vv30"},
-        {row_key2, family, "cc2", 4000, "vv40"}}}};
+       {{row_key2, kFamily, "cc1", 3000, "vv30"},
+        {row_key2, kFamily, "cc2", 4000, "vv40"}}}};
 
   BulkMutation mut;
   for (auto const& row_cells : created) {
@@ -126,7 +124,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
 
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
+  std::vector<bigtable::Cell> created{{key, kFamily, "c1", 0, "v1000"}};
   CreateCells(table, created);
 
   CompletionQueue cq;
@@ -134,8 +132,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
 
   auto fut = table.AsyncCheckAndMutateRow(
       key, bigtable::Filter::ValueRegex("v1000"),
-      {bigtable::SetCell(family, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(family, "c3", 0_ms, "v3000")}, cq);
+      {bigtable::SetCell(kFamily, "c2", 0_ms, "v2000")},
+      {bigtable::SetCell(kFamily, "c3", 0_ms, "v3000")}, cq);
 
   // Block until the asynchronous operation completes. This is not what one
   // would do in a real application (the synchronous API is better in that
@@ -144,8 +142,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
   EXPECT_STATUS_OK(status);
   EXPECT_TRUE(status.ok());
 
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
-                                       {key, family, "c2", 0, "v2000"}};
+  std::vector<bigtable::Cell> expected{{key, kFamily, "c1", 0, "v1000"},
+                                       {key, kFamily, "c2", 0, "v2000"}};
 
   auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
 
@@ -160,7 +158,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
 
   std::string const key = "row-key";
 
-  std::vector<bigtable::Cell> created{{key, family, "c1", 0, "v1000"}};
+  std::vector<bigtable::Cell> created{{key, kFamily, "c1", 0, "v1000"}};
   CreateCells(table, created);
 
   CompletionQueue cq;
@@ -168,8 +166,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
 
   auto fut = table.AsyncCheckAndMutateRow(
       key, bigtable::Filter::ValueRegex("not-there"),
-      {bigtable::SetCell(family, "c2", 0_ms, "v2000")},
-      {bigtable::SetCell(family, "c3", 0_ms, "v3000")}, cq);
+      {bigtable::SetCell(kFamily, "c2", 0_ms, "v2000")},
+      {bigtable::SetCell(kFamily, "c3", 0_ms, "v3000")}, cq);
 
   // Block until the asynchronous operation completes. This is not what one
   // would do in a real application (the synchronous API is better in that
@@ -178,8 +176,8 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
   EXPECT_STATUS_OK(status);
   EXPECT_TRUE(status.ok());
 
-  std::vector<bigtable::Cell> expected{{key, family, "c1", 0, "v1000"},
-                                       {key, family, "c3", 0, "v3000"}};
+  std::vector<bigtable::Cell> expected{{key, kFamily, "c1", 0, "v1000"},
+                                       {key, kFamily, "c3", 0, "v3000"}};
 
   auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
 
@@ -277,12 +275,13 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowsAllRows) {
   promise<Status> stream_status_promise;
   table.AsyncReadRows(
       cq,
-      [&actual](Row row) {
-        std::move(row.cells().begin(), row.cells().end(),
-                  std::back_inserter(actual));
+      [&actual](Row const& row) {
+        auto const& cells = row.cells();
+        actual.reserve(actual.size() + cells.size());
+        actual.insert(actual.end(), cells.begin(), cells.end());
         return make_ready_future(true);
       },
-      [&stream_status_promise](Status stream_status) {
+      [&stream_status_promise](Status const& stream_status) {
         stream_status_promise.set_value(stream_status);
       },
       bigtable::RowSet(bigtable::RowRange::InfiniteRange()),

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -262,9 +262,8 @@ class InstanceAdminEmulator final
       if (std::string::npos == cluster.first.find(project_path)) {
         continue;
       }
-      if (return_all_clusters) {
-        *response->add_clusters() = cluster.second;
-      } else if (std::string::npos != cluster.first.find(prefix)) {
+      if (return_all_clusters ||
+          std::string::npos != cluster.first.find(prefix)) {
         *response->add_clusters() = cluster.second;
       }
     }
@@ -483,15 +482,13 @@ class InstanceAdminEmulator final
   std::map<std::string, google::longrunning::Operation> pending_operations_;
   std::map<std::string, btadmin::AppProfile> app_profiles_;
   std::map<std::string, google::iam::v1::Policy> policies_;
-  long counter_ = 0;
+  std::uint64_t counter_ = 0;
 };
 
 class LongRunningEmulator final
     : public google::longrunning::Operations::Service {
  public:
-  explicit LongRunningEmulator() {}
-
-  virtual grpc::Status ListOperations(
+  grpc::Status ListOperations(
       grpc::ServerContext*, google::longrunning::ListOperationsRequest const*,
       google::longrunning::ListOperationsResponse*) override {
     return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "not implemented");
@@ -519,7 +516,7 @@ class LongRunningEmulator final
 /// The implementation of EmbeddedServer.
 class DefaultEmbeddedServer {
  public:
-  explicit DefaultEmbeddedServer(std::string server_address) {
+  explicit DefaultEmbeddedServer(std::string const& server_address) {
     int port;
     builder_.AddListeningPort(server_address, grpc::InsecureServerCredentials(),
                               &port);

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -286,7 +286,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
   std::string instance_id =
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
-  std::string cluster_id_str = instance_id + "-cl2";
+  std::string const cluster_id = instance_id + "-cl2";
 
   // create instance prerequisites for cluster operations
   auto instance_config = IntegrationTestConfig(
@@ -298,11 +298,10 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
   // create cluster
   auto clusters_before = instance_admin_->ListClusters(instance_id);
   ASSERT_STATUS_OK(clusters_before);
-  ASSERT_FALSE(IsClusterPresent(clusters_before->clusters, cluster_id_str))
-      << "Cluster (" << cluster_id_str << ") already exists."
+  ASSERT_FALSE(IsClusterPresent(clusters_before->clusters, cluster_id))
+      << "Cluster (" << cluster_id << ") already exists."
       << " This is unexpected, as the cluster ids are"
       << " generated at random.";
-  std::string cluster_id(cluster_id_str);
   auto cluster_config =
       bigtable::ClusterConfig(zone_b_, 3, bigtable::ClusterConfig::HDD);
   auto cluster =


### PR DESCRIPTION
part of #3958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4089)
<!-- Reviewable:end -->
