### PR TITLE
cleanup: only dump clang-tidy config in CI builds

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -122,7 +122,7 @@ ${CMAKE_COMMAND} \
 echo
 io::log_yellow "Finished CMake config"
 
-if [[ "${CLANG_TIDY:-}" = "yes" ]]; then
+if [[ "${CLANG_TIDY:-}" == "yes" && "${RUNNING_CI}" == "yes" ]]; then
   io::log_yellow "clang-tidy config:"
   clang-tidy -dump-config
 fi


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4153)
<!-- Reviewable:end -->
