### PR TITLE
ci(spanner): auto drop databases for realsies

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -211,6 +211,8 @@ function (spanner_client_define_tests)
 
     add_library(
         spanner_client_testing # cmake-format: sort
+        testing/cleanup_stale_databases.cc
+        testing/cleanup_stale_databases.h
         testing/cleanup_stale_instances.cc
         testing/cleanup_stale_instances.h
         testing/compiler_supports_regexp.h
@@ -304,6 +306,7 @@ function (spanner_client_define_tests)
         session_pool_options_test.cc
         spanner_version_test.cc
         sql_statement_test.cc
+        testing/cleanup_stale_databases_test.cc
         testing/random_database_name_test.cc
         timestamp_test.cc
         transaction_test.cc

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -304,6 +304,7 @@ function (spanner_client_define_tests)
         session_pool_options_test.cc
         spanner_version_test.cc
         sql_statement_test.cc
+        testing/random_database_name_test.cc
         timestamp_test.cc
         transaction_test.cc
         update_instance_request_builder_test.cc

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for spanner_client_testing - DO NOT EDIT."""
 
 spanner_client_testing_hdrs = [
+    "testing/cleanup_stale_databases.h",
     "testing/cleanup_stale_instances.h",
     "testing/compiler_supports_regexp.h",
     "testing/database_integration_test.h",
@@ -36,6 +37,7 @@ spanner_client_testing_hdrs = [
 ]
 
 spanner_client_testing_srcs = [
+    "testing/cleanup_stale_databases.cc",
     "testing/cleanup_stale_instances.cc",
     "testing/database_integration_test.cc",
     "testing/pick_instance_config.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -68,6 +68,7 @@ spanner_client_unit_tests = [
     "session_pool_options_test.cc",
     "spanner_version_test.cc",
     "sql_statement_test.cc",
+    "testing/cleanup_stale_databases_test.cc",
     "testing/random_database_name_test.cc",
     "timestamp_test.cc",
     "transaction_test.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -68,6 +68,7 @@ spanner_client_unit_tests = [
     "session_pool_options_test.cc",
     "spanner_version_test.cc",
     "sql_statement_test.cc",
+    "testing/random_database_name_test.cc",
     "timestamp_test.cc",
     "transaction_test.cc",
     "update_instance_request_builder_test.cc",

--- a/google/cloud/spanner/testing/cleanup_stale_databases.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/testing/cleanup_stale_databases.h"
 #include "google/cloud/spanner/testing/compiler_supports_regexp.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
+#include <iostream>
 #include <regex>
 
 namespace google {

--- a/google/cloud/spanner/testing/cleanup_stale_databases.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/cleanup_stale_databases.h"
+#include "google/cloud/spanner/testing/compiler_supports_regexp.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include <regex>
 
@@ -25,6 +26,8 @@ Status CleanupStaleDatabases(
     google::cloud::spanner::DatabaseAdminClient admin_client,
     std::string const& project_id, std::string const& instance_id,
     std::chrono::system_clock::time_point tp) {
+  if (!CompilerSupportsRegexp()) return Status(StatusCode::kUnimplemented, "");
+
   // Drop any databases more than 2 days old. This automatically cleans up
   // any databases created by a previous build that may have crashed before
   // having a chance to cleanup.

--- a/google/cloud/spanner/testing/cleanup_stale_databases.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.cc
@@ -1,0 +1,55 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/cleanup_stale_databases.h"
+#include "google/cloud/spanner/testing/random_database_name.h"
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+Status CleanupStaleDatabases(
+    google::cloud::spanner::DatabaseAdminClient admin_client,
+    std::string const& project_id, std::string const& instance_id,
+    std::chrono::system_clock::time_point tp) {
+  // Drop any databases more than 2 days old. This automatically cleans up
+  // any databases created by a previous build that may have crashed before
+  // having a chance to cleanup.
+  auto const expired = RandomDatabasePrefix(tp);
+  std::regex re(RandomDatabasePrefixRegex());
+  for (auto const& db :
+       admin_client.ListDatabases(spanner::Instance(project_id, instance_id))) {
+    if (!db) return std::move(db).status();
+    // Extract the database ID from the database full name.
+    auto pos = db->name().find_last_of('/');
+    if (pos == std::string::npos) continue;
+    auto id = db->name().substr(pos + 1);
+    // Skip databases that do not look like a randomly created DB.
+    if (!std::regex_match(id, re)) continue;
+    // Skip databases that are relatively recent
+    if (id > expired) continue;
+    // Drop the database and ignore errors.
+    (void)admin_client.DropDatabase(
+        spanner::Database(project_id, instance_id, id));
+    std::cout << "Dropped DB " << db->name() << "\n";
+  }
+  return {};
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/cleanup_stale_databases.h
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H
 
 #include "google/cloud/spanner/database_admin_client.h"
+#include <chrono>
 #include <string>
 
 namespace google {

--- a/google/cloud/spanner/testing/cleanup_stale_databases.h
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.h
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H
+
+#include "google/cloud/spanner/database_admin_client.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+Status CleanupStaleDatabases(
+    google::cloud::spanner::DatabaseAdminClient admin_client,
+    std::string const& project_id, std::string const& instance_id,
+    std::chrono::system_clock::time_point tp);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H

--- a/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
@@ -1,0 +1,162 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/cleanup_stale_databases.h"
+#include "google/cloud/spanner/mocks/mock_database_admin_connection.h"
+#include "google/cloud/spanner/testing/compiler_supports_regexp.h"
+#include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
+using ::testing::_;
+using ::testing::UnorderedElementsAreArray;
+namespace gcsa = ::google::spanner::admin::database::v1;
+namespace spanner = ::google::cloud::spanner;
+
+TEST(CleanupStaleDatabases, Empty) {
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+  spanner::Instance const expected_instance("test-project", "test-instance");
+  EXPECT_CALL(*mock, ListDatabases(_))
+      .WillOnce(
+          [&expected_instance](
+              spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
+            EXPECT_EQ(expected_instance, p.instance);
+
+            return google::cloud::spanner::ListDatabaseRange(
+                gcsa::ListDatabasesRequest{},
+                [](gcsa::ListDatabasesRequest const&) {
+                  gcsa::ListDatabasesResponse response;
+                  return StatusOr<gcsa::ListDatabasesResponse>(response);
+                },
+                [](gcsa::ListDatabasesResponse const&) {
+                  return std::vector<gcsa::Database>{};
+                });
+          });
+
+  spanner::DatabaseAdminClient client(mock);
+  auto status = CleanupStaleDatabases(client, "test-project", "test-instance",
+                                      std::chrono::system_clock::now());
+  EXPECT_STATUS_OK(status);
+}
+
+TEST(CleanupStaleDatabases, ListError) {
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+  spanner::Instance const expected_instance("test-project", "test-instance");
+  EXPECT_CALL(*mock, ListDatabases(_))
+      .WillOnce(
+          [&expected_instance](
+              spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
+            EXPECT_EQ(expected_instance, p.instance);
+
+            return google::cloud::spanner::ListDatabaseRange(
+                gcsa::ListDatabasesRequest{},
+                [](gcsa::ListDatabasesRequest const&) {
+                  return StatusOr<gcsa::ListDatabasesResponse>(
+                      Status(StatusCode::kPermissionDenied, "uh-oh"));
+                },
+                [](gcsa::ListDatabasesResponse const&) {
+                  return std::vector<gcsa::Database>{};
+                });
+          });
+
+  spanner::DatabaseAdminClient client(mock);
+  auto status = CleanupStaleDatabases(client, "test-project", "test-instance",
+                                      std::chrono::system_clock::now());
+  EXPECT_EQ(status, Status(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
+TEST(CleanupStaleDatabases, RemovesMatching) {
+  if (!CompilerSupportsRegexp()) GTEST_SKIP();
+
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const now = std::chrono::system_clock::now();
+  auto const day = std::chrono::hours(24);
+  std::vector<std::string> expect_dropped{
+      RandomDatabaseName(generator, now - 5 * day),
+      RandomDatabaseName(generator, now - 3 * day),
+      RandomDatabaseName(generator, now - 3 * day),
+      RandomDatabaseName(generator, now - 3 * day),
+  };
+  std::vector<std::string> expect_not_dropped{
+      RandomDatabaseName(generator, now - 1 * day),
+      RandomDatabaseName(generator, now - 1 * day),
+      RandomDatabaseName(generator, now),
+      RandomDatabaseName(generator, now),
+      "db-not-matching-regex",
+      "not-matching-prefix",
+  };
+
+  spanner::Instance const expected_instance("test-project", "test-instance");
+  EXPECT_CALL(*mock, ListDatabases(_))
+      .WillOnce(
+          [&](spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
+            EXPECT_EQ(expected_instance, p.instance);
+
+            return google::cloud::spanner::ListDatabaseRange(
+                gcsa::ListDatabasesRequest{},
+                [&](gcsa::ListDatabasesRequest const&) {
+                  gcsa::ListDatabasesResponse response;
+                  for (auto const& id : expect_dropped) {
+                    gcsa::Database db;
+                    db.set_name(
+                        spanner::Database(expected_instance, id).FullName());
+                    *response.add_databases() = std::move(db);
+                  }
+                  for (auto const& id : expect_not_dropped) {
+                    gcsa::Database db;
+                    db.set_name(
+                        spanner::Database(expected_instance, id).FullName());
+                    *response.add_databases() = std::move(db);
+                  }
+                  return StatusOr<gcsa::ListDatabasesResponse>(response);
+                },
+                [](gcsa::ListDatabasesResponse const& r) {
+                  return std::vector<gcsa::Database>{r.databases().begin(),
+                                                     r.databases().end()};
+                });
+          });
+
+  std::vector<std::string> dropped;
+  EXPECT_CALL(*mock, DropDatabase(_))
+      .WillRepeatedly(
+          [&](spanner::DatabaseAdminConnection::DropDatabaseParams const& p) {
+            EXPECT_EQ(p.database.instance(), expected_instance);
+            dropped.push_back(p.database.database_id());
+            // Errors should be ignored and the loop should continue.
+            return Status{StatusCode::kPermissionDenied, "uh-oh"};
+          });
+
+  spanner::DatabaseAdminClient client(mock);
+  auto status = CleanupStaleDatabases(client, "test-project", "test-instance",
+                                      now - 2 * day);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(expect_dropped,
+              UnorderedElementsAreArray(dropped.begin(), dropped.end()));
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
@@ -33,6 +33,8 @@ namespace gcsa = ::google::spanner::admin::database::v1;
 namespace spanner = ::google::cloud::spanner;
 
 TEST(CleanupStaleDatabases, Empty) {
+  if (!CompilerSupportsRegexp()) GTEST_SKIP();
+
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   spanner::Instance const expected_instance("test-project", "test-instance");
   EXPECT_CALL(*mock, ListDatabases(_))
@@ -59,6 +61,8 @@ TEST(CleanupStaleDatabases, Empty) {
 }
 
 TEST(CleanupStaleDatabases, ListError) {
+  if (!CompilerSupportsRegexp()) GTEST_SKIP();
+
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   spanner::Instance const expected_instance("test-project", "test-instance");
   EXPECT_CALL(*mock, ListDatabases(_))
@@ -88,8 +92,7 @@ TEST(CleanupStaleDatabases, RemovesMatching) {
   if (!CompilerSupportsRegexp()) GTEST_SKIP();
 
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
-
-  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto generator = google::cloud::internal::DefaultPRNG({});
   auto const now = std::chrono::system_clock::now();
   auto const day = std::chrono::hours(24);
   std::vector<std::string> expect_dropped{

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -14,11 +14,11 @@
 
 #include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/testing/cleanup_stale_databases.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include <regex>
 
 namespace google {
 namespace cloud {
@@ -43,29 +43,9 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
   db_ = new spanner::Database(project_id, *instance_id, database_id);
 
   spanner::DatabaseAdminClient admin_client;
-
-  // Drop any databases more than 2 days old. This automatically cleans up
-  // any databases created by a previous build that may have crashed before
-  // having a chance to cleanup.
-  auto const expired = RandomDatabasePrefix(std::chrono::system_clock::now() -
-                                            std::chrono::hours(48));
-  std::regex re(RandomDatabasePrefixRegex());
-  for (auto const& db : admin_client.ListDatabases(
-           spanner::Instance(project_id, *instance_id))) {
-    if (!db) break;
-    // Extract the database ID from the database full name.
-    auto pos = db->name().find_last_of('/');
-    if (pos == std::string::npos) continue;
-    auto id = db->name().substr(pos + 1);
-    // Skip databases that do not look like a randomly created DB.
-    if (!std::regex_match(id, re)) continue;
-    // Skip databases that are relatively recent
-    if (id > expired) continue;
-    // Drop the database and ignore errors.
-    (void)admin_client.DropDatabase(
-        spanner::Database(project_id, *instance_id, id));
-    std::cout << "Dropped DB " << db->name() << "\n";
-  }
+  CleanupStaleDatabases(
+      admin_client, project_id, *instance_id,
+      std::chrono::system_clock::now() - std::chrono::hours(48));
 
   std::cout << "Creating database and table " << std::flush;
   auto database_future =

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -42,7 +42,6 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
 
   db_ = new spanner::Database(project_id, *instance_id, database_id);
 
-  std::cout << "Creating database and table " << std::flush;
   spanner::DatabaseAdminClient admin_client;
 
   // Drop any databases more than 2 days old. This automatically cleans up
@@ -57,7 +56,7 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
     // Extract the database ID from the database full name.
     auto pos = db->name().find_last_of('/');
     if (pos == std::string::npos) continue;
-    auto id = db->name().substr(pos);
+    auto id = db->name().substr(pos + 1);
     // Skip databases that do not look like a randomly created DB.
     if (!std::regex_match(id, re)) continue;
     // Skip databases that are relatively recent
@@ -65,8 +64,10 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
     // Drop the database and ignore errors.
     (void)admin_client.DropDatabase(
         spanner::Database(project_id, *instance_id, id));
+    std::cout << "Dropped DB " << db->name() << "\n";
   }
 
+  std::cout << "Creating database and table " << std::flush;
   auto database_future =
       admin_client.CreateDatabase(*db_, {R"sql(CREATE TABLE Singers (
                                 SingerId   INT64 NOT NULL,

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -32,12 +32,12 @@ std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {
   return "db-" + date + "-";
 }
 
-std::string RandomDatabaseName(
-    google::cloud::internal::DefaultPRNG& generator) {
+std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator,
+                               std::chrono::system_clock::time_point tp) {
   // A database ID must be between 2 and 30 characters, fitting the regular
   // expression `[a-z][a-z0-9_\-]*[a-z0-9]`
   std::size_t const max_size = 30;
-  auto const prefix = RandomDatabasePrefix(std::chrono::system_clock::now());
+  auto const prefix = RandomDatabasePrefix(tp);
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -22,7 +22,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 std::string RandomDatabasePrefixRegex() {
-  return R"re("^db-\d{4}-\d{2}-\d{2}-)re";
+  return R"re(^db-\d{4}-\d{2}-\d{2}-.*$)re";
 }
 
 std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {

--- a/google/cloud/spanner/testing/random_database_name.h
+++ b/google/cloud/spanner/testing/random_database_name.h
@@ -26,7 +26,9 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 /// Create a random database name given a PRNG generator.
-std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator);
+std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator,
+                               std::chrono::system_clock::time_point tp =
+                                   std::chrono::system_clock::now());
 
 /// Return a regular expression (as a string) suitable to match the random
 /// database IDs

--- a/google/cloud/spanner/testing/random_database_name_test.cc
+++ b/google/cloud/spanner/testing/random_database_name_test.cc
@@ -1,0 +1,45 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/internal/random.h"
+#include <gmock/gmock.h>
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+TEST(RandomDatabaseNameTest, PrefixMatchesRegexp) {
+  auto const prefix = RandomDatabasePrefix(std::chrono::system_clock::now());
+  auto const re = RandomDatabasePrefixRegex();
+
+  EXPECT_TRUE(std::regex_match(prefix, std::regex(re)));
+}
+
+TEST(RandomDatabaseNameTest, NameMatchesRegexp) {
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const name = RandomDatabaseName(generator);
+  auto const re = RandomDatabasePrefixRegex();
+
+  EXPECT_TRUE(std::regex_match(name, std::regex(re)));
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/random_database_name_test.cc
+++ b/google/cloud/spanner/testing/random_database_name_test.cc
@@ -24,6 +24,8 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
+using ::testing::StartsWith;
+
 TEST(RandomDatabaseNameTest, PrefixMatchesRegexp) {
   if (!CompilerSupportsRegexp()) GTEST_SKIP();
   auto const prefix = RandomDatabasePrefix(std::chrono::system_clock::now());
@@ -39,6 +41,15 @@ TEST(RandomDatabaseNameTest, NameMatchesRegexp) {
   auto const re = RandomDatabasePrefixRegex();
 
   EXPECT_TRUE(std::regex_match(name, std::regex(re)));
+}
+
+TEST(RandomDatabaseNameTest, RandomNameHasPrefix) {
+  if (!CompilerSupportsRegexp()) GTEST_SKIP();
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto const now = std::chrono::system_clock::now();
+  auto const prefix = RandomDatabasePrefix(now);
+  auto const name = RandomDatabaseName(generator, now);
+  EXPECT_THAT(name, StartsWith(prefix));
 }
 
 }  // namespace

--- a/google/cloud/spanner/testing/random_database_name_test.cc
+++ b/google/cloud/spanner/testing/random_database_name_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/spanner/testing/compiler_supports_regexp.h"
 #include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
 #include <regex>
@@ -24,6 +25,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 TEST(RandomDatabaseNameTest, PrefixMatchesRegexp) {
+  if (!CompilerSupportsRegexp()) GTEST_SKIP();
   auto const prefix = RandomDatabasePrefix(std::chrono::system_clock::now());
   auto const re = RandomDatabasePrefixRegex();
 
@@ -31,6 +33,7 @@ TEST(RandomDatabaseNameTest, PrefixMatchesRegexp) {
 }
 
 TEST(RandomDatabaseNameTest, NameMatchesRegexp) {
+  if (!CompilerSupportsRegexp()) GTEST_SKIP();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const name = RandomDatabaseName(generator);
   auto const re = RandomDatabasePrefixRegex();


### PR DESCRIPTION
This is mildly embarrassing. C++ regular expressions must match the full
string, and I forgot to skip the '/' when splitting the last component
in the database name.

This fixes #4070 and really fixes #4033

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4371)
<!-- Reviewable:end -->
