### PR TITLE
cleanup: fix struct/class mismatch for bigtable::Mutation

### DIFF
--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -28,7 +28,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 class Cell;
-class Mutation;
+struct Mutation;
 Mutation SetCell(Cell);
 
 /**


### PR DESCRIPTION
It seems the warning is only generated in Bazel builds, which do not
have `-Werror` set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4271)
<!-- Reviewable:end -->
