### PR TITLE
chore: remove comment on the license statement

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -14,7 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-licenses(["notice"])  # Apache 2.0
+licenses(["notice"])
 
 exports_files([
     "LICENSE",


### PR DESCRIPTION
this is now disallowed when importing code to google.
given there's a full license statement a few lines above, this is
not adding much value so we might as well remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4424)
<!-- Reviewable:end -->
