### PR TITLE
refactor(storage/benchmark): throughput results

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -23,8 +23,14 @@ if (BUILD_TESTING)
 
     add_library(
         storage_benchmarks # cmake-format: sort
-        benchmark_utils.cc benchmark_utils.h bounded_queue.h
-        throughput_options.cc throughput_options.h)
+        benchmark_utils.cc
+        benchmark_utils.h
+        bounded_queue.h
+        throughput_options.cc
+        throughput_options.h
+        throughput_result.cc
+        throughput_result.h
+        throughput_result_test.cc)
     target_link_libraries(storage_benchmarks PUBLIC storage_client)
     google_cloud_cpp_add_common_options(storage_benchmarks)
 
@@ -80,7 +86,8 @@ if (BUILD_TESTING)
         benchmark_parse_args_test.cc
         benchmark_parser_test.cc
         benchmark_utils_test.cc
-        throughput_options_test.cc)
+        throughput_options_test.cc
+        throughput_result_test.cc)
 
     foreach (fname ${storage_benchmarks_unit_tests})
         google_cloud_cpp_add_executable(target "storage_benchmarks" "${fname}")

--- a/google/cloud/storage/benchmarks/storage_benchmarks.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks.bzl
@@ -20,9 +20,12 @@ storage_benchmarks_hdrs = [
     "benchmark_utils.h",
     "bounded_queue.h",
     "throughput_options.h",
+    "throughput_result.h",
 ]
 
 storage_benchmarks_srcs = [
     "benchmark_utils.cc",
     "throughput_options.cc",
+    "throughput_result.cc",
+    "throughput_result_test.cc",
 ]

--- a/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks_unit_tests.bzl
@@ -22,4 +22,5 @@ storage_benchmarks_unit_tests = [
     "benchmark_parser_test.cc",
     "benchmark_utils_test.cc",
     "throughput_options_test.cc",
+    "throughput_result_test.cc",
 ]

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/throughput_result.h"
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
+  os << ToString(r.op) << ',' << r.object_size << ',' << r.app_buffer_size
+     << ',' << r.lib_buffer_size << ',' << r.crc_enabled << ',' << r.md5_enabled
+     << ',' << ToString(r.api) << ',' << r.elapsed_time.count() << ','
+     << r.cpu_time.count() << ',' << r.status << '\n';
+}
+
+void PrintThroughputResultHeader(std::ostream& os) {
+  os << "Op,ObjectSize,AppBufferSize,LibBufferSize"
+     << ",Crc32cEnabled,MD5Enabled,ApiName"
+     << ",ElapsedTimeUs,CpuTimeUs,Status\n";
+}
+
+char const* ToString(OpType op) {
+  switch (op) {
+    case kOpRead0:
+      return "READ[0]";
+    case kOpRead1:
+      return "READ[1]";
+    case kOpRead2:
+      return "READ[2]";
+    case kOpWrite:
+      return "WRITE";
+    case kOpInsert:
+      return "INSERT";
+  }
+  return nullptr;  // silence g++ error.
+}
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -1,0 +1,98 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_RESULT_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_RESULT_H
+
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <chrono>
+#include <cstdint>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+/// The operation used for the experiment
+enum OpType {
+  /// The experiment performed a resumable upload, using  Client::WriteObject()
+  /// or an equivalent function.
+  kOpWrite,
+  /// The experiment performed a simple upload, using Client::InsertObject() or
+  /// an
+  /// equivalent function.
+  kOpInsert,
+  /// The experiment performed a downlad, using Client::InsertObject() or an
+  /// equivalent function.
+  /// This was the first download of this object in the experiment.
+  // TODO(#4350) - use a separate field to count downloads / uploads
+  kOpRead0,
+  /// The experiment performed a downlad, using Client::InsertObject() or an
+  /// equivalent function.
+  /// This was the second download of this object in the experiment.
+  kOpRead1,
+  /// The experiment performed a downlad, using Client::InsertObject() or an
+  /// equivalent function.
+  /// This was the third download of this object in the experiment.
+  kOpRead2,
+};
+
+/**
+ * The result of running a throughput benchmark iteration.
+ *
+ * The benchmarks in this directory run the same "experiment" with different
+ * conditions, downloading the same GCS object N times, or uploading objects
+ * with different buffer sizes. This struct is used to represent the conditions
+ * used in the experiment (buffer sizes, object size, checksum settings, API,
+ * etc.) as well as its results: status, CPU time, and elapsed time.
+ */
+struct ThroughputResult {
+  /// The type of operation in this experiment.
+  OpType op;
+  /// The total size of the object involved in this experiment. Currently also
+  /// represents the number of bytes transferred.
+  // TODO(#4349) - use a separate field to represent the bytes transferred
+  std::int64_t object_size;
+  /// The size of the application buffer (for .read() or .write() calls).
+  std::int64_t app_buffer_size;
+  /// The size of the library buffers (if any).
+  std::uint64_t lib_buffer_size;
+  /// True if the CRC32C checksums are enabled in this experiment.
+  bool crc_enabled;
+  /// True if the MD5 hashes are enabled in this experiment.
+  bool md5_enabled;
+  /// The API, protocol, or library used in this expriment.
+  ApiName api;
+  /// The total time used to complete the experiment.
+  std::chrono::microseconds elapsed_time;
+  /// The amount of CPU time (as reported by getrusage(2)) consumed in the
+  /// experiment.
+  std::chrono::microseconds cpu_time;
+  /// The result of the operation. The analysis may need to discard failed
+  /// uploads or downloads.
+  google::cloud::StatusCode status;
+};
+
+/// Print @p r as a CSV line.
+void PrintAsCsv(std::ostream& os, ThroughputResult const& r);
+
+/// Print the field names produced by `PrintAsCsv()`
+void PrintThroughputResultHeader(std::ostream& os);
+
+char const* ToString(OpType op);
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_RESULT_H

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -1,0 +1,68 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/throughput_result.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(ThroughtputResult, HeaderMatches) {
+  std::ostringstream header_stream;
+  PrintThroughputResultHeader(header_stream);
+  EXPECT_TRUE(header_stream);
+  auto const header = std::move(header_stream).str();
+
+  std::ostringstream line_stream;
+  PrintAsCsv(line_stream,
+             ThroughputResult{
+                 kOpInsert, /*object_size=*/3 * kMiB,
+                 /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
+                 /*crc_enabled=*/true, /*md5_enabled=*/false, ApiName::kApiGrpc,
+                 std::chrono::microseconds(234000),
+                 std::chrono::microseconds(345000), StatusCode::kOutOfRange});
+  EXPECT_TRUE(line_stream);
+  auto const line = std::move(line_stream).str();
+
+  ASSERT_FALSE(header.empty());
+  ASSERT_FALSE(line.empty());
+
+  auto const header_fields = std::count(header.begin(), header.end(), ',');
+  auto const line_fields = std::count(line.begin(), line.end(), ',');
+  EXPECT_EQ(header_fields, line_fields);
+  EXPECT_EQ(line.back(), '\n');
+  EXPECT_EQ(header.back(), '\n');
+
+  // We don't want to create a change detector test, but we can verify the basic
+  // fields are formatted correctly.
+  EXPECT_THAT(line, HasSubstr(ToString(kOpInsert)));
+  EXPECT_THAT(line, HasSubstr("," + std::to_string(3 * kMiB) + ","));
+  EXPECT_THAT(line, HasSubstr("," + std::to_string(2 * kMiB) + ","));
+  EXPECT_THAT(line, HasSubstr("," + std::to_string(4 * kMiB) + ","));
+  EXPECT_THAT(line, HasSubstr(",1,"));  // crc_enabled==true
+  EXPECT_THAT(line, HasSubstr(",0,"));  // md5_enabled==false
+  EXPECT_THAT(line, HasSubstr(ToString(ApiName::kApiGrpc)));
+  EXPECT_THAT(line, HasSubstr(",234000,"));
+  EXPECT_THAT(line, HasSubstr(",345000,"));
+  EXPECT_THAT(line, HasSubstr(StatusCodeToString(StatusCode::kOutOfRange)));
+}
+
+}  // namespace
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Move the struct used to represent throughput results to its own file.
Again, this is useful for testing, but I anticipate I will need to write
more throughput benchmarks (e.g. a benchmark that *only* downloads
objects).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4351)
<!-- Reviewable:end -->
