### PR TITLE
fix(source<T>): correct int vs. std::size_t mismatch

### DIFF
--- a/google/cloud/testing_util/fake_source.h
+++ b/google/cloud/testing_util/fake_source.h
@@ -37,7 +37,7 @@ namespace testing_util {
 template <class T, typename E>
 class FakeSource {
  public:
-  FakeSource(std::deque<T> values, E status, std::size_t max_outstanding)
+  FakeSource(std::deque<T> values, E status, int max_outstanding)
       : flow_control_(max_outstanding),
         values_(std::move(values)),
         status_(std::move(status)) {}


### PR DESCRIPTION
This was breaking only on Windows+CMake, which we do not build on PRs. I
tested the fix manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4353)
<!-- Reviewable:end -->
