### PR TITLE
chore: refactored spanner emulator script into a library

### DIFF
--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__:-}" || declare -i GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__=0
+if ((GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__++ != 0)); then
+  return 0
+fi # include guard 
+
+source module lib/io.sh
+
+# Global variable that holds the PID of the Spanner emulator. This will be set
+# when the emulator is started, and it will be used to kill the emulator.
+SPANNER_EMULATOR_PID=0
+
+# Outputs the port number that the emulator chose to listen on.
+function spanner_emulator::internal::read_emulator_port() {
+  local -r logfile="$1"
+  shift
+
+  local emulator_port="0"
+  local -r expected=" : Server address: "
+  for attempt in $(seq 1 8); do
+    if grep -q "${expected}" "${logfile}"; then
+      # The port number is whatever is after the last ':'.
+      emulator_port=$(grep "${expected}" "${logfile}" | awk -F: '{print $NF}')
+      break
+    fi
+    sleep 1
+  done
+  echo "${emulator_port}"
+}
+
+# Starts the cloud spanner emulator. On success, exports the
+# SPANNER_EMULATOR_HOST environment variable containing the host:port where the
+# emulator is listening.
+function spanner_emulator::start() {
+  io::log "Launching Cloud Spanner emulator in the background"
+  if [[ -z "${CLOUD_SDK_LOCATION:-}" ]]; then
+    echo 1>&2 "You must set CLOUD_SDK_LOCATION to find the emulator"
+    return 1
+  fi
+
+  # We cannot use `gcloud beta emulators spanner start` because there is no way
+  # to kill the emulator at the end using that command.
+  readonly SPANNER_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/cloud_spanner_emulator/emulator_main"
+  if [[ ! -x "${SPANNER_EMULATOR_CMD}" ]]; then
+    echo 1>&2 "The spanner emulator does not seem to be installed, aborting"
+    return 1
+  fi
+
+  # The tests typically run in a Docker container, where the ports are largely
+  # free; when using in manual tests, you can set EMULATOR_PORT.
+  "${SPANNER_EMULATOR_CMD}" --host_port localhost:0 >emulator.log 2>&1 </dev/null &
+  SPANNER_EMULATOR_PID=$!
+
+  local -r emulator_port="$(spanner_emulator::internal::read_emulator_port emulator.log)"
+  if [[ "${emulator_port}" = "0" ]]; then
+    echo "Cannot determine Cloud Spanner emulator port." >&2
+    spanner_emulator::kill
+    return 1
+  fi
+
+  export SPANNER_EMULATOR_HOST="localhost:${emulator_port}"
+  io::log "Spanner emulator started at ${SPANNER_EMULATOR_HOST}"
+}
+
+# Kills the running emulator.
+function spanner_emulator::kill() {
+  if (( "${SPANNER_EMULATOR_PID}" > 0 )); then
+    echo -n "Killing Spanner Emulator [${SPANNER_EMULATOR_PID}] "
+    kill "${SPANNER_EMULATOR_PID}" || echo -n "-"
+    wait "${SPANNER_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
+    echo -n "."
+    echo " done."
+    SPANNER_EMULATOR_PID=0
+  fi
+}
+

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -17,7 +17,7 @@
 test -n "${GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__:-}" || declare -i GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__=0
 if ((GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__++ != 0)); then
   return 0
-fi # include guard 
+fi # include guard
 
 source module lib/io.sh
 
@@ -79,7 +79,7 @@ function spanner_emulator::start() {
 
 # Kills the running emulator.
 function spanner_emulator::kill() {
-  if (( "${SPANNER_EMULATOR_PID}" > 0 )); then
+  if (("${SPANNER_EMULATOR_PID}" > 0)); then
     echo -n "Killing Spanner Emulator [${SPANNER_EMULATOR_PID}] "
     kill "${SPANNER_EMULATOR_PID}" || echo -n "-"
     wait "${SPANNER_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
@@ -88,4 +88,3 @@ function spanner_emulator::kill() {
     SPANNER_EMULATOR_PID=0
   fi
 }
-

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -18,6 +18,7 @@ set -eu
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
 source module etc/integration-tests-config.sh
 source module lib/io.sh
+source module lib/spanner_emulator.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"
@@ -26,87 +27,12 @@ fi
 
 # The first argument is where the build scripts have put the binaries, i.e., the
 # -B argument to the cmake configuration step.
-CMAKE_BINARY_DIR="$(
-  cd "${1}"
-  pwd
-)"
+CMAKE_BINARY_DIR="$(realpath "${1}")"
 readonly CMAKE_BINARY_DIR
 shift
 
 # Any additional arguments for the ctest invocation.
 ctest_args=("$@")
-
-spanner_emulator_pid=0
-if [[ -z "${CLOUD_SDK_LOCATION:-}" ]]; then
-  echo 1>&2 "You must set CLOUD_SDK_LOCATION to find the emulator"
-  exit 1
-fi
-
-# We cannot use `gcloud beta emulators spanner start` because there is no way
-# to kill the emulator at the end using that command.
-readonly SPANNER_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/cloud_spanner_emulator/emulator_main"
-if [[ ! -x "${SPANNER_EMULATOR_CMD}" ]]; then
-  echo 1>&2 "The spanner emulator does not seem to be installed, aborting"
-  exit 1
-fi
-
-function kill_emulator() {
-  echo -n "Killing Spanner Emulator [${spanner_emulator_pid}] "
-  kill "${spanner_emulator_pid}" || echo -n "-"
-  wait "${spanner_emulator_pid}" >/dev/null 2>&1 || echo -n "+"
-  echo -n "."
-  echo " done."
-}
-
-################################################
-# Wait until the port number is printed in the log file for one of the
-# emulators
-# Globals:
-#   None
-# Arguments:
-#   logfile: the name of the logfile to wait on.
-# Returns:
-#   None
-################################################
-wait_for_port() {
-  local -r logfile="$1"
-  shift
-
-  local emulator_port="0"
-  local -r expected=' : Server address: '
-  for attempt in $(seq 1 8); do
-    if grep -q "${expected}" "${logfile}"; then
-      # The port number is whatever is after the last ':'. Note that on IPv6
-      # there may be multiple ':' characters, and recall that regular
-      # expressions are greedy. If grep has multiple matches this breaks,
-      # which is Okay because then the emulator is exhibiting unexpected
-      # behavior.
-      emulator_port=$(grep "${expected}" "${logfile}" | sed 's/^.*://')
-      break
-    fi
-    sleep 1
-  done
-
-  if [[ "${emulator_port}" = "0" ]]; then
-    echo "Cannot determine Cloud Spanner emulator port." >&2
-    kill_emulator
-    exit 1
-  fi
-
-  echo "${emulator_port}"
-}
-
-function start_emulator() {
-  echo "Launching Cloud Spanner emulator in the background"
-  trap kill_emulator EXIT
-
-  # The tests typically run in a Docker container, where the ports are largely
-  # free; when using in manual tests, you can set EMULATOR_PORT.
-  "${SPANNER_EMULATOR_CMD}" --host_port localhost:0 >emulator.log 2>&1 </dev/null &
-  spanner_emulator_pid=$!
-  local -r emulator_port="$(wait_for_port emulator.log)"
-  export SPANNER_EMULATOR_HOST="localhost:${emulator_port}"
-}
 
 # Use the same configuration parameters as we use for testing against
 # production. Easier to maintain just one copy.
@@ -114,12 +40,12 @@ export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 export GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
 
 cd "${CMAKE_BINARY_DIR}"
-start_emulator
+
+# Starts the emulator and arranges to kill it.
+spanner_emulator::start
+trap spanner_emulator::kill EXIT
 
 ctest -R "^spanner_" "${ctest_args[@]}"
 exit_status=$?
-
-kill_emulator
-trap '' EXIT
 
 exit "${exit_status}"


### PR DESCRIPTION
With this refactoring, we could start/stop the emulator from bazel
builds as well as cmake (which we use today). 98% of this change is copying existing code from one script to another.

Related to https://github.com/googleapis/google-cloud-cpp/issues/4297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4309)
<!-- Reviewable:end -->
