### PR TITLE
ci(CMake): disable all production Bigtable tests

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -308,6 +308,11 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     # libraries will tag all their tests as "integration-tests-no-emulator",
     # that is fine too. As long as we do not repeat all the tests we are
     # winning.
+    if [[ "${BUILD_NAME:-}" != "coverage" ]]; then
+      # TODO(#4234) - the Bigtable tests are only enabled on the coverage
+      #   builds because they consume too much quota.
+      ctest_args+=(-E bigtable)
+    fi
     env -C "${BINARY_DIR}" ctest \
       -L integration-tests-no-emulator "${ctest_args[@]}"
 


### PR DESCRIPTION
Until such time as the quota issues are resolved, just disable all the
bigtable integration tests that need to run against production.

Part of the work for #4234 it reduces the quota consumption to about
56 per PR. There is some loss of testing coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4235)
<!-- Reviewable:end -->
