### PR TITLE
revert: fix: re-enable spanner backup tests w/ increased timeout

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -41,17 +41,7 @@ io::log "Using Bazel in ${BAZEL_BIN}"
 "${BAZEL_BIN}" version
 echo "================================================================"
 
-bazel_args=(
-  # Sets the test timeouts for small, medium, large, and enormous tests as
-  # defined by the test's "size" attribute (or "timeout") in its BUILD file. A
-  # value of -1 means to use bazel's default. Here we want to increase the
-  # "large" test timeout from 15 to 25 min (the argument is in seconds).
-  # See: https://docs.bazel.build/versions/master/be/common-definitions.html
-  "--test_timeout=-1,-1,1500,-1"
-  "--test_output=errors"
-  "--verbose_failures=true"
-  "--keep_going"
-)
+bazel_args=("--test_output=errors" "--verbose_failures=true" "--keep_going")
 if [[ -n "${RUNS_PER_TEST}" ]]; then
   bazel_args+=("--runs_per_test=${RUNS_PER_TEST}")
 fi

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -95,7 +95,8 @@ elif [[ "${BUILD_NAME}" = "integration" ]]; then
   export DISTRO=ubuntu
   export DISTRO_VERSION=18.04
   RUN_INTEGRATION_TESTS="yes" # Integration tests were explicitly requested.
-  GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
+  # TODO(4306): Enable the backup tests once they don't timeout too often.
+  GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance"
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "integration-nightly" ]]; then
   export DISTRO=ubuntu


### PR DESCRIPTION
Reverts googleapis/google-cloud-cpp#4313

We still saw a timeout from spanner backup test after 15 minutes: https://source.cloud.google.com/results/invocations/9d52df69-7276-47a5-891a-46237d11178d/targets/cloud-cpp%2Fgithub%2Fgoogle-cloud-cpp%2Fmaster%2Fdocker%2Fintegration/log

```
[ RUN      ] BackupTestWithCleanup.BackupTestSuite
google/cloud/spanner/integration_tests/backup_integration_test.cc:169: Failure
Value of: backup
Expected: is OK
Actual: exhausted polling policy with no previous error [DEADLINE_EXCEEDED]
```

However, this was not a bazel timeout, it was a timeout in the code, I think, from this code:

https://github.com/googleapis/google-cloud-cpp/blob/0bf38cf1ecd2a317bd21d7a4e4ea94f428baf478/google/cloud/spanner/testing/policies.h#L29

I'm reverting this to stop the flakes. We should then re-enable the spanner backup tests after we've re-evaluated all the retries, timeouts, etc, and we understand why/where the tests take all the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4316)
<!-- Reviewable:end -->
