### PR TITLE
refactor(storage/benchmarks): options parsing

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -21,8 +21,10 @@ if (BUILD_TESTING)
     find_package(absl CONFIG REQUIRED)
     unset(FPHSA_NAME_MISMATCHED)
 
-    add_library(storage_benchmarks # cmake-format: sort
-                benchmark_utils.cc benchmark_utils.h bounded_queue.h)
+    add_library(
+        storage_benchmarks # cmake-format: sort
+        benchmark_utils.cc benchmark_utils.h bounded_queue.h
+        throughput_options.cc throughput_options.h)
     target_link_libraries(storage_benchmarks PUBLIC storage_client)
     google_cloud_cpp_add_common_options(storage_benchmarks)
 
@@ -74,8 +76,11 @@ if (BUILD_TESTING)
     # List the unit tests, then setup the targets and dependencies.
     set(storage_benchmarks_unit_tests
         # cmake-format: sort
-        benchmark_make_random_test.cc benchmark_parse_args_test.cc
-        benchmark_parser_test.cc benchmark_utils_test.cc)
+        benchmark_make_random_test.cc
+        benchmark_parse_args_test.cc
+        benchmark_parser_test.cc
+        benchmark_utils_test.cc
+        throughput_options_test.cc)
 
     foreach (fname ${storage_benchmarks_unit_tests})
         google_cloud_cpp_add_executable(target "storage_benchmarks" "${fname}")

--- a/google/cloud/storage/benchmarks/storage_benchmarks.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks.bzl
@@ -19,8 +19,10 @@
 storage_benchmarks_hdrs = [
     "benchmark_utils.h",
     "bounded_queue.h",
+    "throughput_options.h",
 ]
 
 storage_benchmarks_srcs = [
     "benchmark_utils.cc",
+    "throughput_options.cc",
 ]

--- a/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
@@ -21,4 +21,5 @@ storage_benchmarks_unit_tests = [
     "benchmark_parse_args_test.cc",
     "benchmark_parser_test.cc",
     "benchmark_utils_test.cc",
+    "throughput_options_test.cc",
 ]

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_OPTIONS_H
+
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+struct ThroughputOptions {
+  std::string project_id;
+  std::string region;
+  std::string bucket_prefix = "cloud-cpp-testing-bm-";
+  std::chrono::seconds duration =
+      std::chrono::seconds(std::chrono::minutes(15));
+  int thread_count = 1;
+  std::int64_t minimum_object_size = 32 * kMiB;
+  std::int64_t maximum_object_size = 256 * kMiB;
+  std::int64_t minimum_write_size = 16 * kMiB;
+  std::int64_t maximum_write_size = 64 * kMiB;
+  std::int64_t write_quantum = 256 * kKiB;
+  std::int64_t minimum_read_size = 4 * kMiB;
+  std::int64_t maximum_read_size = 8 * kMiB;
+  std::int64_t read_quantum = 1 * kMiB;
+  std::int32_t minimum_sample_count = 0;
+  std::int32_t maximum_sample_count = std::numeric_limits<std::int32_t>::max();
+  std::vector<ApiName> enabled_apis = {
+      ApiName::kApiJson,
+      ApiName::kApiXml,
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+      ApiName::kApiGrpc,
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  };
+  std::vector<bool> enabled_crc32c = {false, true};
+  std::vector<bool> enabled_md5 = {false, true};
+};
+
+google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
+    std::vector<std::string> const& argv, std::string const& description = {});
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_OPTIONS_H

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -1,0 +1,170 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/throughput_options.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::UnorderedElementsAre;
+
+TEST(ThroughputOptions, Basic) {
+  auto options = ParseThroughputOptions({
+      "self-test",
+      "--project-id=test-project",
+      "--region=test-region",
+      "--bucket-prefix=test-prefix",
+      "--thread-count=42",
+      "--minimum-object-size=16KiB",
+      "--maximum-object-size=32KiB",
+      "--minimum-write-size=16KiB",
+      "--maximum-write-size=128KiB",
+      "--write-quantum=16KiB",
+      "--minimum-read-size=32KiB",
+      "--maximum-read-size=256KiB",
+      "--read-quantum=32KiB",
+      "--duration=1s",
+      "--minimum-sample-count=1",
+      "--maximum-sample-count=2",
+      "--enabled-apis=JSON,GRPC,XML",
+      "--enabled-crc32c=enabled",
+      "--enabled-md5=disabled",
+  });
+  ASSERT_STATUS_OK(options);
+  EXPECT_EQ("test-project", options->project_id);
+  EXPECT_EQ("test-region", options->region);
+  EXPECT_EQ("test-prefix", options->bucket_prefix);
+  EXPECT_EQ(42, options->thread_count);
+  EXPECT_EQ(16 * kKiB, options->minimum_object_size);
+  EXPECT_EQ(32 * kKiB, options->maximum_object_size);
+  EXPECT_EQ(16 * kKiB, options->minimum_write_size);
+  EXPECT_EQ(128 * kKiB, options->maximum_write_size);
+  EXPECT_EQ(16 * kKiB, options->write_quantum);
+  EXPECT_EQ(32 * kKiB, options->minimum_read_size);
+  EXPECT_EQ(256 * kKiB, options->maximum_read_size);
+  EXPECT_EQ(32 * kKiB, options->read_quantum);
+  EXPECT_EQ(1, options->duration.count());
+  EXPECT_EQ(1, options->minimum_sample_count);
+  EXPECT_EQ(2, options->maximum_sample_count);
+  EXPECT_THAT(options->enabled_apis,
+              UnorderedElementsAre(ApiName::kApiGrpc, ApiName::kApiXml,
+                                   ApiName::kApiJson));
+  EXPECT_THAT(options->enabled_crc32c, ElementsAre(true));
+  EXPECT_THAT(options->enabled_md5, ElementsAre(false));
+}
+
+TEST(ThroughputOptions, Description) {
+  EXPECT_STATUS_OK(ParseThroughputOptions(
+      {"self-test", "--help", "--description", "fake-region"}));
+}
+
+TEST(ThroughputOptions, ParseCrc32c) {
+  EXPECT_FALSE(
+      ParseThroughputOptions({"self-test", "--region=r", "--enabled-crc32c="}));
+  auto options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-crc32c=enabled"});
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(options->enabled_crc32c, ElementsAre(true));
+  options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-crc32c=disabled"});
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(options->enabled_crc32c, ElementsAre(false));
+  options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-crc32c=random"});
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(options->enabled_crc32c, UnorderedElementsAre(false, true));
+}
+
+TEST(ThroughputOptions, MD5) {
+  EXPECT_FALSE(
+      ParseThroughputOptions({"self-test", "--region=r", "--enabled-md5="}));
+  auto options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-md5=enabled"});
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(options->enabled_md5, ElementsAre(true));
+  options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-md5=disabled"});
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(options->enabled_md5, ElementsAre(false));
+  options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-md5=random"});
+  ASSERT_STATUS_OK(options);
+  EXPECT_THAT(options->enabled_md5, UnorderedElementsAre(false, true));
+}
+
+TEST(ThroughputOptions, Apis) {
+  EXPECT_FALSE(
+      ParseThroughputOptions({"self-test", "--region=r", "--enabled-apis="}));
+  EXPECT_FALSE(ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-apis=JSON,XML,INVALID"}));
+  auto options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-apis=JSON,XML,GRPC"});
+  EXPECT_THAT(options->enabled_apis,
+              UnorderedElementsAre(ApiName::kApiJson, ApiName::kApiXml,
+                                   ApiName::kApiGrpc));
+}
+
+TEST(ThroughputOptions, Validate) {
+  EXPECT_FALSE(ParseThroughputOptions({"self-test"}));
+  EXPECT_FALSE(ParseThroughputOptions({"self-test", "unused-1", "unused-2"}));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-object-size=8",
+      "--maximum-object-size=4",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-write-size=8",
+      "--maximum-write-size=4",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-write-size=4",
+      "--maximum-write-size=8",
+      "--write-quantum=5",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-read-size=8",
+      "--maximum-read-size=4",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-read-size=4",
+      "--maximum-read-size=8",
+      "--read-quantum=5",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-sample-count=8",
+      "--maximum-sample-count=4",
+  }));
+}
+
+}  // namespace
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Move functions to parse the throughput_vs_cpu_benchmark options to a
common file in the benchmarks library. If nothing else it makes testing
easier, but I may create separate benchmarks soonish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4345)
<!-- Reviewable:end -->
