### PR TITLE
feat: `CreateDatabase` takes an optional encryption key

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -75,10 +75,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/59f97e6044a1275f83427ab7962a154c00d915b5.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/spanner_cmek.tar.gz",
             ],
-            strip_prefix = "googleapis-59f97e6044a1275f83427ab7962a154c00d915b5",
-            sha256 = "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073",
+            strip_prefix = "googleapis-spanner_cmek",
+            #sha256 = "",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -19,10 +19,10 @@ cmake_minimum_required(VERSION 3.5)
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-    "https://github.com/googleapis/googleapis/archive/59f97e6044a1275f83427ab7962a154c00d915b5.tar.gz"
+    "https://github.com/googleapis/googleapis/archive/spanner_cmek.tar.gz"
 )
-set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-    "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073")
+#set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
+#    "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073")
 
 set(GOOGLEAPIS_CPP_SOURCE
     "${CMAKE_BINARY_DIR}/external/googleapis/src/googleapis_download")

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -27,8 +27,10 @@ DatabaseAdminClient::DatabaseAdminClient(ConnectionOptions const& options)
     : conn_(MakeDatabaseAdminConnection(options)) {}
 
 future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
-    Database db, std::vector<std::string> extra_statements) {
-  return conn_->CreateDatabase({std::move(db), std::move(extra_statements)});
+    Database db, std::vector<std::string> extra_statements,
+    absl::optional<KmsKeyName> encryption_key) {
+  return conn_->CreateDatabase(
+      {std::move(db), std::move(extra_statements), std::move(encryption_key)});
 }
 
 StatusOr<gcsa::Database> DatabaseAdminClient::GetDatabase(Database db) {

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -23,7 +23,9 @@
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/kms_key_name.h"
 #include "google/cloud/status_or.h"
+#include "absl/types/optional.h"
 #include <chrono>
 
 namespace google {
@@ -129,6 +131,9 @@ class DatabaseAdminClient {
    * or dashes (`-`), that is, they must belong to the `[a-z0-9_-]` character
    * set.
    *
+   * @p encryption_key The name of the Cloud KMS key used to encrypt and decrypt
+   * the database.
+   *
    * @return A `google::cloud::future` that becomes satisfied when the operation
    *   completes on the service. Note that this can take minutes in some cases.
    *
@@ -143,7 +148,8 @@ class DatabaseAdminClient {
    *     for the regular expression that must be satisfied by the database id.
    */
   future<StatusOr<google::spanner::admin::database::v1::Database>>
-  CreateDatabase(Database db, std::vector<std::string> extra_statements = {});
+  CreateDatabase(Database db, std::vector<std::string> extra_statements = {},
+                 absl::optional<KmsKeyName> encryption_key = absl::nullopt);
 
   /**
    * Retrieve metadata information about a database.

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -146,6 +146,10 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
     request.set_parent(p.database.instance().FullName());
     request.set_create_statement("CREATE DATABASE `" +
                                  p.database.database_id() + "`");
+    if (p.encryption_key) {
+      request.mutable_encryption_config()->set_kms_key_name(
+          p.encryption_key->FullName());
+    }
     for (auto& s : p.extra_statements) {
       *request.add_extra_statements() = std::move(s);
     }

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -24,6 +24,8 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/pagination_range.h"
+#include "google/cloud/kms_key_name.h"
+#include "absl/types/optional.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <string>
 #include <vector>
@@ -119,6 +121,8 @@ class DatabaseAdminConnection {
     Database database;
     /// Any additional statements to execute after creating the database.
     std::vector<std::string> extra_statements;
+    /// The KMS key that was used to encrypt and decrypt the database.
+    absl::optional<KmsKeyName> encryption_key;
   };
 
   /// Wrap the arguments for `GetDatabase()`.

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/database_admin_connection.h"
 #include "google/cloud/spanner/testing/mock_database_admin_stub.h"
+#include "google/cloud/kms_key_name.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
@@ -73,7 +74,48 @@ TEST(DatabaseAdminClientTest, CreateDatabaseSuccess) {
 
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
-  auto fut = conn->CreateDatabase({dbase, {}});
+  auto fut = conn->CreateDatabase({dbase, {}, absl::nullopt});
+  ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  auto db = fut.get();
+  EXPECT_STATUS_OK(db);
+
+  EXPECT_EQ("test-db", db->name());
+}
+
+/// @test Verify creating a database with an encryption key.
+TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
+  auto mock = std::make_shared<MockDatabaseAdminStub>();
+
+  EXPECT_CALL(*mock, CreateDatabase(_, _))
+      .WillOnce(
+          [](grpc::ClientContext&, gcsa::CreateDatabaseRequest const& request) {
+            EXPECT_TRUE(request.has_encryption_config());
+            EXPECT_EQ(request.encryption_config().kms_key_name(),
+                      "projects/test-project/locations/some-location/keyRings/"
+                      "a-key-ring/cryptoKeys/a-key-name");
+            google::longrunning::Operation op;
+            op.set_name("test-operation-name");
+            op.set_done(false);
+            return make_status_or(op);
+          });
+  EXPECT_CALL(*mock, GetOperation(_, _))
+      .WillOnce([](grpc::ClientContext&,
+                   google::longrunning::GetOperationRequest const& r) {
+        EXPECT_EQ("test-operation-name", r.name());
+        google::longrunning::Operation op;
+        op.set_name(r.name());
+        op.set_done(true);
+        gcsa::Database database;
+        database.set_name("test-db");
+        op.mutable_response()->PackFrom(database);
+        return make_status_or(op);
+      });
+
+  auto conn = CreateTestingConnection(std::move(mock));
+  Database dbase("test-project", "test-instance", "test-db");
+  KmsKeyName encryption_key("test-project", "some-location", "a-key-ring",
+                            "a-key-name");
+  auto fut = conn->CreateDatabase({dbase, {}, encryption_key});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto db = fut.get();
   EXPECT_STATUS_OK(db);
@@ -94,7 +136,7 @@ TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
 
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
-  auto fut = conn->CreateDatabase({dbase, {}});
+  auto fut = conn->CreateDatabase({dbase, {}, absl::nullopt});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
@@ -287,7 +329,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseErrorInPoll) {
 
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
-  auto db = conn->CreateDatabase({dbase, {}}).get();
+  auto db = conn->CreateDatabase({dbase, {}, absl::nullopt}).get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
 }
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -452,6 +452,60 @@ void CreateDatabase(google::cloud::spanner::DatabaseAdminClient client,
 }
 //! [create-database] [END spanner_create_database]
 
+//! [create-database-with-encryption-key] [START spanner_create_database_with_encryption_key]
+void CreateDatabaseWithEncryptionKey(
+    google::cloud::spanner::DatabaseAdminClient client,
+    std::string const& project_id, std::string const& instance_id,
+    std::string const& database_id,
+    google::cloud::KmsKeyName const& encryption_key) {
+  using ::google::cloud::future;
+  using ::google::cloud::StatusOr;
+  using ::google::cloud::spanner::Database;
+  Database database(project_id, instance_id, database_id);
+  future<StatusOr<google::spanner::admin::database::v1::Database>> f =
+      client.CreateDatabase(database, {}, encryption_key);
+  StatusOr<google::spanner::admin::database::v1::Database> db = f.get();
+  if (!db) throw std::runtime_error(db.status().message());
+  std::cout << "Created database [" << database << "]\n";
+
+  // Veerify the encryption key matches the value used during creation.
+  auto get_database = client.GetDatabase(database);
+  if (!get_database) throw std::runtime_error(get_database.status().message());
+  if (!get_database->has_encryption_config()) {
+    throw std::runtime_error("Encryption Config is not present");
+  }
+  auto key_name = google::cloud::MakeKmsKeyName(
+      get_database->encryption_config().kms_key_name());
+  if (!key_name.ok()) {
+    std::ostringstream os;
+    os << key_name.status();
+    throw std::runtime_error("Failed to parse kms_key_name: " + os.str());
+  }
+  std::cout << "Encryption key name: " << *key_name << std::endl;
+  if (*key_name != encryption_key) {
+    throw std::runtime_error("Encryption key name mismatch: expected " +
+                             encryption_key.FullName() + " actual " +
+                             key_name->FullName());
+  }
+}
+//! [create-database-with-encryption-key] [END spanner_create_database_with_encryption_key]
+
+void CreateDatabaseWithEncryptionKeyCommand(
+    std::vector<std::string> const& argv) {
+  if (argv.size() != 6) {
+    throw std::runtime_error(
+        "create-database-with-encryption-key <project-id> <instance-id> "
+        "<database-id> <location> <key-ring> <key-name>");
+  }
+  google::cloud::spanner::DatabaseAdminClient client;
+  google::cloud::KmsKeyName encryption_key(/*project_id=*/argv[0],
+                                           /*location=*/argv[3],
+                                           /*key_ring=*/argv[4],
+                                           /*kms_key_name=*/argv[5]);
+  CreateDatabaseWithEncryptionKey(std::move(client), argv[0], argv[1], argv[2],
+                                  encryption_key);
+}
+
 // [START spanner_create_table_with_datatypes]
 void CreateTableWithDatatypes(
     google::cloud::spanner::DatabaseAdminClient client,
@@ -2898,6 +2952,8 @@ int RunOneCommand(std::vector<std::string> argv) {
       {"remove-database-reader", RemoveDatabaseReaderCommand},
       {"instance-test-iam-permissions", InstanceTestIamPermissionsCommand},
       make_database_command_entry("create-database", CreateDatabase),
+      {"create-database-with-encryption-key",
+       CreateDatabaseWithEncryptionKeyCommand},
       make_database_command_entry("create-table-with-datatypes",
                                   CreateTableWithDatatypes),
       make_database_command_entry("create-table-with-timestamp",
@@ -3112,6 +3168,9 @@ void RunAll(bool emulator) {
   std::string database_id =
       google::cloud::spanner_testing::RandomDatabaseName(generator);
 
+  google::cloud::KmsKeyName encryption_key(
+      project_id, "us-central1", "spanner-cmek", "spanner-cmek-test-key");
+
   google::cloud::spanner::DatabaseAdminClient database_admin_client(
       MakeDatabaseAdminConnection(
           google::cloud::spanner::ConnectionOptions{},
@@ -3206,6 +3265,14 @@ void RunAll(bool emulator) {
 
   std::cout << "\nRunning spanner_create_database sample" << std::endl;
   CreateDatabase(database_admin_client, project_id, instance_id, database_id);
+
+  // TODO(#5048): Remove this check when the emulator supports CMEK.
+  if (!emulator) {
+    std::cout << "\nRunning spanner_create_database_with_encryption_key sample"
+              << std::endl;
+    CreateDatabaseWithEncryptionKey(database_admin_client, project_id,
+                                    instance_id, database_id, encryption_key);
+  }
 
   std::cout << "\nRunning spanner_create_table_with_datatypes sample"
             << std::endl;


### PR DESCRIPTION
There's nothing to do for `ListDatabases` and `GetDatabase` since we don't have our own types and just return the protos.

DO NOT SUBMIT - this uses protos from the `googleapis/googleapis` `spanner-cmek` branch; 
this cannot be merged until those protos are live.

Fixes #4312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4468)
<!-- Reviewable:end -->
