### PR TITLE
fix: potentially flaky examples in bigtable data snippets

### DIFF
--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -89,12 +89,15 @@ void AsyncBulkApply(google::cloud::bigtable::Table table,
             std::cout << "All the mutations were successful\n";
             return;
           }
-          std::cerr << "The following mutations failed:\n";
+          // By default, the `table` object uses the
+          // `SafeIdempotentMutationPolicy` which does not retry if any of the
+          // mutations fails and are not idempotent. In this example we simply
+          // print such failures, if any, and ignore them otherwise.
+          std::cerr << "The following mutations failed and were not retried:\n";
           for (auto const& f : failures) {
             std::cerr << "index[" << f.original_index() << "]=" << f.status()
                       << "\n";
           }
-          throw std::runtime_error(failures.front().status().message());
         })
         .get();  // block to simplify the example
   }

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -233,7 +233,13 @@ void ReadModifyWrite(google::cloud::bigtable::Table table,
         row_key, cbt::ReadModifyWriteRule::IncrementAmount("fam", "counter", 1),
         cbt::ReadModifyWriteRule::AppendValue("fam", "list", ";element"));
 
-    if (!row) throw std::runtime_error(row.status().message());
+    // As the modify in this example is not idempotent, and this example
+    // does not attempt to retry if there is a failure, we simply print
+    // such failures, if any, and otherwise ignore them.
+    if (!row) {
+      std::cout << "Failed to append row: " << row.status().message() << "\n";
+      return;
+    }
     std::cout << row->row_key() << "\n";
   }
   //! [read modify write]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4300)
<!-- Reviewable:end -->
