### PR TITLE
test: deflake background_threads_impl_test

### DIFF
--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -1,5 +1,4 @@
 // Copyright 2019 Google LLC
-// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2019 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,11 +42,12 @@ TEST(CustomerSuppliedBackgroundThreads, LifecycleNoShutdown) {
   auto has_shutdown = p.get_future();
   EXPECT_NE(std::future_status::ready, has_shutdown.wait_for(ms(2)));
 
-  auto expired = cq.MakeRelativeTimer(ms(0));
-  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(500)));
+  std::promise<std::thread::id> bg;
+  cq.RunAsync([&bg] { bg.set_value(std::this_thread::get_id()); });
+  EXPECT_EQ(t.get().get_id(), bg.get_future().get());
 
   cq.Shutdown();
-  EXPECT_EQ(std::future_status::ready, has_shutdown.wait_for(ms(500)));
+  has_shutdown.get();
 }
 
 /// @test Verify that users can supply their own queue and threads.
@@ -63,7 +65,6 @@ TEST(CustomerSuppliedBackgroundThreads, SharesCompletionQueue) {
         return std::this_thread::get_id();
       });
   ScopedThread t([&cq] { cq.Run(); });
-  ASSERT_EQ(std::future_status::ready, id.wait_for(ms(500)));
   EXPECT_EQ(t.get().get_id(), id.get());
 
   cq.Shutdown();
@@ -73,10 +74,9 @@ TEST(CustomerSuppliedBackgroundThreads, SharesCompletionQueue) {
 TEST(AutomaticallyCreatedBackgroundThreads, IsActive) {
   AutomaticallyCreatedBackgroundThreads actual;
 
-  using ms = std::chrono::milliseconds;
-
-  auto expired = actual.cq().MakeRelativeTimer(ms(0));
-  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(500)));
+  promise<std::thread::id> bg;
+  actual.cq().RunAsync([&bg] { bg.set_value(std::this_thread::get_id()); });
+  EXPECT_NE(std::this_thread::get_id(), bg.get_future().get());
 }
 
 }  // namespace


### PR DESCRIPTION
Before this PR the tests would (a) pass without problems when not under
load, (b) when under load (a second build running simultaneously) it
would fail about 80 times out of 10,000. After this change the test
passed 20,000 times under load and another 20,000 times without load.
The worst case running time is about 11 seconds, which suggests to me
the shorter 500ms timeouts are not a good tradeoff as they cost some
flakiness in our builds.

Fixes #4469 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4470)
<!-- Reviewable:end -->
