### PR TITLE
fix: super builds when compiling static libraries

### DIFF
--- a/super/external/grpc.cmake
+++ b/super/external/grpc.cmake
@@ -46,6 +46,7 @@ if (NOT TARGET grpc-project)
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DgRPC_BUILD_TESTS=OFF
+                   -DgRPC_BUILD_CSHARP_EXT=OFF
                    -DgRPC_ABSL_PROVIDER=package
                    -DgRPC_CARES_PROVIDER=package
                    -DgRPC_PROTOBUF_PROVIDER=package


### PR DESCRIPTION
By default gRPC compiles a C# extension shared library (`.so`) even if
all the dependencies (like Abseil) are compiled statically. In some
platforms that just breaks (mixing PIC code and non-PIC code
results in an error). Since we do not use this extension I think the
simplest thing is to disable it for super builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4282)
<!-- Reviewable:end -->
