### PR TITLE
feat: more To/FromProto for Bucket* structs

### DIFF
--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -57,6 +57,7 @@ cc_library(
         "@boringssl//:ssl",
         "@com_github_curl_curl//:curl",
         "@com_github_google_crc32c//:crc32c",
+        "@com_google_absl//absl/algorithm:container",
         "@com_google_googleapis//google/storage/v1:storage_cc_grpc",
         "@com_google_googleapis//google/storage/v1:storage_cc_proto",
     ],

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -181,6 +181,27 @@ class GrpcClient : public RawClient,
   static google::storage::v1::Bucket::Billing ToProto(BucketBilling const&);
   static BucketBilling FromProto(google::storage::v1::Bucket::Billing const&);
 
+  static google::storage::v1::Bucket::Cors ToProto(CorsEntry const&);
+  static CorsEntry FromProto(google::storage::v1::Bucket::Cors const&);
+
+  static google::storage::v1::Bucket::Encryption ToProto(
+      BucketEncryption const&);
+  static BucketEncryption FromProto(
+      google::storage::v1::Bucket::Encryption const&);
+
+  static google::storage::v1::Bucket::IamConfiguration ToProto(
+      BucketIamConfiguration const&);
+  static BucketIamConfiguration FromProto(
+      google::storage::v1::Bucket::IamConfiguration const&);
+
+  static google::storage::v1::Bucket::Logging ToProto(BucketLogging const&);
+  static BucketLogging FromProto(google::storage::v1::Bucket::Logging const&);
+
+  static google::storage::v1::Bucket::RetentionPolicy ToProto(
+      BucketRetentionPolicy const&);
+  static BucketRetentionPolicy FromProto(
+      google::storage::v1::Bucket::RetentionPolicy const&);
+
   static google::storage::v1::Bucket::Versioning ToProto(
       BucketVersioning const&);
   static BucketVersioning FromProto(


### PR DESCRIPTION
In this change: `Bucket::Cors`, `Bucket::Encryption`,
`Bucket::IamConfiguration`, `Bucket::Logging`,
`Bucket::RetentionPolicy`.

This fixes #4169, fixes #4170, fixes #4171, and fixes #4172.
We never created a bug for `IamConfiguration` (it is new-ish).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4260)
<!-- Reviewable:end -->
