### PR TITLE
fix: deflake test that was hitting a 500ms timeout

### DIFF
--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -236,12 +236,12 @@ TEST_F(ErrorInjectionIntegrationTest, InjectErrorOnStreamingWrite) {
 }
 
 TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
-  int const kInjectedErrors = 10;
+  int const k_injected_errors = 10;
   auto opts = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(opts);
   // Make it at least the maximum curl buffer size (which is 512KiB)
   opts->SetDownloadBufferSize(512 * 1024);
-  Client client(*opts, LimitedErrorCountRetryPolicy(kInjectedErrors),
+  Client client(*opts, LimitedErrorCountRetryPolicy(k_injected_errors),
                 ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   auto object_name = MakeRandomObjectName();
@@ -263,11 +263,11 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
   is.read(read_buf.data(), read_buf.size());
   SymbolInterceptor::Instance().StartFailingRecv(
       SymbolInterceptor::Instance().LastSeenRecvDescriptor(), ECONNRESET,
-      kInjectedErrors);
+      k_injected_errors);
   is.read(read_buf.data(), read_buf.size());
   ASSERT_TRUE(is.status().ok());
   is.Close();
-  EXPECT_EQ(SymbolInterceptor::Instance().StopFailingRecv(), kInjectedErrors);
+  EXPECT_EQ(SymbolInterceptor::Instance().StopFailingRecv(), k_injected_errors);
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -236,12 +236,12 @@ TEST_F(ErrorInjectionIntegrationTest, InjectErrorOnStreamingWrite) {
 }
 
 TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
-  int const k_injected_errors = 10;
+  auto constexpr kInjectedErrors = 10;
   auto opts = ClientOptions::CreateDefaultClientOptions();
   ASSERT_STATUS_OK(opts);
   // Make it at least the maximum curl buffer size (which is 512KiB)
   opts->SetDownloadBufferSize(512 * 1024);
-  Client client(*opts, LimitedErrorCountRetryPolicy(k_injected_errors),
+  Client client(*opts, LimitedErrorCountRetryPolicy(kInjectedErrors),
                 ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   auto object_name = MakeRandomObjectName();
@@ -263,11 +263,11 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
   is.read(read_buf.data(), read_buf.size());
   SymbolInterceptor::Instance().StartFailingRecv(
       SymbolInterceptor::Instance().LastSeenRecvDescriptor(), ECONNRESET,
-      k_injected_errors);
+      kInjectedErrors);
   is.read(read_buf.data(), read_buf.size());
   ASSERT_TRUE(is.status().ok());
   is.Close();
-  EXPECT_EQ(SymbolInterceptor::Instance().StopFailingRecv(), k_injected_errors);
+  EXPECT_EQ(SymbolInterceptor::Instance().StopFailingRecv(), kInjectedErrors);
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);


### PR DESCRIPTION
Change `ErrorInjectionIntegrationTest.InjectRecvErrorOnRead` to use a
`LimitedErrorCountRetryPolicy`.  The 500ms `LimitedTimeRetryPolicy`
used previously could be hit if the `CurlDownloadRequest::Read()` call
was delayed sufficiently in `CurlDownloadRequest::WaitForHandles()`.

Now we also expect that we see all the injected errors before the final
success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4390)
<!-- Reviewable:end -->
