### PR TITLE
ci: patch Abseil base/options.h to pin C++11 types

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -58,6 +58,7 @@ RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
 WORKDIR /var/tmp/build
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz | \
     tar -xzf - --strip-components=1 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -54,6 +54,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -50,6 +50,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -46,6 +46,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -44,6 +44,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -52,6 +52,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -49,6 +49,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -50,6 +50,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -37,6 +37,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -38,6 +38,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -37,6 +37,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -225,6 +225,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -303,6 +304,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -380,6 +382,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -506,6 +509,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -616,6 +620,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -726,6 +731,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -860,6 +866,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -932,6 +939,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -1070,6 +1078,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \
@@ -1197,6 +1206,7 @@ cd $HOME/Downloads
 wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
     tar -xf 20200225.2.tar.gz && \
     cd abseil-cpp-20200225.2 && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE="Release" \
       -DBUILD_TESTING=OFF \

--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -54,6 +54,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
         "@boringssl//:crypto",
         "@boringssl//:ssl",
         "@com_github_curl_curl//:curl",
+        "@com_google_absl//absl/strings",
     ],
 ) for test in storage_benchmark_programs]
 

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -15,6 +15,12 @@
 # ~~~
 
 if (BUILD_TESTING)
+    # TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl
+    # release
+    set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
+    find_package(absl CONFIG REQUIRED)
+    unset(FPHSA_NAME_MISMATCHED)
+
     add_library(storage_benchmarks # cmake-format: sort
                 benchmark_utils.cc benchmark_utils.h bounded_queue.h)
     target_link_libraries(storage_benchmarks PUBLIC storage_client)
@@ -51,6 +57,7 @@ if (BUILD_TESTING)
                     storage_client
                     storage_client_testing
                     google_cloud_cpp_common
+                    absl::strings
                     CURL::libcurl
                     Threads::Threads
                     nlohmann_json)
@@ -86,6 +93,7 @@ if (BUILD_TESTING)
                         GTest::gmock
                         GTest::gtest
                         CURL::libcurl
+                        absl::strings
                         nlohmann_json)
             google_cloud_cpp_add_common_options(${target})
             if (MSVC)

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "absl/strings/str_split.h"
 #include <future>
 #include <sstream>
 
@@ -460,9 +461,7 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
              {"GRPC", gcs_bm::ApiName::kApiGrpc},
          };
          std::vector<ApiName> apis;
-         std::istringstream is(val);
-         std::string token;
-         while (std::getline(is, token, ',')) {
+         for (auto& token : absl::StrSplit(val, ',')) {
            auto const l = names.find(std::string(token));
            if (l == names.end()) continue;  // Ignore errors for now
            apis.push_back(l->second);

--- a/super/external/abseil-patch.cmake
+++ b/super/external/abseil-patch.cmake
@@ -1,0 +1,40 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+message("PATCHING absl/base/options.h")
+
+file(READ "absl/base/options.h" content)
+# Using REGEX REPLACE does not work for some reason. We replace each macro and
+# verify (at the end) that there are no other such macros left
+string(REPLACE "#define ABSL_OPTION_USE_STD_ANY 2"
+               "#define ABSL_OPTION_USE_STD_ANY 0" content "${content}")
+string(REPLACE "#define ABSL_OPTION_USE_STD_OPTIONAL 2"
+               "#define ABSL_OPTION_USE_STD_OPTIONAL 0" content "${content}")
+string(REPLACE "#define ABSL_OPTION_USE_STD_STRING_VIEW 2"
+               "#define ABSL_OPTION_USE_STD_STRING_VIEW 0" content "${content}")
+string(REPLACE "#define ABSL_OPTION_USE_STD_VARIANT 2"
+               "#define ABSL_OPTION_USE_STD_VARIANT 0" content "${content}")
+
+string(REGEX MATCH "#define ABSL_OPTION_USE_.* 2\n" matches "${content}")
+if ("${matches}" STREQUAL "")
+    file(WRITE "absl/base/options.h" "${content}")
+else ()
+    file(
+        WRITE "absl/base/options.h"
+        "#error \"google-cloud-cpp cannot fully patch this file, fix abseil-patch.cmake\"\n"
+    )
+    message(ERROR_FATAL "##### <${matches}>")
+endif ()

--- a/super/external/abseil.cmake
+++ b/super/external/abseil.cmake
@@ -45,9 +45,17 @@ if (NOT TARGET abseil-cpp-project)
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> ${PARALLEL}
-        LOG_DOWNLOAD ON
-        LOG_CONFIGURE ON
+        BUILD_COMMAND
+            ${CMAKE_COMMAND}
+            --build
+            <BINARY_DIR>
+            ${PARALLEL}
+            PATCH_COMMAND
+            ${CMAKE_COMMAND}
+            -P
+            "${CMAKE_CURRENT_LIST_DIR}/abseil-patch.cmake"
+        LOG_DOWNLOAD OFF
+        LOG_CONFIGURE OFF
         LOG_BUILD ON
         LOG_INSTALL ON)
 endif ()


### PR DESCRIPTION
Abseil has a configuration file that controls whether it uses some types
(`std::any`, `std::variant`, `std::string_view`, etc.) from the standard
library, provides its own, or dynamically discovers if they are
available in the library.

If you want to compile Abseil once, and then use with both C++11 and
C++17 compilers you need to edit `base/options.h` and pin these types to
the `absl::` versions. This is what we do in our CI builds, so we need
to patch the file.

Fixes #4305

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4311)
<!-- Reviewable:end -->
