### PR TITLE
cleanup: enable clang-tidy for additional headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks: >
 WarningsAsErrors: "*"
 
 # TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|pubsub|spanner)/.*"
+HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|grpc_utils|internal|pubsub|spanner|testing_util)/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/internal/async_read_stream_impl.h
+++ b/google/cloud/internal/async_read_stream_impl.h
@@ -138,6 +138,7 @@ class AsyncReadStreamImpl
   template <typename AsyncFunctionType, typename Request>
   void Start(AsyncFunctionType&& async_call, Request const& request,
              std::unique_ptr<grpc::ClientContext> context,
+             // NOLINTNEXTLINE(performance-unnecessary-value-param)  TODO(#4112)
              std::shared_ptr<CompletionQueueImpl> cq) {
     // An adapter to call OnStart() via the completion queue.
     class NotifyStart final : public AsyncGrpcOperation {
@@ -326,14 +327,14 @@ template <
     typename Response, typename OnReadHandler, typename OnFinishHandler,
     typename std::enable_if<
         google::cloud::internal::is_invocable<OnReadHandler, Response>::value,
-        int>::type on_read_is_invocable_with_response = 0,
+        int>::type OnReadIsInvocableWithResponse = 0,
     typename std::enable_if<
         std::is_same<future<bool>, google::cloud::internal::invoke_result_t<
                                        OnReadHandler, Response>>::value,
-        int>::type on_read_returns_future_bool = 0,
+        int>::type OnReadReturnsFutureBool = 0,
     typename std::enable_if<
         google::cloud::internal::is_invocable<OnFinishHandler, Status>::value,
-        int>::type on_finish_is_invocable_with_status = 0>
+        int>::type OnFinishIsInvocableWithStatus = 0>
 inline std::shared_ptr<
     AsyncReadStreamImpl<Response, OnReadHandler, OnFinishHandler>>
 MakeAsyncReadStreamImpl(OnReadHandler&& on_read, OnFinishHandler&& on_finish) {

--- a/google/cloud/internal/async_retry_unary_rpc.h
+++ b/google/cloud/internal/async_retry_unary_rpc.h
@@ -194,30 +194,31 @@ class RetryAsyncUnaryRpc {
  *     retryable error, but the request is non-idempotent, or (d) the
  *     retry policy is expired.
  */
-template <typename RPCBackoffPolicy, typename RPCRetryPolicy,
-          typename AsyncCallType, typename RequestType,
-          typename async_call_t = typename std::decay<AsyncCallType>::type,
-          typename request_t = typename std::decay<RequestType>::type,
-          typename std::enable_if<
-              google::cloud::internal::is_invocable<
-                  async_call_t, grpc::ClientContext*, request_t const&,
-                  grpc::CompletionQueue*>::value,
-              int>::type = 0>
-future<StatusOr<typename AsyncCallResponseType<async_call_t, request_t>::type>>
+template <
+    typename RPCBackoffPolicy, typename RPCRetryPolicy, typename AsyncCallType,
+    typename RequestType,
+    typename AsyncCallT = typename std::decay<AsyncCallType>::type,
+    typename RequestT = typename std::decay<RequestType>::type,
+    typename std::enable_if<google::cloud::internal::is_invocable<
+                                AsyncCallT, grpc::ClientContext*,
+                                RequestT const&, grpc::CompletionQueue*>::value,
+                            int>::type = 0>
+future<StatusOr<typename AsyncCallResponseType<AsyncCallT, RequestT>::type>>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)  TODO(#4112)
 StartRetryAsyncUnaryRpc(CompletionQueue cq, char const* location,
                         std::unique_ptr<RPCRetryPolicy> rpc_retry_policy,
                         std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy,
                         bool is_idempotent, AsyncCallType&& async_call,
                         RequestType&& request) {
-  return RetryAsyncUnaryRpc<RPCBackoffPolicy, RPCRetryPolicy, async_call_t,
-                            request_t>::Start(std::move(cq), location,
-                                              std::move(rpc_retry_policy),
-                                              std::move(rpc_backoff_policy),
-                                              is_idempotent,
-                                              std::forward<AsyncCallType>(
-                                                  async_call),
-                                              std::forward<RequestType>(
-                                                  request));
+  return RetryAsyncUnaryRpc<RPCBackoffPolicy, RPCRetryPolicy, AsyncCallT,
+                            RequestT>::Start(std::move(cq), location,
+                                             std::move(rpc_retry_policy),
+                                             std::move(rpc_backoff_policy),
+                                             is_idempotent,
+                                             std::forward<AsyncCallType>(
+                                                 async_call),
+                                             std::forward<RequestType>(
+                                                 request));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/completion_queue_impl.h
+++ b/google/cloud/internal/completion_queue_impl.h
@@ -229,7 +229,7 @@ using AsyncCallResponseType = AsyncCallResponseTypeUnwrap<
  */
 class CompletionQueueImpl {
  public:
-  CompletionQueueImpl() : cq_(), shutdown_(false) {}
+  CompletionQueueImpl() = default;
   virtual ~CompletionQueueImpl() = default;
 
   /// Run the event loop until Shutdown() is called.
@@ -299,7 +299,7 @@ class CompletionQueueImpl {
  private:
   grpc::CompletionQueue cq_;
   mutable std::mutex mu_;
-  bool shutdown_;  // GUARDED_BY(mu_)
+  bool shutdown_{false};  // GUARDED_BY(mu_)
   std::unordered_map<std::intptr_t, std::shared_ptr<AsyncGrpcOperation>>
       pending_ops_;  // GUARDED_BY(mu_)
 };

--- a/google/cloud/internal/disjunction.h
+++ b/google/cloud/internal/disjunction.h
@@ -26,6 +26,7 @@ namespace internal {
 /// A metafunction that folds || across a list of types, the specialization for
 /// an empty list.
 template <typename...>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct disjunction : std::false_type {};
 
 /// A metafunction that folds || across a list of types, the specialization for

--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -25,39 +25,39 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
 enum class file_type {
-  none = 0,
-  not_found,
-  regular,
-  directory,
-  symlink,
-  block,
-  character,
-  fifo,
-  socket,
-  unknown,
+  none = 0,   // NOLINT(readability-identifier-naming)
+  not_found,  // NOLINT(readability-identifier-naming)
+  regular,    // NOLINT(readability-identifier-naming)
+  directory,  // NOLINT(readability-identifier-naming)
+  symlink,    // NOLINT(readability-identifier-naming)
+  block,      // NOLINT(readability-identifier-naming)
+  character,  // NOLINT(readability-identifier-naming)
+  fifo,       // NOLINT(readability-identifier-naming)
+  socket,     // NOLINT(readability-identifier-naming)
+  unknown,    // NOLINT(readability-identifier-naming)
 };
 
 enum class perms {
-  none = 0,
-  owner_read = 0400,
-  owner_write = 0200,
-  owner_exec = 0100,
-  owner_all = 0700,
-  group_read = 0040,
-  group_write = 0020,
-  group_exec = 0010,
-  group_all = 0070,
-  others_read = 0004,
-  others_write = 0002,
-  others_exec = 0001,
-  others_all = 0007,
-  all = 0777,
-  set_uid = 04000,
-  set_gid = 02000,
-  sticky_bit = 01000,
-  mask = 07777,
+  none = 0,             // NOLINT(readability-identifier-naming)
+  owner_read = 0400,    // NOLINT(readability-identifier-naming)
+  owner_write = 0200,   // NOLINT(readability-identifier-naming)
+  owner_exec = 0100,    // NOLINT(readability-identifier-naming)
+  owner_all = 0700,     // NOLINT(readability-identifier-naming)
+  group_read = 0040,    // NOLINT(readability-identifier-naming)
+  group_write = 0020,   // NOLINT(readability-identifier-naming)
+  group_exec = 0010,    // NOLINT(readability-identifier-naming)
+  group_all = 0070,     // NOLINT(readability-identifier-naming)
+  others_read = 0004,   // NOLINT(readability-identifier-naming)
+  others_write = 0002,  // NOLINT(readability-identifier-naming)
+  others_exec = 0001,   // NOLINT(readability-identifier-naming)
+  others_all = 0007,    // NOLINT(readability-identifier-naming)
+  all = 0777,           // NOLINT(readability-identifier-naming)
+  set_uid = 04000,      // NOLINT(readability-identifier-naming)
+  set_gid = 02000,      // NOLINT(readability-identifier-naming)
+  sticky_bit = 01000,   // NOLINT(readability-identifier-naming)
+  mask = 07777,         // NOLINT(readability-identifier-naming)
 
-  unknown = 0xFFFF,
+  unknown = 0xFFFF,  // NOLINT(readability-identifier-naming)
 };
 
 inline perms operator&(perms lhs, perms rhs) {
@@ -100,7 +100,7 @@ inline perms operator^=(perms& lhs, perms rhs) {
  *
  * Implement the C++17 `std::filesystem::file_status` class.
  */
-class file_status {
+class file_status {  // NOLINT(readability-identifier-naming)
  public:
   file_status() noexcept : file_status(file_type::none) {}
   explicit file_status(file_type type, perms permissions = perms::unknown)

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -31,7 +31,7 @@ namespace internal {
  * @tparam T
  */
 template <typename T>
-class future_base {
+class future_base {  // NOLINT(readability-identifier-naming)
  public:
   future_base() noexcept = default;
   future_base(future_base&&) noexcept = default;
@@ -147,7 +147,7 @@ class future_base {
 };
 
 template <typename T>
-class promise_base {
+class promise_base {  // NOLINT(readability-identifier-naming)
  public:
   explicit promise_base(std::function<void()> cancellation_callback)
       : shared_state_(

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -45,7 +45,7 @@ namespace internal {
  * A continuation object will hold both the callable and the state to call it
  * with, the implementation of `.then()` takes care of those details.
  */
-class continuation_base {
+class continuation_base {  // NOLINT(readability-identifier-naming)
  public:
   virtual ~continuation_base() = default;
 
@@ -66,13 +66,11 @@ class continuation_base {
  *   on a future invalidates the future for further use. The shared state does
  *   not record that state change.
  */
-class future_shared_state_base {
+class future_shared_state_base {  // NOLINT(readability-identifier-naming)
  public:
   future_shared_state_base() : future_shared_state_base([] {}) {}
   explicit future_shared_state_base(std::function<void()> cancellation_callback)
-      : mu_(),
-        cv_(),
-        current_state_(state::not_ready),
+      : current_state_(state::not_ready),
         cancellation_callback_(std::move(cancellation_callback)) {}
   /// Return true if the shared state has a value or an exception.
   bool is_ready() const {
@@ -288,9 +286,9 @@ class future_shared_state_base {
   mutable std::mutex mu_;
   std::condition_variable cv_;
   enum class state {
-    not_ready,
-    has_exception,
-    has_value,
+    not_ready,      // NOLINT(readability-identifier-naming)
+    has_exception,  // NOLINT(readability-identifier-naming)
+    has_value,      // NOLINT(readability-identifier-naming)
   };
   state current_state_;
   std::exception_ptr exception_;
@@ -334,6 +332,7 @@ template <typename T>
 class future_shared_state final : private future_shared_state_base {
  public:
   future_shared_state() : future_shared_state_base(), buffer_() {}
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   explicit future_shared_state(std::function<void()> cancellation_callback)
       : future_shared_state_base(std::move(cancellation_callback)), buffer_() {}
   ~future_shared_state() {
@@ -472,7 +471,7 @@ class future_shared_state final : private future_shared_state_base {
 template <>
 class future_shared_state<void> final : private future_shared_state_base {
  public:
-  future_shared_state() : future_shared_state_base() {}
+  future_shared_state() = default;
   explicit future_shared_state(std::function<void()> cancellation_callback)
       : future_shared_state_base(std::move(cancellation_callback)) {}
 
@@ -662,6 +661,7 @@ void continuation_execute_delegate(
  *   `is_invocable<Functor, future_shared_state<R>>` requirement.
  */
 template <typename Functor, typename R>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct continuation : public continuation_base {
   using result_t = typename continuation_helper<Functor, R>::result_t;
   using input_shared_state_t = future_shared_state<R>;
@@ -718,6 +718,7 @@ struct continuation : public continuation_base {
  *   `is_invocable<Functor, future_shared_state<R>>` requirement.
  */
 template <typename Functor, typename T>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct unwrapping_continuation : public continuation_base {
   using R = typename unwrapping_continuation_helper<Functor, T>::result_t;
   using input_shared_state_t = future_shared_state<T>;

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -532,11 +532,11 @@ TEST(FutureImplObservable, NeverSet) {
   {
     future_shared_state<Observable> shared_state;
     EXPECT_FALSE(shared_state.is_ready());
-    EXPECT_EQ(0, Observable::default_constructor);
-    EXPECT_EQ(0, Observable::destructor);
+    EXPECT_EQ(0, Observable::default_constructor());
+    EXPECT_EQ(0, Observable::destructor());
   }
-  EXPECT_EQ(0, Observable::default_constructor);
-  EXPECT_EQ(0, Observable::destructor);
+  EXPECT_EQ(0, Observable::default_constructor());
+  EXPECT_EQ(0, Observable::destructor());
 }
 
 TEST(FutureImplObservable, SetValue) {
@@ -546,38 +546,38 @@ TEST(FutureImplObservable, SetValue) {
     EXPECT_FALSE(shared_state.is_ready());
 
     shared_state.set_value(Observable("set value"));
-    EXPECT_EQ(0, Observable::default_constructor);
-    EXPECT_EQ(1, Observable::value_constructor);
-    EXPECT_EQ(0, Observable::copy_constructor);
-    EXPECT_EQ(1, Observable::move_constructor);
-    EXPECT_EQ(0, Observable::copy_assignment);
-    EXPECT_EQ(0, Observable::move_assignment);
-    EXPECT_EQ(1, Observable::destructor);
+    EXPECT_EQ(0, Observable::default_constructor());
+    EXPECT_EQ(1, Observable::value_constructor());
+    EXPECT_EQ(0, Observable::copy_constructor());
+    EXPECT_EQ(1, Observable::move_constructor());
+    EXPECT_EQ(0, Observable::copy_assignment());
+    EXPECT_EQ(0, Observable::move_assignment());
+    EXPECT_EQ(1, Observable::destructor());
     {
       Observable value = shared_state.get();
-      EXPECT_EQ(0, Observable::default_constructor);
-      EXPECT_EQ(1, Observable::value_constructor);
-      EXPECT_EQ(0, Observable::copy_constructor);
-      EXPECT_EQ(2, Observable::move_constructor);
-      EXPECT_EQ(0, Observable::copy_assignment);
-      EXPECT_EQ(0, Observable::move_assignment);
-      EXPECT_EQ(1, Observable::destructor);
+      EXPECT_EQ(0, Observable::default_constructor());
+      EXPECT_EQ(1, Observable::value_constructor());
+      EXPECT_EQ(0, Observable::copy_constructor());
+      EXPECT_EQ(2, Observable::move_constructor());
+      EXPECT_EQ(0, Observable::copy_assignment());
+      EXPECT_EQ(0, Observable::move_assignment());
+      EXPECT_EQ(1, Observable::destructor());
     }
-    EXPECT_EQ(0, Observable::default_constructor);
-    EXPECT_EQ(1, Observable::value_constructor);
-    EXPECT_EQ(0, Observable::copy_constructor);
-    EXPECT_EQ(2, Observable::move_constructor);
-    EXPECT_EQ(0, Observable::copy_assignment);
-    EXPECT_EQ(0, Observable::move_assignment);
-    EXPECT_EQ(2, Observable::destructor);
+    EXPECT_EQ(0, Observable::default_constructor());
+    EXPECT_EQ(1, Observable::value_constructor());
+    EXPECT_EQ(0, Observable::copy_constructor());
+    EXPECT_EQ(2, Observable::move_constructor());
+    EXPECT_EQ(0, Observable::copy_assignment());
+    EXPECT_EQ(0, Observable::move_assignment());
+    EXPECT_EQ(2, Observable::destructor());
   }
-  EXPECT_EQ(0, Observable::default_constructor);
-  EXPECT_EQ(1, Observable::value_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
-  EXPECT_EQ(2, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(3, Observable::destructor);
+  EXPECT_EQ(0, Observable::default_constructor());
+  EXPECT_EQ(1, Observable::value_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
+  EXPECT_EQ(2, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(3, Observable::destructor());
 }
 
 }  // namespace

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -62,7 +62,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   // underlying class. Because we need to support C++11, we use a local class
   // instead of a lambda, as support for move+capture in lambdas is a C++14
   // feature.
-  struct adapter {
+  struct adapter {  // NOLINT(readability-identifier-naming)
     explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
@@ -103,7 +103,7 @@ typename internal::then_helper<F, T>::future_t future<T>::then_impl(
   //
   // Because we need to support C++11, we use a local class instead of a lambda,
   // as support for move+capture in lambdas is a C++14 feature.
-  struct adapter {
+  struct adapter {  // NOLINT(readability-identifier-naming)
     explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
@@ -145,7 +145,7 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   // underlying class. Because we need to support C++11, we use a local class
   // instead of a lambda, as support for move+capture in lambdas is a C++14
   // feature.
-  struct adapter {
+  struct adapter {  // NOLINT(readability-identifier-naming)
     explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)
@@ -185,7 +185,7 @@ typename internal::then_helper<F, void>::future_t future<void>::then_impl(
   //
   // Because we need to support C++11, we use a local class instead of a lambda,
   // as support for move+capture in lambdas is a C++14 feature.
-  struct adapter {
+  struct adapter {  // NOLINT(readability-identifier-naming)
     explicit adapter(F&& func) : functor(std::forward<F>(func)) {}
 
     auto operator()(std::shared_ptr<local_state_type> state)

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -34,7 +34,7 @@ class future_shared_state;
 
 /// Compute the return type for a `future<T>::then()`
 template <typename FunctorReturn>
-struct unwrap_then {
+struct unwrap_then {  // NOLINT(readability-identifier-naming)
   using type = FunctorReturn;
   using requires_unwrap_t = std::false_type;
 };
@@ -48,7 +48,7 @@ struct unwrap_then<future<U>> {
 
 /// Specialize the `unwrap_then<>` for functors that return `future<U>`
 template <typename U>
-struct unwrap_internal {
+struct unwrap_internal {  // NOLINT(readability-identifier-naming)
   using type = U;
   using requires_unwrap_t = std::false_type;
 };
@@ -93,7 +93,7 @@ template <
     typename std::enable_if<
         is_invocable<Functor, std::shared_ptr<future_shared_state<T>>>::value,
         int>::type = 0>
-struct continuation_helper {
+struct continuation_helper {  // NOLINT(readability-identifier-naming)
   /// The type returned by calling the functor with the given future type.
   using functor_result_t =
       invoke_result_t<Functor, std::shared_ptr<future_shared_state<T>>>;
@@ -144,6 +144,7 @@ template <
     typename std::enable_if<
         is_invocable<Functor, std::shared_ptr<future_shared_state<T>>>::value,
         int>::type = 0>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct unwrapping_continuation_helper {
   /// The type returned by calling the functor with the given future type.
   using functor_result_t =
@@ -182,7 +183,7 @@ struct unwrapping_continuation_helper {
 template <typename Functor, typename T,
           typename std::enable_if<is_invocable<Functor, future<T>>::value,
                                   int>::type = 0>
-struct then_helper {
+struct then_helper {  // NOLINT(readability-identifier-naming)
   /// The type returned by the functor
   using functor_result_t = invoke_result_t<Functor, future<T>>;
 
@@ -203,7 +204,7 @@ struct then_helper {
 };
 
 template <typename T, typename U>
-struct make_ready_helper {
+struct make_ready_helper {  // NOLINT(readability-identifier-naming)
   using type = typename std::decay<T>::type;
 };
 
@@ -216,7 +217,7 @@ struct make_ready_helper<T, std::reference_wrapper<X>> {
  * Compute the return type of make_ready_future<T>.
  */
 template <typename T>
-struct make_ready_return {
+struct make_ready_return {  // NOLINT(readability-identifier-naming)
   using type =
       typename make_ready_helper<T, typename std::decay<T>::type>::type;
 };

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -63,7 +63,7 @@ using void_t = void;
  *     specialization.
  */
 template <typename T>
-struct invoke_impl {
+struct invoke_impl {  // NOLINT(readability-identifier-naming)
   /**
    * Determine the result type of calling `f(ArgTypes...)`
    *
@@ -139,7 +139,7 @@ auto invoker_function(F&& f, ArgTypes&&... a)
 
 // The default (failure) SFINAE branch for `invoke_result_impl`.
 template <typename AlwaysVoid, typename, typename...>
-struct invoke_result_impl {};
+struct invoke_result_impl {};  // NOLINT(readability-identifier-naming)
 
 /**
  * The implementation details for `invoke_result<>`.
@@ -176,6 +176,7 @@ struct invoke_result_impl<decltype(void(invoker_function(
  *     about `std::invoke_result` and `std::result_of` (deprecated in C++17).
  */
 template <typename F, typename... ArgTypes>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct invoke_result : public invoke_result_impl<void, F, ArgTypes...> {};
 
 /// Implement the C++17 `std::invoke_result_t<>` meta-function.
@@ -184,6 +185,7 @@ using invoke_result_t = typename invoke_result<F, ArgTypes...>::type;
 
 // The default (failure) SFINAE branch for `is_invocable_impl`.
 template <typename AlwaysVoid, typename, typename...>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct is_invocable_impl : public std::false_type {};
 
 template <typename F, typename... ArgTypes>
@@ -202,6 +204,7 @@ struct is_invocable_impl<decltype(void(invoker_function(
  * @tparam ArgTypes the type of the arguments.
  */
 template <typename F, typename... ArgTypes>
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct is_invocable : public is_invocable_impl<void, F, ArgTypes...> {};
 
 }  // namespace internal

--- a/google/cloud/internal/ios_flags_saver.h
+++ b/google/cloud/internal/ios_flags_saver.h
@@ -42,7 +42,8 @@ namespace internal {
  */
 class IosFlagsSaver final {
  public:
-  IosFlagsSaver(std::ios_base& ios) : ios_(ios), flags_(ios_.flags()) {}
+  explicit IosFlagsSaver(std::ios_base& ios)
+      : ios_(ios), flags_(ios_.flags()) {}
   ~IosFlagsSaver() { ios_.setf(flags_); }
 
  private:

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -27,8 +27,8 @@ namespace internal {
 
 // Reimplementation of C++14 `std::integer_sequence`.
 template <class T, T... I>
-struct integer_sequence {
-  typedef T value_type;
+struct integer_sequence {  // NOLINT(readability-identifier-naming)
+  using value_type = T;
   static std::size_t constexpr size() noexcept { return sizeof...(I); }
 };
 

--- a/google/cloud/optional_test.cc
+++ b/google/cloud/optional_test.cc
@@ -47,7 +47,7 @@ TEST(OptionalTest, Simple) {
 TEST(OptionalTest, NoDefaultConstruction) {
   Observable::reset_counters();
   OptionalObservable other;
-  EXPECT_EQ(0, Observable::default_constructor);
+  EXPECT_EQ(0, Observable::default_constructor());
   EXPECT_FALSE(other.has_value());
 }
 
@@ -55,11 +55,11 @@ TEST(OptionalTest, Copy) {
   Observable::reset_counters();
   OptionalObservable other(Observable("foo"));
   EXPECT_EQ("foo", other.value().str());
-  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::move_constructor());
 
   Observable::reset_counters();
   OptionalObservable copy(other);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(1, Observable::copy_constructor());
   EXPECT_TRUE(copy.has_value());
   EXPECT_TRUE(other.has_value());
   EXPECT_EQ("foo", copy->str());
@@ -69,11 +69,11 @@ TEST(OptionalTest, MoveCopy) {
   Observable::reset_counters();
   OptionalObservable other(Observable("foo"));
   EXPECT_EQ("foo", other.value().str());
-  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::move_constructor());
 
   Observable::reset_counters();
   OptionalObservable copy(std::move(other));
-  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::move_constructor());
   EXPECT_TRUE(copy.has_value());
   EXPECT_EQ("foo", copy->str());
   // The spec requires moved-from optionals to have a value, but the value
@@ -92,11 +92,11 @@ TEST(OptionalTest, MoveAssignmentNoValueNoValue) {
   assigned = std::move(other);
   EXPECT_FALSE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.has_value());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, MoveAssignmentNoValueValue) {
@@ -111,11 +111,11 @@ TEST(OptionalTest, MoveAssignmentNoValueValue) {
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(1, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(1, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, MoveAssignmentNoValueT) {
@@ -128,11 +128,11 @@ TEST(OptionalTest, MoveAssignmentNoValueT) {
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(1, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(1, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, MoveAssignmentValueNoValue) {
@@ -145,11 +145,11 @@ TEST(OptionalTest, MoveAssignmentValueNoValue) {
   assigned = std::move(other);
   EXPECT_FALSE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.has_value());
-  EXPECT_EQ(1, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(1, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, MoveAssignmentValueValue) {
@@ -162,11 +162,11 @@ TEST(OptionalTest, MoveAssignmentValueValue) {
   assigned = std::move(other);
   EXPECT_TRUE(other.has_value());  // NOLINT(bugprone-use-after-move)
   EXPECT_TRUE(assigned.has_value());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(1, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(1, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
 }
@@ -179,11 +179,11 @@ TEST(OptionalTest, MoveAssignmentValueT) {
   Observable::reset_counters();
   assigned = std::move(other);
   EXPECT_TRUE(assigned.has_value());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(1, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(1, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
 }
@@ -194,8 +194,8 @@ TEST(OptionalTest, CopyAssignLvalue) {
   OptionalObservable other(original);
   EXPECT_EQ("foo", original.str());
   EXPECT_EQ("foo", other->str());
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(1, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, CopyAssignmentNoValueNoValue) {
@@ -208,11 +208,11 @@ TEST(OptionalTest, CopyAssignmentNoValueNoValue) {
   assigned = other;
   EXPECT_FALSE(other.has_value());
   EXPECT_FALSE(assigned.has_value());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, CopyAssignmentNoValueValue) {
@@ -227,11 +227,11 @@ TEST(OptionalTest, CopyAssignmentNoValueValue) {
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(1, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, CopyAssignmentNoValueT) {
@@ -244,11 +244,11 @@ TEST(OptionalTest, CopyAssignmentNoValueT) {
   EXPECT_TRUE(assigned.has_value());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other.str());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(1, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, CopyAssignmentValueNoValue) {
@@ -261,11 +261,11 @@ TEST(OptionalTest, CopyAssignmentValueNoValue) {
   assigned = other;
   EXPECT_FALSE(other.has_value());
   EXPECT_FALSE(assigned.has_value());
-  EXPECT_EQ(1, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(1, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 TEST(OptionalTest, CopyAssignmentValueValue) {
@@ -278,11 +278,11 @@ TEST(OptionalTest, CopyAssignmentValueValue) {
   assigned = other;
   EXPECT_TRUE(other.has_value());
   EXPECT_TRUE(assigned.has_value());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(1, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(1, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
 }
@@ -295,11 +295,11 @@ TEST(OptionalTest, CopyAssignmentValueT) {
   Observable::reset_counters();
   assigned = other;
   EXPECT_TRUE(assigned.has_value());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(1, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(1, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other.str());
 }

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -186,7 +186,7 @@ using testing_util::Observable;
 TEST(StatusOrObservableTest, NoDefaultConstruction) {
   Observable::reset_counters();
   StatusOr<Observable> other;
-  EXPECT_EQ(0, Observable::default_constructor);
+  EXPECT_EQ(0, Observable::default_constructor());
   EXPECT_FALSE(other.ok());
 }
 
@@ -195,11 +195,11 @@ TEST(StatusOrObservableTest, Copy) {
   Observable::reset_counters();
   StatusOr<Observable> other(Observable("foo"));
   EXPECT_EQ("foo", other.value().str());
-  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::move_constructor());
 
   Observable::reset_counters();
   StatusOr<Observable> copy(other);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(1, Observable::copy_constructor());
   EXPECT_STATUS_OK(copy);
   EXPECT_STATUS_OK(other);
   EXPECT_EQ("foo", copy->str());
@@ -210,11 +210,11 @@ TEST(StatusOrObservableTest, MoveCopy) {
   Observable::reset_counters();
   StatusOr<Observable> other(Observable("foo"));
   EXPECT_EQ("foo", other.value().str());
-  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::move_constructor());
 
   Observable::reset_counters();
   StatusOr<Observable> copy(std::move(other));
-  EXPECT_EQ(1, Observable::move_constructor);
+  EXPECT_EQ(1, Observable::move_constructor());
   EXPECT_STATUS_OK(copy);
   EXPECT_EQ("foo", copy->str());
   EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
@@ -232,11 +232,11 @@ TEST(StatusOrObservableTest, MoveAssignmentNoValueNoValue) {
   assigned = std::move(other);
   EXPECT_FALSE(other.ok());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.ok());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
@@ -252,11 +252,11 @@ TEST(StatusOrObservableTest, MoveAssignmentNoValueValue) {
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(1, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(1, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
@@ -270,11 +270,11 @@ TEST(StatusOrObservableTest, MoveAssignmentNoValueT) {
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(1, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(1, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
@@ -288,11 +288,11 @@ TEST(StatusOrObservableTest, MoveAssignmentValueNoValue) {
   assigned = std::move(other);
   EXPECT_FALSE(other.ok());  // NOLINT(bugprone-use-after-move)
   EXPECT_FALSE(assigned.ok());
-  EXPECT_EQ(1, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(1, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 /// @test A move-assigned status calls the right assignments and destructors.
@@ -306,11 +306,11 @@ TEST(StatusOrObservableTest, MoveAssignmentValueValue) {
   assigned = std::move(other);
   EXPECT_STATUS_OK(other);  // NOLINT(bugprone-use-after-move)
   EXPECT_STATUS_OK(assigned);
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(1, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(1, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other->str());
 }
@@ -324,11 +324,11 @@ TEST(StatusOrObservableTest, MoveAssignmentValueT) {
   Observable::reset_counters();
   assigned = std::move(other);
   EXPECT_STATUS_OK(assigned);
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(1, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(1, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("moved-out", other.str());  // NOLINT(bugprone-use-after-move)
 }
@@ -344,11 +344,11 @@ TEST(StatusOrObservableTest, CopyAssignmentNoValueNoValue) {
   assigned = other;
   EXPECT_FALSE(other.ok());
   EXPECT_FALSE(assigned.ok());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
@@ -364,11 +364,11 @@ TEST(StatusOrObservableTest, CopyAssignmentNoValueValue) {
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(1, Observable::copy_constructor());
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
@@ -382,11 +382,11 @@ TEST(StatusOrObservableTest, CopyAssignmentNoValueT) {
   EXPECT_STATUS_OK(assigned);
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other.str());
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(1, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(1, Observable::copy_constructor());
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
@@ -400,11 +400,11 @@ TEST(StatusOrObservableTest, CopyAssignmentValueNoValue) {
   assigned = other;
   EXPECT_FALSE(other.ok());
   EXPECT_FALSE(assigned.ok());
-  EXPECT_EQ(1, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(0, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(1, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(0, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
 }
 
 /// @test A copy-assigned status calls the right assignments and destructors.
@@ -418,11 +418,11 @@ TEST(StatusOrObservableTest, CopyAssignmentValueValue) {
   assigned = other;
   EXPECT_STATUS_OK(other);
   EXPECT_STATUS_OK(assigned);
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(1, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(1, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other->str());
 }
@@ -436,11 +436,11 @@ TEST(StatusOrObservableTest, CopyAssignmentValueT) {
   Observable::reset_counters();
   assigned = other;
   EXPECT_STATUS_OK(assigned);
-  EXPECT_EQ(0, Observable::destructor);
-  EXPECT_EQ(0, Observable::move_assignment);
-  EXPECT_EQ(1, Observable::copy_assignment);
-  EXPECT_EQ(0, Observable::move_constructor);
-  EXPECT_EQ(0, Observable::copy_constructor);
+  EXPECT_EQ(0, Observable::destructor());
+  EXPECT_EQ(0, Observable::move_assignment());
+  EXPECT_EQ(1, Observable::copy_assignment());
+  EXPECT_EQ(0, Observable::move_constructor());
+  EXPECT_EQ(0, Observable::copy_constructor());
   EXPECT_EQ("foo", assigned->str());
   EXPECT_EQ("foo", other.str());
 }

--- a/google/cloud/status_test.cc
+++ b/google/cloud/status_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/expect_exception.h"
-#include "google/cloud/testing_util/testing_types.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/testing_util/chrono_literals.h
+++ b/google/cloud/testing_util/chrono_literals.h
@@ -24,26 +24,33 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 namespace chrono_literals {
+
+// NOLINTNEXTLINE(google-runtime-int)
 std::chrono::hours constexpr operator"" _h(unsigned long long h) {
   return std::chrono::hours(h);
 }
 
+// NOLINTNEXTLINE(google-runtime-int)
 std::chrono::minutes constexpr operator"" _min(unsigned long long m) {
   return std::chrono::minutes(m);
 }
 
+// NOLINTNEXTLINE(google-runtime-int)
 std::chrono::seconds constexpr operator"" _s(unsigned long long s) {
   return std::chrono::seconds(s);
 }
 
+// NOLINTNEXTLINE(google-runtime-int)
 std::chrono::milliseconds constexpr operator"" _ms(unsigned long long ms) {
   return std::chrono::milliseconds(ms);
 }
 
+// NOLINTNEXTLINE(google-runtime-int)
 std::chrono::microseconds constexpr operator"" _us(unsigned long long us) {
   return std::chrono::microseconds(us);
 }
 
+// NOLINTNEXTLINE(google-runtime-int)
 std::chrono::nanoseconds constexpr operator"" _ns(unsigned long long ns) {
   return std::chrono::nanoseconds(ns);
 }

--- a/google/cloud/testing_util/testing_types.cc
+++ b/google/cloud/testing_util/testing_types.cc
@@ -19,13 +19,13 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
-int Observable::default_constructor = 0;
-int Observable::value_constructor = 0;
-int Observable::copy_constructor = 0;
-int Observable::move_constructor = 0;
-int Observable::copy_assignment = 0;
-int Observable::move_assignment = 0;
-int Observable::destructor = 0;
+int Observable::default_constructor_ = 0;
+int Observable::value_constructor_ = 0;
+int Observable::copy_constructor_ = 0;
+int Observable::move_constructor_ = 0;
+int Observable::copy_assignment_ = 0;
+int Observable::move_assignment_ = 0;
+int Observable::destructor_ = 0;
 
 }  // namespace testing_util
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/testing_util/testing_types.h
+++ b/google/cloud/testing_util/testing_types.h
@@ -34,6 +34,7 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
+
 /// A class without a default constructor.
 class NoDefaultConstructor {
  public:
@@ -64,50 +65,58 @@ inline bool operator!=(NoDefaultConstructor const& lhs,
  */
 class Observable {
  public:
-  static int default_constructor;
-  static int value_constructor;
-  static int copy_constructor;
-  static int move_constructor;
-  static int copy_assignment;
-  static int move_assignment;
-  static int destructor;
+  static int default_constructor() { return default_constructor_; }
+  static int value_constructor() { return value_constructor_; }
+  static int copy_constructor() { return copy_constructor_; }
+  static int move_constructor() { return move_constructor_; }
+  static int copy_assignment() { return copy_assignment_; }
+  static int move_assignment() { return move_assignment_; }
+  static int destructor() { return destructor_; }
 
   static void reset_counters() {
-    default_constructor = 0;
-    value_constructor = 0;
-    copy_constructor = 0;
-    move_constructor = 0;
-    copy_assignment = 0;
-    move_assignment = 0;
-    destructor = 0;
+    default_constructor_ = 0;
+    value_constructor_ = 0;
+    copy_constructor_ = 0;
+    move_constructor_ = 0;
+    copy_assignment_ = 0;
+    move_assignment_ = 0;
+    destructor_ = 0;
   }
 
-  Observable() { ++default_constructor; }
+  Observable() { ++default_constructor_; }
   explicit Observable(std::string s) : str_(std::move(s)) {
-    ++value_constructor;
+    ++value_constructor_;
   }
-  Observable(Observable const& rhs) : str_(rhs.str_) { ++copy_constructor; }
+  Observable(Observable const& rhs) : str_(rhs.str_) { ++copy_constructor_; }
   Observable(Observable&& rhs) noexcept : str_(std::move(rhs.str_)) {
     rhs.str_ = "moved-out";
-    ++move_constructor;
+    ++move_constructor_;
   }
 
   Observable& operator=(Observable const& rhs) {
     str_ = rhs.str_;
-    ++copy_assignment;
+    ++copy_assignment_;
     return *this;
   }
   Observable& operator=(Observable&& rhs) noexcept {
     str_ = std::move(rhs.str_);
     rhs.str_ = "moved-out";
-    ++move_assignment;
+    ++move_assignment_;
     return *this;
   }
-  ~Observable() { ++destructor; }
+  ~Observable() { ++destructor_; }
 
   std::string const& str() const { return str_; }
 
  private:
+  static int default_constructor_;
+  static int value_constructor_;
+  static int copy_constructor_;
+  static int move_constructor_;
+  static int copy_assignment_;
+  static int move_assignment_;
+  static int destructor_;
+
   std::string str_;
 };
 


### PR DESCRIPTION
This time `grpc_utils`, `internal`, and `testing_util`.

Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4127)
<!-- Reviewable:end -->
