### PR TITLE
feat: support X-Upload-Content-Length header

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1103,7 +1103,8 @@ class Client {
    *   `EncryptionKey`, `IfGenerationMatch`, `IfGenerationNotMatch`,
    *   `IfMetagenerationMatch`, `IfMetagenerationNotMatch`, `KmsKeyName`,
    *   `MD5HashValue`, `PredefinedAcl`, `Projection`,
-   *   `UseResumableUploadSession`, `UserProject`, and `WithObjectMetadata`.
+   *   `UseResumableUploadSession`, `UserProject`, `WithObjectMetadata` and
+   *   `UploadContentLength`.
    *
    * @par Idempotency
    * This operation is only idempotent if restricted by pre-conditions, in this
@@ -3035,7 +3036,7 @@ class Client {
                                           Options&&... options) {
     internal::ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return UploadFileResumable(file_name, request);
+    return UploadFileResumable(file_name, std::move(request));
   }
 
   // The version of UploadFile() where UseResumableUploadSession is *not* one of
@@ -3055,7 +3056,7 @@ class Client {
     }
     internal::ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
-    return UploadFileResumable(file_name, request);
+    return UploadFileResumable(file_name, std::move(request));
   }
 
   bool UseSimpleUpload(std::string const& file_name) const;
@@ -3064,8 +3065,7 @@ class Client {
       std::string const& file_name, internal::InsertObjectMediaRequest request);
 
   StatusOr<ObjectMetadata> UploadFileResumable(
-      std::string const& file_name,
-      internal::ResumableUploadRequest const& request);
+      std::string const& file_name, internal::ResumableUploadRequest request);
 
   StatusOr<ObjectMetadata> UploadStreamResumable(
       std::istream& source, internal::ResumableUploadRequest const& request);

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -168,6 +168,7 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
   builder.AddOption(request.template GetOption<IfMatchEtag>());
   builder.AddOption(request.template GetOption<IfNoneMatchEtag>());
   builder.AddOption(request.template GetOption<QuotaUser>());
+  builder.AddOption(request.template GetOption<UploadContentLength>());
   SetupBuilderUserIp(builder, request);
 
   builder.AddQueryParameter("uploadType", "resumable");

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -93,6 +93,20 @@ class CurlRequestBuilder {
     return *this;
   }
 
+  /// Adds one of the well-known headers to the request.
+  template <typename P, typename V,
+            typename Enabled = typename std::enable_if<
+                std::is_arithmetic<V>::value, void>::type>
+  CurlRequestBuilder& AddOption(WellKnownHeader<P, V> const& p) {
+    if (p.has_value()) {
+      std::string header = p.header_name();
+      header += ": ";
+      header += std::to_string(p.value());
+      AddHeader(header);
+    }
+    return *this;
+  }
+
   /// Adds a custom header to the request.
   CurlRequestBuilder& AddOption(CustomHeader const& p) {
     if (p.has_value()) {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -361,7 +361,7 @@ class ResumableUploadRequest
           EncryptionKey, IfGenerationMatch, IfGenerationNotMatch,
           IfMetagenerationMatch, IfMetagenerationNotMatch, KmsKeyName,
           MD5HashValue, PredefinedAcl, Projection, UseResumableUploadSession,
-          UserProject, WithObjectMetadata> {
+          UserProject, WithObjectMetadata, UploadContentLength> {
  public:
   ResumableUploadRequest() = default;
 

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -723,6 +723,12 @@ class GcsBucket(object):
         upload["next_byte"] = next_byte
         response_payload = ""
         if final_chunk and next_byte >= total:
+            expected_bytes = upload["expected_bytes"]
+            if expected_bytes is not None and expected_bytes != total:
+                raise error_response.ErrorResponse(
+                    "X-Upload-Content-Length"
+                    "validation failed. Expected=%d, got %d." % (expected_bytes, total)
+                )
             upload["done"] = True
             object_name = upload.get("object_name")
             object_path, blob = testbench_utils.get_object(

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/storage/well_known_headers.h"
 #include <string>
 
 namespace google {
@@ -53,6 +54,20 @@ inline UseResumableUploadSession RestoreResumableUploadSession(
 inline UseResumableUploadSession NewResumableUploadSession() {
   return UseResumableUploadSession("");
 }
+
+/**
+ * Provide an expected final length of an uploaded object.
+ *
+ * Resumable uploads allow or an additional integrity check - make GCS check
+ * if the uploaded content matches the declared length. If it doesn't the upload
+ * will fail.
+ */
+struct UploadContentLength
+    : public internal::WellKnownHeader<UploadContentLength, std::uintmax_t> {
+  using internal::WellKnownHeader<UploadContentLength,
+                                  std::uintmax_t>::WellKnownHeader;
+  static char const* header_name() { return "X-Upload-Content-Length"; }
+};
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
This fixes #3162.

Unfortunately, there does not seem to be a way to set the counterpart of
this header for gRPC version, so only cURL is supported.

Emulator is updated to support this too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4284)
<!-- Reviewable:end -->
