### PR TITLE
feat(source<T>): flow control for FakeSource 

### DIFF
--- a/google/cloud/internal/source_accumulators_test.cc
+++ b/google/cloud/internal/source_accumulators_test.cc
@@ -65,25 +65,10 @@ TEST(SourceAccumulators, AccumulateAllErrorAfterData) {
   EXPECT_EQ(absl::get<1>(actual).message(), "uh-oh");
 }
 
-TEST(SourceAccumulators, AccumulateAllCopy) {
-  FakeSource<int, Status> mock({1, 2, 3, 4}, Status{});
-  auto const actual = AccumulateAllEvents(mock).get();
-  ASSERT_EQ(actual.index(), 0);  // expect success
-  EXPECT_THAT(absl::get<0>(actual), ElementsAre(1, 2, 3, 4));
-}
-
 TEST(SourceAccumulators, AccumulateAllRef) {
   FakeSource<int, Status> mock({1, 2, 3, 4}, Status{});
   auto& ref = mock;
-  auto const actual = AccumulateAllEvents(ref).get();
-  ASSERT_EQ(actual.index(), 0);  // expect success
-  EXPECT_THAT(absl::get<0>(actual), ElementsAre(1, 2, 3, 4));
-}
-
-TEST(SourceAccumulators, AccumulateAllConstRef) {
-  FakeSource<int, Status> mock({1, 2, 3, 4}, Status{});
-  auto const& cref = mock;
-  auto const actual = AccumulateAllEvents(cref).get();
+  auto const actual = AccumulateAllEvents(std::move(ref)).get();
   ASSERT_EQ(actual.index(), 0);  // expect success
   EXPECT_THAT(absl::get<0>(actual), ElementsAre(1, 2, 3, 4));
 }

--- a/google/cloud/testing_util/fake_source.h
+++ b/google/cloud/testing_util/fake_source.h
@@ -39,7 +39,8 @@ class FakeSource {
  public:
   FakeSource(std::deque<T> values, E status, std::size_t max_outstanding)
       : flow_control_(max_outstanding),
-        values_(std::move(values)), status_(std::move(status)) {}
+        values_(std::move(values)),
+        status_(std::move(status)) {}
 
   FakeSource(std::deque<T> values, E status)
       : FakeSource(std::move(values), std::move(status), 1) {}
@@ -48,9 +49,7 @@ class FakeSource {
   using value_type = T;
   using error_type = E;
 
-  future<internal::ReadyToken> ready() {
-    return flow_control_.Acquire();
-  }
+  future<internal::ReadyToken> ready() { return flow_control_.Acquire(); }
 
   future<absl::variant<T, E>> next(internal::ReadyToken token) {
     if (!flow_control_.Release(std::move(token))) {


### PR DESCRIPTION
With this change we use flow control for FakeSource, which required
changing the existing accumulator and SlowIota (another test source) to
also use flow control. This completes the API for the test sources.

Fixes #4339 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4346)
<!-- Reviewable:end -->
