### PR TITLE
test: reduce flakiness in CreateBucket/DeleteBucket

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -42,3 +42,5 @@ RUN /var/tmp/ci/install-cloud-sdk.sh
 
 # Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh
+
+RUN dnf makecache && dnf install -y llvm

--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -19,14 +19,20 @@ FROM fedora:${DISTRO_VERSION}
 # then compile our code.
 RUN dnf makecache && \
     dnf install -y clang clang-tools-extra cmake findutils gcc-c++ git \
-        llvm llvm-devel make ninja-build openssl-devel python3-lit tar unzip \
-        which wget xz
+        llvm llvm-devel make ninja-build openssl-devel python3 python3-devel \
+        python3-lit python3-pip tar unzip which wget xz
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
 # the container's /etc/passwd file.
 RUN echo 'root:' | chpasswd
+
+# Install the Python modules needed to run the storage testbench
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools
+RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
+    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
 WORKDIR /var/tmp/build
 RUN wget -q http://releases.llvm.org/8.0.0/libcxx-8.0.0.src.tar.xz

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -131,11 +131,10 @@ if should_run_integration_tests; then
 
   readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
 
-  echo
+  echo "================================================================"
   io::log_yellow "running storage integration tests via Bazel+Emulator"
-  echo
   "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-    "${BAZEL_BIN}" "${bazel_args[@]}"
+    "${BAZEL_BIN}" "${bazel_args[@]}" --test_timeout=600
 
   # TODO(#441) - remove the for loops below.
   # Sometimes the integration tests manage to crash the Bigtable emulator.

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -19,7 +19,7 @@ source "$(dirname "$0")/../../../../ci/lib/init.sh"
 source module etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $(basename "$0") [bazel-test-args]"
+  echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"
   exit 1
 fi
 

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -37,7 +37,13 @@ class ThroughputExperimentIntegrationTest
   std::string bucket_name_;
 };
 
+bool ProductionOnly(ApiName api) {
+  return api == ApiName::kApiRawGrpc || api == ApiName::kApiGrpc;
+}
+
 TEST_P(ThroughputExperimentIntegrationTest, Upload) {
+  if (UsingTestbench() && ProductionOnly(GetParam())) GTEST_SKIP();
+
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -65,6 +71,8 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
 }
 
 TEST_P(ThroughputExperimentIntegrationTest, Download) {
+  if (UsingTestbench() && ProductionOnly(GetParam())) GTEST_SKIP();
+
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module etc/integration-tests-config.sh
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"
+  exit 1
+fi
+
+# Configure run_emulators_utils.sh to find the instance admin emulator.
+BAZEL_BIN="$1"
+shift
+bazel_test_args=("$@")
+
+# Configure run_emulators_utils.sh to find the instance admin emulator.
+# Configure run_emulators_utils.sh to find the instance admin emulator.
+source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
+
+# These can only run against production
+production_only_targets=(
+  "//google/cloud/storage/examples:storage_grpc_samples"
+  "//google/cloud/storage/examples:storage_policy_doc_samples"
+  "//google/cloud/storage/examples:storage_signed_url_v2_samples"
+  "//google/cloud/storage/examples:storage_signed_url_v4_samples"
+  "//google/cloud/storage/tests:grpc_integration_test"
+  "//google/cloud/storage/tests:key_file_integration_test"
+  "//google/cloud/storage/tests:signed_url_integration_test"
+)
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" \
+  --test_tag_filters="integration-test" -- \
+  "${production_only_targets[@]}"
+
+# `start_testbench` creates unsightly *.log files in the current directory
+# (which is ${PROJECT_ROOT}) and we cannot use a subshell because we want the
+# environment variables that it sets.
+pushd "${HOME}" >/dev/null
+# Start the testbench on a fixed port, otherwise the Bazel cache gets
+# invalidated on each run.
+start_testbench 8585
+popd >/dev/null
+
+excluded_targets=(
+  # This test does not work with Bazel, because it depends on dynamic loading
+  # and some CMake magic. It is also skipped against production, so most Bazel
+  # builds run it but it is a no-op.
+  "-//google/cloud/storage/tests:error_injection_integration_test"
+)
+for target in "${production_only_targets[@]}"; do
+  excluded_targets+=("-${target}")
+done
+
+# GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME is automatically created, but we
+# need to create the *DESTINATION_BUCKET_NAME too. Note that when the
+# `storage_bucket_samples` binary is missing the examples that use said bucket
+# are missing too.
+testbench_args=(
+  "--test_env=CLOUD_STORAGE_TESTBENCH_ENDPOINT=${CLOUD_STORAGE_TESTBENCH_ENDPOINT}"
+  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT=fake-service-account-sign@example.com"
+  "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
+)
+"${BAZEL_BIN}" run "${bazel_test_args[@]}" "${testbench_args[@]}" \
+  "//google/cloud/storage/examples:storage_bucket_samples" \
+  -- create-bucket-for-project \
+  "${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}" \
+  "${GOOGLE_CLOUD_PROJECT}" >/dev/null
+
+# We need to forward some environment variables suitable for running against
+# the testbench. Note that the HMAC service account is completely invalid and
+# it is not unique to each test, neither is a problem when using the emulator.
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" "${testbench_args[@]}" \
+  --test_tag_filters="integration-test" -- \
+  "//google/cloud/storage/...:all" \
+  "${excluded_targets[@]}"
+exit_status=$?
+
+kill_testbench
+trap '' EXIT
+
+exit "${exit_status}"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -28,8 +28,7 @@ BAZEL_BIN="$1"
 shift
 bazel_test_args=("$@")
 
-# Configure run_emulators_utils.sh to find the instance admin emulator.
-# Configure run_emulators_utils.sh to find the instance admin emulator.
+# Configure run_testbench_utils.sh to run the GCS testbench.
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 
 # These can only run against production
@@ -88,8 +87,5 @@ testbench_args=(
   "//google/cloud/storage/...:all" \
   "${excluded_targets[@]}"
 exit_status=$?
-
-kill_testbench
-trap '' EXIT
 
 exit "${exit_status}"

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -250,8 +250,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   auto const reader = gcs::BucketAccessControl::ROLE_READER();

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
+#include <thread>
 
 namespace {
 
@@ -246,10 +246,13 @@ void RunAll(std::vector<std::string> const& argv) {
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   auto const reader = gcs::BucketAccessControl::ROLE_READER();
   auto const owner = gcs::BucketAccessControl::ROLE_OWNER();
@@ -281,6 +284,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning RemoveBucketOwner() example" << std::endl;
   RemoveBucketOwner(client, {bucket_name, entity});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -104,8 +104,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning the SetCorsConfiguration() example" << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
+#include <thread>
 
 namespace {
 
@@ -112,10 +113,13 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning the GetBucketDefaultKmsKey() example [1]"
             << std::endl;
@@ -131,6 +135,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning the RemoveBucketDefaultKmsKey() example" << std::endl;
   RemoveBucketDefaultKmsKey(client, {bucket_name});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -117,8 +117,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning the GetBucketDefaultKmsKey() example [1]"

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -402,8 +402,8 @@ void RunAll(std::vector<std::string> const& argv) {
               gcs::BucketMetadata{}.set_iam_configuration(iam_configuration()))
           .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetBucketIamPolicy() example" << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <thread>
 
 namespace {
 
@@ -400,6 +401,10 @@ void RunAll(std::vector<std::string> const& argv) {
               bucket_name, project_id,
               gcs::BucketMetadata{}.set_iam_configuration(iam_configuration()))
           .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetBucketIamPolicy() example" << std::endl;
   GetBucketIamPolicy(client, {bucket_name});
@@ -456,6 +461,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning SetBucketPublicIam() example" << std::endl;
   SetBucketPublicIam(client, {bucket_name});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -191,8 +191,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetBilling() example [1]" << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
+#include <thread>
 
 namespace {
 
@@ -187,10 +187,13 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetBilling() example [1]" << std::endl;
   GetBilling(client, {bucket_name, project_id});
@@ -216,6 +219,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning GetBilling() example [3]" << std::endl;
   GetBilling(client, {bucket_name, project_id});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -17,8 +17,6 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
-#include <sstream>
 
 namespace {
 
@@ -99,7 +97,7 @@ void CreateBucketForProject(google::cloud::storage::Client client,
      std::string const& project_id) {
     StatusOr<gcs::BucketMetadata> bucket_metadata =
         client.CreateBucketForProject(bucket_name, project_id,
-                                      gcs::BucketMetadata());
+                                      gcs::BucketMetadata{});
 
     if (!bucket_metadata) {
       throw std::runtime_error(bucket_metadata.status().message());

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -207,8 +207,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   auto const reader = gcs::BucketAccessControl::ROLE_READER();

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -127,8 +127,8 @@ void RunAll(std::vector<std::string> const& argv) {
   (void)client.CreateBucketForProject(bucket_name, project_id,
                                       gcs::BucketMetadata{});
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetDefaultEventBasedHold() example" << std::endl;

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -17,8 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
-#include <sstream>
+#include <thread>
 
 namespace {
 
@@ -133,6 +132,10 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nCreating bucket to run the examples" << std::endl;
   (void)client.CreateBucketForProject(bucket_name, project_id,
                                       gcs::BucketMetadata());
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning EnableBucketLifecycleManagement() example"
             << std::endl;
@@ -149,6 +152,7 @@ void RunAll(std::vector<std::string> const& argv) {
   GetBucketLifecycleManagement(client, {bucket_name});
 
   std::cout << "\nCleaning up" << std::endl;
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -133,8 +133,8 @@ void RunAll(std::vector<std::string> const& argv) {
   (void)client.CreateBucketForProject(bucket_name, project_id,
                                       gcs::BucketMetadata());
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning EnableBucketLifecycleManagement() example"

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
+#include <thread>
 
 namespace {
 
@@ -129,10 +130,13 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning ListNotifications() example [1]" << std::endl;
   ListNotifications(client, {bucket_name});
@@ -174,6 +178,7 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning DeleteNotification() example [2]" << std::endl;
   DeleteNotification(client, {bucket_name, n2.id()});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -134,8 +134,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning ListNotifications() example [1]" << std::endl;

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -263,8 +263,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   auto const object_name = examples::MakeRandomObjectName(generator, "object-");

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
+#include <thread>
 
 namespace {
 
@@ -111,10 +111,13 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   auto const cmek_object_name =
       examples::MakeRandomObjectName(generator, "cmek-object-") + ".txt";
@@ -155,6 +158,7 @@ void RunAll(std::vector<std::string> const& argv) {
   }
   (void)client.DeleteObject(bucket_name, csek_object_name);
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -115,8 +115,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   auto const cmek_object_name =

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -526,8 +526,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::string const object_media("a-string-to-serve-as-object-media");

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -18,10 +18,8 @@
 #include "google/cloud/storage/parallel_upload.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include "google/cloud/internal/getenv.h"
-#include <fstream>
 #include <iostream>
 #include <map>
-#include <sstream>
 #include <string>
 #include <thread>
 
@@ -524,10 +522,13 @@ void RunAll(std::vector<std::string> const& argv) {
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::string const object_media("a-string-to-serve-as-object-media");
   auto const object_name = examples::MakeRandomObjectName(generator, "object-");
@@ -623,6 +624,7 @@ void RunAll(std::vector<std::string> const& argv) {
                             {bucket_name, object_name_retry, object_media});
   DeleteObject(client, {bucket_name, object_name_retry});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_object_versioning_samples.cc
+++ b/google/cloud/storage/examples/storage_object_versioning_samples.cc
@@ -175,8 +175,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning the GetObjectVersioning() example [1]" << std::endl;

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 namespace {
 
@@ -129,10 +130,13 @@ void RunAll(std::vector<std::string> const& argv) {
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning the CreatedSignedPolicyDocumentV2() example"
             << std::endl;
@@ -146,6 +150,7 @@ void RunAll(std::vector<std::string> const& argv) {
             << std::endl;
   CreatePolicyDocumentFormV4(client, {bucket_name, object_name});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -134,8 +134,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning the CreatedSignedPolicyDocumentV2() example"

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -179,8 +179,8 @@ void RunAll(std::vector<std::string> const& argv) {
   (void)client.CreateBucketForProject(bucket_name, project_id,
                                       gcs::BucketMetadata{});
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetRetentionPolicy() example" << std::endl;

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -17,8 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <iostream>
-#include <map>
-#include <sstream>
+#include <thread>
 
 namespace {
 
@@ -178,7 +177,11 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;
   (void)client.CreateBucketForProject(bucket_name, project_id,
-                                      gcs::BucketMetadata());
+                                      gcs::BucketMetadata{});
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning GetRetentionPolicy() example" << std::endl;
   GetRetentionPolicy(client, {bucket_name});
@@ -196,6 +199,7 @@ void RunAll(std::vector<std::string> const& argv) {
   LockRetentionPolicy(client, {bucket_name});
 
   std::cout << "\nCleaning up" << std::endl;
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -144,8 +144,8 @@ void RunAll(std::vector<std::string> const& argv) {
       .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
       .value();
   // In GCS a single project cannot create or delete buckets more often than
-  // once every two seconds. We will pause for at least that long before
-  // deleting the bucket.
+  // once every two seconds. We will pause until that time before deleting the
+  // bucket.
   auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning SetStaticWebsiteConfiguration() example" << std::endl;

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -15,7 +15,9 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
+#include <chrono>
 #include <iostream>
+#include <thread>
 
 namespace {
 
@@ -138,10 +140,13 @@ void RunAll(std::vector<std::string> const& argv) {
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;
-  auto bucket_metadata = client
-                             .CreateBucketForProject(bucket_name, project_id,
-                                                     gcs::BucketMetadata{})
-                             .value();
+  (void)client
+      .CreateBucketForProject(bucket_name, project_id, gcs::BucketMetadata{})
+      .value();
+  // In GCS a single project cannot create or delete buckets more often than
+  // once every two seconds. We will pause for at least that long before
+  // deleting the bucket.
+  auto pause = std::chrono::steady_clock::now() + std::chrono::seconds(2);
 
   std::cout << "\nRunning SetStaticWebsiteConfiguration() example" << std::endl;
   SetStaticWebsiteConfiguration(
@@ -154,6 +159,7 @@ void RunAll(std::vector<std::string> const& argv) {
             << std::endl;
   RemoveStaticWebsiteConfiguration(client, {bucket_name});
 
+  if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
   (void)client.DeleteBucket(bucket_name);
 }
 

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -51,9 +51,11 @@ StorageIntegrationTest::MakeBucketIntegrationTestClient() {
   auto constexpr kInitialDelay = std::chrono::seconds(5);
   auto constexpr kMaximumBackoffDelay = std::chrono::minutes(5);
   auto constexpr kBackoffScalingFactor = 2.0;
+  // This is comparable to the timeout for each integration test, it makes
+  // little sense to wait any longer.
+  auto constexpr kMaximumRetryTime = std::chrono::minutes(10);
   return MakeIntegrationTestClient(
-      LimitedTimeRetryPolicy(/*maximum_duration=*/2 * kMaximumBackoffDelay)
-          .clone(),
+      LimitedTimeRetryPolicy(kMaximumRetryTime).clone(),
       ExponentialBackoffPolicy(kInitialDelay, kMaximumBackoffDelay,
                                kBackoffScalingFactor)
           .clone());

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -19,7 +19,9 @@
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace google {
@@ -31,11 +33,35 @@ namespace testing {
  */
 class StorageIntegrationTest : public ::testing::Test {
  protected:
+  /**
+   * Return a client suitable for most integration tests.
+   *
+   * Most integration tests, particularly when running against the testbench,
+   * should use short backoff and retry periods. This returns a client so
+   * configured.
+   */
   static google::cloud::StatusOr<google::cloud::storage::Client>
   MakeIntegrationTestClient();
 
+  /**
+   * Return a client with retry policies suitable for CreateBucket() class.
+   *
+   * Creating (and deleting) buckets require (specially when using production)
+   * longer backoff and retry periods. A single project cannot create more than
+   * one bucket every two seconds, suggesting that the default backoff should be
+   * at least that long.
+   */
+  static google::cloud::StatusOr<google::cloud::storage::Client>
+  MakeBucketIntegrationTestClient();
+
+  /// Like MakeIntegrationTestClient() but with a custom retry policy
   static google::cloud::StatusOr<google::cloud::storage::Client>
   MakeIntegrationTestClient(std::unique_ptr<RetryPolicy> retry_policy);
+
+  /// Like MakeIntegrationTestClient() but with custom retry and bucket policies
+  static google::cloud::StatusOr<google::cloud::storage::Client>
+  MakeIntegrationTestClient(std::unique_ptr<RetryPolicy> retry_policy,
+                            std::unique_ptr<BackoffPolicy> backoff_policy);
 
   static std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
   static std::unique_ptr<RetryPolicy> TestRetryPolicy();

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -56,7 +56,7 @@ class GrpcIntegrationTest
 };
 
 TEST_F(GrpcIntegrationTest, BucketCRUD) {
-  auto client = MakeIntegrationTestClient();
+  auto client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
@@ -89,12 +89,15 @@ TEST_F(GrpcIntegrationTest, BucketCRUD) {
 }
 
 TEST_F(GrpcIntegrationTest, ObjectCRUD) {
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -114,7 +117,7 @@ TEST_F(GrpcIntegrationTest, ObjectCRUD) {
       bucket_name, object_name, Generation(object_metadata->generation()));
   EXPECT_STATUS_OK(delete_object_status);
 
-  auto delete_bucket_status = client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
@@ -167,11 +170,14 @@ TEST_F(GrpcIntegrationTest, WriteResume) {
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 /// @test Verify that NOT_FOUND is returned for missing objects
 TEST_F(GrpcIntegrationTest, GetObjectMediaNotFound) {
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   auto client = Client::CreateDefaultClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
-  auto bucket_metadata = client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -196,7 +202,7 @@ TEST_F(GrpcIntegrationTest, GetObjectMediaNotFound) {
   auto status = stream->Finish();
   ASSERT_EQ(grpc::StatusCode::NOT_FOUND, status.error_code())
       << "message = " << status.error_message();
-  auto delete_bucket_status = client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
@@ -212,11 +218,14 @@ TEST_F(GrpcIntegrationTest, GetObjectMediaNotFound) {
 TEST_F(GrpcIntegrationTest, ReproLargeInsert) {
   if (!UsingGrpc()) GTEST_SKIP();
 
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   auto client = Client::CreateDefaultClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
-  auto bucket_metadata = client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -277,19 +286,22 @@ TEST_F(GrpcIntegrationTest, ReproLargeInsert) {
   auto delete_object_status = client->DeleteObject(bucket_name, object_name);
   EXPECT_STATUS_OK(delete_object_status);
 
-  auto delete_bucket_status = client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 TEST_F(GrpcIntegrationTest, InsertLarge) {
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -310,17 +322,20 @@ TEST_F(GrpcIntegrationTest, InsertLarge) {
   auto status = client->DeleteObject(bucket_name, object_name);
   EXPECT_STATUS_OK(status);
 
-  auto delete_bucket_status = client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 
 TEST_F(GrpcIntegrationTest, StreamLargeChunks) {
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
   auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
   auto object_name = MakeRandomObjectName();
-  auto bucket_metadata = client->CreateBucketForProject(
+  auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
 
@@ -342,7 +357,7 @@ TEST_F(GrpcIntegrationTest, StreamLargeChunks) {
   auto status = client->DeleteObject(bucket_name, object_name);
   EXPECT_STATUS_OK(status);
 
-  auto delete_bucket_status = client->DeleteBucket(bucket_name);
+  auto delete_bucket_status = bucket_client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_bucket_status);
 }
 

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -105,10 +105,13 @@ std::vector<ObjectNameList> DivideIntoEqualSizedGroups(
 TEST_F(ThreadIntegrationTest, Unshared) {
   std::string bucket_name =
       MakeRandomBucketName(/*prefix=*/"cloud-cpp-testing-");
+  auto bucket_client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(bucket_client);
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  StatusOr<BucketMetadata> meta = client->CreateBucketForProject(
+  StatusOr<BucketMetadata> meta = bucket_client->CreateBucketForProject(
       bucket_name, project_id_,
       BucketMetadata()
           .set_storage_class(storage_class::Standard())
@@ -153,7 +156,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
     t.get();
   }
 
-  auto delete_status = client->DeleteBucket(bucket_name);
+  auto delete_status = bucket_client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(delete_status);
   // This is basically a smoke test, if the test does not crash it was
   // successful.

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -53,11 +53,13 @@ kill_testbench() {
 #   None
 ################################################
 start_testbench() {
+  local port="${1:-0}"
+
   echo "${IO_COLOR_GREEN}[ -------- ]${IO_COLOR_RESET} Integration test environment set-up"
   echo "Launching testbench emulator in the background"
   trap kill_testbench EXIT
 
-  gunicorn --bind 0.0.0.0:0 \
+  gunicorn --bind "0.0.0.0:${port}" \
     --worker-class gevent \
     --access-logfile - \
     --pythonpath "${PROJECT_ROOT}/google/cloud/storage/testbench" \
@@ -94,7 +96,7 @@ start_testbench() {
     delay=$((delay * 2))
   done
 
-  if [ "${connected}" = "no" ]; then
+  if [[ "${connected}" = "no" ]]; then
     echo "Cannot connect to testbench; aborting test." >&2
     exit 1
   else


### PR DESCRIPTION
A single project (and we use a single project in our CI builds) can make
at most one CreateBucket or DeleteBucket request every 2 seconds. While
we have taken measures to minimize the number of times we touch
production (e.g. the CMake builds use the testbench, the Bazel builds
cache tests), sometimes there are enough CI builds hitting production
that we exceed this limit.

In this PR we take some additional measures to reduce the problems:

- The ci/kokoro/docker builds based on Bazel now use the GCS emulator
  (aka testbench) for most tests (a few tests must use production, but
  they do not create buckets AFAIK). This leaves the macOS and Windows
  builds running against production.
- Any loops that create buckets with different configurations now pause
  before each iteration. I do not think this slows down the builds
  because those "fast" calls failed and needed to retry anyway.
- For integration tests that create and/or delete buckets we use a
  longer initial backoff (5s) and longer total retry period (10m), as
  the default (for integration tests) were too short to actually work.
- In the examples, where we often create a temporary bucket, we pause
  before deleting the bucket if the total time is less than 2 seconds.
  Otherwise the delete operation will need to retry anyway.

This should minimize the problems in #4255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4463)
<!-- Reviewable:end -->
