### PR TITLE
refactor: move ApiName enum to common routines

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -315,6 +315,16 @@ void DeleteAllObjects(google::cloud::storage::Client client,
             << "ms\n";
 }
 
+char const* ToString(ApiName api) {
+  switch (api) {
+    case ApiName::kApiJson:
+      return "JSON";
+    case ApiName::kApiXml:
+      return "XML";
+  }
+  return "";
+}
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -130,6 +130,9 @@ std::string FormatSize(std::uintmax_t size);
 void DeleteAllObjects(google::cloud::storage::Client client,
                       std::string const& bucket_name, int thread_count);
 
+enum class ApiName { kApiJson, kApiXml };
+char const* ToString(ApiName api);
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_benchmark.cc
@@ -25,6 +25,7 @@
 namespace {
 namespace gcs = google::cloud::storage;
 namespace gcs_bm = google::cloud::storage_benchmarks;
+using gcs_bm::ApiName;
 
 char const kDescription[] = R"""(
 A throughput benchmark for the Google Cloud Storage C++ client library.
@@ -89,7 +90,6 @@ struct Options {
 };
 
 enum class OpType { kOpRead, kOpWrite, kOpCreate };
-enum class ApiName { kApiJson, kApiXml };
 struct IterationResult {
   OpType op;
   ApiName api;
@@ -99,7 +99,6 @@ struct IterationResult {
 using TestResult = std::vector<IterationResult>;
 
 char const* ToString(OpType type);
-char const* ToString(ApiName api);
 void PrintResult(TestResult const& result);
 
 std::vector<std::string> CreateAllObjects(
@@ -233,20 +232,10 @@ char const* ToString(OpType type) {
   return "";
 }
 
-char const* ToString(ApiName api) {
-  switch (api) {
-    case ApiName::kApiJson:
-      return "JSON";
-    case ApiName::kApiXml:
-      return "XML";
-  }
-  return "";
-}
-
 void PrintResult(TestResult const& result) {
   for (auto const& r : result) {
-    std::cout << ToString(r.op) << ',' << ToString(r.api) << ',' << r.bytes
-              << ',' << r.elapsed.count() << "\n";
+    std::cout << ToString(r.op) << ',' << gcs_bm::ToString(r.api) << ','
+              << r.bytes << ',' << r.elapsed.count() << "\n";
   }
 }
 


### PR DESCRIPTION
I will need this in the throughput_vs_cpu_benchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4276)
<!-- Reviewable:end -->
