### PR TITLE
ci: enable su to root in docker containers

### DIFF
--- a/ci/kokoro/docker/Dockerfile.centos
+++ b/ci/kokoro/docker/Dockerfile.centos
@@ -23,6 +23,13 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN yum makecache && \
     yum install -y automake ccache cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar unzip wget which zlib-devel
+
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \
     ln -sf /usr/bin/ctest3 /usr/bin/ctest
 

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -22,6 +22,12 @@ RUN dnf makecache && \
         make openssl-devel pkgconfig python3 python3-devel python3-pip tar \
         unzip wget which zlib-devel
 
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
 # Install the Python modules needed to run the storage testbench
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -26,6 +26,12 @@ RUN dnf makecache && \
         make ninja-build openssl-devel pkgconfig protobuf-compiler python3 python3-pip \
         ShellCheck tar unzip w3m wget which zlib-devel
 
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
 # Install the the buildifier tool, which does not compile with the default
 # golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
 RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier

--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -22,6 +22,12 @@ RUN dnf makecache && \
         llvm-devel make ninja-build openssl-devel python3-lit tar unzip which \
         wget xz
 
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
 WORKDIR /var/tmp/build
 RUN wget -q http://releases.llvm.org/8.0.0/libcxx-8.0.0.src.tar.xz
 RUN tar -xf libcxx-8.0.0.src.tar.xz

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -50,6 +50,12 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
+# Sets root's password to the empty string to enable users to get a root shell
+# inside the container with `su -` and no password. Sudo would not work because
+# we run these containers as the invoking user's uid, which does not exist in
+# the container's /etc/passwd file.
+RUN echo 'root:' | chpasswd
+
 # Install the the buildifier tool, which does not compile with the default
 # golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
 RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/4272

The reason for this PR is that often when we're debugging an issue it
may be easiest to reproduce in the docker container, and to debug it, we
may need to install some debugging tools. We need root access in order
to install this software, and this change gives us that ability. For
example:

```sh
bash-4.2$ su -
Password:
[root@b54ad8707594 ~]#
```

Note that I did not use sudo because sudo requires the invoking user's
UID to appear in /etc/passwd, but since we run our container with
effectively `--user=$(id -u):$(id -g)`, the UID does not appear in the
container's /etc/passwd file and so sudo doesn't work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4358)
<!-- Reviewable:end -->
