### PR TITLE
ci(spanner): auto cleanup old databases

### DIFF
--- a/google/cloud/internal/format_time_point.cc
+++ b/google/cloud/internal/format_time_point.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/format_time_point.h"
 #include <array>
 #include <cstdio>
+#include <ctime>
 
 namespace {
 std::string FormatFractional(std::chrono::nanoseconds ns) {

--- a/google/cloud/internal/format_time_point.cc
+++ b/google/cloud/internal/format_time_point.cc
@@ -13,13 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/internal/format_time_point.h"
-#include "google/cloud/internal/throw_delegate.h"
 #include <array>
-#include <cctype>
 #include <cstdio>
-#include <iomanip>
-#include <iostream>
-#include <sstream>
 
 namespace {
 std::string FormatFractional(std::chrono::nanoseconds ns) {
@@ -59,6 +54,13 @@ std::string FormatFractional(std::chrono::nanoseconds ns) {
   return buffer.data();
 }
 
+}  // namespace
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
 std::tm AsUtcTm(std::chrono::system_clock::time_point tp) {
   std::time_t time = std::chrono::system_clock::to_time_t(tp);
   std::tm tm{};
@@ -71,12 +73,6 @@ std::tm AsUtcTm(std::chrono::system_clock::time_point tp) {
 #endif  // _WIN32
   return tm;
 }
-}  // namespace
-
-namespace google {
-namespace cloud {
-inline namespace GOOGLE_CLOUD_CPP_NS {
-namespace internal {
 
 auto constexpr kTimestampFormatSize = 256;
 static_assert(kTimestampFormatSize > ((4 + 1)    // YYYY-

--- a/google/cloud/internal/format_time_point.h
+++ b/google/cloud/internal/format_time_point.h
@@ -48,6 +48,9 @@ std::string FormatV4SignedUrlTimestamp(
 /// Format a time point to use in the scope of a V4 signed url.
 std::string FormatV4SignedUrlScope(std::chrono::system_clock::time_point tp);
 
+/// Return the `tm` struct for @p tp using UTC as the timezone.
+std::tm AsUtcTm(std::chrono::system_clock::time_point tp);
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include <regex>
 
 namespace google {
 namespace cloud {
@@ -43,6 +44,29 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
 
   std::cout << "Creating database and table " << std::flush;
   spanner::DatabaseAdminClient admin_client;
+
+  // Drop any databases more than 2 days old. This automatically cleans up
+  // any databases created by a previous build that may have crashed before
+  // having a chance to cleanup.
+  auto const expired = RandomDatabasePrefix(std::chrono::system_clock::now() -
+                                            std::chrono::hours(48));
+  std::regex re(RandomDatabasePrefixRegex());
+  for (auto const& db : admin_client.ListDatabases(
+           spanner::Instance(project_id, *instance_id))) {
+    if (!db) break;
+    // Extract the database ID from the database full name.
+    auto pos = db->name().find_last_of('/');
+    if (pos == std::string::npos) continue;
+    auto id = db->name().substr(pos);
+    // Skip databases that do not look like a randomly created DB.
+    if (!std::regex_match(id, re)) continue;
+    // Skip databases that are relatively recent
+    if (id > expired) continue;
+    // Drop the database and ignore errors.
+    (void)admin_client.DropDatabase(
+        spanner::Database(project_id, *instance_id, id));
+  }
+
   auto database_future =
       admin_client.CreateDatabase(*db_, {R"sql(CREATE TABLE Singers (
                                 SingerId   INT64 NOT NULL,

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/format_time_point.h"
+#include <ctime>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -22,7 +22,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 std::string RandomDatabasePrefixRegex() {
-  return R"re("^db-\d{4}-\d{2}-\d{2})re";
+  return R"re("^db-\d{4}-\d{2}-\d{2}-)re";
 }
 
 std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -13,17 +13,30 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/internal/format_time_point.h"
 
 namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
+
+std::string RandomDatabasePrefixRegex() {
+  return R"re("^db-\d{4}-\d{2}-\d{2})re";
+}
+
+std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {
+  auto tm = google::cloud::internal::AsUtcTm(tp);
+  std::string date = "1970-01-01";
+  std::strftime(&date[0], date.size() + 1, "%Y-%m-%d", &tm);
+  return "db-" + date + "-";
+}
+
 std::string RandomDatabaseName(
     google::cloud::internal::DefaultPRNG& generator) {
   // A database ID must be between 2 and 30 characters, fitting the regular
   // expression `[a-z][a-z0-9_\-]*[a-z0-9]`
   std::size_t const max_size = 30;
-  std::string const prefix = "db-";
+  auto const prefix = RandomDatabasePrefix(std::chrono::system_clock::now());
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(

--- a/google/cloud/spanner/testing/random_database_name.h
+++ b/google/cloud/spanner/testing/random_database_name.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/random.h"
+#include <chrono>
 #include <string>
 
 namespace google {
@@ -26,6 +27,13 @@ inline namespace SPANNER_CLIENT_NS {
 
 /// Create a random database name given a PRNG generator.
 std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator);
+
+/// Return a regular expression (as a string) suitable to match the random
+/// database IDs
+std::string RandomDatabasePrefixRegex();
+
+// The prefix for databases created on the (UTC) day at @p tp.
+std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_testing

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/random_instance_name.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <chrono>
 #include <ctime>
 
@@ -28,17 +29,8 @@ std::string RandomInstanceName(
   // An instance ID must be between 2 and 64 characters, fitting the regular
   // expression `[a-z][-a-z0-9]*[a-z0-9]`
   std::size_t const max_size = 64;
-  auto now = std::chrono::system_clock::now();
-  auto time_t = std::chrono::system_clock::to_time_t(now);
-  std::string date = "1973-03-01";
-  // The standard C++ function to convert time_t to a struct tm is not thread
-  // safe (it holds global storage), use some OS specific stuff here:
-  std::tm tm{};
-#if _WIN32
-  gmtime_s(&tm, &time_t);
-#else
-  gmtime_r(&time_t, &tm);
-#endif  // _WIN32
+  auto tm = google::cloud::internal::AsUtcTm(std::chrono::system_clock::now());
+  std::string date = "1970-01-01";
   std::strftime(&date[0], date.size() + 1, "%Y-%m-%d", &tm);
   std::string prefix = "temporary-instance-" + date + "-";
   auto size = static_cast<int>(max_size - 1 - prefix.size());


### PR DESCRIPTION
Our CI builds create randomly named databases (for isolation). Normally
these are cleaned up by the tests that create them, from time to time
these may crash or get interrupted and the cleanup does not happen. From
now on the instances are prefixed by the date (in `db-YYYY-MM-DD`
format). Any database with an ID matching that format and older than 48
hours is automatically removed.

This is part of the work for #4070 and fixes #4033 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4364)
<!-- Reviewable:end -->
