### PR TITLE
cleanup: enable clang-tidy for `google/cloud` headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks: >
 WarningsAsErrors: "*"
 
 # TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|grpc_utils|internal|pubsub|spanner|testing_util)/.*"
+HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|grpc_utils|internal|pubsub|spanner|testing_util)/.*|google/cloud/[^/]*$"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -56,6 +56,7 @@ class ConnectionOptions {
 
   /// Change the gRPC credentials value.
   ConnectionOptions& set_credentials(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
       std::shared_ptr<grpc::ChannelCredentials> v) {
     credentials_ = std::move(v);
     return *this;
@@ -75,6 +76,7 @@ class ConnectionOptions {
    *
    * The default value is set by `ConnectionTraits::default_endpoint()`.
    */
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   ConnectionOptions& set_endpoint(std::string v) {
     endpoint_ = std::move(v);
     return *this;
@@ -148,6 +150,7 @@ class ConnectionOptions {
   }
 
   /// Set the value for `channel_pool_domain()`.
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   ConnectionOptions& set_channel_pool_domain(std::string v) {
     channel_pool_domain_ = std::move(v);
     return *this;

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -39,7 +39,7 @@ class future final : private internal::future_base<T> {
 
   // workaround Apple Clang-7xx series bug, if we use `= default` here, the
   // compiler believes there is no default constructor defined. :shrug:
-  future() noexcept = default;
+  future() noexcept {}  // NOLINT(modernize-use-equals-default)
 
   /**
    * Creates a new future that unwraps @p rhs.

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -39,7 +39,7 @@ class future final : private internal::future_base<T> {
 
   // workaround Apple Clang-7xx series bug, if we use `= default` here, the
   // compiler believes there is no default constructor defined. :shrug:
-  future() noexcept {}
+  future() noexcept = default;
 
   /**
    * Creates a new future that unwraps @p rhs.
@@ -56,6 +56,7 @@ class future final : private internal::future_base<T> {
    *   dynamically allocated, and the allocator (which might be the default
    *   `operator new`) may raise.
    */
+  // NOLINTNEXTLINE(google-explicit-constructor)
   future(future<future<T>>&& rhs) noexcept(false);
 
   /**
@@ -133,8 +134,11 @@ template <typename T>
 class promise final : private internal::promise_base<T> {
  public:
   /// Creates a promise with an unsatisfied shared state.
-  promise(std::function<void()> cancellation_callback = [] {})
-      : internal::promise_base<T>(cancellation_callback) {}
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  promise(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+      std::function<void()> cancellation_callback = [] {})
+      : internal::promise_base<T>(std::move(cancellation_callback)) {}
 
   /// Constructs a new promise and transfer any shared state from @p rhs.
   promise(promise&&) noexcept = default;

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -39,7 +39,7 @@ class future<void> final : private internal::future_base<void> {
 
   // workaround Apple Clang-7xx series bug, if we use `= default` here, the
   // compiler believes there is no default constructor defined. :shrug:
-  future() noexcept = default;
+  future() noexcept {}  // NOLINT(modernize-use-equals-default)
 
   /**
    * Creates a new future that unwraps @p rhs.

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -39,7 +39,7 @@ class future<void> final : private internal::future_base<void> {
 
   // workaround Apple Clang-7xx series bug, if we use `= default` here, the
   // compiler believes there is no default constructor defined. :shrug:
-  future() noexcept {}
+  future() noexcept = default;
 
   /**
    * Creates a new future that unwraps @p rhs.
@@ -56,6 +56,7 @@ class future<void> final : private internal::future_base<void> {
    *   dynamically allocated, and the allocator (which might be the default
    *   `operator new`) may raise.
    */
+  // NOLINTNEXTLINE(google-explicit-constructor)
   future(future<future<void>>&& rhs) noexcept(false);
 
   /**
@@ -129,8 +130,9 @@ template <>
 class promise<void> final : private internal::promise_base<void> {
  public:
   /// Creates a promise with an unsatisfied shared state.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   promise(std::function<void()> cancellation_callback = [] {})
-      : promise_base(cancellation_callback) {}
+      : promise_base(std::move(cancellation_callback)) {}
 
   /// Constructs a new promise and transfer any shared state from @p rhs.
   promise(promise&&) noexcept = default;

--- a/google/cloud/iam_bindings.h
+++ b/google/cloud/iam_bindings.h
@@ -37,6 +37,7 @@ class IamBindings {
  public:
   IamBindings() = default;
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit IamBindings(std::vector<IamBinding> bindings) {
     for (auto& it : bindings) {
       bindings_.insert({std::move(it.role()), std::move(it.members())});

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -177,30 +177,31 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 enum class Severity : int {
   /// Use this level for messages that indicate the code is entering and leaving
   /// functions.
-  GCP_LS_TRACE,
+  GCP_LS_TRACE,  // NOLINT(readability-identifier-naming)
   /// Use this level for debug messages that should not be present in
   /// production.
   GCP_LS_DEBUG,
   /// Informational messages, such as normal progress.
-  GCP_LS_INFO,
+  GCP_LS_INFO,  // NOLINT(readability-identifier-naming)
   /// Informational messages, such as unusual, but expected conditions.
-  GCP_LS_NOTICE,
+  GCP_LS_NOTICE,  // NOLINT(readability-identifier-naming)
   /// An indication of problems, users may need to take action.
-  GCP_LS_WARNING,
+  GCP_LS_WARNING,  // NOLINT(readability-identifier-naming)
   /// An error has been detected.  Do not use for normal conditions, such as
   /// remote servers disconnecting.
-  GCP_LS_ERROR,
+  GCP_LS_ERROR,  // NOLINT(readability-identifier-naming)
   /// The system is in a critical state, such as running out of local resources.
-  GCP_LS_CRITICAL,
+  GCP_LS_CRITICAL,  // NOLINT(readability-identifier-naming)
   /// The system is at risk of immediate failure.
-  GCP_LS_ALERT,
+  GCP_LS_ALERT,  // NOLINT(readability-identifier-naming)
   /// The system is about to crash or terminate.
-  GCP_LS_FATAL,
+  GCP_LS_FATAL,  // NOLINT(readability-identifier-naming)
   /// The highest possible severity level.
-  GCP_LS_HIGHEST = int(GCP_LS_FATAL),
+  GCP_LS_HIGHEST = int(GCP_LS_FATAL),  // NOLINT(readability-identifier-naming)
   /// The lowest possible severity level.
-  GCP_LS_LOWEST = int(GCP_LS_TRACE),
+  GCP_LS_LOWEST = int(GCP_LS_TRACE),  // NOLINT(readability-identifier-naming)
   /// The lowest level that is enabled at compile-time.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   GCP_LS_LOWEST_ENABLED = int(GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED),
 };
 
@@ -296,7 +297,9 @@ class LogSink {
     return static_cast<Severity>(minimum_severity_.load());
   }
 
+  // NOLINTNEXTLINE(google-runtime-int)
   long AddBackend(std::shared_ptr<LogBackend> backend);
+  // NOLINTNEXTLINE(google-runtime-int)
   void RemoveBackend(long id);
   void ClearBackends();
   std::size_t BackendCount() const;
@@ -317,14 +320,17 @@ class LogSink {
  private:
   void EnableStdClogImpl();
   void DisableStdClogImpl();
+  // NOLINTNEXTLINE(google-runtime-int)
   long AddBackendImpl(std::shared_ptr<LogBackend> backend);
+  // NOLINTNEXTLINE(google-runtime-int)
   void RemoveBackendImpl(long id);
 
   std::atomic<bool> empty_;
   std::atomic<int> minimum_severity_;
   std::mutex mutable mu_;
-  long next_id_;
-  long clog_backend_id_;
+  long next_id_{0};          // NOLINT(google-runtime-int)
+  long clog_backend_id_{0};  // NOLINT(google-runtime-int)
+  // NOLINTNEXTLINE(google-runtime-int)
   std::map<long, std::shared_ptr<LogBackend>> backends_;
 };
 
@@ -347,11 +353,11 @@ struct NullStream {
 /**
  * Define the class to capture a log message.
  *
- * @tparam compile_time_enabled this represents whether the severity has been
+ * @tparam CompileTimeEnabled this represents whether the severity has been
  *   disabled at compile-time. The class is specialized for `false` to minimize
  *   the run-time impact of (and, in practice, completely elide) disabled logs.
  */
-template <bool compile_time_enabled>
+template <bool CompileTimeEnabled>
 class Logger {
  public:
   Logger(Severity severity, char const* function, char const* filename,
@@ -412,8 +418,10 @@ class Logger<false> {
    * @name Provide trivial implementations that meet the generic `Logger<bool>`
    * interface.
    */
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   constexpr bool enabled() const { return false; }
   void LogTo(LogSink&) {}
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   NullStream Stream() { return NullStream(); }
   //@}
 };

--- a/google/cloud/optional.h
+++ b/google/cloud/optional.h
@@ -50,19 +50,19 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
  * TODO(#687) - replace with absl::optional<> or std::optional<> when possible.
  */
 template <typename T>
-class optional {
+class optional {  // NOLINT(readability-identifier-naming)
  private:
   template <typename T1, typename U1>
   using AllowImplicit = typename std::is_convertible<U1&&, T1>;
 
  public:
-  optional() : buffer_{}, has_value_(false) {}
+  optional() : buffer_{} {}
   optional(optional const& rhs) : has_value_(rhs.has_value_) {
     if (has_value_) {
       new (reinterpret_cast<T*>(&buffer_)) T(*rhs);
     }
   }
-  optional(optional&& rhs) : has_value_(rhs.has_value_) {
+  optional(optional&& rhs) noexcept : has_value_(rhs.has_value_) {
     if (has_value_) {
       new (reinterpret_cast<T*>(&buffer_)) T(std::move(*rhs));
     }
@@ -73,7 +73,8 @@ class optional {
                     std::is_constructible<T, U&&>::value &&
                     AllowImplicit<T, U>::value,
                 int>::type = 0>
-  optional(U&& x) : has_value_(true) {
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
+  optional(U&& x) : has_value_(true) {  // NOLINT(google-explicit-constructor)
     new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(x));
   }
   template <typename U = T,
@@ -82,6 +83,7 @@ class optional {
                     std::is_constructible<T, U&&>::value &&
                     !AllowImplicit<T, U>::value,
                 int>::type = 0>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   explicit optional(U&& x) : has_value_(true) {
     new (reinterpret_cast<T*>(&buffer_)) T(std::forward<U>(x));
   }
@@ -133,7 +135,7 @@ class optional {
   // cv-qualified version of optional<T>, so we need to apply std::decay<> to
   // it first.
   template <typename U = T>
-  typename std::enable_if<
+  typename std::enable_if<  // NOLINT(misc-unconventional-assign-operator)
       !std::is_same<optional, typename std::decay<U>::type>::value,
       optional>::type&
   operator=(U&& rhs) {
@@ -227,7 +229,7 @@ class optional {
   // either.
   using aligned_storage_t = std::aligned_storage<sizeof(T), alignof(T)>;
   typename aligned_storage_t::type buffer_;
-  bool has_value_;
+  bool has_value_{false};
 };
 
 template <typename T>

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -62,7 +62,7 @@ std::ostream& operator<<(std::ostream& os, StatusCode code);
  */
 class Status {
  public:
-  Status() : code_(StatusCode::kOk) {}
+  Status() = default;
 
   explicit Status(StatusCode status_code, std::string message)
       : code_(status_code), message_(std::move(message)) {}
@@ -73,7 +73,7 @@ class Status {
   std::string const& message() const { return message_; }
 
  private:
-  StatusCode code_;
+  StatusCode code_{StatusCode::kOk};
   std::string message_;
 };
 

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -118,16 +118,17 @@ class StatusOr final {
    *     the program terminates via `google::cloud::Terminate()`
    */
   StatusOr& operator=(Status status) {
-    return *this = StatusOr(std::move(status));
+    *this = StatusOr(std::move(status));
+    return *this;
   }
 
-  StatusOr(StatusOr&& rhs) : status_(std::move(rhs.status_)) {
+  StatusOr(StatusOr&& rhs) noexcept : status_(std::move(rhs.status_)) {
     if (status_.ok()) {
       new (&value_) T(std::move(*rhs));
     }
   }
 
-  StatusOr& operator=(StatusOr&& rhs) {
+  StatusOr& operator=(StatusOr&& rhs) noexcept {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.
@@ -192,7 +193,7 @@ class StatusOr final {
   // cv-qualified version of StatusOr<T>, so we need to apply std::decay<> to
   // it first.
   template <typename U = T>
-  typename std::enable_if<
+  typename std::enable_if<  // NOLINT(misc-unconventional-assign-operator)
       !std::is_same<StatusOr, typename std::decay<U>::type>::value,
       StatusOr>::type&
   operator=(U&& rhs) {
@@ -220,10 +221,10 @@ class StatusOr final {
    * @throws only if `T`'s move constructor throws.
    */
   // NOLINTNEXTLINE(google-explicit-constructor)
-  StatusOr(T&& rhs) : status_() { new (&value_) T(std::move(rhs)); }
+  StatusOr(T&& rhs) { new (&value_) T(std::move(rhs)); }
 
   // NOLINTNEXTLINE(google-explicit-constructor)
-  StatusOr(T const& rhs) : status_() { new (&value_) T(rhs); }
+  StatusOr(T const& rhs) { new (&value_) T(rhs); }
 
   bool ok() const { return status_.ok(); }
   explicit operator bool() const { return status_.ok(); }

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -122,13 +122,16 @@ class StatusOr final {
     return *this;
   }
 
-  StatusOr(StatusOr&& rhs) noexcept : status_(std::move(rhs.status_)) {
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+  StatusOr(StatusOr&& rhs) noexcept(noexcept(T(std::move(*rhs))))
+      : status_(std::move(rhs.status_)) {
     if (status_.ok()) {
       new (&value_) T(std::move(*rhs));
     }
   }
 
-  StatusOr& operator=(StatusOr&& rhs) noexcept {
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+  StatusOr& operator=(StatusOr&& rhs) noexcept(noexcept(T(std::move(*rhs)))) {
     // There may be shorter ways to express this, but this is fairly readable,
     // and should be reasonably efficient. Note that we must avoid destructing
     // the destination and/or default initializing it unless really needed.


### PR DESCRIPTION
Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4154)
<!-- Reviewable:end -->
