### PR TITLE
ci(macos): less flaky bigtable examples

### DIFF
--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -33,11 +33,10 @@ void AsyncApply(google::cloud::bigtable::Table table,
         std::chrono::system_clock::now().time_since_epoch());
 
     cbt::SingleRowMutation mutation(row_key);
-    mutation.emplace_back(cbt::SetCell("fam", "some-column", "some-value"));
     mutation.emplace_back(
-        cbt::SetCell("fam", "another-column", "another-value"));
-    mutation.emplace_back(cbt::SetCell("fam", "even-more-columns", timestamp,
-                                       "with-explicit-timestamp"));
+        cbt::SetCell("fam", "column0", timestamp, "value for column0"));
+    mutation.emplace_back(
+        cbt::SetCell("fam", "column1", timestamp, "value for column1"));
 
     future<google::cloud::Status> status_future =
         table.AsyncApply(std::move(mutation), cq);
@@ -335,7 +334,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::bigtable::CreateDefaultDataClient(
           admin.project(), admin.instance_id(),
           google::cloud::bigtable::ClientOptions()),
-      table_id);
+      table_id, cbt::AlwaysRetryMutationPolicy());
 
   google::cloud::CompletionQueue cq;
   std::thread th([&cq] { cq.Run(); });


### PR DESCRIPTION
The default for the Cloud Bigtable library is to only retry idempotent
operations. On the macOS builds we are getting a lot of transient errors,
and with the default policy these result in broken builds.

I changed the default policy in the examples, taking care to not make
this part of any example showing how to initialize the library.

I also changed some examples to use safer (idempotent) mutations, because
we should show how to use the service correctly.

Part of the work for #4119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4369)
<!-- Reviewable:end -->
