### PR TITLE
feat: enable angle-bracket includes of Abseil headers

### DIFF
--- a/bazel/abseil.BUILD
+++ b/bazel/abseil.BUILD
@@ -22,7 +22,7 @@ licenses(["notice"])  # Apache 2.0
 # us to dial-up the warnings in our own code, without seeing compiler warnings
 # from their headers, which we do not own.
 cc_library(
-    name = "googleapis_system_includes",
+    name = "absl_system_includes",
     includes = [
         ".",
     ],

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -46,6 +46,7 @@ def google_cloud_cpp_deps():
                 "https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz",
             ],
             sha256 = "f41868f7a938605c92936230081175d1eae87f6ea2c248f41077c8f88316f111",
+            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:abseil.BUILD",
         )
 
     # Load a version of googletest that we know works.

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -76,6 +76,7 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
+        "@com_google_absl//:absl_system_includes",
         "@com_google_absl//absl/memory",
         "@com_google_googletest//:gtest_main",
     ],

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "absl/memory/memory.h"
+#include <absl/memory/memory.h>
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <chrono>


### PR DESCRIPTION
This creates an overlay BUILD file for the Abseil repo, which gives us a
target that will find Abseil's headers when included with
angle-brackets.

What are the downsides to doing this? I'm not 100% certain, but I think
one downside is that our bazel-using customers will also need to provide
this overlay BUILD target for Abseil. This is partly related to the way
bazel requires all users to list/fetch the dependencies of their
dependencies. However, we've already decided that it's OK to do this for
our googleapis.BUILD file, which would also force a requirement on our
bazel customers.

If we're OK doing it for one, why not both? Or maybe we should drop this
target from both and use double-quote includes?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4091)
<!-- Reviewable:end -->
