### PR TITLE
fix(storage): accept more than one matching log line

### DIFF
--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -172,7 +172,8 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
                     [](std::string const& line) {
                       return line.rfind("x-goog-hash: crc32c=", 0) == 0;
                     });
-  EXPECT_EQ(1, count);
+  // The count could be > 1 if there was a retry.
+  EXPECT_LE(1, count);
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -204,7 +205,8 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
         // contents.
         return line.rfind("content-type: multipart/related; boundary=", 0) == 0;
       });
-  EXPECT_EQ(1, count);
+  // The count could be > 1 if there was a retry.
+  EXPECT_LE(1, count);
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
     // When running against the testbench, we have some more information to

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -67,7 +67,8 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
                     [](std::string const& line) {
                       return line.rfind("x-goog-hash: md5=", 0) == 0;
                     });
-  EXPECT_EQ(1, count);
+  // The count could be > 1 if there was a retry.
+  EXPECT_LE(1, count);
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -99,7 +100,8 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
         // contents.
         return line.rfind("content-type: multipart/related; boundary=", 0) == 0;
       });
-  EXPECT_EQ(1, count);
+  // The count could be > 1 if there was a retry.
+  EXPECT_LE(1, count);
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
     // When running against the testbench, we have some more information to


### PR DESCRIPTION
Some of the integration tests for storage look for specific log lines to
verify the right data is sent to the server. Typically only one such
line is present, but if the library retries two or more might appear. I
ran into this in one of my builds, but seems to be fairly rare.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4445)
<!-- Reviewable:end -->
