### PR TITLE
cleanup: do not prefix Bazel test targets

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -49,7 +49,7 @@ load(
 )
 
 [cc_test(
-    name = "google_cloud_cpp_common_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -46,7 +46,7 @@ cc_library(
 load(":bigquery_client_unit_tests.bzl", "bigquery_client_unit_tests")
 
 [cc_test(
-    name = "bigquery_client_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
         ":bigquery_client",

--- a/google/cloud/bigtable/BUILD
+++ b/google/cloud/bigtable/BUILD
@@ -57,7 +57,7 @@ cc_library(
 load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
 
 [cc_test(
-    name = "bigtable_client_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
         ":bigtable_client",
@@ -72,7 +72,7 @@ load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
 ) for test in bigtable_client_unit_tests]
 
 cc_test(
-    name = "bigtable_client_internal_readrowsparser_test",
+    name = "internal_readrowsparser_test",
     srcs = [
         "internal/readrowsparser_acceptance_tests.inc",
         "internal/readrowsparser_test.cc",

--- a/google/cloud/bigtable/benchmarks/BUILD
+++ b/google/cloud/bigtable/benchmarks/BUILD
@@ -50,7 +50,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
 load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
 
 [cc_test(
-    name = "bigtable_benchmark_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],

--- a/google/cloud/firestore/BUILD
+++ b/google/cloud/firestore/BUILD
@@ -28,7 +28,7 @@ cc_library(
 load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")
 
 [cc_test(
-    name = "firestore_client_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -68,7 +68,7 @@ cc_library(
 load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
 
 [cc_test(
-    name = "spanner_client_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
         ":spanner_client",
@@ -85,7 +85,7 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
 load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks")
 
 [cc_test(
-    name = "spanner_client_" + benchmark.replace("/", "_").replace(".cc", ""),
+    name = benchmark.replace("/", "_").replace(".cc", ""),
     srcs = [benchmark],
     tags = ["benchmark"],
     deps = [

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -19,7 +19,7 @@ licenses(["notice"])  # Apache 2.0
 load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests")
 
 [cc_test(
-    name = "spanner_client_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
     tags = [

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -108,7 +108,7 @@ cc_library(
 load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
 
 [cc_test(
-    name = "storage_client_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,

--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -61,7 +61,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
 load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
 
 [cc_test(
-    name = "storage_benchmark_" + test.replace("/", "_").replace(".cc", ""),
+    name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],


### PR DESCRIPTION
Some (but not all) of our test targets for Bazel were prefixed with the
library that they tested. This is unnecessary with Bazel, as the targets
are already scoped to each BUILD file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4322)
<!-- Reviewable:end -->
