### PR TITLE
fix: flake in bigtable AsyncReadModifyWrite example

### DIFF
--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -277,7 +277,11 @@ void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
     row_future
         .then([](future<StatusOr<cbt::Row>> f) {
           auto row = f.get();
-          if (!row) throw std::runtime_error(row.status().message());
+          // By default, the `table` object uses the
+          // `SafeIdempotentMutationPolicy` which does not retry if the modify
+          // fails and is not idempotent. In this example we simply print such
+          // failures, if any, and ignore them otherwise.
+          if (!row) std::cout << "Failed to append " << row->row_key() << "\n";
           std::cout << "Successfully appended to " << row->row_key() << "\n";
         })
         .get();  // block to simplify example.

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -277,11 +277,14 @@ void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
     row_future
         .then([](future<StatusOr<cbt::Row>> f) {
           auto row = f.get();
-          // By default, the `table` object uses the
-          // `SafeIdempotentMutationPolicy` which does not retry if the modify
-          // fails and is not idempotent. In this example we simply print such
-          // failures, if any, and ignore them otherwise.
-          if (!row) std::cout << "Failed to append " << row->row_key() << "\n";
+          // As the modify in this example is not idempotent, and this example
+          // does not attempt to retry if there is a failure, we simply print
+          // such failures, if any, and otherwise ignore them.
+          if (!row) {
+            std::cout << "Failed to append row: " << row.status().message()
+                      << "\n";
+            return;
+          }
           std::cout << "Successfully appended to " << row->row_key() << "\n";
         })
         .get();  // block to simplify example.


### PR DESCRIPTION
fixes #4119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4296)
<!-- Reviewable:end -->
