### PR TITLE
cleanup: enable clang-tidy for `bigtable` headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks: >
 WarningsAsErrors: "*"
 
 # TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/(bigquery|firestore|pubsub|spanner)/.*"
+HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|pubsub|spanner)/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/bigtable/app_profile_config.h
+++ b/google/cloud/bigtable/app_profile_config.h
@@ -49,19 +49,17 @@ class AppProfileConfig {
     return *this;
   }
 
-  // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::CreateAppProfileRequest const& as_proto()
       const& {
     return proto_;
   }
 
-  // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::CreateAppProfileRequest&& as_proto() && {
     return std::move(proto_);
   }
 
  private:
-  AppProfileConfig() : proto_() {}
+  AppProfileConfig() = default;
 
  private:
   google::bigtable::admin::v2::CreateAppProfileRequest proto_;
@@ -70,7 +68,7 @@ class AppProfileConfig {
 /// Build a proto to update an Application Profile configuration.
 class AppProfileUpdateConfig {
  public:
-  AppProfileUpdateConfig() : proto_() {}
+  AppProfileUpdateConfig() = default;
 
   AppProfileUpdateConfig& set_ignore_warnings(bool value) {
     proto_.set_ignore_warnings(value);
@@ -105,13 +103,11 @@ class AppProfileUpdateConfig {
     return *this;
   }
 
-  // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::UpdateAppProfileRequest const& as_proto()
       const& {
     return proto_;
   }
 
-  // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::UpdateAppProfileRequest&& as_proto() && {
     return std::move(proto_);
   }

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -46,6 +46,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
                            AsyncRowReader<RowFunctor, FinishFunctor>> {
  public:
   /// Special value to be used as rows_limit indicating no limit.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static std::int64_t constexpr NO_ROWS_LIMIT = 0;
   // Callbacks keep pointers to these objects.
   AsyncRowReader(AsyncRowReader&&) = delete;
@@ -63,11 +64,16 @@ class AsyncRowReader : public std::enable_shared_from_this<
       "RowFunctor should return a future<bool>.");
 
   static std::shared_ptr<AsyncRowReader> Create(
+      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
       CompletionQueue cq, std::shared_ptr<DataClient> client,
+      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
       std::string app_profile_id, std::string table_name, RowFunctor on_row,
+      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
       FinishFunctor on_finish, RowSet row_set, std::int64_t rows_limit,
+      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
       Filter filter, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
       MetadataUpdatePolicy metadata_update_policy,
       std::unique_ptr<internal::ReadRowsParserFactory> parser_factory) {
     std::shared_ptr<AsyncRowReader> res(new AsyncRowReader(
@@ -139,7 +145,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
         [self](google::bigtable::v2::ReadRowsResponse r) {
           return self->OnDataReceived(std::move(r));
         },
-        [self](Status s) { self->OnStreamFinished(std::move(s)); });
+        [self](Status const& s) { self->OnStreamFinished(s); });
   }
 
   /**
@@ -233,7 +239,8 @@ class AsyncRowReader : public std::enable_shared_from_this<
   }
 
   /// Called when lower layers provide us with a response chunk.
-  future<bool> OnDataReceived(google::bigtable::v2::ReadRowsResponse response) {
+  future<bool> OnDataReceived(
+      google::bigtable::v2::ReadRowsResponse const& response) {
     // assert(!whole_op_finished_);
     // assert(!continue_reading_);
     // assert(status_.ok());
@@ -263,7 +270,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
   }
 
   /// Called when the whole stream finishes.
-  void OnStreamFinished(Status status) {
+  void OnStreamFinished(Status const& status) {
     // assert(!continue_reading_);
     if (status_.ok()) {
       status_ = std::move(status);

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -64,16 +64,16 @@ class AsyncRowReader : public std::enable_shared_from_this<
       "RowFunctor should return a future<bool>.");
 
   static std::shared_ptr<AsyncRowReader> Create(
-      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
       CompletionQueue cq, std::shared_ptr<DataClient> client,
-      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
       std::string app_profile_id, std::string table_name, RowFunctor on_row,
-      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
       FinishFunctor on_finish, RowSet row_set, std::int64_t rows_limit,
-      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
       Filter filter, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
       std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-      // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
       MetadataUpdatePolicy metadata_update_policy,
       std::unique_ptr<internal::ReadRowsParserFactory> parser_factory) {
     std::shared_ptr<AsyncRowReader> res(new AsyncRowReader(

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -145,7 +145,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
         [self](google::bigtable::v2::ReadRowsResponse r) {
           return self->OnDataReceived(std::move(r));
         },
-        [self](Status const& s) { self->OnStreamFinished(s); });
+        [self](Status s) { self->OnStreamFinished(std::move(s)); });
   }
 
   /**
@@ -270,7 +270,8 @@ class AsyncRowReader : public std::enable_shared_from_this<
   }
 
   /// Called when the whole stream finishes.
-  void OnStreamFinished(Status const& status) {
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  void OnStreamFinished(Status status) {
     // assert(!continue_reading_);
     if (status_.ok()) {
       status_ = std::move(status);

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -104,10 +104,10 @@ class Cell {
 
   /// Create a Cell and fill it with a 64-bit value encoded as big endian.
   template <typename KeyType, typename ColumnType>
-  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   Cell(KeyType&& row_key, std::string family_name,
        ColumnType&& column_qualifier, std::int64_t timestamp,
-       // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+       // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
        std::int64_t value, std::vector<std::string> labels)
       : Cell(std::forward<KeyType>(row_key), std::move(family_name),
              std::forward<ColumnType>(column_qualifier), timestamp,
@@ -116,7 +116,7 @@ class Cell {
 
   /// Create a cell and fill it with data, but with empty labels.
   template <typename KeyType, typename ColumnType, typename ValueType>
-  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   Cell(KeyType&& row_key, std::string family_name,
        ColumnType&& column_qualifier, std::int64_t timestamp, ValueType&& value)
       : Cell(std::forward<KeyType>(row_key), std::move(family_name),

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -104,8 +104,10 @@ class Cell {
 
   /// Create a Cell and fill it with a 64-bit value encoded as big endian.
   template <typename KeyType, typename ColumnType>
+  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
   Cell(KeyType&& row_key, std::string family_name,
        ColumnType&& column_qualifier, std::int64_t timestamp,
+       // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
        std::int64_t value, std::vector<std::string> labels)
       : Cell(std::forward<KeyType>(row_key), std::move(family_name),
              std::forward<ColumnType>(column_qualifier), timestamp,
@@ -114,6 +116,7 @@ class Cell {
 
   /// Create a cell and fill it with data, but with empty labels.
   template <typename KeyType, typename ColumnType, typename ValueType>
+  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
   Cell(KeyType&& row_key, std::string family_name,
        ColumnType&& column_qualifier, std::int64_t timestamp, ValueType&& value)
       : Cell(std::forward<KeyType>(row_key), std::move(family_name),

--- a/google/cloud/bigtable/cluster_config.h
+++ b/google/cloud/bigtable/cluster_config.h
@@ -22,15 +22,20 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+
 /// Specify the initial configuration for a new cluster.
 class ClusterConfig {
  public:
   using StorageType = google::bigtable::admin::v2::StorageType;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static StorageType STORAGE_TYPE_UNSPECIFIED =
       google::bigtable::admin::v2::STORAGE_TYPE_UNSPECIFIED;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static StorageType SSD = google::bigtable::admin::v2::SSD;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static StorageType HDD = google::bigtable::admin::v2::HDD;
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   ClusterConfig(google::bigtable::admin::v2::Cluster cluster)
       : proto_(std::move(cluster)) {}
 
@@ -43,12 +48,10 @@ class ClusterConfig {
 
   std::string const& GetName() { return proto_.name(); }
 
-  // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::Cluster const& as_proto() const& {
     return proto_;
   }
 
-  // NOLINT: accessors can (and should) be snake_case.
   google::bigtable::admin::v2::Cluster&& as_proto() && {
     return std::move(proto_);
   }

--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -123,10 +123,10 @@ class GcRule {
                       std::is_convertible<GcRuleTypes, GcRule>...>::value,
                   "The arguments to Union must be convertible to GcRule");
     GcRule tmp;
-    auto& union_ = *tmp.gc_rule_.mutable_union_();
+    auto& gc_rule_union = *tmp.gc_rule_.mutable_union_();
     std::initializer_list<GcRule> list{std::forward<GcRuleTypes>(gc_rules)...};
     for (GcRule const& rule : list) {
-      *union_.add_rules() = rule.as_proto();
+      *gc_rule_union.add_rules() = rule.as_proto();
     }
     return tmp;
   }
@@ -150,7 +150,7 @@ class GcRule {
   //@}
 
  private:
-  GcRule() {}
+  GcRule() = default;
 
  private:
   google::bigtable::admin::v2::GcRule gc_rule_;
@@ -217,7 +217,7 @@ class ColumnFamilyModification {
   //@}
 
  private:
-  ColumnFamilyModification() {}
+  ColumnFamilyModification() = default;
 
  private:
   ::google::bigtable::admin::v2::ModifyColumnFamiliesRequest::Modification mod_;

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -185,7 +185,7 @@ std::shared_ptr<DataClient> CreateDefaultDataClient(std::string project_id,
  * Compute the full path of the instance associated with the client, i.e.,
  * `projects/instances/<client->project_id()>/instances/<client->instance_id()>`
  */
-inline std::string InstanceName(std::shared_ptr<DataClient> client) {
+inline std::string InstanceName(std::shared_ptr<DataClient> const& client) {
   return "projects/" + client->project_id() + "/instances/" +
          client->instance_id();
 }

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -205,9 +205,9 @@ class Filter {
   template <typename Rep1, typename Period1, typename Rep2, typename Period2>
   static Filter TimestampRange(std::chrono::duration<Rep1, Period1> start,
                                std::chrono::duration<Rep2, Period2> end) {
-    using namespace std::chrono;
-    return TimestampRangeMicros(duration_cast<microseconds>(start).count(),
-                                duration_cast<microseconds>(end).count());
+    return TimestampRangeMicros(
+        std::chrono::duration_cast<std::chrono::microseconds>(start).count(),
+        std::chrono::duration_cast<std::chrono::microseconds>(end).count());
   }
 
   /**
@@ -687,7 +687,7 @@ class Filter {
 
  private:
   /// An empty filter, discards all data.
-  Filter() : filter_() {}
+  Filter() = default;
 
  private:
   google::bigtable::v2::RowFilter filter_;

--- a/google/cloud/bigtable/idempotent_mutation_policy.h
+++ b/google/cloud/bigtable/idempotent_mutation_policy.h
@@ -23,6 +23,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
+
 /**
  * Defines the interface to control which mutations are idempotent and therefore
  * can be re-tried.
@@ -53,7 +54,7 @@ std::unique_ptr<IdempotentMutationPolicy> DefaultIdempotentMutationPolicy();
  */
 class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
  public:
-  SafeIdempotentMutationPolicy() {}
+  SafeIdempotentMutationPolicy() = default;
 
   std::unique_ptr<IdempotentMutationPolicy> clone() const override;
   bool is_idempotent(google::bigtable::v2::Mutation const&) override;
@@ -73,13 +74,14 @@ class SafeIdempotentMutationPolicy : public IdempotentMutationPolicy {
  */
 class AlwaysRetryMutationPolicy : public IdempotentMutationPolicy {
  public:
-  AlwaysRetryMutationPolicy() {}
+  AlwaysRetryMutationPolicy() = default;
 
   std::unique_ptr<IdempotentMutationPolicy> clone() const override;
   bool is_idempotent(google::bigtable::v2::Mutation const&) override;
   bool is_idempotent(
       google::bigtable::v2::CheckAndMutateRowRequest const&) override;
 };
+
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -157,7 +157,7 @@ class InstanceAdmin {
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.
    */
   template <typename... Policies>
-  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   explicit InstanceAdmin(std::shared_ptr<InstanceAdminClient> client,
                          Policies&&... policies)
       : InstanceAdmin(std::move(client)) {

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -157,6 +157,7 @@ class InstanceAdmin {
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.
    */
   template <typename... Policies>
+  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
   explicit InstanceAdmin(std::shared_ptr<InstanceAdminClient> client,
                          Policies&&... policies)
       : InstanceAdmin(std::move(client)) {

--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -40,10 +40,13 @@ class InstanceConfig {
   //@{
   /// @name Convenient shorthands for the instance types.
   using InstanceType = google::bigtable::admin::v2::Instance::Type;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static InstanceType TYPE_UNSPECIFIED =
       google::bigtable::admin::v2::Instance::TYPE_UNSPECIFIED;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static InstanceType PRODUCTION =
       google::bigtable::admin::v2::Instance::PRODUCTION;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static InstanceType DEVELOPMENT =
       google::bigtable::admin::v2::Instance::DEVELOPMENT;
   //@}

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -31,6 +31,7 @@ using Instance = ::google::bigtable::admin::v2::Instance;
 /// Specify the initial configuration for updating an instance.
 class InstanceUpdateConfig {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor)
   InstanceUpdateConfig(Instance instance) {
     proto_.mutable_instance()->Swap(&instance);
   }
@@ -38,10 +39,13 @@ class InstanceUpdateConfig {
   //@{
   /// @name Convenient shorthands for the instance types.
   using InstanceType = google::bigtable::admin::v2::Instance::Type;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static InstanceType TYPE_UNSPECIFIED =
       google::bigtable::admin::v2::Instance::TYPE_UNSPECIFIED;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static InstanceType PRODUCTION =
       google::bigtable::admin::v2::Instance::PRODUCTION;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static InstanceType DEVELOPMENT =
       google::bigtable::admin::v2::Instance::DEVELOPMENT;
   //@}
@@ -49,10 +53,13 @@ class InstanceUpdateConfig {
   //@{
   /// @name Convenient shorthands for the instance state.
   using StateType = google::bigtable::admin::v2::Instance::State;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static StateType STATE_NOT_KNOWN =
       google::bigtable::admin::v2::Instance::STATE_NOT_KNOWN;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static StateType READY =
       google::bigtable::admin::v2::Instance::READY;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static StateType CREATING =
       google::bigtable::admin::v2::Instance::CREATING;
   //@}

--- a/google/cloud/bigtable/internal/async_longrunning_op.h
+++ b/google/cloud/bigtable/internal/async_longrunning_op.h
@@ -40,7 +40,7 @@ class AsyncLongrunningOperation {
       : client_(std::move(client)), operation_(std::move(operation)) {}
 
   AsyncLongrunningOperation(AsyncLongrunningOperation const&) = delete;
-  AsyncLongrunningOperation(AsyncLongrunningOperation&&) = default;
+  AsyncLongrunningOperation(AsyncLongrunningOperation&&) noexcept = default;
 
   // The semantics of the value returned by the future is as follows:
   // - outer status is the attempt's status (e.g. couldn't reach CBT)
@@ -97,15 +97,14 @@ class AsyncLongrunningOperation {
       return optional<StatusOr<Response>>(
           Status(static_cast<StatusCode>(operation_.error().code()),
                  operation_.error().message()));
-    } else {
-      Response res;
-      if (!operation_.response().UnpackTo(&res)) {
-        return optional<StatusOr<Response>>(
-            Status(StatusCode::kInternal,
-                   "Longrunning operation's result didn't parse."));
-      }
-      return optional<StatusOr<Response>>(std::move(res));
     }
+    Response res;
+    if (!operation_.response().UnpackTo(&res)) {
+      return optional<StatusOr<Response>>(
+          Status(StatusCode::kInternal,
+                 "Longrunning operation's result didn't parse."));
+    }
+    return optional<StatusOr<Response>>(std::move(res));
   }
 
   std::shared_ptr<Client> client_;

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -205,7 +205,9 @@ future<
     StatusOr<typename PollableOperationRequestTraits<Operation>::ResponseType>>
 StartAsyncPollOp(char const* location,
                  std::unique_ptr<PollingPolicy> polling_policy,
+                 // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
                  MetadataUpdatePolicy metadata_update_policy,
+                 // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
                  CompletionQueue cq, Operation operation) {
   auto req = std::shared_ptr<PollAsyncOpFuture<Operation>>(
       new PollAsyncOpFuture<Operation>(location, std::move(polling_policy),

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -203,12 +203,12 @@ class PollAsyncOpFuture {
 template <typename Operation>
 future<
     StatusOr<typename PollableOperationRequestTraits<Operation>::ResponseType>>
-StartAsyncPollOp(char const* location,
-                 std::unique_ptr<PollingPolicy> polling_policy,
-                 // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
-                 MetadataUpdatePolicy metadata_update_policy,
-                 // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
-                 CompletionQueue cq, Operation operation) {
+StartAsyncPollOp(
+    char const* location, std::unique_ptr<PollingPolicy> polling_policy,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+    MetadataUpdatePolicy metadata_update_policy,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+    CompletionQueue cq, Operation operation) {
   auto req = std::shared_ptr<PollAsyncOpFuture<Operation>>(
       new PollAsyncOpFuture<Operation>(location, std::move(polling_policy),
                                        std::move(metadata_update_policy),

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -207,10 +207,10 @@ template <typename AsyncCallType, typename Request, typename Accumulator,
 future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
     char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
-    // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+    // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
     MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
     Request request, Accumulator accumulator,
-    // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+    // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
     CombiningFunction combining_function, CompletionQueue cq) {
   std::shared_ptr<AsyncRetryMultiPageFuture<AsyncCallType, Request, Accumulator,
                                             CombiningFunction>>

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -207,8 +207,10 @@ template <typename AsyncCallType, typename Request, typename Accumulator,
 future<StatusOr<Accumulator>> StartAsyncRetryMultiPage(
     char const* location, std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
+    // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
     MetadataUpdatePolicy metadata_update_policy, AsyncCallType async_call,
     Request request, Accumulator accumulator,
+    // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
     CombiningFunction combining_function, CompletionQueue cq) {
   std::shared_ptr<AsyncRetryMultiPageFuture<AsyncCallType, Request, Accumulator,
                                             CombiningFunction>>

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -61,6 +61,7 @@ future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
     std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
     IdempotencyPolicy idempotent_policy,
+    // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
     MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
     AsyncCallType async_call, RequestType request, CompletionQueue cq) {
   static_assert(

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -61,7 +61,7 @@ future<StatusOr<Response>> AsyncStartPollAfterRetryUnaryRpc(
     std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
     std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
     IdempotencyPolicy idempotent_policy,
-    // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+    // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
     MetadataUpdatePolicy metadata_update_policy, std::shared_ptr<Client> client,
     AsyncCallType async_call, RequestType request, CompletionQueue cq) {
   static_assert(

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -53,7 +53,7 @@ class CommonClient {
   using ChannelPtr = std::shared_ptr<grpc::Channel>;
   //@}
 
-  CommonClient(bigtable::ClientOptions options)
+  explicit CommonClient(bigtable::ClientOptions options)
       : options_(std::move(options)), current_index_(0) {}
 
   /**

--- a/google/cloud/bigtable/internal/conjunction.h
+++ b/google/cloud/bigtable/internal/conjunction.h
@@ -27,6 +27,7 @@ namespace internal {
 // TODO(#108) - use std::conjunction<> if available.
 /// A metafunction to fold && across a list of types, empty list case.
 template <typename...>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct conjunction : std::true_type {};
 
 /// A metafunction to fold && across a list of types, a list with a single

--- a/google/cloud/bigtable/internal/readrowsparser.h
+++ b/google/cloud/bigtable/internal/readrowsparser.h
@@ -51,14 +51,7 @@ namespace internal {
  */
 class ReadRowsParser {
  public:
-  ReadRowsParser()
-      : row_key_(""),
-        cells_(),
-        cell_first_chunk_(true),
-        cell_(),
-        last_seen_row_key_(""),
-        row_ready_(false),
-        end_of_stream_(false) {}
+  ReadRowsParser() : row_key_(""), last_seen_row_key_("") {}
 
   virtual ~ReadRowsParser() = default;
 
@@ -125,7 +118,7 @@ class ReadRowsParser {
   std::vector<Cell> cells_;
 
   /// Is the next incoming chunk the first in a cell?
-  bool cell_first_chunk_;
+  bool cell_first_chunk_{true};
 
   /// Stores partial fields.
   ParseCell cell_;
@@ -134,10 +127,10 @@ class ReadRowsParser {
   RowKeyType last_seen_row_key_;
 
   /// True iff cells_ make up a complete row.
-  bool row_ready_;
+  bool row_ready_{false};
 
   /// Have we received the end of stream call?
-  bool end_of_stream_;
+  bool end_of_stream_{false};
 };
 
 /// Factory for creating parser instances, defined for testability.

--- a/google/cloud/bigtable/internal/rowreaderiterator.cc
+++ b/google/cloud/bigtable/internal/rowreaderiterator.cc
@@ -25,8 +25,6 @@ RowReaderIterator::RowReaderIterator(RowReader* owner) : owner_(owner) {
   Advance();
 }
 
-RowReaderIterator::RowReaderIterator() : owner_() {}
-
 // Defined here because it needs to see the definition of RowReader
 RowReaderIterator& RowReaderIterator::operator++() {
   if (owner_ == nullptr) {

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -51,8 +51,8 @@ class RowReaderIterator {
   using reference = value_type&;
   //@}
 
-  RowReaderIterator(RowReader* owner);
-  RowReaderIterator();
+  explicit RowReaderIterator(RowReader* owner);
+  RowReaderIterator() = default;
 
   RowReaderIterator& operator++();
   RowReaderIterator operator++(int) {
@@ -77,7 +77,7 @@ class RowReaderIterator {
 
   void Advance();
   /// nullptr indicates end()
-  RowReader* owner_;
+  RowReader* owner_{};
   /// Current value of the iterator.
   StatusOr<Row> row_;
 };

--- a/google/cloud/bigtable/metadata_update_policy.h
+++ b/google/cloud/bigtable/metadata_update_policy.h
@@ -39,18 +39,24 @@ inline namespace BIGTABLE_CLIENT_NS {
  */
 class MetadataParamTypes final {
  public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static MetadataParamTypes const PARENT;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static MetadataParamTypes const NAME;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static MetadataParamTypes const RESOURCE;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static MetadataParamTypes const TABLE_NAME;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static MetadataParamTypes const APP_PROFILE_NAME;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static MetadataParamTypes const INSTANCE_NAME;
 
   std::string const& type() const { return type_; }
 
  private:
+  explicit MetadataParamTypes(std::string type) : type_(std::move(type)) {}
   std::string type_;
-  MetadataParamTypes(std::string type) : type_(std::move(type)) {}
 };
 
 inline bool operator==(MetadataParamTypes const& lhs,
@@ -78,6 +84,7 @@ class MetadataUpdatePolicy {
                        MetadataParamTypes const& metadata_param_type);
 
   MetadataUpdatePolicy(MetadataUpdatePolicy&&) noexcept = default;
+  MetadataUpdatePolicy& operator=(MetadataUpdatePolicy&&) = default;
   MetadataUpdatePolicy(MetadataUpdatePolicy const&) = default;
   MetadataUpdatePolicy& operator=(MetadataUpdatePolicy const&) = default;
 

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -32,9 +32,9 @@ using ::testing::HasSubstr;
 
 /// @test A test for setting metadata for admin operations.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
-  grpc::string expected = "parent=" + kInstanceName_;
+  grpc::string expected = "parent=" + std::string(kInstanceName);
   auto gc = bigtable::GcRule::MaxNumVersions(42);
-  admin_->CreateTable(kTableName_, bigtable::TableConfig({{"fam", gc}}, {}));
+  admin_->CreateTable(kTableName, bigtable::TableConfig({{"fam", gc}}, {}));
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
@@ -44,8 +44,8 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
 
 /// @test A test for setting metadata when table is not known.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
-  grpc::string expected = "name=" + kTableName_;
-  admin_->GetTable(kTableId_);
+  grpc::string expected = "name=" + std::string(kTableName);
+  admin_->GetTable(kTableId);
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
@@ -55,7 +55,7 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
 
 /// @test A test for setting metadata when table is known.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
-  grpc::string expected = "table_name=" + kTableName_;
+  grpc::string expected = "table_name=" + std::string(kTableName);
   auto reader = table_->ReadRows(bigtable::RowSet("row1"), 1,
                                  bigtable::Filter::PassAllFilter());
   // lets make the RPC call to send metadata
@@ -69,8 +69,8 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
 
 /// @test A cloning test for normal construction of metadata .
 TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
-  auto const x_google_request_params = "parent=" + kInstanceName_;
-  bigtable::MetadataUpdatePolicy created(kInstanceName_,
+  auto const x_google_request_params = "parent=" + std::string(kInstanceName);
+  bigtable::MetadataUpdatePolicy created(kInstanceName,
                                          bigtable::MetadataParamTypes::PARENT);
   EXPECT_EQ(x_google_request_params, created.value());
   EXPECT_THAT(created.api_client_header(), HasSubstr("gl-cpp/"));

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -32,9 +32,9 @@ using ::testing::HasSubstr;
 
 /// @test A test for setting metadata for admin operations.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
-  grpc::string expected = "parent=" + kInstanceName;
+  grpc::string expected = "parent=" + kInstanceName_;
   auto gc = bigtable::GcRule::MaxNumVersions(42);
-  admin_->CreateTable(kTableName, bigtable::TableConfig({{"fam", gc}}, {}));
+  admin_->CreateTable(kTableName_, bigtable::TableConfig({{"fam", gc}}, {}));
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
@@ -44,8 +44,8 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
 
 /// @test A test for setting metadata when table is not known.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
-  grpc::string expected = "name=" + kTableName;
-  admin_->GetTable(kTableId);
+  grpc::string expected = "name=" + kTableName_;
+  admin_->GetTable(kTableId_);
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
@@ -55,7 +55,7 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
 
 /// @test A test for setting metadata when table is known.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
-  grpc::string expected = "table_name=" + kTableName;
+  grpc::string expected = "table_name=" + kTableName_;
   auto reader = table_->ReadRows(bigtable::RowSet("row1"), 1,
                                  bigtable::Filter::PassAllFilter());
   // lets make the RPC call to send metadata
@@ -69,8 +69,8 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
 
 /// @test A cloning test for normal construction of metadata .
 TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
-  auto const x_google_request_params = "parent=" + kInstanceName;
-  bigtable::MetadataUpdatePolicy created(kInstanceName,
+  auto const x_google_request_params = "parent=" + kInstanceName_;
+  bigtable::MetadataUpdatePolicy created(kInstanceName_,
                                          bigtable::MetadataParamTypes::PARENT);
   EXPECT_EQ(x_google_request_params, created.value());
   EXPECT_THAT(created.api_client_header(), HasSubstr("gl-cpp/"));

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -209,10 +209,10 @@ class MutationBatcher {
    * another attempt before invoking callbacks for the previous one.
    */
   struct Batch {
-    Batch() : num_mutations(), requests_size() {}
+    Batch() = default;
 
-    size_t num_mutations;
-    size_t requests_size;
+    size_t num_mutations{};
+    size_t requests_size{};
     BulkMutation requests;
     std::vector<MutationData> mutation_data;
   };

--- a/google/cloud/bigtable/read_modify_write_rule.h
+++ b/google/cloud/bigtable/read_modify_write_rule.h
@@ -77,7 +77,7 @@ class ReadModifyWriteRule {
    *
    * Empty operations are not usable, so this constructor is private.
    */
-  ReadModifyWriteRule() {}
+  ReadModifyWriteRule() = default;
 
  private:
   google::bigtable::v2::ReadModifyWriteRule rule_;

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -47,6 +47,7 @@ class RowReader {
    * Zero is used as a magic value that means "get all rows" in the
    * Cloud Bigtable RPC protocol.
    */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static std::int64_t constexpr NO_ROWS_LIMIT = 0;
 
   RowReader(std::shared_ptr<DataClient> client, std::string table_name,

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -156,7 +156,7 @@ class RowReaderTest : public bigtable::testing::TableTestFixture {
   RowReaderTest()
       : retry_policy_(new RetryPolicyMock),
         backoff_policy_(new BackoffPolicyMock),
-        metadata_update_policy_(kTableName,
+        metadata_update_policy_(kTableName_,
                                 bigtable::MetadataParamTypes::TABLE_NAME),
         parser_factory_(new ReadRowsParserMockFactory) {}
 

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -156,7 +156,7 @@ class RowReaderTest : public bigtable::testing::TableTestFixture {
   RowReaderTest()
       : retry_policy_(new RetryPolicyMock),
         backoff_policy_(new BackoffPolicyMock),
-        metadata_update_policy_(kTableName_,
+        metadata_update_policy_(kTableName,
                                 bigtable::MetadataParamTypes::TABLE_NAME),
         parser_factory_(new ReadRowsParserMockFactory) {}
 

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -32,7 +32,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 class RowSet {
  public:
   /// Create an empty set.
-  RowSet() {}
+  RowSet() = default;
 
   RowSet(RowSet&&) noexcept = default;
   RowSet& operator=(RowSet&&) noexcept = default;
@@ -40,7 +40,7 @@ class RowSet {
   RowSet& operator=(RowSet const&) = default;
 
   template <typename... Arg>
-  RowSet(Arg&&... a) {
+  RowSet(Arg&&... a) {  // NOLINT(google-explicit-constructor)
     AppendAll(std::forward<Arg&&>(a)...);
   }
 

--- a/google/cloud/bigtable/rpc_backoff_policy.h
+++ b/google/cloud/bigtable/rpc_backoff_policy.h
@@ -85,9 +85,10 @@ std::unique_ptr<RPCBackoffPolicy> DefaultRPCBackoffPolicy(
  */
 class ExponentialBackoffPolicy : public RPCBackoffPolicy {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor)
   ExponentialBackoffPolicy(internal::RPCPolicyParameters defaults);
-  template <typename duration_t1, typename duration_t2>
-  ExponentialBackoffPolicy(duration_t1 initial_delay, duration_t2 maximum_delay)
+  template <typename DurationT1, typename DurationT2>
+  ExponentialBackoffPolicy(DurationT1 initial_delay, DurationT2 maximum_delay)
       : impl_(initial_delay / 2, maximum_delay, 2.0) {}
 
   std::unique_ptr<RPCBackoffPolicy> clone() const override;

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -148,8 +148,8 @@ class LimitedErrorCountRetryPolicy : public RPCRetryPolicy {
 class LimitedTimeRetryPolicy : public RPCRetryPolicy {
  public:
   explicit LimitedTimeRetryPolicy(internal::RPCPolicyParameters defaults);
-  template <typename duration_t>
-  explicit LimitedTimeRetryPolicy(duration_t maximum_duration)
+  template <typename DurationT>
+  explicit LimitedTimeRetryPolicy(DurationT maximum_duration)
       : impl_(maximum_duration) {}
 
   std::unique_ptr<RPCRetryPolicy> clone() const override;

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -59,9 +59,9 @@ class MutationBatcher;
  *
  * Where the project id and instance id come from the @p client parameter.
  */
-inline std::string TableName(std::shared_ptr<DataClient> client,
+inline std::string TableName(std::shared_ptr<DataClient> const& client,
                              std::string const& table_id) {
-  return InstanceName(std::move(client)) + "/tables/" + table_id;
+  return InstanceName(client) + "/tables/" + table_id;
 }
 
 /**
@@ -169,14 +169,14 @@ class Table {
 
   /// A meta function to check if @p P is a valid Policy type.
   template <typename P>
-  struct valid_policy : google::cloud::internal::disjunction<
-                            std::is_base_of<RPCBackoffPolicy, P>,
-                            std::is_base_of<RPCRetryPolicy, P>,
-                            std::is_base_of<IdempotentMutationPolicy, P>> {};
+  struct ValidPolicy : google::cloud::internal::disjunction<
+                           std::is_base_of<RPCBackoffPolicy, P>,
+                           std::is_base_of<RPCRetryPolicy, P>,
+                           std::is_base_of<IdempotentMutationPolicy, P>> {};
 
   /// A meta function to check if all the @p Policies are valid policy types.
   template <typename... Policies>
-  struct valid_policies : internal::conjunction<valid_policy<Policies>...> {};
+  struct ValidPolicies : internal::conjunction<ValidPolicy<Policies>...> {};
 
  public:
   /**
@@ -274,9 +274,10 @@ class Table {
    * @par Modified Retry Policy Example
    * @snippet data_snippets.cc apply custom retry
    */
-  template <typename... Policies,
-            typename std::enable_if<valid_policies<Policies...>::value,
-                                    int>::type = 0>
+  template <
+      typename... Policies,
+      typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0>
+  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
   Table(std::shared_ptr<DataClient> client, std::string const& table_id,
         Policies&&... policies)
       : Table(std::move(client), table_id) {
@@ -337,9 +338,10 @@ class Table {
    * @par Modified Retry Policy Example
    * @snippet data_snippets.cc apply custom retry
    */
-  template <typename... Policies,
-            typename std::enable_if<valid_policies<Policies...>::value,
-                                    int>::type = 0>
+  template <
+      typename... Policies,
+      typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0>
+  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
   Table(std::shared_ptr<DataClient> client, std::string app_profile_id,
         std::string const& table_id, Policies&&... policies)
       : Table(std::move(client), std::move(app_profile_id), table_id) {

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -277,7 +277,7 @@ class Table {
   template <
       typename... Policies,
       typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0>
-  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   Table(std::shared_ptr<DataClient> client, std::string const& table_id,
         Policies&&... policies)
       : Table(std::move(client), table_id) {
@@ -341,7 +341,7 @@ class Table {
   template <
       typename... Policies,
       typename std::enable_if<ValidPolicies<Policies...>::value, int>::type = 0>
-  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   Table(std::shared_ptr<DataClient> client, std::string app_profile_id,
         std::string const& table_id, Policies&&... policies)
       : Table(std::move(client), std::move(app_profile_id), table_id) {

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -173,6 +173,7 @@ class TableAdmin {
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.
    */
   template <typename... Policies>
+  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,
              Policies&&... policies)
       : TableAdmin(std::move(client), std::move(instance_id)) {
@@ -186,19 +187,24 @@ class TableAdmin {
   /// @name Convenience shorthands for the schema views.
   using TableView = google::bigtable::admin::v2::Table::View;
   /// Use the default view as defined for each function.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TableView VIEW_UNSPECIFIED =
       google::bigtable::admin::v2::Table::VIEW_UNSPECIFIED;
   /// Populate only the name in the responses.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TableView NAME_ONLY =
       google::bigtable::admin::v2::Table::NAME_ONLY;
   /// Populate only the name and the fields related to the table schema.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TableView SCHEMA_VIEW =
       google::bigtable::admin::v2::Table::SCHEMA_VIEW;
   /// Populate only the name and the fields related to the table replication
   /// state.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TableView REPLICATION_VIEW =
       google::bigtable::admin::v2::Table::REPLICATION_VIEW;
   /// Populate all the fields in the response.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TableView FULL = google::bigtable::admin::v2::Table::FULL;
   //@}
 

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -173,7 +173,7 @@ class TableAdmin {
    *     LimitedErrorCountRetryPolicy, LimitedTimeRetryPolicy.
    */
   template <typename... Policies>
-  // NOLINTNEXTLINE(BOGUS,performance-unnecessary-value-param)
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,
              Policies&&... policies)
       : TableAdmin(std::move(client), std::move(instance_id)) {

--- a/google/cloud/bigtable/table_config.h
+++ b/google/cloud/bigtable/table_config.h
@@ -44,8 +44,10 @@ class TableConfig {
 
   using TimestampGranularity =
       ::google::bigtable::admin::v2::Table::TimestampGranularity;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TimestampGranularity MILLIS =
       ::google::bigtable::admin::v2::Table::MILLIS;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr static TimestampGranularity TIMESTAMP_GRANULARITY_UNSPECIFIED =
       ::google::bigtable::admin::v2::Table::TIMESTAMP_GRANULARITY_UNSPECIFIED;
 

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -27,22 +27,22 @@ class TableTest : public bigtable::testing::TableTestFixture {};
 }  // anonymous namespace
 
 TEST_F(TableTest, ClientProjectId) {
-  EXPECT_EQ(kProjectId_, client_->project_id());
+  EXPECT_EQ(kProjectId, client_->project_id());
 }
 
 TEST_F(TableTest, ClientInstanceId) {
-  EXPECT_EQ(kInstanceId_, client_->instance_id());
+  EXPECT_EQ(kInstanceId, client_->instance_id());
 }
 
 TEST_F(TableTest, StandaloneInstanceName) {
-  EXPECT_EQ(kInstanceName_, bigtable::InstanceName(client_));
+  EXPECT_EQ(kInstanceName, bigtable::InstanceName(client_));
 }
 
 TEST_F(TableTest, StandaloneTableName) {
-  EXPECT_EQ(kTableName_, bigtable::TableName(client_, kTableId_));
+  EXPECT_EQ(kTableName, bigtable::TableName(client_, kTableId));
 }
 
-TEST_F(TableTest, TableName) { EXPECT_EQ(kTableName_, table_.table_name()); }
+TEST_F(TableTest, TableName) { EXPECT_EQ(kTableName, table_.table_name()); }
 
 TEST_F(TableTest, TableConstructor) {
   std::string const other_table_id = "my-table";

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -27,26 +27,22 @@ class TableTest : public bigtable::testing::TableTestFixture {};
 }  // anonymous namespace
 
 TEST_F(TableTest, ClientProjectId) {
-  EXPECT_EQ(kProjectId, client_->project_id());
+  EXPECT_EQ(kProjectId_, client_->project_id());
 }
 
 TEST_F(TableTest, ClientInstanceId) {
-  EXPECT_EQ(kInstanceId, client_->instance_id());
+  EXPECT_EQ(kInstanceId_, client_->instance_id());
 }
 
 TEST_F(TableTest, StandaloneInstanceName) {
-  EXPECT_EQ(kInstanceName, bigtable::InstanceName(client_));
+  EXPECT_EQ(kInstanceName_, bigtable::InstanceName(client_));
 }
 
 TEST_F(TableTest, StandaloneTableName) {
-  EXPECT_EQ(kTableName, bigtable::TableName(client_, kTableId));
+  EXPECT_EQ(kTableName_, bigtable::TableName(client_, kTableId_));
 }
 
-TEST_F(TableTest, TableName) {
-  // clang-format: you are drunk, placing this short function in a single line
-  // is not nice.
-  EXPECT_EQ(kTableName, table_.table_name());
-}
+TEST_F(TableTest, TableName) { EXPECT_EQ(kTableName_, table_.table_name()); }
 
 TEST_F(TableTest, TableConstructor) {
   std::string const other_table_id = "my-table";

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -42,14 +42,14 @@ void EmbeddedServerTestFixture::SetUp() {
   std::shared_ptr<grpc::Channel> data_channel =
       server_->InProcessChannel(channel_arguments);
   data_client_ = std::make_shared<InProcessDataClient>(
-      std::move(kProjectId), std::move(kInstanceId), std::move(data_channel));
-  table_ = std::make_shared<bigtable::Table>(data_client_, kTableId);
+      kProjectId_, kInstanceId_, std::move(data_channel));
+  table_ = std::make_shared<bigtable::Table>(data_client_, kTableId_);
 
   std::shared_ptr<grpc::Channel> admin_channel =
       server_->InProcessChannel(channel_arguments);
   admin_client_ = std::make_shared<InProcessAdminClient>(
-      std::move(kProjectId), std::move(admin_channel));
-  admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_, kInstanceId);
+      kProjectId_, std::move(admin_channel));
+  admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_, kInstanceId_);
 }
 
 void EmbeddedServerTestFixture::TearDown() {

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -22,6 +22,12 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
+char const* const EmbeddedServerTestFixture::kProjectId;
+char const* const EmbeddedServerTestFixture::kInstanceId;
+char const* const EmbeddedServerTestFixture::kTableId;
+char const* const EmbeddedServerTestFixture::kInstanceName;
+char const* const EmbeddedServerTestFixture::kTableName;
+
 void EmbeddedServerTestFixture::StartServer() {
   int port;
   std::string server_address("[::]:0");
@@ -38,18 +44,22 @@ void EmbeddedServerTestFixture::SetUp() {
 
   grpc::ChannelArguments channel_arguments;
   channel_arguments.SetUserAgentPrefix(ClientOptions::UserAgentPrefix());
+  std::string project_id = kProjectId;
+  std::string instance_id = kInstanceId;
+  std::string table_id = kTableId;
 
   std::shared_ptr<grpc::Channel> data_channel =
       server_->InProcessChannel(channel_arguments);
-  data_client_ = std::make_shared<InProcessDataClient>(
-      kProjectId_, kInstanceId_, std::move(data_channel));
-  table_ = std::make_shared<bigtable::Table>(data_client_, kTableId_);
+  data_client_ = std::make_shared<InProcessDataClient>(project_id, instance_id,
+                                                       std::move(data_channel));
+  table_ = std::make_shared<bigtable::Table>(data_client_, std::move(table_id));
 
   std::shared_ptr<grpc::Channel> admin_channel =
       server_->InProcessChannel(channel_arguments);
   admin_client_ = std::make_shared<InProcessAdminClient>(
-      kProjectId_, std::move(admin_channel));
-  admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_, kInstanceId_);
+      std::move(project_id), std::move(admin_channel));
+  admin_ = std::make_shared<bigtable::TableAdmin>(admin_client_,
+                                                  std::move(instance_id));
 }
 
 void EmbeddedServerTestFixture::TearDown() {

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -22,11 +22,16 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
-char const* const EmbeddedServerTestFixture::kProjectId;
-char const* const EmbeddedServerTestFixture::kInstanceId;
-char const* const EmbeddedServerTestFixture::kTableId;
-char const* const EmbeddedServerTestFixture::kInstanceName;
-char const* const EmbeddedServerTestFixture::kTableName;
+char const EmbeddedServerTestFixture::kProjectId[] = "foo-project";
+char const EmbeddedServerTestFixture::kInstanceId[] = "bar-instance";
+char const EmbeddedServerTestFixture::kTableId[] = "baz-table";
+
+// These are hardcoded, and not computed, because we want to test the
+// computation.
+char const EmbeddedServerTestFixture::kInstanceName[] =
+    "projects/foo-project/instances/bar-instance";
+char const EmbeddedServerTestFixture::kTableName[] =
+    "projects/foo-project/instances/bar-instance/tables/baz-table";
 
 void EmbeddedServerTestFixture::StartServer() {
   int port;

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -96,16 +96,11 @@ class EmbeddedServerTestFixture : public ::testing::Test {
   void TearDown() override;
   void ResetChannel();
 
-  static auto constexpr kProjectId = "foo-project";
-  static auto constexpr kInstanceId = "bar-instance";
-  static auto constexpr kTableId = "baz-table";
-
-  // These are hardcoded, and not computed, because we want to test the
-  // computation.
-  static auto constexpr kInstanceName =
-      "projects/foo-project/instances/bar-instance";
-  static auto constexpr kTableName =
-      "projects/foo-project/instances/bar-instance/tables/baz-table";
+  static char const kProjectId[];
+  static char const kInstanceId[];
+  static char const kTableId[];
+  static char const kInstanceName[];
+  static char const kTableName[];
 
   std::string project_id_ = kProjectId;
   std::string instance_id_ = kInstanceId;

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -50,11 +50,11 @@ inline void GetClientMetadata(grpc::ServerContext* context,
  */
 class BigtableImpl final : public google::bigtable::v2::Bigtable::Service {
  public:
-  BigtableImpl() {}
+  BigtableImpl() = default;
   grpc::Status ReadRows(
       grpc::ServerContext* context,
       google::bigtable::v2::ReadRowsRequest const*,
-      grpc::ServerWriter<google::bigtable::v2::ReadRowsResponse>*) {
+      grpc::ServerWriter<google::bigtable::v2::ReadRowsResponse>*) override {
     GetClientMetadata(context, client_metadata_);
     return grpc::Status::OK;
   }
@@ -67,7 +67,7 @@ class BigtableImpl final : public google::bigtable::v2::Bigtable::Service {
 class TableAdminImpl final
     : public google::bigtable::admin::v2::BigtableTableAdmin::Service {
  public:
-  TableAdminImpl() {}
+  TableAdminImpl() = default;
 
   grpc::Status CreateTable(
       grpc::ServerContext* context,
@@ -92,24 +92,23 @@ class TableAdminImpl final
 class EmbeddedServerTestFixture : public ::testing::Test {
  protected:
   void StartServer();
-  void SetUp();
-  void TearDown();
+  void SetUp() override;
+  void TearDown() override;
   void ResetChannel();
 
-  std::string const kProjectId = "foo-project";
-  std::string const kInstanceId = "bar-instance";
-  std::string const kTableId = "baz-table";
-  std::string const kClusterId = "test_cluster";
+  std::string const kProjectId_ = "foo-project";
+  std::string const kInstanceId_ = "bar-instance";
+  std::string const kTableId_ = "baz-table";
 
   // These are hardcoded, and not computed, because we want to test the
   // computation.
-  std::string const kInstanceName =
+  std::string const kInstanceName_ =
       "projects/foo-project/instances/bar-instance";
-  std::string const kTableName =
+  std::string const kTableName_ =
       "projects/foo-project/instances/bar-instance/tables/baz-table";
 
-  std::string project_id_ = kProjectId;
-  std::string instance_id_ = kInstanceId;
+  std::string project_id_ = kProjectId_;
+  std::string instance_id_ = kInstanceId_;
   std::shared_ptr<DataClient> data_client_;
   std::shared_ptr<AdminClient> admin_client_;
   std::shared_ptr<bigtable::Table> table_;

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -96,19 +96,19 @@ class EmbeddedServerTestFixture : public ::testing::Test {
   void TearDown() override;
   void ResetChannel();
 
-  std::string const kProjectId_ = "foo-project";
-  std::string const kInstanceId_ = "bar-instance";
-  std::string const kTableId_ = "baz-table";
+  static auto constexpr kProjectId = "foo-project";
+  static auto constexpr kInstanceId = "bar-instance";
+  static auto constexpr kTableId = "baz-table";
 
   // These are hardcoded, and not computed, because we want to test the
   // computation.
-  std::string const kInstanceName_ =
+  static auto constexpr kInstanceName =
       "projects/foo-project/instances/bar-instance";
-  std::string const kTableName_ =
+  static auto constexpr kTableName =
       "projects/foo-project/instances/bar-instance/tables/baz-table";
 
-  std::string project_id_ = kProjectId_;
-  std::string instance_id_ = kInstanceId_;
+  std::string project_id_ = kProjectId;
+  std::string instance_id_ = kInstanceId;
   std::shared_ptr<DataClient> data_client_;
   std::shared_ptr<AdminClient> admin_client_;
   std::shared_ptr<bigtable::Table> table_;

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -49,8 +49,8 @@ struct MockAsyncFailingRpcFactory {
                ResponseType>) {}
 
   /// Refactor the boilerplate common to most tests.
-  std::function<SignatureType> Create(std::string expected_request,
-                                      std::string method) {
+  std::function<SignatureType> Create(std::string const& expected_request,
+                                      std::string const& method) {
     return std::function<SignatureType>([expected_request, method, this](
                                             grpc::ClientContext* context,
                                             RequestType const& request,

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -38,7 +38,8 @@ namespace testing {
 template <typename Response, typename Request>
 class MockResponseReader : public grpc::ClientReaderInterface<Response> {
  public:
-  MockResponseReader(std::string method) : method_(std::move(method)) {}
+  explicit MockResponseReader(std::string method)
+      : method_(std::move(method)) {}
   MOCK_METHOD0(WaitForInitialMetadata, void());
   MOCK_METHOD0(Finish, grpc::Status());
   MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -133,7 +133,7 @@ class TableIntegrationTest : public ::testing::Test {
   static std::string RandomTableId();
 
   /// Some tests cannot run on the emulator.
-  bool UsingCloudBigtableEmulator() const {
+  static bool UsingCloudBigtableEmulator() {
     return TableTestEnvironment::UsingCloudBigtableEmulator();
   }
 

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -21,11 +21,16 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
-char const* const TableTestFixture::kProjectId;
-char const* const TableTestFixture::kInstanceId;
-char const* const TableTestFixture::kTableId;
-char const* const TableTestFixture::kInstanceName;
-char const* const TableTestFixture::kTableName;
+char const TableTestFixture::kProjectId[] = "foo-project";
+char const TableTestFixture::kInstanceId[] = "bar-instance";
+char const TableTestFixture::kTableId[] = "baz-table";
+
+// These are hardcoded, and not computed, because we want to test the
+// computation.
+char const TableTestFixture::kInstanceName[] =
+    "projects/foo-project/instances/bar-instance";
+char const TableTestFixture::kTableName[] =
+    "projects/foo-project/instances/bar-instance/tables/baz-table";
 
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
     std::string const& repr) {

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -21,6 +21,12 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
+char const* const TableTestFixture::kProjectId;
+char const* const TableTestFixture::kInstanceId;
+char const* const TableTestFixture::kTableId;
+char const* const TableTestFixture::kInstanceName;
+char const* const TableTestFixture::kTableName;
+
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
     std::string const& repr) {
   google::bigtable::v2::ReadRowsResponse response;

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -30,16 +30,11 @@ class TableTestFixture : public ::testing::Test {
 
   std::shared_ptr<MockDataClient> SetupMockClient();
 
-  static auto constexpr kProjectId = "foo-project";
-  static auto constexpr kInstanceId = "bar-instance";
-  static auto constexpr kTableId = "baz-table";
-
-  // These are hardcoded, and not computed, because we want to test the
-  // computation.
-  static auto constexpr kInstanceName =
-      "projects/foo-project/instances/bar-instance";
-  static auto constexpr kTableName =
-      "projects/foo-project/instances/bar-instance/tables/baz-table";
+  static char const kProjectId[];
+  static char const kInstanceId[];
+  static char const kTableId[];
+  static char const kInstanceName[];
+  static char const kTableName[];
 
   std::string project_id_ = kProjectId;
   std::string instance_id_ = kInstanceId;

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -30,21 +30,21 @@ class TableTestFixture : public ::testing::Test {
 
   std::shared_ptr<MockDataClient> SetupMockClient();
 
-  std::string const kProjectId_ = "foo-project";
-  std::string const kInstanceId_ = "bar-instance";
-  std::string const kTableId_ = "baz-table";
+  static auto constexpr kProjectId = "foo-project";
+  static auto constexpr kInstanceId = "bar-instance";
+  static auto constexpr kTableId = "baz-table";
 
   // These are hardcoded, and not computed, because we want to test the
   // computation.
-  std::string const kInstanceName_ =
+  static auto constexpr kInstanceName =
       "projects/foo-project/instances/bar-instance";
-  std::string const kTableName_ =
+  static auto constexpr kTableName =
       "projects/foo-project/instances/bar-instance/tables/baz-table";
 
-  std::string project_id_ = kProjectId_;
-  std::string instance_id_ = kInstanceId_;
+  std::string project_id_ = kProjectId;
+  std::string instance_id_ = kInstanceId;
   std::shared_ptr<MockDataClient> client_ = SetupMockClient();
-  bigtable::Table table_ = bigtable::Table(client_, kTableId_);
+  bigtable::Table table_ = bigtable::Table(client_, kTableId);
 };
 
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -26,25 +26,25 @@ namespace testing {
 /// Common fixture for the bigtable::Table tests.
 class TableTestFixture : public ::testing::Test {
  protected:
-  TableTestFixture() {}
+  TableTestFixture() = default;
 
   std::shared_ptr<MockDataClient> SetupMockClient();
 
-  std::string const kProjectId = "foo-project";
-  std::string const kInstanceId = "bar-instance";
-  std::string const kTableId = "baz-table";
+  std::string const kProjectId_ = "foo-project";
+  std::string const kInstanceId_ = "bar-instance";
+  std::string const kTableId_ = "baz-table";
 
   // These are hardcoded, and not computed, because we want to test the
   // computation.
-  std::string const kInstanceName =
+  std::string const kInstanceName_ =
       "projects/foo-project/instances/bar-instance";
-  std::string const kTableName =
+  std::string const kTableName_ =
       "projects/foo-project/instances/bar-instance/tables/baz-table";
 
-  std::string project_id_ = kProjectId;
-  std::string instance_id_ = kInstanceId;
+  std::string project_id_ = kProjectId_;
+  std::string instance_id_ = kInstanceId_;
   std::shared_ptr<MockDataClient> client_ = SetupMockClient();
-  bigtable::Table table_ = bigtable::Table(client_, kTableId);
+  bigtable::Table table_ = bigtable::Table(client_, kTableId_);
 };
 
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(


### PR DESCRIPTION
Note that some "performance-unnecessary-value-param" NOLINT
directives are only due to an apparent clang-tidy bug, and
are tagged as "TODO(#4112)" to make their later removal easy.

Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4111)
<!-- Reviewable:end -->
