### PR TITLE
refactor(storage/benchmark): wrap upload/download in classes

### DIFF
--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -26,12 +26,15 @@ if (BUILD_TESTING)
         benchmark_utils.cc
         benchmark_utils.h
         bounded_queue.h
+        throughput_experiment.cc
+        throughput_experiment.h
         throughput_options.cc
         throughput_options.h
         throughput_result.cc
         throughput_result.h
         throughput_result_test.cc)
-    target_link_libraries(storage_benchmarks PUBLIC storage_client)
+    target_link_libraries(storage_benchmarks PUBLIC storage_client
+                                                    storage_client_testing)
     google_cloud_cpp_add_common_options(storage_benchmarks)
 
     include(CheckCXXSymbolExists)

--- a/google/cloud/storage/benchmarks/storage_benchmarks.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks.bzl
@@ -19,12 +19,14 @@
 storage_benchmarks_hdrs = [
     "benchmark_utils.h",
     "bounded_queue.h",
+    "throughput_experiment.h",
     "throughput_options.h",
     "throughput_result.h",
 ]
 
 storage_benchmarks_srcs = [
     "benchmark_utils.cc",
+    "throughput_experiment.cc",
     "throughput_options.cc",
     "throughput_result.cc",
     "throughput_result_test.cc",

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -363,9 +363,6 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
     return google::cloud::Status(google::cloud::StatusCode::kUnknown,
                                  std::move(os).str());
   }
-  auto const* const thread_count_arg =
-      gcs_bm::SimpleTimer::SupportPerThreadUsage() ? "--thread-count=2"
-                                                   : "--thread-count=1";
   return gcs_bm::ParseThroughputOptions(
       {
           argv0,
@@ -373,7 +370,7 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
           "--region=" +
               GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID").value(),
           "--bucket-prefix=cloud-cpp-testing-ci-",
-          thread_count_arg,
+          "--thread-count=1",
           "--minimum-object-size=16KiB",
           "--maximum-object-size=32KiB",
           "--minimum-write-size=16KiB",
@@ -383,8 +380,8 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
           "--maximum-read-size=128KiB",
           "--read-quantum=16KiB",
           "--duration=1s",
-          "--minimum-sample-count=1",
-          "--maximum-sample-count=2",
+          "--minimum-sample-count=4",
+          "--maximum-sample-count=10",
           "--enabled-apis=JSON,GRPC,XML",
           "--enabled-crc32c=enabled",
           "--enabled-md5=disabled",

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -382,7 +382,7 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
           "--duration=1s",
           "--minimum-sample-count=4",
           "--maximum-sample-count=10",
-          "--enabled-apis=JSON,GRPC,XML",
+          "--enabled-apis=JSON,XML",
           "--enabled-crc32c=enabled",
           "--enabled-md5=disabled",
       },

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/benchmarks/throughput_experiment.h"
 #include "google/cloud/storage/benchmarks/throughput_options.h"
 #include "google/cloud/storage/benchmarks/throughput_result.h"
 #include "google/cloud/storage/client.h"
@@ -21,6 +22,8 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "absl/algorithm/container.h"
+#include "absl/memory/memory.h"
 #include "absl/strings/str_join.h"
 #include <future>
 #include <set>
@@ -55,16 +58,25 @@ taken into account.
 After creating this bucket the program creates a number of threads, configurable
 via the command line, to obtain more samples in parallel. Configure this value
 with a small enough number of threads such that you do not saturate the CPU.
-Each thread creates a separate copy of the `storage::Client` object, and repeats
-this loop (see below for the conditions to stop the loop):
+
+Each thread creates C++ objects to perform the "upload experiments". Each one
+of these objects represents the "api" used to perform the upload, that is XML,
+JSON and/or gRPC (though technically gRPC is just another protocol for the JSON
+API). Likewise, the thread creates a number of "download experiments", also
+based on the APIs configured via the command-line.
+
+Then the thread repeats the following steps (see below for the conditions to
+stop the loop):
 
 - Select a random size, between two values configured in the command line of the
   object to upload.
 - The application buffer sizes for `read()` and `write()` calls are also
   selected at random. These sizes are quantized, and the quantum can be
   configured in the command-line.
-- Select, at random, the protocol / API used to perform the test, could be XML,
-  JSON, or gRPC.
+- Select a random uploader, that is, which API will be used to upload the
+  object.
+- Select a random downloader, that is, which API will be used to download the
+  object.
 - Select, at random, if the client library will perform CRC32C and/or MD5 hashes
   on the uploaded and downloaded data.
 - Upload an object of the selected size, choosing the name of the object at
@@ -72,9 +84,10 @@ this loop (see below for the conditions to stop the loop):
 - Once the object is fully uploaded, the program captures the object size, the
   write buffer size, the elapsed time (in microseconds), the CPU time
   (in microseconds) used during the upload, and the status code for the upload.
-- Then the program downloads the same object, and captures the object size, the
-  read buffer size, the elapsed time (in microseconds), the CPU time (in
-  microseconds) used during the download, and the status code for the download.
+- Then the program downloads the same object (3 times), and captures the object
+  size, the read buffer size, the elapsed time (in microseconds), the CPU time
+  (in microseconds) used during the download, and the status code for the
+  download.
 - The program then deletes this object and starts another iteration.
 
 The loop stops when any of the following conditions are met:
@@ -225,7 +238,6 @@ void PrintResults(TestResults const& results) {
 TestResults RunThread(ThroughputOptions const& options,
                       std::string const& bucket_name) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto contents = gcs_bm::MakeRandomData(generator, options.maximum_write_size);
   google::cloud::StatusOr<gcs::ClientOptions> client_options =
       gcs::ClientOptions::CreateDefaultClientOptions();
   if (!client_options) {
@@ -237,13 +249,27 @@ TestResults RunThread(ThroughputOptions const& options,
   std::uint64_t download_buffer_size = client_options->download_buffer_size();
 
   gcs::Client rest_client(*client_options);
-#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
-  gcs::Client grpc_client =
-      google::cloud::storage_experimental::DefaultGrpcClient(
-          *std::move(client_options));
-#else
-  gcs::Client grpc_client(rest_client);
-#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRP
+
+  auto uploaders = gcs_bm::CreateUploadExperiments(options, *client_options);
+  if (uploaders.empty()) {
+    // This is possible if only gRPC is requested but the benchmark was compiled
+    // without gRPC support.
+    std::cout << "# None of the APIs configured are available\n";
+    return {};
+  }
+  auto downloaders =
+      gcs_bm::CreateDownloadExperiments(options, *client_options);
+  if (downloaders.empty()) {
+    // This is possible if only gRPC is requested but the benchmark was compiled
+    // without gRPC support.
+    std::cout << "# None of the APIs configured are available\n";
+    return {};
+  }
+
+  std::uniform_int_distribution<std::size_t> uploader_generator(
+      0, uploaders.size() - 1);
+  std::uniform_int_distribution<std::size_t> downloader_generator(
+      0, downloaders.size() - 1);
 
   std::uniform_int_distribution<std::int64_t> size_generator(
       options.minimum_object_size, options.maximum_object_size);
@@ -287,97 +313,31 @@ TestResults RunThread(ThroughputOptions const& options,
     bool const enable_crc = options.enabled_crc32c[crc32c_generator(generator)];
     bool const enable_md5 = options.enabled_md5[md5_generator(generator)];
     auto const api = options.enabled_apis[api_generator(generator)];
-    auto xml_write_selector = gcs::Fields();
-    auto json_read_selector = gcs::IfGenerationNotMatch();
 
-    auto* client = &rest_client;
-    switch (api) {
-      case gcs_bm::ApiName::kApiXml:
-        // For writes (uploads) the default is JSON, but if the application is
-        // not interested in any fields on the metadata the library can switch
-        // to XML and does.
-        xml_write_selector = gcs::Fields("");
-        break;
+    auto& uploader = uploaders[uploader_generator(generator)];
+    auto upload_result =
+        uploader->Run(bucket_name, object_name,
+                      gcs_bm::ThroughputExperimentConfig{
+                          gcs_bm::kOpWrite, object_size, write_size,
+                          upload_buffer_size, enable_crc, enable_md5});
+    auto status = upload_result.status;
+    results.emplace_back(std::move(upload_result));
 
-      case gcs_bm::ApiName::kApiJson:
-        // For reads (downloads) the default is XML, unless the application is
-        // using features that only JSON supports, like `IfGenerationNotMatch`.
-        json_read_selector = gcs::IfGenerationNotMatch(0);
-        break;
-
-      case gcs_bm::ApiName::kApiGrpc:
-        client = &grpc_client;
-        break;
-    }
-
-    auto perform_upload = [&options, &contents, client, bucket_name,
-                           object_name, object_size, write_size, enable_crc,
-                           enable_md5, xml_write_selector](bool prefer_insert) {
-      // When the object is relatively small using `ObjectInsert` might be more
-      // efficient. Randomly select about 1/2 of the small writes to use
-      // ObjectInsert()
-      if (object_size < options.maximum_write_size && prefer_insert) {
-        std::string data = contents.substr(0, object_size);
-        auto object_metadata = client->InsertObject(
-            bucket_name, object_name, std::move(data),
-            gcs::DisableCrc32cChecksum(!enable_crc),
-            gcs::DisableMD5Hash(!enable_md5), xml_write_selector);
-        return std::make_pair(gcs_bm::kOpInsert, std::move(object_metadata));
-      }
-      auto writer = client->WriteObject(
-          bucket_name, object_name, gcs::DisableCrc32cChecksum(!enable_crc),
-          gcs::DisableMD5Hash(!enable_md5), xml_write_selector);
-      for (std::int64_t offset = 0; offset < object_size;
-           offset += write_size) {
-        auto len = write_size;
-        if (offset + len > object_size) {
-          len = object_size - offset;
-        }
-        writer.write(contents.data(), len);
-      }
-      writer.Close();
-      return std::make_pair(gcs_bm::kOpWrite, writer.metadata());
-    };
-
-    timer.Start();
-    auto upload_result = perform_upload(use_insert(generator));
-    timer.Stop();
-
-    auto object_metadata = std::move(upload_result.second);
-    results.emplace_back(ThroughputResult{
-        upload_result.first, object_size, write_size, upload_buffer_size,
-        enable_crc, enable_md5, api, timer.elapsed_time(), timer.cpu_time(),
-        object_metadata.status().code()});
-
-    if (!object_metadata) {
+    if (status != google::cloud::StatusCode::kOk) {
       if (options.thread_count == 1) {
-        std::cerr << "# status=" << object_metadata.status()
-                  << ", api=" << gcs_bm::ToString(api) << "\n";
+        std::cout << "# status=" << status << ", api=" << gcs_bm::ToString(api)
+                  << "\n";
       }
       continue;
     }
 
+    auto& downloader = downloaders[downloader_generator(generator)];
     for (auto op : {gcs_bm::kOpRead0, gcs_bm::kOpRead1, gcs_bm::kOpRead2}) {
-      timer.Start();
-      auto reader = client->ReadObject(
-          bucket_name, object_name, gcs::DisableCrc32cChecksum(!enable_crc),
-          gcs::DisableMD5Hash(!enable_md5), json_read_selector);
-      std::vector<char> buffer(read_size);
-      for (size_t num_read = 0; reader.read(buffer.data(), buffer.size());
-           num_read += reader.gcount()) {
-      }
-      timer.Stop();
-      results.emplace_back(
-          ThroughputResult{op, object_size, read_size, download_buffer_size,
-                           enable_crc, enable_md5, api, timer.elapsed_time(),
-                           timer.cpu_time(), reader.status().code()});
-
-      if (options.thread_count == 1 && !reader.status().ok()) {
-        std::cerr << "# status=" << reader.status() << "\n"
-                  << "# metadata=" << *object_metadata << "\n"
-                  << "# json_read_selector=" << json_read_selector.has_value()
-                  << "\n";
-      }
+      results.emplace_back(downloader->Run(
+          bucket_name, object_name,
+          gcs_bm::ThroughputExperimentConfig{op, object_size, read_size,
+                                             download_buffer_size, enable_crc,
+                                             enable_md5}));
     }
     if (options.thread_count == 1) {
       // Immediately print the results, this makes it easier to debug problems.
@@ -385,7 +345,7 @@ TestResults RunThread(ThroughputOptions const& options,
       results.clear();
     }
 
-    auto status = client->DeleteObject(bucket_name, object_name);
+    (void)rest_client.DeleteObject(bucket_name, object_name);
   }
   return results;
 }

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -1,0 +1,228 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/benchmarks/throughput_experiment.h"
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/grpc_plugin.h"
+#include "absl/memory/memory.h"
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+namespace gcs = google::cloud::storage;
+
+namespace {
+
+class UploadObject : public ThroughputExperiment {
+ public:
+  explicit UploadObject(google::cloud::storage::Client client, ApiName api,
+                        std::string random_data, bool prefer_insert)
+      : client_(std::move(client)),
+        api_(api),
+        random_data_(std::move(random_data)),
+        prefer_insert_(prefer_insert) {}
+  ~UploadObject() override = default;
+
+  ThroughputResult Run(std::string const& bucket_name,
+                       std::string const& object_name,
+                       ThroughputExperimentConfig const& config) override {
+    auto api_selector = gcs::Fields();
+    if (api_ == ApiName::kApiXml) {
+      // The default API is JSON, we force XML by not using features that XML
+      // does not implement:
+      api_selector = gcs::Fields("");
+    }
+
+    std::vector<char> buffer(config.app_buffer_size);
+
+    SimpleTimer timer;
+    timer.Start();
+    // When the object is relatively small using `ObjectInsert` might be more
+    // efficient. Randomly select about 1/2 of the small writes to use
+    // ObjectInsert()
+    if (static_cast<std::size_t>(config.object_size) < random_data_.size() &&
+        prefer_insert_) {
+      std::string data = random_data_.substr(0, config.object_size);
+      auto object_metadata = client_.InsertObject(
+          bucket_name, object_name, std::move(data),
+          gcs::DisableCrc32cChecksum(!config.enable_crc32c),
+          gcs::DisableMD5Hash(!config.enable_md5), api_selector);
+      return ThroughputResult{kOpInsert,
+                              config.object_size,
+                              config.app_buffer_size,
+                              config.lib_buffer_size,
+                              config.enable_crc32c,
+                              config.enable_md5,
+                              api_,
+                              timer.elapsed_time(),
+                              timer.cpu_time(),
+                              object_metadata.status().code()};
+    }
+    auto writer = client_.WriteObject(
+        bucket_name, object_name,
+        gcs::DisableCrc32cChecksum(!config.enable_crc32c),
+        gcs::DisableMD5Hash(!config.enable_md5), api_selector);
+    for (std::int64_t offset = 0; offset < config.object_size;
+         offset += config.app_buffer_size) {
+      auto len = config.app_buffer_size;
+      if (offset + len > config.object_size) {
+        len = config.object_size - offset;
+      }
+      writer.write(random_data_.data(), len);
+    }
+    writer.Close();
+    timer.Stop();
+
+    return ThroughputResult{kOpWrite,
+                            config.object_size,
+                            config.app_buffer_size,
+                            config.lib_buffer_size,
+                            config.enable_crc32c,
+                            config.enable_md5,
+                            api_,
+                            timer.elapsed_time(),
+                            timer.cpu_time(),
+                            writer.metadata().status().code()};
+  }
+
+ private:
+  google::cloud::storage::Client client_;
+  ApiName api_;
+  std::string random_data_;
+  bool prefer_insert_;
+};
+
+/**
+ * Download objects using the GCS client.
+ */
+class DownloadObject : public ThroughputExperiment {
+ public:
+  explicit DownloadObject(google::cloud::storage::Client client, ApiName api)
+      : client_(std::move(client)), api_(api) {}
+  ~DownloadObject() override = default;
+
+  ThroughputResult Run(std::string const& bucket_name,
+                       std::string const& object_name,
+                       ThroughputExperimentConfig const& config) override {
+    auto api_selector = gcs::IfGenerationNotMatch();
+    if (api_ == ApiName::kApiJson) {
+      // The default API is XML, we force JSON by using a feature not available
+      // in XML.
+      api_selector = gcs::IfGenerationNotMatch(0);
+    }
+
+    std::vector<char> buffer(config.app_buffer_size);
+
+    SimpleTimer timer;
+    timer.Start();
+    auto reader = client_.ReadObject(
+        bucket_name, object_name,
+        gcs::DisableCrc32cChecksum(!config.enable_crc32c),
+        gcs::DisableMD5Hash(!config.enable_md5), api_selector);
+    for (size_t num_read = 0; reader.read(buffer.data(), buffer.size());
+         num_read += reader.gcount()) {
+    }
+    timer.Stop();
+    return ThroughputResult{config.op,
+                            config.object_size,
+                            config.app_buffer_size,
+                            config.lib_buffer_size,
+                            config.enable_crc32c,
+                            config.enable_md5,
+                            api_,
+                            timer.elapsed_time(),
+                            timer.cpu_time(),
+                            reader.status().code()};
+  }
+
+ private:
+  google::cloud::storage::Client client_;
+  ApiName api_;
+};
+}  // namespace
+
+std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
+    ThroughputOptions const& options,
+    google::cloud::storage::ClientOptions const& client_options) {
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto contents = MakeRandomData(generator, options.maximum_write_size);
+  gcs::Client rest_client(client_options);
+
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  gcs::Client grpc_client =
+      google::cloud::storage_experimental::DefaultGrpcClient(client_options);
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+
+  std::vector<std::unique_ptr<ThroughputExperiment>> result;
+  for (auto a : options.enabled_apis) {
+    switch (a) {
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+      case ApiName::kApiGrpc:
+        result.push_back(
+            absl::make_unique<UploadObject>(grpc_client, a, contents, false));
+        result.push_back(
+            absl::make_unique<UploadObject>(grpc_client, a, contents, true));
+        break;
+#else
+      case ApiName::kApiGrpc:
+        break;
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+      case ApiName::kApiXml:
+      case ApiName::kApiJson:
+        result.push_back(
+            absl::make_unique<UploadObject>(rest_client, a, contents, false));
+        result.push_back(
+            absl::make_unique<UploadObject>(rest_client, a, contents, true));
+        break;
+    }
+  }
+  return result;
+}
+
+std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
+    ThroughputOptions const& options,
+    google::cloud::storage::ClientOptions const& client_options) {
+  gcs::Client rest_client(client_options);
+
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  gcs::Client grpc_client =
+      google::cloud::storage_experimental::DefaultGrpcClient(client_options);
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+
+  std::vector<std::unique_ptr<ThroughputExperiment>> result;
+  for (auto a : options.enabled_apis) {
+    switch (a) {
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+      case ApiName::kApiGrpc:
+        result.push_back(absl::make_unique<DownloadObject>(grpc_client, a));
+        break;
+#else
+      case ApiName::kApiGrpc:
+        break;
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+      case ApiName::kApiXml:
+      case ApiName::kApiJson:
+        result.push_back(absl::make_unique<DownloadObject>(rest_client, a));
+        break;
+    }
+  }
+  return result;
+}
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -1,0 +1,74 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_EXPERIMENT_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_EXPERIMENT_H
+
+#include "google/cloud/storage/benchmarks/throughput_options.h"
+#include "google/cloud/storage/benchmarks/throughput_result.h"
+#include <memory>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_benchmarks {
+
+struct ThroughputExperimentConfig {
+  OpType op;
+  std::int64_t object_size;
+  std::int64_t app_buffer_size;
+  std::uint64_t lib_buffer_size;
+  bool enable_crc32c;
+  bool enable_md5;
+};
+
+/**
+ * Run a single experiment in a throughput benchmark.
+ *
+ * Throughput benchmarks typically repeat the same "experiment" multiple times,
+ * sometimes choosing at random which experiment to run, and which parameters to
+ * use. An experiment might be "upload an object using XML" or "download an
+ * an object using raw libcurl calls".
+ */
+class ThroughputExperiment {
+ public:
+  virtual ~ThroughputExperiment() = default;
+
+  virtual ThroughputResult Run(std::string const& bucket_name,
+                               std::string const& object_name,
+                               ThroughputExperimentConfig const& config) = 0;
+};
+
+/**
+ * Create the list of upload experiments based on the @p options.
+ */
+std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
+    ThroughputOptions const& options,
+    google::cloud::storage::ClientOptions const& client_options);
+
+/**
+ * Create the list of download experiments based on the @p options.
+ *
+ * Some benchmarks need to distinguish upload vs. download experiments because
+ * they depend on the upload experiment to create the objects to be downloaded.
+ */
+std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
+    ThroughputOptions const& options,
+    google::cloud::storage::ClientOptions const& client_options);
+
+}  // namespace storage_benchmarks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_EXPERIMENT_H


### PR DESCRIPTION
Refactor the code to upload and/or download objects to classes. This
will make these experiments reusable in other benchmarks, and will also
allow us to add new experiments, such as "download using raw gRPC
calls".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4357)
<!-- Reviewable:end -->
