### PR TITLE
feat: log exceptions in example driver

### DIFF
--- a/google/cloud/testing_util/example_driver.cc
+++ b/google/cloud/testing_util/example_driver.cc
@@ -70,6 +70,9 @@ int Example::Run(int argc, char const* const argv[]) try {
 } catch (Usage const& u) {
   PrintUsage(argv[0], u.what());
   return 1;
+} catch (std::exception const& ex) {
+  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+  throw;
 }
 
 void Example::PrintUsage(std::string const& cmd, std::string const& msg) {


### PR DESCRIPTION
If there is an error we want to log as much detail as we can to help
troubleshoot the problem, before this change we just get a "terminated"
without any details.

See some of the recently captured logs in #4255 for motivation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4453)
<!-- Reviewable:end -->
