### PR TITLE
cleanup: `bigtable/benchmarks` is clang-clean after #4138

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -145,12 +145,12 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   # followed by all changed .h files that also match the HeaderFilterRegex from
   # the .clang-tidy file.
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E "\.cc$" | grep -v 'google/cloud/bigtable/benchmarks/' |
+    grep -E "\.cc$" |
     xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
   RE=$(grep -o '^HeaderFilterRegex.*' "${PROJECT_ROOT}/.clang-tidy" |
     sed -e 's/HeaderFilterRegex: "//' -e 's/"//')
   git diff --name-only "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-${BRANCH}}" |
-    grep -E "\.h$" | grep -E "${RE}" | grep -v 'google/cloud/bigtable/benchmarks/' |
+    grep -E "\.h$" | grep -E "${RE}" |
     xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}"
 fi
 


### PR DESCRIPTION
The presubmit tests won't verify that, but I'll assert it,
and we'll learn whether I'm wrong as future edits are made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4231)
<!-- Reviewable:end -->
