### PR TITLE
cleanup: make the test labels/tags more consistent

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -183,7 +183,7 @@ if should_run_integration_tests; then
   # below to avoid invalidating the cached test results for all the other tests.
   "${BAZEL_BIN}" test \
     "${bazel_args[@]}" \
-    "--test_tag_filters=storage-integration-tests,pubsub-integration-tests,spanner-integration-tests" \
+    "--test_tag_filters=integration-test" \
     -- //google/cloud/...:all "${excluded_targets[@]}"
 
   # Changing the PATH disables the Bazel cache, so use an absolute path.

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -173,7 +173,13 @@ if should_run_integration_tests; then
   access_token_targets=(
     "//google/cloud/bigtable/examples:bigtable_grpc_credentials"
   )
-  excluded_targets=()
+  excluded_targets=(
+    # The Bigtable integrations that use the emulator *and* production were
+    # already run by the "run_integration_tests_emulator_bazel.sh" script that
+    # was called above. The one exception is the bigtable_grpc_credentials
+    # test, which requires an access token and will be run separately.
+    "-//google/cloud/bigtable/..."
+  )
   for t in "${hmac_service_account_targets[@]}" "${access_token_targets[@]}"; do
     excluded_targets+=("-${t}")
   done

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -61,7 +61,7 @@ echo "================================================================"
 io::log "Compiling and running unit tests"
 echo "================================================================"
 "${BAZEL_BIN}" test \
-  "${bazel_args[@]}" "--test_tag_filters=-integration-tests" \
+  "${bazel_args[@]}" "--test_tag_filters=-integration-test" \
   -- //google/cloud/...:all
 
 echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -209,7 +209,7 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
       # TODO(#441) - when the emulator crashes the tests can take a long time.
       # The slowest test normally finishes in about 6 seconds, 60 seems safe.
       if "${PROJECT_ROOT}/google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
-        "${BINARY_DIR}" "${ctest_args[@]}" --timeout 60; then
+        "${BINARY_DIR}" "${ctest_args[@]}" -L integration-test-emulator --timeout 60; then
         success=yes
         break
       fi
@@ -224,13 +224,13 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     io::log_yellow "running storage integration tests via CTest+Emulator"
     echo
     "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-      "${BINARY_DIR}" "${ctest_args[@]}"
+      "${BINARY_DIR}" "${ctest_args[@]}" -L integration-test-emulator
 
     echo
     io::log_yellow "running spanner integration tests via CTest+Emulator"
     echo
     "${PROJECT_ROOT}/google/cloud/spanner/ci/${EMULATOR_SCRIPT}" \
-      "${BINARY_DIR}" "${ctest_args[@]}"
+      "${BINARY_DIR}" "${ctest_args[@]}" -L integration-test-emulator
   fi
 
   readonly GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON="/c/kokoro-run-key.json"
@@ -310,10 +310,10 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     if [[ "${BUILD_NAME:-}" != "coverage" ]]; then
       # TODO(#4234) - the Bigtable tests are only enabled on the coverage
       #   builds because they consume too much quota.
-      ctest_args+=(-E bigtable)
+      ctest_args+=(-E "^bigtable_")
     fi
-    env -C "${BINARY_DIR}" ctest \
-      -L integration-test-production "${ctest_args[@]}"
+    env -C "${BINARY_DIR}" ctest "${ctest_args[@]}" \
+      -L integration-test-production
 
     echo "================================================================"
     io::log_yellow "Completed the integration tests against production"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -187,7 +187,7 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
     echo
     io::log_yellow "Running unit tests"
     echo
-    (cd "${BINARY_DIR}" && ctest "-LE" "integration-tests" "${ctest_args[@]}")
+    (cd "${BINARY_DIR}" && ctest "-LE" "integration-test" "${ctest_args[@]}")
     echo
     io::log_yellow "Completed unit tests"
     echo

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -304,7 +304,7 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
 
     # Since we already run multiple integration tests against the emulator we
     # only need to run the tests here that cannot use the emulator. Some
-    # libraries will tag all their tests as "integration-tests-no-emulator",
+    # libraries will tag all their tests as "integration-test-production",
     # that is fine too. As long as we do not repeat all the tests we are
     # winning.
     if [[ "${BUILD_NAME:-}" != "coverage" ]]; then
@@ -313,7 +313,7 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
       ctest_args+=(-E bigtable)
     fi
     env -C "${BINARY_DIR}" ctest \
-      -L integration-tests-no-emulator "${ctest_args[@]}"
+      -L integration-test-production "${ctest_args[@]}"
 
     echo "================================================================"
     io::log_yellow "Completed the integration tests against production"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -69,7 +69,7 @@ echo
 echo "================================================================"
 io::log_yellow "build and run unit tests."
 "${BAZEL_BIN}" test \
-  "${bazel_args[@]}" "--test_tag_filters=-integration-tests" \
+  "${bazel_args[@]}" "--test_tag_filters=-integration-test" \
   -- //google/cloud/...:all
 
 echo

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -130,7 +130,7 @@ if should_run_integration_tests; then
 
   "${BAZEL_BIN}" test \
     "${bazel_args[@]}" \
-    "--test_tag_filters=bigtable-integration-tests,storage-integration-tests,spanner-integration-tests" \
+    "--test_tag_filters=integration-test" \
     -- //google/cloud/...:all \
     -//google/cloud/bigtable/examples:bigtable_grpc_credentials \
     -//google/cloud/storage/examples:storage_service_account_samples \

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -70,7 +70,7 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
   (
     cd "${BINARY_DIR}"
     ctest \
-      -LE integration-tests \
+      -LE integration-test \
       --output-on-failure -j "${NCPU}"
   )
   echo "================================================================"

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -106,7 +106,7 @@ if should_run_integration_tests; then
       cd "${BINARY_DIR}"
     fi
     ctest \
-      -L '(bigtable-integration-tests|storage-integration-tests|spanner-integration-tests|integration-test-production)' \
+      -L 'integration-test-production' \
       -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test)' \
       --output-on-failure -j "${NCPU}"
   )

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -106,7 +106,7 @@ if should_run_integration_tests; then
       cd "${BINARY_DIR}"
     fi
     ctest \
-      -L '(bigtable-integration-tests|storage-integration-tests|spanner-integration-tests|integration-tests-no-emulator)' \
+      -L '(bigtable-integration-tests|storage-integration-tests|spanner-integration-tests|integration-test-production)' \
       -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test)' \
       --output-on-failure -j "${NCPU}"
   )

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -188,7 +188,7 @@ if (Integration-Tests-Enabled) {
         "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT=${env:GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT}"
     )
     bazel $common_flags test $test_flags $integration_flags `
-        "--test_tag_filters=bigtable-integration-tests,storage-integration-tests,spanner-integration-tests" `
+        "--test_tag_filters=integration-test" `
         -- //google/cloud/...:all `
         -//google/cloud/bigtable/examples:bigtable_grpc_credentials `
         -//google/cloud/storage/examples:storage_service_account_samples `

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -120,7 +120,7 @@ ForEach($_ in (1, 2, 3)) {
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling and running unit tests"
 bazel $common_flags test $test_flags `
-  --test_tag_filters=-integration-tests `
+  --test_tag_filters=-integration-test `
   -- //google/cloud/...:all
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "bazel test failed with exit code ${LastExitCode}."

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -68,7 +68,7 @@ if (Test-Path env:RUNNING_CI) {
 $NCPU=(Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
 
 $ctest_flags = @("--output-on-failure", "-j", $NCPU, "-C", $env:CONFIG)
-ctest $ctest_flags -LE integration-tests
+ctest $ctest_flags -LE integration-test
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "ctest failed with exit code $LastExitCode"
     Exit ${LastExitCode}
@@ -76,7 +76,7 @@ if ($LastExitCode) {
 
 if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "true")) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running integration tests $env:CONFIG"
-    ctest $ctest_flags -L integration-tests
+    ctest $ctest_flags -L integration-test
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "Integration tests failed with exit code $LastExitCode"
         Exit ${LastExitCode}

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -110,7 +110,7 @@ if (Integration-Tests-Enabled) {
     Set-Location "${project_root}"
     Set-Location "${binary_dir}"
     ctest $ctest_flags `
-        -L '(bigtable-integration-tests|storage-integration-tests|spanner-integration-tests|integration-tests-no-emulator)' `
+        -L '(bigtable-integration-tests|storage-integration-tests|spanner-integration-tests|integration-test-production)' `
         -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test)'
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "Integration tests failed with exit code ${LastExitCode}."

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -110,7 +110,7 @@ if (Integration-Tests-Enabled) {
     Set-Location "${project_root}"
     Set-Location "${binary_dir}"
     ctest $ctest_flags `
-        -L '(bigtable-integration-tests|storage-integration-tests|spanner-integration-tests|integration-test-production)' `
+        -L 'integration-test-production' `
         -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test)'
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "Integration tests failed with exit code ${LastExitCode}."

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -78,7 +78,7 @@ You may need to clone and compile the code as described [here](setup-cmake-envir
 Run the tests using:
 
 ```console
-env -C cmake-out/home ctest --output-on-failure -LE integration-tests
+env -C cmake-out/home ctest --output-on-failure -LE integration-test
 ```
 
 Run the Google Cloud Storage integration tests:

--- a/google/cloud/bigquery/samples/CMakeLists.txt
+++ b/google/cloud/bigquery/samples/CMakeLists.txt
@@ -39,7 +39,9 @@ function (bigquery_client_define_samples)
 
     foreach (fname ${bigquery_client_integration_samples})
         google_cloud_cpp_set_target_name(target "bigquery" "${fname}")
-        set_tests_properties(${target} PROPERTIES LABELS "integration-test")
+        set_tests_properties(
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-production")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/bigquery/samples/CMakeLists.txt
+++ b/google/cloud/bigquery/samples/CMakeLists.txt
@@ -39,7 +39,7 @@ function (bigquery_client_define_samples)
 
     foreach (fname ${bigquery_client_integration_samples})
         google_cloud_cpp_set_target_name(target "bigquery" "${fname}")
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
+        set_tests_properties(${target} PROPERTIES LABELS "integration-test")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/bigquery/samples/CMakeLists.txt
+++ b/google/cloud/bigquery/samples/CMakeLists.txt
@@ -39,9 +39,13 @@ function (bigquery_client_define_samples)
 
     foreach (fname ${bigquery_client_integration_samples})
         google_cloud_cpp_set_target_name(target "bigquery" "${fname}")
-        set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;integration-test-production")
+        # These tests are intended to be integration tests, but they don't yet
+        # work against an emulator or production. Until they work, we'll add the
+        # 'integration-test' label so they can be excluded from certain test
+        # patterns (e.g., `ctest -LE integration-test`), but we're not adding
+        # the 'integration-test-production' or 'integration-test-emulator'
+        # labels until they work.
+        set_tests_properties(${target} PROPERTIES LABELS "integration-test")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/bigtable/benchmarks/BUILD
+++ b/google/cloud/bigtable/benchmarks/BUILD
@@ -39,7 +39,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
     }),
     tags = [
         "bigtable-integration-tests",
-        "integration-tests",
+        "integration-test",
     ],
     deps = [
         ":bigtable_benchmark_common",

--- a/google/cloud/bigtable/benchmarks/BUILD
+++ b/google/cloud/bigtable/benchmarks/BUILD
@@ -38,7 +38,6 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
         "//conditions:default": ["-lpthread"],
     }),
     tags = [
-        "bigtable-integration-tests",
         "integration-test",
     ],
     deps = [

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -98,7 +98,10 @@ foreach (fname ${bigtable_benchmark_programs})
     if (BUILD_TESTING)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;bigtable-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;bigtable-integration-tests"
+        )
     endif ()
 endforeach ()

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -98,10 +98,7 @@ foreach (fname ${bigtable_benchmark_programs})
     if (BUILD_TESTING)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;bigtable-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
     endif ()
 endforeach ()

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -99,6 +99,6 @@ foreach (fname ${bigtable_benchmark_programs})
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;bigtable-integration-tests")
+                                 "integration-test;bigtable-integration-tests")
     endif ()
 endforeach ()

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -40,7 +40,7 @@ production_only_targets=(
   "//google/cloud/bigtable/tests:admin_iam_policy_integration_test"
 )
 "${BAZEL_BIN}" test "${bazel_test_args[@]}" \
-  --test_tag_filters="bigtable-integration-tests" -- \
+  --test_tag_filters="integration-test" -- \
   "${production_only_targets[@]}"
 
 # `start_emulators` creates unsightly *.log files in the current directory
@@ -64,8 +64,8 @@ done
   --test_env="BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST=${BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST}" \
   --test_env="ENABLE_BIGTABLE_ADMIN_INTEGRATION_TEST=yes" \
   --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
-  --test_tag_filters="bigtable-integration-tests" -- \
-  "//google/cloud/...:all" \
+  --test_tag_filters="integration-test" -- \
+  "//google/cloud/bigtable/...:all" \
   "${excluded_targets[@]}"
 exit_status=$?
 

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -44,7 +44,7 @@ export ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS="yes"
 cd "${BINARY_DIR}"
 start_emulators
 
-ctest -L "bigtable-integration-tests" "${ctest_args[@]}"
+ctest -R "^bigtable_" "${ctest_args[@]}"
 exit_status=$?
 
 kill_emulators

--- a/google/cloud/bigtable/examples/BUILD
+++ b/google/cloud/bigtable/examples/BUILD
@@ -55,7 +55,7 @@ load(":bigtable_examples.bzl", "bigtable_examples")
     srcs = [test],
     tags = [
         "bigtable-integration-tests",
-        "integration-tests",
+        "integration-test",
     ],
     deps = [
         ":bigtable_examples_common",

--- a/google/cloud/bigtable/examples/BUILD
+++ b/google/cloud/bigtable/examples/BUILD
@@ -54,7 +54,6 @@ load(":bigtable_examples.bzl", "bigtable_examples")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     tags = [
-        "bigtable-integration-tests",
         "integration-test",
     ],
     deps = [

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -91,10 +91,9 @@ if (BUILD_TESTING)
                     gRPC::grpc
                     protobuf::libprotobuf)
         add_test(NAME ${target} COMMAND ${target})
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;bigtable-integration-tests")
+                                 "integration-test;bigtable-integration-tests")
         google_cloud_cpp_add_common_options(${target})
         google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()
@@ -107,7 +106,7 @@ if (BUILD_TESTING)
     foreach (fname ${bigtable_examples_production})
         google_cloud_cpp_set_target_name(target "bigtable_examples" "${fname}")
         set_tests_properties(
-            ${target}
-            PROPERTIES LABELS "integration-tests;integration-test-production")
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-production")
     endforeach ()
 endif ()

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -92,11 +92,8 @@ if (BUILD_TESTING)
                     protobuf::libprotobuf)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;bigtable-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
         google_cloud_cpp_add_common_options(${target})
         google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -92,8 +92,11 @@ if (BUILD_TESTING)
                     protobuf::libprotobuf)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;bigtable-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;bigtable-integration-tests"
+        )
         google_cloud_cpp_add_common_options(${target})
         google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -108,6 +108,6 @@ if (BUILD_TESTING)
         google_cloud_cpp_set_target_name(target "bigtable_examples" "${fname}")
         set_tests_properties(
             ${target}
-            PROPERTIES LABELS "integration-tests;integration-tests-no-emulator")
+            PROPERTIES LABELS "integration-tests;integration-test-production")
     endforeach ()
 endif ()

--- a/google/cloud/bigtable/tests/BUILD
+++ b/google/cloud/bigtable/tests/BUILD
@@ -27,7 +27,7 @@ load(
     srcs = [test],
     tags = [
         "bigtable-integration-tests",
-        "integration-tests",
+        "integration-test",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/bigtable/tests/BUILD
+++ b/google/cloud/bigtable/tests/BUILD
@@ -26,7 +26,6 @@ load(
     timeout = "long",
     srcs = [test],
     tags = [
-        "bigtable-integration-tests",
         "integration-test",
     ],
     deps = [

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -50,8 +50,11 @@ foreach (fname ${bigtable_client_integration_tests})
                 protobuf::libprotobuf)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
-        ${target} PROPERTIES LABELS
-                             "integration-test;bigtable-integration-tests")
+        ${target}
+        PROPERTIES
+            LABELS
+            "integration-test;integration-test-emulator;bigtable-integration-tests"
+    )
     google_cloud_cpp_add_common_options(${target})
     google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach (fname ${bigtable_client_integration_tests})
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
         ${target} PROPERTIES LABELS
-                             "integration-tests;bigtable-integration-tests")
+                             "integration-test;bigtable-integration-tests")
     google_cloud_cpp_add_common_options(${target})
     google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()
@@ -72,5 +72,5 @@ foreach (fname ${bigtable_integration_tests_production})
     google_cloud_cpp_set_target_name(target "bigtable" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS
-                             "integration-tests;integration-test-production")
+                             "integration-test;integration-test-production")
 endforeach ()

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -72,5 +72,5 @@ foreach (fname ${bigtable_integration_tests_production})
     google_cloud_cpp_set_target_name(target "bigtable" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS
-                             "integration-tests;integration-tests-no-emulator")
+                             "integration-tests;integration-test-production")
 endforeach ()

--- a/google/cloud/bigtable/tests/CMakeLists.txt
+++ b/google/cloud/bigtable/tests/CMakeLists.txt
@@ -50,11 +50,8 @@ foreach (fname ${bigtable_client_integration_tests})
                 protobuf::libprotobuf)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
-        ${target}
-        PROPERTIES
-            LABELS
-            "integration-test;integration-test-emulator;bigtable-integration-tests"
-    )
+        ${target} PROPERTIES LABELS
+                             "integration-test;integration-test-emulator")
     google_cloud_cpp_add_common_options(${target})
     google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -26,5 +26,5 @@ if (BUILD_TESTING)
     add_test(NAME gcs2cbt COMMAND gcs2cbt)
     set_tests_properties(
         gcs2cbt PROPERTIES LABELS
-                           "integration-tests;integration-test-production")
+                           "integration-test;integration-test-production")
 endif ()

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -26,5 +26,5 @@ if (BUILD_TESTING)
     add_test(NAME gcs2cbt COMMAND gcs2cbt)
     set_tests_properties(
         gcs2cbt PROPERTIES LABELS
-                           "integration-tests;integration-tests-no-emulator")
+                           "integration-tests;integration-test-production")
 endif ()

--- a/google/cloud/pubsub/integration_tests/BUILD
+++ b/google/cloud/pubsub/integration_tests/BUILD
@@ -25,7 +25,6 @@ load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
     srcs = [test],
     tags = [
         "integration-test",
-        "pubsub-integration-tests",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",
@@ -40,7 +39,6 @@ load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
     srcs = [test],
     tags = [
         "integration-test",
-        "pubsub-integration-tests",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/pubsub/integration_tests/BUILD
+++ b/google/cloud/pubsub/integration_tests/BUILD
@@ -24,7 +24,7 @@ load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
     timeout = "long",
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "pubsub-integration-tests",
     ],
     deps = [
@@ -39,7 +39,7 @@ load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "pubsub-integration-tests",
     ],
     deps = [

--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -56,7 +56,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target}
-            PROPERTIES LABELS "integration-tests;integration-tests-no-emulator")
+            PROPERTIES LABELS "integration-tests;integration-test-production")
         add_dependencies(pubsub-client-integration-tests ${target})
     endforeach ()
 
@@ -73,7 +73,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target}
-            PROPERTIES LABELS "integration-tests;integration-tests-no-emulator")
+            PROPERTIES LABELS "integration-tests;integration-test-production")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -55,8 +55,8 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         endif ()
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES LABELS "integration-tests;integration-test-production")
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-production")
         add_dependencies(pubsub-client-integration-tests ${target})
     endforeach ()
 
@@ -72,8 +72,8 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
 
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES LABELS "integration-tests;integration-test-production")
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-production")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/pubsub/samples/BUILD
+++ b/google/cloud/pubsub/samples/BUILD
@@ -54,7 +54,6 @@ load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
     srcs = [test],
     tags = [
         "integration-test",
-        "pubsub-integration-tests",
     ],
     deps = [
         ":pubsub_samples_common",

--- a/google/cloud/pubsub/samples/BUILD
+++ b/google/cloud/pubsub/samples/BUILD
@@ -53,7 +53,7 @@ load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
     timeout = "long",
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "pubsub-integration-tests",
     ],
     deps = [

--- a/google/cloud/pubsub/samples/CMakeLists.txt
+++ b/google/cloud/pubsub/samples/CMakeLists.txt
@@ -85,8 +85,8 @@ function (pubsub_client_define_samples)
     foreach (fname ${pubsub_client_integration_samples})
         google_cloud_cpp_set_target_name(target "pubsub" "${fname}")
         set_tests_properties(
-            ${target}
-            PROPERTIES LABELS "integration-tests;integration-test-production")
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-production")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/pubsub/samples/CMakeLists.txt
+++ b/google/cloud/pubsub/samples/CMakeLists.txt
@@ -86,7 +86,7 @@ function (pubsub_client_define_samples)
         google_cloud_cpp_set_target_name(target "pubsub" "${fname}")
         set_tests_properties(
             ${target}
-            PROPERTIES LABELS "integration-tests;integration-tests-no-emulator")
+            PROPERTIES LABELS "integration-tests;integration-test-production")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/benchmarks/BUILD
+++ b/google/cloud/spanner/benchmarks/BUILD
@@ -39,7 +39,6 @@ cc_library(
     srcs = [test],
     tags = [
         "integration-test",
-        "spanner-integration-tests",
     ],
     deps = [
         ":spanner_client_benchmarks",

--- a/google/cloud/spanner/benchmarks/BUILD
+++ b/google/cloud/spanner/benchmarks/BUILD
@@ -38,7 +38,7 @@ cc_library(
     timeout = "long",
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "spanner-integration-tests",
     ],
     deps = [

--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -90,7 +90,7 @@ function (spanner_client_define_benchmarks)
         # label them as tests.
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;spanner-integration-tests")
+                                 "integration-test;spanner-integration-tests")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -89,8 +89,11 @@ function (spanner_client_define_benchmarks)
         # To automatically smoke-test the benchmarks as part of the CI build we
         # label them as tests.
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;spanner-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;spanner-integration-tests"
+        )
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -89,11 +89,8 @@ function (spanner_client_define_benchmarks)
         # To automatically smoke-test the benchmarks as part of the CI build we
         # label them as tests.
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;spanner-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -116,7 +116,7 @@ export RUN_SLOW_INTEGRATION_TESTS="instance"
 cd "${CMAKE_BINARY_DIR}"
 start_emulator
 
-ctest -L "spanner-integration-tests" "${ctest_args[@]}"
+ctest -R "^spanner_" "${ctest_args[@]}"
 exit_status=$?
 
 kill_emulator

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -23,7 +23,7 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
     timeout = "long",
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "spanner-integration-tests",
     ],
     deps = [

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -24,7 +24,6 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
     srcs = [test],
     tags = [
         "integration-test",
-        "spanner-integration-tests",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -60,7 +60,7 @@ function (spanner_client_define_integration_tests)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;spanner-integration-tests")
+                                 "integration-test;spanner-integration-tests")
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
     if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -59,11 +59,8 @@ function (spanner_client_define_integration_tests)
         endif ()
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;spanner-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
     if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -59,8 +59,11 @@ function (spanner_client_define_integration_tests)
         endif ()
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;spanner-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;spanner-integration-tests"
+        )
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
     if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -26,7 +26,7 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     timeout = "long",
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "spanner-integration-tests",
     ],
     deps = [

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -27,7 +27,6 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     srcs = [test],
     tags = [
         "integration-test",
-        "spanner-integration-tests",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -44,8 +44,11 @@ function (spanner_client_define_samples)
     foreach (fname ${spanner_client_integration_samples})
         google_cloud_cpp_set_target_name(target "spanner" "${fname}")
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;spanner-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;spanner-integration-tests"
+        )
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -44,11 +44,8 @@ function (spanner_client_define_samples)
     foreach (fname ${spanner_client_integration_samples})
         google_cloud_cpp_set_target_name(target "spanner" "${fname}")
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;spanner-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -45,7 +45,7 @@ function (spanner_client_define_samples)
         google_cloud_cpp_set_target_name(target "spanner" "${fname}")
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;spanner-integration-tests")
+                                 "integration-test;spanner-integration-tests")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -44,7 +44,6 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
     }),
     tags = [
         "integration-test",
-        "storage-integration-tests",
     ],
     deps = [
         ":storage_benchmarks",

--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -43,7 +43,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
         "//conditions:default": ["-lpthread"],
     }),
     tags = [
-        "integration-tests",
+        "integration-test",
         "storage-integration-tests",
     ],
     deps = [

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -62,11 +62,8 @@ if (BUILD_TESTING)
         google_cloud_cpp_add_clang_tidy(${target})
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;storage-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
     endforeach ()
 
     export_list_to_bazel("storage_benchmark_programs.bzl"

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -63,7 +63,7 @@ if (BUILD_TESTING)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;storage-integration-tests")
+                                 "integration-test;storage-integration-tests")
     endforeach ()
 
     export_list_to_bazel("storage_benchmark_programs.bzl"

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -62,8 +62,11 @@ if (BUILD_TESTING)
         google_cloud_cpp_add_clang_tidy(${target})
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;storage-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;storage-integration-tests"
+        )
     endforeach ()
 
     export_list_to_bazel("storage_benchmark_programs.bzl"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -56,7 +56,7 @@ if [[ -x "google/cloud/storage/examples/storage_bucket_samples" ]]; then
     "${GOOGLE_CLOUD_PROJECT}" >/dev/null
 fi
 
-ctest -L "storage-integration-tests" "${ctest_args[@]}"
+ctest -R "^storage_" "${ctest_args[@]}"
 exit_status=$?
 
 kill_testbench

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -51,7 +51,6 @@ load(":storage_examples.bzl", "storage_examples")
     srcs = [test],
     tags = [
         "integration-test",
-        "storage-integration-tests",
     ],
     deps = [
         ":storage_examples_common",

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -50,7 +50,7 @@ load(":storage_examples.bzl", "storage_examples")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     tags = [
-        "integration-tests",
+        "integration-test",
         "storage-integration-tests",
     ],
     deps = [

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -107,6 +107,6 @@ if (BUILD_TESTING)
         google_cloud_cpp_set_target_name(target "storage_examples" "${fname}")
         set_tests_properties(
             ${target}
-            PROPERTIES LABELS "integration-tests;integration-tests-no-emulator")
+            PROPERTIES LABELS "integration-tests;integration-test-production")
     endforeach ()
 endif ()

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -91,8 +91,11 @@ if (BUILD_TESTING)
                     google_cloud_cpp_common google_cloud_cpp_testing)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target} PROPERTIES LABELS
-                                 "integration-test;storage-integration-tests")
+            ${target}
+            PROPERTIES
+                LABELS
+                "integration-test;integration-test-emulator;storage-integration-tests"
+        )
         google_cloud_cpp_add_common_options(${target})
         google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -90,10 +90,9 @@ if (BUILD_TESTING)
             PRIVATE storage_examples_common storage_client_grpc storage_client
                     google_cloud_cpp_common google_cloud_cpp_testing)
         add_test(NAME ${target} COMMAND ${target})
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-tests;storage-integration-tests")
+                                 "integration-test;storage-integration-tests")
         google_cloud_cpp_add_common_options(${target})
         google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()
@@ -106,7 +105,7 @@ if (BUILD_TESTING)
     foreach (fname ${storage_integration_tests_production})
         google_cloud_cpp_set_target_name(target "storage_examples" "${fname}")
         set_tests_properties(
-            ${target}
-            PROPERTIES LABELS "integration-tests;integration-test-production")
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-production")
     endforeach ()
 endif ()

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -91,11 +91,8 @@ if (BUILD_TESTING)
                     google_cloud_cpp_common google_cloud_cpp_testing)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
-            ${target}
-            PROPERTIES
-                LABELS
-                "integration-test;integration-test-emulator;storage-integration-tests"
-        )
+            ${target} PROPERTIES LABELS
+                                 "integration-test;integration-test-emulator")
         google_cloud_cpp_add_common_options(${target})
         google_cloud_cpp_add_clang_tidy(${target})
     endforeach ()

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -34,7 +34,6 @@ load(
     }),
     tags = [
         "integration-test",
-        "storage-integration-tests",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -33,7 +33,7 @@ load(
         ],
     }),
     tags = [
-        "integration-tests",
+        "integration-test",
         "storage-integration-tests",
     ],
     deps = [

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -65,8 +65,11 @@ foreach (fname ${storage_client_integration_tests})
                 nlohmann_json)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
-        ${target} PROPERTIES LABELS
-                             "integration-test;storage-integration-tests")
+        ${target}
+        PROPERTIES
+            LABELS
+            "integration-test;integration-test-emulator;storage-integration-tests"
+    )
     google_cloud_cpp_add_common_options(${target})
     google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -66,7 +66,7 @@ foreach (fname ${storage_client_integration_tests})
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
         ${target} PROPERTIES LABELS
-                             "integration-tests;storage-integration-tests")
+                             "integration-test;storage-integration-tests")
     google_cloud_cpp_add_common_options(${target})
     google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()
@@ -80,7 +80,7 @@ foreach (
     google_cloud_cpp_set_target_name(target "storage" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS
-                             "integration-tests;integration-test-production")
+                             "integration-test;integration-test-production")
 endforeach ()
 
 target_link_libraries(storage_error_injection_integration_test

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -65,11 +65,8 @@ foreach (fname ${storage_client_integration_tests})
                 nlohmann_json)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
-        ${target}
-        PROPERTIES
-            LABELS
-            "integration-test;integration-test-emulator;storage-integration-tests"
-    )
+        ${target} PROPERTIES LABELS
+                             "integration-test;integration-test-emulator")
     google_cloud_cpp_add_common_options(${target})
     google_cloud_cpp_add_clang_tidy(${target})
 endforeach ()

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ foreach (
     google_cloud_cpp_set_target_name(target "storage" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS
-                             "integration-tests;integration-tests-no-emulator")
+                             "integration-tests;integration-test-production")
 endforeach ()
 
 target_link_libraries(storage_error_injection_integration_test

--- a/super/CMakeLists.txt
+++ b/super/CMakeLists.txt
@@ -81,7 +81,7 @@ ExternalProject_Add(
         ${CMAKE_CTEST_COMMAND}
         --output-on-failure
         -LE
-        integration-tests
+        integration-test
         --
         -j
         "${NCPU}"


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-cpp/issues/3868

This PR attempts to make our use of labels (cmake) and tags (bazel) a bit simpler and more consistent. This might be a small step in that direction:

* Use the singular term "integration-test" everywhere
* Removed all `$product-integration-test` labels. These are no longer needed. Products are identified in ctest invocations using `-R $product`, and in bazel invocations using `bazel test google/cloud/$product/...`.
* All integration tests in bazel and cmake have an `integration-test` label. This is most helpful when *excluding* all integration tests from a test run.
* [CMAKE ONLY] All integration tests also have a label of either `integration-test-emulator` or `integration-test-production`, to identify whether or not they should run w/ an emulator. (there's one documented exception here about a bigquery integration test that just doesn't fully work today because it needs a script to invoke it w/ some arguments, and that's more than we need to do today).

That last bullet point suggests something odd: The bazel and cmake labels are not in sync. In bazel we have no indication of whether integration tests use an emulator or not. Instead, when we run integration tests in bazel, we manually pick and choose which tests do what (see [build-in-docker-bazel.sh](https://github.com/googleapis/google-cloud-cpp/blob/master/ci/kokoro/docker/build-in-docker-bazel.sh)). It would be nice to clean that up in another PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4257)
<!-- Reviewable:end -->
