### PR TITLE
cleanup: prefer ASSERT_STATUS_OK(v) over ASSERT_TRUE(v.ok())

### DIFF
--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/query_partition.h"
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/testing/matchers.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -108,7 +109,7 @@ TEST(QueryPartitionTest, SerializeDeserialize) {
   StatusOr<QueryPartition> partition = DeserializeQueryPartition(
       *(SerializeQueryPartition(expected_partition.Partition())));
 
-  ASSERT_TRUE(partition.ok());
+  ASSERT_STATUS_OK(partition);
   QueryPartitionTester actual_partition = QueryPartitionTester(*partition);
   EXPECT_EQ(expected_partition.PartitionToken(),
             actual_partition.PartitionToken());

--- a/google/cloud/spanner/read_partition_test.cc
+++ b/google/cloud/spanner/read_partition_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/read_partition.h"
 #include "google/cloud/spanner/testing/matchers.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -125,7 +126,7 @@ TEST(ReadPartitionTest, SerializeDeserialize) {
   StatusOr<ReadPartition> partition = DeserializeReadPartition(
       *(SerializeReadPartition(expected_partition.Partition())));
 
-  ASSERT_TRUE(partition.ok());
+  ASSERT_STATUS_OK(partition);
   ReadPartitionTester actual_partition = ReadPartitionTester(*partition);
   EXPECT_EQ(expected_partition.PartitionToken(),
             actual_partition.PartitionToken());

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/spanner/testing/matchers.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -57,7 +58,7 @@ TEST(SqlStatementTest, GetParameterExists) {
                                     {"first", Value("Elwood")}};
   SqlStatement stmt("select * from foo", params);
   auto results = stmt.GetParameter("first");
-  ASSERT_TRUE(results.ok());
+  ASSERT_STATUS_OK(results);
   EXPECT_EQ(expected, *results);
   EXPECT_EQ(std::string("Elwood"), *(results->get<std::string>()));
 }

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -265,7 +265,7 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
       SymbolInterceptor::Instance().LastSeenRecvDescriptor(), ECONNRESET,
       kInjectedErrors);
   is.read(read_buf.data(), read_buf.size());
-  ASSERT_TRUE(is.status().ok());
+  ASSERT_STATUS_OK(is.status());
   is.Close();
   EXPECT_EQ(SymbolInterceptor::Instance().StopFailingRecv(), kInjectedErrors);
 


### PR DESCRIPTION
The former will emit the failing `Status`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4392)
<!-- Reviewable:end -->
