### PR TITLE
test: do not wait on unsatisfied futures

### DIFF
--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -1168,7 +1168,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencySimple) {
   // AsyncCheckConsistency() -> consistent
   cq_impl->SimulateCompletion(true);
   future_status = result.wait_for(0_ms);
-  EXPECT_EQ(std::future_status::ready, future_status);
+  ASSERT_EQ(std::future_status::ready, future_status);
 
   // The future becomes ready on the first request that completes with a
   // permanent error.
@@ -1221,7 +1221,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencyFailure) {
   // The future becomes ready on the first request that completes with a
   // permanent error.
   future_status = result.wait_for(0_ms);
-  EXPECT_EQ(std::future_status::ready, future_status);
+  ASSERT_EQ(std::future_status::ready, future_status);
 
   auto consistent = result.get();
   EXPECT_FALSE(consistent.ok());

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/future_generic.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/expect_future_error.h"
+#include "google/cloud/testing_util/scoped_thread.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,6 +25,7 @@ namespace {
 using ::testing::HasSubstr;
 using testing_util::chrono_literals::operator"" _ms;
 using testing_util::ExpectFutureError;
+using testing_util::ScopedThread;
 
 /// @test Verify that destructing a promise does not introduce race conditions.
 TEST(FutureTestInt, DestroyInWaitingThread) {
@@ -436,7 +438,7 @@ TEST(FutureTestInt, conform_30_6_6_15) {
   std::promise<void> p_get_future_called;
   std::promise<void> f_get_called;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     future<int> f = p.get_future();
     p_get_future_called.set_value();
     f.get();
@@ -451,9 +453,7 @@ TEST(FutureTestInt, conform_30_6_6_15) {
   p.set_value(42);
   // now thread `t` can make progress.
   ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
   waiter.get();
-  t.join();
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
@@ -549,7 +549,7 @@ TEST(FutureTestInt, conform_30_6_6_20) {
   std::promise<void> thread_started;
   std::promise<void> f_wait_returned;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     thread_started.set_value();
     f.wait();
     f_wait_returned.set_value();
@@ -560,9 +560,7 @@ TEST(FutureTestInt, conform_30_6_6_20) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
-  t.join();
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
@@ -578,7 +576,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
   std::promise<void> thread_started;
   std::promise<void> f_wait_returned;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     thread_started.set_value();
     f.wait_for(500_ms);
     f_wait_returned.set_value();
@@ -589,9 +587,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
-  t.join();
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 }
 
 // Paragraph 30.6.6.22.1 refers to futures that hold a deferred function (like
@@ -640,7 +636,7 @@ TEST(FutureTestInt, conform_30_6_6_24) {
   std::promise<void> thread_started;
   std::promise<void> f_wait_returned;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     thread_started.set_value();
     f.wait_until(std::chrono::system_clock::now() + 500_ms);
     f_wait_returned.set_value();
@@ -651,9 +647,7 @@ TEST(FutureTestInt, conform_30_6_6_24) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
-  t.join();
+  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 }
 
 // Paragraph 30.6.6.25.1 refers to futures that hold a deferred function (like

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -450,7 +450,7 @@ TEST(FutureTestInt, conform_30_6_6_15) {
 
   p.set_value(42);
   // now thread `t` can make progress.
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
+  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   waiter.get();
   t.join();
@@ -560,7 +560,7 @@ TEST(FutureTestInt, conform_30_6_6_20) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
+  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -589,7 +589,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
+  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -607,7 +607,7 @@ TEST(FutureTestInt, conform_30_6_6_22_2) {
 
   p0.set_value(42);
   auto s = f0.wait_for(0_ms);
-  EXPECT_EQ(std::future_status::ready, s);
+  ASSERT_EQ(std::future_status::ready, s);
   EXPECT_EQ(42, f0.get());
 }
 
@@ -651,7 +651,7 @@ TEST(FutureTestInt, conform_30_6_6_24) {
   auto waiter = f_wait_returned.get_future();
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
+  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   t.join();
 }
@@ -669,7 +669,7 @@ TEST(FutureTestInt, conform_30_6_6_25_2) {
 
   p0.set_value(42);
   auto s = f0.wait_until(std::chrono::system_clock::now());
-  EXPECT_EQ(std::future_status::ready, s);
+  ASSERT_EQ(std::future_status::ready, s);
   ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
   EXPECT_EQ(42, f0.get());
 }

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -44,7 +44,7 @@ TEST(FutureTestInt, ThenSimple) {
   p.set_value(42);
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   EXPECT_EQ(84, next.get());
   EXPECT_FALSE(next.valid());
@@ -72,7 +72,7 @@ TEST(FutureTestInt, ThenException) {
   p.set_value(42);
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   EXPECT_THROW(
       try { next.get(); } catch (std::runtime_error const& ex) {
@@ -146,7 +146,7 @@ TEST(FutureTestInt, ThenMoveOnlyCallable) {
   p.set_value(42);
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   EXPECT_EQ(2 * 42, next.get());
   EXPECT_FALSE(next.valid());
@@ -170,7 +170,7 @@ TEST(FutureTestInt, ThenByCopy) {
   p.set_value(42);
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   EXPECT_EQ(2 * 42, next.get());
   EXPECT_FALSE(next.valid());
@@ -430,7 +430,7 @@ TEST(FutureTestInt, conform_2_3_8_d) {
   future<int> next = f.then([&](future<int> r) { return 2 * r.get(); });
   EXPECT_TRUE(next.valid());
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
   EXPECT_EQ(84, next.get());
 }
 
@@ -448,7 +448,7 @@ TEST(FutureTestInt, conform_2_3_8_e) {
   EXPECT_TRUE(next.valid());
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p.set_value(42);
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
   EXPECT_THROW(
       try { next.get(); } catch (std::runtime_error const& ex) {
         EXPECT_THAT(ex.what(), HasSubstr("test exception in functor"));
@@ -663,7 +663,7 @@ TEST(FutureTestString, conform_2_10_4_2_a) {
   // When T is a simple value type we get back T.
   future<std::string> f = make_ready_future(std::string("42"));
   EXPECT_TRUE(f.valid());
-  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, f.wait_for(0_ms));
   EXPECT_EQ("42", f.get());
 }
 
@@ -675,7 +675,7 @@ TEST(FutureTestString, conform_2_10_4_2_b) {
   std::string& sref = value;
   future<std::string> f = make_ready_future(sref);
   EXPECT_TRUE(f.valid());
-  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, f.wait_for(0_ms));
   EXPECT_EQ("42", f.get());
 }
 
@@ -692,7 +692,7 @@ TEST(FutureTestString, conform_2_10_4_2_c) {
   std::string value("42");
   future<std::string&> f = make_ready_future(std::ref(value));
   EXPECT_TRUE(f.valid());
-  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, f.wait_for(0_ms));
   EXPECT_EQ("42", f.get());
 #endif  // 1
 }

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -461,7 +461,7 @@ TEST(FutureTestVoid, conform_30_6_6_15) {
 
   p.set_value();
   // now thread `t` can make progress.
-  EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
+  ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   waiter.get();
   t.join();
@@ -618,7 +618,7 @@ TEST(FutureTestVoid, conform_30_6_6_22_2) {
 
   p0.set_value();
   auto s = f0.wait_for(0_ms);
-  EXPECT_EQ(std::future_status::ready, s);
+  ASSERT_EQ(std::future_status::ready, s);
   f0.get();
   SUCCEED();
 }
@@ -681,7 +681,7 @@ TEST(FutureTestVoid, conform_30_6_6_25_2) {
 
   p0.set_value();
   auto s = f0.wait_until(std::chrono::system_clock::now());
-  EXPECT_EQ(std::future_status::ready, s);
+  ASSERT_EQ(std::future_status::ready, s);
   ASSERT_EQ(std::future_status::ready, f0.wait_for(0_ms));
   f0.get();
   SUCCEED();

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/future_void.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/expect_future_error.h"
+#include "google/cloud/testing_util/scoped_thread.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,6 +25,7 @@ namespace {
 using ::testing::HasSubstr;
 using testing_util::chrono_literals::operator"" _ms;
 using testing_util::ExpectFutureError;
+using testing_util::ScopedThread;
 
 // Verify we are testing the types we think we should be testing.
 static_assert(std::is_same<future<void>, ::google::cloud::future<void>>::value,
@@ -447,7 +449,7 @@ TEST(FutureTestVoid, conform_30_6_6_15) {
   std::promise<void> p_get_future_called;
   std::promise<void> f_get_called;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     future<void> f = p.get_future();
     p_get_future_called.set_value();
     f.get();
@@ -464,7 +466,6 @@ TEST(FutureTestVoid, conform_30_6_6_15) {
   ASSERT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
 
   waiter.get();
-  t.join();
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
@@ -560,7 +561,7 @@ TEST(FutureTestVoid, conform_30_6_6_20) {
   std::promise<void> thread_started;
   std::promise<void> f_wait_returned;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     thread_started.set_value();
     f.wait();
     f_wait_returned.set_value();
@@ -572,8 +573,6 @@ TEST(FutureTestVoid, conform_30_6_6_20) {
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value();
   EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
-  t.join();
 }
 
 /// @test Verify conformance with section 30.6.6 of the C++14 spec.
@@ -589,7 +588,7 @@ TEST(FutureTestVoid, conform_30_6_6_21) {
   std::promise<void> thread_started;
   std::promise<void> f_wait_returned;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     thread_started.set_value();
     f.wait_for(500_ms);
     f_wait_returned.set_value();
@@ -601,8 +600,6 @@ TEST(FutureTestVoid, conform_30_6_6_21) {
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value();
   EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
-  t.join();
 }
 
 // Paragraph 30.6.6.22.1 refers to futures that hold a deferred function (like
@@ -652,7 +649,7 @@ TEST(FutureTestVoid, conform_30_6_6_24) {
   std::promise<void> thread_started;
   std::promise<void> f_wait_returned;
 
-  std::thread t([&] {
+  ScopedThread t([&] {
     thread_started.set_value();
     f.wait_until(std::chrono::system_clock::now() + 500_ms);
     f_wait_returned.set_value();
@@ -664,8 +661,6 @@ TEST(FutureTestVoid, conform_30_6_6_24) {
   EXPECT_EQ(std::future_status::timeout, waiter.wait_for(2_ms));
   p.set_value();
   EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
-
-  t.join();
 }
 
 // Paragraph 30.6.6.25.1 refers to futures that hold a deferred function (like
@@ -700,9 +695,9 @@ TEST(FutureTestVoid, conform_30_6_6_25_3) {
   ASSERT_NE(std::future_status::ready, f0.wait_for(0_ms));
 }
 
-// Paragraph 30.6.6.26 asserts that if the clock raises then wait_until() might
-// raise too. We do not need to test for that, exceptions are always propagated,
-// this is just giving implementors freedom.
+// Paragraph 30.6.6.26 asserts that if the clock raises then wait_until()
+// might raise too. We do not need to test for that, exceptions are always
+// propagated, this is just giving implementors freedom.
 
 /// @test Verify the behavior around cancellation.
 // NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -41,7 +41,7 @@ TEST(FutureTestVoid, ThenSimple) {
   p.set_value();
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   next.get();
   SUCCEED();
@@ -66,7 +66,7 @@ TEST(FutureTestVoid, ThenException) {
   p.set_value();
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   EXPECT_THROW(
       try { next.get(); } catch (std::runtime_error const& ex) {
@@ -137,7 +137,7 @@ TEST(FutureTestVoid, ThenMoveOnlyCallable) {
   p.set_value();
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   next.get();
   EXPECT_FALSE(next.valid());
@@ -158,7 +158,7 @@ TEST(FutureTestVoid, ThenByCopy) {
   p.set_value();
   EXPECT_TRUE(called);
   EXPECT_TRUE(next.valid());
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
 
   next.get();
   EXPECT_FALSE(next.valid());
@@ -417,7 +417,7 @@ TEST(FutureTestVoid, conform_2_3_8_d) {
   future<int> next = f.then([&](future<void>) -> int { return 42; });
   EXPECT_TRUE(next.valid());
   p.set_value();
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
   EXPECT_EQ(42, next.get());
 }
 
@@ -436,7 +436,7 @@ TEST(FutureTestVoid, conform_2_3_8_e) {
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
   p.set_value();
-  EXPECT_EQ(std::future_status::ready, next.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, next.wait_for(0_ms));
   EXPECT_THROW(
       try { next.get(); } catch (std::runtime_error const& ex) {
         EXPECT_THAT(ex.what(), HasSubstr("test exception in functor"));
@@ -652,7 +652,7 @@ TEST(FutureTestVoid, conform_2_3_11_c) {
 TEST(FutureTestVoid, conform_2_10_4) {
   future<void> f = make_ready_future();
   EXPECT_TRUE(f.valid());
-  EXPECT_EQ(std::future_status::ready, f.wait_for(0_ms));
+  ASSERT_EQ(std::future_status::ready, f.wait_for(0_ms));
   f.get();
   SUCCEED();
 }

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -126,7 +126,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
   impl->SimulateCompletion(true);
 
   EXPECT_TRUE(impl->empty());
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(0_us));
   auto result = fut.get();
   ASSERT_STATUS_OK(result);
   EXPECT_EQ("fake/table/name/response", result->name());
@@ -175,7 +175,7 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
   impl->SimulateCompletion(true);
 
   EXPECT_TRUE(impl->empty());
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(0_us));
   auto result = fut.get();
   ASSERT_STATUS_OK(result);
 }
@@ -223,7 +223,7 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
   impl->SimulateCompletion(true);
 
   EXPECT_TRUE(impl->empty());
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(0_us));
   auto result = fut.get();
   EXPECT_FALSE(result);
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
@@ -303,7 +303,7 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
   impl->SimulateCompletion(true);
   EXPECT_TRUE(impl->empty());
 
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(0_us));
   auto result = fut.get();
   EXPECT_FALSE(result);
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
@@ -355,7 +355,7 @@ TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
   impl->SimulateCompletion(true);
 
   EXPECT_TRUE(impl->empty());
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(0_us));
   auto result = fut.get();
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("non-idempotent"));

--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -62,7 +62,7 @@ TEST(CustomerSuppliedBackgroundThreads, SharesCompletionQueue) {
         return std::this_thread::get_id();
       });
   std::thread t([&cq] { cq.Run(); });
-  EXPECT_EQ(std::future_status::ready, id.wait_for(ms(500)));
+  ASSERT_EQ(std::future_status::ready, id.wait_for(ms(500)));
   EXPECT_EQ(t.get_id(), id.get());
 
   cq.Shutdown();

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -52,7 +52,7 @@ TEST(DatabaseAdminClientTest, CreateDatabase) {
 
   DatabaseAdminClient client(std::move(mock));
   auto fut = client.CreateDatabase(dbase, {"-- NOT SQL for test"});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_STATUS_OK(db);
 
@@ -121,7 +121,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabase) {
 
   DatabaseAdminClient client(std::move(mock));
   auto fut = client.UpdateDatabase(dbase, {"-- test only: NOT SQL"});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_STATUS_OK(db);
 
@@ -361,7 +361,7 @@ TEST(DatabaseAdminClientTest, CreateBackup) {
 
   DatabaseAdminClient client(std::move(mock));
   auto fut = client.CreateBackup(dbase, backup_id, expire_time);
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto backup = fut.get();
   EXPECT_STATUS_OK(backup);
 
@@ -388,7 +388,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabase) {
 
   DatabaseAdminClient client(std::move(mock));
   auto fut = client.RestoreDatabase(dbase, backup);
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto database = fut.get();
   EXPECT_STATUS_OK(database);
 
@@ -417,7 +417,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseOverload) {
 
   DatabaseAdminClient client(std::move(mock));
   auto fut = client.RestoreDatabase(dbase, backup);
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto database = fut.get();
   EXPECT_STATUS_OK(database);
 

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -74,7 +74,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseSuccess) {
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
   auto fut = conn->CreateDatabase({dbase, {}});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto db = fut.get();
   EXPECT_STATUS_OK(db);
 
@@ -95,7 +95,7 @@ TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
   auto fut = conn->CreateDatabase({dbase, {}});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
 }
@@ -234,7 +234,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabaseSuccess) {
   Database dbase("test-project", "test-instance", "test-db");
   auto fut = conn->UpdateDatabase(
       {dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"}});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto metadata = fut.get();
   EXPECT_STATUS_OK(metadata);
 
@@ -257,7 +257,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabaseErrorInPoll) {
   Database dbase("test-project", "test-instance", "test-db");
   auto fut = conn->UpdateDatabase(
       {dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"}});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
 }
@@ -434,7 +434,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseSuccess) {
   Database dbase("test-project", "test-instance", "test-db");
   Backup backup(Instance("test-project", "test-instance"), "test-backup");
   auto fut = conn->RestoreDatabase({dbase, backup.FullName()});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto db = fut.get();
   EXPECT_STATUS_OK(db);
 
@@ -456,7 +456,7 @@ TEST(DatabaseAdminClientTest, HandleRestoreDatabaseError) {
   Database dbase("test-project", "test-instance", "test-db");
   Backup backup(Instance("test-project", "test-instance"), "test-backup");
   auto fut = conn->RestoreDatabase({dbase, backup.FullName()});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
 }
@@ -689,7 +689,7 @@ TEST(DatabaseAdminClientTest, CreateBackupSuccess) {
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
   auto fut = conn->CreateBackup({dbase, "test-backup", {}});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto backup = fut.get();
   EXPECT_STATUS_OK(backup);
 
@@ -767,7 +767,7 @@ TEST(DatabaseAdminClientTest, HandleCreateBackupError) {
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
   auto fut = conn->CreateBackup({dbase, "test-backup", {}});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto backup = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, backup.status().code());
 }

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -149,7 +149,7 @@ TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
            .SetNodeCount(1)
            .SetLabels({{"key", "value"}})
            .Build()});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto instance = fut.get();
   EXPECT_STATUS_OK(instance);
 
@@ -173,7 +173,7 @@ TEST(InstanceAdminClientTest, CreateInstanceError) {
            .SetNodeCount(1)
            .SetLabels({{"key", "value"}})
            .Build()});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
 }
@@ -210,7 +210,7 @@ TEST(InstanceAdminClientTest, UpdateInstanceSuccess) {
   gcsa::UpdateInstanceRequest req;
   req.mutable_instance()->set_name(expected_name);
   auto fut = conn->UpdateInstance({req});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto instance = fut.get();
   EXPECT_STATUS_OK(instance);
 
@@ -228,7 +228,7 @@ TEST(InstanceAdminClientTest, UpdateInstancePermanentFailure) {
 
   auto conn = MakeLimitedRetryConnection(std::move(mock));
   auto fut = conn->UpdateInstance({gcsa::UpdateInstanceRequest()});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
 }
@@ -245,7 +245,7 @@ TEST(InstanceAdminClientTest, UpdateInstanceTooManyTransients) {
           });
   auto conn = MakeLimitedRetryConnection(std::move(mock));
   auto fut = conn->UpdateInstance({gcsa::UpdateInstanceRequest()});
-  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
   EXPECT_EQ(StatusCode::kUnavailable, instance.status().code());
 }

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -33,6 +33,7 @@ if (BUILD_TESTING)
         fake_source.h
         scoped_environment.cc
         scoped_environment.h
+        scoped_thread.h
         testing_types.cc
         testing_types.h)
     target_link_libraries(

--- a/google/cloud/testing_util/google_cloud_cpp_testing.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing.bzl
@@ -27,6 +27,7 @@ google_cloud_cpp_testing_hdrs = [
     "expect_future_error.h",
     "fake_source.h",
     "scoped_environment.h",
+    "scoped_thread.h",
     "testing_types.h",
 ]
 

--- a/google/cloud/testing_util/scoped_thread.h
+++ b/google/cloud/testing_util/scoped_thread.h
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_THREAD_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_THREAD_H
+
+#include <thread>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+/**
+ * A simple wrapper around std::thread that automatically joins the thread
+ * (if needed) on destruction.
+ */
+class ScopedThread {
+ public:
+  /// call the `std::thread()` constructor with the given `args`
+  template <class... Args>
+  explicit ScopedThread(Args&&... args)
+      : t_(std::forward<Args>(args)...) {}
+  ~ScopedThread() {
+    if (t_.joinable()) t_.join();
+  }
+
+  /// Access the owned `std::thread`
+  std::thread& get() { return t_; }
+
+ private:
+  std::thread t_;
+};
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_THREAD_H

--- a/google/cloud/testing_util/scoped_thread.h
+++ b/google/cloud/testing_util/scoped_thread.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_THREAD_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_THREAD_H
 
+#include "google/cloud/version.h"
 #include <thread>
 
 namespace google {
@@ -41,6 +42,7 @@ class ScopedThread {
  private:
   std::thread t_;
 };
+
 }  // namespace testing_util
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/testing_util/scoped_thread.h
+++ b/google/cloud/testing_util/scoped_thread.h
@@ -30,8 +30,7 @@ class ScopedThread {
  public:
   /// call the `std::thread()` constructor with the given `args`
   template <class... Args>
-  explicit ScopedThread(Args&&... args)
-      : t_(std::forward<Args>(args)...) {}
+  explicit ScopedThread(Args&&... args) : t_(std::forward<Args>(args)...) {}
   ~ScopedThread() {
     if (t_.joinable()) t_.join();
   }


### PR DESCRIPTION
when using this pattern:
```
EXPECT_EQ(std::future_status::ready, waiter.wait_for(500_ms));
waiter.get();
```

If `wait_for` times out, the subsequent `get()` may wait indefinitely,
until the test times out (which can take a long time, 25 minutes has
been observed).  Use `ASSERT_EQ` in these situations instead to make
the test fail immediately.

Part of #4425

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4426)
<!-- Reviewable:end -->
