### PR TITLE
cleanup: remove ProgressReporter in benchmarks

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -227,23 +227,6 @@ bool SimpleTimer::SupportPerThreadUsage() {
 #endif  // GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
 }
 
-void ProgressReporter::Start() {
-  progress_.clear();
-  start_ = std::chrono::steady_clock::now();
-  progress_.emplace_back(TimePoint{0, std::chrono::microseconds(0)});
-}
-
-void ProgressReporter::Advance(size_t progress) {
-  progress_.emplace_back(
-      TimePoint{progress, std::chrono::duration_cast<std::chrono::microseconds>(
-                              std::chrono::steady_clock::now() - start_)});
-}
-
-std::vector<ProgressReporter::TimePoint> const&
-ProgressReporter::GetAccumulatedProgress() const {
-  return progress_;
-}
-
 std::string FormatSize(std::uintmax_t size) {
   struct {
     std::uintmax_t limit;

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -107,24 +107,6 @@ class SimpleTimer {
   std::string annotations_;
 };
 
-/**
- * A small class to accumulate time-points with progress.
- */
-class ProgressReporter {
- public:
-  struct TimePoint {
-    std::uint64_t bytes;
-    std::chrono::microseconds elapsed;
-  };
-  void Start();
-  void Advance(size_t progress);
-  std::vector<TimePoint> const& GetAccumulatedProgress() const;
-
- private:
-  std::chrono::steady_clock::time_point start_;
-  std::vector<TimePoint> progress_;
-};
-
 std::string FormatSize(std::uintmax_t size);
 
 void DeleteAllObjects(google::cloud::storage::Client client,

--- a/google/cloud/storage/benchmarks/benchmark_utils_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils_test.cc
@@ -21,23 +21,6 @@ namespace cloud {
 namespace storage_benchmarks {
 namespace {
 
-TEST(ProgressReporterTest, Trivial) {
-  ProgressReporter rep;
-  rep.Start();
-  std::this_thread::sleep_for(std::chrono::milliseconds(2));
-  rep.Advance(5);
-  std::this_thread::sleep_for(std::chrono::milliseconds(3));
-  rep.Advance(7);
-  auto res = rep.GetAccumulatedProgress();
-  EXPECT_EQ(3U, res.size());
-  EXPECT_EQ(0, res[0].bytes);
-  EXPECT_EQ(0, res[0].elapsed.count());
-  EXPECT_EQ(5, res[1].bytes);
-  EXPECT_LE(2000, res[1].elapsed.count());
-  EXPECT_EQ(7, res[2].bytes);
-  EXPECT_LE(3000, res[2].elapsed.count());
-}
-
 TEST(FormatSize, Basic) {
   EXPECT_EQ("1023.0B", FormatSize(1023));
   EXPECT_EQ("1.0KiB", FormatSize(kKiB));


### PR DESCRIPTION
I thought it would be useful to report throughput stats after N bytes,
but turns out we did not need that data. Removing the code because I
would rather not carry unused code around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4283)
<!-- Reviewable:end -->
