### PR TITLE
feat(storage/benchmarks): control CRC32C/MD5 options

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -465,9 +465,11 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
   auto parse_checksums = [](std::string const& val) -> std::vector<bool> {
     if (val == "enabled") {
       return {true};
-    } else if (val == "disabled") {
+    }
+    if (val == "disabled") {
       return {false};
-    } else if (val == "random") {
+    }
+    if (val == "random") {
       return {false, true};
     }
     return {};


### PR DESCRIPTION
Sometimes we want to run a benchmark with fixed values for CRC32C and/or
MD5 hashing. This adds command line options to run the benchmarks with
either these options fixed to some value from the command-line, or to
chose a random value on each iteration (the default, as before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4326)
<!-- Reviewable:end -->
