### PR TITLE
ci: use emulator for Bigtable+Bazel integration tests

### DIFF
--- a/ci/lib/init.sh
+++ b/ci/lib/init.sh
@@ -49,7 +49,7 @@ PROJECT_ROOT="$(init::repo_root "${PROGRAM_DIR}")"
 
 # Sets the path to the `module` library in PATH so that it can be found when
 # callers use `source module <args>`
-if [[ ! "$PATH" =~ "${PROJECT_ROOT}/ci/lib" ]]; then
+if [[ ! "$PATH" =~ ${PROJECT_ROOT}/ci/lib ]]; then
   # Changing PATH invalidates the Bazel cache, while this script runs at most
   # once when called by a single script, it might be loaded again by a child
   # script.

--- a/ci/lib/init.sh
+++ b/ci/lib/init.sh
@@ -49,7 +49,12 @@ PROJECT_ROOT="$(init::repo_root "${PROGRAM_DIR}")"
 
 # Sets the path to the `module` library in PATH so that it can be found when
 # callers use `source module <args>`
-PATH="${PROJECT_ROOT}/ci/lib:${PATH}"
+if [[ ! "$PATH" =~ "${PROJECT_ROOT}/ci/lib" ]]; then
+  # Changing PATH invalidates the Bazel cache, while this script runs at most
+  # once when called by a single script, it might be loaded again by a child
+  # script.
+  PATH="${PROJECT_ROOT}/ci/lib:${PATH}"
+fi
 
 # Sets a search path array for the "modules" that can be sourced. When a
 # caller writes `source module lib/foo.sh`, this path/array will be searched in

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -46,9 +46,9 @@ production_only_targets=(
 # `start_emulators` creates unsightly *.log files in the current directory
 # (which is ${PROJECT_ROOT}) and we cannot use a subshell because we want the
 # environment variables that it sets.
-pushd "${HOME}"
+pushd "${HOME}" >/dev/null
 start_emulators
-popd
+popd >/dev/null
 
 excluded_targets=(
   # This test can only run against production, *and* needs dynamically created

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module etc/integration-tests-config.sh
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") [bazel-test-args]"
+  exit 1
+fi
+
+BAZEL_BIN="$1"
+shift
+bazel_test_args=("$@")
+
+# Configure run_emulators_utils.sh to find the instance admin emulator.
+BAZEL_BIN_DIR="$("${BAZEL_BIN}" info bazel-bin)"
+readonly BAZEL_BIN_DIR
+export CBT_INSTANCE_ADMIN_EMULATOR_CMD="${BAZEL_BIN_DIR}/google/cloud/bigtable/tests/instance_admin_emulator"
+
+source "${PROJECT_ROOT}/google/cloud/bigtable/tools/run_emulator_utils.sh"
+
+# These can only run against production
+production_only_targets=(
+  "//google/cloud/bigtable/examples:table_admin_iam_policy_snippets"
+  "//google/cloud/bigtable/tests:admin_iam_policy_integration_test"
+)
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" \
+  --test_tag_filters="bigtable-integration-tests" -- \
+  "${production_only_targets[@]}"
+
+# `start_emulators` creates unsightly *.log files in the current directory
+# (which is ${PROJECT_ROOT}) and we cannot use a subshell because we want the
+# environment variables that it sets.
+pushd "${HOME}"
+start_emulators
+popd
+
+excluded_targets=(
+  # This test can only run against production, *and* needs dynamically created
+  # environment variables, it is called from build-in-docker-bazel.sh
+  "-//google/cloud/bigtable/examples:bigtable_grpc_credentials"
+)
+for target in "${production_only_targets[@]}"; do
+  excluded_targets+=("-${target}")
+done
+
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" \
+  --test_env="BIGTABLE_EMULATOR_HOST=${BIGTABLE_EMULATOR_HOST}" \
+  --test_env="BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}" \
+  --test_env="ENABLE_BIGTABLE_ADMIN_INTEGRATION_TEST=yes" \
+  --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
+  --test_tag_filters="bigtable-integration-tests" -- \
+  "//google/cloud/...:all" \
+  "${excluded_targets[@]}"
+exit_status=$?
+
+kill_emulators
+trap '' EXIT
+
+exit "${exit_status}"


### PR DESCRIPTION
We are running out of quota in production to run the Bigtable
integration tests. This change moves the Bazel-based builds to use the
emulators. A future PR will restore the nightly build to use production,
but we need to unblock progress first. The CMake-based builds already
use the emulator(s) for integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4121)
<!-- Reviewable:end -->
