### PR TITLE
chore: fix forward declaration of Mutation to match definition

### DIFF
--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -28,7 +28,7 @@ namespace cloud {
 namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 class Cell;
-class Mutation;
+struct Mutation;
 Mutation SetCell(Cell);
 
 /**


### PR DESCRIPTION
Noticed some warnings indicating a struct/class mismatch in the forward declaration of Mutation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4274)
<!-- Reviewable:end -->
