### PR TITLE
cleanup: enable clang-tidy across the board

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,8 +55,7 @@ Checks: >
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"
 
-# TODO(#3920) - Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/(bigquery|bigtable|firestore|grpc_utils|internal|pubsub|spanner|storage|testing_util)/.*\\.h$|google/cloud/[^/]*$"
+HeaderFilterRegex: "google/cloud/.*\\.h$"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -28,6 +28,7 @@ if (BUILD_TESTING)
         gRPC::grpc
         protobuf::libprotobuf)
     google_cloud_cpp_add_common_options(bigtable_examples_common)
+    google_cloud_cpp_add_clang_tidy(bigtable_examples_common)
 
     set(bigtable_examples
         # cmake-format: sort

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(gcs2cbt gcs2cbt.cc)
 target_link_libraries(gcs2cbt bigtable_client storage_client
                       google_cloud_cpp_grpc_utils)
 google_cloud_cpp_add_common_options(gcs2cbt)
+google_cloud_cpp_add_clang_tidy(gcs2cbt)
 if (BUILD_TESTING)
     add_test(NAME gcs2cbt COMMAND gcs2cbt)
     set_tests_properties(

--- a/google/cloud/examples/gcs2cbt.cc
+++ b/google/cloud/examples/gcs2cbt.cc
@@ -46,8 +46,8 @@ namespace {
  *
  * TODO() - make the separator configurable.
  */
-std::vector<std::string> ParseLine(long lineno, std::string const& line,
-                                   char separator);
+std::vector<std::string> ParseLine(long lineno,  // NOLINT(google-runtime-int)
+                                   std::string const& line, char separator);
 
 struct Options {
   char separator;
@@ -196,7 +196,8 @@ int main(int argc, char* argv[]) try {
 }
 
 namespace {
-std::vector<std::string> ParseLine(long lineno, std::string const& line,
+std::vector<std::string> ParseLine(long lineno,  // NOLINT(google-runtime-int)
+                                   std::string const& line,
                                    char separator) try {
   std::vector<std::string> result;
 

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -20,6 +20,7 @@ if (BUILD_TESTING)
                 benchmark_utils.cc benchmark_utils.h bounded_queue.h)
     target_link_libraries(storage_benchmarks PUBLIC storage_client)
     google_cloud_cpp_add_common_options(storage_benchmarks)
+    google_cloud_cpp_add_clang_tidy(storage_benchmarks)
 
     include(CheckCXXSymbolExists)
     check_cxx_symbol_exists(getrusage sys/resource.h
@@ -58,6 +59,7 @@ if (BUILD_TESTING)
                     Threads::Threads
                     nlohmann_json)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target} PROPERTIES LABELS
@@ -91,6 +93,7 @@ if (BUILD_TESTING)
                         CURL::libcurl
                         nlohmann_json)
             google_cloud_cpp_add_common_options(${target})
+            google_cloud_cpp_add_clang_tidy(${target})
             if (MSVC)
                 target_compile_options(${target} PRIVATE "/bigobj")
             endif ()

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -33,7 +33,7 @@ bool EndsWith(std::string const& val, std::string const& suffix) {
 // This parser does not validate the input fully, but it is good enough for our
 // purposes.
 std::int64_t ParseSize(std::string const& val) {
-  long s = std::stol(val);
+  long s = std::stol(val);  // NOLINT(google-runtime-int)
   if (EndsWith(val, "TiB")) {
     return s * kTiB;
   }
@@ -64,7 +64,7 @@ std::int64_t ParseSize(std::string const& val) {
 // This parser does not validate the input fully, but it is good enough for our
 // purposes.
 std::chrono::seconds ParseDuration(std::string const& val) {
-  long s = std::stol(val);
+  long s = std::stol(val);  // NOLINT(google-runtime-int)
   if (EndsWith(val, "h")) {
     return s * std::chrono::seconds(std::chrono::hours(1));
   }
@@ -84,11 +84,8 @@ google::cloud::optional<bool> ParseBoolean(std::string const& val) {
   auto lower = val;
   std::transform(lower.begin(), lower.end(), lower.begin(),
                  [](char x) { return static_cast<char>(std::tolower(x)); });
-  if (lower == "true") {
-    return true;
-  } else if (lower == "false") {
-    return false;
-  }
+  if (lower == "true") return true;
+  if (lower == "false") return false;
   return {};
 }
 
@@ -170,12 +167,13 @@ void SimpleTimer::Start() {
 }
 
 void SimpleTimer::Stop() {
-  using namespace std::chrono;
-  elapsed_time_ = duration_cast<microseconds>(steady_clock::now() - start_);
+  elapsed_time_ = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - start_);
 
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
   auto as_usec = [](timeval const& tv) {
-    return microseconds(seconds(tv.tv_sec)) + microseconds(tv.tv_usec);
+    return std::chrono::microseconds(std::chrono::seconds(tv.tv_sec)) +
+           std::chrono::microseconds(tv.tv_usec);
   };
 
   struct rusage now {};
@@ -274,7 +272,7 @@ std::string FormatSize(std::uintmax_t size) {
 }
 
 void DeleteAllObjects(google::cloud::storage::Client client,
-                      std::string bucket_name, int thread_count) {
+                      std::string const& bucket_name, int thread_count) {
   using WorkQueue = BoundedQueue<google::cloud::storage::ObjectMetadata>;
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -128,7 +128,7 @@ class ProgressReporter {
 std::string FormatSize(std::uintmax_t size);
 
 void DeleteAllObjects(google::cloud::storage::Client client,
-                      std::string bucket_name, int thread_count);
+                      std::string const& bucket_name, int thread_count);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/bounded_queue.h
+++ b/google/cloud/storage/benchmarks/bounded_queue.h
@@ -29,7 +29,7 @@ class BoundedQueue {
  public:
   BoundedQueue() : BoundedQueue(512, 1024) {}
   explicit BoundedQueue(std::size_t lwm, std::size_t hwm)
-      : lwm_(lwm), hwm_(hwm), is_shutdown_(false) {}
+      : lwm_(lwm), hwm_(hwm) {}
 
   void Shutdown() {
     std::unique_lock<std::mutex> lk(mu_);

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -135,11 +135,11 @@ int main(int argc, char* argv[]) {
     double gbps = options->file_size * 8.0 / upload_elapsed.count();
     auto ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(upload_elapsed);
-    auto MiBs =
+    auto mi_bs =
         (double(options->file_size) / gcs_bm::kMiB) / (ms.count() / 1000.0);
     std::cout << "FileUpload," << options->file_size << ','
               << upload_elapsed.count() << ',' << gbps << ',' << ms.count()
-              << ',' << MiBs << ',' << object_metadata.status().code() << "\n";
+              << ',' << mi_bs << ',' << object_metadata.status().code() << "\n";
     if (!object_metadata) {
       std::cout << "# Error in FileUpload: " << object_metadata.status()
                 << "\n";
@@ -156,10 +156,10 @@ int main(int argc, char* argv[]) {
     gbps = options->file_size * 8.0 / download_elapsed.count();
     ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(download_elapsed);
-    MiBs = (double(options->file_size) / gcs_bm::kMiB) / (ms.count() / 1000.0);
+    mi_bs = (double(options->file_size) / gcs_bm::kMiB) / (ms.count() / 1000.0);
     std::cout << "FileDownload," << options->file_size << ','
               << download_elapsed.count() << ',' << gbps << ',' << ms.count()
-              << ',' << MiBs << ',' << object_metadata.status().code() << "\n";
+              << ',' << mi_bs << ',' << object_metadata.status().code() << "\n";
 
     (void)client.DeleteObject(object_metadata->bucket(),
                               object_metadata->name(),

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -93,18 +93,19 @@ struct Options {
   std::int64_t maximum_object_size = 8 * gcs_bm::kGiB;
   std::int64_t minimum_num_shards = 1;
   std::int64_t maximum_num_shards = 128;
-  long minimum_sample_count = 0;
+  long minimum_sample_count = 0;  // NOLINT(google-runtime-int)
+  // NOLINTNEXTLINE(google-runtime-int)
   long maximum_sample_count = std::numeric_limits<long>::max();
 };
 
 StatusOr<std::string> CreateTempFile(
     std::string const& directory,
     google::cloud::internal::DefaultPRNG& generator, std::uintmax_t size_left) {
-  std::size_t const kSingleBufSize = 4 * 1024 * 1024;
+  std::size_t const single_buf_size = 4 * 1024 * 1024;
   auto const file_name = directory + (directory.empty() ? "" : "/") +
                          gcs_bm::MakeRandomFileName(generator);
 
-  std::string random_data = gcs_bm::MakeRandomData(generator, kSingleBufSize);
+  std::string random_data = gcs_bm::MakeRandomData(generator, single_buf_size);
 
   std::ofstream file(file_name, std::ios::binary | std::ios::trunc);
   if (!file.good()) {
@@ -147,7 +148,7 @@ Status PerformUpload(gcs::Client& client, std::string const& file_name,
 }
 
 StatusOr<std::chrono::milliseconds> TimeSingleUpload(
-    gcs::Client& client, std::string global_prefix,
+    gcs::Client& client, std::string const& global_prefix,
     std::string const& bucket_name, std::size_t num_shards,
     std::string const& file_name) {
   using std::chrono::milliseconds;

--- a/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
@@ -87,7 +87,7 @@ struct IterationResult {
 using TestResult = std::vector<IterationResult>;
 
 std::vector<std::string> CreateAllObjects(
-    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    gcs::Client const& client, google::cloud::internal::DefaultPRNG& gen,
     std::string const& bucket_name, Options const& options);
 
 IterationResult RunOneIteration(google::cloud::internal::DefaultPRNG& generator,
@@ -157,19 +157,20 @@ int main(int argc, char* argv[]) {
   std::vector<std::string> const object_names =
       CreateAllObjects(client, generator, bucket_name, *options);
 
-  double MiBs_sum = 0.0;
+  double mi_bs_sum = 0.0;
+  // NOLINTNEXTLINE(google-runtime-int)
   for (long i = 0; i != options->iteration_count; ++i) {
     auto const r =
         RunOneIteration(generator, *options, bucket_name, object_names);
     std::cout << r.bytes << ',' << r.elapsed.count() << std::endl;
-    auto const MiB = r.bytes / gcs_bm::kMiB;
-    auto const MiBs =
-        MiB * (1.0 * decltype(r.elapsed)::period::den) / r.elapsed.count();
-    MiBs_sum += MiBs;
+    auto const mi_b = r.bytes / gcs_bm::kMiB;
+    auto const mi_bs =
+        mi_b * (1.0 * decltype(r.elapsed)::period::den) / r.elapsed.count();
+    mi_bs_sum += mi_bs;
   }
 
-  auto const MiBs_avg = MiBs_sum / options->iteration_count;
-  std::cout << "# Average Bandwidth (MiB/s): " << MiBs_avg << "\n";
+  auto const mi_bs_avg = mi_bs_sum / options->iteration_count;
+  std::cout << "# Average Bandwidth (MiB/s): " << mi_bs_avg << "\n";
 
   gcs_bm::DeleteAllObjects(client, bucket_name, options->thread_count);
 
@@ -186,7 +187,8 @@ int main(int argc, char* argv[]) {
 namespace {
 
 void CreateGroup(gcs::Client client, std::string const& bucket_name,
-                 Options const& options, std::vector<std::string> group) {
+                 Options const& options,
+                 std::vector<std::string> const& group) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
@@ -205,7 +207,7 @@ void CreateGroup(gcs::Client client, std::string const& bucket_name,
 }
 
 std::vector<std::string> CreateAllObjects(
-    gcs::Client client, google::cloud::internal::DefaultPRNG& gen,
+    gcs::Client const& client, google::cloud::internal::DefaultPRNG& gen,
     std::string const& bucket_name, Options const& options) {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;
@@ -217,6 +219,7 @@ std::vector<std::string> CreateAllObjects(
   // Generate the list of object names.
   std::vector<std::string> object_names;
   object_names.reserve(options.object_count);
+  // NOLINTNEXTLINE(google-runtime-int)
   for (long c = 0; c != options.object_count; ++c) {
     object_names.emplace_back(gcs_bm::MakeRandomObjectName(gen));
   }
@@ -285,6 +288,7 @@ IterationResult RunOneIteration(google::cloud::internal::DefaultPRNG& generator,
 
   auto const download_start = std::chrono::steady_clock::now();
   std::int64_t total_bytes = 0;
+  // NOLINTNEXTLINE(google-runtime-int)
   for (long i = 0; i != options.iteration_size; ++i) {
     auto const object = object_generator(generator);
     auto const chunk = chunk_generator(generator);

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -90,11 +90,12 @@ struct Options {
   std::int64_t maximum_object_size = 256 * gcs_bm::kMiB;
   std::int64_t minimum_chunk_size = 128 * gcs_bm::kKiB;
   std::int64_t maximum_chunk_size = 4096 * gcs_bm::kKiB;
-  long minimum_sample_count = 0;
+  long minimum_sample_count = 0;  // NOLINT(google-runtime-int)
+  // NOLINTNEXTLINE(google-runtime-int)
   long maximum_sample_count = std::numeric_limits<long>::max();
 };
 
-enum OpType { OP_UPLOAD, OP_DOWNLOAD };
+enum OpType { kOpUpload, kOpDownload };
 struct IterationResult {
   OpType op;
   std::uint64_t object_size;
@@ -202,9 +203,9 @@ int main(int argc, char* argv[]) {
 namespace {
 char const* ToString(OpType type) {
   switch (type) {
-    case OP_DOWNLOAD:
+    case kOpDownload:
       return "DOWNLOAD";
-    case OP_UPLOAD:
+    case kOpUpload:
       return "UPLOAD";
   }
   return nullptr;  // silence g++ error.
@@ -271,14 +272,14 @@ TestResults RunThread(Options const& options, std::string const& bucket_name) {
   gcs_bm::SimpleTimer timer;
   // This obviously depends on the size of the objects, but a good estimate for
   // the upload + download bandwidth is 250MiB/s.
-  constexpr long expected_bandwidth = 250 * gcs_bm::kMiB;
+  constexpr auto kExpectedBandwidth = 250 * gcs_bm::kMiB;
   auto const median_size =
       (options.minimum_object_size + options.minimum_object_size) / 2;
-  auto const objects_per_second = median_size / expected_bandwidth;
+  auto const objects_per_second = median_size / kExpectedBandwidth;
   TestResults results;
   results.reserve(options.duration.count() * objects_per_second);
 
-  long iteration_count = 0;
+  long iteration_count = 0;  // NOLINT(google-runtime-int)
   for (auto start = std::chrono::steady_clock::now();
        iteration_count < options.maximum_sample_count &&
        (iteration_count < options.minimum_sample_count || start < deadline);
@@ -309,7 +310,7 @@ TestResults RunThread(Options const& options, std::string const& bucket_name) {
 
     auto object_metadata = writer.metadata();
     results.emplace_back(IterationResult{
-        OP_UPLOAD, object_size, chunk_size, download_buffer_size, enable_crc,
+        kOpUpload, object_size, chunk_size, download_buffer_size, enable_crc,
         enable_md5, timer.elapsed_time(), timer.cpu_time(),
         object_metadata.status().code(), progress.GetAccumulatedProgress()});
 
@@ -331,7 +332,7 @@ TestResults RunThread(Options const& options, std::string const& bucket_name) {
     }
     timer.Stop();
     results.emplace_back(IterationResult{
-        OP_DOWNLOAD, object_size, chunk_size, upload_buffer_size, enable_crc,
+        kOpDownload, object_size, chunk_size, upload_buffer_size, enable_crc,
         enable_md5, timer.elapsed_time(), timer.cpu_time(),
         reader.status().code(), progress.GetAccumulatedProgress()});
 

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -20,6 +20,7 @@ if (BUILD_TESTING)
     target_link_libraries(storage_examples_common storage_client
                           google_cloud_cpp_common)
     google_cloud_cpp_add_common_options(storage_examples_common)
+    google_cloud_cpp_add_clang_tidy(storage_examples_common)
 
     set(storage_examples
         # cmake-format: sort

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -39,6 +39,7 @@ if (BUILD_TESTING)
         PUBLIC absl::symbolize absl::failure_signal_handler
                google_cloud_cpp_common GTest::gmock)
     google_cloud_cpp_add_common_options(google_cloud_cpp_testing)
+    google_cloud_cpp_add_clang_tidy(google_cloud_cpp_testing)
 
     create_bazel_config(google_cloud_cpp_testing YEAR 2019)
 
@@ -57,6 +58,7 @@ if (BUILD_TESTING)
             ${target} PRIVATE google_cloud_cpp_testing google_cloud_cpp_common
                               GTest::gmock_main GTest::gmock GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
         if (MSVC)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
@@ -72,6 +74,7 @@ if (BUILD_TESTING)
         google_cloud_cpp_testing_grpc PUBLIC google_cloud_cpp_common
                                              protobuf::libprotobuf GTest::gmock)
     google_cloud_cpp_add_common_options(google_cloud_cpp_testing_grpc)
+    google_cloud_cpp_add_clang_tidy(google_cloud_cpp_testing_grpc)
 
     create_bazel_config(google_cloud_cpp_testing_grpc YEAR 2020)
 
@@ -93,6 +96,7 @@ if (BUILD_TESTING)
                     GTest::gmock
                     GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
+        google_cloud_cpp_add_clang_tidy(${target})
         if (MSVC)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()


### PR DESCRIPTION
The clang-tidy `HeaderFilterRegex` now covers all `google/cloud`
header files, and `google_cloud_cpp_add_clang_tidy()` is applied
in every `CMakeLists.txt` file.

Tweak the "presubmit builds only tidy changed files" support to
extract the `HeaderFilterRegex` using `clang-tidy -dump-config`
so that unescaping is done before passing the RE to `grep`.

Part of #3958.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4238)
<!-- Reviewable:end -->
