### PR TITLE
fix: enable grpc_utils if any gRPC-based library is

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,11 +138,25 @@ option(GOOGLE_CLOUD_CPP_ENABLE_FIRESTORE
        "Enable building the Firestore library." ON)
 option(GOOGLE_CLOUD_CPP_ENABLE_PUBSUB "Enable building the Pub/Sub library." ON)
 
+# Compute the default value for GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS, use a
+# function to create a scope for the temporary variables.
+function(google_cloud_cpp_grpc_utils_expression)
+    set(expression "GOOGLE_CLOUD_CPP_ENABLE_BIGQUERY")
+    foreach (lib BIGTABLE SPANNER PUBSUB)
+        string(APPEND expression " OR GOOGLE_CLOUD_CPP_ENABLE_${lib}")
+    endforeach()
+    set(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION "${expression}" PARENT_SCOPE)
+endfunction()
+google_cloud_cpp_grpc_utils_expression()
+
 cmake_dependent_option(
-    GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS
-    "Enable building the gRPC utilities library." ON
-    "GOOGLE_CLOUD_CPP_ENABLE_BIGTABLE" OFF)
+        GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS
+        "Enable building the gRPC utilities library." ON
+        "${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION}" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
+
+message(STATUS "GRPC_UTILS = ${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS}")
+message(STATUS "GRPC_UTILS_DEFAULT = ${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION}")
 
 # Enable testing in this directory so we can do a top-level `make test`. This
 # also includes the BUILD_TESTING option, which is on by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,23 +140,18 @@ option(GOOGLE_CLOUD_CPP_ENABLE_PUBSUB "Enable building the Pub/Sub library." ON)
 
 # Compute the default value for GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS, use a
 # function to create a scope for the temporary variables.
-function(google_cloud_cpp_grpc_utils_expression)
-    set(expression "GOOGLE_CLOUD_CPP_ENABLE_BIGQUERY")
-    foreach (lib BIGTABLE SPANNER PUBSUB)
-        string(APPEND expression " OR GOOGLE_CLOUD_CPP_ENABLE_${lib}")
-    endforeach()
-    set(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION "${expression}" PARENT_SCOPE)
-endfunction()
-google_cloud_cpp_grpc_utils_expression()
+string(
+    CONCAT GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION
+           "GOOGLE_CLOUD_CPP_ENABLE_BIGQUERY OR "
+           "GOOGLE_CLOUD_CPP_ENABLE_BIGTABLE OR "
+           "GOOGLE_CLOUD_CPP_ENABLE_SPANNER OR "
+           "GOOGLE_CLOUD_CPP_ENABLE_PUBSUB")
 
 cmake_dependent_option(
-        GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS
-        "Enable building the gRPC utilities library." ON
-        "${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION}" OFF)
+    GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS
+    "Enable building the gRPC utilities library." ON
+    "${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION}" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS)
-
-message(STATUS "GRPC_UTILS = ${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS}")
-message(STATUS "GRPC_UTILS_DEFAULT = ${GOOGLE_CLOUD_CPP_ENABLE_GRPC_UTILS_EXPRESSION}")
 
 # Enable testing in this directory so we can do a top-level `make test`. This
 # also includes the BUILD_TESTING option, which is on by default.


### PR DESCRIPTION
The `cmake_dependent_option` expression was incomplete.

Fixes #4130 and fixes #3926

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4133)
<!-- Reviewable:end -->
