### PR TITLE
feat: optionally use host network in docker containers

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -373,6 +373,13 @@ mkdir -p "${BUILD_HOME}"
 
 # We use an array for the flags so they are easier to document.
 docker_flags=(
+  # Our docker containers don't need network-level isolation from the host,
+  # because we can run our builds directly on the host anyway. Additionally,
+  # some hosts have non-trivial networking configurations that the container
+  # should also use (DNS caches, etc). Therefore, our containers will directly
+  # use the host network.
+  "--net" "host"
+
   # Enable ptrace as it is needed by s
   "--cap-add" "SYS_PTRACE"
 

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -373,13 +373,6 @@ mkdir -p "${BUILD_HOME}"
 
 # We use an array for the flags so they are easier to document.
 docker_flags=(
-  # Our docker containers don't need network-level isolation from the host,
-  # because we can run our builds directly on the host anyway. Additionally,
-  # some hosts have non-trivial networking configurations that the container
-  # should also use (DNS caches, etc). Therefore, our containers will directly
-  # use the host network.
-  "--net" "host"
-
   # Enable ptrace as it is needed by s
   "--cap-add" "SYS_PTRACE"
 
@@ -519,6 +512,13 @@ fi
 
 if [[ -n "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-}" ]]; then
   docker_flags+=("--env" "KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH=${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-}")
+fi
+
+# Optionally allow the docker container to use the host's networking in order
+# to take advantage of potentially non-trivial network configurations (e.g.,
+# DNS cache) that might be a PITA to duplicate within the container itself.
+if [[ -n "${DOCKER_USE_HOST_NETWORK:-}" ]]; then
+  docker_flags+=("--net" "host")
 fi
 
 # When running on Travis the build gets a tty, and docker can produce nicer

--- a/ci/kokoro/gcloud-functions.sh
+++ b/ci/kokoro/gcloud-functions.sh
@@ -58,7 +58,11 @@ create_gcloud_config() {
       create --no-activate "${GCLOUD_CONFIG}" >/dev/null
   fi
   if [[ -n "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
-    "${GCLOUD}" "${GCLOUD_ARGS[@]}" config set project "${GOOGLE_CLOUD_PROJECT}"
+    # At this point, we haven't yet activated our service account, but we also
+    # don't want this config setting to use any default account that may
+    # already exist on the machine, so we explicitly set `--account=""` to
+    # avoid using incidental gcloud accounts.
+    "${GCLOUD}" "${GCLOUD_ARGS[@]}" --account="" config set project "${GOOGLE_CLOUD_PROJECT}"
   fi
 }
 


### PR DESCRIPTION
When enabled with the `DOCKER_USE_HOST_NETWORK` environment variable, our docker containers will share the host's networking. This can be useful when running on a host with a non-trivial networking configuration, such as DNS caches, etc, that you want to share with the docker container. 

This change also exposed an issue where some of our gcloud commands used
incidental gcloud accounts that existed on the system, other than the
service acount that we intended. This is fixed by passing `--account=""`
to some gcloud commands where we know we don't want to use any existing
system account.

I believe this should fix the issue that @devbww and I were having when running the integration tests on our GCE instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4288)
<!-- Reviewable:end -->
