### PR TITLE
cleanup: enable clang-tidy for `bigtable/benchmarks`

### DIFF
--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
     gRPC::grpc
     protobuf::libprotobuf)
 google_cloud_cpp_add_common_options(bigtable_benchmark_common)
+google_cloud_cpp_add_clang_tidy(bigtable_benchmark_common)
 
 include(CreateBazelConfig)
 create_bazel_config(bigtable_benchmark_common YEAR 2020)
@@ -66,6 +67,7 @@ if (BUILD_TESTING)
                     gRPC::grpc
                     protobuf::libprotobuf)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
         if (MSVC)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
@@ -92,6 +94,7 @@ foreach (fname ${bigtable_benchmark_programs})
                 gRPC::grpc
                 protobuf::libprotobuf)
     google_cloud_cpp_add_common_options(${target})
+    google_cloud_cpp_add_clang_tidy(${target})
     if (BUILD_TESTING)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(

--- a/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/apply_read_latency_benchmark.cc
@@ -73,8 +73,16 @@
 
 /// Helper functions and types for the apply_read_latency_benchmark.
 namespace {
+
 namespace bigtable = google::cloud::bigtable;
-using namespace bigtable::benchmarks;
+using bigtable::benchmarks::Benchmark;
+using bigtable::benchmarks::BenchmarkResult;
+using bigtable::benchmarks::FormatDuration;
+using bigtable::benchmarks::kColumnFamily;
+using bigtable::benchmarks::kNumFields;
+using bigtable::benchmarks::MakeBenchmarkSetup;
+using bigtable::benchmarks::MakeRandomMutation;
+using bigtable::benchmarks::OperationResult;
 
 struct LatencyBenchmarkResult {
   BenchmarkResult apply_results;
@@ -111,8 +119,8 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  benchmark.PrintThroughputResult(std::cout, "perf", "Upload",
-                                  *populate_results);
+  Benchmark::PrintThroughputResult(std::cout, "perf", "Upload",
+                                   *populate_results);
 
   auto data_client = benchmark.MakeDataClient();
   // Start the threads running the latency test.
@@ -163,10 +171,10 @@ int main(int argc, char* argv[]) {
             << ", Ops=" << combined.apply_results.operations.size()
             << ", Rows=" << combined.apply_results.row_count << "\n";
 
-  benchmark.PrintLatencyResult(std::cout, "perf", "Apply()",
-                               combined.apply_results);
-  benchmark.PrintLatencyResult(std::cout, "perf", "ReadRow()",
-                               combined.read_results);
+  Benchmark::PrintLatencyResult(std::cout, "perf", "Apply()",
+                                combined.apply_results);
+  Benchmark::PrintLatencyResult(std::cout, "perf", "ReadRow()",
+                                combined.read_results);
 
   std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << "\n";
   benchmark.PrintResultCsv(std::cout, "perf", "BulkApply()", "Latency",
@@ -211,7 +219,8 @@ google::cloud::StatusOr<LatencyBenchmarkResult> RunBenchmark(
   LatencyBenchmarkResult result = {};
 
   auto data_client = benchmark.MakeDataClient();
-  bigtable::Table table(std::move(data_client), app_profile_id, table_id);
+  bigtable::Table table(std::move(data_client), std::move(app_profile_id),
+                        table_id);
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();
   std::uniform_int_distribution<int> prng_operation(0, 1);

--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -37,7 +37,7 @@ struct OperationResult {
 struct BenchmarkResult {
   std::chrono::milliseconds elapsed;
   std::deque<OperationResult> operations;
-  long row_count;
+  long row_count;  // NOLINT(google-runtime-int)
 };
 
 /**
@@ -45,7 +45,7 @@ struct BenchmarkResult {
  */
 class Benchmark {
  public:
-  explicit Benchmark(BenchmarkSetup const& setup);
+  explicit Benchmark(BenchmarkSetup setup);
   ~Benchmark();
 
   Benchmark(Benchmark const&) = delete;
@@ -67,7 +67,7 @@ class Benchmark {
   std::string MakeRandomKey(google::cloud::internal::DefaultPRNG& gen) const;
 
   /// Return the key for row @p id.
-  std::string MakeKey(long id) const;
+  std::string MakeKey(long id) const;  // NOLINT(google-runtime-int)
 
   /// Measure the time to compute an operation.
   template <typename Operation>
@@ -81,14 +81,15 @@ class Benchmark {
   }
 
   /// Print the result of a throughput test in human readable form.
-  void PrintThroughputResult(std::ostream& os, std::string const& test_name,
-                             std::string const& phase,
-                             BenchmarkResult const& result) const;
+  static void PrintThroughputResult(std::ostream& os,
+                                    std::string const& test_name,
+                                    std::string const& phase,
+                                    BenchmarkResult const& result);
 
   /// Print the result of a latency test in human readable form.
-  void PrintLatencyResult(std::ostream& os, std::string const& test_name,
-                          std::string const& operation,
-                          BenchmarkResult& result) const;
+  static void PrintLatencyResult(std::ostream& os, std::string const& test_name,
+                                 std::string const& operation,
+                                 BenchmarkResult& result);
 
   /// Return the header for CSV results.
   static std::string ResultsCsvHeader();
@@ -119,7 +120,8 @@ class Benchmark {
  private:
   /// Populate the table rows in the range [@p begin, @p end)
   google::cloud::StatusOr<BenchmarkResult> PopulateTableShard(
-      bigtable::Table& table, long begin, long end);
+      bigtable::Table& table, long begin,  // NOLINT(google-runtime-int)
+      long end);                           // NOLINT(google-runtime-int)
 
   /**
    * Return how much space to reserve for digits if the table has @p table_size
@@ -138,7 +140,7 @@ class Benchmark {
 /// Helper class to pretty print durations.
 struct FormatDuration {
   template <typename Rep, typename Period>
-  FormatDuration(std::chrono::duration<Rep, Period> d)
+  explicit FormatDuration(std::chrono::duration<Rep, Period> d)
       : ns(std::chrono::duration_cast<std::chrono::nanoseconds>(d)) {}
   std::chrono::nanoseconds ns;
 };

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -17,8 +17,12 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
-using namespace google::cloud::bigtable::benchmarks;
-using testing::HasSubstr;
+using ::google::cloud::bigtable::benchmarks::Benchmark;
+using ::google::cloud::bigtable::benchmarks::BenchmarkResult;
+using ::google::cloud::bigtable::benchmarks::kBulkSize;
+using ::google::cloud::bigtable::benchmarks::MakeBenchmarkSetup;
+using ::google::cloud::bigtable::benchmarks::OperationResult;
+using ::testing::HasSubstr;
 
 namespace {
 char arg0[] = "program";
@@ -109,7 +113,7 @@ TEST(BenchmarkTest, PrintThroughputResult) {
   result.operations.resize(3450);
 
   std::ostringstream os;
-  bm.PrintThroughputResult(os, "foo", "bar", result);
+  Benchmark::PrintThroughputResult(os, "foo", "bar", result);
   std::string output = os.str();
 
   // We do not want a change detector test, so the following assertions are
@@ -140,7 +144,7 @@ TEST(BenchmarkTest, PrintLatencyResult) {
   });
 
   std::ostringstream os;
-  bm.PrintLatencyResult(os, "foo", "bar", result);
+  Benchmark::PrintLatencyResult(os, "foo", "bar", result);
   std::string output = os.str();
 
   // We do not want a change detector test, so the following assertions are
@@ -174,7 +178,7 @@ TEST(BenchmarkTest, PrintCsv) {
                            std::chrono::microseconds(++count * 100)};
   });
 
-  std::string header = bm.ResultsCsvHeader();
+  std::string header = Benchmark::ResultsCsvHeader();
   auto const field_count = std::count(header.begin(), header.end(), ',');
 
   std::ostringstream os;

--- a/google/cloud/bigtable/benchmarks/constants.h
+++ b/google/cloud/bigtable/benchmarks/constants.h
@@ -28,7 +28,7 @@ namespace benchmarks {
  * Most of these were requirements in the original bugs (#189, #196).
  */
 /// The size of the table.
-constexpr long kDefaultTableSize = 10000000;
+constexpr long kDefaultTableSize = 10000000;  // NOLINT(google-runtime-int)
 
 /// The name of the column family used in the benchmark.
 constexpr char kColumnFamily[] = "cf";
@@ -40,7 +40,7 @@ constexpr int kNumFields = 10;
 constexpr int kFieldSize = 100;
 
 /// The size of each BulkApply request.
-constexpr long kBulkSize = 1000;
+constexpr long kBulkSize = 1000;  // NOLINT(google-runtime-int)
 
 /// The number of threads running the latency test.
 constexpr int kDefaultThreads = 8;

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -20,7 +20,7 @@
 #include <thread>
 
 namespace bigtable = google::cloud::bigtable;
-using namespace bigtable::benchmarks;
+using bigtable::benchmarks::CreateEmbeddedServer;
 using std::chrono::milliseconds;
 
 TEST(EmbeddedServer, WaitAndShutdown) {

--- a/google/cloud/bigtable/benchmarks/format_duration_test.cc
+++ b/google/cloud/bigtable/benchmarks/format_duration_test.cc
@@ -15,8 +15,13 @@
 #include "google/cloud/bigtable/benchmarks/benchmark.h"
 #include <gmock/gmock.h>
 
-using namespace google::cloud::bigtable::benchmarks;
-using namespace std::chrono;
+using ::google::cloud::bigtable::benchmarks::FormatDuration;
+using ::std::chrono::hours;
+using ::std::chrono::microseconds;
+using ::std::chrono::milliseconds;
+using ::std::chrono::minutes;
+using ::std::chrono::nanoseconds;
+using ::std::chrono::seconds;
 
 TEST(BenchmarksFormatDuration, NanoSeconds) {
   std::ostringstream os;

--- a/google/cloud/bigtable/benchmarks/random_mutation.cc
+++ b/google/cloud/bigtable/benchmarks/random_mutation.cc
@@ -27,9 +27,9 @@ bigtable::Mutation MakeRandomMutation(google::cloud::internal::DefaultPRNG& gen,
 }
 
 std::string MakeRandomValue(google::cloud::internal::DefaultPRNG& generator) {
-  static std::string const letters(
+  static std::string const kLetters(
       "ABCDEFGHIJLKMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz0123456789-/_");
-  return google::cloud::internal::Sample(generator, kFieldSize, letters);
+  return google::cloud::internal::Sample(generator, kFieldSize, kLetters);
 }
 }  // namespace benchmarks
 }  // namespace bigtable

--- a/google/cloud/bigtable/benchmarks/read_sync_vs_async_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/read_sync_vs_async_benchmark.cc
@@ -82,8 +82,14 @@
 
 /// Helper functions and types for the apply_read_latency_benchmark.
 namespace {
+
 namespace bigtable = google::cloud::bigtable;
-using namespace bigtable::benchmarks;
+using bigtable::benchmarks::Benchmark;
+using bigtable::benchmarks::BenchmarkResult;
+using bigtable::benchmarks::FormatDuration;
+using bigtable::benchmarks::kColumnFamily;
+using bigtable::benchmarks::MakeBenchmarkSetup;
+using bigtable::benchmarks::OperationResult;
 
 /// Run an iteration of the test.
 google::cloud::StatusOr<BenchmarkResult> RunSyncBenchmark(
@@ -150,8 +156,8 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  benchmark.PrintThroughputResult(std::cout, "perf", "Upload",
-                                  *populate_results);
+  Benchmark::PrintThroughputResult(std::cout, "perf", "Upload",
+                                   *populate_results);
 
   google::cloud::CompletionQueue cq;
   std::vector<std::thread> cq_threads;
@@ -207,9 +213,9 @@ int main(int argc, char* argv[]) {
             << ", Ops=" << sync_results.operations.size()
             << ", Rows=" << sync_results.row_count << "\n";
 
-  benchmark.PrintLatencyResult(std::cout, "perf", "AsyncReadRow()",
-                               async_results);
-  benchmark.PrintLatencyResult(std::cout, "perf", "ReadRow()", sync_results);
+  Benchmark::PrintLatencyResult(std::cout, "perf", "AsyncReadRow()",
+                                async_results);
+  Benchmark::PrintLatencyResult(std::cout, "perf", "ReadRow()", sync_results);
 
   std::cout << bigtable::benchmarks::Benchmark::ResultsCsvHeader() << "\n";
   benchmark.PrintResultCsv(std::cout, "perf", "BulkApply()", "Latency",
@@ -231,7 +237,7 @@ int main(int argc, char* argv[]) {
 namespace {
 
 void AsyncBenchmark::ActivateCompletionQueue() {
-  cq_threads_.push_back(std::thread([this] { cq_.Run(); }));
+  cq_threads_.emplace_back(std::thread([this] { cq_.Run(); }));
 }
 
 BenchmarkResult AsyncBenchmark::Run(std::chrono::seconds test_duration,

--- a/google/cloud/bigtable/benchmarks/setup.cc
+++ b/google/cloud/bigtable/benchmarks/setup.cc
@@ -48,13 +48,13 @@ std::string FormattedAnnotations() {
 }
 
 std::string MakeRandomTableId(std::string const& prefix) {
-  static std::string const table_id_chars(
+  static std::string const kTableIdChars(
       "ABCDEFGHIJLKMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz0123456789_");
   auto gen = google::cloud::internal::MakeDefaultPRNG();
   return prefix + "-" +
          google::cloud::internal::Sample(
              gen, google::cloud::bigtable::benchmarks::kTableIdRandomLetters,
-             table_id_chars);
+             kTableIdChars);
 }
 }  // anonymous namespace
 
@@ -63,7 +63,7 @@ namespace cloud {
 namespace bigtable {
 namespace benchmarks {
 BenchmarkSetup::BenchmarkSetup(BenchmarkSetupData setup_data)
-    : setup_data_(setup_data) {}
+    : setup_data_(std::move(setup_data)) {}
 
 google::cloud::StatusOr<BenchmarkSetup> MakeBenchmarkSetup(
     std::string const& prefix, int& argc, char* argv[]) {
@@ -142,7 +142,7 @@ google::cloud::StatusOr<BenchmarkSetup> MakeBenchmarkSetup(
   if (argc == 1) {
     return BenchmarkSetup{setup_data};
   }
-  long seconds = std::stol(shift());
+  long seconds = std::stol(shift());  // NOLINT(google-runtime-int)
   if (seconds <= 0) {
     return usage("test-duration-seconds should be > 0");
   }

--- a/google/cloud/bigtable/benchmarks/setup.h
+++ b/google/cloud/bigtable/benchmarks/setup.h
@@ -36,7 +36,7 @@ struct BenchmarkSetupData {
   std::string app_profile_id;
   std::string table_id;
   int thread_count;
-  long table_size;
+  long table_size;  // NOLINT(google-runtime-int)
   std::chrono::seconds test_duration;
   bool use_embedded_server;
 
@@ -63,7 +63,9 @@ class BenchmarkSetup {
   /// The randomly generated table id for the benchmark.
   std::string const& table_id() const { return setup_data_.table_id; }
 
-  long table_size() const { return setup_data_.table_size; }
+  long table_size() const {  // NOLINT(google-runtime-int)
+    return setup_data_.table_size;
+  }
   int thread_count() const { return setup_data_.thread_count; }
   std::chrono::seconds test_duration() const {
     return setup_data_.test_duration;

--- a/google/cloud/bigtable/benchmarks/setup_test.cc
+++ b/google/cloud/bigtable/benchmarks/setup_test.cc
@@ -17,7 +17,11 @@
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 
-using namespace google::cloud::bigtable::benchmarks;
+using ::google::cloud::bigtable::benchmarks::kDefaultTableSize;
+using ::google::cloud::bigtable::benchmarks::kDefaultTestDuration;
+using ::google::cloud::bigtable::benchmarks::kDefaultThreads;
+using ::google::cloud::bigtable::benchmarks::kTableIdRandomLetters;
+using ::google::cloud::bigtable::benchmarks::MakeBenchmarkSetup;
 using ::testing::HasSubstr;
 
 namespace {


### PR DESCRIPTION
Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4138)
<!-- Reviewable:end -->
