### PR TITLE
feat(storage/benchmarks): measure warm downloads

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_plots.py
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_plots.py
@@ -65,7 +65,7 @@ use_y_log10 = max(data["MiB"]) <= 8.0
 # %%
 # A common facet for all plots
 facet = p9.facet_grid(
-    "OpName ~ Crc32cEnabled + MD5Enabled", labeller="label_both", scales="free_y"
+    "Op ~ Crc32cEnabled + MD5Enabled", labeller="label_both", scales="free_y"
 )
 
 # %%


### PR DESCRIPTION
Download the same file more than once to get data about warm downloads.
Shorten some field names in the output because the plots were unreadable
with longer names.

Not that it matters, because they are fixed numbers and unused in the
plots, but the download vs. upload buffer sizes were reported backwards,
ooops.

Fixes #4292

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4299)
<!-- Reviewable:end -->
