### PR TITLE
cleanup: enable clang-tidy for `storage` headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,7 +56,7 @@ Checks: >
 WarningsAsErrors: "*"
 
 # TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|grpc_utils|internal|pubsub|spanner|testing_util)/.*|google/cloud/[^/]*$"
+HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|grpc_utils|internal|pubsub|spanner|storage|testing_util)/.*\\.h$|google/cloud/[^/]*$"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -42,10 +42,11 @@ class GrpcClient;
  *     information on "Requester Pays" billing.
  */
 struct BucketBilling {
-  BucketBilling() : requester_pays(false) {}
+  BucketBilling() = default;
+  // NOLINTNEXTLINE(google-explicit-constructor)
   BucketBilling(bool v) : requester_pays(v) {}
 
-  bool requester_pays;
+  bool requester_pays{false};
 };
 
 inline bool operator==(BucketBilling const& lhs, BucketBilling const& rhs) {
@@ -53,7 +54,7 @@ inline bool operator==(BucketBilling const& lhs, BucketBilling const& rhs) {
 }
 
 inline bool operator<(BucketBilling const& lhs, BucketBilling const& rhs) {
-  return lhs.requester_pays < rhs.requester_pays;
+  return !lhs.requester_pays && rhs.requester_pays;
 }
 
 inline bool operator!=(BucketBilling const& lhs, BucketBilling const& rhs) {
@@ -427,10 +428,10 @@ std::ostream& operator<<(std::ostream& os, BucketRetentionPolicy const& rhs);
  *     information on "Requester Pays" billing.
  */
 struct BucketVersioning {
-  BucketVersioning() : enabled(true) {}
+  BucketVersioning() = default;
   explicit BucketVersioning(bool flag) : enabled(flag) {}
 
-  bool enabled;
+  bool enabled{true};
 };
 
 inline bool operator==(BucketVersioning const& lhs,
@@ -440,7 +441,7 @@ inline bool operator==(BucketVersioning const& lhs,
 
 inline bool operator<(BucketVersioning const& lhs,
                       BucketVersioning const& rhs) {
-  return lhs.enabled < rhs.enabled;
+  return !lhs.enabled && rhs.enabled;
 }
 
 inline bool operator!=(BucketVersioning const& lhs,
@@ -750,7 +751,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return logging_;
   }
   BucketMetadata& set_logging(BucketLogging v) {
-    logging_ = v;
+    logging_ = std::move(v);
     return *this;
   }
   BucketMetadata& reset_logging() {
@@ -879,7 +880,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   std::string location_;
   std::string location_type_;
   google::cloud::optional<BucketLogging> logging_;
-  std::int64_t project_number_;
+  std::int64_t project_number_{0};
   google::cloud::optional<BucketRetentionPolicy> retention_policy_;
   google::cloud::optional<BucketVersioning> versioning_;
   google::cloud::optional<BucketWebsite> website_;
@@ -901,7 +902,7 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
  */
 class BucketMetadataPatchBuilder {
  public:
-  BucketMetadataPatchBuilder() : labels_subpatch_dirty_(false) {}
+  BucketMetadataPatchBuilder() = default;
 
   std::string BuildPatch() const;
 
@@ -976,9 +977,10 @@ class BucketMetadataPatchBuilder {
 
  private:
   internal::PatchBuilder impl_;
-  bool labels_subpatch_dirty_;
+  bool labels_subpatch_dirty_{false};
   internal::PatchBuilder labels_subpatch_;
 };
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -746,7 +746,7 @@ class Client {
    */
   template <typename... Options>
   StatusOr<NativeIamPolicy> SetNativeBucketIamPolicy(
-      std::string const& bucket_name, NativeIamPolicy iam_policy,
+      std::string const& bucket_name, NativeIamPolicy const& iam_policy,
       Options&&... options) {
     internal::SetNativeBucketIamPolicyRequest request(bucket_name, iam_policy);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -3241,6 +3241,7 @@ class ScopedDeleter {
  public:
   // The actual deletion depends on local's types in a very non-trivial way,
   // so we abstract this away by providing the function to delete one object.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   ScopedDeleter(std::function<Status(std::string, std::int64_t)> delete_fun);
   ScopedDeleter(ScopedDeleter const&) = delete;
   ScopedDeleter& operator=(ScopedDeleter const&) = delete;
@@ -3365,7 +3366,7 @@ StatusOr<ObjectMetadata> ComposeMany(
   auto to_source_objects = [](std::vector<ObjectMetadata> objects) {
     std::vector<ComposeSourceObject> sources(objects.size());
     std::transform(objects.begin(), objects.end(), sources.begin(),
-                   [](ObjectMetadata m) {
+                   [](ObjectMetadata const& m) {
                      return ComposeSourceObject{m.name(), m.generation(), {}};
                    });
     return sources;

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -66,7 +66,7 @@ class ChannelOptions {
 class ClientOptions {
  public:
   explicit ClientOptions(std::shared_ptr<oauth2::Credentials> credentials)
-      : ClientOptions(credentials, {}) {}
+      : ClientOptions(std::move(credentials), {}) {}
   ClientOptions(std::shared_ptr<oauth2::Credentials> credentials,
                 ChannelOptions channel_options);
 

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -37,7 +37,7 @@ struct ReadRangeData {
  * excludes the `end` byte.
  */
 struct ReadRange : public internal::ComplexOption<ReadRange, ReadRangeData> {
-  ReadRange() : ComplexOption() {}
+  ReadRange() = default;
   explicit ReadRange(std::int64_t begin, std::int64_t end)
       : ComplexOption(ReadRangeData{begin, end}) {}
   static char const* name() { return "read-range"; }

--- a/google/cloud/storage/iam_policy.h
+++ b/google/cloud/storage/iam_policy.h
@@ -44,6 +44,7 @@ class NativeExpression {
    *     expression for error reporting, e.g. a file name and a position in the
    *     file.
    */
+  // NOLINTNEXTLINE(google-explicit-constructor)
   NativeExpression(std::string expression, std::string title = "",
                    std::string description = "", std::string location = "");
   ~NativeExpression();

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -37,7 +37,7 @@ struct BucketAccessControlParser {
 class ListBucketAclRequest
     : public GenericRequest<ListBucketAclRequest, UserProject> {
  public:
-  ListBucketAclRequest() : GenericRequest() {}
+  ListBucketAclRequest() = default;
   explicit ListBucketAclRequest(std::string bucket)
       : bucket_name_(std::move(bucket)) {}
 
@@ -115,6 +115,7 @@ class GenericChangeBucketAclRequest : public GenericBucketAclRequest<Derived> {
  public:
   GenericChangeBucketAclRequest() = default;
 
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   explicit GenericChangeBucketAclRequest(std::string bucket, std::string entity,
                                          std::string role)
       : GenericBucketAclRequest<Derived>(std::move(bucket), std::move(entity)),

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -75,7 +75,7 @@ class GrpcClient;
 template <typename Derived>
 class CommonMetadata {
  public:
-  CommonMetadata() : metageneration_(0), owner_() {}
+  CommonMetadata() = default;
 
   static Status ParseFromJson(CommonMetadata<Derived>& result,
                               internal::nl::json const& json) {
@@ -110,6 +110,7 @@ class CommonMetadata {
   std::int64_t metageneration() const { return metageneration_; }
 
   std::string const& name() const { return name_; }
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)  TODO(#4112)
   void set_name(std::string value) { name_ = std::move(value); }
 
   bool has_owner() const { return owner_.has_value(); }
@@ -118,6 +119,7 @@ class CommonMetadata {
   std::string const& self_link() const { return self_link_; }
 
   std::string const& storage_class() const { return storage_class_; }
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)  TODO(#4112)
   void set_storage_class(std::string value) {
     storage_class_ = std::move(value);
   }
@@ -134,7 +136,7 @@ class CommonMetadata {
   std::string etag_;
   std::string id_;
   std::string kind_;
-  std::int64_t metageneration_;
+  std::int64_t metageneration_{0};
   std::string name_;
   google::cloud::optional<Owner> owner_;
   std::string self_link_;

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -78,8 +78,8 @@ class CurlHandle {
     return AsStatus(e, __func__);
   }
 
-  StatusOr<long> GetResponseCode() {
-    long code;
+  StatusOr<long> GetResponseCode() {  // NOLINT(google-runtime-int)
+    long code;                        // NOLINT(google-runtime-int)
     auto e = curl_easy_getinfo(handle_.get(), CURLINFO_RESPONSE_CODE, &code);
     if (e == CURLE_OK) {
       return code;

--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -66,7 +66,7 @@ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory();
 class DefaultCurlHandleFactory : public CurlHandleFactory {
  public:
   DefaultCurlHandleFactory() = default;
-  DefaultCurlHandleFactory(ChannelOptions options)
+  explicit DefaultCurlHandleFactory(ChannelOptions options)
       : options_(std::move(options)) {}
 
   CurlPtr CreateHandle() override;

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -104,9 +104,11 @@ class CurlRequestBuilder {
   /// Adds one of the well-known encryption header groups to the request.
   CurlRequestBuilder& AddOption(EncryptionKey const& p) {
     if (p.has_value()) {
-      AddHeader(std::string(p.prefix()) + "algorithm: " + p.value().algorithm);
-      AddHeader(std::string(p.prefix()) + "key: " + p.value().key);
-      AddHeader(std::string(p.prefix()) + "key-sha256: " + p.value().sha256);
+      AddHeader(std::string(EncryptionKey::prefix()) +
+                "algorithm: " + p.value().algorithm);
+      AddHeader(std::string(EncryptionKey::prefix()) + "key: " + p.value().key);
+      AddHeader(std::string(EncryptionKey::prefix()) +
+                "key-sha256: " + p.value().sha256);
     }
     return *this;
   }
@@ -114,9 +116,12 @@ class CurlRequestBuilder {
   /// Adds one of the well-known encryption header groups to the request.
   CurlRequestBuilder& AddOption(SourceEncryptionKey const& p) {
     if (p.has_value()) {
-      AddHeader(std::string(p.prefix()) + "Algorithm: " + p.value().algorithm);
-      AddHeader(std::string(p.prefix()) + "Key: " + p.value().key);
-      AddHeader(std::string(p.prefix()) + "Key-Sha256: " + p.value().sha256);
+      AddHeader(std::string(SourceEncryptionKey::prefix()) +
+                "Algorithm: " + p.value().algorithm);
+      AddHeader(std::string(SourceEncryptionKey::prefix()) +
+                "Key: " + p.value().key);
+      AddHeader(std::string(SourceEncryptionKey::prefix()) +
+                "Key-Sha256: " + p.value().sha256);
     }
     return *this;
   }

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -28,11 +28,12 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+
 /// Represents a request to call the `DefaultObjectAccessControls: list` API.
 class ListDefaultObjectAclRequest
     : public GenericRequest<ListDefaultObjectAclRequest, UserProject> {
  public:
-  ListDefaultObjectAclRequest() : GenericRequest() {}
+  ListDefaultObjectAclRequest() = default;
   explicit ListDefaultObjectAclRequest(std::string bucket)
       : bucket_name_(std::move(bucket)) {}
 
@@ -115,9 +116,9 @@ class GenericChangeDefaultObjectAclRequest
  public:
   GenericChangeDefaultObjectAclRequest() = default;
 
-  explicit GenericChangeDefaultObjectAclRequest(std::string bucket,
-                                                std::string entity,
-                                                std::string role)
+  explicit GenericChangeDefaultObjectAclRequest(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+      std::string bucket, std::string entity, std::string role)
       : GenericDefaultObjectAclRequest<Derived>(std::move(bucket),
                                                 std::move(entity)),
         role_(std::move(role)) {}

--- a/google/cloud/storage/internal/generic_object_request.h
+++ b/google/cloud/storage/internal/generic_object_request.h
@@ -23,6 +23,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
+
 /// Common attributes for requests about objects.
 template <typename Derived, typename... Parameters>
 class GenericObjectRequest : public GenericRequest<Derived, Parameters...> {
@@ -35,12 +36,14 @@ class GenericObjectRequest : public GenericRequest<Derived, Parameters...> {
         object_name_(std::move(object_name)) {}
 
   std::string const& bucket_name() const { return bucket_name_; }
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   Derived& set_bucket_name(std::string bucket_name) {
     bucket_name_ = std::move(bucket_name);
     return *static_cast<Derived*>(this);
   }
 
   std::string const& object_name() const { return object_name_; }
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   Derived& set_object_name(std::string object_name) {
     object_name_ = std::move(object_name);
     return *static_cast<Derived*>(this);

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -41,7 +41,7 @@ using StreamMaker = std::function<std::unique_ptr<grpc::ClientReaderInterface<
 class GrpcObjectReadSource : public ObjectReadSource {
  public:
   explicit GrpcObjectReadSource(StreamMaker const& maker)
-      : context_(), stream_(maker(context_)) {}
+      : stream_(maker(context_)) {}
 
   ~GrpcObjectReadSource() override;
 

--- a/google/cloud/storage/internal/hash_validator_impl.cc
+++ b/google/cloud/storage/internal/hash_validator_impl.cc
@@ -66,8 +66,6 @@ HashValidator::Result MD5HashValidator::Finish() && {
   return Result{std::move(received_hash_), std::move(computed), is_mismatch};
 }
 
-Crc32cHashValidator::Crc32cHashValidator() : current_(0) {}
-
 void Crc32cHashValidator::Update(char const* buf, std::size_t n) {
   current_ =
       crc32c::Extend(current_, reinterpret_cast<std::uint8_t const*>(buf), n);

--- a/google/cloud/storage/internal/hash_validator_impl.h
+++ b/google/cloud/storage/internal/hash_validator_impl.h
@@ -51,7 +51,7 @@ class MD5HashValidator : public HashValidator {
  */
 class Crc32cHashValidator : public HashValidator {
  public:
-  Crc32cHashValidator();
+  Crc32cHashValidator() = default;
 
   Crc32cHashValidator(Crc32cHashValidator const&) = delete;
   Crc32cHashValidator& operator=(Crc32cHashValidator const&) = delete;
@@ -63,7 +63,7 @@ class Crc32cHashValidator : public HashValidator {
   Result Finish() && override;
 
  private:
-  std::uint32_t current_;
+  std::uint32_t current_{0};
   std::string received_hash_;
 };
 

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -38,7 +38,7 @@ template <typename Derived, typename... Options>
 class GenericHmacKeyRequest : public GenericRequest<Derived, Options...> {
  public:
   GenericHmacKeyRequest() = default;
-  GenericHmacKeyRequest(std::string project_id)
+  explicit GenericHmacKeyRequest(std::string project_id)
       : project_id_(std::move(project_id)) {}
 
   std::string const& project_id() const { return project_id_; }

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -70,7 +70,7 @@ enum HttpStatusCode {
  * Contains the results of a HTTP request.
  */
 struct HttpResponse {
-  long status_code;
+  long status_code;  // NOLINT(google-runtime-int)
   std::string payload;
   std::multimap<std::string, std::string> headers;
 };

--- a/google/cloud/storage/internal/nljson.h
+++ b/google/cloud/storage/internal/nljson.h
@@ -39,6 +39,7 @@
 #undef NLOHMANN_JSON_HPP
 #undef NLOHMANN_JSON_FWD_HPP
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 #define nlohmann google_cloud_storage_internal_nlohmann_3_4_0
 #include "google/cloud/storage/internal/nlohmann_json.hpp"
 

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -38,7 +38,7 @@ struct NotificationMetadataParser {
 class ListNotificationsRequest
     : public GenericRequest<ListNotificationsRequest, UserProject> {
  public:
-  ListNotificationsRequest() : GenericRequest() {}
+  ListNotificationsRequest() = default;
   explicit ListNotificationsRequest(std::string bucket)
       : bucket_name_(std::move(bucket)) {}
 

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -68,6 +68,7 @@ class GenericObjectAclRequest
     : public GenericObjectRequest<Derived, Generation, UserProject> {
  public:
   GenericObjectAclRequest() = default;
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   GenericObjectAclRequest(std::string bucket, std::string object,
                           std::string entity)
       : GenericObjectRequest<Derived, Generation, UserProject>(
@@ -113,8 +114,13 @@ class GenericChangeObjectAclRequest : public GenericObjectAclRequest<Derived> {
  public:
   GenericChangeObjectAclRequest() = default;
 
-  explicit GenericChangeObjectAclRequest(std::string bucket, std::string object,
-                                         std::string entity, std::string role)
+  explicit GenericChangeObjectAclRequest(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+      std::string bucket,
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+      std::string object,
+      // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
+      std::string entity, std::string role)
       : GenericObjectAclRequest<Derived>(std::move(bucket), std::move(object),
                                          std::move(entity)),
         role_(std::move(role)) {}

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -116,7 +116,7 @@ class InsertObjectMediaRequest
           MD5HashValue, PredefinedAcl, Projection, UserProject,
           WithObjectMetadata> {
  public:
-  InsertObjectMediaRequest() : GenericObjectRequest(), contents_() {}
+  InsertObjectMediaRequest() = default;
 
   explicit InsertObjectMediaRequest(std::string bucket_name,
                                     std::string object_name,
@@ -379,16 +379,12 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
   UploadChunkRequest() = default;
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
                      std::string payload)
-      : GenericRequest(),
-        upload_session_url_(std::move(upload_session_url)),
+      : upload_session_url_(std::move(upload_session_url)),
         range_begin_(range_begin),
-        payload_(std::move(payload)),
-        source_size_(0),
-        last_chunk_(false) {}
+        payload_(std::move(payload)) {}
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
                      std::string payload, std::uint64_t source_size)
-      : GenericRequest(),
-        upload_session_url_(std::move(upload_session_url)),
+      : upload_session_url_(std::move(upload_session_url)),
         range_begin_(range_begin),
         payload_(std::move(payload)),
         source_size_(source_size),
@@ -435,7 +431,7 @@ class QueryResumableUploadRequest
  public:
   QueryResumableUploadRequest() = default;
   explicit QueryResumableUploadRequest(std::string upload_session_url)
-      : GenericRequest(), upload_session_url_(std::move(upload_session_url)) {}
+      : upload_session_url_(std::move(upload_session_url)) {}
 
   std::string const& upload_session_url() const { return upload_session_url_; }
 

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -35,7 +35,8 @@ StatusOr<std::string> PostPolicyV4Escape(std::string const& utf8_bytes);
 class PolicyDocumentRequest {
  public:
   PolicyDocumentRequest() = default;
-  PolicyDocumentRequest(PolicyDocument document) : document_(document) {}
+  explicit PolicyDocumentRequest(PolicyDocument document)
+      : document_(std::move(document)) {}
 
   PolicyDocument const& policy_document() const { return document_; }
 
@@ -76,8 +77,8 @@ std::ostream& operator<<(std::ostream& os, PolicyDocumentRequest const& r);
 
 class PolicyDocumentV4Request {
  public:
-  PolicyDocumentV4Request() : scheme_("https"), virtual_host_name_() {}
-  PolicyDocumentV4Request(PolicyDocumentV4 document)
+  PolicyDocumentV4Request() : scheme_("https") {}
+  explicit PolicyDocumentV4Request(PolicyDocumentV4 document)
       : PolicyDocumentV4Request() {
     document_ = std::move(document);
   }
@@ -142,7 +143,7 @@ class PolicyDocumentV4Request {
   std::vector<std::pair<std::string, std::string>> extension_fields_;
   optional<std::string> bucket_bound_domain_;
   std::string scheme_;
-  bool virtual_host_name_;
+  bool virtual_host_name_{false};
 };
 
 std::ostream& operator<<(std::ostream& os, PolicyDocumentV4Request const& r);

--- a/google/cloud/storage/internal/range_from_pagination.h
+++ b/google/cloud/storage/internal/range_from_pagination.h
@@ -48,7 +48,7 @@ class PaginationIterator {
     return *this;
   }
 
-  PaginationIterator const operator++(int) {
+  PaginationIterator operator++(int) {
     PaginationIterator tmp(*this);
     operator++();
     return tmp;
@@ -108,7 +108,6 @@ class PaginationRange {
       std::function<StatusOr<Response>(Request const& r)> loader)
       : request_(std::move(request)),
         next_page_loader_(std::move(loader)),
-        next_page_token_(),
         on_last_page_(false) {
     current_ = current_page_.begin();
   }
@@ -141,12 +140,12 @@ class PaginationRange {
    *   status. If the stream is exhausted, it returns the `.end()` iterator.
    */
   iterator GetNext() {
-    static Status const past_the_end_error(
+    static Status const kPastTheEndError(
         StatusCode::kFailedPrecondition,
         "Cannot iterating past the end of ListObjectReader");
     if (current_page_.end() == current_) {
       if (on_last_page_) {
-        return iterator(nullptr, past_the_end_error);
+        return iterator(nullptr, kPastTheEndError);
       }
       request_.set_page_token(std::move(next_page_token_));
       auto response = next_page_loader_(request_);
@@ -164,7 +163,7 @@ class PaginationRange {
         on_last_page_ = true;
       }
       if (current_page_.end() == current_) {
-        return iterator(nullptr, past_the_end_error);
+        return iterator(nullptr, kPastTheEndError);
       }
     }
     return iterator(this, std::move(*current_++));

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -120,7 +120,7 @@ class ResumableUploadSessionError : public ResumableUploadSession {
                               std::string id)
       : last_response_(std::move(status)),
         next_expected_byte_(next_expected_byte),
-        id_(id) {}
+        id_(std::move(id)) {}
 
   ~ResumableUploadSessionError() override = default;
 

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -38,6 +38,7 @@ class RetryClient : public RawClient,
                        DefaultPolicies unused);
 
   template <typename... Policies>
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   explicit RetryClient(std::shared_ptr<RawClient> client,
                        Policies&&... policies)
       : RetryClient(std::move(client), DefaultPolicies{}) {

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -49,8 +49,7 @@ class SignBlobRequest
   explicit SignBlobRequest(std::string service_account,
                            std::string base64_encoded_blob,
                            std::vector<std::string> delegates)
-      : GenericRequestBase(),
-        service_account_(std::move(service_account)),
+      : service_account_(std::move(service_account)),
         base64_encoded_blob_(std::move(base64_encoded_blob)),
         delegates_(std::move(delegates)) {}
 

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -80,8 +80,8 @@ class ComputeEngineCredentials : public Credentials {
  public:
   explicit ComputeEngineCredentials() : ComputeEngineCredentials("default") {}
 
-  explicit ComputeEngineCredentials(std::string const& service_account_email)
-      : clock_(), service_account_email_(service_account_email) {}
+  explicit ComputeEngineCredentials(std::string service_account_email)
+      : clock_(), service_account_email_(std::move(service_account_email)) {}
 
   StatusOr<std::string> AuthorizationHeader() override {
     std::unique_lock<std::mutex> lock(mu_);

--- a/google/cloud/storage/oauth2/credential_constants.h
+++ b/google/cloud/storage/oauth2/credential_constants.h
@@ -30,6 +30,7 @@ namespace oauth2 {
  * We currently only support RSA with SHA-256, but use this enum for
  * readability and easy addition of support for other algorithms.
  */
+// NOLINTNEXTLINE(readability-identifier-naming)
 enum class JwtSigningAlgorithms { RS256 };
 
 /// The max lifetime in seconds of an access token.

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.cc
@@ -23,13 +23,13 @@ namespace oauth2 {
 
 bool RefreshingCredentialsWrapper::IsExpired(
     std::chrono::system_clock::time_point now) const {
-  return now > (temporary_token.expiration_time -
+  return now > (temporary_token_.expiration_time -
                 GoogleOAuthAccessTokenExpirationSlack());
 }
 
 bool RefreshingCredentialsWrapper::IsValid(
     std::chrono::system_clock::time_point now) const {
-  return !temporary_token.token.empty() && !IsExpired(now);
+  return !temporary_token_.token.empty() && !IsExpired(now);
 }
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
+++ b/google/cloud/storage/oauth2/refreshing_credentials_wrapper.h
@@ -27,6 +27,7 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace oauth2 {
+
 /**
  * Wrapper for refreshable parts of a Credentials object.
  */
@@ -42,13 +43,13 @@ class RefreshingCredentialsWrapper {
       std::chrono::system_clock::time_point now,
       RefreshFunctor refresh_fn) const {
     if (IsValid(now)) {
-      return temporary_token.token;
+      return temporary_token_.token;
     }
 
     StatusOr<TemporaryToken> new_token = refresh_fn();
     if (new_token) {
-      temporary_token = *std::move(new_token);
-      return temporary_token.token;
+      temporary_token_ = *std::move(new_token);
+      return temporary_token_.token;
     }
     return new_token.status();
   }
@@ -75,7 +76,7 @@ class RefreshingCredentialsWrapper {
   bool IsValid(std::chrono::system_clock::time_point now) const;
 
  private:
-  mutable TemporaryToken temporary_token;
+  mutable TemporaryToken temporary_token_;
 };
 
 }  // namespace oauth2

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -130,8 +130,9 @@ template <typename HttpRequestBuilderType =
           typename ClockType = std::chrono::system_clock>
 class ServiceAccountCredentials : public Credentials {
  public:
+  // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
   explicit ServiceAccountCredentials(ServiceAccountCredentialsInfo info)
-      : ServiceAccountCredentials(info, {}) {}
+      : ServiceAccountCredentials(std::move(info), {}) {}
   ServiceAccountCredentials(ServiceAccountCredentialsInfo info,
                             ChannelOptions const& options)
       : info_(std::move(info)), clock_() {

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -90,7 +90,7 @@ class ObjectAccessControl : private internal::AccessControlCommon {
   friend struct internal::ObjectAccessControlParser;
   friend class internal::GrpcClient;
 
-  std::int64_t generation_;
+  std::int64_t generation_{0};
   std::string object_;
 };
 

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -86,7 +86,7 @@ inline bool operator>=(CustomerEncryption const& lhs,
  */
 class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
  public:
-  ObjectMetadata() : generation_(0), size_(0) {}
+  ObjectMetadata() = default;
 
   // Please keep these in alphabetical order, that make it easier to verify we
   // have actually implemented all of them.

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -86,7 +86,7 @@ inline bool operator>=(CustomerEncryption const& lhs,
  */
 class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
  public:
-  ObjectMetadata() : component_count_(0), generation_(0), size_(0) {}
+  ObjectMetadata() : generation_(0), size_(0) {}
 
   // Please keep these in alphabetical order, that make it easier to verify we
   // have actually implemented all of them.
@@ -243,22 +243,22 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::vector<ObjectAccessControl> acl_;
   std::string bucket_;
   std::string cache_control_;
-  std::int32_t component_count_;
+  std::int32_t component_count_{0};
   std::string content_disposition_;
   std::string content_encoding_;
   std::string content_language_;
   std::string content_type_;
   std::string crc32c_;
   google::cloud::optional<CustomerEncryption> customer_encryption_;
-  bool event_based_hold_ = false;
-  std::int64_t generation_;
+  bool event_based_hold_{false};
+  std::int64_t generation_{0};
   std::string kms_key_name_;
   std::string md5_hash_;
   std::string media_link_;
   std::map<std::string, std::string> metadata_;
   std::chrono::system_clock::time_point retention_expiration_time_;
-  std::uint64_t size_;
-  bool temporary_hold_ = false;
+  std::uint64_t size_{0};
+  bool temporary_hold_{false};
   std::chrono::system_clock::time_point time_deleted_;
   std::chrono::system_clock::time_point time_storage_class_updated_;
 };
@@ -279,7 +279,7 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs);
  */
 class ObjectMetadataPatchBuilder {
  public:
-  ObjectMetadataPatchBuilder() : metadata_subpatch_dirty_(false) {}
+  ObjectMetadataPatchBuilder() = default;
 
   std::string BuildPatch() const;
 
@@ -315,7 +315,7 @@ class ObjectMetadataPatchBuilder {
 
  private:
   internal::PatchBuilder impl_;
-  bool metadata_subpatch_dirty_;
+  bool metadata_subpatch_dirty_{false};
   internal::PatchBuilder metadata_subpatch_;
 };
 

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -96,7 +96,7 @@ class ObjectReadStream : public std::basic_istream<char> {
   /// Closes the stream (if necessary).
   ~ObjectReadStream() override;
 
-  bool IsOpen() const { return (bool)buf_ && buf_->IsOpen(); }
+  bool IsOpen() const { return static_cast<bool>(buf_) && buf_->IsOpen(); }
 
   /**
    * Terminate the download, possibly before completing it.

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -42,6 +42,7 @@ inline namespace STORAGE_CLIENT_NS {
  */
 class MaxStreams {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor)
   MaxStreams(std::size_t value) : value_(value) {}
   std::size_t value() const { return value_; }
 
@@ -58,6 +59,7 @@ class MaxStreams {
  */
 class MinStreamSize {
  public:
+  // NOLINTNEXTLINE(google-explicit-constructor)
   MinStreamSize(std::uintmax_t value) : value_(value) {}
   std::uintmax_t value() const { return value_; }
 
@@ -114,8 +116,9 @@ class ParallelUploadExtraPersistentState {
 
   template <typename... Options>
   friend StatusOr<std::vector<ParallelUploadFileShard>> CreateUploadShards(
-      Client client, std::string file_name, std::string bucket_name,
-      std::string object_name, std::string prefix, Options&&... options);
+      Client client, std::string file_name, std::string const& bucket_name,
+      std::string const& object_name, std::string const& prefix,
+      Options&&... options);
 };
 
 class ParallelObjectWriteStreambuf;
@@ -237,6 +240,7 @@ class ParallelUploadStateImpl
   std::string resumable_session_id_;
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 static char const* kSessionIdPrefix = "ParUpl:";
 
 struct ComposeManyApplyHelper {
@@ -256,15 +260,16 @@ struct ComposeManyApplyHelper {
 
 class SetOptionsApplyHelper {
  public:
-  SetOptionsApplyHelper(ResumableUploadRequest& request) : request(request) {}
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  SetOptionsApplyHelper(ResumableUploadRequest& request) : request_(request) {}
 
   template <typename... Options>
   void operator()(Options&&... options) const {
-    request.set_multiple_options(std::forward<Options>(options)...);
+    request_.set_multiple_options(std::forward<Options>(options)...);
   }
 
  private:
-  ResumableUploadRequest& request;
+  ResumableUploadRequest& request_;
 };
 
 struct ReadObjectApplyHelper {
@@ -374,8 +379,9 @@ class ParallelUploadFileShard {
 
   template <typename... Options>
   friend StatusOr<std::vector<ParallelUploadFileShard>> CreateUploadShards(
-      Client client, std::string file_name, std::string bucket_name,
-      std::string object_name, std::string prefix, Options&&... options);
+      Client client, std::string file_name, std::string const& bucket_name,
+      std::string const& object_name, std::string const& prefix,
+      Options&&... options);
 };
 
 /**
@@ -460,8 +466,9 @@ class NonResumableParallelUploadState {
   friend class NonResumableParallelObjectWriteStreambuf;
   template <typename... Options>
   friend StatusOr<std::vector<ParallelUploadFileShard>> CreateUploadShards(
-      Client client, std::string file_name, std::string bucket_name,
-      std::string object_name, std::string prefix, Options&&... options);
+      Client client, std::string file_name, std::string const& bucket_name,
+      std::string const& object_name, std::string const& prefix,
+      Options&&... options);
 };
 
 /**
@@ -583,8 +590,9 @@ class ResumableParallelUploadState {
   friend class ResumableParallelObjectWriteStreambuf;
   template <typename... Options>
   friend StatusOr<std::vector<ParallelUploadFileShard>> CreateUploadShards(
-      Client client, std::string file_name, std::string bucket_name,
-      std::string object_name, std::string prefix, Options&&... options);
+      Client client, std::string file_name, std::string const& bucket_name,
+      std::string const& object_name, std::string const& prefix,
+      Options&&... options);
 };
 
 /**
@@ -614,7 +622,7 @@ template <typename... Options,
           typename std::enable_if<
               NotAmong<typename std::decay<Options>::type...>::template TPred<
                   UseResumableUploadSession>::value,
-              int>::type enable_if_not_resumable = 0>
+              int>::type EnableIfNotResumable = 0>
 StatusOr<NonResumableParallelUploadState> PrepareParallelUpload(
     Client client, std::string const& bucket_name,
     std::string const& object_name, std::size_t num_shards,
@@ -629,7 +637,7 @@ template <typename... Options,
           typename std::enable_if<
               Among<typename std::decay<Options>::type...>::template TPred<
                   UseResumableUploadSession>::value,
-              int>::type enable_if_resumable = 0>
+              int>::type EnableIfResumable = 0>
 StatusOr<ResumableParallelUploadState> PrepareParallelUpload(
     Client client, std::string const& bucket_name,
     std::string const& object_name, std::size_t num_shards,
@@ -728,8 +736,8 @@ NonResumableParallelUploadState::Create(Client client,
 
 template <typename... Options>
 std::shared_ptr<ScopedDeleter> ResumableParallelUploadState::CreateDeleter(
-    Client client, std::string const& bucket_name,
-    std::tuple<Options...> const& options) {
+    Client client,  // NOLINT(performance-unnecessary-value-param)
+    std::string const& bucket_name, std::tuple<Options...> const& options) {
   using internal::StaticTupleFilter;
   auto delete_options =
       StaticTupleFilter<Among<QuotaUser, UserProject, UserIp>::TPred>(options);
@@ -745,9 +753,10 @@ std::shared_ptr<ScopedDeleter> ResumableParallelUploadState::CreateDeleter(
 
 template <typename... Options>
 Composer ResumableParallelUploadState::CreateComposer(
-    Client client, std::string const& bucket_name,
-    std::string const& object_name, std::int64_t expected_generation,
-    std::string const& prefix, std::tuple<Options...> const& options) {
+    Client client,  // NOLINT(performance-unnecessary-value-param)
+    std::string const& bucket_name, std::string const& object_name,
+    std::int64_t expected_generation, std::string const& prefix,
+    std::tuple<Options...> const& options) {
   auto compose_options = std::tuple_cat(
       StaticTupleFilter<
           Among<DestinationPredefinedAcl, EncryptionKey, KmsKeyName, QuotaUser,
@@ -814,7 +823,7 @@ StatusOr<ResumableParallelUploadState> ResumableParallelUploadState::CreateNew(
       StaticTupleFilter<
           Among<ContentEncoding, ContentType, DisableCrc32cChecksum,
                 DisableMD5Hash, EncryptionKey, KmsKeyName, PredefinedAcl,
-                UserProject, WithObjectMetadata>::TPred>(std::move(options)),
+                UserProject, WithObjectMetadata>::TPred>(options),
       std::make_tuple(UseResumableUploadSession("")));
   auto& raw_client = *client.raw_client_;
   for (std::size_t i = 0; i < num_shards; ++i) {
@@ -872,7 +881,7 @@ StatusOr<ResumableParallelUploadState> ResumableParallelUploadState::Resume(
   auto read_options = std::tuple_cat(
       StaticTupleFilter<Among<DisableCrc32cChecksum, DisableMD5Hash,
                               EncryptionKey, Generation, UserProject>::TPred>(
-          std::move(options)),
+          options),
       std::make_tuple(IfGenerationMatch(state_and_gen->second)));
 
   auto state_stream = google::cloud::internal::apply(
@@ -953,16 +962,16 @@ std::vector<std::uintmax_t> ComputeParallelFileUploadSplitPoints(
   };
   // These defaults were obtained by experiments summarized in
   // https://github.com/googleapis/google-cloud-cpp/issues/2951#issuecomment-566237128
-  MaxStreams const kDefaultMaxStreams(64);
-  MinStreamSize const kDefaultMinStreamSize(32 * 1024 * 1024);
+  MaxStreams const k_default_max_streams(64);
+  MinStreamSize const k_default_min_stream_size(32 * 1024 * 1024);
 
   std::uintmax_t const min_stream_size =
       (std::max<std::uintmax_t>)(1, ExtractFirstOccurenceOfType<MinStreamSize>(
                                         options)
-                                        .value_or(kDefaultMinStreamSize)
+                                        .value_or(k_default_min_stream_size)
                                         .value());
   auto const max_streams = ExtractFirstOccurenceOfType<MaxStreams>(options)
-                               .value_or(kDefaultMaxStreams)
+                               .value_or(k_default_max_streams)
                                .value();
 
   std::size_t const wanted_num_streams =
@@ -1052,8 +1061,10 @@ struct PrepareParallelUploadApplyHelper {
  */
 template <typename... Options>
 StatusOr<std::vector<ParallelUploadFileShard>> CreateUploadShards(
-    Client client, std::string file_name, std::string bucket_name,
-    std::string object_name, std::string prefix, Options&&... options) {
+    Client client,  // NOLINT(performance-unnecessary-value-param)
+    std::string file_name, std::string const& bucket_name,
+    std::string const& object_name, std::string const& prefix,
+    Options&&... options) {
   std::error_code size_err;
   auto file_size = google::cloud::internal::file_size(file_name, size_err);
   if (size_err) {

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -962,16 +962,16 @@ std::vector<std::uintmax_t> ComputeParallelFileUploadSplitPoints(
   };
   // These defaults were obtained by experiments summarized in
   // https://github.com/googleapis/google-cloud-cpp/issues/2951#issuecomment-566237128
-  MaxStreams const k_default_max_streams(64);
-  MinStreamSize const k_default_min_stream_size(32 * 1024 * 1024);
+  MaxStreams const default_max_streams(64);
+  MinStreamSize const default_min_stream_size(32 * 1024 * 1024);
 
   std::uintmax_t const min_stream_size =
       (std::max<std::uintmax_t>)(1, ExtractFirstOccurenceOfType<MinStreamSize>(
                                         options)
-                                        .value_or(k_default_min_stream_size)
+                                        .value_or(default_min_stream_size)
                                         .value());
   auto const max_streams = ExtractFirstOccurenceOfType<MaxStreams>(options)
-                               .value_or(k_default_max_streams)
+                               .value_or(default_max_streams)
                                .value();
 
   std::size_t const wanted_num_streams =

--- a/google/cloud/storage/policy_document.h
+++ b/google/cloud/storage/policy_document.h
@@ -32,8 +32,9 @@ inline namespace STORAGE_CLIENT_NS {
 class PolicyDocumentCondition {
  public:
   PolicyDocumentCondition() = default;
+  // NOLINTNEXTLINE(google-explicit-constructor)
   PolicyDocumentCondition(std::vector<std::string> elements)
-      : elements_(elements) {}
+      : elements_(std::move(elements)) {}
 
   std::vector<std::string> const& elements() const { return elements_; }
 

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -220,7 +220,7 @@ struct VirtualHostname : public internal::ComplexOption<VirtualHostname, bool> {
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   VirtualHostname() = default;
-  char const* option_name() const { return "virtual-hostname"; }
+  static char const* option_name() { return "virtual-hostname"; }
 };
 
 /**
@@ -235,7 +235,7 @@ struct BucketBoundHostname
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   BucketBoundHostname() = default;
-  char const* option_name() const { return "domain-named-bucket"; }
+  static char const* option_name() { return "domain-named-bucket"; }
 };
 
 /// Use the specified scheme (e.g. "http") in a V4 signed URL.
@@ -244,7 +244,7 @@ struct Scheme : public internal::ComplexOption<Scheme, std::string> {
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   Scheme() = default;
-  char const* option_name() const { return "scheme"; }
+  static char const* option_name() { return "scheme"; }
 };
 
 /**

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -62,6 +62,7 @@ class MockHttpRequest {
 class MockHttpRequestBuilder {
  public:
   explicit MockHttpRequestBuilder(
+      // NOLINTNEXTLINE(performance-unnecessary-value-param)
       std::string url, std::shared_ptr<internal::CurlHandleFactory>) {
     mock_->Constructor(std::move(url));
   }
@@ -92,24 +93,32 @@ class MockHttpRequestBuilder {
     mock_->AddQueryParameter(p.parameter_name(), p.value() ? "true" : "false");
   }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   MockHttpRequest BuildRequest() { return mock_->BuildRequest(); }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   void AddUserAgentPrefix(std::string const& prefix) {
     mock_->AddUserAgentPrefix(prefix);
   }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   void AddHeader(std::string const& header) { mock_->AddHeader(header); }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   void AddQueryParameter(std::string const& key, std::string const& value) {
     mock_->AddQueryParameter(key, value);
   }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   void SetMethod(std::string const& method) { mock_->SetMethod(method); }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   void SetDebugLogging(bool enable) { mock_->SetDebugLogging(enable); }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   std::string UserAgentSuffix() { return mock_->UserAgentSuffix(); }
 
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   std::unique_ptr<char[]> MakeEscapedString(std::string const& tmp) {
     return mock_->MakeEscapedString(tmp);
   }

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -239,7 +239,7 @@ void TooManyFailuresStatusTest(
 template <typename ReturnType, typename F>
 void PermanentFailureStatusTest(
     Client& client, ::testing::internal::TypedExpectation<F>& oncall,
-    std::function<Status(Client& client)> tested_operation,
+    std::function<Status(Client& client)> const& tested_operation,
     char const* api_name) {
   using ::google::cloud::storage::testing::canonical_errors::PermanentError;
   using ::testing::HasSubstr;

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -264,7 +264,9 @@ template <typename Generator>
 static EncryptionKeyData CreateKeyFromGenerator(Generator& gen) {
   constexpr int kKeySize = 256 / std::numeric_limits<unsigned char>::digits;
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr auto minchar = (std::numeric_limits<char>::min)();
+  // NOLINTNEXTLINE(readability-identifier-naming)
   constexpr auto maxchar = (std::numeric_limits<char>::max)();
   std::uniform_int_distribution<int> uni(minchar, maxchar);
   std::string key(static_cast<std::size_t>(kKeySize), ' ');


### PR DESCRIPTION
Adding `\\.h$` to `HeaderFilterRegex` eliminates checking of `nlohmann_json.hpp`.

Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4226)
<!-- Reviewable:end -->
