### PR TITLE
ci: increase Windows build timeout to 180m

### DIFF
--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
-timeout_mins: 120
+timeout_mins: 180
 
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"


### PR DESCRIPTION
The builds are taking (routinely) about 110m, we need to increase
the timeout to make room for new code, such as `cpp-cmakefiles`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4251)
<!-- Reviewable:end -->
