### PR TITLE
fix: CompletionQueue::RunAsync is always async

### DIFF
--- a/google/cloud/completion_queue.cc
+++ b/google/cloud/completion_queue.cc
@@ -104,7 +104,7 @@ class AsyncFunction : public internal::AsyncGrpcOperation {
 
   std::shared_ptr<internal::CompletionQueueImpl> cq_;
   std::unique_ptr<internal::RunAsyncBase> fun_;
-  // Holds the underlying handle, it might be a nullpotr in tests.
+  // Holds the underlying handle, it might be a nullptr in tests.
   std::unique_ptr<grpc::Alarm> alarm_;
 };
 


### PR DESCRIPTION
Prior to this change we sometimes ran the callable passed to
`CompletionQueue::RunAsync()` in the calling thread and not
in the thread pool, which was hard to reason about.

As part of these changes I also fixed the code to support
move-only callables, and added a test for it.

The code is "future proofed" to support a `void()` callable.
Which is interesting for a number of reasons (think "executors").

Fixes #4083 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4448)
<!-- Reviewable:end -->
