### PR TITLE
fix: MSVC+CMake builds with GCS+gRPC disabled

### DIFF
--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -13,19 +13,22 @@
 // limitations under the License.
 
 #include "google/cloud/storage/client.h"
-#include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/nljson.h"
 #include "google/cloud/storage/object_stream.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
-#include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <crc32c/crc32c.h>
 #include <gmock/gmock.h>
-#include <grpcpp/grpcpp.h>
 #include <algorithm>
 #include <vector>
+
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+#include "google/cloud/storage/internal/grpc_client.h"
+#include "google/cloud/grpc_error_delegate.h"
+#include <grpcpp/grpcpp.h>
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
With MSVC+CMake when we disable the GCS+gRPC plugin we cannot
even include the gRPC-related headers. This is because Protobuf
requires some magic `-D...` options in the command-line, and these are
only present if you link the Protobuf library, and the point of disabling the
GCS+gRPC plugin is to **not** link said library.

This goes undetected on Bazel, where we always build the GCS+gRPC plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4221)
<!-- Reviewable:end -->
