### PR TITLE
test: deflake CompletionQueueTest.ShutdownWithPending

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -116,7 +116,7 @@ TEST(CompletionQueueTest, ShutdownWithPending) {
     // call `cq.Shutdown()`, use a little loop to avoid this. In most runs this
     // loop will exit after the first iteration. By my measurements the loop
     // would need to run more than once every 10,000 runs. On the other hand,
-    // this should prevent the flake reported in #4246.
+    // this should prevent the flake reported in #4384.
     for (auto i = 0; i != 5; ++i) {
       timer = cq.MakeRelativeTimer(ms(500)).then(
           [](future<StatusOr<std::chrono::system_clock::time_point>> f) {

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -124,6 +124,11 @@ TEST(CompletionQueueTest, ShutdownWithPending) {
             EXPECT_STATUS_OK(f.get().status());
           });
       if (timer.wait_for(ms(0)) == std::future_status::timeout) break;
+      // This should be so rare that it is Okay to fail the test. We expect a
+      // the following assertion to fail once every 10^25 runs, if we see even
+      // one that means something is terribly wrong with my math and/or the
+      // code.
+      ASSERT_NE(i, 4);
     }
     cq.Shutdown();
     runner.join();
@@ -459,8 +464,8 @@ TEST(CompletionQueueTest, ShutdownWithReschedulingTimer) {
 
   cq.Shutdown();
   t.join();
-  // This is a "it did not crash nor hung" test, if we get here it was
-  // successful
+  // This is a "neither crashed nor hung" test. Reaching this point is success.
+  SUCCEED();
 }
 
 TEST(CompletionQueueTest, ShutdownWithFastReschedulingTimer) {
@@ -484,8 +489,8 @@ TEST(CompletionQueueTest, ShutdownWithFastReschedulingTimer) {
   for (auto& t : threads) {
     t.join();
   }
-  // This is a "it did not crash nor hung" test, if we get here it was
-  // successful
+  // This is a "neither crashed nor hung" test. Reaching this point is success.
+  SUCCEED();
 }
 
 TEST(CompletionQueueTest, CancelAndShutdownWithReschedulingTimer) {
@@ -497,8 +502,8 @@ TEST(CompletionQueueTest, CancelAndShutdownWithReschedulingTimer) {
   cq.CancelAll();
   cq.Shutdown();
   t.join();
-  // This is a "it did not crash nor hung" test, if we get here it was
-  // successful
+  // This is a "neither crashed nor hung" test. Reaching this point is success.
+  SUCCEED();
 }
 
 TEST(CompletionQueueTest, CancelTimerSimple) {


### PR DESCRIPTION
Very rarely this test would fail because the 20ms timer expired before
the very next line could run (scheduling is hard). Fixed the test by (a)
making the timer 500ms, and (b) put a loop to create a new timer if the
first few expired.

In a few cases this would be testing "nothing" as the timer could expire
before the completion queue really is shutdown, but that (rare) false
positive is better (I think) than rare false negatives.

Fixes #4384 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4474)
<!-- Reviewable:end -->
