### PR TITLE
fix: clang-tidy HeaderFilterRegex was not working

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -140,13 +140,18 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   io::log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
   ${CMAKE_COMMAND} --build "${BINARY_DIR}" --target nlohmann_json_project
   io::log "Running clang-tidy for: "
-  # TODO(#3958) - use a simple regular expression like '\.(h|cc)$' when all
-  # targets are clang-tidy clean.
+  # TODO(#3958) - Combine these two invocations of "xargs clang-tidy" into a
+  # single one using a simple regular expression like '\.(h|cc)$' when all
+  # targets are clang-tidy clean. Until then, we format all changed .cc files,
+  # followed by all changed .h files that also match the HeaderFilterRegex from
+  # the .clang-tidy file.
+  git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
+    grep -E "\.cc$" | grep -v 'google/cloud/bigtable/benchmarks/' |
+    xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
   RE=$(grep -o '^HeaderFilterRegex.*' "${PROJECT_ROOT}/.clang-tidy" |
     sed -e 's/HeaderFilterRegex: "//' -e 's/"//')
-  RE="(\.cc|${RE}\.h)$"
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E "${RE}" | grep -v 'google/cloud/bigtable/benchmarks/' |
+    grep -E "\.h$" | grep -E "${RE}" | grep -v 'google/cloud/bigtable/benchmarks/' |
     xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
 fi
 


### PR DESCRIPTION
It's not always safe to append "\.h$" to a regex, so this PR changes our
clang-tidy filtering to two invocations. One to handle all .cc files,
where it can ignore the HeaderFitlerRegex. And a second invocation that
applies to all .h files that also match HeaderFitlerRegex.

Related: This should fix issues like [this one](https://source.cloud.google.com/results/invocations/bae42914-9b04-463a-9b8e-3156ce046a40/targets/cloud-cpp%2Fgithub%2Fgoogle-cloud-cpp%2Fmaster%2Fdocker%2Fclang-tidy-presubmit/log) where we were running clang-tidy on BUILD and CMakeLists.txt files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4225)
<!-- Reviewable:end -->
