### PR TITLE
fix: eliminate data race between storage "service account" tests

### DIFF
--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -101,34 +101,30 @@ void ListHmacKeysWithServiceAccount(google::cloud::storage::Client client,
 
 std::string CreateHmacKey(google::cloud::storage::Client client,
                           std::vector<std::string> const& argv) {
-  std::string created_id;
   //! [create hmac key] [START storage_create_hmac_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string const& service_account_email,
-     std::string& access_id) {
+  return [](gcs::Client client, std::string const& service_account_email) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> key_info =
         client.CreateHmacKey(service_account_email);
     if (!key_info) throw std::runtime_error(key_info.status().message());
 
-    access_id = key_info->first.access_id();
     std::cout << "The base64 encoded secret is: " << key_info->second
               << "\nDo not miss that secret, there is no API to recover it."
               << "\nThe HMAC key metadata is: " << key_info->first << "\n";
+    return key_info->first.access_id();
   }
   //! [create hmac key] [END storage_create_hmac_key]
-  (std::move(client), argv.at(0), created_id);
-  return created_id;
+  (std::move(client), argv.at(0));
 }
 
 std::string CreateHmacKeyForProject(google::cloud::storage::Client client,
                                     std::vector<std::string> const& argv) {
-  std::string created_id;
   //! [create hmac key project]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string const& project_id,
-     std::string const& service_account_email, std::string& access_id) {
+  return [](gcs::Client client, std::string const& project_id,
+            std::string const& service_account_email) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> hmac_key_details =
         client.CreateHmacKey(service_account_email,
                              gcs::OverrideDefaultProject(project_id));
@@ -136,15 +132,14 @@ std::string CreateHmacKeyForProject(google::cloud::storage::Client client,
       throw std::runtime_error(hmac_key_details.status().message());
     }
 
-    access_id = hmac_key_details->first.access_id();
     std::cout << "The base64 encoded secret is: " << hmac_key_details->second
               << "\nDo not miss that secret, there is no API to recover it."
               << "\nThe HMAC key metadata is: " << hmac_key_details->first
               << "\n";
+    return hmac_key_details->first.access_id();
   }
   //! [create hmac key project]
-  (std::move(client), argv.at(0), argv.at(1), created_id);
-  return created_id;
+  (std::move(client), argv.at(0), argv.at(1));
 }
 
 void DeleteHmacKey(google::cloud::storage::Client client,

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -99,45 +99,52 @@ void ListHmacKeysWithServiceAccount(google::cloud::storage::Client client,
   (std::move(client), argv.at(0));
 }
 
-void CreateHmacKey(google::cloud::storage::Client client,
-                   std::vector<std::string> const& argv) {
+std::string CreateHmacKey(google::cloud::storage::Client client,
+                          std::vector<std::string> const& argv) {
+  std::string created_id;
   //! [create hmac key] [START storage_create_hmac_key]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
-  [](gcs::Client client, std::string const& service_account_email) {
+  [](gcs::Client client, std::string const& service_account_email,
+     std::string& access_id) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> key_info =
         client.CreateHmacKey(service_account_email);
     if (!key_info) throw std::runtime_error(key_info.status().message());
 
+    access_id = key_info->first.access_id();
     std::cout << "The base64 encoded secret is: " << key_info->second
               << "\nDo not miss that secret, there is no API to recover it."
               << "\nThe HMAC key metadata is: " << key_info->first << "\n";
   }
   //! [create hmac key] [END storage_create_hmac_key]
-  (std::move(client), argv.at(0));
+  (std::move(client), argv.at(0), created_id);
+  return created_id;
 }
 
-void CreateHmacKeyForProject(google::cloud::storage::Client client,
-                             std::vector<std::string> const& argv) {
+std::string CreateHmacKeyForProject(google::cloud::storage::Client client,
+                                    std::vector<std::string> const& argv) {
+  std::string created_id;
   //! [create hmac key project]
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& project_id,
-     std::string const& service_account_email) {
+     std::string const& service_account_email, std::string& access_id) {
     StatusOr<std::pair<gcs::HmacKeyMetadata, std::string>> hmac_key_details =
         client.CreateHmacKey(service_account_email,
                              gcs::OverrideDefaultProject(project_id));
-
     if (!hmac_key_details) {
       throw std::runtime_error(hmac_key_details.status().message());
     }
+
+    access_id = hmac_key_details->first.access_id();
     std::cout << "The base64 encoded secret is: " << hmac_key_details->second
               << "\nDo not miss that secret, there is no API to recover it."
               << "\nThe HMAC key metadata is: " << hmac_key_details->first
               << "\n";
   }
   //! [create hmac key project]
-  (std::move(client), argv.at(0), argv.at(1));
+  (std::move(client), argv.at(0), argv.at(1), created_id);
+  return created_id;
 }
 
 void DeleteHmacKey(google::cloud::storage::Client client,
@@ -267,10 +274,11 @@ void RunAll(std::vector<std::string> const& argv) {
           .value();
 
   std::cout << "\nRunning CreateHmacKey() example" << std::endl;
-  CreateHmacKey(client, {service_account});
+  auto const hmac_access_id = CreateHmacKey(client, {service_account});
 
   std::cout << "\nRunning CreateHmacKeyForProject() example" << std::endl;
-  CreateHmacKeyForProject(client, {project_id, service_account});
+  auto const project_hmac_access_id =
+      CreateHmacKeyForProject(client, {project_id, service_account});
 
   std::cout << "\nRunning ListHmacKeys() example [2]" << std::endl;
   ListHmacKeys(client, {});
@@ -294,13 +302,11 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning DeleteHmacKey() example" << std::endl;
   DeleteHmacKey(client, {key_info.first.access_id()});
 
-  for (auto const& key :
-       client.ListHmacKeys(gcs::ServiceAccountFilter(service_account))) {
-    if (!key) break;
-    (void)client.UpdateHmacKey(key->access_id(),
+  for (auto const& access_id : {project_hmac_access_id, hmac_access_id}) {
+    (void)client.UpdateHmacKey(access_id,
                                gcs::HmacKeyMetadata().set_state(
                                    gcs::HmacKeyMetadata::state_inactive()));
-    (void)client.DeleteHmacKey(key->access_id());
+    (void)client.DeleteHmacKey(access_id);
   }
 }
 


### PR DESCRIPTION
`storage_service_account_samples` should only delete the HMAC keys
that it creates, rather than everything for the service account,
otherwise it can interfere with other tests running in parallel,
notably `service_account_integration_test`.

We could also try to delete old keys, but it isn't worth it since
these tests are only run against the testbench emulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4403)
<!-- Reviewable:end -->
