### PR TITLE
cleanup: remove unnecessary calls to testing::Invoke()

### DIFF
--- a/google/cloud/bigtable/async_list_app_profiles_test.cc
+++ b/google/cloud/bigtable/async_list_app_profiles_test.cc
@@ -35,7 +35,6 @@ namespace btadmin = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::MockCompletionQueue;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::ReturnRef;
 
 using MockAsyncListAppProfilesReader =
@@ -73,7 +72,7 @@ class AsyncListAppProfilesTest : public ::testing::Test {
   std::unique_ptr<MockAsyncListAppProfilesReader> profiles_reader_3_;
 };
 
-// Dynamically create the lambda for `Invoke()`, note that the return type is
+// Dynamically create the lambda for `Finish()`. Note that the return type is
 // unknown, so a function or function template would not work. Alternatively,
 // writing this inline is very repetitive.
 auto create_list_profiles_lambda =
@@ -105,9 +104,9 @@ std::vector<std::string> AppProfileNames(
 /// @test One successful page with 1 one profile.
 TEST_F(AsyncListAppProfilesTest, Simple) {
   EXPECT_CALL(*client_, AsyncListAppProfiles(_, _, _))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -115,9 +114,9 @@ TEST_F(AsyncListAppProfilesTest, Simple) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_1_.get());
-      }));
+      });
   EXPECT_CALL(*profiles_reader_1_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_profiles_lambda("", {"profile_1"})));
+      .WillOnce(create_list_profiles_lambda("", {"profile_1"}));
 
   Start();
 
@@ -134,9 +133,9 @@ TEST_F(AsyncListAppProfilesTest, Simple) {
 /// @test Test 3 pages, no failures, multiple profiles.
 TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
   EXPECT_CALL(*client_, AsyncListAppProfiles(_, _, _))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -144,10 +143,10 @@ TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_1_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -155,10 +154,10 @@ TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_2_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -166,14 +165,14 @@ TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_3_.get());
-      }));
+      });
   EXPECT_CALL(*profiles_reader_1_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_profiles_lambda("token_1", {"profile_1"})));
+      .WillOnce(create_list_profiles_lambda("token_1", {"profile_1"}));
   EXPECT_CALL(*profiles_reader_2_, Finish(_, _, _))
-      .WillOnce(Invoke(
-          create_list_profiles_lambda("token_2", {"profile_2", "profile_3"})));
+      .WillOnce(
+          create_list_profiles_lambda("token_2", {"profile_2", "profile_3"}));
   EXPECT_CALL(*profiles_reader_3_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_profiles_lambda("", {"profile_4"})));
+      .WillOnce(create_list_profiles_lambda("", {"profile_4"}));
 
   Start();
 
@@ -204,9 +203,9 @@ TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
 /// @test Test 2 pages, with a filure between them.
 TEST_F(AsyncListAppProfilesTest, FailuresAreRetried) {
   EXPECT_CALL(*client_, AsyncListAppProfiles(_, _, _))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -214,10 +213,10 @@ TEST_F(AsyncListAppProfilesTest, FailuresAreRetried) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_1_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -225,10 +224,10 @@ TEST_F(AsyncListAppProfilesTest, FailuresAreRetried) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_2_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btadmin::ListAppProfilesRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btadmin::ListAppProfilesRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListAppProfiles"));
@@ -236,16 +235,16 @@ TEST_F(AsyncListAppProfilesTest, FailuresAreRetried) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_3_.get());
-      }));
+      });
   EXPECT_CALL(*profiles_reader_1_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_profiles_lambda("token_1", {"profile_1"})));
+      .WillOnce(create_list_profiles_lambda("token_1", {"profile_1"}));
   EXPECT_CALL(*profiles_reader_2_, Finish(_, _, _))
-      .WillOnce(Invoke(
+      .WillOnce(
           [](btadmin::ListAppProfilesResponse*, grpc::Status* status, void*) {
             *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "");
-          }));
+          });
   EXPECT_CALL(*profiles_reader_3_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_profiles_lambda("", {"profile_2"})));
+      .WillOnce(create_list_profiles_lambda("", {"profile_2"}));
 
   Start();
 

--- a/google/cloud/bigtable/async_list_clusters_test.cc
+++ b/google/cloud/bigtable/async_list_clusters_test.cc
@@ -35,7 +35,6 @@ namespace btproto = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::MockCompletionQueue;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::ReturnRef;
 
 using MockAsyncListClustersReader =
@@ -75,7 +74,7 @@ class AsyncListClustersTest : public ::testing::Test {
   std::unique_ptr<MockAsyncListClustersReader> clusters_reader_3_;
 };
 
-// Dynamically create the lambda for `Invoke()`, note that the return type is
+// Dynamically create the lambda for `Finish()`. Note that the return type is
 // unknown, so a function or function template would not work. Alternatively,
 // writing this inline is very repetitive.
 auto create_list_clusters_lambda =
@@ -111,9 +110,9 @@ std::vector<std::string> ClusterNames(ClusterList const& response) {
 /// @test One successful page with 1 one cluster.
 TEST_F(AsyncListClustersTest, Simple) {
   EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -122,10 +121,10 @@ TEST_F(AsyncListClustersTest, Simple) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_1_.get());
-      }));
+      });
   EXPECT_CALL(*clusters_reader_1_, Finish(_, _, _))
-      .WillOnce(Invoke(
-          create_list_clusters_lambda("", {"cluster_1"}, {"failed_loc_1"})));
+      .WillOnce(
+          create_list_clusters_lambda("", {"cluster_1"}, {"failed_loc_1"}));
 
   Start();
 
@@ -143,9 +142,9 @@ TEST_F(AsyncListClustersTest, Simple) {
 /// @test Test 3 pages, no failures, multiple clusters and failed locations.
 TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
   EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -154,10 +153,10 @@ TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_1_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -166,10 +165,10 @@ TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_2_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -178,17 +177,17 @@ TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_3_.get());
-      }));
+      });
   EXPECT_CALL(*clusters_reader_1_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_clusters_lambda("token_1", {"cluster_1"},
-                                                   {"failed_loc_1"})));
+      .WillOnce(create_list_clusters_lambda("token_1", {"cluster_1"},
+                                            {"failed_loc_1"}));
   EXPECT_CALL(*clusters_reader_2_, Finish(_, _, _))
-      .WillOnce(Invoke(
-          create_list_clusters_lambda("token_2", {"cluster_2", "cluster_3"},
-                                      {"failed_loc_1", "failed_loc_2"})));
+      .WillOnce(create_list_clusters_lambda("token_2",
+                                            {"cluster_2", "cluster_3"},
+                                            {"failed_loc_1", "failed_loc_2"}));
   EXPECT_CALL(*clusters_reader_3_, Finish(_, _, _))
-      .WillOnce(Invoke(
-          create_list_clusters_lambda("", {"cluster_4"}, {"failed_loc_1"})));
+      .WillOnce(
+          create_list_clusters_lambda("", {"cluster_4"}, {"failed_loc_1"}));
 
   Start();
 
@@ -223,9 +222,9 @@ TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
 /// @test Test 2 pages, with a filure between them.
 TEST_F(AsyncListClustersTest, FailuresAreRetried) {
   EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -234,10 +233,10 @@ TEST_F(AsyncListClustersTest, FailuresAreRetried) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_1_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -246,10 +245,10 @@ TEST_F(AsyncListClustersTest, FailuresAreRetried) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_2_.get());
-      }))
-      .WillOnce(Invoke([this](grpc::ClientContext* context,
-                              btproto::ListClustersRequest const& request,
-                              grpc::CompletionQueue*) {
+      })
+      .WillOnce([this](grpc::ClientContext* context,
+                       btproto::ListClustersRequest const& request,
+                       grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.ListClusters"));
@@ -258,18 +257,18 @@ TEST_F(AsyncListClustersTest, FailuresAreRetried) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_3_.get());
-      }));
+      });
   EXPECT_CALL(*clusters_reader_1_, Finish(_, _, _))
-      .WillOnce(Invoke(create_list_clusters_lambda("token_1", {"cluster_1"},
-                                                   {"failed_loc_1"})));
+      .WillOnce(create_list_clusters_lambda("token_1", {"cluster_1"},
+                                            {"failed_loc_1"}));
   EXPECT_CALL(*clusters_reader_2_, Finish(_, _, _))
-      .WillOnce(Invoke(
+      .WillOnce(
           [](btproto::ListClustersResponse*, grpc::Status* status, void*) {
             *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "");
-          }));
+          });
   EXPECT_CALL(*clusters_reader_3_, Finish(_, _, _))
-      .WillOnce(Invoke(
-          create_list_clusters_lambda("", {"cluster_2"}, {"failed_loc_2"})));
+      .WillOnce(
+          create_list_clusters_lambda("", {"cluster_2"}, {"failed_loc_2"}));
 
   Start();
 

--- a/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common_test.cc
@@ -27,7 +27,6 @@ namespace examples {
 
 using ::testing::_;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::ReturnRef;
 using ::testing::StartsWith;
 
@@ -103,16 +102,16 @@ TEST(BigtableExamplesCommon, CleanupOldTables) {
   EXPECT_CALL(*mock, project()).WillRepeatedly(ReturnRef(project_id));
 
   EXPECT_CALL(*mock, ListTables(_, _, _))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::ListTablesRequest const& request,
-                           btadmin::ListTablesResponse* response) {
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::ListTablesRequest const& request,
+                    btadmin::ListTablesResponse* response) {
         for (auto const& id : {id_1, id_2, id_3, id_4, id_5}) {
           auto& instance = *response->add_tables();
           instance.set_name(request.parent() + "/tables/" + id);
         }
         response->clear_next_page_token();
         return grpc::Status::OK;
-      }));
+      });
 
   bigtable::TableAdmin admin(mock, instance_id);
   auto const name_1 = admin.TableName(id_1);
@@ -120,18 +119,18 @@ TEST(BigtableExamplesCommon, CleanupOldTables) {
 
   // Verify only `name_1` and `name_2` are deleted.
   EXPECT_CALL(*mock, DeleteTable(_, _, _))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::DeleteTableRequest const& request,
-                           google::protobuf::Empty*) {
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::DeleteTableRequest const& request,
+                    google::protobuf::Empty*) {
         EXPECT_EQ(request.name(), name_1);
         return grpc::Status::OK;
-      }))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::DeleteTableRequest const& request,
-                           google::protobuf::Empty*) {
+      })
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::DeleteTableRequest const& request,
+                    google::protobuf::Empty*) {
         EXPECT_EQ(request.name(), name_2);
         return grpc::Status::OK;
-      }));
+      });
 
   CleanupOldTables("test-", admin);
 }
@@ -161,32 +160,31 @@ TEST(BigtableExamplesCommon, CleanupOldBackups) {
   EXPECT_CALL(*mock, project()).WillRepeatedly(ReturnRef(project_id));
 
   EXPECT_CALL(*mock, ListBackups(_, _, _))
-      .WillOnce(
-          Invoke([&](grpc::ClientContext*, btadmin::ListBackupsRequest const&,
-                     btadmin::ListBackupsResponse* response) {
-            for (auto const& backup : {backup_1, backup_2}) {
-              auto& instance = *response->add_backups();
-              instance = backup;
-            }
-            response->clear_next_page_token();
-            return grpc::Status::OK;
-          }));
+      .WillOnce([&](grpc::ClientContext*, btadmin::ListBackupsRequest const&,
+                    btadmin::ListBackupsResponse* response) {
+        for (auto const& backup : {backup_1, backup_2}) {
+          auto& instance = *response->add_backups();
+          instance = backup;
+        }
+        response->clear_next_page_token();
+        return grpc::Status::OK;
+      });
 
   bigtable::TableAdmin admin(mock, instance_id);
 
   EXPECT_CALL(*mock, DeleteBackup(_, _, _))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::DeleteBackupRequest const& request,
-                           google::protobuf::Empty*) {
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::DeleteBackupRequest const& request,
+                    google::protobuf::Empty*) {
         EXPECT_EQ(request.name(), backup_1.name());
         return grpc::Status::OK;
-      }))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::DeleteBackupRequest const& request,
-                           google::protobuf::Empty*) {
+      })
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::DeleteBackupRequest const& request,
+                    google::protobuf::Empty*) {
         EXPECT_EQ(request.name(), backup_2.name());
         return grpc::Status::OK;
-      }));
+      });
 
   CleanupOldBackups("test-instance-id-c1", admin);
 }
@@ -241,16 +239,16 @@ TEST(BigtableExamplesCommon, CleanupOldInstances) {
   EXPECT_CALL(*mock, project()).WillRepeatedly(ReturnRef(project_id));
 
   EXPECT_CALL(*mock, ListInstances(_, _, _))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::ListInstancesRequest const& request,
-                           btadmin::ListInstancesResponse* response) {
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::ListInstancesRequest const& request,
+                    btadmin::ListInstancesResponse* response) {
         for (auto const& id : {id_1, id_2, id_3, id_4, id_5}) {
           auto& instance = *response->add_instances();
           instance.set_name(request.parent() + "/instances/" + id);
         }
         response->clear_next_page_token();
         return grpc::Status::OK;
-      }));
+      });
 
   bigtable::InstanceAdmin admin(mock);
   auto const name_1 = admin.InstanceName(id_1);
@@ -258,18 +256,18 @@ TEST(BigtableExamplesCommon, CleanupOldInstances) {
 
   // Verify only `name_1` and `name_2` are deleted.
   EXPECT_CALL(*mock, DeleteInstance(_, _, _))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::DeleteInstanceRequest const& request,
-                           google::protobuf::Empty*) {
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::DeleteInstanceRequest const& request,
+                    google::protobuf::Empty*) {
         EXPECT_EQ(request.name(), name_1);
         return grpc::Status::OK;
-      }))
-      .WillOnce(Invoke([&](grpc::ClientContext*,
-                           btadmin::DeleteInstanceRequest const& request,
-                           google::protobuf::Empty*) {
+      })
+      .WillOnce([&](grpc::ClientContext*,
+                    btadmin::DeleteInstanceRequest const& request,
+                    google::protobuf::Empty*) {
         EXPECT_EQ(request.name(), name_2);
         return grpc::Status::OK;
-      }));
+      });
 
   CleanupOldInstances("test-", admin);
 }

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -33,7 +33,6 @@ using MockAdminClient = bigtable::testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::MockCompletionQueue;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -246,8 +245,7 @@ TEST_F(InstanceAdminTest, MoveAssignment) {
 TEST_F(InstanceAdminTest, ListInstances) {
   bigtable::InstanceAdmin tested(client_);
   auto mock_list_instances = create_list_instances_lambda("", "", {"t0", "t1"});
-  EXPECT_CALL(*client_, ListInstances(_, _, _))
-      .WillOnce(Invoke(mock_list_instances));
+  EXPECT_CALL(*client_, ListInstances(_, _, _)).WillOnce(mock_list_instances);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListInstances();
@@ -273,11 +271,11 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
   auto batch0 = create_list_instances_lambda("", "token-001", {"t0", "t1"});
   auto batch1 = create_list_instances_lambda("token-001", "", {"t2", "t3"});
   EXPECT_CALL(*client_, ListInstances(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch0))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch1));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch0)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch1);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListInstances();
@@ -315,7 +313,7 @@ TEST_F(InstanceAdminTest, DeleteInstance) {
   auto mock = MockRpcFactory<btadmin::DeleteInstanceRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteInstance");
-  EXPECT_CALL(*client_, DeleteInstance(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DeleteInstance(_, _, _)).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
   ASSERT_STATUS_OK(tested.DeleteInstance("the-instance"));
 }
@@ -348,8 +346,7 @@ TEST_F(InstanceAdminTest, ListClusters) {
   std::string const& instance_id = "the-instance";
   auto mock_list_clusters =
       create_list_clusters_lambda("", "", instance_id, {"t0", "t1"});
-  EXPECT_CALL(*client_, ListClusters(_, _, _))
-      .WillOnce(Invoke(mock_list_clusters));
+  EXPECT_CALL(*client_, ListClusters(_, _, _)).WillOnce(mock_list_clusters);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListClusters(instance_id);
@@ -377,11 +374,11 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
   auto batch1 =
       create_list_clusters_lambda("token-001", "", instance_id, {"t2", "t3"});
   EXPECT_CALL(*client_, ListClusters(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch0))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch1));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch0)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch1);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListClusters(instance_id);
@@ -414,7 +411,7 @@ TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
 TEST_F(InstanceAdminTest, GetCluster) {
   bigtable::InstanceAdmin tested(client_);
   auto mock = create_get_cluster_mock();
-  EXPECT_CALL(*client_, GetCluster(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, GetCluster(_, _, _)).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
   auto cluster = tested.GetCluster("the-instance", "the-cluster");
   ASSERT_STATUS_OK(cluster);
@@ -444,9 +441,9 @@ TEST_F(InstanceAdminTest, GetClusterRecoverableError) {
 
   auto mock_cluster = create_get_cluster_mock();
   EXPECT_CALL(*client_, GetCluster(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_cluster));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_cluster);
 
   // After all the setup, make the actual call we want to test.
   auto cluster = tested.GetCluster("the-instance", "the-cluster");
@@ -465,7 +462,7 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
   auto mock = MockRpcFactory<btadmin::DeleteClusterRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteCluster");
-  EXPECT_CALL(*client_, DeleteCluster(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DeleteCluster(_, _, _)).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
   ASSERT_STATUS_OK(tested.DeleteCluster("the-instance", "the-cluster"));
 }
@@ -494,11 +491,10 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
 /// @test Verify positive scenario for InstanceAdmin::GetIamPolicy.
 TEST_F(InstanceAdminTest, GetIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
 
   bigtable::InstanceAdmin tested(client_);
   auto mock_policy = create_get_policy_mock();
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(Invoke(mock_policy));
+  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   tested.GetIamPolicy(resource);
@@ -507,13 +503,12 @@ TEST_F(InstanceAdminTest, GetIamPolicy) {
 /// @test Verify that IamPolicies with conditions cause failures.
 TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
   using ::testing::_;
-  using ::testing::Invoke;
 
   bigtable::InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
-      .WillOnce(Invoke([](grpc::ClientContext* context,
-                          ::google::iam::v1::GetIamPolicyRequest const&,
-                          ::google::iam::v1::Policy* response) {
+      .WillOnce([](grpc::ClientContext* context,
+                   ::google::iam::v1::GetIamPolicyRequest const&,
+                   ::google::iam::v1::Policy* response) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableInstanceAdmin.GetIamPolicy"));
@@ -527,7 +522,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
         new_binding->set_allocated_condition(new google::type::Expr);
 
         return grpc::Status::OK;
-      }));
+      });
 
   std::string resource = "test-resource";
   auto res = tested.GetIamPolicy(resource);
@@ -554,7 +549,6 @@ TEST_F(InstanceAdminTest, GetIamPolicyUnrecoverableError) {
 /// @test Verify recoverable errors for InstanceAdmin::GetIamPolicy.
 TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
 
   bigtable::InstanceAdmin tested(client_);
@@ -570,8 +564,8 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
   auto mock_policy = create_get_policy_mock();
 
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_policy));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   tested.GetIamPolicy(resource);
@@ -580,11 +574,10 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
 /// @test Verify positive scenario for InstanceAdmin::GetNativeIamPolicy.
 TEST_F(InstanceAdminTest, GetNativeIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
 
   bigtable::InstanceAdmin tested(client_);
   auto mock_policy = create_get_policy_mock();
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(Invoke(mock_policy));
+  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto policy = tested.GetNativeIamPolicy(resource);
@@ -612,7 +605,6 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyUnrecoverableError) {
 /// @test Verify recoverable errors for InstanceAdmin::GetNativeIamPolicy.
 TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
 
   bigtable::InstanceAdmin tested(client_);
@@ -628,8 +620,8 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
   auto mock_policy = create_get_policy_mock();
 
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_policy));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto policy = tested.GetNativeIamPolicy(resource);
@@ -651,10 +643,9 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
         reader_(new MockAsyncIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncGetIamPolicy(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                ::google::iam::v1::GetIamPolicyRequest const&
-                                    request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         ::google::iam::v1::GetIamPolicyRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableInstanceAdmin.GetIamPolicy"));
@@ -663,7 +654,7 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
           // This is safe, see comments in MockAsyncResponseReader.
           return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
               ::google::iam::v1::Policy>>(reader_.get());
-        }));
+        });
   }
 
  protected:
@@ -690,18 +681,16 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
 /// @test Verify that AsyncGetIamPolicy works in simple case.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            response->set_version(3);
-            response->set_etag("random-tag");
-            *status = grpc::Status::OK;
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        response->set_version(3);
+        response->set_etag("random-tag");
+        *status = grpc::Status::OK;
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -716,16 +705,14 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncGetIamPolicy.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -741,18 +728,16 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
 /// @test Verify that AsyncGetNativeIamPolicy works in simple case.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            response->set_version(3);
-            response->set_etag("random-tag");
-            *status = grpc::Status::OK;
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        response->set_version(3);
+        response->set_etag("random-tag");
+        *status = grpc::Status::OK;
+      });
 
   StartNative();
   EXPECT_EQ(std::future_status::timeout, user_native_future_.wait_for(1_ms));
@@ -767,16 +752,14 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicy) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncGetNativeIamPolicy.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicyUnrecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
+      });
 
   StartNative();
   EXPECT_EQ(std::future_status::timeout, user_native_future_.wait_for(1_ms));
@@ -792,11 +775,10 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicyUnrecoverableError) {
 /// @test Verify positive scenario for InstanceAdmin::SetIamPolicy.
 TEST_F(InstanceAdminTest, SetIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
 
   bigtable::InstanceAdmin tested(client_);
   auto mock_policy = create_policy_with_params();
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(Invoke(mock_policy));
+  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   google::cloud::IamBindings iam_bindings =
@@ -828,7 +810,6 @@ TEST_F(InstanceAdminTest, SetIamPolicyUnrecoverableError) {
 /// @test Verify recoverable errors for InstanceAdmin::SetIamPolicy.
 TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
 
   bigtable::InstanceAdmin tested(client_);
@@ -844,8 +825,8 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
   auto mock_policy = create_policy_with_params();
 
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_policy));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   google::cloud::IamBindings iam_bindings =
@@ -860,11 +841,10 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
 /// @test Verify positive scenario for InstanceAdmin::SetIamPolicy (native).
 TEST_F(InstanceAdminTest, SetNativeIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
 
   bigtable::InstanceAdmin tested(client_);
   auto mock_policy = create_policy_with_params();
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(Invoke(mock_policy));
+  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto iam_policy = bigtable::IamPolicy(
@@ -898,7 +878,6 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyUnrecoverableError) {
 /// @test Verify recoverable errors for InstanceAdmin::SetIamPolicy (native).
 TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
 
   bigtable::InstanceAdmin tested(client_);
@@ -914,8 +893,8 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
   auto mock_policy = create_policy_with_params();
 
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_policy));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto iam_policy = bigtable::IamPolicy(
@@ -930,7 +909,6 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
 /// @test Verify that InstanceAdmin::TestIamPermissions works in simple case.
 TEST_F(InstanceAdminTest, TestIamPermissions) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
@@ -949,7 +927,7 @@ TEST_F(InstanceAdminTest, TestIamPermissions) {
   };
 
   EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
-      .WillOnce(Invoke(mock_permission_set));
+      .WillOnce(mock_permission_set);
 
   std::string resource = "the-resource";
   auto permission_set =
@@ -979,7 +957,6 @@ TEST_F(InstanceAdminTest, TestIamPermissionsUnrecoverableError) {
 /// @test Test for recoverable errors for InstanceAdmin::TestIamPermissions.
 TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
@@ -1006,8 +983,8 @@ TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
     return grpc::Status::OK;
   };
   EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_permission_set));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_permission_set);
 
   std::string resource = "the-resource";
   auto permission_set =
@@ -1030,9 +1007,9 @@ class AsyncDeleteClusterTest : public ::testing::Test {
         reader_(new MockAsyncDeleteClusterReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncDeleteCluster(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                btadmin::DeleteClusterRequest const& request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         btadmin::DeleteClusterRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteCluster"));
@@ -1043,7 +1020,7 @@ class AsyncDeleteClusterTest : public ::testing::Test {
           // This is safe, see comments in MockAsyncResponseReader.
           return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
               ::google::protobuf::Empty>>(reader_.get());
-        }));
+        });
   }
 
  protected:
@@ -1063,15 +1040,14 @@ class AsyncDeleteClusterTest : public ::testing::Test {
 /// @test Verify that AsyncDeleteCluster works in simple case.
 TEST_F(AsyncDeleteClusterTest, AsyncDeleteCluster) {
   using ::testing::_;
-  using ::testing::Invoke;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(Invoke(
+      .WillOnce(
           [](::google::protobuf::Empty* response, grpc::Status* status, void*) {
             EXPECT_NE(nullptr, response);
             *status = grpc::Status::OK;
-          }));
+          });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1084,15 +1060,14 @@ TEST_F(AsyncDeleteClusterTest, AsyncDeleteCluster) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncDeleteCluster.
 TEST_F(AsyncDeleteClusterTest, AsyncDeleteClusterUnrecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(Invoke(
+      .WillOnce(
           [](::google::protobuf::Empty* response, grpc::Status* status, void*) {
             EXPECT_NE(nullptr, response);
             *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+          });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1116,10 +1091,9 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
         reader_(new MockAsyncSetIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncSetIamPolicy(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                ::google::iam::v1::SetIamPolicyRequest const&
-                                    request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         ::google::iam::v1::SetIamPolicyRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableInstanceAdmin.SetIamPolicy"));
@@ -1128,7 +1102,7 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
           // This is safe, see comments in MockAsyncResponseReader.
           return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
               ::google::iam::v1::Policy>>(reader_.get());
-        }));
+        });
   }
 
  protected:
@@ -1163,22 +1137,20 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
 /// @test Verify that AsyncSetIamPolicy works in simple case.
 TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
 
-            auto new_binding = response->add_bindings();
-            new_binding->set_role("writer");
-            new_binding->add_members("abc@gmail.com");
-            new_binding->add_members("xyz@gmail.com");
-            response->set_etag("test-tag");
-            *status = grpc::Status::OK;
-          }));
+        auto new_binding = response->add_bindings();
+        new_binding->set_role("writer");
+        new_binding->add_members("abc@gmail.com");
+        new_binding->add_members("xyz@gmail.com");
+        response->set_etag("test-tag");
+        *status = grpc::Status::OK;
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1194,16 +1166,14 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncSetIamPolicy.
 TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1219,22 +1189,20 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
 /// @test Verify that AsyncSetIamPolicy works in simple case (native).
 TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicy) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
 
-            auto new_binding = response->add_bindings();
-            new_binding->set_role("writer");
-            new_binding->add_members("abc@gmail.com");
-            new_binding->add_members("xyz@gmail.com");
-            response->set_etag("test-tag");
-            *status = grpc::Status::OK;
-          }));
+        auto new_binding = response->add_bindings();
+        new_binding->set_role("writer");
+        new_binding->add_members("abc@gmail.com");
+        new_binding->add_members("xyz@gmail.com");
+        response->set_etag("test-tag");
+        *status = grpc::Status::OK;
+      });
 
   StartNative();
   EXPECT_EQ(std::future_status::timeout, user_native_future_.wait_for(1_ms));
@@ -1250,16 +1218,14 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicy) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncSetIamPolicy native.
 TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicyUnrecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
+      });
 
   StartNative();
   EXPECT_EQ(std::future_status::timeout, user_native_future_.wait_for(1_ms));
@@ -1285,7 +1251,7 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
         reader_(new MockAsyncTestIamPermissionsReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncTestIamPermissions(_, _, _))
-        .WillOnce(Invoke(
+        .WillOnce(
             [this](grpc::ClientContext* context,
                    ::google::iam::v1::TestIamPermissionsRequest const& request,
                    grpc::CompletionQueue*) {
@@ -1300,7 +1266,7 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
               return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
                   ::google::iam::v1::TestIamPermissionsResponse>>(
                   reader_.get());
-            }));
+            });
   }
 
  protected:
@@ -1321,18 +1287,17 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
 /// @test Verify that AsyncTestIamPermissions works in simple case.
 TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(Invoke([](iamproto::TestIamPermissionsResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](iamproto::TestIamPermissionsResponse* response,
+                   grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         response->add_permissions("writer");
         response->add_permissions("reader");
         *status = grpc::Status::OK;
-      }));
+      });
 
   Start({"reader", "writer", "owner"});
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1346,16 +1311,15 @@ TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncTestIamPermissions.
 TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissionsUnrecoverableError) {
   using ::testing::_;
-  using ::testing::Invoke;
   namespace iamproto = ::google::iam::v1;
   bigtable::InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(Invoke([](iamproto::TestIamPermissionsResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](iamproto::TestIamPermissionsResponse* response,
+                   grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-      }));
+      });
 
   Start({"reader", "writer", "owner"});
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1403,13 +1367,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
       btadmin::CreateAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateAppProfile(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               parent: "projects/the-project/instances/the-instance"
               app_profile_id: "prof"
               app_profile: { multi_cluster_routing_use_any { } }
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateAppProfile")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateAppProfile"));
   FinishTest(instance_admin_->AsyncCreateAppProfile(
       cq_, "the-instance",
       bigtable::AppProfileConfig::MultiClusterUseAny("prof")));
@@ -1421,12 +1385,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
       btadmin::DeleteAppProfileRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteAppProfile(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
               ignore_warnings: true
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteAppProfile")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteAppProfile"));
   auto res_future = instance_admin_->AsyncDeleteAppProfile(cq_, "the-instance",
                                                            "the-profile");
   EXPECT_EQ(1U, cq_impl_->size());
@@ -1442,11 +1406,11 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
                                                 google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteInstance(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance"
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteInstance")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteInstance"));
   auto res_future = instance_admin_->AsyncDeleteInstance("the-instance", cq_);
   EXPECT_EQ(1U, cq_impl_->size());
   cq_impl_->SimulateCompletion(true);
@@ -1461,11 +1425,11 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
                                                 btadmin::AppProfile>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetAppProfile(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.GetAppProfile")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.GetAppProfile"));
   FinishTest(
       instance_admin_->AsyncGetAppProfile(cq_, "the-instance", "the-profile"));
 }
@@ -1476,11 +1440,11 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
                                                 btadmin::Cluster>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetCluster(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance/clusters/the-cluster"
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.GetCluster")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.GetCluster"));
   FinishTest(
       instance_admin_->AsyncGetCluster(cq_, "the-instance", "the-cluster"));
 }
@@ -1491,11 +1455,11 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
                                                 btadmin::Instance>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetInstance(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance"
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.GetInstance")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.GetInstance"));
   FinishTest(instance_admin_->AsyncGetInstance(cq_, "the-instance"));
 }
 
@@ -1505,7 +1469,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
                                                 google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateCluster(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               parent: "projects/the-project/instances/the-instance"
               cluster_id: "the-cluster"
@@ -1515,7 +1479,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
                   default_storage_type: SSD
               }
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateCluster")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateCluster"));
   FinishTest(instance_admin_->AsyncCreateCluster(
       cq_, bigtable::ClusterConfig("loc1", 3, bigtable::ClusterConfig::SSD),
       "the-instance", "the-cluster"));
@@ -1527,13 +1491,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
                                                 google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateInstance(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               parent: "projects/the-project"
               instance_id: "the-instance"
               instance: { display_name: "Displayed instance" }
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateInstance")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateInstance"));
   FinishTest(instance_admin_->AsyncCreateInstance(
       cq_, bigtable::InstanceConfig("the-instance", "Displayed instance", {})));
 }
@@ -1544,13 +1508,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
       btadmin::UpdateAppProfileRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateAppProfile(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               app_profile: {
                   name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
               }
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.UpdateAppProfile")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.UpdateAppProfile"));
   FinishTest(instance_admin_->AsyncUpdateAppProfile(
       cq_, "the-instance", "the-profile", bigtable::AppProfileUpdateConfig()));
 }
@@ -1561,14 +1525,14 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
                                                 google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateCluster(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               location: "loc1"
               serve_nodes: 3
               default_storage_type: SSD
               name: "projects/the-project/instances/the-instance/clusters/the-cluster"
           )""",
-          "google.bigtable.admin.v2.BigtableInstanceAdmin.UpdateCluster")));
+          "google.bigtable.admin.v2.BigtableInstanceAdmin.UpdateCluster"));
   auto cluster =
       bigtable::ClusterConfig("loc1", 3, bigtable::ClusterConfig::SSD)
           .as_proto();
@@ -1584,14 +1548,14 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateInstance) {
       btadmin::PartialUpdateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateInstance(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               instance: {
                   name: "projects/the-project/instances/the-instance"
               }
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin."
-          "PartialUpdateInstance")));
+          "PartialUpdateInstance"));
   bigtable::Instance instance;
   instance.set_name("projects/the-project/instances/the-instance");
   FinishTest(instance_admin_->AsyncUpdateInstance(
@@ -1609,7 +1573,7 @@ TEST_F(InstanceAdminTest, CreateAppProfile) {
                              btadmin::AppProfile>::
       Create(expected_text,
              "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateAppProfile");
-  EXPECT_CALL(*client_, CreateAppProfile(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, CreateAppProfile(_, _, _)).WillOnce(mock);
   ASSERT_STATUS_OK(tested.CreateAppProfile(
       "the-instance", bigtable::AppProfileConfig::MultiClusterUseAny("prof")));
 }
@@ -1624,7 +1588,7 @@ TEST_F(InstanceAdminTest, DeleteAppProfile) {
   auto mock = MockRpcFactory<btadmin::DeleteAppProfileRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteAppProfile");
-  EXPECT_CALL(*client_, DeleteAppProfile(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DeleteAppProfile(_, _, _)).WillOnce(mock);
   ASSERT_STATUS_OK(tested.DeleteAppProfile("the-instance", "the-profile"));
 }
 
@@ -1639,7 +1603,7 @@ TEST_F(InstanceAdminTest, GetAppProfile) {
           Create(
               expected_text,
               "google.bigtable.admin.v2.BigtableInstanceAdmin.GetAppProfile");
-  EXPECT_CALL(*client_, GetAppProfile(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, GetAppProfile(_, _, _)).WillOnce(mock);
   ASSERT_STATUS_OK(tested.GetAppProfile("the-instance", "the-profile"));
 }
 
@@ -1653,6 +1617,6 @@ TEST_F(InstanceAdminTest, GetInstance) {
       MockRpcFactory<btadmin::GetInstanceRequest, btadmin::Instance>::Create(
           expected_text,
           "google.bigtable.admin.v2.BigtableInstanceAdmin.GetInstance");
-  EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(mock);
   ASSERT_STATUS_OK(tested.GetInstance("the-instance"));
 }

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -73,19 +73,18 @@ class AsyncStartPollAfterRetryUnaryRpcTest
   }
   void ExpectCreateCluster(grpc::StatusCode mocked_code) {
     using ::testing::_;
-    using ::testing::Invoke;
     EXPECT_CALL(*create_cluster_reader, Finish(_, _, _))
-        .WillOnce(Invoke([mocked_code](longrunning::Operation* response,
-                                       grpc::Status* status, void*) {
+        .WillOnce([mocked_code](longrunning::Operation* response,
+                                grpc::Status* status, void*) {
           response->set_name("create_cluster_op_1");
           *status = mocked_code != grpc::StatusCode::OK
                         ? grpc::Status(mocked_code, "mocked-status")
                         : grpc::Status::OK;
-        }));
+        });
     EXPECT_CALL(*client, AsyncCreateCluster(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                btproto::CreateClusterRequest const& request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         btproto::CreateClusterRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateCluster"));
@@ -94,17 +93,16 @@ class AsyncStartPollAfterRetryUnaryRpcTest
           return std::unique_ptr<
               grpc::ClientAsyncResponseReaderInterface<longrunning::Operation>>(
               create_cluster_reader.get());
-        }));
+        });
   }
 
   void ExpectPolling(bool polling_finished,
                      grpc::StatusCode polling_error_code) {
     using ::testing::_;
-    using ::testing::Invoke;
     EXPECT_CALL(*get_operation_reader, Finish(_, _, _))
-        .WillOnce(Invoke([polling_finished, polling_error_code](
-                             longrunning::Operation* response,
-                             grpc::Status* status, void*) {
+        .WillOnce([polling_finished, polling_error_code](
+                      longrunning::Operation* response, grpc::Status* status,
+                      void*) {
           if (!polling_finished) {
             *status = (polling_error_code != grpc::StatusCode::OK)
                           ? grpc::Status(polling_error_code, "mocked-status")
@@ -124,11 +122,11 @@ class AsyncStartPollAfterRetryUnaryRpcTest
             any->PackFrom(response_content);
             response->set_allocated_response(any.release());
           }
-        }));
+        });
     EXPECT_CALL(*client, AsyncGetOperation(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                longrunning::GetOperationRequest const& request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         longrunning::GetOperationRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context, "google.longrunning.Operations.GetOperation"));
           EXPECT_EQ("create_cluster_op_1", request.name());
@@ -136,7 +134,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
           return std::unique_ptr<
               grpc::ClientAsyncResponseReaderInterface<longrunning::Operation>>(
               get_operation_reader.get());
-        }));
+        });
   }
 
   future<StatusOr<btproto::Cluster>> SimulateCreateCluster() {

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -40,7 +40,6 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _s;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::MockCompletionQueue;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -202,7 +201,7 @@ TEST_F(TableAdminTest, Default) {
 TEST_F(TableAdminTest, ListTables) {
   bigtable::TableAdmin tested(client_, kInstanceId);
   auto mock_list_tables = create_list_tables_lambda("", "", {"t0", "t1"});
-  EXPECT_CALL(*client_, ListTables(_, _, _)).WillOnce(Invoke(mock_list_tables));
+  EXPECT_CALL(*client_, ListTables(_, _, _)).WillOnce(mock_list_tables);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btadmin::Table::FULL);
@@ -227,11 +226,11 @@ TEST_F(TableAdminTest, ListTablesRecoverableFailures) {
   auto batch0 = create_list_tables_lambda("", "token-001", {"t0", "t1"});
   auto batch1 = create_list_tables_lambda("token-001", "", {"t2", "t3"});
   EXPECT_CALL(*client_, ListTables(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch0))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch1));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch0)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch1);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListTables(btadmin::Table::FULL);
@@ -274,7 +273,7 @@ TEST_F(TableAdminTest, ListTablesTooManyFailures) {
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   EXPECT_CALL(*client_, ListTables(_, _, _))
-      .WillRepeatedly(Invoke(mock_recoverable_failure));
+      .WillRepeatedly(mock_recoverable_failure);
 
   EXPECT_FALSE(tested.ListTables(btadmin::Table::FULL));
 }
@@ -305,8 +304,7 @@ TEST_F(TableAdminTest, CreateTableSimple) {
       MockRpcFactory<btadmin::CreateTableRequest, btadmin::Table>::Create(
           expected_text,
           "google.bigtable.admin.v2.BigtableTableAdmin.CreateTable");
-  EXPECT_CALL(*client_, CreateTable(_, _, _))
-      .WillOnce(Invoke(mock_create_table));
+  EXPECT_CALL(*client_, CreateTable(_, _, _)).WillOnce(mock_create_table);
 
   // After all the setup, make the actual call we want to test.
   using GC = bigtable::GcRule;
@@ -390,7 +388,7 @@ TEST_F(TableAdminTest, GetTableSimple) {
   EXPECT_CALL(*client_, GetTable(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
-      .WillOnce(Invoke(mock));
+      .WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   tested.GetTable("the-table");
@@ -436,7 +434,7 @@ TEST_F(TableAdminTest, DeleteTable) {
   )pb";
   auto mock = MockRpcFactory<btadmin::DeleteTableRequest, Empty>::Create(
       expected_text, "google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable");
-  EXPECT_CALL(*client_, DeleteTable(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DeleteTable(_, _, _)).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   EXPECT_STATUS_OK(tested.DeleteTable("the-table"));
@@ -461,8 +459,7 @@ TEST_F(TableAdminTest, DeleteTableFailure) {
 TEST_F(TableAdminTest, ListBackups) {
   bigtable::TableAdmin tested(client_, kInstanceId);
   auto mock_list_backups = create_list_backups_lambda("", "", {"b0", "b1"});
-  EXPECT_CALL(*client_, ListBackups(_, _, _))
-      .WillOnce(Invoke(mock_list_backups));
+  EXPECT_CALL(*client_, ListBackups(_, _, _)).WillOnce(mock_list_backups);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListBackups({});
@@ -487,11 +484,11 @@ TEST_F(TableAdminTest, ListBackupsRecoverableFailures) {
   auto batch0 = create_list_backups_lambda("", "token-001", {"b0", "b1"});
   auto batch1 = create_list_backups_lambda("token-001", "", {"b2", "b3"});
   EXPECT_CALL(*client_, ListBackups(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch0))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(batch1));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch0)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(batch1);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListBackups({});
@@ -534,7 +531,7 @@ TEST_F(TableAdminTest, ListBackupsTooManyFailures) {
     return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
   };
   EXPECT_CALL(*client_, ListBackups(_, _, _))
-      .WillRepeatedly(Invoke(mock_recoverable_failure));
+      .WillRepeatedly(mock_recoverable_failure);
 
   EXPECT_FALSE(tested.ListBackups({}));
 }
@@ -552,7 +549,7 @@ TEST_F(TableAdminTest, GetBackupSimple) {
   EXPECT_CALL(*client_, GetBackup(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
-      .WillOnce(Invoke(mock));
+      .WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   tested.GetBackup("the-cluster", "the-backup");
@@ -607,7 +604,7 @@ TEST_F(TableAdminTest, UpdateBackupSimple) {
   EXPECT_CALL(*client_, UpdateBackup(_, _, _))
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
-      .WillOnce(Invoke(mock));
+      .WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   google::protobuf::Timestamp expire_time;
@@ -672,9 +669,7 @@ TEST_F(TableAdminTest, DeleteBackup) {
   auto mock = MockRpcFactory<btadmin::DeleteBackupRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableTableAdmin.DeleteBackup");
-  EXPECT_CALL(*client_, DeleteBackup(_, _, _))
-      .WillOnce(Invoke(mock))
-      .WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DeleteBackup(_, _, _)).WillOnce(mock).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   EXPECT_STATUS_OK(tested.DeleteBackup("the-cluster", "the-backup"));
@@ -724,7 +719,7 @@ TEST_F(TableAdminTest, ModifyColumnFamilies) {
       Create(
           expected_text,
           "google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies");
-  EXPECT_CALL(*client_, ModifyColumnFamilies(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, ModifyColumnFamilies(_, _, _)).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   using M = bigtable::ColumnFamilyModification;
@@ -764,7 +759,7 @@ TEST_F(TableAdminTest, DropRowsByPrefix) {
   auto mock = MockRpcFactory<btadmin::DropRowRangeRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange");
-  EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   EXPECT_STATUS_OK(tested.DropRowsByPrefix("the-table", "foobar"));
@@ -795,7 +790,7 @@ TEST_F(TableAdminTest, DropAllRows) {
   auto mock = MockRpcFactory<btadmin::DropRowRangeRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange");
-  EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, DropRowRange(_, _, _)).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   EXPECT_STATUS_OK(tested.DropAllRows("the-table"));
@@ -829,8 +824,7 @@ TEST_F(TableAdminTest, GenerateConsistencyTokenSimple) {
       Create(expected_text,
              "google.bigtable.admin.v2.BigtableTableAdmin."
              "GenerateConsistencyToken");
-  EXPECT_CALL(*client_, GenerateConsistencyToken(_, _, _))
-      .WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, GenerateConsistencyToken(_, _, _)).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   tested.GenerateConsistencyToken("the-table");
@@ -864,7 +858,7 @@ TEST_F(TableAdminTest, CheckConsistencySimple) {
                              btadmin::CheckConsistencyResponse>::
       Create(expected_text,
              "google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency");
-  EXPECT_CALL(*client_, CheckConsistency(_, _, _)).WillOnce(Invoke(mock));
+  EXPECT_CALL(*client_, CheckConsistency(_, _, _)).WillOnce(mock);
 
   // After all the setup, make the actual call we want to test.
   auto result = tested.CheckConsistency("the-table", "test-token");
@@ -889,7 +883,7 @@ TEST_F(TableAdminTest, CheckConsistencyFailure) {
 TEST_F(TableAdminTest, GetIamPolicy) {
   bigtable::TableAdmin tested(client_, "the-instance");
   auto mock_policy = create_get_policy_mock();
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(Invoke(mock_policy));
+  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto policy = tested.GetIamPolicy(resource);
@@ -927,8 +921,8 @@ TEST_F(TableAdminTest, GetIamPolicyRecoverableError) {
   auto mock_policy = create_get_policy_mock();
 
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_policy));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto policy = tested.GetIamPolicy(resource);
@@ -941,7 +935,7 @@ TEST_F(TableAdminTest, GetIamPolicyRecoverableError) {
 TEST_F(TableAdminTest, SetIamPolicy) {
   bigtable::TableAdmin tested(client_, "the-instance");
   auto mock_policy = create_policy_with_params();
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(Invoke(mock_policy));
+  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto iam_policy = bigtable::IamPolicy(
@@ -985,8 +979,8 @@ TEST_F(TableAdminTest, SetIamPolicyRecoverableError) {
   auto mock_policy = create_policy_with_params();
 
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_policy));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto iam_policy = bigtable::IamPolicy(
@@ -1019,7 +1013,7 @@ TEST_F(TableAdminTest, TestIamPermissions) {
       };
 
   EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
-      .WillOnce(Invoke(mock_permission_set));
+      .WillOnce(mock_permission_set);
 
   std::string resource = "the-resource";
   auto permission_set =
@@ -1071,8 +1065,8 @@ TEST_F(TableAdminTest, TestIamPermissionsRecoverableError) {
         return grpc::Status::OK;
       };
   EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
-      .WillOnce(Invoke(mock_recoverable_failure))
-      .WillOnce(Invoke(mock_permission_set));
+      .WillOnce(mock_recoverable_failure)
+      .WillOnce(mock_permission_set);
 
   std::string resource = "the-resource";
   auto permission_set =
@@ -1095,27 +1089,27 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencySimple) {
 
   auto r1 = absl::make_unique<MockAsyncCheckConsistencyResponse>();
   EXPECT_CALL(*r1, Finish(_, _, _))
-      .WillOnce(Invoke([](btadmin::CheckConsistencyResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](btadmin::CheckConsistencyResponse* response,
+                   grpc::Status* status, void*) {
         ASSERT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try again");
-      }));
+      });
   auto r2 = absl::make_unique<MockAsyncCheckConsistencyResponse>();
   EXPECT_CALL(*r2, Finish(_, _, _))
-      .WillOnce(Invoke([](btadmin::CheckConsistencyResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](btadmin::CheckConsistencyResponse* response,
+                   grpc::Status* status, void*) {
         ASSERT_NE(nullptr, response);
         response->set_consistent(false);
         *status = grpc::Status::OK;
-      }));
+      });
   auto r3 = absl::make_unique<MockAsyncCheckConsistencyResponse>();
   EXPECT_CALL(*r3, Finish(_, _, _))
-      .WillOnce(Invoke([](btadmin::CheckConsistencyResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](btadmin::CheckConsistencyResponse* response,
+                   grpc::Status* status, void*) {
         ASSERT_NE(nullptr, response);
         response->set_consistent(true);
         *status = grpc::Status::OK;
-      }));
+      });
 
   auto make_invoke = [](std::unique_ptr<MockAsyncCheckConsistencyResponse>& r) {
     return [&r](grpc::ClientContext* context,
@@ -1135,9 +1129,9 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencySimple) {
 
   EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
   EXPECT_CALL(*client_, AsyncCheckConsistency(_, _, _))
-      .WillOnce(Invoke(make_invoke(r1)))
-      .WillOnce(Invoke(make_invoke(r2)))
-      .WillOnce(Invoke(make_invoke(r3)));
+      .WillOnce(make_invoke(r1))
+      .WillOnce(make_invoke(r2))
+      .WillOnce(make_invoke(r3));
 
   std::shared_ptr<MockCompletionQueue> cq_impl(new MockCompletionQueue);
   bigtable::CompletionQueue cq(cq_impl);
@@ -1192,16 +1186,16 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencyFailure) {
   bigtable::TableAdmin tested(client_, "test-instance");
   auto reader = absl::make_unique<MockAsyncCheckConsistencyResponse>();
   EXPECT_CALL(*reader, Finish(_, _, _))
-      .WillOnce(Invoke([](btadmin::CheckConsistencyResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](btadmin::CheckConsistencyResponse* response,
+                   grpc::Status* status, void*) {
         ASSERT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "oh no");
-      }));
+      });
   EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
   EXPECT_CALL(*client_, AsyncCheckConsistency(_, _, _))
-      .WillOnce(Invoke([&](grpc::ClientContext* context,
-                           btadmin::CheckConsistencyRequest const& request,
-                           grpc::CompletionQueue*) {
+      .WillOnce([&](grpc::ClientContext* context,
+                    btadmin::CheckConsistencyRequest const& request,
+                    grpc::CompletionQueue*) {
         EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
             *context,
             "google.bigtable.admin.v2.BigtableTableAdmin.CheckConsistency"));
@@ -1211,7 +1205,7 @@ TEST_F(TableAdminTest, AsyncWaitForConsistencyFailure) {
         // This is safe, see comments in MockAsyncResponseReader.
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             ::btadmin::CheckConsistencyResponse>>(reader.get());
-      }));
+      });
 
   std::shared_ptr<MockCompletionQueue> cq_impl(new MockCompletionQueue);
   bigtable::CompletionQueue cq(cq_impl);
@@ -1280,13 +1274,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateTable) {
                                                 btadmin::Table>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateTable(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             parent: "projects/the-project/instances/the-instance"
             table_id: "the-table"
             table: {}
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.CreateTable")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.CreateTable"));
   FinishTest(table_admin_->AsyncCreateTable(cq_, "the-table",
                                             bigtable::TableConfig()));
 }
@@ -1296,11 +1290,11 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteTable) {
                                                 google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteTable(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             name: "projects/the-project/instances/the-instance/tables/the-table"
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.DeleteTable"));
   FinishTest(table_admin_->AsyncDeleteTable(cq_, "the-table"));
 }
 
@@ -1310,7 +1304,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
                                                 google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateBackup(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             parent: "projects/the-project/instances/the-instance/clusters/the-cluster"
             backup_id: "the-backup"
@@ -1319,7 +1313,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
               expire_time: { seconds: 1893387600 }
             }
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.CreateBackup"));
   google::protobuf::Timestamp expire_time;
   EXPECT_TRUE(google::protobuf::util::TimeUtil::FromString(
       "2029-12-31T00:00:00.000-05:00", &expire_time));
@@ -1335,13 +1329,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncRestoreTable) {
                                                 google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncRestoreTable(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             parent: "projects/the-project/instances/the-instance"
             table_id: "restored-table"
             backup: "projects/the-project/instances/the-instance/clusters/the-cluster/backups/the-backup"
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable"));
   bigtable::TableAdmin::RestoreTableParams params("restored-table",
                                                   "the-cluster", "the-backup");
   FinishTest(table_admin_->AsyncRestoreTable(cq_, std::move(params)));
@@ -1352,12 +1346,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncDropAllRows) {
                                                 google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDropRowRange(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             name: "projects/the-project/instances/the-instance/tables/the-table"
             delete_all_data_from_table: true
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange"));
   FinishTest(table_admin_->AsyncDropAllRows(cq_, "the-table"));
 }
 
@@ -1366,12 +1360,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncDropRowsByPrefix) {
                                                 google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDropRowRange(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             name: "projects/the-project/instances/the-instance/tables/the-table"
             row_key_prefix: "prefix"
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.DropRowRange"));
   FinishTest(table_admin_->AsyncDropRowsByPrefix(cq_, "the-table", "prefix"));
 }
 
@@ -1381,12 +1375,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncGenerateConsistencyToken) {
       btadmin::GenerateConsistencyTokenResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGenerateConsistencyToken(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             name: "projects/the-project/instances/the-instance/tables/the-table"
           )pb",
           "google.bigtable.admin.v2.BigtableTableAdmin."
-          "GenerateConsistencyToken")));
+          "GenerateConsistencyToken"));
   FinishTest(table_admin_->AsyncGenerateConsistencyToken(cq_, "the-table"));
 }
 
@@ -1395,12 +1389,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncListTables) {
                                                 btadmin::ListTablesResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncListTables(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             parent: "projects/the-project/instances/the-instance"
             view: SCHEMA_VIEW
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.ListTables")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.ListTables"));
   FinishTest(table_admin_->AsyncListTables(cq_, btadmin::Table::SCHEMA_VIEW));
 }
 
@@ -1409,11 +1403,11 @@ TEST_F(ValidContextMdAsyncTest, AsyncModifyColumnFamilies) {
       btadmin::ModifyColumnFamiliesRequest, btadmin::Table>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncModifyColumnFamilies(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"pb(
             name: "projects/the-project/instances/the-instance/tables/the-table"
           )pb",
-          "google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies")));
+          "google.bigtable.admin.v2.BigtableTableAdmin.ModifyColumnFamilies"));
   FinishTest(table_admin_->AsyncModifyColumnFamilies(cq_, "the-table", {}));
 }
 
@@ -1430,10 +1424,9 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
         reader_(new MockAsyncIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncGetIamPolicy(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                ::google::iam::v1::GetIamPolicyRequest const&
-                                    request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         ::google::iam::v1::GetIamPolicyRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableTableAdmin.GetIamPolicy"));
@@ -1443,7 +1436,7 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
           // This is safe, see comments in MockAsyncResponseReader.
           return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
               ::google::iam::v1::Policy>>(reader_.get());
-        }));
+        });
   }
 
  protected:
@@ -1466,13 +1459,12 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
   bigtable::TableAdmin tested(client_, "the-instance");
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            response->set_version(3);
-            response->set_etag("random-tag");
-            *status = grpc::Status::OK;
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        response->set_version(3);
+        response->set_etag("random-tag");
+        *status = grpc::Status::OK;
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1490,11 +1482,10 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
   bigtable::TableAdmin tested(client_, "the-instance");
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1520,10 +1511,9 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
         reader_(new MockAsyncSetIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncSetIamPolicy(_, _, _))
-        .WillOnce(Invoke([this](grpc::ClientContext* context,
-                                ::google::iam::v1::SetIamPolicyRequest const&
-                                    request,
-                                grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         ::google::iam::v1::SetIamPolicyRequest const& request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableTableAdmin.SetIamPolicy"));
@@ -1533,7 +1523,7 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
           // This is safe, see comments in MockAsyncResponseReader.
           return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
               ::google::iam::v1::Policy>>(reader_.get());
-        }));
+        });
   }
 
  protected:
@@ -1560,17 +1550,16 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
   bigtable::TableAdmin tested(client_, "the-instance");
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
 
-            auto new_binding = response->add_bindings();
-            new_binding->set_role("writer");
-            new_binding->add_members("abc@gmail.com");
-            new_binding->add_members("xyz@gmail.com");
-            response->set_etag("test-tag");
-            *status = grpc::Status::OK;
-          }));
+        auto new_binding = response->add_bindings();
+        new_binding->set_role("writer");
+        new_binding->add_members("abc@gmail.com");
+        new_binding->add_members("xyz@gmail.com");
+        response->set_etag("test-tag");
+        *status = grpc::Status::OK;
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1589,11 +1578,10 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
   bigtable::TableAdmin tested(client_, "the-instance");
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(
-          Invoke([](iamproto::Policy* response, grpc::Status* status, void*) {
-            EXPECT_NE(nullptr, response);
-            *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+      .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
+        EXPECT_NE(nullptr, response);
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
+      });
 
   Start();
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1619,11 +1607,10 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
         reader_(new MockAsyncTestIamPermissionsReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncTestIamPermissions(_, _, _))
-        .WillOnce(Invoke([this](
-                             grpc::ClientContext* context,
-                             ::google::iam::v1::TestIamPermissionsRequest const&
-                                 request,
-                             grpc::CompletionQueue*) {
+        .WillOnce([this](grpc::ClientContext* context,
+                         ::google::iam::v1::TestIamPermissionsRequest const&
+                             request,
+                         grpc::CompletionQueue*) {
           EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
               *context,
               "google.bigtable.admin.v2.BigtableTableAdmin."
@@ -1634,7 +1621,7 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
           // This is safe, see comments in MockAsyncResponseReader.
           return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
               ::google::iam::v1::TestIamPermissionsResponse>>(reader_.get());
-        }));
+        });
   }
 
  protected:
@@ -1658,13 +1645,13 @@ TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
   bigtable::TableAdmin tested(client_, "the-instance");
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(Invoke([](iamproto::TestIamPermissionsResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](iamproto::TestIamPermissionsResponse* response,
+                   grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         response->add_permissions("writer");
         response->add_permissions("reader");
         *status = grpc::Status::OK;
-      }));
+      });
 
   Start({"reader", "writer", "owner"});
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));
@@ -1681,11 +1668,11 @@ TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissionsUnrecoverableError) {
   bigtable::TableAdmin tested(client_, "the-instance");
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
-      .WillOnce(Invoke([](iamproto::TestIamPermissionsResponse* response,
-                          grpc::Status* status, void*) {
+      .WillOnce([](iamproto::TestIamPermissionsResponse* response,
+                   grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-      }));
+      });
 
   Start({"reader", "writer", "owner"});
   EXPECT_EQ(std::future_status::timeout, user_future_.wait_for(1_ms));

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -21,7 +21,6 @@
 namespace bigtable = ::google::cloud::bigtable;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::testing::_;
-using ::testing::Invoke;
 
 /// Define helper types and functions for this test.
 namespace {
@@ -43,7 +42,7 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {};
 /// @test Verify that Table::Apply() works in a simplest case.
 TEST_F(TableApplyTest, Simple) {
   EXPECT_CALL(*client_, MutateRow(_, _, _))
-      .WillOnce(Invoke(mock_mutate_row(grpc::Status::OK)));
+      .WillOnce(mock_mutate_row(grpc::Status::OK));
 
   auto status = table_.Apply(bigtable::SingleRowMutation(
       "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
@@ -53,8 +52,8 @@ TEST_F(TableApplyTest, Simple) {
 /// @test Verify that Table::Apply() raises an exception on permanent failures.
 TEST_F(TableApplyTest, Failure) {
   EXPECT_CALL(*client_, MutateRow(_, _, _))
-      .WillRepeatedly(Invoke(mock_mutate_row(
-          grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh"))));
+      .WillRepeatedly(mock_mutate_row(
+          grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh")));
 
   auto status = table_.Apply(bigtable::SingleRowMutation(
       "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
@@ -65,13 +64,13 @@ TEST_F(TableApplyTest, Failure) {
 /// @test Verify that Table::Apply() retries on partial failures.
 TEST_F(TableApplyTest, Retry) {
   EXPECT_CALL(*client_, MutateRow(_, _, _))
-      .WillOnce(Invoke(mock_mutate_row(
-          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again"))))
-      .WillOnce(Invoke(mock_mutate_row(
-          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again"))))
-      .WillOnce(Invoke(mock_mutate_row(
-          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again"))))
-      .WillOnce(Invoke(mock_mutate_row((grpc::Status::OK))));
+      .WillOnce(mock_mutate_row(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(mock_mutate_row(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(mock_mutate_row(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(mock_mutate_row((grpc::Status::OK)));
 
   auto status = table_.Apply(bigtable::SingleRowMutation(
       "bar", {bigtable::SetCell("fam", "col", 0_ms, "val")}));
@@ -81,8 +80,8 @@ TEST_F(TableApplyTest, Retry) {
 /// @test Verify that Table::Apply() retries only idempotent mutations.
 TEST_F(TableApplyTest, RetryIdempotent) {
   EXPECT_CALL(*client_, MutateRow(_, _, _))
-      .WillRepeatedly(Invoke(mock_mutate_row(
-          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again"))));
+      .WillRepeatedly(mock_mutate_row(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
   auto status = table_.Apply(bigtable::SingleRowMutation(
       "not-idempotent", {bigtable::SetCell("fam", "col", "val")}));

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -21,7 +21,6 @@
 namespace bigtable = google::cloud::bigtable;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::testing::_;
-using ::testing::Invoke;
 
 /// Define helper types and functions for this test.
 namespace {
@@ -44,7 +43,7 @@ auto mock_check_and_mutate = [](grpc::Status const& status) {
 /// @test Verify that Table::CheckAndMutateRow() works in a simplest case.
 TEST_F(TableCheckAndMutateRowTest, Simple) {
   EXPECT_CALL(*client_, CheckAndMutateRow(_, _, _))
-      .WillOnce(Invoke(mock_check_and_mutate(grpc::Status::OK)));
+      .WillOnce(mock_check_and_mutate(grpc::Status::OK));
 
   auto mut = table_.CheckAndMutateRow(
       "foo", bigtable::Filter::PassAllFilter(),
@@ -58,8 +57,8 @@ TEST_F(TableCheckAndMutateRowTest, Simple) {
 /// @test Verify that Table::CheckAndMutateRow() raises an on failures.
 TEST_F(TableCheckAndMutateRowTest, Failure) {
   EXPECT_CALL(*client_, CheckAndMutateRow(_, _, _))
-      .WillRepeatedly(Invoke(mock_check_and_mutate(
-          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again"))));
+      .WillRepeatedly(mock_check_and_mutate(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
   EXPECT_FALSE(table_.CheckAndMutateRow(
       "foo", bigtable::Filter::PassAllFilter(),

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -23,7 +23,6 @@ namespace btproto = ::google::bigtable::v2;
 namespace bigtable = ::google::cloud::bigtable;
 
 using ::testing::_;
-using ::testing::Invoke;
 
 /// Define helper types and functions for this test.
 namespace {
@@ -92,7 +91,7 @@ row {
       create_rules_lambda(request_text, response_text);
 
   EXPECT_CALL(*client_, ReadModifyWriteRow(_, _, _))
-      .WillOnce(Invoke(mock_read_modify_write_row));
+      .WillOnce(mock_read_modify_write_row);
 
   auto row = table_.ReadModifyWriteRow(
       row_key,
@@ -162,7 +161,7 @@ TEST_F(TableReadModifyWriteTest, MultipleIncrementAmountTest) {
       create_rules_lambda(request_text, response_text);
 
   EXPECT_CALL(*client_, ReadModifyWriteRow(_, _, _))
-      .WillOnce(Invoke(mock_read_modify_write_row));
+      .WillOnce(mock_read_modify_write_row);
 
   auto row = table_.ReadModifyWriteRow(
       row_key,
@@ -236,7 +235,7 @@ TEST_F(TableReadModifyWriteTest, MultipleMixedRuleTest) {
       create_rules_lambda(request_text, response_text);
 
   EXPECT_CALL(*client_, ReadModifyWriteRow(_, _, _))
-      .WillOnce(Invoke(mock_read_modify_write_row));
+      .WillOnce(mock_read_modify_write_row);
 
   auto row = table_.ReadModifyWriteRow(
       row_key,
@@ -263,14 +262,13 @@ TEST_F(TableReadModifyWriteTest, UnrecoverableFailureTest) {
   std::string const column_id1 = "colid1";
 
   EXPECT_CALL(*client_, ReadModifyWriteRow(_, _, _))
-      .WillRepeatedly(
-          Invoke([](grpc::ClientContext* context,
-                    google::bigtable::v2::ReadModifyWriteRowRequest const&,
-                    google::bigtable::v2::ReadModifyWriteRowResponse*) {
-            EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
-                *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow"));
-            return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
-          }));
+      .WillRepeatedly([](grpc::ClientContext* context,
+                         google::bigtable::v2::ReadModifyWriteRowRequest const&,
+                         google::bigtable::v2::ReadModifyWriteRowResponse*) {
+        EXPECT_STATUS_OK(google::cloud::bigtable::testing::IsContextMDValid(
+            *context, "google.bigtable.v2.Bigtable.ReadModifyWriteRow"));
+        return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh");
+      });
 
   EXPECT_FALSE(table_.ReadModifyWriteRow(
       row_key,

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -22,7 +22,6 @@
 namespace bigtable = google::cloud::bigtable;
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 
 /// Define types and functions used for this tests.
@@ -38,15 +37,15 @@ TEST_F(TableSampleRowKeysTest, DefaultParameterTest) {
   auto reader =
       new MockSampleRowKeysReader("google.bigtable.v2.Bigtable.SampleRowKeys");
   EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(reader->MakeMockReturner()));
+      .WillOnce(reader->MakeMockReturner());
   EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
+      .WillOnce([](btproto::SampleRowKeysResponse* r) {
         {
           r->set_row_key("test1");
           r->set_offset_bytes(11);
         }
         return true;
-      }))
+      })
       .WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
   auto result = table_.SampleRows();
@@ -65,15 +64,15 @@ TEST_F(TableSampleRowKeysTest, SimpleVectorTest) {
   auto reader =
       new MockSampleRowKeysReader("google.bigtable.v2.Bigtable.SampleRowKeys");
   EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(reader->MakeMockReturner()));
+      .WillOnce(reader->MakeMockReturner());
   EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
+      .WillOnce([](btproto::SampleRowKeysResponse* r) {
         {
           r->set_row_key("test1");
           r->set_offset_bytes(11);
         }
         return true;
-      }))
+      })
       .WillOnce(Return(false));
   EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
   auto result = table_.SampleRows();
@@ -93,17 +92,17 @@ TEST_F(TableSampleRowKeysTest, SampleRowKeysRetryTest) {
   auto reader_retry =
       new MockSampleRowKeysReader("google.bigtable.v2.Bigtable.SampleRowKeys");
   EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(reader->MakeMockReturner()))
-      .WillOnce(Invoke(reader_retry->MakeMockReturner()));
+      .WillOnce(reader->MakeMockReturner())
+      .WillOnce(reader_retry->MakeMockReturner());
 
   EXPECT_CALL(*reader, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
+      .WillOnce([](btproto::SampleRowKeysResponse* r) {
         {
           r->set_row_key("test1");
           r->set_offset_bytes(11);
         }
         return true;
-      }))
+      })
       .WillOnce(Return(false));
 
   EXPECT_CALL(*reader, Finish())
@@ -111,20 +110,20 @@ TEST_F(TableSampleRowKeysTest, SampleRowKeysRetryTest) {
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
   EXPECT_CALL(*reader_retry, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
+      .WillOnce([](btproto::SampleRowKeysResponse* r) {
         {
           r->set_row_key("test2");
           r->set_offset_bytes(123);
         }
         return true;
-      }))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
+      })
+      .WillOnce([](btproto::SampleRowKeysResponse* r) {
         {
           r->set_row_key("test3");
           r->set_offset_bytes(1234);
         }
         return true;
-      }))
+      })
       .WillOnce(Return(false));
 
   EXPECT_CALL(*reader_retry, Finish()).WillOnce(Return(grpc::Status::OK));
@@ -161,13 +160,13 @@ TEST_F(TableSampleRowKeysTest, TooManyFailures) {
   auto r1 =
       new MockSampleRowKeysReader("google.bigtable.v2.Bigtable.SampleRowKeys");
   EXPECT_CALL(*r1, Read(_))
-      .WillOnce(Invoke([](btproto::SampleRowKeysResponse* r) {
+      .WillOnce([](btproto::SampleRowKeysResponse* r) {
         {
           r->set_row_key("test1");
           r->set_offset_bytes(11);
         }
         return true;
-      }))
+      })
       .WillOnce(Return(false));
   EXPECT_CALL(*r1, Finish())
       .WillOnce(Return(grpc::Status(grpc::StatusCode::ABORTED, "")));
@@ -183,9 +182,9 @@ TEST_F(TableSampleRowKeysTest, TooManyFailures) {
   };
 
   EXPECT_CALL(*client_, SampleRowKeys(_, _))
-      .WillOnce(Invoke(r1->MakeMockReturner()))
-      .WillOnce(Invoke(create_cancelled_stream))
-      .WillOnce(Invoke(create_cancelled_stream));
+      .WillOnce(r1->MakeMockReturner())
+      .WillOnce(create_cancelled_stream)
+      .WillOnce(create_cancelled_stream);
 
   EXPECT_FALSE(custom_table.SampleRows());
 }

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -156,13 +156,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncApply) {
                                                 bt::MutateRowResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncMutateRow(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               table_name: "projects/the-project/instances/the-instance/tables/the-table"
               row_key: "row_key"
               mutations: { delete_from_row { } }
           )""",
-          "google.bigtable.v2.Bigtable.MutateRow")));
+          "google.bigtable.v2.Bigtable.MutateRow"));
   FinishTest(table_->AsyncApply(
       bigtable::SingleRowMutation("row_key", bigtable::DeleteFromRow()), cq_));
 }
@@ -173,14 +173,14 @@ TEST_F(ValidContextMdAsyncTest, AsyncCheckAndMutateRow) {
                                                 bt::CheckAndMutateRowResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCheckAndMutateRow(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               table_name: "projects/the-project/instances/the-instance/tables/the-table"
               row_key: "row_key"
               true_mutations: { delete_from_row { } }
               predicate_filter: { pass_all_filter: true }
           )""",
-          "google.bigtable.v2.Bigtable.CheckAndMutateRow")));
+          "google.bigtable.v2.Bigtable.CheckAndMutateRow"));
   FinishTest(table_->AsyncCheckAndMutateRow(
       "row_key", bigtable::Filter::PassAllFilter(), {bigtable::DeleteFromRow()},
       {}, cq_));
@@ -192,7 +192,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncReadModifyWriteRow) {
                                                 bt::ReadModifyWriteRowResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncReadModifyWriteRow(_, _, _))
-      .WillOnce(::testing::Invoke(rpc_factory.Create(
+      .WillOnce(rpc_factory.Create(
           R"""(
               table_name: "projects/the-project/instances/the-instance/tables/the-table"
               row_key: "row_key"
@@ -207,7 +207,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncReadModifyWriteRow) {
                   append_value: ";element"
               }
           )""",
-          "google.bigtable.v2.Bigtable.ReadModifyWriteRow")));
+          "google.bigtable.v2.Bigtable.ReadModifyWriteRow"));
   FinishTest(table_->AsyncReadModifyWriteRow(
       "row_key", cq_,
       bigtable::ReadModifyWriteRule::IncrementAmount("fam", "counter", 1),

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -56,7 +56,6 @@ struct MockAsyncFailingRpcFactory {
                                             RequestType const& request,
                                             grpc::CompletionQueue*) {
       using ::testing::_;
-      using ::testing::Invoke;
       EXPECT_STATUS_OK(IsContextMDValid(*context, method));
       RequestType expected;
       // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
@@ -68,11 +67,10 @@ struct MockAsyncFailingRpcFactory {
       EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
 
       EXPECT_CALL(*reader, Finish(_, _, _))
-          .WillOnce(Invoke([](ResponseType* response, grpc::Status* status,
-                              void*) {
+          .WillOnce([](ResponseType* response, grpc::Status* status, void*) {
             EXPECT_NE(nullptr, response);
             *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
-          }));
+          });
       // This is safe, see comments in MockAsyncResponseReader.
       return std::unique_ptr<
           grpc::ClientAsyncResponseReaderInterface<ResponseType>>(reader.get());


### PR DESCRIPTION
It is not necessary to `Invoke()` a lambda in the context of
`WillOnce()` or `WillRepeatedly()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4433)
<!-- Reviewable:end -->
