### PR TITLE
feat: convert To/From protos for Bucket* structs

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -853,6 +853,48 @@ BucketAccessControl GrpcClient::FromProto(
   return result;
 }
 
+google::storage::v1::Bucket::Billing GrpcClient::ToProto(
+    BucketBilling const& rhs) {
+  google::storage::v1::Bucket::Billing result;
+  result.set_requester_pays(rhs.requester_pays);
+  return result;
+}
+
+BucketBilling GrpcClient::FromProto(
+    google::storage::v1::Bucket::Billing const& rhs) {
+  BucketBilling result;
+  result.requester_pays = rhs.requester_pays();
+  return result;
+}
+
+google::storage::v1::Bucket::Versioning GrpcClient::ToProto(
+    BucketVersioning const& rhs) {
+  google::storage::v1::Bucket::Versioning result;
+  result.set_enabled(rhs.enabled);
+  return result;
+}
+
+BucketVersioning GrpcClient::FromProto(
+    google::storage::v1::Bucket::Versioning const& rhs) {
+  BucketVersioning result;
+  result.enabled = rhs.enabled();
+  return result;
+}
+
+google::storage::v1::Bucket::Website GrpcClient::ToProto(BucketWebsite rhs) {
+  google::storage::v1::Bucket::Website result;
+  result.set_main_page_suffix(std::move(rhs.main_page_suffix));
+  result.set_not_found_page(std::move(rhs.not_found_page));
+  return result;
+}
+
+BucketWebsite GrpcClient::FromProto(google::storage::v1::Bucket::Website rhs) {
+  BucketWebsite result;
+  result.main_page_suffix = std::move(*rhs.mutable_main_page_suffix());
+  result.not_found_page = std::move(*rhs.mutable_not_found_page());
+  return result;
+}
+
 google::storage::v1::CommonEnums::Projection GrpcClient::ToProto(
     Projection const& p) {
   if (p.value() == Projection::NoAcl().value()) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -178,6 +178,17 @@ class GrpcClient : public RawClient,
   static BucketAccessControl FromProto(
       google::storage::v1::BucketAccessControl acl);
 
+  static google::storage::v1::Bucket::Billing ToProto(BucketBilling const&);
+  static BucketBilling FromProto(google::storage::v1::Bucket::Billing const&);
+
+  static google::storage::v1::Bucket::Versioning ToProto(
+      BucketVersioning const&);
+  static BucketVersioning FromProto(
+      google::storage::v1::Bucket::Versioning const&);
+
+  static google::storage::v1::Bucket::Website ToProto(BucketWebsite);
+  static BucketWebsite FromProto(google::storage::v1::Bucket::Website);
+
   static google::storage::v1::CommonEnums::Projection ToProto(
       Projection const& p);
   static google::storage::v1::CommonEnums::PredefinedBucketAcl ToProtoBucket(

--- a/google/cloud/storage/internal/grpc_client_bucket_metadata_test.cc
+++ b/google/cloud/storage/internal/grpc_client_bucket_metadata_test.cc
@@ -192,6 +192,46 @@ TEST(GrpcClientBucketMetadata, BucketMetadata) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcClientBucketMetadata, BucketBillingRoundtrip) {
+  auto constexpr kText = R"pb(
+    requester_pays: true
+  )pb";
+  google::storage::v1::Bucket::Billing start;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &start));
+  auto const expected = BucketBilling{true};
+  auto const middle = GrpcClient::FromProto(start);
+  EXPECT_EQ(middle, expected);
+  auto const end = GrpcClient::ToProto(middle);
+  EXPECT_THAT(end, IsProtoEqual(start));
+}
+
+TEST(GrpcClientBucketMetadata, BucketVersioningRoundtrip) {
+  auto constexpr kText = R"pb(
+    enabled: true
+  )pb";
+  google::storage::v1::Bucket::Versioning start;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &start));
+  auto const expected = BucketVersioning{true};
+  auto const middle = GrpcClient::FromProto(start);
+  EXPECT_EQ(middle, expected);
+  auto const end = GrpcClient::ToProto(middle);
+  EXPECT_THAT(end, IsProtoEqual(start));
+}
+
+TEST(GrpcClientBucketMetadata, BucketWebsiteRoundtrip) {
+  auto constexpr kText = R"pb(
+    main_page_suffix: "index.html"
+    not_found_page: "404.html"
+  )pb";
+  google::storage::v1::Bucket::Website start;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &start));
+  auto const expected = BucketWebsite{"index.html", "404.html"};
+  auto const middle = GrpcClient::FromProto(start);
+  EXPECT_EQ(middle, expected);
+  auto const end = GrpcClient::ToProto(middle);
+  EXPECT_THAT(end, IsProtoEqual(start));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
The BucketMetadata class has many different components (e.g.
BucketBilling, BucketWebsite, BucketVersioning), this adds conversion
functions for them.

Fixes #4164, fixes #4167, and fixes #4168

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4254)
<!-- Reviewable:end -->
