### PR TITLE
fix: libcurl Bazel rules

### DIFF
--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -330,15 +330,17 @@ cc_library(
         ":macos": [
             "-fno-constant-cfstrings",
         ],
+        "//conditions:default": [],
+    }),
+    defines = ["CURL_STATICLIB"] + select({
         ":windows": [
             # See curl.h for discussion of write size and Windows
-            "/DCURL_MAX_WRITE_SIZE=16384",
+            "CURL_MAX_WRITE_SIZE=16384",
         ],
         "//conditions:default": [
-            "-DCURL_MAX_WRITE_SIZE=65536",
+            "CURL_MAX_WRITE_SIZE=65536",
         ],
     }),
-    defines = ["CURL_STATICLIB"],
     includes = ["include"],
     linkopts = select({
         ":macos": [


### PR DESCRIPTION
We have custom Bazel rules for libcurl, as the library does not support
Bazel. Our rules were definining CURL_MAX_WRITE_SIZE to 64KiB when
*compiling* libcurl, but used the default (16KiB) when *using* libcurl.
This macro defines the maximum buffer passed to the write callback, and
we use it in the storage library to size our buffers. You can now see
how this is a problem. Lucky for us, when running against production the
actual data received is around 1500 bytes (the MTU maybe?) so things
worked, but trying to run the tests against the emulator did not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4461)
<!-- Reviewable:end -->
