### PR TITLE
fix: reduce flakiness in macos/cmake-super build

### DIFF
--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -540,12 +540,15 @@ void InsertTestData(google::cloud::bigtable::Table table,
     char buf[32];
     snprintf(buf, sizeof(buf), "key-%06d", i);
     cbt::SingleRowMutation mutation(buf);
-    mutation.emplace_back(
-        cbt::SetCell("fam", "col0", "value0-" + std::to_string(i)));
-    mutation.emplace_back(
-        cbt::SetCell("fam", "col1", "value1-" + std::to_string(i)));
-    mutation.emplace_back(
-        cbt::SetCell("fam", "col2", "value2-" + std::to_string(i)));
+    mutation.emplace_back(cbt::SetCell("fam", "col0",
+                                       std::chrono::milliseconds(0),
+                                       "value0-" + std::to_string(i)));
+    mutation.emplace_back(cbt::SetCell("fam", "col1",
+                                       std::chrono::milliseconds(0),
+                                       "value1-" + std::to_string(i)));
+    mutation.emplace_back(cbt::SetCell("fam", "col2",
+                                       std::chrono::milliseconds(0),
+                                       "value2-" + std::to_string(i)));
     bulk.emplace_back(std::move(mutation));
   }
   auto failures = table.BulkApply(std::move(bulk));
@@ -573,8 +576,9 @@ void PopulateTableHierarchy(google::cloud::bigtable::Table table,
         row_key += std::to_string(j) + "/";
         row_key += std::to_string(k);
         cbt::SingleRowMutation mutation(row_key);
-        mutation.emplace_back(
-            cbt::SetCell("fam", "col0", "value-" + std::to_string(q)));
+        mutation.emplace_back(cbt::SetCell("fam", "col0",
+                                           std::chrono::milliseconds(0),
+                                           "value-" + std::to_string(q)));
         ++q;
         google::cloud::Status status = table.Apply(std::move(mutation));
         if (!status.ok()) throw std::runtime_error(status.message());


### PR DESCRIPTION
These builds are failing with "Socket closed" errors (reported as
exceptions by the sample code, but that is not important). Whatever the
underlying gRPC error is, the mutations changed in this PR were not
idempotent and therefore not retried by the library, and because they
are only sample data for the code, this was entirely unnecessary.

I expect that with these changes the errors will be less common, and the
builds will be less flaky, but I cannot say if they will go away.

Part of the work for #4119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4148)
<!-- Reviewable:end -->
