### PR TITLE
fix: empty version in cmake package

### DIFF
--- a/google/cloud/pubsub/config-version.cmake.in
+++ b/google/cloud/pubsub/config-version.cmake.in
@@ -16,7 +16,7 @@ set(PACKAGE_VERSION @DOXYGEN_PROJECT_NUMBER@)
 
 # This package has not reached 1.0, there are no compatibility guarantees
 # before then.
-if (@GOOGLE_CLOUD_CPP_CLIENT_VERSION@ EQUAL 0)
+if (@GOOGLE_CLOUD_CPP_VERSION@ EQUAL 0)
     if ("${PACKAGE_FIND_VERSION}" STREQUAL "")
         set(PACKAGE_VERSION_COMPATIBLE TRUE)
     elseif ("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")


### PR DESCRIPTION
GOOGLE_CLOUD_CPP_CLIENT_VERSION is not defined so it's replaced by an empty string and version config is invalid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4411)
<!-- Reviewable:end -->
