### PR TITLE
fix: docker build on ubuntu

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -50,12 +50,6 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
-# Sets root's password to the empty string to enable users to get a root shell
-# inside the container with `su -` and no password. Sudo would not work because
-# we run these containers as the invoking user's uid, which does not exist in
-# the container's /etc/passwd file.
-RUN echo 'root:' | chpasswd
-
 # Install the the buildifier tool, which does not compile with the default
 # golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
 RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier


### PR DESCRIPTION
On Ubuntu chpasswd fails if the password is the empty string. So we
can't use that trick to enable passwordless `su` on Ubuntu. We should be
able to also make this change by tweaking `/etc/pam.d/su-l`, and this
works on all distros that I tested, including Ubuntu 19+, but it fails
on Ubuntu 18 and 16. So I'm not sure how to enable passwordless `su` on
these Ubuntu distros.

Fixes the issue that @mr-salty mentioned in https://github.com/googleapis/google-cloud-cpp/commit/80b9f3fa6415aed4e75909945a37d2538c3cdd15#commitcomment-39798302

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4380)
<!-- Reviewable:end -->
