### PR TITLE
ci: only clang-tidy headers in the .clang-tidy regexp

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -129,11 +129,13 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   io::log "Running clang-tidy for: "
   # TODO(#3958) - use a simple regular expression like '\.(h|cc)$' when all
   # targets are clang-tidy clean.
+  RE=$(grep -o '^HeaderFilterRegex.*' "${PROJECT_ROOT}/.clang-tidy" |
+    sed -e 's/HeaderFilterRegex: "//' -e 's/"//')
+  RE="(\.cc|${RE}\.h)$"
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$' |
-    xargs -r echo
+    grep -E "${RE}" | xargs -r echo
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$' |
+    grep -E "${RE}" |
     xargs -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
 fi
 

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -126,8 +126,13 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   echo
   io::log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
   ${CMAKE_COMMAND} --build "${BINARY_DIR}" --target nlohmann_json_project
+  io::log "Running clang-tidy for: "
+  # TODO(#3958) - use a simple regular expression like '\.(h|cc)$' when all
+  # targets are clang-tidy clean.
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E '\.(cc|h)$' |
+    grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$'
+  git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
+    grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$' |
     xargs -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
 fi
 

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -130,7 +130,8 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   # TODO(#3958) - use a simple regular expression like '\.(h|cc)$' when all
   # targets are clang-tidy clean.
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$'
+    grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$' |
+    xargs -r echo
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
     grep -E '(\.cc|/(bigquery|firestore|pubsub|spanner)/.*\.h)$' |
     xargs -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"


### PR DESCRIPTION
Many of our headers are not clang-tidy clean, so we need to limit the
regular expression to whatever is on the `.clang-tidy` file.

There is some cleanup which can happen after #3958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4097)
<!-- Reviewable:end -->
