### PR TITLE
cleanup: enable /WX (aka -Werror) with MSVC

### DIFF
--- a/cmake/EnableCoverage.cmake
+++ b/cmake/EnableCoverage.cmake
@@ -16,6 +16,7 @@
 
 # For the GCC and Clang compiler families, enable a Coverage build type.
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Clang|GNU)$")
+    include(CheckCXXCompilerFlag)
 
     # But only if the compiler supports the --coverage flag.  Older versions of
     # these compilers did not support it.

--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -1,0 +1,55 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+option(GOOGLE_CLOUD_CPP_ENABLE_WERROR
+       "If set, compiles the library with -Werror and /WX (MSVC)." ON)
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_WERROR)
+
+# Find out what flags turn on all available warnings and turn those warnings
+# into errors.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wall GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
+check_cxx_compiler_flag(-Wextra GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
+check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
+
+function (google_cloud_cpp_add_common_options target)
+    if (MSVC)
+        target_compile_options(${target} INTERFACE "/W3")
+        if (GOOGLE_CLOUD_CPP_ENABLE_WERROR)
+            target_compile_options(${target} INTERFACE "/WX")
+        endif ()
+        target_compile_options(${target} INTERFACE "/experimental:external")
+        target_compile_options(${target} INTERFACE "/external:W0")
+        target_compile_options(${target} INTERFACE "/external:anglebrackets")
+        return()
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
+        target_compile_options(${target} INTERFACE "-Wall")
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
+        target_compile_options(${target} INTERFACE "-Wextra")
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR
+        AND GOOGLE_CLOUD_CPP_ENABLE_WERROR)
+        target_compile_options(${target} INTERFACE "-Werror")
+    endif ()
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
+        AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 5.0)
+        # With GCC 4.x this warning is too noisy to be useful.
+        target_compile_options(${target}
+                               INTERFACE "-Wno-missing-field-initializers")
+    endif ()
+endfunction ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -18,18 +18,6 @@
 get_filename_component(GOOGLE_CLOUD_CPP_SUBPROJECT
                        "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
-# Find out what flags turn on all available warnings and turn those warnings
-# into errors.
-include(CheckCXXCompilerFlag)
-if (NOT MSVC)
-    check_cxx_compiler_flag(-Wall GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
-    check_cxx_compiler_flag(-Wextra GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
-    check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
-else ()
-    check_cxx_compiler_flag("/std:c++latest"
-                            GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CPP_LATEST)
-endif ()
-
 # If possible, enable a code coverage build type.
 include(EnableCoverage)
 
@@ -47,6 +35,9 @@ include(FindGMockWithTargets)
 
 # Pick the right MSVC runtime libraries.
 include(SelectMSVCRuntime)
+
+# Enable Werror
+include(EnableWerror)
 
 if (${CMAKE_VERSION} VERSION_LESS "3.9")
 
@@ -123,27 +114,6 @@ else ()
         endif ()
     endif ()
 endif ()
-
-function (google_cloud_cpp_add_common_options target)
-    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CPP_LATEST)
-        target_compile_options(${target} INTERFACE "/std:c++latest")
-    endif ()
-    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
-        target_compile_options(${target} INTERFACE "-Wall")
-    endif ()
-    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
-        target_compile_options(${target} INTERFACE "-Wextra")
-    endif ()
-    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
-        target_compile_options(${target} INTERFACE "-Werror")
-    endif ()
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
-        AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 5.0)
-        # With GCC 4.x this warning is too noisy to be useful.
-        target_compile_options(${target}
-                               INTERFACE "-Wno-missing-field-initializers")
-    endif ()
-endfunction ()
 
 function (google_cloud_cpp_add_clang_tidy target)
     if (GOOGLE_CLOUD_CPP_CLANG_TIDY_PROGRAM AND GOOGLE_CLOUD_CPP_CLANG_TIDY)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -111,7 +111,6 @@ configure_file(internal/build_info.cc.in internal/build_info.cc)
 # the client library
 add_library(
     google_cloud_cpp_common
-    # cmake-format: sort
     ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
     future.h
     future_generic.h
@@ -216,6 +215,7 @@ if (BUILD_TESTING)
         internal/parse_rfc3339_test.cc
         internal/random_test.cc
         internal/retry_policy_test.cc
+        internal/strerror_test.cc
         internal/throw_delegate_test.cc
         internal/tuple_test.cc
         internal/utility_test.cc

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -111,6 +111,7 @@ configure_file(internal/build_info.cc.in internal/build_info.cc)
 # the client library
 add_library(
     google_cloud_cpp_common
+    # cmake-format: sort
     ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
     future.h
     future_generic.h
@@ -128,6 +129,9 @@ add_library(
     internal/compiler_info.h
     internal/conjunction.h
     internal/disjunction.h
+    internal/diagnostics_pop.inc
+    internal/diagnostics_push.inc
+    internal/disable_msvc_crt_secure_warnings.inc
     internal/filesystem.cc
     internal/filesystem.h
     internal/format_time_point.cc
@@ -151,6 +155,8 @@ add_library(
     internal/retry_policy.h
     internal/setenv.cc
     internal/setenv.h
+    internal/strerror.cc
+    internal/strerror.h
     internal/throw_delegate.cc
     internal/throw_delegate.h
     internal/tuple.h
@@ -167,10 +173,7 @@ add_library(
     tracing_options.h
     tracing_options.cc
     version.cc
-    version.h
-    internal/strerror.h
-    internal/strerror.cc
-    internal/diagnostics_push.inc)
+    version.h)
 target_link_libraries(
     google_cloud_cpp_common
     PUBLIC Threads::Threads

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -167,7 +167,10 @@ add_library(
     tracing_options.h
     tracing_options.cc
     version.cc
-    version.h)
+    version.h
+    internal/strerror.h
+    internal/strerror.cc
+    internal/diagnostics_push.inc)
 target_link_libraries(
     google_cloud_cpp_common
     PUBLIC Threads::Threads
@@ -180,16 +183,6 @@ target_include_directories(
            $<INSTALL_INTERFACE:include>)
 target_compile_options(google_cloud_cpp_common
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-if (MSVC)
-    # MSVC warns about using sscanf(), this is a valuable warning, so we do not
-    # want to disable for everything. But for these files the usage is "safe".
-    # This is a relatively obscure feature to add compile flags to just one
-    # source:
-    set_property(
-        SOURCE internal/parse_rfc3339.cc
-        APPEND_STRING
-        PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
-endif ()
 
 set_target_properties(
     google_cloud_cpp_common

--- a/google/cloud/bigquery/read_result.h
+++ b/google/cloud/bigquery/read_result.h
@@ -55,7 +55,7 @@ class ReadResult {
 
   // Returns a zero-based index of the last row returned by the `Rows()`
   // iterator. If no rows have been read yet, returns -1.
-  int CurrentOffset() { return source_->CurrentOffset(); }
+  std::size_t CurrentOffset() { return source_->CurrentOffset(); }
 
   // Returns a value between 0 and 1, inclusive, that indicates the estimated
   // progress in the result set based on the number of rows the server has

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -163,8 +163,6 @@ std::string RandomClusterId(std::string const& prefix,
 
 void CleanupOldInstances(std::string const& prefix,
                          google::cloud::bigtable::InstanceAdmin admin) {
-  namespace cbt = google::cloud::bigtable;
-
   auto const threshold =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   auto const max_instance_id = InstancePrefix(prefix, threshold);
@@ -222,7 +220,7 @@ void CheckEnvironmentVariablesAreSet(std::vector<std::string> const& vars) {
 
 google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
     std::string const& name, std::vector<std::string> const& args,
-    TableCommandType function) {
+    TableCommandType const& function) {
   auto command = [=](std::vector<std::string> argv) {
     if (argv.size() != 3 + args.size()) {
       std::ostringstream os;

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -145,9 +145,9 @@ std::string RandomInstanceId(std::string const& prefix,
     throw std::invalid_argument("prefix too long for RandomInstanceId()");
   }
   auto const suffix_len = kMaxInstanceIdLength - timestamped_prefix.size();
-  return timestamped_prefix +
-         google::cloud::internal::Sample(generator, suffix_len,
-                                         "abcdefhijklmnopqrstuvwxyz0123456789");
+  return timestamped_prefix + google::cloud::internal::Sample(
+                                  generator, static_cast<int>(suffix_len),
+                                  "abcdefhijklmnopqrstuvwxyz0123456789");
 }
 
 std::string RandomClusterId(std::string const& prefix,
@@ -156,9 +156,9 @@ std::string RandomClusterId(std::string const& prefix,
     throw std::invalid_argument("prefix too long for RandomClusterId()");
   }
   auto const suffix_len = kMaxClusterIdLength - prefix.size();
-  return prefix +
-         google::cloud::internal::Sample(generator, suffix_len,
-                                         "abcdefhijklmnopqrstuvwxyz0123456789");
+  return prefix + google::cloud::internal::Sample(
+                      generator, static_cast<int>(suffix_len),
+                      "abcdefhijklmnopqrstuvwxyz0123456789");
 }
 
 void CleanupOldInstances(std::string const& prefix,

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -99,7 +99,7 @@ using TableCommandType = std::function<void(google::cloud::bigtable::Table,
 
 google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
     std::string const& name, std::vector<std::string> const& args,
-    TableCommandType function);
+    TableCommandType const& function);
 
 using TableAdminCommandType = std::function<void(
     google::cloud::bigtable::TableAdmin, std::vector<std::string>)>;

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -29,6 +29,9 @@ google_cloud_cpp_common_hdrs = [
     "internal/compiler_info.h",
     "internal/conjunction.h",
     "internal/disjunction.h",
+    "internal/diagnostics_pop.inc",
+    "internal/diagnostics_push.inc",
+    "internal/disable_msvc_crt_secure_warnings.inc",
     "internal/filesystem.h",
     "internal/format_time_point.h",
     "internal/future_base.h",
@@ -45,6 +48,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/random.h",
     "internal/retry_policy.h",
     "internal/setenv.h",
+    "internal/strerror.h",
     "internal/throw_delegate.h",
     "internal/tuple.h",
     "internal/utility.h",
@@ -56,8 +60,6 @@ google_cloud_cpp_common_hdrs = [
     "terminate_handler.h",
     "tracing_options.h",
     "version.h",
-    "internal/strerror.h",
-    "internal/diagnostics_push.inc",
 ]
 
 google_cloud_cpp_common_srcs = [
@@ -72,11 +74,11 @@ google_cloud_cpp_common_srcs = [
     "internal/parse_rfc3339.cc",
     "internal/random.cc",
     "internal/setenv.cc",
+    "internal/strerror.cc",
     "internal/throw_delegate.cc",
     "log.cc",
     "status.cc",
     "terminate_handler.cc",
     "tracing_options.cc",
     "version.cc",
-    "internal/strerror.cc",
 ]

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -56,6 +56,8 @@ google_cloud_cpp_common_hdrs = [
     "terminate_handler.h",
     "tracing_options.h",
     "version.h",
+    "internal/strerror.h",
+    "internal/diagnostics_push.inc",
 ]
 
 google_cloud_cpp_common_srcs = [
@@ -76,4 +78,5 @@ google_cloud_cpp_common_srcs = [
     "terminate_handler.cc",
     "tracing_options.cc",
     "version.cc",
+    "internal/strerror.cc",
 ]

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -33,6 +33,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/parse_rfc3339_test.cc",
     "internal/random_test.cc",
     "internal/retry_policy_test.cc",
+    "internal/strerror_test.cc",
     "internal/throw_delegate_test.cc",
     "internal/tuple_test.cc",
     "internal/utility_test.cc",

--- a/google/cloud/internal/diagnostics_pop.inc
+++ b/google/cloud/internal/diagnostics_pop.inc
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if _MSC_VER
+#pragma warning(pop)
+#elif __clang__
+#pragma clang diagnostic pop
+#elif __GNUC__
+#pragma GCC diagnostic pop
+#else
+#warning "Unknown compiler, cannot pop diagnostics state"
+#endif  // _MSC_VER

--- a/google/cloud/internal/diagnostics_push.inc
+++ b/google/cloud/internal/diagnostics_push.inc
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if _MSC_VER
+#pragma warning(push)
+#elif __clang__
+#pragma clang diagnostic push
+#elif __GNUC__
+#pragma GCC diagnostic push
+#else
+#warning "Unknown compiler, cannot pop diagnostics state"
+#endif  // _MSC_VER

--- a/google/cloud/internal/disable_msvc_crt_secure_warnings.inc
+++ b/google/cloud/internal/disable_msvc_crt_secure_warnings.inc
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/diagnostics_push.inc"
+#if _MSC_VER
+#pragma warning(disable : 4996)
+#endif  // _MSC_VER

--- a/google/cloud/internal/parse_rfc3339.cc
+++ b/google/cloud/internal/parse_rfc3339.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/parse_rfc3339.h"
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 #include "google/cloud/internal/throw_delegate.h"
 #include <array>
 #include <cctype>
@@ -20,7 +21,6 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-
 namespace {
 [[noreturn]] void ReportError(std::string const& timestamp, char const* msg) {
   std::ostringstream os;
@@ -183,6 +183,7 @@ std::chrono::seconds ParseOffset(char const*& buffer,
   return std::chrono::seconds(0);
 }
 }  // anonymous namespace
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/parse_rfc3339.cc
+++ b/google/cloud/internal/parse_rfc3339.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/internal/parse_rfc3339.h"
-#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 #include "google/cloud/internal/throw_delegate.h"
 #include <array>
 #include <cctype>
@@ -21,6 +20,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+
 namespace {
 [[noreturn]] void ReportError(std::string const& timestamp, char const* msg) {
   std::ostringstream os;
@@ -42,6 +42,7 @@ auto constexpr kMinutesInHour =
 auto constexpr kSecondsInMinute =
     std::chrono::seconds(std::chrono::minutes(1)).count();
 
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 std::chrono::system_clock::time_point ParseDateTime(
     char const*& buffer, std::string const& timestamp) {
   // Use std::mktime to compute the number of seconds because RFC 3339 requires
@@ -182,8 +183,9 @@ std::chrono::seconds ParseOffset(char const*& buffer,
   ++buffer;
   return std::chrono::seconds(0);
 }
-}  // anonymous namespace
+
 #include "google/cloud/internal/diagnostics_pop.inc"
+}  // anonymous namespace
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/strerror.cc
+++ b/google/cloud/internal/strerror.cc
@@ -13,27 +13,48 @@
 // limitations under the License.
 
 #include "google/cloud/internal/strerror.h"
-#include <cstdlib>
 #include <cstring>
+#include <sstream>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
+namespace {
 
-/// A portable and thread-safe version of std::strerror()
+// Depending on the compilation flags, strerror_r() returns `int` or `char*`,
+// while `strerror_s()` (on WIN32) returns `errno_t`.  Use overload resolution
+// to handle all cases, and SFINAE to avoid the "unused function" warnings.
+template <typename T,
+          typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+std::string handle_strerror_r_error(char const* msg, int errnum, T result) {
+  if (result == 0) return msg;
+  std::ostringstream os;
+  os << "Cannot get error message for errno=" << errnum << ", result=" << result
+     << ", errno=" << errno;
+  return std::move(os).str();
+}
+
+std::string handle_strerror_r_error(char const* msg, int, char const*) {
+  return msg;
+}
+
+}  // namespace
+
 std::string strerror(int errnum) {
   auto constexpr kMaxErrorMessageLength = 1024;
   char error_msg[kMaxErrorMessageLength];
 #ifdef _WIN32
-  (void)strerror_s(error_msg, sizeof(error_msg) - 1, errnum);
+  auto const result = strerror_s(error_msg, sizeof(error_msg) - 1, errnum);
+  return handle_strerror_r_error(error_msg, errnum, result);
 #else
-  (void)strerror_r(errnum, error_msg, sizeof(error_msg) - 1);
-#endif  // _WIN32
-  return error_msg;
+  // NOLINTNE
+  auto const result = strerror_r(errnum, error_msg, sizeof(error_msg) - 1);
+  return handle_strerror_r_error(error_msg, errnum, result);
 }
+#endif  // _WIN32
 
+}  // namespace internal
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
-}  // namespace google

--- a/google/cloud/internal/strerror.cc
+++ b/google/cloud/internal/strerror.cc
@@ -57,12 +57,11 @@ std::string strerror(int errnum) {
   char error_msg[kMaxErrorMessageLength];
 #ifdef _WIN32
   auto const result = strerror_s(error_msg, sizeof(error_msg) - 1, errnum);
-  return handle_strerror_r_error(error_msg, errnum, result);
 #else
   auto const result = strerror_r(errnum, error_msg, sizeof(error_msg) - 1);
+#endif  // _WIN32
   return handle_strerror_r_error(error_msg, errnum, result);
 }
-#endif  // _WIN32
 
 }  // namespace internal
 }  // namespace internal

--- a/google/cloud/internal/strerror.cc
+++ b/google/cloud/internal/strerror.cc
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/strerror.h"
+#include <cstdlib>
+#include <cstring>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// A portable and thread-safe version of std::strerror()
+std::string strerror(int errnum) {
+  auto constexpr kMaxErrorMessageLength = 1024;
+  char error_msg[kMaxErrorMessageLength];
+#ifdef _WIN32
+  (void)strerror_s(error_msg, sizeof(error_msg) - 1, errnum);
+#else
+  (void)strerror_r(errnum, error_msg, sizeof(error_msg) - 1);
+#endif  // _WIN32
+  return error_msg;
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/strerror.cc
+++ b/google/cloud/internal/strerror.cc
@@ -64,6 +64,6 @@ std::string strerror(int errnum) {
 }
 
 }  // namespace internal
-}  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/strerror.h
+++ b/google/cloud/internal/strerror.h
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STRERROR_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STRERROR_H
+
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// A portable and thread-safe version of std::strerror()
+std::string strerror(int errnum);
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STRERROR_H

--- a/google/cloud/internal/strerror_test.cc
+++ b/google/cloud/internal/strerror_test.cc
@@ -25,6 +25,7 @@ namespace {
 
 using ::testing::HasSubstr;
 
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 TEST(StrErrorTest, Simple) {
   auto const actual = ::google::cloud::internal::strerror(EDOM);
   // In the test we can call `std::strerror()` because the test is single
@@ -32,6 +33,7 @@ TEST(StrErrorTest, Simple) {
   std::string expected = std::strerror(EDOM);
   EXPECT_EQ(actual, expected);
 }
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 TEST(StrErrorTest, InvalidErrno) {
   auto const actual = ::google::cloud::internal::strerror(-123456789);

--- a/google/cloud/internal/strerror_test.cc
+++ b/google/cloud/internal/strerror_test.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/internal/strerror.h"
 #include <gmock/gmock.h>
+#include <cerrno>
+#include <cstring>
 
 namespace google {
 namespace cloud {
@@ -22,12 +24,13 @@ namespace internal {
 namespace {
 
 using ::testing::HasSubstr;
-using ::testing::Not;
 
 TEST(StrErrorTest, Simple) {
-  auto const actual = ::google::cloud::internal::strerror(ENAMETOOLONG);
-  EXPECT_FALSE(actual.empty());
-  EXPECT_THAT(actual, Not(HasSubstr("Cannot get error message")));
+  auto const actual = ::google::cloud::internal::strerror(EDOM);
+  // In the test we can call `std::strerror()` because the test is single
+  // threaded.
+  std::string expected = std::strerror(EDOM);
+  EXPECT_EQ(actual, expected);
 }
 
 TEST(StrErrorTest, InvalidErrno) {

--- a/google/cloud/internal/strerror_test.cc
+++ b/google/cloud/internal/strerror_test.cc
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/strerror.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::Not;
+
+TEST(StrErrorTest, Simple) {
+  auto const actual = ::google::cloud::internal::strerror(ENAMETOOLONG);
+  EXPECT_FALSE(actual.empty());
+  EXPECT_THAT(actual, Not(HasSubstr("Cannot get error message")));
+}
+
+TEST(StrErrorTest, InvalidErrno) {
+  auto const actual = ::google::cloud::internal::strerror(-123456789);
+  EXPECT_FALSE(actual.empty());
+  EXPECT_THAT(actual, HasSubstr("-123456789"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/log.cc
+++ b/google/cloud/log.cc
@@ -40,7 +40,8 @@ struct Timestamp {
     gmtime_r(&tt, &tm);
 #endif
     auto const ss = tp - std::chrono::system_clock::from_time_t(tt);
-    nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(ss).count();
+    nanos = static_cast<std::int32_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(ss).count());
   }
   std::tm tm;
   std::int32_t nanos;

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -349,8 +349,8 @@ struct ImplicitlyConvertible {
 };
 
 TEST(OptionalTest, ValueConstructorWithImplicitConversion) {
-  optional<int> i = 123.5;
-  EXPECT_EQ(*i, 123);
+  optional<double> d = 123;
+  EXPECT_NEAR(*d, 123.0, 0.01);
   optional<std::string> x = "hi";
   EXPECT_EQ(*x, "hi");
   optional<std::string> implicit_conversion = ImplicitlyConvertible{};

--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -60,17 +60,6 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         add_dependencies(pubsub-client-integration-tests ${target})
     endforeach ()
 
-    if (MSVC)
-        # MSVC warns about using localtime(), this is a valuable warning, so we
-        # do not want to disable for everything. But for these files the usage
-        # is "safe". This is a relatively obscure feature to add compile flags
-        # to just one source:
-        set_property(
-            SOURCE instance_admin_integration_test.cc
-            APPEND_STRING
-            PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
-    endif ()
-
     if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         return()
     endif ()

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -33,17 +33,6 @@ set(DOXYGEN_EXCLUDE_PATTERNS
 
 include(GoogleCloudCppCommon)
 
-if (MSVC)
-    # MSVC warns about using sscanf(), this is a valuable warning, so we do not
-    # want to disable for everything. But for these files the usage is "safe".
-    # This is a relatively obscure feature to add compile flags to just few
-    # sources:
-    set_property(
-        SOURCE value.cc internal/date.cc
-        APPEND_STRING
-        PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
-endif ()
-
 configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(
     spanner_client

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -63,18 +63,6 @@ function (spanner_client_define_integration_tests)
                                  "integration-tests;spanner-integration-tests")
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
-
-    if (MSVC)
-        # MSVC warns about using localtime(), this is a valuable warning, so we
-        # do not want to disable for everything. But for these files the usage
-        # is "safe". This is a relatively obscure feature to add compile flags
-        # to just one source:
-        set_property(
-            SOURCE instance_admin_integration_test.cc
-            APPEND_STRING
-            PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
-    endif ()
-
     if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         return()
     endif ()

--- a/google/cloud/spanner/internal/date.cc
+++ b/google/cloud/spanner/internal/date.cc
@@ -30,6 +30,7 @@ std::string DateToString(Date d) {
   return std::string(buf.data());
 }
 
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 StatusOr<Date> DateFromString(std::string const& s) {
   std::int64_t year;
   int month;
@@ -52,6 +53,7 @@ StatusOr<Date> DateFromString(std::string const& s) {
   }
   return date;
 }
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -14,11 +14,11 @@
 
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/spanner/internal/date.h"
+#include "google/cloud/internal/strerror.h"
 #include "google/cloud/log.h"
 #include <cerrno>
 #include <cmath>
 #include <cstdlib>
-#include <cstring>
 #include <ios>
 #include <string>
 
@@ -384,8 +384,8 @@ StatusOr<std::int64_t> Value::GetValue(std::int64_t,
   errno = 0;
   std::int64_t x = {std::strtoll(s.c_str(), &end, 10)};
   if (errno != 0) {
-    auto const err = std::string(std::strerror(errno));
-    return Status(StatusCode::kUnknown, err + ": \"" + s + "\"");
+    return Status(StatusCode::kUnknown,
+                  google::cloud::internal::strerror(errno) + ": \"" + s + "\"");
   }
   if (end == s.c_str()) {
     return Status(StatusCode::kUnknown, "No numeric conversion: \"" + s + "\"");

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -241,16 +241,6 @@ target_include_directories(
            $<INSTALL_INTERFACE:include>)
 target_compile_options(storage_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
-if (MSVC)
-    # MSVC warns about using sscanf(), this is a valuable warning, so we do not
-    # want to disable for everything. But for these files the usage is "safe".
-    # This is a relatively obscure feature to add compile flags to just one
-    # source:
-    set_property(
-        SOURCE internal/object_requests.cc
-        APPEND_STRING
-        PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
-endif ()
 
 # GCC-7.3 (the default GCC version on Ubuntu:18.04) issues a warning (a member
 # variable may be used without being initialized), in this file. GCC-8.0 no
@@ -260,8 +250,10 @@ endif ()
 # it was fixed. I do not believe we need to be that accurate.
 if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
                                                 VERSION_LESS 8.0)
-    set_property(SOURCE list_objects_reader.cc APPEND_STRING
-                 PROPERTY COMPILE_FLAGS "-Wno-maybe-uninitialized")
+    set_property(
+        SOURCE list_objects_reader.cc
+        APPEND_STRING
+        PROPERTY COMPILE_FLAGS "-Wno-maybe-uninitialized")
 endif ()
 
 set_target_properties(

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/storage/internal/curl_handle.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
+#include "google/cloud/internal/strerror.h"
 #include "google/cloud/log.h"
-#include <string.h>  // NOLINT
 #ifdef _WIN32
 #include <winsock.h>
 #else
@@ -67,6 +67,7 @@ extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
 
 extern "C" int CurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
                                     curlsocktype purpose) {
+  auto errno_msg = [] { return google::cloud::internal::strerror(errno); };
   auto* options = reinterpret_cast<CurlHandle::SocketOptions*>(userdata);
   switch (purpose) {
     case CURLSOCKTYPE_IPCXN:
@@ -84,8 +85,7 @@ extern "C" int CurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
         if (r != 0) {
           GCP_LOG(ERROR) << __func__
                          << "(): setting socket recv buffer size to " << size
-                         << " error=" << ::strerror(errno) << " [" << errno
-                         << "]";
+                         << " error=" << errno_msg() << " [" << errno << "]";
           return CURL_SOCKOPT_ERROR;
         }
       }
@@ -101,8 +101,7 @@ extern "C" int CurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
         if (r != 0) {
           GCP_LOG(ERROR) << __func__
                          << "(): setting socket send buffer size to " << size
-                         << " error=" << ::strerror(errno) << " [" << errno
-                         << "]";
+                         << " error=" << errno_msg() << " [" << errno << "]";
           return CURL_SOCKOPT_ERROR;
         }
       }

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -316,6 +316,7 @@ std::ostream& operator<<(std::ostream& os, ReadObjectRangeRequest const& r) {
   return os << "}";
 }
 
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 ReadObjectRangeResponse ReadObjectRangeResponse::FromHttpResponse(
     HttpResponse&& response) {
   auto loc = response.headers.find(std::string("content-range"));
@@ -370,6 +371,7 @@ ReadObjectRangeResponse ReadObjectRangeResponse::FromHttpResponse(
   return ReadObjectRangeResponse{std::move(response.payload), first_byte,
                                  last_byte, object_size};
 }
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 std::ostream& operator<<(std::ostream& os, ReadObjectRangeResponse const& r) {
   return os << "ReadObjectRangeResponse={range=" << r.first_byte << "-"

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -77,6 +77,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
       /*subject*/ {}};
 }
 
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
     std::string const& source, std::string const& default_token_uri) {
   OpenSSL_add_all_algorithms();
@@ -183,6 +184,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
                                        /*scopes*/ {},
                                        /*subject*/ {}};
 }
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,

--- a/google/cloud/storage/parallel_uploads_test.cc
+++ b/google/cloud/storage/parallel_uploads_test.cc
@@ -95,7 +95,7 @@ ObjectMetadata MockObject(std::string const& object_name, int generation) {
 class ExpectedDeletions {
  public:
   explicit ExpectedDeletions(
-      std::map<std::pair<std::string, int>, Status> expectations)
+      std::map<std::pair<std::string, std::int64_t>, Status> expectations)
       : deletions_(std::move(expectations)) {}
 
   ~ExpectedDeletions() {
@@ -123,7 +123,8 @@ class ExpectedDeletions {
   };
 
  private:
-  Status RemoveExpectation(std::string const& object_name, int generation) {
+  Status RemoveExpectation(std::string const& object_name,
+                           std::int64_t generation) {
     std::lock_guard<std::mutex> lk(mu_);
     auto it = deletions_.find(std::make_pair(object_name, generation));
     if (it == deletions_.end()) {
@@ -137,7 +138,7 @@ class ExpectedDeletions {
     return res;
   }
   std::mutex mu_;
-  std::map<std::pair<std::string, int>, Status> deletions_;
+  std::map<std::pair<std::string, std::int64_t>, Status> deletions_;
 };
 
 class ParallelUploadTest : public ::testing::Test {


### PR DESCRIPTION
Fix all the warnings generated by MSVC, most of them were useful. I also
chose to use pragmas to disable warning 4996 (aka you are using an
insecure function) because we should keep that warning enable in as much
of our code as possible. Previously we were disabling it for full files.

Because users may compile with newer versions of the compiler this PR
also includes a CMake option to disable /WX (and -Werror), in case the
newer (or older I suppose) version of the compiler generates warnings we
have not handled.

Fixes #3068

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4095)
<!-- Reviewable:end -->
