### PR TITLE
cleanup: fix TODO entries in GCS+gRPC plugin

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -467,7 +467,7 @@ void SetCommonParameters(GrpcRequest& request, StorageRequest const& req) {
     request.mutable_common_request_params()->set_quota_user(
         req.template GetOption<QuotaUser>().value());
   }
-  // TODO(b/139062142) - what do we do with FieldMask, as the representation for
+  // TODO(#4215) - what do we do with FieldMask, as the representation for
   // `fields` is different.
 }
 
@@ -632,9 +632,9 @@ std::chrono::system_clock::time_point AsChronoTimepoint(
 
 BucketMetadata GrpcClient::FromProto(google::storage::v1::Bucket bucket) {
   BucketMetadata metadata;
-  // TODO(b/137665304) - convert acl() field.
-  // TODO(b/137666290) - convert default_object_acl() field.
-  // TODO(b/137665068) - convert lifecycle
+  // TODO(#4174) - convert acl() field.
+  // TODO(#4173) - convert default_object_acl() field.
+  // TODO(#4165) - convert lifecycle
   if (bucket.has_time_created()) {
     metadata.time_created_ = AsChronoTimepoint(bucket.time_created());
   }
@@ -649,7 +649,7 @@ BucketMetadata GrpcClient::FromProto(google::storage::v1::Bucket bucket) {
   }
   metadata.project_number_ = bucket.project_number();
   metadata.metageneration_ = bucket.metageneration();
-  // TODO(b/137663603) - convert cors() field.
+  // TODO(#4169) - convert cors() field.
   metadata.location_ = std::move(*bucket.mutable_location());
   metadata.storage_class_ = std::move(*bucket.mutable_storage_class());
   metadata.etag_ = std::move(*bucket.mutable_etag());
@@ -660,13 +660,13 @@ BucketMetadata GrpcClient::FromProto(google::storage::v1::Bucket bucket) {
   for (auto& kv : *bucket.mutable_labels()) {
     metadata.labels_.emplace(std::make_pair(kv.first, std::move(kv.second)));
   }
-  // TODO(b/137664907) - convert website() field.
-  // TODO(b/137665070) - convert versioning() field.
-  // TODO(b/137663316) - convert logging() field.
-  // TODO(b/137663320) - convert owner() field.
-  // TODO(b/137663319) - convert encryption() field.
-  // TODO(b/137665065) - convert billing() field.
-  // TODO(b/137665069) - convert retention_policy() field.
+  // TODO(#4168) - convert website() field.
+  // TODO(#4167) - convert versioning() field.
+  // TODO(#4172) - convert logging() field.
+  // TODO(#4170) - convert owner() field.
+  // TODO(#4171) - convert encryption() field.
+  // TODO(#4164) - convert billing() field.
+  // TODO(#4166) - convert retention_policy() field.
 
   return metadata;
 }
@@ -873,7 +873,7 @@ google::storage::v1::Bucket GrpcClient::ToProto(
     BucketMetadata const& metadata) {
   google::storage::v1::Bucket bucket;
   bucket.set_name(metadata.name());
-  // TODO(b/137739543) - convert the other fields.
+  // TODO(#4173) - convert the other fields.
   return bucket;
 }
 
@@ -945,9 +945,9 @@ google::storage::v1::InsertObjectRequest GrpcClient::ToProto(
   r.set_write_offset(0);
 
   auto& checksums = *r.mutable_object_checksums();
-  // TODO(b/137859833) - use the crc32c value in the request options.
+  // TODO(#4156) - use the crc32c value in the request options.
   checksums.mutable_crc32c()->set_value(crc32c::Crc32c(request.contents()));
-  // TODO(b/137863755) - use the MD5 hash value in the request options.
+  // TODO(#4157) - use the MD5 hash value in the request options.
   checksums.set_md5_hash(MD5ToProto(ComputeMD5Hash(request.contents())));
 
   return r;

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -32,9 +32,9 @@ using ::google::cloud::testing_util::IsProtoEqual;
 TEST(GrpcClientFromProto, BucketAllFields) {
   storage_proto::Bucket input;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-# TODO(b/137665304) - convert acl() field.
-# TODO(b/137666290) - convert default_object_acl() field.
-# TODO(b/137665068) - convert lifecycle
+# TODO(#4174) - convert acl() field.
+# TODO(#4173) - convert default_object_acl() field.
+# TODO(#4165) - convert lifecycle
     time_created: {
       seconds: 1565194924
       nanos: 123456789
@@ -43,7 +43,7 @@ TEST(GrpcClientFromProto, BucketAllFields) {
     name: "test-bucket"
     project_number: 123456
     metageneration: 1234567
-# TODO(b/137663603) - convert cors() field.
+# TODO(#4169) - convert cors() field.
     location: "test-location"
     storage_class: "test-storage-class"
     etag: "test-etag"
@@ -54,13 +54,13 @@ TEST(GrpcClientFromProto, BucketAllFields) {
     default_event_based_hold: true
     labels: { key: "test-key-1" value: "test-value-1" }
     labels: { key: "test-key-2" value: "test-value-2" }
-# TODO(b/137664907) - convert website() field.
-# TODO(b/137665070) - convert versioning() field.
-# TODO(b/137663316) - convert logging() field.
-# TODO(b/137663320) - convert owner() field.
-# TODO(b/137663319) - convert encryption() field.
-# TODO(b/137665065) - convert billing() field.
-# TODO(b/137665069) - convert retention_policy() field.
+# TODO(#4168) - convert website() field.
+# TODO(#4167) - convert versioning() field.
+# TODO(#4172) - convert logging() field.
+# TODO(#4170) - convert owner() field.
+# TODO(#4171) - convert encryption() field.
+# TODO(#4164) - convert billing() field.
+# TODO(#4166) - convert retention_policy() field.
 )""",
                                                             &input));
 
@@ -99,7 +99,7 @@ TEST(GrpcClientFromProto, ObjectSimple) {
     content_encoding: "test-content-encoding"
     content_disposition: "test-content-disposition"
     cache_control: "test-cache-control"
-# TODO(b/137666290) - convert acl() field.
+# TODO(#4217) - convert acl() field.
     content_language: "test-content-language"
     metageneration: 42
     time_deleted: {
@@ -338,7 +338,7 @@ TEST(GrpcClientToProto, BucketMetadata) {
   storage_proto::Bucket expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
     name: "test-bucket"
-# TODO(b/137739543) - convert the other fields.
+# TODO(#4173) - convert the other fields.
 )""",
                                                             &expected));
 
@@ -352,7 +352,7 @@ TEST(GrpcClientToProto, CreateBucketRequestSimple) {
     project: "test-project-id"
     bucket: {
       name: "test-bucket"
-# TODO(b/137739543) - convert the other fields.
+# TODO(#4173) - convert the other fields.
     }
 )""",
                                                             &expected));
@@ -376,7 +376,7 @@ TEST(GrpcClientToProto, CreateBucketRequestAllOptions) {
     projection: FULL
     bucket: {
       name: "test-bucket"
-# TODO(b/137739543) - convert the other fields.
+# TODO(#4173) - convert the other fields.
     }
     common_request_params: {
       quota_user: "test-quota-user"

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -118,8 +118,8 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadFinalChunk(
   request.mutable_checksummed_data()->set_content(trailer);
   request.mutable_checksummed_data()->mutable_crc32c()->set_value(
       crc32c::Crc32c(trailer));
-  // TODO(b/137859833) - compute the crc32c value inline and set it here
-  // TODO(b/137863755) - compute the MD5 hash value and set it here
+  // TODO(#4156) - compute the crc32c value inline and set it here
+  // TODO(#4157) - compute the MD5 hash value and set it here
   auto success =
       upload_writer_->Write(request, grpc::WriteOptions().set_last_message());
   if (!success) {
@@ -167,7 +167,7 @@ void GrpcResumableUploadSession::CreateUploadWriter() {
   if (upload_writer_) {
     return;
   }
-  // TODO(b/...) - set the timeout
+  // TODO(#4216) - set the timeout
   upload_context_ = absl::make_unique<grpc::ClientContext>();
   google::storage::v1::InsertObjectRequest request;
   request.set_upload_id(session_id_);

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -319,7 +319,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileUploadFailure) {
   // condition should fail because the object already exists.
   StatusOr<ObjectMetadata> upload = client->UploadFile(
       file_name, bucket_name_, object_name, IfGenerationMatch(0));
-  // TODO(b/146800819) - accept both errors for now.
+  // The GCS server returns a different error code depending on the protocol
+  // (REST vs. gRPC) used
   EXPECT_THAT(upload.status().code(), AnyOf(Eq(StatusCode::kFailedPrecondition),
                                             Eq(StatusCode::kAborted)))
       << " upload.status=" << upload.status();

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -251,8 +251,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithMetadata) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -273,8 +271,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclAuthenticatedRead) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -300,8 +296,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerFullControl) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -328,8 +322,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclBucketOwnerRead) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -352,8 +344,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPrivate) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -375,8 +365,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclProjectPrivate) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -397,8 +385,6 @@ TEST_P(ObjectInsertIntegrationTest, InsertPredefinedAclPublicRead) {
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclAuthenticatedRead) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -453,8 +439,6 @@ TEST_P(ObjectInsertIntegrationTest,
 }
 
 TEST_P(ObjectInsertIntegrationTest, XmlInsertPredefinedAclBucketOwnerRead) {
-  // TODO(b/146782749) - enable this test once the gRPC server is fixed
-  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -510,7 +510,8 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailure) {
   testing_util::ExpectException<std::ios::failure>(
       [&] { os.Close(); },
       [&](std::ios::failure const&) {
-        // TODO(b/146800819) - accept both errors for now.
+        // The GCS server returns a different error code depending on the
+        // protocol (REST vs. gRPC) used
         EXPECT_THAT(os.metadata().status().code(),
                     AnyOf(Eq(StatusCode::kFailedPrecondition),
                           Eq(StatusCode::kAborted)))
@@ -545,7 +546,8 @@ TEST_F(ObjectIntegrationTest, StreamingWriteFailureNoex) {
   // This operation should fail because the object already exists.
   os.Close();
   EXPECT_TRUE(os.bad());
-  // TODO(b/146800819) - accept both errors for now.
+  // The GCS server returns a different error code depending on the
+  // protocol (REST vs. gRPC) used
   EXPECT_THAT(
       os.metadata().status().code(),
       AnyOf(Eq(StatusCode::kFailedPrecondition), Eq(StatusCode::kAborted)))

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -409,9 +409,9 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
   EXPECT_STATUS_OK(status);
 }
 
-/// @test Read the last chunk of an object by setting ReadLasst option.
+/// @test Read the last chunk of an object by setting ReadLast option.
 TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
-  // TODO(b/146888259) - enable this test once the gRPC server is fixed
+  // TODO(#4219) - implement support for `gcs::ReadLast`
   if (UsingGrpc()) GTEST_SKIP();
 
   StatusOr<Client> client = MakeIntegrationTestClient();

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -221,7 +221,8 @@ TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
   os.Close();
   EXPECT_TRUE(os.bad());
   EXPECT_FALSE(os.metadata().ok());
-  // TODO(b/146800819) - accept both errors for now.
+  // The GCS server returns a different error code depending on the
+  // protocol (REST vs. gRPC) used
   EXPECT_THAT(
       os.metadata().status().code(),
       AnyOf(Eq(StatusCode::kFailedPrecondition), Eq(StatusCode::kAborted)))


### PR DESCRIPTION
In most cases, I pointed the entry to the right GitHub issue. In some
cases the bug was fixed, and I took the opportunity to remove the
workaround. In a couple of cases the bug is in the server-side, and
I left the internal bug tracking number for those.

Part of the work for #4143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4220)
<!-- Reviewable:end -->
