### PR TITLE
feat: CompletionQueue::RunAsync with no arguments

### DIFF
--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -231,7 +231,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
         return;
       }
       if (break_recursion) {
-        self->cq_.RunAsync([self](CompletionQueue&) { self->UserWantsRows(); });
+        self->cq_.RunAsync([self] { self->UserWantsRows(); });
         return;
       }
       self->UserWantsRows();

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -208,6 +208,32 @@ class CompletionQueue {
         absl::make_unique<Wrapper>(impl_, std::forward<Functor>(functor)));
   }
 
+  /**
+   * Asynchronously run a functor on a thread `Run()`ning the `CompletionQueue`.
+   *
+   * @tparam Functor the functor to call on the CompletionQueue thread.
+   *   It must satisfy the `void()` signature.
+   * @param functor the value of the functor.
+   * @return an asynchronous operation wrapping the functor; it can be used for
+   *   cancelling but it makes little sense given that it will be completed
+   *   straight away
+   */
+  template <typename Functor,
+            typename std::enable_if<internal::is_invocable<Functor>::value,
+                                    int>::type = 0>
+  void RunAsync(Functor&& functor) {
+    class Wrapper : public internal::RunAsyncBase {
+     public:
+      Wrapper(Functor&& f) : fun_(std::forward<Functor>(f)) {}
+      ~Wrapper() override = default;
+      void exec() override { fun_(); }
+
+     private:
+      absl::decay_t<Functor> fun_;
+    };
+    RunAsyncImpl(absl::make_unique<Wrapper>(std::forward<Functor>(functor)));
+  }
+
  private:
   void RunAsyncImpl(std::unique_ptr<internal::RunAsyncBase>);
 

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -224,7 +224,7 @@ class CompletionQueue {
   void RunAsync(Functor&& functor) {
     class Wrapper : public internal::RunAsyncBase {
      public:
-      Wrapper(Functor&& f) : fun_(std::forward<Functor>(f)) {}
+      explicit Wrapper(Functor&& f) : fun_(std::forward<Functor>(f)) {}
       ~Wrapper() override = default;
       void exec() override { fun_(); }
 

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -180,9 +180,6 @@ class CompletionQueue {
    * @tparam Functor the functor to call on the CompletionQueue thread.
    *   It must satisfy the `void(CompletionQueue&)` signature.
    * @param functor the value of the functor.
-   * @return an asynchronous operation wrapping the functor; it can be used for
-   *   cancelling but it makes little sense given that it will be completed
-   *   straight away
    */
   template <typename Functor,
             typename std::enable_if<
@@ -214,9 +211,6 @@ class CompletionQueue {
    * @tparam Functor the functor to call on the CompletionQueue thread.
    *   It must satisfy the `void()` signature.
    * @param functor the value of the functor.
-   * @return an asynchronous operation wrapping the functor; it can be used for
-   *   cancelling but it makes little sense given that it will be completed
-   *   straight away
    */
   template <typename Functor,
             typename std::enable_if<internal::is_invocable<Functor>::value,


### PR DESCRIPTION
Support callables that take no arguments (not even a CompletionQueue),
this is already useful in some tests, AsyncRowReader, and I think will
be useful if completion queues will model an executor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4450)
<!-- Reviewable:end -->
