### PR TITLE
feat: add xsan build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -66,6 +66,10 @@ build:msan --linkopt=-stdlib=libc++
 build:msan --linkopt=-lc++
 build:msan --linkopt=-lc++abi
 
+# --config xsan: Run several sanitizers that are safe to run together.
+build:xsan --config=asan
+build:xsan --config=ubsan
+
 # --config libcxx: Compile and link using libc++.
 build:libcxx --cxxopt=-stdlib=libc++
 build:libcxx --linkopt=-stdlib=libc++

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -143,6 +143,15 @@ elif [[ "${BUILD_NAME}" = "ubsan" ]]; then
   export DISTRO_VERSION=31
   export BAZEL_CONFIG="ubsan"
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
+elif [[ "${BUILD_NAME}" = "xsan" ]]; then
+  # Compile with several sanitizers that can be run together. See the top-level
+  # .bazelrc for details.
+  export CC=clang
+  export CXX=clang++
+  export DISTRO=fedora
+  export DISTRO_VERSION=31
+  export BAZEL_CONFIG="xsan"
+  in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="super"
   export BUILD_TYPE=Release


### PR DESCRIPTION
This build runs asan + ubsan, which are all safe to
run together. Once this build is enabled, we can delete the separate
asan and ubsan builds.

Related to https://github.com/googleapis/google-cloud-cpp/issues/4413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4414)
<!-- Reviewable:end -->
