### PR TITLE
fix: deadlock in MutationBatcher

### DIFF
--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -93,6 +93,8 @@ class MutationBatcher {
         num_requests_pending_(),
         cur_batch_(std::make_shared<Batch>()) {}
 
+  virtual ~MutationBatcher() = default;
+
   /**
    * Asynchronously apply mutation.
    *
@@ -155,6 +157,11 @@ class MutationBatcher {
    *     the returned future is already satisfied.
    */
   future<void> AsyncWaitForNoPendingRequests();
+
+ protected:
+  // Wrap calling underlying operation in a virtual function to ease testing.
+  virtual future<std::vector<FailedMutation>> AsyncBulkApplyImpl(
+      Table& table, BulkMutation&& mut, CompletionQueue& cq);
 
  private:
   using CompletionPromise = promise<Status>;

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -178,13 +178,15 @@ class CompletionQueue {
                 internal::CheckRunAsyncCallback<Functor>::value, int>::type = 0>
   void RunAsync(Functor&& functor) {
     MakeRelativeTimer(std::chrono::seconds(0))
-        .then([this, functor](
-                  future<StatusOr<std::chrono::system_clock::time_point>>) {
-          // We intentionally ignore the status here; the functor is always
-          // called, even after a call to `CancelAll`.
-          CompletionQueue cq(impl_);
-          functor(cq);
-        });
+        .then(
+            [this, functor](
+                future<
+                    StatusOr<std::chrono::system_clock::time_point>>) mutable {
+              // We intentionally ignore the status here; the functor is always
+              // called, even after a call to `CancelAll`.
+              CompletionQueue cq(impl_);
+              functor(cq);
+            });
   }
 
  private:


### PR DESCRIPTION
This fixes #4083.

The used to happen when the continuation of `AsyncBulkApply` was
executed synchronously (which happened if the operation finished really
quickly). In order to overcome it, the continuation now schedules the
continuation on the completion queue explicitly. A solution in which
`FlushIfPossible` was releasing the mutex was hard because the mutex
would have to be reacquired later making the code very brittle and
perhaps incorrect.

The added reproducer fails without the fix.