### PR TITLE
fix: fix off-by-one in uploading streams to GCS

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -42,6 +42,9 @@
 namespace google {
 namespace cloud {
 namespace storage {
+namespace testing {
+class ClientTester;
+}  // namespace testing
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 class NonResumableParallelUploadState;
@@ -3096,6 +3099,7 @@ class Client {
 
   friend class internal::NonResumableParallelUploadState;
   friend class internal::ResumableParallelUploadState;
+  friend class testing::ClientTester;
 };
 
 /**


### PR DESCRIPTION
This fixes #3432.

Before this change, `seekg` was called for proper behavior for every
`UploadChink`. Because it was `expected`, which was broken, the `seekg`
was effectively a noop, so everything worked, except for generating
warnings.
    
This PR also removes the `seekg` from that execution path altogether.
Playing with tests proved that unless there is a bug in the code, there
is no way to end up in a situation when `seekg` was called and even if
this situation occurred, it would be impossible to properly recover from
it. In order to not increase the likelihood of a corruption, I replaced
this logic with returning an error.
    
In order to make sure that resumable upload sessions are properly
handled, a `seekg` is added at the beginning to handle resuming a
stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4250)
<!-- Reviewable:end -->
