### PR TITLE
fix: installed cmake files list absl as a dep

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -75,6 +75,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_common",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/memory",
         "@com_google_googleapis//:googleapis_system_includes",
         "@com_google_googleapis//google/rpc:status_cc_proto",
     ],

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ~~~
 
+find_package(absl CONFIG REQUIRED)
+
 string(CONCAT GOOGLE_CLOUD_CPP_VERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}" "."
               "${GOOGLE_CLOUD_CPP_VERSION_MINOR}" "."
               "${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
@@ -326,7 +328,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
         internal/pagination_range.h)
     target_link_libraries(
         google_cloud_cpp_grpc_utils
-        PUBLIC googleapis-c++::rpc_status_protos google_cloud_cpp_common
+        PUBLIC absl::memory googleapis-c++::rpc_status_protos google_cloud_cpp_common
                gRPC::grpc++ gRPC::grpc
         PRIVATE google_cloud_cpp_common_options)
     google_cloud_cpp_add_clang_tidy(google_cloud_cpp_grpc_utils)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -328,8 +328,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
         internal/pagination_range.h)
     target_link_libraries(
         google_cloud_cpp_grpc_utils
-        PUBLIC absl::memory googleapis-c++::rpc_status_protos google_cloud_cpp_common
-               gRPC::grpc++ gRPC::grpc
+        PUBLIC absl::memory googleapis-c++::rpc_status_protos
+               google_cloud_cpp_common gRPC::grpc++ gRPC::grpc
         PRIVATE google_cloud_cpp_common_options)
     google_cloud_cpp_add_clang_tidy(google_cloud_cpp_grpc_utils)
     target_include_directories(

--- a/google/cloud/bigtable/BUILD
+++ b/google/cloud/bigtable/BUILD
@@ -29,6 +29,7 @@ cc_library(
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
+        "@com_google_absl//absl/memory",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
         "@com_google_googleapis//google/longrunning:longrunning_cc_grpc",

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -15,6 +15,7 @@
 # ~~~
 
 find_package(googleapis CONFIG REQUIRED)
+find_package(absl CONFIG REQUIRED)
 
 set(DOXYGEN_PROJECT_NAME "Google Cloud Bigtable C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")
@@ -174,7 +175,7 @@ add_library(
     version_info.h)
 target_link_libraries(
     bigtable_client
-    PUBLIC bigtable_protos google_cloud_cpp_common google_cloud_cpp_grpc_utils
+    PUBLIC absl::memory bigtable_protos google_cloud_cpp_common google_cloud_cpp_grpc_utils
            gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
     PRIVATE bigtable_common_options)
 google_cloud_cpp_add_common_options(bigtable_client)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -175,8 +175,13 @@ add_library(
     version_info.h)
 target_link_libraries(
     bigtable_client
-    PUBLIC absl::memory bigtable_protos google_cloud_cpp_common google_cloud_cpp_grpc_utils
-           gRPC::grpc++ gRPC::grpc protobuf::libprotobuf
+    PUBLIC absl::memory
+           bigtable_protos
+           google_cloud_cpp_common
+           google_cloud_cpp_grpc_utils
+           gRPC::grpc++
+           gRPC::grpc
+           protobuf::libprotobuf
     PRIVATE bigtable_common_options)
 google_cloud_cpp_add_common_options(bigtable_client)
 google_cloud_cpp_add_clang_tidy(bigtable_client)

--- a/google/cloud/bigtable/config.cmake.in
+++ b/google/cloud/bigtable/config.cmake.in
@@ -17,6 +17,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
+find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
 

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/log.h"
+#include "absl/memory/memory.h"
 #include <thread>
 
 namespace google {
@@ -121,7 +122,7 @@ void RowReader::MakeRequest() {
     request.set_rows_limit(rows_limit_ - rows_count_);
   }
 
-  context_ = google::cloud::internal::make_unique<grpc::ClientContext>();
+  context_ = absl::make_unique<grpc::ClientContext>();
   retry_policy_->Setup(*context_);
   backoff_policy_->Setup(*context_);
   metadata_update_policy_.Setup(*context_);

--- a/google/cloud/connection_options.cc
+++ b/google/cloud/connection_options.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/log.h"
+#include "absl/memory/memory.h"
 #include <sstream>
 
 namespace google {
@@ -43,8 +44,7 @@ TracingOptions DefaultTracingOptions() {
 }
 
 std::unique_ptr<BackgroundThreads> DefaultBackgroundThreads() {
-  return google::cloud::internal::make_unique<
-      AutomaticallyCreatedBackgroundThreads>();
+  return absl::make_unique<AutomaticallyCreatedBackgroundThreads>();
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -28,6 +28,7 @@ cc_library(
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
+        "@com_google_absl//absl/memory",
         "@com_google_googleapis//google/longrunning:longrunning_cc_grpc",
         "@com_google_googleapis//google/spanner/admin/database/v1:database_cc_grpc",
         "@com_google_googleapis//google/spanner/admin/instance/v1:instance_cc_grpc",

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -158,8 +158,9 @@ target_include_directories(
            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
-    spanner_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-                          googleapis-c++::spanner_protos)
+    spanner_client
+    PUBLIC absl::memory google_cloud_cpp_grpc_utils google_cloud_cpp_common
+           googleapis-c++::spanner_protos)
 set_target_properties(
     spanner_client PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"
                               SOVERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}")

--- a/google/cloud/spanner/config.cmake.in
+++ b/google/cloud/spanner/config.cmake.in
@@ -15,6 +15,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
+find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/spanner-targets.cmake")
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -330,8 +330,8 @@ RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
         absl::make_unique<DefaultPartialResultSetReader>(
             std::move(context), stub->StreamingRead(*context, request));
     if (tracing_enabled) {
-      reader = absl::make_unique<LoggingResultSetReader>(
-          std::move(reader), tracing_options);
+      reader = absl::make_unique<LoggingResultSetReader>(std::move(reader),
+                                                         tracing_options);
     }
     return reader;
   };
@@ -472,14 +472,13 @@ ResultType ConnectionImpl::CommonQueryImpl(
     auto factory = [stub, request, tracing_enabled,
                     tracing_options](std::string const& resume_token) mutable {
       request.set_resume_token(resume_token);
-      auto context =
-          absl::make_unique<grpc::ClientContext>();
+      auto context = absl::make_unique<grpc::ClientContext>();
       std::unique_ptr<PartialResultSetReader> reader =
           absl::make_unique<DefaultPartialResultSetReader>(
               std::move(context), stub->ExecuteStreamingSql(*context, request));
       if (tracing_enabled) {
-        reader = absl::make_unique<LoggingResultSetReader>(
-            std::move(reader), tracing_options);
+        reader = absl::make_unique<LoggingResultSetReader>(std::move(reader),
+                                                           tracing_options);
       }
       return reader;
     };

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -52,9 +52,9 @@ cc_library(
         "//google/cloud:google_cloud_cpp_common",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
-        "@com_google_absl//absl/memory",
         "@com_github_curl_curl//:curl",
         "@com_github_google_crc32c//:crc32c",
+        "@com_google_absl//absl/memory",
     ],
 )
 

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -52,6 +52,7 @@ cc_library(
         "//google/cloud:google_cloud_cpp_common",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
+        "@com_google_absl//absl/memory",
         "@com_github_curl_curl//:curl",
         "@com_github_google_crc32c//:crc32c",
     ],

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ~~~
 
+find_package(absl CONFIG REQUIRED)
+
 set(DOXYGEN_PROJECT_NAME "Google Cloud Storage C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Storage")
 set(DOXYGEN_PROJECT_NUMBER
@@ -223,7 +225,8 @@ add_library(
     well_known_parameters.h)
 target_link_libraries(
     storage_client
-    PUBLIC google_cloud_cpp_common
+    PUBLIC absl::memory
+           google_cloud_cpp_common
            nlohmann_json
            Crc32c::crc32c
            CURL::libcurl

--- a/google/cloud/storage/config.cmake.in
+++ b/google/cloud/storage/config.cmake.in
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
+find_dependency(absl)
 find_dependency(CURL)
 find_dependency(Crc32c)
 find_dependency(google_cloud_cpp_common)

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -83,11 +83,10 @@ StatusOr<ObjectWriteStream> ParallelUploadStateImpl::CreateStream(
       StreamInfo{request.object_name(), (*session)->session_id(), {}, false});
   assert(idx < streams_.size());
   lk.unlock();
-  return ObjectWriteStream(
-      absl::make_unique<ParallelObjectWriteStreambuf>(
-          shared_from_this(), idx, *std::move(session),
-          raw_client.client_options().upload_buffer_size(),
-          CreateHashValidator(request)));
+  return ObjectWriteStream(absl::make_unique<ParallelObjectWriteStreambuf>(
+      shared_from_this(), idx, *std::move(session),
+      raw_client.client_options().upload_buffer_size(),
+      CreateHashValidator(request)));
 }
 
 std::string ParallelUploadPersistentState::ToString() const {

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/parallel_upload.h"
+#include "absl/memory/memory.h"
 
 namespace google {
 namespace cloud {
@@ -83,7 +84,7 @@ StatusOr<ObjectWriteStream> ParallelUploadStateImpl::CreateStream(
   assert(idx < streams_.size());
   lk.unlock();
   return ObjectWriteStream(
-      google::cloud::internal::make_unique<ParallelObjectWriteStreambuf>(
+      absl::make_unique<ParallelObjectWriteStreambuf>(
           shared_from_this(), idx, *std::move(session),
           raw_client.client_options().upload_buffer_size(),
           CreateHashValidator(request)));


### PR DESCRIPTION
Our installed cmake files were previously not listing `absl` as a dep, so callers were not able to link with our installed libraries and cmake files. This PR adds the correct cmake rules and also adds a non-test dep on `absl::make_unique` to common, bigtable, storage, and spanner, to show that the installed code actually works and links when running our quickstart tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4110)
<!-- Reviewable:end -->
