### PR TITLE
ci: install llvm-symbolizer for *san builds

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -19,8 +19,8 @@ FROM fedora:${DISTRO_VERSION}
 RUN dnf makecache && \
     dnf install -y clang clang-tools-extra cmake diffutils findutils \
         gcc-c++ git libcxx-devel libcxxabi-devel libasan libubsan libtsan \
-        make openssl-devel pkgconfig python3 python3-devel python3-pip tar \
-        unzip wget which zlib-devel
+        llvm make openssl-devel pkgconfig python3 python3-devel python3-pip \
+        tar unzip wget which zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because

--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -19,8 +19,8 @@ FROM fedora:${DISTRO_VERSION}
 # then compile our code.
 RUN dnf makecache && \
     dnf install -y clang clang-tools-extra cmake findutils gcc-c++ git \
-        llvm-devel make ninja-build openssl-devel python3-lit tar unzip which \
-        wget xz
+        llvm llvm-devel make ninja-build openssl-devel python3-lit tar unzip \
+        which wget xz
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because


### PR DESCRIPTION
The sanitizers (I tested AddressSanitizer, but I hope all of them),
produce must more readable stack traces if the llvm-symbolizer is
installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4462)
<!-- Reviewable:end -->
