### PR TITLE
cleanup: remove references to google-cloud-cpp-*

### DIFF
--- a/ci/generate-markdown/generate-spanner-readme.sh
+++ b/ci/generate-markdown/generate-spanner-readme.sh
@@ -49,7 +49,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-spanner/latest/
 [cloud-spanner-docs]: https://cloud.google.com/spanner/docs/
-[source-link]: https://github.com/googleapis/google-cloud-cpp-spanner/tree/master/google/cloud/spanner
+[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud/spanner
 
 ## Quickstart
 

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -58,7 +58,6 @@ fi
   ./bootstrap-vcpkg.sh
   ./vcpkg remove --outdated --recurse
   ./vcpkg install google-cloud-cpp
-  ./vcpkg install google-cloud-cpp-spanner
 )
 # Use the new installed/ directory to create the cache.
 rm -fr "${HOME}/vcpkg-quickstart-cache"

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -88,7 +88,7 @@ if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
     $env:VCPKG_TRIPLET = "x64-windows-static"
     $env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/master/vcpkg/Debug/x64-windows-static/quickstart.zip"
     $DependencyScript = "build-cmake-dependencies.ps1"
-    $DependencyScriptArgs=@("cmake-out/vcpkg-quickstart", "google-cloud-cpp", "google-cloud-cpp-spanner")
+    $DependencyScriptArgs=@("cmake-out/vcpkg-quickstart", "google-cloud-cpp")
     $BuildScript = "build-quickstart-cmake.ps1"
 } elseif ($BuildName -eq "quickstart-cmake-dll") {
     $env:CONFIG = "Debug"
@@ -96,7 +96,7 @@ if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
     $env:VCPKG_TRIPLET = "x64-windows"
     $env:BUILD_CACHE = "gs://cloud-cpp-kokoro-results/build-cache/google-cloud-cpp/master/vcpkg/Debug/x64-windows/quickstart.zip"
     $DependencyScript = "build-cmake-dependencies.ps1"
-    $DependencyScriptArgs=@("cmake-out/vcpkg-quickstart", "google-cloud-cpp", "google-cloud-cpp-spanner")
+    $DependencyScriptArgs=@("cmake-out/vcpkg-quickstart", "google-cloud-cpp")
     $BuildScript = "build-quickstart-cmake.ps1"
 }
 

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -187,7 +187,6 @@ installing `google-cloud-cpp` itself:
 
 ```console
 > vcpkg.exe install google-cloud-cpp:x64-windows-static
-> vcpkg.exe install --recurse google-cloud-cpp-common[test]:x64-windows-static
 > vcpkg.exe integrate install
 ```
 

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -69,7 +69,7 @@ load(":google_cloud_cpp_grpc_utils.bzl", "google_cloud_cpp_grpc_utils_hdrs", "go
 cc_library(
     name = "google_cloud_cpp_grpc_utils",
     srcs = google_cloud_cpp_grpc_utils_srcs,
-    # TODO(googleapis/google-cloud-cpp-common##171) - remove the filtering
+    # TODO(googleapis/google-cloud-cpp-common#171) - remove the filtering
     #    comprehension.
     hdrs = [
         header

--- a/google/cloud/README.md
+++ b/google/cloud/README.md
@@ -30,7 +30,7 @@ notice. These include `google/cloud/internal/`, and
 * Detailed header comments in our [public `.h`][source-link] files
 
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-common/latest/
-[source-link]: https://github.com/googleapis/google-cloud-cpp-common/tree/master/google/cloud
+[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud
 
 ## Contributing changes
 

--- a/google/cloud/spanner/README.md
+++ b/google/cloud/spanner/README.md
@@ -25,7 +25,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-spanner/latest/
 [cloud-spanner-docs]: https://cloud.google.com/spanner/docs/
-[source-link]: https://github.com/googleapis/google-cloud-cpp-spanner/tree/master/google/cloud/spanner
+[source-link]: https://github.com/googleapis/google-cloud-cpp/tree/master/google/cloud/spanner
 
 ## Quickstart
 

--- a/google/cloud/spanner/benchmarks/README.md
+++ b/google/cloud/spanner/benchmarks/README.md
@@ -40,8 +40,8 @@ You must compile both the library and its dependencies with optimization, using
 CMake this is:
 
 ```bash
-git clone https://github.com/googleapis/google-cloud-cpp-spanner.git
-cd google-cloud-cpp-spanner
+git clone https://github.com/googleapis/google-cloud-cpp.git
+cd google-cloud-cpp
 cmake -Hsuper -Bcmake-out/si -DCMAKE_BUILD_TYPE=Release \
      -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local-spanner
 cmake --build cmake-out/si --target project-dependencies

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -35,8 +35,8 @@ includes detailed instructions on how to compile the library for use in your
 application. You can fetch the source from [GitHub][github-link] as normal:
 
 @code{.sh}
-git clone https://github.com/googleapis/google-cloud-cpp-spanner.git
-cd google-cloud-cpp-spanner/google/cloud/spanner/quickstart
+git clone https://github.com/googleapis/google-cloud-cpp.git
+cd google-cloud-cpp/google/cloud/spanner/quickstart
 @endcode
 
 @par Example: Hello World
@@ -157,8 +157,8 @@ period between retries.
 [concepts-link]: https://cloud.google.com/storage/docs/concepts 'GCS Concepts'
 [authentication-quickstart]: https://cloud.google.com/docs/authentication/getting-started 'Authentication Getting Started'
 [gcloud-quickstart]: https://cloud.google.com/sdk/docs/quickstarts
-[github-link]: https://github.com/googleapis/google-cloud-cpp-spanner 'GitHub Repository'
-[quickstart-link]:  https://github.com/googleapis/google-cloud-cpp-spanner/blob/master/google/cloud/spanner/quickstart
-[status-or-header]: https://github.com/googleapis/google-cloud-cpp-common/blob/master/google/cloud/status_or.h
+[github-link]: https://github.com/googleapis/google-cloud-cpp 'GitHub Repository'
+[quickstart-link]:  https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/spanner/quickstart
+[status-or-header]: https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/status_or.h
 
 */

--- a/google/cloud/spanner/quickstart/CMakeLists.txt
+++ b/google/cloud/spanner/quickstart/CMakeLists.txt
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-# This CMake file shows how to use `google-cloud-cpp-spanner` from a larger
+# This CMake file shows how to use the Cloud Spanner C++ client from a larger
 # CMake project.
 
 cmake_minimum_required(VERSION 3.5)

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -1,4 +1,4 @@
-# HOWTO: using google-cloud-cpp-spanner in your project
+# HOWTO: using the Cloud Spanner C++ client in your project
 
 This directory contains small examples showing how to use the Cloud Spanner C++
 client library in your own project. These instructions assume that you have
@@ -36,7 +36,7 @@ https://cloud.google.com/docs/authentication/production
 2. Compile this example using Bazel:
 
    ```bash
-   cd $HOME/google-cloud-cpp-spanner/quickstart
+   cd $HOME/google-cloud-cpp/quickstart
    bazel build ...
    ```
 
@@ -60,7 +60,7 @@ If you are using Windows or macOS there are additional instructions at the end o
 
    ```bash
    cd $HOME/vcpkg
-   ./vcpkg install google-cloud-cpp-spanner
+   ./vcpkg install google-cloud-cpp
    ```
 
 3. Configure CMake, if necessary, configure the directory where you installed the dependencies:

--- a/release/release.sh
+++ b/release/release.sh
@@ -33,16 +33,16 @@
 # Examples:
 #
 #   # NO CHANGES ARE PUSHED. Shows what commands would be run.
-#   $ release.sh googleapis/google-cloud-cpp-spanner
+#   $ release.sh googleapis/google-cloud-cpp
 #
 #   # NO CHANGES ARE PUSHED. Shows what commands would be run.
-#   $ release.sh googleapis/google-cloud-cpp-spanner 2.0.0
+#   $ release.sh googleapis/google-cloud-cpp 2.0.0
 #
 #   # PUSHES CHANGES to release -spanner
-#   $ release.sh -f googleapis/google-cloud-cpp-spanner
+#   $ release.sh -f googleapis/google-cloud-cpp
 #
 #   # PUSHES CHANGES to release -spanner, setting its new version to 2.0.0
-#   $ release.sh -f googleapis/google-cloud-cpp-spanner 2.0.0
+#   $ release.sh -f googleapis/google-cloud-cpp 2.0.0
 
 set -eu
 


### PR DESCRIPTION
I was just going to remove the vcpkg references, but I found many
other references in the documentation and comments that needed fixing
too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4329)
<!-- Reviewable:end -->
