### PR TITLE
feat: Bazel always compiles GCS+gRPC plugin

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -75,10 +75,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/fea22b1d9f27f86ef355c1d0dba00e0791a08a19.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/abd6b709a5533ba5d0bc435189ffda7f2445cd4b.tar.gz",
             ],
-            strip_prefix = "googleapis-fea22b1d9f27f86ef355c1d0dba00e0791a08a19",
-            sha256 = "957ef432cdedbace1621bb023e6d8637ecbaa78856b3fc6e299f9b277ae990ff",
+            strip_prefix = "googleapis-abd6b709a5533ba5d0bc435189ffda7f2445cd4b",
+            sha256 = "c45d0e135ac7ad54c34546404d5338e4980d0b397f093e1e2cb185ec8813430f",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 

--- a/google/cloud/bigquery/internal/storage_stub.cc
+++ b/google/cloud/bigquery/internal/storage_stub.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/bigquery/connection_options.h"
 #include "google/cloud/bigquery/internal/stream_reader.h"
 #include "google/cloud/bigquery/version.h"
-#include "google/cloud/grpc_utils/grpc_error_delegate.h"
+#include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include <google/cloud/bigquery/storage/v1beta1/storage.grpc.pb.h>
@@ -37,9 +37,9 @@ constexpr auto kRoutingHeader = "x-goog-request-params";
 
 namespace bigquerystorage_proto = ::google::cloud::bigquery::storage::v1beta1;
 
+using ::google::cloud::MakeStatusFromRpcError;
 using ::google::cloud::optional;
 using ::google::cloud::StatusOr;
-using ::google::cloud::grpc_utils::MakeStatusFromRpcError;
 
 // An implementation of StreamReader for gRPC unary-streaming methods.
 template <class T>

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -38,6 +38,28 @@ cc_library(
 )
 
 load(":storage_client.bzl", "storage_client_hdrs", "storage_client_srcs")
+load(":storage_client_grpc.bzl", "storage_client_grpc_hdrs", "storage_client_grpc_srcs")
+
+cc_library(
+    name = "storage_client_grpc",
+    srcs = storage_client_grpc_srcs,
+    hdrs = storage_client_grpc_hdrs,
+    copts = select({
+        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":nlohmann_json",
+        ":storage_client",
+        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+        "@com_github_curl_curl//:curl",
+        "@com_github_google_crc32c//:crc32c",
+        "@com_google_googleapis//google/storage/v1:storage_cc_grpc",
+        "@com_google_googleapis//google/storage/v1:storage_cc_proto",
+    ],
+)
 
 cc_library(
     name = "storage_client",
@@ -71,6 +93,7 @@ cc_library(
     deps = [
         ":nlohmann_json",
         ":storage_client",
+        ":storage_client_grpc",
         "//google/cloud:google_cloud_cpp_common",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
@@ -106,3 +129,30 @@ load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in storage_client_unit_tests]
+
+load(":storage_client_grpc_unit_tests.bzl", "storage_client_grpc_unit_tests")
+
+[cc_test(
+    name = test.replace("/", "_").replace(".cc", ""),
+    srcs = [test],
+    copts = select({
+        "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "@bazel_tools//src/conditions:windows": [],
+        "//conditions:default": ["-lpthread"],
+    }),
+    deps = [
+        ":nlohmann_json",
+        ":storage_client",
+        ":storage_client_testing",
+        "//google/cloud/testing_util:google_cloud_cpp_testing",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
+        "@boringssl//:crypto",
+        "@boringssl//:ssl",
+        "@com_github_curl_curl//:curl",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+) for test in storage_client_grpc_unit_tests]

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -44,11 +44,11 @@ cc_library(
     name = "storage_client_grpc",
     srcs = storage_client_grpc_srcs,
     hdrs = storage_client_grpc_hdrs,
-    defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
     }),
+    defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     deps = [
         ":nlohmann_json",
         ":storage_client",

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -44,6 +44,7 @@ cc_library(
     name = "storage_client_grpc",
     srcs = storage_client_grpc_srcs,
     hdrs = storage_client_grpc_hdrs,
+    defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -56,6 +56,7 @@ load(":storage_examples.bzl", "storage_examples")
         ":storage_examples_common",
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client",
+        "//google/cloud/storage:storage_client_grpc",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in storage_examples]

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -30,6 +30,7 @@ set(storage_examples
     storage_bucket_samples.cc
     storage_default_object_acl_samples.cc
     storage_event_based_hold_samples.cc
+    storage_grpc_samples.cc
     storage_lifecycle_management_samples.cc
     storage_notification_samples.cc
     storage_object_acl_samples.cc
@@ -82,13 +83,7 @@ if (BUILD_TESTING)
     endforeach ()
 endif ()
 
-# TODO(#4143) - this example should always be in the list to support Bazel
-set(storage_examples_grpc)
-if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
-    list(APPEND storage_examples_grpc storage_grpc_samples.cc)
-endif ()
-
-foreach (fname ${storage_examples} ${storage_examples_grpc})
+foreach (fname ${storage_examples})
     google_cloud_cpp_add_executable(target "storage_examples" "${fname}")
     target_link_libraries(
         ${target} PRIVATE storage_examples_common storage_client_grpc
@@ -105,7 +100,7 @@ endforeach ()
 # We just know that these tests need to be run against production.
 set(storage_integration_tests_production
     # cmake-format: sort
-    ${storage_examples_grpc} storage_policy_doc_samples.cc
+    storage_grpc_samples.cc storage_policy_doc_samples.cc
     storage_signed_url_v2_samples.cc storage_signed_url_v4_samples.cc)
 foreach (fname ${storage_integration_tests_production})
     google_cloud_cpp_set_target_name(target "storage_examples" "${fname}")

--- a/google/cloud/storage/examples/storage_examples.bzl
+++ b/google/cloud/storage/examples/storage_examples.bzl
@@ -25,6 +25,7 @@ storage_examples = [
     "storage_bucket_samples.cc",
     "storage_default_object_acl_samples.cc",
     "storage_event_based_hold_samples.cc",
+    "storage_grpc_samples.cc",
     "storage_lifecycle_management_samples.cc",
     "storage_notification_samples.cc",
     "storage_object_acl_samples.cc",

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -19,6 +19,7 @@
 namespace {
 namespace examples = ::google::cloud::storage::examples;
 
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 //! [grpc-read-write]
 void GrpcReadWrite(std::string const& bucket_name) {
   namespace gcs = google::cloud::storage;
@@ -48,6 +49,9 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             << ",md5=" << object->md5_hash() << "\n";
 }
 //! [grpc-read-write]
+#else
+void GrpcReadWrite(std::string const& bucket_name) {}
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 void GrpcReadWriteCommand(std::vector<std::string> argv) {
   if (argv.size() != 1 || argv[0] == "--help") {
@@ -56,6 +60,7 @@ void GrpcReadWriteCommand(std::vector<std::string> argv) {
   GrpcReadWrite(argv[0]);
 }
 
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 //! [grpc-client-with-project]
 void GrpcClientWithProject(std::string project_id) {
   namespace gcs = google::cloud::storage;
@@ -66,6 +71,9 @@ void GrpcClientWithProject(std::string project_id) {
   std::cout << "Successfully created a gcs::Client configured to use gRPC\n";
 }
 //! [grpc-client-with-project]
+#else
+void GrpcClientWithProject(std::string const&) {}
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 void GrpcClientWithProjectCommand(std::vector<std::string> argv) {
   if (argv.size() != 1 || argv[0] == "--help") {

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -50,7 +50,7 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 }
 //! [grpc-read-write]
 #else
-void GrpcReadWrite(std::string const& bucket_name) {}
+void GrpcReadWrite(std::string const&) {}
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 void GrpcReadWriteCommand(std::vector<std::string> argv) {

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -897,7 +897,7 @@ google::storage::v1::ListBucketsRequest GrpcClient::ToProto(
     // The maximum page size is 1,000 anyway, if this cast
     // fails the request was invalid (but it can mask errors)
     r.set_max_results(static_cast<google::protobuf::int32>(
-      request.GetOption<MaxResults>().value()));
+        request.GetOption<MaxResults>().value()));
   }
   r.set_page_token(request.page_token());
   r.set_project(request.project_id());

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -894,7 +894,10 @@ google::storage::v1::ListBucketsRequest GrpcClient::ToProto(
     ListBucketsRequest const& request) {
   google::storage::v1::ListBucketsRequest r;
   if (request.HasOption<MaxResults>()) {
-    r.set_max_results(request.GetOption<MaxResults>().value());
+    // The maximum page size is 1,000 anyway, if this cast
+    // fails the request was invalid (but it can mask errors)
+    r.set_max_results(static_cast<google::protobuf::int32>(
+      request.GetOption<MaxResults>().value()));
   }
   r.set_page_token(request.page_token());
   r.set_project(request.project_id());

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(storage_client_integration_tests
     curl_resumable_upload_session_integration_test.cc
     curl_sign_blob_integration_test.cc
     error_injection_integration_test.cc
+    grpc_integration_test.cc
     key_file_integration_test.cc
     object_basic_crud_integration_test.cc
     object_checksum_integration_test.cc
@@ -71,8 +72,11 @@ foreach (fname ${storage_client_integration_tests})
 endforeach ()
 
 # We just know that these tests need to be run against production.
-foreach (fname # cmake-format: sort
-               key_file_integration_test.cc signed_url_integration_test.cc)
+foreach (
+    fname
+    # cmake-format: sort
+    grpc_integration_test.cc key_file_integration_test.cc
+    signed_url_integration_test.cc)
     google_cloud_cpp_set_target_name(target "storage" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS
@@ -81,30 +85,6 @@ endforeach ()
 
 target_link_libraries(storage_error_injection_integration_test
                       PRIVATE ${CMAKE_DL_LIBS})
-
-if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
-    find_package(gRPC REQUIRED)
-    find_package(googleapis CONFIG REQUIRED)
-    google_cloud_cpp_add_executable(target "storage" grpc_integration_test.cc)
-    target_link_libraries(
-        ${target}
-        PRIVATE storage_client_testing
-                storage_client
-                google_cloud_cpp_testing
-                google_cloud_cpp_common
-                GTest::gmock_main
-                GTest::gmock
-                GTest::gtest
-                CURL::libcurl
-                Threads::Threads
-                nlohmann_json)
-    google_cloud_cpp_add_common_options(${target})
-    google_cloud_cpp_add_clang_tidy(${target})
-    add_test(NAME ${target} COMMAND ${target})
-    set_tests_properties(
-        ${target} PROPERTIES LABELS
-                             "integration-tests;integration-tests-no-emulator")
-endif ()
 
 include(CreateBazelConfig)
 export_list_to_bazel("storage_client_integration_tests.bzl"

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -25,7 +25,6 @@
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
 #include <algorithm>
-#include <cstdlib>
 #include <vector>
 
 namespace google {
@@ -162,6 +161,7 @@ TEST_F(GrpcIntegrationTest, WriteResume) {
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 /// @test Verify that NOT_FOUND is returned for missing objects
 TEST_F(GrpcIntegrationTest, GetObjectMediaNotFound) {
   auto client = Client::CreateDefaultClient();
@@ -277,6 +277,8 @@ TEST_F(GrpcIntegrationTest, ReproLargeInsert) {
   auto delete_bucket_status = client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
+
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 TEST_F(GrpcIntegrationTest, InsertLarge) {
   auto client = MakeIntegrationTestClient();

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -14,16 +14,13 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/grpc_client.h"
-#include "google/cloud/storage/internal/hybrid_client.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
-#include "google/cloud/grpc_utils/grpc_error_delegate.h"
+#include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/getenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_environment.h"
-#include "absl/memory/memory.h"
 #include <crc32c/crc32c.h>
 #include <gmock/gmock.h>
 #include <grpcpp/grpcpp.h>
@@ -38,6 +35,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+// When GOOGLE_CLOUD_CPP_HAVE_GRPC is not set these tests compile, but they
+// actually just run against the regular GCS REST API. That is fine.
 class GrpcIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -227,8 +227,8 @@ TEST_F(GrpcIntegrationTest, ReproLargeInsert) {
   auto constexpr kChunkSize = 256 * 1024L;
   static_assert(kMaxBuffersize % kChunkSize == 0, "Broken test configuration");
 
-  auto send_in_chunks = [bucket_name, object_name, &stub,
-                         this](int desired_size, std::int64_t chunk_size) {
+  auto send_in_chunks = [bucket_name, object_name, &stub, this](
+                            int desired_size, std::int64_t chunk_size) {
     grpc::ClientContext context;
     google::storage::v1::Object object;
     auto stream = stub->InsertObject(&context, &object);

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -23,6 +23,7 @@ storage_client_integration_tests = [
     "curl_resumable_upload_session_integration_test.cc",
     "curl_sign_blob_integration_test.cc",
     "error_injection_integration_test.cc",
+    "grpc_integration_test.cc",
     "key_file_integration_test.cc",
     "object_basic_crud_integration_test.cc",
     "object_checksum_integration_test.cc",


### PR DESCRIPTION
With these changes Bazel always compiles the GCS+gRPC plugin. The
application may still link only against the REST API, but our tests and
examples link against both, all the time. This does mean we have a gap
in our testing (applications that only want to link GCS with the REST
API, but using Bazel). Seems like a small gap to me.

Part of the work for #4143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4155)
<!-- Reviewable:end -->
