### PR TITLE
feat: remove notice about moving to monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@
 [codecov-shield]: https://codecov.io/gh/googleapis/google-cloud-cpp/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/googleapis/google-cloud-cpp
 
-> **NOTICE:** This repo will soon contain the code for all the other related
-`google-cloud-cpp-*` repos. As a new monorepo
-([#3612](https://github.com/googleapis/google-cloud-cpp/issues/3612)), the
-versioning of this repo will be changing to have a single per-repo version. See
-https://github.com/googleapis/google-cloud-cpp/issues/3615 for more info.
-
 This repository contains idiomatic C++ client libraries for the following
 [Google Cloud Platform](https://cloud.google.com/) services.
 

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -50,12 +50,6 @@ cat <<"EOF"
 [codecov-shield]: https://codecov.io/gh/googleapis/google-cloud-cpp/branch/master/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/googleapis/google-cloud-cpp
 
-> **NOTICE:** This repo will soon contain the code for all the other related
-`google-cloud-cpp-*` repos. As a new monorepo
-([#3612](https://github.com/googleapis/google-cloud-cpp/issues/3612)), the
-versioning of this repo will be changing to have a single per-repo version. See
-https://github.com/googleapis/google-cloud-cpp/issues/3615 for more info.
-
 This repository contains idiomatic C++ client libraries for the following
 [Google Cloud Platform](https://cloud.google.com/) services.
 


### PR DESCRIPTION
The move to a monorepo is finished.

Fixes: https://github.com/googleapis/google-cloud-cpp/issues/3612

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4348)
<!-- Reviewable:end -->
