### PR TITLE
ci: fix storage testbench on ubuntu-based builds

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -65,8 +65,11 @@ RUN pip3 install cmake_format==0.6.8
 
 # Install Python packages used in the integration tests.
 RUN pip3 install setuptools
-RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
-    gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
+RUN pip3 install Jinja2==2.11.2 MarkupSafe==1.1.1 Werkzeug==1.0.0 \
+    blinker==1.4 brotlipy==0.7.0 cffi==1.14.0 click==7.1.2 crc32c==2.0 \
+    decorator==4.4.2 flask==1.1.1 gevent==1.4.0 greenlet==0.4.16 \
+    gunicorn==19.10.0 httpbin==0.7.0 itsdangerous==1.1.0 pycparser==2.20 \
+    raven==6.10.0
 
 # Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
 # client.  They are used in the integration tests.

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -335,6 +335,10 @@ io::log_yellow "Logging to ${BUILD_OUTPUT}/create-build-docker-image.log"
 # is an error, so disabling from this point on is the right choice.
 set +e
 mkdir -p "${BUILD_OUTPUT}"
+echo "DEBUG DEBUG DEBUG DO NOT MERGE"
+echo docker build "${docker_build_flags[@]}" ci
+docker build "${docker_build_flags[@]}" ci
+echo "DEBUG DEBUG DEBUG DO NOT MERGE"
 if timeout 3600s docker build "${docker_build_flags[@]}" ci \
   >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null; then
   update_cache="true"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -335,10 +335,6 @@ io::log_yellow "Logging to ${BUILD_OUTPUT}/create-build-docker-image.log"
 # is an error, so disabling from this point on is the right choice.
 set +e
 mkdir -p "${BUILD_OUTPUT}"
-echo "DEBUG DEBUG DEBUG DO NOT MERGE"
-echo docker build "${docker_build_flags[@]}" ci
-docker build "${docker_build_flags[@]}" ci
-echo "DEBUG DEBUG DEBUG DO NOT MERGE"
 if timeout 3600s docker build "${docker_build_flags[@]}" ci \
   >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null; then
   update_cache="true"

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -78,7 +78,8 @@ start_testbench() {
   done
 
   if [[ -z "${testbench_port}" ]]; then
-    echo "Cannot find listening port for testbench." >&2
+    echo "${IO_COLOR_RED}Cannot find listening port for testbench.${IO_COLOR_RESET}" >&2
+    cat testbench.log
     exit 1
   fi
 
@@ -97,7 +98,8 @@ start_testbench() {
   done
 
   if [[ "${connected}" = "no" ]]; then
-    echo "Cannot connect to testbench; aborting test." >&2
+    echo "${IO_COLOR_RED}Cannot connect to testbench; aborting test.${IO_COLOR_RESET}" >&2
+    cat testbench.log
     exit 1
   else
     echo "Successfully connected to testbench [${TESTBENCH_PID}]"


### PR DESCRIPTION
The Ubuntu-based builds cannot start the storage testbench. This
seems to be a recent problem, as this worked on my workstation
with a cached Docker image, but failed when building the Docker
image from scratch. There are only a handful on Ubuntu-based
builds, and only `integration` and `integration-nightly` actually
use the testbench.

Added some additional logging to diagnose this problem, left it on
because it might help in the future.

This fixes #4471 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4472)
<!-- Reviewable:end -->
