### PR TITLE
chore: add missing version.h includes in headers

### DIFF
--- a/google/cloud/bigtable/iam_policy.h
+++ b/google/cloud/bigtable/iam_policy.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_IAM_POLICY_H
 
 #include "google/cloud/bigtable/iam_binding.h"
+#include "google/cloud/bigtable/version.h"
 #include <list>
 
 namespace google {

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/async_read_stream_impl.h"
 #include "google/cloud/internal/completion_queue_impl.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/tracing_options.h"
+#include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>
 #include <functional>
 #include <memory>

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/future_then_meta.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/future_then_meta.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/iam_policy.h
+++ b/google/cloud/iam_policy.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_IAM_POLICY_H
 
 #include "google/cloud/iam_bindings.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/background_threads_impl.h
+++ b/google/cloud/internal/background_threads_impl.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/background_threads.h"
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/version.h"
 #include <thread>
 
 namespace google {

--- a/google/cloud/internal/backoff_policy.h
+++ b/google/cloud/internal/backoff_policy.h
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/optional.h"
+#include "google/cloud/version.h"
 #include <chrono>
 #include <memory>
 

--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
 #include <array>
 #include <cstdint>
 #include <limits>

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -21,6 +21,7 @@
  */
 
 #include "google/cloud/internal/future_impl.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -22,6 +22,7 @@
 
 #include "google/cloud/internal/future_then_meta.h"
 #include "google/cloud/terminate_handler.h"
+#include "google/cloud/version.h"
 #include "absl/memory/memory.h"
 #include <condition_variable>
 #include <exception>

--- a/google/cloud/internal/future_then_impl.h
+++ b/google/cloud/internal/future_then_impl.h
@@ -28,6 +28,7 @@
 
 #include "google/cloud/future_generic.h"
 #include "google/cloud/future_void.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/future_then_meta.h
+++ b/google/cloud/internal/future_then_meta.h
@@ -22,6 +22,7 @@
 
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/internal/getenv.h
+++ b/google/cloud/internal/getenv.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GETENV_H
 
 #include "google/cloud/optional.h"
+#include "google/cloud/version.h"
 #include <string>
 
 namespace google {

--- a/google/cloud/internal/setenv.h
+++ b/google/cloud/internal/setenv.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETENV_H
 
 #include "google/cloud/optional.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/source_accumulators.h
+++ b/google/cloud/internal/source_accumulators.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/future.h"
 #include "google/cloud/internal/source_ready_token.h"
+#include "google/cloud/version.h"
 #include "absl/meta/type_traits.h"
 #include "absl/types/variant.h"
 #include <vector>

--- a/google/cloud/internal/source_builder.h
+++ b/google/cloud/internal/source_builder.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SOURCE_BUILDER_H
 
 #include "google/cloud/internal/source_transforms.h"
+#include "google/cloud/version.h"
 #include "absl/meta/type_traits.h"
 #include <utility>
 

--- a/google/cloud/internal/source_transforms.h
+++ b/google/cloud/internal/source_transforms.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/source_ready_token.h"
+#include "google/cloud/version.h"
 #include "absl/meta/type_traits.h"
 #include "absl/types/variant.h"
 

--- a/google/cloud/internal/throw_delegate.h
+++ b/google/cloud/internal/throw_delegate.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_THROW_DELEGATE_H
 
 #include "google/cloud/status.h"
+#include "google/cloud/version.h"
 #include <system_error>
 
 namespace google {

--- a/google/cloud/pubsub/create_subscription_builder.h
+++ b/google/cloud/pubsub/create_subscription_builder.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/topic.h"
+#include "google/cloud/pubsub/version.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 
 namespace google {

--- a/google/cloud/pubsub/create_topic_builder.h
+++ b/google/cloud/pubsub/create_topic_builder.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_TOPIC_BUILDER_H
 
 #include "google/cloud/pubsub/topic.h"
+#include "google/cloud/pubsub/version.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 
 namespace google {

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_PUBLISHER_STUB_H
 
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/version.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.grpc.pb.h>
 

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIBER_STUB_H
 
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/version.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.grpc.pb.h>
 

--- a/google/cloud/pubsub/publisher_client.h
+++ b/google/cloud/pubsub/publisher_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/create_topic_builder.h"
 #include "google/cloud/pubsub/publisher_connection.h"
+#include "google/cloud/pubsub/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/topic.h"
+#include "google/cloud/pubsub/version.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>

--- a/google/cloud/pubsub/subscriber_client.h
+++ b/google/cloud/pubsub/subscriber_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/create_subscription_builder.h"
 #include "google/cloud/pubsub/subscriber_connection.h"
+#include "google/cloud/pubsub/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/pubsub/version.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -34,6 +34,7 @@
 #include "google/cloud/spanner/session_pool_options.h"
 #include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/spanner/transaction.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -21,6 +21,7 @@
 #include "google/cloud/spanner/database_admin_connection.h"
 #include "google/cloud/spanner/iam_updater.h"
 #include "google/cloud/spanner/instance.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <chrono>

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -22,6 +22,7 @@
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <string>

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/iam_updater.h"
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/instance_admin_connection.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 
 namespace google {

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
 #include <map>

--- a/google/cloud/spanner/internal/database_admin_logging.h
+++ b/google/cloud/spanner/internal/database_admin_logging.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/spanner/tracing_options.h"
+#include "google/cloud/spanner/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/database_admin_metadata.h
+++ b/google/cloud/spanner/internal/database_admin_metadata.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_METADATA_H
 
 #include "google/cloud/spanner/internal/database_admin_stub.h"
+#include "google/cloud/spanner/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H
 
 #include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/tracing_options.h"
+#include "google/cloud/spanner/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_INSTANCE_ADMIN_METADATA_H
 
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
+#include "google/cloud/spanner/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_INSTANCE_ADMIN_STUB_H
 
 #include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/partial_result_set_reader.h"
 #include "google/cloud/spanner/tracing_options.h"
+#include "google/cloud/spanner/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/logging_spanner_stub.h
+++ b/google/cloud/spanner/internal/logging_spanner_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/tracing_options.h"
+#include "google/cloud/spanner/version.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_METADATA_SPANNER_STUB_H
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
+#include "google/cloud/spanner/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/internal/partial_result_set_reader.h"
 #include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
 #include <functional>
 #include <memory>
 

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/partial_result_set_reader.h"
 #include "google/cloud/spanner/results.h"
 #include "google/cloud/spanner/value.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"

--- a/google/cloud/spanner/internal/polling_loop.h
+++ b/google/cloud/spanner/internal/polling_loop.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_POLLING_LOOP_H
 
 #include "google/cloud/spanner/polling_policy.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/status_or.h"

--- a/google/cloud/spanner/internal/retry_loop.h
+++ b/google/cloud/spanner/internal/retry_loop.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/status_or.h"
 #include <grpcpp/grpcpp.h>

--- a/google/cloud/spanner/mocks/mock_database_admin_connection.h
+++ b/google/cloud/spanner/mocks/mock_database_admin_connection.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_MOCKS_MOCK_DATABASE_ADMIN_CONNECTION_H
 
 #include "google/cloud/spanner/database_admin_connection.h"
+#include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/mocks/mock_instance_admin_connection.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_MOCKS_MOCK_INSTANCE_ADMIN_CONNECTION_H
 
 #include "google/cloud/spanner/instance_admin_connection.h"
+#include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/query_partition.h"
 #include "google/cloud/spanner/read_partition.h"
 #include "google/cloud/spanner/row.h"
+#include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/value.h"
+#include "google/cloud/spanner/version.h"
 #include <google/spanner/v1/mutation.pb.h>
 #include <vector>
 

--- a/google/cloud/spanner/polling_policy.h
+++ b/google/cloud/spanner/polling_policy.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/status.h"
 
 namespace google {

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/sql_statement.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include <memory>
 #include <string>

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/timestamp.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include <google/spanner/v1/spanner.pb.h>
 #include <memory>

--- a/google/cloud/spanner/sql_statement.h
+++ b/google/cloud/spanner/sql_statement.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_SQL_STATEMENT_H
 
 #include "google/cloud/spanner/value.h"
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/v1/spanner.pb.h>
 #include <string>

--- a/google/cloud/spanner/testing/cleanup_stale_databases.h
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_DATABASES_H
 
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/version.h"
 #include <chrono>
 #include <string>
 

--- a/google/cloud/spanner/testing/fake_clock.h
+++ b/google/cloud/spanner/testing/fake_clock.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_FAKE_CLOCK_H
 
 #include "google/cloud/spanner/internal/clock.h"
+#include "google/cloud/spanner/version.h"
 #include <chrono>
 #include <mutex>
 

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_INSTANCE_ADMIN_STUB_H
 
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
+#include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/status.h"
+#include "google/cloud/version.h"
 #include <type_traits>
 #include <utility>
 

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_GRPC_PLUGIN_H
 
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 
 namespace google {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CLIENT_H
 
 #include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/storage/version.h"
 #include <google/storage/v1/storage.grpc.pb.h>
 
 namespace google {

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_OBJECT_READ_SOURCE_H
 
 #include "google/cloud/storage/internal/object_read_source.h"
+#include "google/cloud/storage/version.h"
 #include <google/storage/v1/storage.grpc.pb.h>
 #include <functional>
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
+#include "google/cloud/storage/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/storage/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_SIGN_BLOB_REQUESTS_H
 
 #include "google/cloud/storage/internal/generic_request.h"
+#include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 #include <string>
 #include <vector>

--- a/google/cloud/testing_util/capture_log_lines_backend.h
+++ b/google/cloud/testing_util/capture_log_lines_backend.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_CAPTURE_LOG_LINES_BACKEND_H
 
 #include "google/cloud/log.h"
+#include "google/cloud/version.h"
 #include <vector>
 
 namespace google {

--- a/google/cloud/testing_util/fake_source.h
+++ b/google/cloud/testing_util/fake_source.h
@@ -18,6 +18,7 @@
 #include "google/cloud/future.h"
 #include "google/cloud/internal/source_ready_token.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/version.h"
 #include "absl/types/variant.h"
 #include <chrono>
 #include <deque>

--- a/google/cloud/testing_util/mock_completion_queue.h
+++ b/google/cloud/testing_util/mock_completion_queue.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_COMPLETION_QUEUE_H
 
 #include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/testing_types.h
+++ b/google/cloud/testing_util/testing_types.h
@@ -27,6 +27,7 @@
  */
 
 #include "google/cloud/log.h"
+#include "google/cloud/version.h"
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
For future reference, I found these using:

```
grep -rl --include='*.h' 'namespace.*_NS' google | xargs grep -L '#include.*version\.h' | xargs
```
(it produces one false positive for `google/cloud/version.h` itself.)

it's possible there are some .cc files that should include version.h (if they don't have their own matching header that includes it),
but that's more difficult to determine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4436)
<!-- Reviewable:end -->
