### PR TITLE
fix: test with correct MockCompletionQueue

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/mock_completion_queue.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gmock/gmock.h>
@@ -27,13 +28,9 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 
-class MockCompletionQueue : public internal::CompletionQueueImpl {
- public:
-  using internal::CompletionQueueImpl::SimulateCompletion;
-};
-
 namespace btadmin = ::google::bigtable::admin::v2;
 namespace btproto = ::google::bigtable::v2;
+using ::google::cloud::testing_util::MockCompletionQueue;
 using ::testing::_;
 using ::testing::StrictMock;
 


### PR DESCRIPTION
Mocking a CompletionQueue is not as trivial as one might thing because
gRPC alarms are finicky. We have a good mock class, we needed to use it
in this test too.

Fixes #4423 

For the record, I ran the test 500,000 times without problems. Before this
change 10,000 times was enough to trigger the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4427)
<!-- Reviewable:end -->
