### PR TITLE
fix(storage): handle 408 errors as retryable

### DIFF
--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -76,6 +76,11 @@ Status AsStatus(HttpResponse const& http_response) {
   if (http_response.status_code == HttpStatusCode::kMethodNotAllowed) {
     return Status(StatusCode::kPermissionDenied, http_response.payload);
   }
+  if (http_response.status_code == HttpStatusCode::kRequestTimeout) {
+    // GCS uses a 408 to signal that an upload has suffered a broken
+    // connection, and that the client should retry.
+    return Status(StatusCode::kUnavailable, http_response.payload);
+  }
   if (http_response.status_code == HttpStatusCode::kConflict) {
     return Status(StatusCode::kAborted, http_response.payload);
   }

--- a/google/cloud/storage/internal/http_response.h
+++ b/google/cloud/storage/internal/http_response.h
@@ -53,6 +53,7 @@ enum HttpStatusCode {
   kForbidden = 403,
   kNotFound = 404,
   kMethodNotAllowed = 405,
+  kRequestTimeout = 408,
   kConflict = 409,
   kGone = 410,
   kLengthRequired = 411,

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -61,6 +61,8 @@ TEST(HttpResponseTest, AsStatus) {
             AsStatus(HttpResponse{404, "not found", {}}).code());
   EXPECT_EQ(StatusCode::kPermissionDenied,
             AsStatus(HttpResponse{405, "method not allowed", {}}).code());
+  EXPECT_EQ(StatusCode::kUnavailable,
+            AsStatus(HttpResponse{408, "request timeout", {}}).code());
   EXPECT_EQ(StatusCode::kAborted,
             AsStatus(HttpResponse{409, "conflict", {}}).code());
   EXPECT_EQ(StatusCode::kNotFound,


### PR DESCRIPTION
as per https://cloud.google.com/storage/docs/resumable-uploads#practices.

Fixes #4396.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4397)
<!-- Reviewable:end -->
