### PR TITLE
cleanup: be careful with the type of bigtable::Cell::value()

### DIFF
--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -86,7 +86,6 @@ TEST(CellTest, RValueRefAccessors) {
       "Member function `value` is expected to return a value from an r-value "
       "reference to row.");
 
-  std::string moved_value = std::move(cell).value();
-
+  auto moved_value = std::move(cell).value();
   EXPECT_EQ(value, moved_value);
 }


### PR DESCRIPTION
Do not assume that `google::cloud::bigtable::CellValueType` can be
directly converted to a `std::string`.  Here we just use `auto` to
avoid mentioning a specific type altogether.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4317)
<!-- Reviewable:end -->
