### PR TITLE
test: retry gcloud iam commands

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -53,7 +53,8 @@ fi
 echo "================================================================"
 io::log "Fetching dependencies"
 echo "================================================================"
-"${PROJECT_ROOT}/ci/retry-command.sh" \
+# retry up to 3 times with exponential backoff, initial interval 120s
+"${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
   "${BAZEL_BIN}" fetch -- //google/cloud/...:all
 
 echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -62,7 +62,8 @@ build_quickstart() {
   io::log "capture bazel version"
   ${BAZEL_BIN} version
   io::log "fetch dependencies for ${library}'s quickstart"
-  "${PROJECT_ROOT}/ci/retry-command.sh" \
+  # retry up to 3 times with exponential backoff, initial interval 120s
+  "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
     "${BAZEL_BIN}" fetch -- ...
 
   echo


### PR DESCRIPTION
* pass the number of retries and interval to `retry-program.sh`.
* apply 50% jitter to exponential backoff instead of 0-60s
* the existing cases pass the same parameters, so their behavior is
  unchanged aside from the jitter changes.

Fixes #4113 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4118)
<!-- Reviewable:end -->
