### PR TITLE
ci: add configuration for Bazel CI system

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,25 @@
+---
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+tasks:
+  ubuntu1804:
+    platform: ubuntu1804
+    build_targets:
+      - "//google/cloud/..."
+    test_flags:
+      - "--test_tag_filters=-integration-test"
+    test_targets:
+      - "//google/cloud/..."


### PR DESCRIPTION
Eventually we would want new versions of Bazel to be tested against our
code before going out, though naturally the Bazel folks would only look
at our builds as a signal once they are sufficiently stable.

Fixes #3898 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4398)
<!-- Reviewable:end -->
