### PR TITLE
fix: Windows CI scripts sometimes masked the exit code

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -123,13 +123,15 @@ bazel $common_flags test $test_flags `
   --test_tag_filters=-integration-tests `
   -- //google/cloud/...:all
 if ($LastExitCode) {
-    throw "bazel test failed with exit code ${LastExitCode}."
+    Write-Host -ForegroundColor Red "bazel test failed with exit code ${LastExitCode}."
+    Exit ${LastExitCode}
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling extra programs"
 bazel $common_flags build $build_flags -- //google/cloud/...:all
 if ($LastExitCode) {
-    throw "bazel test failed with exit code ${LastExitCode}."
+    Write-Host -ForegroundColor Red "bazel test failed with exit code ${LastExitCode}."
+    Exit ${LastExitCode}
 }
 
 function Integration-Tests-Enabled {
@@ -192,7 +194,8 @@ if (Integration-Tests-Enabled) {
         -//google/cloud/storage/examples:storage_service_account_samples `
         -//google/cloud/storage/tests:service_account_integration_test
     if ($LastExitCode) {
-        throw "Integration tests failed with exit code ${LastExitCode}."
+        Write-Host -ForegroundColor Red "Integration tests failed with exit code ${LastExitCode}."
+        Exit ${LastExitCode}
     }
 }
 

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -151,7 +151,9 @@ ForEach($library in ("bigtable", "storage", "spanner")) {
         "Compiling quickstart for ${library}"
     bazel $common_flags build ...
     if ($LastExitCode) {
-        throw "bazel test failed with exit code ${LastExitCode}."
+        Write-Host -ForegroundColor Red `
+            "bazel test failed with exit code ${LastExitCode}."
+        Exit ${LastExitCode}
     }
 
     if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "true")) {
@@ -160,7 +162,9 @@ ForEach($library in ("bigtable", "storage", "spanner")) {
         bazel $common_flags run "--spawn_strategy=local" `
             ":quickstart" -- $quickstart_args[${library}]
         if ($LastExitCode) {
-            throw "quickstart test for ${library} failed with exit code ${LastExitCode}."
+            Write-Host -ForegroundColor Red `
+                "quickstart test for ${library} failed with exit code ${LastExitCode}."
+            Exit ${LastExitCode}
         }
     }
 

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -35,7 +35,7 @@ if ($args.count -eq 1) {
     # strict when run in a CI, but a little more friendly when run by a human.
     $env:RUNNING_CI = "yes"
 } else {
-    throw @"
+    Write-Host -ForegroundColor Red @"
 Aborting build as the build name is not defined.
 If you are invoking this script via the command line use:
 
@@ -44,6 +44,7 @@ $PSCommandPath <build-name>
 If this script is invoked by Kokoro, the CI system is expected to set
 the KOKORO_JOB_NAME environment variable.
 "@
+    Exit 1
 }
 
 $DependencyScriptArgs=@()
@@ -104,7 +105,8 @@ $ScriptLocation = Split-Path $PSCommandPath -Parent
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Building dependencies for $BuildName build"
 powershell -exec bypass "${ScriptLocation}/${DependencyScript}" $DependencyScriptArgs
 if ($LastExitCode) {
-    throw "Building dependencies failed with exit code $LastExitCode"
+    Write-Host -ForegroundColor Red "Building dependencies failed with ${LastExitCode}"
+    Exit ${LastExitCode}
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running build script for $BuildName build"
@@ -129,5 +131,6 @@ if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
 }
 
 if ($BuildExitCode) {
-    throw "Build failed with exit code ${BuildExitCode}"
+    Write-Host -ForegroundColor Red "Build failed with exit code ${BuildExitCode}"
+    Exit ${BuildExitCode}
 }

--- a/google/cloud/internal/strerror_test.cc
+++ b/google/cloud/internal/strerror_test.cc
@@ -34,7 +34,6 @@ TEST(StrErrorTest, Simple) {
   std::string const expected = std::strerror(EDOM);
   EXPECT_EQ(actual, expected);
 }
-#include "google/cloud/internal/diagnostics_pop.inc"
 
 TEST(StrErrorTest, InvalidErrno) {
   auto constexpr kInvalidErrno = -1234;
@@ -47,6 +46,7 @@ TEST(StrErrorTest, InvalidErrno) {
   // condition, so we cannot print why this failed.
   EXPECT_THAT(actual, AnyOf(HasSubstr("-1234"), HasSubstr(expected)));
 }
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 }  // namespace
 }  // namespace internal


### PR DESCRIPTION
Fixes #4103 

I tested by first building code that had a failing test. Note that this doe not cover every path where we need to explicitly handle the exit code, but at least it shows the pattern of `if ($LastExitCode) { Exit ${LastExitCode} }` works.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4105)
<!-- Reviewable:end -->
