### PR TITLE
cleanup: remove unnecessary calls to testing::Invoke()

### DIFF
--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
@@ -116,11 +115,11 @@ TEST_F(BucketAccessControlsTest, ListBucketAcl) {
   EXPECT_CALL(*mock_, ListBucketAcl(_))
       .WillOnce(
           Return(StatusOr<internal::ListBucketAclResponse>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::ListBucketAclRequest const& r) {
+      .WillOnce([&expected](internal::ListBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
 
         return make_status_or(internal::ListBucketAclResponse{expected});
-      }));
+      });
 
   StatusOr<std::vector<BucketAccessControl>> actual =
       client_->ListBucketAcl("test-bucket");
@@ -156,13 +155,13 @@ TEST_F(BucketAccessControlsTest, CreateBucketAcl) {
 
   EXPECT_CALL(*mock_, CreateBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::CreateBucketAclRequest const& r) {
+      .WillOnce([&expected](internal::CreateBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("READER", r.role());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<BucketAccessControl> actual = client_->CreateBucketAcl(
       "test-bucket", "user-test-user-1", BucketAccessControl::ROLE_READER());
   ASSERT_STATUS_OK(actual);
@@ -205,12 +204,12 @@ TEST_F(BucketAccessControlsTest, CreateBucketAclPermanentFailure) {
 TEST_F(BucketAccessControlsTest, DeleteBucketAcl) {
   EXPECT_CALL(*mock_, DeleteBucketAcl(_))
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
-      .WillOnce(Invoke([](internal::DeleteBucketAclRequest const& r) {
+      .WillOnce([](internal::DeleteBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
         return make_status_or(internal::EmptyResponse{});
-      }));
+      });
   auto status = client_->DeleteBucketAcl("test-bucket", "user-test-user-1");
   ASSERT_STATUS_OK(status);
 }
@@ -248,12 +247,12 @@ TEST_F(BucketAccessControlsTest, GetBucketAcl) {
 
   EXPECT_CALL(*mock_, GetBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::GetBucketAclRequest const& r) {
+      .WillOnce([&expected](internal::GetBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<BucketAccessControl> actual =
       client_->GetBucketAcl("test-bucket", "user-test-user-1");
   ASSERT_STATUS_OK(actual);
@@ -292,13 +291,13 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAcl) {
 
   EXPECT_CALL(*mock_, UpdateBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::UpdateBucketAclRequest const& r) {
+      .WillOnce([&expected](internal::UpdateBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("OWNER", r.role());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<BucketAccessControl> actual = client_->UpdateBucketAcl(
       "test-bucket",
       BucketAccessControl().set_entity("user-test-user-1").set_role("OWNER"));
@@ -353,7 +352,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
 
   EXPECT_CALL(*mock_, PatchBucketAcl(_))
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
-      .WillOnce(Invoke([&result](internal::PatchBucketAclRequest const& r) {
+      .WillOnce([&result](internal::PatchBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         internal::nl::json expected{{"role", "OWNER"}};
@@ -361,7 +360,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
         EXPECT_EQ(expected, payload);
 
         return make_status_or(result);
-      }));
+      });
   StatusOr<BucketAccessControl> actual = client_->PatchBucketAcl(
       "test-bucket", "user-test-user-1",
       BucketAccessControlPatchBuilder().set_role("OWNER"));

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
@@ -78,12 +77,11 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
   EXPECT_CALL(*mock_, ListDefaultObjectAcl(_))
       .WillOnce(Return(
           StatusOr<internal::ListDefaultObjectAclResponse>(TransientError())))
-      .WillOnce(Invoke([&expected](
-                           internal::ListDefaultObjectAclRequest const& r) {
+      .WillOnce([&expected](internal::ListDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
 
         return make_status_or(internal::ListDefaultObjectAclResponse{expected});
-      }));
+      });
 
   StatusOr<std::vector<ObjectAccessControl>> actual =
       client_->ListDefaultObjectAcl("test-bucket");
@@ -119,14 +117,13 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
 
   EXPECT_CALL(*mock_, CreateDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(
-          Invoke([&expected](internal::CreateDefaultObjectAclRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
-            EXPECT_EQ("user-test-user-1", r.entity());
-            EXPECT_EQ("READER", r.role());
+      .WillOnce([&expected](internal::CreateDefaultObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_EQ("user-test-user-1", r.entity());
+        EXPECT_EQ("READER", r.role());
 
-            return make_status_or(expected);
-          }));
+        return make_status_or(expected);
+      });
   StatusOr<ObjectAccessControl> actual = client_->CreateDefaultObjectAcl(
       "test-bucket", "user-test-user-1", ObjectAccessControl::ROLE_READER());
   ASSERT_STATUS_OK(actual);
@@ -171,12 +168,12 @@ TEST_F(DefaultObjectAccessControlsTest,
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
   EXPECT_CALL(*mock_, DeleteDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
-      .WillOnce(Invoke([](internal::DeleteDefaultObjectAclRequest const& r) {
+      .WillOnce([](internal::DeleteDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("user-test-user", r.entity());
 
         return make_status_or(internal::EmptyResponse{});
-      }));
+      });
   auto status =
       client_->DeleteDefaultObjectAcl("test-bucket", "user-test-user");
   ASSERT_STATUS_OK(status);
@@ -218,13 +215,12 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
 
   EXPECT_CALL(*mock_, GetDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(
-          Invoke([&expected](internal::GetDefaultObjectAclRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
-            EXPECT_EQ("user-test-user-1", r.entity());
+      .WillOnce([&expected](internal::GetDefaultObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_EQ("user-test-user-1", r.entity());
 
-            return make_status_or(expected);
-          }));
+        return make_status_or(expected);
+      });
   StatusOr<ObjectAccessControl> actual =
       client_->GetDefaultObjectAcl("test-bucket", "user-test-user-1");
   ASSERT_STATUS_OK(actual);
@@ -263,14 +259,13 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
 
   EXPECT_CALL(*mock_, UpdateDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(
-          Invoke([&expected](internal::UpdateDefaultObjectAclRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
-            EXPECT_EQ("user-test-user-1", r.entity());
-            EXPECT_EQ("READER", r.role());
+      .WillOnce([&expected](internal::UpdateDefaultObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_EQ("user-test-user-1", r.entity());
+        EXPECT_EQ("READER", r.role());
 
-            return make_status_or(expected);
-          }));
+        return make_status_or(expected);
+      });
   StatusOr<ObjectAccessControl> actual = client_->UpdateDefaultObjectAcl(
       "test-bucket", ObjectAccessControl()
                          .set_entity("user-test-user-1")
@@ -322,16 +317,15 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
 
   EXPECT_CALL(*mock_, PatchDefaultObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(
-          Invoke([result](internal::PatchDefaultObjectAclRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
-            EXPECT_EQ("user-test-user-1", r.entity());
-            internal::nl::json expected{{"role", "OWNER"}};
-            auto payload = internal::nl::json::parse(r.payload());
-            EXPECT_EQ(expected, payload);
+      .WillOnce([result](internal::PatchDefaultObjectAclRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_EQ("user-test-user-1", r.entity());
+        internal::nl::json expected{{"role", "OWNER"}};
+        auto payload = internal::nl::json::parse(r.payload());
+        EXPECT_EQ(expected, payload);
 
-            return make_status_or(result);
-          }));
+        return make_status_or(result);
+      });
   auto actual = client_->PatchDefaultObjectAcl(
       "test-bucket", "user-test-user-1",
       ObjectAccessControlPatchBuilder().set_role("OWNER"));

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -32,7 +32,6 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
@@ -79,12 +78,11 @@ TEST_F(NotificationsTest, ListNotifications) {
   EXPECT_CALL(*mock_, ListNotifications(_))
       .WillOnce(Return(
           StatusOr<internal::ListNotificationsResponse>(TransientError())))
-      .WillOnce(Invoke([&expected](
-                           internal::ListNotificationsRequest const& r) {
+      .WillOnce([&expected](internal::ListNotificationsRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
 
         return make_status_or(internal::ListNotificationsResponse{expected});
-      }));
+      });
   StatusOr<std::vector<NotificationMetadata>> actual =
       client_->ListNotifications("test-bucket");
   ASSERT_STATUS_OK(actual);
@@ -122,16 +120,15 @@ TEST_F(NotificationsTest, CreateNotification) {
 
   EXPECT_CALL(*mock_, CreateNotification(_))
       .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
-      .WillOnce(
-          Invoke([&expected](internal::CreateNotificationRequest const& r) {
-            EXPECT_EQ("test-bucket", r.bucket_name());
-            EXPECT_THAT(r.json_payload(), HasSubstr("test-topic-1"));
-            EXPECT_THAT(r.json_payload(), HasSubstr("JSON_API_V1"));
-            EXPECT_THAT(r.json_payload(), HasSubstr("test-object-prefix-"));
-            EXPECT_THAT(r.json_payload(), HasSubstr("OBJECT_FINALIZE"));
+      .WillOnce([&expected](internal::CreateNotificationRequest const& r) {
+        EXPECT_EQ("test-bucket", r.bucket_name());
+        EXPECT_THAT(r.json_payload(), HasSubstr("test-topic-1"));
+        EXPECT_THAT(r.json_payload(), HasSubstr("JSON_API_V1"));
+        EXPECT_THAT(r.json_payload(), HasSubstr("test-object-prefix-"));
+        EXPECT_THAT(r.json_payload(), HasSubstr("OBJECT_FINALIZE"));
 
-            return make_status_or(expected);
-          }));
+        return make_status_or(expected);
+      });
   StatusOr<NotificationMetadata> actual = client_->CreateNotification(
       "test-bucket", "test-topic-1", payload_format::JsonApiV1(),
       NotificationMetadata()
@@ -180,12 +177,12 @@ TEST_F(NotificationsTest, GetNotification) {
 
   EXPECT_CALL(*mock_, GetNotification(_))
       .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::GetNotificationRequest const& r) {
+      .WillOnce([&expected](internal::GetNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<NotificationMetadata> actual =
       client_->GetNotification("test-bucket", "test-notification-1");
   ASSERT_STATUS_OK(actual);
@@ -215,12 +212,12 @@ TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
 TEST_F(NotificationsTest, DeleteNotification) {
   EXPECT_CALL(*mock_, DeleteNotification(_))
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
-      .WillOnce(Invoke([](internal::DeleteNotificationRequest const& r) {
+      .WillOnce([](internal::DeleteNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
         return make_status_or(internal::EmptyResponse{});
-      }));
+      });
   auto status =
       client_->DeleteNotification("test-bucket", "test-notification-1");
   ASSERT_STATUS_OK(status);

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -28,7 +28,6 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
@@ -79,12 +78,12 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
   EXPECT_CALL(*mock_, ListObjectAcl(_))
       .WillOnce(
           Return(StatusOr<internal::ListObjectAclResponse>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::ListObjectAclRequest const& r) {
+      .WillOnce([&expected](internal::ListObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
 
         return make_status_or(internal::ListObjectAclResponse{expected});
-      }));
+      });
   StatusOr<std::vector<ObjectAccessControl>> actual =
       client_->ListObjectAcl("test-bucket", "test-object");
   ASSERT_STATUS_OK(actual);
@@ -122,14 +121,14 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
 
   EXPECT_CALL(*mock_, CreateObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::CreateObjectAclRequest const& r) {
+      .WillOnce([&expected](internal::CreateObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());
         EXPECT_EQ("READER", r.role());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<ObjectAccessControl> actual =
       client_->CreateObjectAcl("test-bucket", "test-object", "user-test-user-1",
                                ObjectAccessControl::ROLE_READER());
@@ -175,13 +174,13 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAclPermanentFailure) {
 TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
   EXPECT_CALL(*mock_, DeleteObjectAcl(_))
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
-      .WillOnce(Invoke([](internal::DeleteObjectAclRequest const& r) {
+      .WillOnce([](internal::DeleteObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user", r.entity());
 
         return make_status_or(internal::EmptyResponse{});
-      }));
+      });
   client_->DeleteObjectAcl("test-bucket", "test-object", "user-test-user");
   SUCCEED();
 }
@@ -221,13 +220,13 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
 
   EXPECT_CALL(*mock_, GetObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::GetObjectAclRequest const& r) {
+      .WillOnce([&expected](internal::GetObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<ObjectAccessControl> actual =
       client_->GetObjectAcl("test-bucket", "test-object", "user-test-user-1");
   ASSERT_STATUS_OK(actual);
@@ -268,14 +267,14 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
                       .value();
   EXPECT_CALL(*mock_, UpdateObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(Invoke([expected](internal::UpdateObjectAclRequest const& r) {
+      .WillOnce([expected](internal::UpdateObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user", r.entity());
         EXPECT_EQ("OWNER", r.role());
 
         return make_status_or(expected);
-      }));
+      });
   ObjectAccessControl acl =
       ObjectAccessControl().set_role("OWNER").set_entity("user-test-user");
   auto actual = client_->UpdateObjectAcl("test-bucket", "test-object", acl);
@@ -323,7 +322,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
                     .value();
   EXPECT_CALL(*mock_, PatchObjectAcl(_))
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
-      .WillOnce(Invoke([result](internal::PatchObjectAclRequest const& r) {
+      .WillOnce([result](internal::PatchObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-object", r.object_name());
         EXPECT_EQ("user-test-user-1", r.entity());
@@ -332,7 +331,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
         EXPECT_EQ(expected, payload);
 
         return make_status_or(result);
-      }));
+      });
   auto actual = client_->PatchObjectAcl(
       "test-bucket", "test-object", "user-test-user-1",
       ObjectAccessControlPatchBuilder().set_role("OWNER"));

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
@@ -69,13 +68,13 @@ TEST_F(ObjectCopyTest, CopyObject) {
       storage::internal::ObjectMetadataParser::FromString(text).value();
 
   EXPECT_CALL(*mock_, CopyObject(_))
-      .WillOnce(Invoke([&expected](internal::CopyObjectRequest const& request) {
+      .WillOnce([&expected](internal::CopyObjectRequest const& request) {
         EXPECT_EQ("test-bucket-name", request.destination_bucket());
         EXPECT_EQ("test-object-name", request.destination_object());
         EXPECT_EQ("source-bucket-name", request.source_bucket());
         EXPECT_EQ("source-object-name", request.source_object());
         return make_status_or(expected);
-      }));
+      });
   StatusOr<ObjectMetadata> actual =
       client_->CopyObject("source-bucket-name", "source-object-name",
                           "test-bucket-name", "test-object-name");
@@ -142,7 +141,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
 
   EXPECT_CALL(*mock_, ComposeObject(_))
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::ComposeObjectRequest const& r) {
+      .WillOnce([&expected](internal::ComposeObjectRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
         EXPECT_EQ("test-object-name", r.object_name());
         internal::nl::json actual_payload =
@@ -152,7 +151,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
             {"sourceObjects", {{{"name", "object1"}}, {{"name", "object2"}}}}};
         EXPECT_EQ(expected_payload, actual_payload);
         return make_status_or(expected);
-      }));
+      });
   auto actual = client_->ComposeObject(
       "test-bucket-name", {{"object1", {}, {}}, {"object2", {}, {}}},
       "test-object-name");
@@ -197,7 +196,7 @@ TEST_F(ObjectCopyTest, RewriteObject) {
   EXPECT_CALL(*mock_, RewriteObject(_))
       .WillOnce(
           Return(StatusOr<internal::RewriteObjectResponse>(TransientError())))
-      .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
+      .WillOnce([](internal::RewriteObjectRequest const& r) {
         EXPECT_EQ("test-source-bucket-name", r.source_bucket());
         EXPECT_EQ("test-source-object-name", r.source_object());
         EXPECT_EQ("test-destination-bucket-name", r.destination_bucket());
@@ -212,8 +211,8 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             "rewriteToken": "abcd-test-token-0"
         })""";
         return internal::RewriteObjectResponse::FromHttpResponse(response);
-      }))
-      .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
+      })
+      .WillOnce([](internal::RewriteObjectRequest const& r) {
         EXPECT_EQ("test-source-bucket-name", r.source_bucket());
         EXPECT_EQ("test-source-object-name", r.source_object());
         EXPECT_EQ("test-destination-bucket-name", r.destination_bucket());
@@ -228,8 +227,8 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             "rewriteToken": "abcd-test-token-2"
         })""";
         return internal::RewriteObjectResponse::FromHttpResponse(response);
-      }))
-      .WillOnce(Invoke([](internal::RewriteObjectRequest const& r) {
+      })
+      .WillOnce([](internal::RewriteObjectRequest const& r) {
         EXPECT_EQ("test-source-bucket-name", r.source_bucket());
         EXPECT_EQ("test-source-object-name", r.source_object());
         EXPECT_EQ("test-destination-bucket-name", r.destination_bucket());
@@ -248,7 +247,7 @@ TEST_F(ObjectCopyTest, RewriteObject) {
             }
         })""";
         return internal::RewriteObjectResponse::FromHttpResponse(response);
-      }));
+      });
   auto copier = client_->RewriteObject(
       "test-source-bucket-name", "test-source-object-name",
       "test-destination-bucket-name", "test-destination-object-name",

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -30,7 +30,6 @@ namespace {
 using ::google::cloud::storage::oauth2::CreateAnonymousCredentials;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 using ms = std::chrono::milliseconds;
@@ -67,12 +66,12 @@ TEST_F(ServiceAccountTest, GetProjectServiceAccount) {
 
   EXPECT_CALL(*mock_, GetServiceAccount(_))
       .WillOnce(Return(StatusOr<ServiceAccount>(TransientError())))
-      .WillOnce(Invoke(
+      .WillOnce(
           [&expected](internal::GetProjectServiceAccountRequest const& r) {
             EXPECT_EQ("test-project", r.project_id());
 
             return make_status_or(expected);
-          }));
+          });
   StatusOr<ServiceAccount> actual =
       client_->GetServiceAccountForProject("test-project");
   ASSERT_STATUS_OK(actual);
@@ -106,12 +105,12 @@ TEST_F(ServiceAccountTest, CreateHmacKey) {
   EXPECT_CALL(*mock_, CreateHmacKey(_))
       .WillOnce(
           Return(StatusOr<internal::CreateHmacKeyResponse>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::CreateHmacKeyRequest const& r) {
+      .WillOnce([&expected](internal::CreateHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
         EXPECT_EQ("test-service-account", r.service_account());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<std::pair<HmacKeyMetadata, std::string>> actual =
       client_->CreateHmacKey("test-service-account",
                              OverrideDefaultProject("test-project"));
@@ -141,12 +140,12 @@ TEST_F(ServiceAccountTest, CreateHmacKeyPermanentFailure) {
 TEST_F(ServiceAccountTest, DeleteHmacKey) {
   EXPECT_CALL(*mock_, DeleteHmacKey(_))
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
-      .WillOnce(Invoke([](internal::DeleteHmacKeyRequest const& r) {
+      .WillOnce([](internal::DeleteHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
         EXPECT_EQ("test-access-id-1", r.access_id());
 
         return make_status_or(internal::EmptyResponse{});
-      }));
+      });
   Status actual = client_->DeleteHmacKey(
       "test-access-id-1", OverrideDefaultProject("test-project"));
   ASSERT_STATUS_OK(actual);
@@ -174,12 +173,12 @@ TEST_F(ServiceAccountTest, GetHmacKey) {
 
   EXPECT_CALL(*mock_, GetHmacKey(_))
       .WillOnce(Return(StatusOr<HmacKeyMetadata>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::GetHmacKeyRequest const& r) {
+      .WillOnce([&expected](internal::GetHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
         EXPECT_EQ("test-access-id-1", r.access_id());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<HmacKeyMetadata> actual = client_->GetHmacKey(
       "test-access-id-1", OverrideDefaultProject("test-project"));
   ASSERT_STATUS_OK(actual);
@@ -213,12 +212,12 @@ TEST_F(ServiceAccountTest, UpdateHmacKey) {
 
   EXPECT_CALL(*mock_, UpdateHmacKey(_))
       .WillOnce(Return(StatusOr<HmacKeyMetadata>(TransientError())))
-      .WillOnce(Invoke([&expected](internal::UpdateHmacKeyRequest const& r) {
+      .WillOnce([&expected](internal::UpdateHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
         EXPECT_EQ("test-access-id-1", r.access_id());
 
         return make_status_or(expected);
-      }));
+      });
   StatusOr<HmacKeyMetadata> actual = client_->UpdateHmacKey(
       "test-access-id-1", HmacKeyMetadata().set_state("ACTIVE"),
       OverrideDefaultProject("test-project"));

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -32,7 +32,6 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -157,11 +156,10 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignRemote) {
 
   EXPECT_CALL(*mock_, SignBlob(_))
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
-      .WillOnce(
-          Invoke([&expected_signed_blob](internal::SignBlobRequest const&) {
-            return make_status_or(internal::SignBlobResponse{
-                "test-key-id", expected_signed_blob});
-          }));
+      .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
+        return make_status_or(
+            internal::SignBlobResponse{"test-key-id", expected_signed_blob});
+      });
   auto actual =
       client_->CreateSignedPolicyDocument(CreatePolicyDocumentForTest());
   ASSERT_STATUS_OK(actual);

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -31,7 +31,6 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -120,11 +119,10 @@ TEST_F(CreateSignedUrlTest, V2SignRemote) {
 
   EXPECT_CALL(*mock_, SignBlob(_))
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
-      .WillOnce(
-          Invoke([&expected_signed_blob](internal::SignBlobRequest const&) {
-            return make_status_or(internal::SignBlobResponse{
-                "test-key-id", expected_signed_blob});
-          }));
+      .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
+        return make_status_or(
+            internal::SignBlobResponse{"test-key-id", expected_signed_blob});
+      });
   StatusOr<std::string> actual =
       client_->CreateV2SignedUrl("GET", "test-bucket", "test-object");
   ASSERT_STATUS_OK(actual);
@@ -270,11 +268,10 @@ TEST_F(CreateSignedUrlTest, V4SignRemote) {
 
   EXPECT_CALL(*mock_, SignBlob(_))
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
-      .WillOnce(
-          Invoke([&expected_signed_blob](internal::SignBlobRequest const&) {
-            return make_status_or(internal::SignBlobResponse{
-                "test-key-id", expected_signed_blob});
-          }));
+      .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
+        return make_status_or(
+            internal::SignBlobResponse{"test-key-id", expected_signed_blob});
+      });
   StatusOr<std::string> actual =
       client_->CreateV4SignedUrl("GET", "test-bucket", "test-object");
   ASSERT_STATUS_OK(actual);

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -26,7 +26,6 @@ namespace internal {
 namespace {
 
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 
 class MockGrpcUploadWriter : public GrpcClient::UploadWriter {
@@ -142,10 +141,10 @@ TEST(GrpcResumableUploadSessionTest, Reset) {
   ResumableUploadResponse const resume_response{
       {}, 2 * size - 1, {}, ResumableUploadResponse::kInProgress, {}};
   EXPECT_CALL(*mock, QueryResumableUpload(_))
-      .WillOnce(Invoke([&](QueryResumableUploadRequest const& request) {
+      .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ("test-upload-id", request.upload_session_url());
         return make_status_or(resume_response);
-      }));
+      });
 
   auto upload = session.UploadChunk(payload);
   EXPECT_EQ(size, session.next_expected_byte());

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -28,7 +28,6 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::_;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 
 class MockLogBackend : public google::cloud::LogBackend {
@@ -73,17 +72,17 @@ TEST_F(LoggingClientTest, GetBucketMetadata) {
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
   EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("GetBucketMetadataRequest={"));
         EXPECT_THAT(lr.message, HasSubstr("my-bucket"));
-      }))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      })
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" >> "));
         EXPECT_THAT(lr.message, HasSubstr("payload={"));
         EXPECT_THAT(lr.message, HasSubstr("US"));
         EXPECT_THAT(lr.message, HasSubstr("my-bucket"));
-      }));
+      });
 
   LoggingClient client(mock);
   client.GetBucketMetadata(GetBucketMetadataRequest("my-bucket"));
@@ -97,15 +96,15 @@ TEST_F(LoggingClientTest, GetBucketMetadataWithError) {
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
   EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("GetBucketMetadataRequest={"));
         EXPECT_THAT(lr.message, HasSubstr("my-bucket"));
-      }))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      })
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" >> "));
         EXPECT_THAT(lr.message, HasSubstr("status={"));
-      }));
+      });
 
   LoggingClient client(mock);
   client.GetBucketMetadata(GetBucketMetadataRequest("my-bucket"));
@@ -126,19 +125,19 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
   EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("InsertObjectMediaRequest={"));
         EXPECT_THAT(lr.message, HasSubstr("foo-bar"));
         EXPECT_THAT(lr.message, HasSubstr("baz"));
         EXPECT_THAT(lr.message, HasSubstr("the contents"));
-      }))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      })
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" >> "));
         EXPECT_THAT(lr.message, HasSubstr("payload={"));
         EXPECT_THAT(lr.message, HasSubstr("foo-bar"));
         EXPECT_THAT(lr.message, HasSubstr("baz"));
-      }));
+      });
 
   LoggingClient client(mock);
   client.InsertObjectMedia(
@@ -161,19 +160,19 @@ TEST_F(LoggingClientTest, ListObjects) {
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
   EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("ListObjectsRequest={"));
         EXPECT_THAT(lr.message, HasSubstr("my-bucket"));
-      }))
-      .WillOnce(Invoke([](LogRecord const& lr) {
+      })
+      .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" >> "));
         EXPECT_THAT(lr.message, HasSubstr("payload={"));
         EXPECT_THAT(lr.message, HasSubstr("ListObjectsResponse={"));
         EXPECT_THAT(lr.message, HasSubstr("a-token"));
         EXPECT_THAT(lr.message, HasSubstr("response-object-o1"));
         EXPECT_THAT(lr.message, HasSubstr("response-object-o2"));
-      }));
+      });
 
   LoggingClient client(mock);
   client.ListObjects(ListObjectsRequest("my-bucket"));

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 using ::google::cloud::testing_util::CaptureLogLinesBackend;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::ReturnRef;
 
 class LoggingResumableUploadSessionTest : public ::testing::Test {
@@ -61,11 +60,11 @@ TEST_F(LoggingResumableUploadSessionTest, UploadChunk) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
   std::string const payload = "test-payload-data";
-  EXPECT_CALL(*mock, UploadChunk(_)).WillOnce(Invoke([&](std::string const& p) {
+  EXPECT_CALL(*mock, UploadChunk(_)).WillOnce([&](std::string const& p) {
     EXPECT_EQ(payload, p);
     return StatusOr<ResumableUploadResponse>(
         AsStatus(HttpResponse{503, "uh oh", {}}));
-  }));
+  });
 
   LoggingResumableUploadSession session(std::move(mock));
 
@@ -81,12 +80,12 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
 
   std::string const payload = "test-payload-data";
   EXPECT_CALL(*mock, UploadFinalChunk(_, _))
-      .WillOnce(Invoke([&](std::string const& p, std::uint64_t s) {
+      .WillOnce([&](std::string const& p, std::uint64_t s) {
         EXPECT_EQ(payload, p);
         EXPECT_EQ(513 * 1024, s);
         return StatusOr<ResumableUploadResponse>(
             AsStatus(HttpResponse{503, "uh oh", {}}));
-      }));
+      });
 
   LoggingResumableUploadSession session(std::move(mock));
 
@@ -101,10 +100,10 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
 TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
-  EXPECT_CALL(*mock, ResetSession()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*mock, ResetSession()).WillOnce([&]() {
     return StatusOr<ResumableUploadResponse>(
         Status(AsStatus(HttpResponse{308, "uh oh", {}})));
-  }));
+  });
 
   LoggingResumableUploadSession session(std::move(mock));
 
@@ -118,9 +117,9 @@ TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
 TEST_F(LoggingResumableUploadSessionTest, NextExpectedByte) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
-  EXPECT_CALL(*mock, next_expected_byte()).WillOnce(Invoke([&]() {
+  EXPECT_CALL(*mock, next_expected_byte()).WillOnce([&]() {
     return 512 * 1024U;
-  }));
+  });
 
   LoggingResumableUploadSession session(std::move(mock));
 

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -31,7 +31,6 @@ using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::testing::_;
 using ::testing::ContainerEq;
-using ::testing::Invoke;
 using ::testing::Return;
 
 BucketMetadata CreateElement(int index) {
@@ -73,9 +72,9 @@ TEST(ListBucketsReaderTest, Basic) {
 
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListBuckets(_))
-      .WillOnce(Invoke(create_mock(0)))
-      .WillOnce(Invoke(create_mock(1)))
-      .WillOnce(Invoke(create_mock(2)));
+      .WillOnce(create_mock(0))
+      .WillOnce(create_mock(1))
+      .WillOnce(create_mock(2));
 
   ListBucketsReader reader(
       ListBucketsRequest("foo-bar-baz").set_multiple_options(Prefix("dir/")),
@@ -122,11 +121,11 @@ TEST(ListBucketsReaderTest, PermanentFailure) {
 
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListBuckets(_))
-      .WillOnce(Invoke(create_mock(0)))
-      .WillOnce(Invoke(create_mock(1)))
-      .WillOnce(Invoke([](ListBucketsRequest const&) {
+      .WillOnce(create_mock(0))
+      .WillOnce(create_mock(1))
+      .WillOnce([](ListBucketsRequest const&) {
         return StatusOr<ListBucketsResponse>(PermanentError());
-      }));
+      });
 
   ListBucketsReader reader(
       ListBucketsRequest("test-project"),
@@ -173,12 +172,10 @@ TEST(ListBucketsReaderTest, IteratorCompare) {
   };
 
   auto mock1 = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock1, ListBuckets(_))
-      .WillOnce(Invoke(create_mock(0, page_count)));
+  EXPECT_CALL(*mock1, ListBuckets(_)).WillOnce(create_mock(0, page_count));
 
   auto mock2 = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock2, ListBuckets(_))
-      .WillOnce(Invoke(create_mock(0, page_count)));
+  EXPECT_CALL(*mock2, ListBuckets(_)).WillOnce(create_mock(0, page_count));
 
   ListBucketsReader reader1(
       ListBucketsRequest("foo-bar-baz").set_multiple_options(Prefix("dir/")),

--- a/google/cloud/storage/list_hmac_keys_reader_test.cc
+++ b/google/cloud/storage/list_hmac_keys_reader_test.cc
@@ -31,7 +31,6 @@ using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::testing::_;
 using ::testing::ContainerEq;
-using ::testing::Invoke;
 using ::testing::Return;
 
 HmacKeyMetadata CreateElement(int index) {
@@ -73,9 +72,9 @@ TEST(ListHmacKeysReaderTest, Basic) {
 
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListHmacKeys(_))
-      .WillOnce(Invoke(create_mock(0)))
-      .WillOnce(Invoke(create_mock(1)))
-      .WillOnce(Invoke(create_mock(2)));
+      .WillOnce(create_mock(0))
+      .WillOnce(create_mock(1))
+      .WillOnce(create_mock(2));
 
   ListHmacKeysReader reader(
       ListHmacKeysRequest("test-project-id"),
@@ -122,11 +121,11 @@ TEST(ListHmacKeysReaderTest, PermanentFailure) {
 
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListHmacKeys(_))
-      .WillOnce(Invoke(create_mock(0)))
-      .WillOnce(Invoke(create_mock(1)))
-      .WillOnce(Invoke([](ListHmacKeysRequest const&) {
+      .WillOnce(create_mock(0))
+      .WillOnce(create_mock(1))
+      .WillOnce([](ListHmacKeysRequest const&) {
         return StatusOr<ListHmacKeysResponse>(PermanentError());
-      }));
+      });
 
   ListHmacKeysReader reader(
       ListHmacKeysRequest("test-project"),
@@ -173,12 +172,10 @@ TEST(ListHmacKeysReaderTest, IteratorCompare) {
   };
 
   auto mock1 = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock1, ListHmacKeys(_))
-      .WillOnce(Invoke(create_mock(0, page_count)));
+  EXPECT_CALL(*mock1, ListHmacKeys(_)).WillOnce(create_mock(0, page_count));
 
   auto mock2 = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock2, ListHmacKeys(_))
-      .WillOnce(Invoke(create_mock(0, page_count)));
+  EXPECT_CALL(*mock2, ListHmacKeys(_)).WillOnce(create_mock(0, page_count));
 
   ListHmacKeysReader reader1(
       ListHmacKeysRequest("test-project-id"),

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -31,7 +31,6 @@ using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::testing::_;
 using ::testing::ContainerEq;
-using ::testing::Invoke;
 using ::testing::Return;
 
 ObjectMetadata CreateElement(int index) {
@@ -75,9 +74,9 @@ TEST(ListObjectsReaderTest, Basic) {
 
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListObjects(_))
-      .WillOnce(Invoke(create_mock(0)))
-      .WillOnce(Invoke(create_mock(1)))
-      .WillOnce(Invoke(create_mock(2)));
+      .WillOnce(create_mock(0))
+      .WillOnce(create_mock(1))
+      .WillOnce(create_mock(2));
 
   ListObjectsReader reader(
       ListObjectsRequest("foo-bar-baz").set_multiple_options(Prefix("dir/")),
@@ -124,11 +123,11 @@ TEST(ListObjectsReaderTest, PermanentFailure) {
 
   auto mock = std::make_shared<MockClient>();
   EXPECT_CALL(*mock, ListObjects(_))
-      .WillOnce(Invoke(create_mock(0)))
-      .WillOnce(Invoke(create_mock(1)))
-      .WillOnce(Invoke([](ListObjectsRequest const&) {
+      .WillOnce(create_mock(0))
+      .WillOnce(create_mock(1))
+      .WillOnce([](ListObjectsRequest const&) {
         return StatusOr<ListObjectsResponse>(PermanentError());
-      }));
+      });
 
   ListObjectsReader reader(
       ListObjectsRequest("test-bucket"),
@@ -175,12 +174,10 @@ TEST(ListObjectsReaderTest, IteratorCompare) {
   };
 
   auto mock1 = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock1, ListObjects(_))
-      .WillOnce(Invoke(create_mock(0, page_count)));
+  EXPECT_CALL(*mock1, ListObjects(_)).WillOnce(create_mock(0, page_count));
 
   auto mock2 = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock2, ListObjects(_))
-      .WillOnce(Invoke(create_mock(0, page_count)));
+  EXPECT_CALL(*mock2, ListObjects(_)).WillOnce(create_mock(0, page_count));
 
   ListObjectsReader reader1(
       ListObjectsRequest("foo-bar-baz").set_multiple_options(Prefix("dir/")),

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -36,7 +36,6 @@ using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
 
@@ -59,30 +58,30 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
 })""";
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
   EXPECT_CALL(*mock_request, MakeRequest(_))
-      .WillOnce(Invoke([response](std::string const& payload) {
+      .WillOnce([response](std::string const& payload) {
         EXPECT_THAT(payload, HasSubstr("grant_type=refresh_token"));
         EXPECT_THAT(payload, HasSubstr("client_id=a-client-id.example.com"));
         EXPECT_THAT(payload, HasSubstr("client_secret=a-123456ABCDEF"));
         EXPECT_THAT(payload, HasSubstr("refresh_token=1/THETOKEN"));
         return HttpResponse{200, response, {}};
-      }));
+      });
 
   auto mock_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_builder,
               Constructor(StrEq("https://oauth2.googleapis.com/token")))
       .Times(1);
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request]() {
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request]() {
     MockHttpRequest result;
     result.mock = mock_request;
     return result;
-  }));
+  });
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(Invoke([](std::string const& s) {
+      .WillRepeatedly([](std::string const& s) {
         auto t = std::unique_ptr<char[]>(new char[s.size() + 1]);
         std::copy(s.begin(), s.end(), t.get());
         t[s.size()] = '\0';
         return t;
-      }));
+      });
 
   std::string config = R"""({
       "client_id": "a-client-id.example.com",
@@ -122,20 +121,20 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
 
   // Now setup the builder to return those responses.
   auto mock_builder = MockHttpRequestBuilder::mock_;
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request] {
     MockHttpRequest request;
     request.mock = mock_request;
     return request;
-  }));
+  });
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(Invoke([](std::string const& s) {
+      .WillRepeatedly([](std::string const& s) {
         auto t = std::unique_ptr<char[]>(new char[s.size() + 1]);
         std::copy(s.begin(), s.end(), t.get());
         t[s.size()] = '\0';
         return t;
-      }));
+      });
 
   std::string config = R"""({
       "client_id": "a-client-id.example.com",
@@ -163,20 +162,20 @@ TEST_F(AuthorizedUserCredentialsTest, FailedRefresh) {
 
   // Now setup the builder to return those responses.
   auto mock_builder = MockHttpRequestBuilder::mock_;
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request] {
     MockHttpRequest request;
     request.mock = mock_request;
     return request;
-  }));
+  });
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(Invoke([](std::string const& s) {
+      .WillRepeatedly([](std::string const& s) {
         auto t = std::unique_ptr<char[]>(new char[s.size() + 1]);
         std::copy(s.begin(), s.end(), t.get());
         t[s.size()] = '\0';
         return t;
-      }));
+      });
 
   std::string config = R"""({
       "client_id": "a-client-id.example.com",

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -38,7 +38,6 @@ using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::testing::_;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::UnorderedElementsAre;
@@ -77,16 +76,16 @@ TEST_F(ComputeEngineCredentialsTest,
 
   auto mock_req_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_req_builder, BuildRequest())
-      .WillOnce(Invoke([first_mock_req_impl] {
+      .WillOnce([first_mock_req_impl] {
         MockHttpRequest mock_request;
         mock_request.mock = first_mock_req_impl;
         return mock_request;
-      }))
-      .WillOnce(Invoke([second_mock_req_impl] {
+      })
+      .WillOnce([second_mock_req_impl] {
         MockHttpRequest mock_request;
         mock_request.mock = second_mock_req_impl;
         return mock_request;
-      }));
+      });
 
   // Both requests add this header.
   EXPECT_CALL(*mock_req_builder, AddHeader(StrEq("metadata-flavor: Google")))
@@ -233,11 +232,11 @@ TEST_F(ComputeEngineCredentialsTest, FailedRetrieveServiceAccountInfo) {
   auto mock_req_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_req_builder, BuildRequest())
       .Times(3)
-      .WillRepeatedly(Invoke([first_mock_req_impl] {
+      .WillRepeatedly([first_mock_req_impl] {
         MockHttpRequest mock_request;
         mock_request.mock = first_mock_req_impl;
         return mock_request;
-      }));
+      });
 
   EXPECT_CALL(*mock_req_builder, AddHeader(StrEq("metadata-flavor: Google")))
       .Times(3);
@@ -297,11 +296,11 @@ TEST_F(ComputeEngineCredentialsTest, FailedRefresh) {
       .WillOnce(Return(HttpResponse{1, token_info_resp, {}}));
 
   auto mock_req_builder = MockHttpRequestBuilder::mock_;
-  auto mock_matcher = Invoke([mock_req] {
+  auto mock_matcher = [mock_req] {
     MockHttpRequest mock_request;
     mock_request.mock = mock_req;
     return mock_request;
-  });
+  };
   EXPECT_CALL(*mock_req_builder, BuildRequest())
       .Times(7)
       .WillRepeatedly(mock_matcher);
@@ -370,11 +369,11 @@ TEST_F(ComputeEngineCredentialsTest, AccountEmail) {
 
   auto mock_req_builder = MockHttpRequestBuilder::mock_;
   EXPECT_CALL(*mock_req_builder, BuildRequest())
-      .WillOnce(Invoke([first_mock_req_impl] {
+      .WillOnce([first_mock_req_impl] {
         MockHttpRequest mock_request;
         mock_request.mock = first_mock_req_impl;
         return mock_request;
-      }));
+      });
 
   // Both requests add this header.
   EXPECT_CALL(*mock_req_builder, AddHeader(StrEq("metadata-flavor: Google")))

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -41,7 +41,6 @@ using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::StartsWith;
 using ::testing::StrEq;
@@ -110,20 +109,20 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
       "expires_in": 1234
   })""";
   EXPECT_CALL(*mock_request, MakeRequest(_))
-      .WillOnce(Invoke([response, assertion](std::string const& payload) {
+      .WillOnce([response, assertion](std::string const& payload) {
         EXPECT_THAT(payload, HasSubstr(assertion));
         // Hard-coded in this order in ServiceAccountCredentials class.
         EXPECT_THAT(payload,
                     HasSubstr(std::string("grant_type=") + kGrantParamEscaped));
         return HttpResponse{200, response, {}};
-      }));
+      });
 
   auto mock_builder = MockHttpRequestBuilder::mock_;
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request] {
     MockHttpRequest result;
     result.mock = mock_request;
     return result;
-  }));
+  });
 
   std::string expected_header =
       "Content-Type: application/x-www-form-urlencoded";
@@ -131,15 +130,13 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(
-          Invoke([](std::string const& s) -> std::unique_ptr<char[]> {
-            EXPECT_EQ(kGrantParamUnescaped, s);
-            auto t =
-                std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
-            std::copy(kGrantParamEscaped,
-                      kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
-            return t;
-          }));
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
 
   ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
       info);
@@ -190,24 +187,22 @@ TEST_F(ServiceAccountCredentialsTest,
 
   // Now setup the builder to return those responses.
   auto mock_builder = MockHttpRequestBuilder::mock_;
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request] {
     MockHttpRequest request;
     request.mock = mock_request;
     return request;
-  }));
+  });
   EXPECT_CALL(*mock_builder, AddHeader(An<std::string const&>())).Times(1);
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(
-          Invoke([](std::string const& s) -> std::unique_ptr<char[]> {
-            EXPECT_EQ(kGrantParamUnescaped, s);
-            auto t =
-                std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
-            std::copy(kGrantParamEscaped,
-                      kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
-            return t;
-          }));
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
   ASSERT_STATUS_OK(info);
@@ -394,15 +389,15 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
   auto const clock_value_1 = 10000;
   auto const clock_value_2 = 20000;
   EXPECT_CALL(*mock_request, MakeRequest(_))
-      .WillOnce(Invoke(make_request_assertion(clock_value_1)))
-      .WillOnce(Invoke(make_request_assertion(clock_value_2)));
+      .WillOnce(make_request_assertion(clock_value_1))
+      .WillOnce(make_request_assertion(clock_value_2));
 
   auto mock_builder = MockHttpRequestBuilder::mock_;
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([mock_request] {
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([mock_request] {
     MockHttpRequest result;
     result.mock = mock_request;
     return result;
-  }));
+  });
 
   std::string expected_header =
       "Content-Type: application/x-www-form-urlencoded";
@@ -410,15 +405,13 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(
-          Invoke([](std::string const& s) -> std::unique_ptr<char[]> {
-            EXPECT_EQ(kGrantParamUnescaped, s);
-            auto t =
-                std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
-            std::copy(kGrantParamEscaped,
-                      kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
-            return t;
-          }));
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
 
   FakeClock::now_value_ = clock_value_1;
   ServiceAccountCredentials<MockHttpRequestBuilder, FakeClock> credentials(
@@ -448,18 +441,16 @@ TEST_F(ServiceAccountCredentialsTest, SignBlob) {
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(
-          Invoke([](std::string const& s) -> std::unique_ptr<char[]> {
-            EXPECT_EQ(kGrantParamUnescaped, s);
-            auto t =
-                std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
-            std::copy(kGrantParamEscaped,
-                      kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
-            return t;
-          }));
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([] {
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([] {
     return MockHttpRequest();
-  }));
+  });
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
   ASSERT_STATUS_OK(info);
@@ -502,18 +493,16 @@ TEST_F(ServiceAccountCredentialsTest, SignBlobFailure) {
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(
-          Invoke([](std::string const& s) -> std::unique_ptr<char[]> {
-            EXPECT_EQ(kGrantParamUnescaped, s);
-            auto t =
-                std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
-            std::copy(kGrantParamEscaped,
-                      kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
-            return t;
-          }));
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([] {
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([] {
     return MockHttpRequest();
-  }));
+  });
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
   ASSERT_STATUS_OK(info);
@@ -538,18 +527,16 @@ TEST_F(ServiceAccountCredentialsTest, ClientId) {
   EXPECT_CALL(*mock_builder, Constructor(GoogleOAuthRefreshEndpoint()))
       .Times(1);
   EXPECT_CALL(*mock_builder, MakeEscapedString(An<std::string const&>()))
-      .WillRepeatedly(
-          Invoke([](std::string const& s) -> std::unique_ptr<char[]> {
-            EXPECT_EQ(kGrantParamUnescaped, s);
-            auto t =
-                std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
-            std::copy(kGrantParamEscaped,
-                      kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
-            return t;
-          }));
-  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce(Invoke([] {
+      .WillRepeatedly([](std::string const& s) -> std::unique_ptr<char[]> {
+        EXPECT_EQ(kGrantParamUnescaped, s);
+        auto t = std::unique_ptr<char[]>(new char[sizeof(kGrantParamEscaped)]);
+        std::copy(kGrantParamEscaped,
+                  kGrantParamEscaped + sizeof(kGrantParamEscaped), t.get());
+        return t;
+      });
+  EXPECT_CALL(*mock_builder, BuildRequest()).WillOnce([] {
     return MockHttpRequest();
-  }));
+  });
 
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
   ASSERT_STATUS_OK(info);

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -380,15 +380,13 @@ TEST(CurlRequestTest, Logging) {
   google::cloud::LogSink::Instance().AddBackend(mock_logger);
 
   using ::testing::_;
-  using ::testing::Invoke;
 
   std::string log_messages;
   EXPECT_CALL(*mock_logger, ProcessWithOwnership(_))
-      .WillRepeatedly(
-          Invoke([&log_messages](google::cloud::LogRecord const& lr) {
-            log_messages += lr.message;
-            log_messages += "\n";
-          }));
+      .WillRepeatedly([&log_messages](google::cloud::LogRecord const& lr) {
+        log_messages += lr.message;
+        log_messages += "\n";
+      });
 
   {
     storage::internal::CurlRequestBuilder request(


### PR DESCRIPTION
It is not necessary to `Invoke()` a lambda in the context of
`WillOnce()` or `WillRepeatedly()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4430)
<!-- Reviewable:end -->
