### PR TITLE
Revert "fix: don't preserve symlinks in 7z archive"

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -81,6 +81,8 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
         $extract_flags=@(
             # Preserve full path
             "-spf",
+            # Preserve symbolic links
+            "-snl",
             # Preserve hard links
             "-snh",
             # Overwrite all items
@@ -209,6 +211,8 @@ if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     $archive_flags=@(
         # Preserve hard links
         "-snh",
+        # Preserve soft links
+        "-snl",
         # Preserve full path
         "-spf",
         # Exclude directories named "install"

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -82,6 +82,8 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
         $extract_flags=@(
             # Preserve full path
             "-spf",
+            # Preserve symbolic links
+            "-snl",
             # Preserve hard links
             "-snh",
             # Overwrite all items
@@ -185,6 +187,8 @@ if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     $archive_flags=@(
         # Preserve hard links
         "-snh",
+        # Preserve soft links
+        "-snl",
         # Preserve full path
         "-spf",
         # Exclude directories named "install"


### PR DESCRIPTION
Reverts googleapis/google-cloud-cpp#4355

This breaks the non-presubmit windows/bazel builds.
https://source.cloud.google.com/results/invocations/6cc3d1b6-3c2e-46ad-bc8a-6f183a577c82/targets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4361)
<!-- Reviewable:end -->
