### PR TITLE
fix: GCS+gRPC use the documented behavior for ReadLast

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -479,11 +479,11 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     if (BUILD_TESTING)
         set(storage_client_grpc_unit_tests
             # cmake-format: sort
-            internal/grpc_client_failures_test.cc
-            internal/grpc_client_test.cc
             internal/grpc_client_bucket_metadata_test.cc
             internal/grpc_client_bucket_request_test.cc
+            internal/grpc_client_failures_test.cc
             internal/grpc_client_object_request_test.cc
+            internal/grpc_client_test.cc
             internal/grpc_object_read_source_test.cc
             internal/grpc_resumable_upload_session_test.cc)
 

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1025,7 +1025,7 @@ google::storage::v1::GetObjectMediaRequest GrpcClient::ToProto(
   }
   if (request.HasOption<ReadLast>()) {
     auto const offset = request.GetOption<ReadLast>().value();
-    r.set_read_offset(-(offset + 1));
+    r.set_read_offset(-offset);
   }
   if (request.HasOption<ReadFromOffset>()) {
     auto const offset = request.GetOption<ReadFromOffset>().value();

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -229,6 +229,17 @@ StatusOr<ObjectMetadata> GrpcClient::GetObjectMetadata(
 
 StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
     ReadObjectRangeRequest const& request) {
+  // With the REST API this condition was detected by the server as an error,
+  // generally we prefer the server to detect errors because its answers are
+  // authoritative. In this case, the server cannot: with gRPC '0' is the same
+  // as "not set" and the server would send back the full file, which was
+  // unlikely to be the customer's intent.
+  if (request.HasOption<ReadLast>() &&
+      request.GetOption<ReadLast>().value() == 0) {
+    return Status(
+        StatusCode::kOutOfRange,
+        "ReadLast(0) is invalid in REST and produces incorrect output in gRPC");
+  }
   auto const proto_request = ToProto(request);
   auto create_stream = [&proto_request, this](grpc::ClientContext& context) {
     return stub_->GetObjectMedia(&context, proto_request);

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/grpc_client.h"
+#include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -413,6 +415,27 @@ TEST(GrpcClientObjectRequest, ReadObjectRangeRequestReadLast) {
 
   auto const actual = GrpcClient::ToProto(req);
   EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientObjectRequest, ReadObjectRangeRequestReadLastZero) {
+  google::storage::v1::GetObjectMediaRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        bucket: "test-bucket" object: "test-object"
+      )pb",
+      &expected));
+
+  ReadObjectRangeRequest req("test-bucket", "test-object");
+  req.set_multiple_options(ReadLast(0));
+
+  auto const actual = GrpcClient::ToProto(req);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+
+  testing_util::ScopedEnvironment grpc_endpoint{
+      "GOOGLE_CLOUD_CPP_STORAGE_GRPC_ENDPOINT", "locahost:1"};
+  GrpcClient client{ClientOptions{oauth2::CreateAnonymousCredentials()}};
+  StatusOr<std::unique_ptr<ObjectReadSource>> reader = client.ReadObject(req);
+  EXPECT_EQ(reader.status().code(), StatusCode::kOutOfRange);
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -404,7 +404,7 @@ TEST(GrpcClientObjectRequest, ReadObjectRangeRequestReadLast) {
   google::storage::v1::GetObjectMediaRequest expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
-        bucket: "test-bucket" object: "test-object" read_offset: -2001
+        bucket: "test-bucket" object: "test-object" read_offset: -2000
       )pb",
       &expected));
 

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -17,11 +17,11 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_client_grpc_unit_tests = [
-    "internal/grpc_client_failures_test.cc",
-    "internal/grpc_client_test.cc",
     "internal/grpc_client_bucket_metadata_test.cc",
     "internal/grpc_client_bucket_request_test.cc",
+    "internal/grpc_client_failures_test.cc",
     "internal/grpc_client_object_request_test.cc",
+    "internal/grpc_client_test.cc",
     "internal/grpc_object_read_source_test.cc",
     "internal/grpc_resumable_upload_session_test.cc",
 ]

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -411,6 +411,9 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromSpill) {
 
 /// @test Read the last chunk of an object by setting ReadLast option.
 TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
+  // TODO(#4233) - disabled because GCS will change behavior without notice
+  //   the test passes today, but soon it will break as GCS is fixed.
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4237)
<!-- Reviewable:end -->
