### PR TITLE
feat: implement ReadLast option for GCS+gRPC plugin

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1011,6 +1011,10 @@ google::storage::v1::GetObjectMediaRequest GrpcClient::ToProto(
     r.set_read_offset(range.begin);
     r.set_read_limit(range.end - range.begin);
   }
+  if (request.HasOption<ReadLast>()) {
+    auto const offset = request.GetOption<ReadLast>().value();
+    r.set_read_offset(-(offset + 1));
+  }
   if (request.HasOption<ReadFromOffset>()) {
     auto const offset = request.GetOption<ReadFromOffset>().value();
     if (offset > r.read_offset()) {

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -940,6 +940,21 @@ TEST(GrpcClientToProto, ReadObjectRangeRequestAllFields) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcClientToProto, ReadObjectRangeRequestReadLast) {
+  google::storage::v1::GetObjectMediaRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        bucket: "test-bucket" object: "test-object" read_offset: -2001
+      )pb",
+      &expected));
+
+  ReadObjectRangeRequest req("test-bucket", "test-object");
+  req.set_multiple_options(ReadLast(2000));
+
+  auto const actual = GrpcClient::ToProto(req);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -411,9 +411,6 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
 
 /// @test Read the last chunk of an object by setting ReadLast option.
 TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
-  // TODO(#4219) - implement support for `gcs::ReadLast`
-  if (UsingGrpc()) GTEST_SKIP();
-
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
For applications that want to read the last N bytes of a GCS object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4229)
<!-- Reviewable:end -->
