### PR TITLE
ci: compile protos before running clang-tidy

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -139,6 +139,7 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   echo
   io::log_yellow "Running clang-tidy on presubmit build, only changed files are tested."
   ${CMAKE_COMMAND} --build "${BINARY_DIR}" --target nlohmann_json_project
+  ${CMAKE_COMMAND} --build "${BINARY_DIR}" --target google-cloud-cpp-protos
   # TODO(#3958) - Combine these two invocations of "xargs clang-tidy" into a
   # single one using a simple regular expression like '\.(h|cc)$' when all
   # targets are clang-tidy clean. Until then, we check all changed .cc files,

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -163,7 +163,10 @@ function (googleapis_cpp_add_library proto)
     endif ()
 endfunction ()
 
+add_custom_target(google-cloud-cpp-protos)
+
 function (googleapis_cpp_set_version_and_alias short_name)
+    add_dependencies(google-cloud-cpp-protos "googleapis_cpp_${short_name}")
     add_dependencies("googleapis_cpp_${short_name}" googleapis_download)
     set_target_properties(
         "googleapis_cpp_${short_name}"


### PR DESCRIPTION
If clang-tidy does not find a header (like a generated `*.pb.h` file) it
gets really confused and generates many spurious errors.

To see such a spurious failure look at:

https://source.cloud.google.com/results/invocations/63b78a23-c7b7-4f0d-9f4c-61a9e29c7c90

If we prefer to move the `clang-tidy` phase until all the code is
generated, we can do that, just keep in mind that this will delay
clang-tidy results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4256)
<!-- Reviewable:end -->
