### PR TITLE
fix: cleanup how shared libs get a VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ project(google-cloud-cpp CXX C)
 set(GOOGLE_CLOUD_CPP_VERSION_MAJOR 1)
 set(GOOGLE_CLOUD_CPP_VERSION_MINOR 14)
 set(GOOGLE_CLOUD_CPP_VERSION_PATCH 0)
+string(CONCAT GOOGLE_CLOUD_CPP_VERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}"
+              ".${GOOGLE_CLOUD_CPP_VERSION_MINOR}"
+              ".${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
 
 # Configure the Compiler options, we use C++11 features by default.
 set(GOOGLE_CLOUD_CPP_CXX_STANDARD

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -16,11 +16,6 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-string(
-    CONCAT GOOGLE_APIS_CPP_PROTOS_VERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}"
-           "." "${GOOGLE_CLOUD_CPP_VERSION_MINOR}" "."
-           "${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
-
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
@@ -170,7 +165,7 @@ function (googleapis_cpp_set_version_and_alias short_name)
     add_dependencies("googleapis_cpp_${short_name}" googleapis_download)
     set_target_properties(
         "googleapis_cpp_${short_name}"
-        PROPERTIES VERSION "${GOOGLE_APIS_CPP_PROTOS_VERSION}"
+        PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"
                    SOVERSION ${GOOGLE_CLOUD_CPP_VERSION_MAJOR})
     add_library("googleapis-c++::${short_name}" ALIAS
                 "googleapis_cpp_${short_name}")

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -19,10 +19,6 @@ set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
 unset(FPHSA_NAME_MISMATCHED)
 
-string(CONCAT GOOGLE_CLOUD_CPP_VERSION "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}" "."
-              "${GOOGLE_CLOUD_CPP_VERSION_MINOR}" "."
-              "${GOOGLE_CLOUD_CPP_VERSION_PATCH}")
-
 # Generate the version information from the CMake values.
 configure_file(internal/version_info.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/internal/version_info.h)

--- a/google/cloud/pubsub/config-version.cmake.in
+++ b/google/cloud/pubsub/config-version.cmake.in
@@ -16,7 +16,7 @@ set(PACKAGE_VERSION @DOXYGEN_PROJECT_NUMBER@)
 
 # This package has not reached 1.0, there are no compatibility guarantees
 # before then.
-if (@GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION@ EQUAL 0)
+if (@GOOGLE_CLOUD_CPP_CLIENT_VERSION@ EQUAL 0)
     if ("${PACKAGE_FIND_VERSION}" STREQUAL "")
         set(PACKAGE_VERSION_COMPATIBLE TRUE)
     elseif ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")


### PR DESCRIPTION
Always use GOOGLE_CLOUD_CPP_VERSION which is now set in the top-level
CMake file.

Also fixed the pubsub/config-version.cmake.in file which was referencing
GOOGLE_CLOUD_CPP_**PUBSUB**_VERSION, a variable that no longer exists.

Fixes #4265 and fixes #4266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4268)
<!-- Reviewable:end -->
