### PR TITLE
feat: add rvalue reference overloads to `Cell`

### DIFF
--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -144,7 +144,9 @@ class Cell {
 
   /// Return the contents of this cell. The returned value is not valid after
   /// this object is deleted.
-  CellValueType const& value() const { return value_; }
+  CellValueType const& value() const& { return value_; }
+  /// Return the contents of this cell.
+  CellValueType&& value() && { return std::move(value_); }
 
   /**
    * Interpret the value as a big-endian encoded `T` and return it.

--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -70,3 +70,23 @@ TEST(CellTest, SimpleNumericNegativeValue) {
   EXPECT_STATUS_OK(decoded);
   EXPECT_EQ(value, *decoded);
 }
+
+/// @test Verify Cell rvalue-ref accessors.
+TEST(CellTest, RValueRefAccessors) {
+  std::string row_key = "row";
+  std::string family_name = "family";
+  std::string column_qualifier = "column";
+  std::int64_t timestamp = 42;
+  std::string value = "value";
+
+  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
+
+  static_assert(
+      !std::is_lvalue_reference<decltype(bigtable::Cell(cell).value())>::value,
+      "Member function `value` is expected to return a value from an r-value "
+      "reference to row.");
+
+  std::string moved_value = std::move(cell).value();
+
+  EXPECT_EQ(value, moved_value);
+}


### PR DESCRIPTION
This fixes #4108.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4240)
<!-- Reviewable:end -->
