### PR TITLE
ci: do not try to tidy removed files

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -144,7 +144,7 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   SOURCE_FILTER_REGEX='google/cloud/.*\.cc$'
   # We disable the misc-unused-using-decls check because it produces false
   # positives when run on headers. For more details, see issue #4230.
-  git diff --name-only "${TARGET_BRANCH}" |
+  git diff --diff-filter=d --name-only "${TARGET_BRANCH}" |
     grep -E "(${HEADER_FILTER_REGEX})|(${SOURCE_FILTER_REGEX})" |
     xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}" \
       -checks="-misc-unused-using-decls"


### PR DESCRIPTION
We were trying to run clang-tidy over removed files, that always fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4280)
<!-- Reviewable:end -->
