### PR TITLE
feat: DefaultGrpcClient(Options) cannot fail

### DIFF
--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -38,7 +38,7 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient() {
   return DefaultGrpcClient(*std::move(options));
 }
 
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient(
+google::cloud::storage::Client DefaultGrpcClient(
     google::cloud::storage::ClientOptions options) {
   if (UseGrpcForMetadata()) {
     return storage::Client(

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -51,7 +51,7 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient();
  * @warning this is an experimental feature, and subject to change without
  *     notice.
  */
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient(
+google::cloud::storage::Client DefaultGrpcClient(
     google::cloud::storage::ClientOptions options);
 
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
This overload cannot fail, its return type should indicate that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4278)
<!-- Reviewable:end -->
