### PR TITLE
ci: log the clang-tidy config

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -118,6 +118,11 @@ ${CMAKE_COMMAND} \
 echo
 io::log_yellow "Finished CMake config"
 
+if [[ "${CLANG_TIDY:-}" = "yes" ]]; then
+  io::log_yellow "clang-tidy config:"
+  clang-tidy -dump-config
+fi
+
 if [[ "${CLANG_TIDY:-}" == "yes" && (\
   "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" || \
   "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GIT_ON_BORG") ]]; then


### PR DESCRIPTION
This helps make tracking of clang-tidy warnings a little easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4137)
<!-- Reviewable:end -->
