### PR TITLE
ci: fix openSUSE (Leap) install build

### DIFF
--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -26,7 +26,8 @@ ARG NCPU=4
 # ```bash
 RUN zypper refresh && \
     zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
-        gzip libcurl-devel libopenssl-devel libtool make tar wget which
+        gzip libcurl-devel libopenssl-devel libtool make tar wget which \
+        zlib zlib-devel-static
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. openSUSE

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -359,7 +359,8 @@ workstation or build server.
 ```bash
 sudo zypper refresh && \
 sudo zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
-        gzip libcurl-devel libopenssl-devel libtool make tar wget which
+        gzip libcurl-devel libopenssl-devel libtool make tar wget which \
+        zlib zlib-devel-static
 ```
 
 The following steps will install libraries and tools in `/usr/local`. openSUSE


### PR DESCRIPTION
At some point in the last few days the dependencies changed, and now
`zlib-devel` needs to be explicitly installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4466)
<!-- Reviewable:end -->
