### PR TITLE
feat(storage/benchmarks): quantize app buffers

### DIFF
--- a/google/cloud/storage/benchmarks/README.md
+++ b/google/cloud/storage/benchmarks/README.md
@@ -22,7 +22,7 @@ cmake -Hsuper -B.build/si -GNinja \
   -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local-cpp
 cmake --build .build/si --target project-dependencies
 cmake -H. -B.build/release -GNinja \
-  -DCMAKE_BUILD_TYPE=Release -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_PREFIX_PATH=$HOME/local-cpp \
   -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON
 cmake --build .build/release

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -54,8 +54,9 @@ this loop (see below for the conditions to stop the loop):
 
 - Select a random size, between two values configured in the command line of the
   object to upload.
-- Select a random chunk size, between two values configured in the command line,
-  the data is uploaded in chunks of this size.
+- The application buffer sizes for `read()` and `write()` calls are also
+  selected at random. These sizes are quantized, and the quantum can be
+  configured in the command-line.
 - Select, at random, the protocol / API used to perform the test, could be XML,
   JSON, or gRPC.
 - Select, at random, if the client library will perform CRC32C and/or MD5 hashes
@@ -63,11 +64,11 @@ this loop (see below for the conditions to stop the loop):
 - Upload an object of the selected size, choosing the name of the object at
   random.
 - Once the object is fully uploaded, the program captures the object size, the
-  chunk size, the elapsed time (in microseconds), the CPU time (in microseconds)
-  used during the upload, and the status code for the upload.
+  write buffer size, the elapsed time (in microseconds), the CPU time
+  (in microseconds) used during the upload, and the status code for the upload.
 - Then the program downloads the same object, and captures the object size, the
-  chunk size, the elapsed time (in microseconds), the CPU time (in microseconds)
-  used during the download, and the status code for the download.
+  read buffer size, the elapsed time (in microseconds), the CPU time (in
+  microseconds) used during the download, and the status code for the download.
 - The program then deletes this object and starts another iteration.
 
 The loop stops when any of the following conditions are met:
@@ -460,9 +461,9 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
        [&options](std::string const& val) {
          options.maximum_write_size = gcs_bm::ParseSize(val);
        }},
-      {"--read-quantum", "quantize the buffer sizes for read() calls",
+      {"--write-quantum", "quantize the buffer sizes for write() calls",
        [&options](std::string const& val) {
-         options.read_quantum = gcs_bm::ParseSize(val);
+         options.write_quantum = gcs_bm::ParseSize(val);
        }},
       {"--minimum-read-size",
        "configure the minimum buffer size for read() calls",
@@ -556,8 +557,9 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
   if (options.write_quantum <= 0 ||
       options.write_quantum > options.minimum_write_size) {
     std::ostringstream os;
-    os << "Invalid value for write quantum should be in the [0,"
-       << options.minimum_write_size << "] range";
+    os << "Invalid value for --write-quantum (" << options.write_quantum
+       << "), it should be in the [0," << options.minimum_write_size
+       << "] range";
     return make_status(os);
   }
 
@@ -570,8 +572,9 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
   if (options.read_quantum <= 0 ||
       options.read_quantum > options.minimum_read_size) {
     std::ostringstream os;
-    os << "Invalid value for read quantum should be in the [0,"
-       << options.minimum_read_size << "] range";
+    os << "Invalid value for --read-quantum (" << options.read_quantum
+       << "), it should be in the [0," << options.minimum_read_size
+       << "] range";
     return make_status(os);
   }
 

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -558,7 +558,7 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
       options.write_quantum > options.minimum_write_size) {
     std::ostringstream os;
     os << "Invalid value for --write-quantum (" << options.write_quantum
-       << "), it should be in the [0," << options.minimum_write_size
+       << "), it should be in the [1," << options.minimum_write_size
        << "] range";
     return make_status(os);
   }
@@ -573,7 +573,7 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
       options.read_quantum > options.minimum_read_size) {
     std::ostringstream os;
     os << "Invalid value for --read-quantum (" << options.read_quantum
-       << "), it should be in the [0," << options.minimum_read_size
+       << "), it should be in the [1," << options.minimum_read_size
        << "] range";
     return make_status(os);
   }


### PR DESCRIPTION
The benchmark uses randomly sized application-level buffers to upload
and download objects. There are some sizes that are known to be much
better. For example, for uploads, anything that is a multiple of 256KiB.
Sometimes it is interesting to test with "bad" buffer sizes, but most
often it is better to use the right values.

There is also no reason to upload and download with the same buffer
sizes, this change uses different buffer sizes for each.

Furthermore, the benchmark called application-level buffers "chunks",
this was a poorly chosen name. There are other "chunks" in a resumable
upload, and this made things confusing.

Finally, changed the default values for these application level buffers
to something that is more reasonable.

Fixes #4303

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4307)
<!-- Reviewable:end -->
