### PR TITLE
cleanup: remove unnecessary calls to testing::Invoke()

### DIFF
--- a/google/cloud/bigquery/internal/connection_impl_test.cc
+++ b/google/cloud/bigquery/internal/connection_impl_test.cc
@@ -69,11 +69,10 @@ TEST(ConnectionImplTest, ParallelReadRpcFailure) {
   auto mock = std::make_shared<bigquery_testing::MockStorageStub>();
   auto conn = MakeConnection(mock);
   EXPECT_CALL(*mock, CreateReadSession(_))
-      .WillOnce(
-          testing::Invoke([](bigquerystorage_proto::
-                                 CreateReadSessionRequest const& /*request*/) {
-            return Status(StatusCode::kPermissionDenied, "Permission denied!");
-          }));
+      .WillOnce([](bigquerystorage_proto::
+                       CreateReadSessionRequest const& /*request*/) {
+        return Status(StatusCode::kPermissionDenied, "Permission denied!");
+      });
 
   StatusOr<std::vector<ReadStream>> result = conn->ParallelRead(
       "my-parent-project", "my-project:my-dataset.my-table", {});
@@ -85,7 +84,7 @@ TEST(ConnectionImplTest, ParallelReadRpcSuccess) {
   auto mock = std::make_shared<bigquery_testing::MockStorageStub>();
   auto conn = MakeConnection(mock);
   EXPECT_CALL(*mock, CreateReadSession(_))
-      .WillOnce(testing::Invoke(
+      .WillOnce(
           [](bigquerystorage_proto::CreateReadSessionRequest const& request)
               -> StatusOr<bigquerystorage_proto::ReadSession> {
             EXPECT_THAT(request.parent(), Eq("projects/my-parent-project"));
@@ -108,7 +107,7 @@ TEST(ConnectionImplTest, ParallelReadRpcSuccess) {
             )pb";
             EXPECT_TRUE(TextFormat::ParseFromString(text, &response));
             return response;
-          }));
+          });
 
   StatusOr<std::vector<ReadStream>> result =
       conn->ParallelRead("my-parent-project", "my-project:my-dataset.my-table",


### PR DESCRIPTION
It is not necessary to `Invoke()` a lambda in the context of
`WillOnce()` or `WillRepeatedly()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4434)
<!-- Reviewable:end -->
