### PR TITLE
feat(storage): noncurrent time OLM

### DIFF
--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -99,6 +99,15 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
       result.condition_.num_newer_versions.emplace(
           internal::ParseIntField(condition, "numNewerVersions"));
     }
+    if (condition.count("daysSinceNoncurrentTime") != 0) {
+      result.condition_.days_since_noncurrent_time.emplace(
+          internal::ParseIntField(condition, "daysSinceNoncurrentTime"));
+    }
+    if (condition.count("noncurrentTimeBefore") != 0) {
+      result.condition_.noncurrent_time_before.emplace(
+          google::cloud::internal::ParseRfc3339(
+              condition.value("noncurrentTimeBefore", "")));
+    }
   }
   return result;
 }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/lifecycle_rule.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <algorithm>
 #include <iostream>
 
@@ -70,8 +71,8 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
     sep = ", ";
   }
   if (rhs.created_before.has_value()) {
-    os << sep
-       << "created_before=" << rhs.created_before->time_since_epoch().count();
+    os << sep << "created_before="
+       << google::cloud::internal::FormatRfc3339(*rhs.created_before);
     sep = ", ";
   }
   if (rhs.is_live.has_value()) {
@@ -92,6 +93,17 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
   }
   if (rhs.num_newer_versions.has_value()) {
     os << sep << "num_newer_versions=" << *rhs.num_newer_versions;
+    sep = ", ";
+  }
+  if (rhs.days_since_noncurrent_time.has_value()) {
+    os << sep
+       << "days_since_noncurrent_time=" << *rhs.days_since_noncurrent_time;
+    sep = ", ";
+  }
+  if (rhs.noncurrent_time_before.has_value()) {
+    os << sep << "noncurrent_time_before="
+       << google::cloud::internal::FormatRfc3339(*rhs.noncurrent_time_before);
+    sep = ", ";
   }
   return os << "}";
 }
@@ -150,6 +162,22 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
     } else {
       auto tmp = *rhs.num_newer_versions;
       result.num_newer_versions.emplace(std::forward<std::int32_t>(tmp));
+    }
+  }
+  if (rhs.days_since_noncurrent_time.has_value()) {
+    if (result.days_since_noncurrent_time.has_value()) {
+      *result.days_since_noncurrent_time = (std::max)(
+          *result.days_since_noncurrent_time, *rhs.days_since_noncurrent_time);
+    } else {
+      result.days_since_noncurrent_time = *rhs.days_since_noncurrent_time;
+    }
+  }
+  if (rhs.noncurrent_time_before.has_value()) {
+    if (result.noncurrent_time_before.has_value()) {
+      *result.noncurrent_time_before = (std::min)(
+          *result.noncurrent_time_before, *rhs.noncurrent_time_before);
+    } else {
+      result.noncurrent_time_before = *rhs.noncurrent_time_before;
     }
   }
 }


### PR DESCRIPTION
Support "noncurrent time" attributes in the Object Lifecycle Management
conditions.

Part of the work for #4275

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4395)
<!-- Reviewable:end -->
