### PR TITLE
chore: further automate the release process

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -11,54 +11,26 @@ familiar with the project itself, [git][git-docs], [GitHub][github-guides],
 
 ## Preparing for a release
 
-Assuming you are working on your own fork of the `google-cloud-cpp` project,
-and `upstream` points to the `googleapis/google-cloud-cpp` remote, these
-commands should be useful in identifying important changes for inclusion in the
-release notes.
+The following sections assume you are working on your own fork of the
+`google-cloud-cpp` project, and `upstream` points to the
+`googleapis/google-cloud-cpp` remote.
 
 ### Update CHANGELOG.md
 
-Update `CHANGELOG.md` based on the release notes for Bigtable, Storage,
-Spanner, and the common libraries:
+We first need to update `CHANGELOG.md` with the release notes for Bigtable,
+Storage, Spanner, and the common libraries. This step is handled automatically
+for us by the [`./release/changelog.pl`
+script](https://github.com/googleapis/google-cloud-cpp/blob/master/release/changelog.pl), which summarizes the PRs merged into each component.
 
 ```bash
-# Summarize the output of this into CHANGELOG.md under the "Bigtable" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/master)..HEAD \
-    upstream/master -- google/cloud/bigtable
+$ ./release/changelog.pl
 ```
 
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Storage" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/master)..HEAD \
-    upstream/master -- google/cloud/storage
-```
+Run `git diff CHANGELOG.md` to check the edit. Any
+**chore**/**ci**/**test**-tagged PRs will have been omitted as they are not
+interesting to our users.
 
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Spanner" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/master)..HEAD \
-    upstream/master -- google/cloud/spanner
-```
-
-```bash
-# Summarize the output of this into CHANGELOG.md under the "Common libraries" header
-git log --no-merges --format="format:* %s" \
-    $(git describe --tags --abbrev=0 upstream/master)..HEAD \
-    upstream/master -- google/cloud \
-   ':(exclude)google/cloud/firestore/' \
-   ':(exclude)google/cloud/bigquery/' \
-   ':(exclude)google/cloud/bigtable/' \
-   ':(exclude)google/cloud/pubsub/' \
-   ':(exclude)google/cloud/spanner/' \
-   ':(exclude)google/cloud/storage/'
-```
-
-Any **chore**/**ci**/**test**-tagged PRs in the above lists should probably be
-discarded as they are uninteresting to our users.
-
-### Send a PR with all these changes
+### Send a PR with these changes
 
 It is not recommended that you create the release branch before this PR is
 *merged*, but in some circumstances it might be needed, for example, if a large

--- a/release/changelog.pl
+++ b/release/changelog.pl
@@ -1,0 +1,103 @@
+#!/usr/bin/env perl
+#
+# Usage:
+#   $ release/changelog.pl
+#
+# This script adds a new release entry to "CHANGELOG.md".
+
+use integer;
+use strict;
+use File::Basename qw(fileparse);
+use Getopt::Long;
+use POSIX qw(strftime);
+
+Getopt::Long::Configure(qw{bundling
+                           no_auto_abbrev
+                           no_ignore_case
+                           require_order});
+
+my ($prog, $dir, $suffix) = fileparse($0, '.pl');
+my ($help, $changelog) = (0, 'CHANGELOG.md');
+
+sub fatal {
+  warn @_;
+  exit 1;
+}
+
+sub usage {
+  warn @_ if @_;
+  warn <<EOT;
+Usage: ${dir}${prog}${suffix} [<options>] [<changelog-file>]
+
+ where the options are:
+    -h, --help    Display this message.
+
+Patches a new release entry into <changelog-file> (default: ${changelog}).
+If <changelog-file> is '-', the entry is instead written to stdout.
+EOT
+  exit 2;
+}
+
+my $getops = GetOptions('h|help' => \$help);
+usage if !$getops || $help || @ARGV > 1;
+$changelog = shift if @ARGV;
+
+my $year_month = strftime('%Y-%m', localtime);
+my $commitish = 'upstream/master';
+
+chomp(my $cur_version = qx{git describe --tags --abbrev=0 ${commitish}});
+my ($major, $minor, $patch) = $cur_version =~ m{^v(\d+).(\d+).(\d+)$}
+  or fatal "${cur_version}: Unexpected version format\n";
+my $new_version = sprintf 'v%d.%d.%d', $major, $minor + 1, 0;  # next minor
+my $fut_version = sprintf 'v%d.%d.%d', $major, $minor + 2, 0;  # prediction
+
+# Enumerate commits modifying the argument paths since the last release.
+sub commits {
+  my $entry = '';
+  my $banner = "\n### " . shift . "\n\n";
+  open CMD, '-|', qw{git log --no-merges --format=%s},  # subject only
+                  "${cur_version}..HEAD", ${commitish}, '--', @_
+    or fatal "git log: $!";
+  while (my $line = <CMD>) {
+    # Skip commits with uninteresting tags.
+    next if $line =~ m{^(?:chore|ci|test)(?:\(.*?\))?!?:};
+    $entry .= $banner . '* ' . $line;
+    $banner = '';
+  }
+  close CMD or exit 1;
+  $entry .= $banner . "* No changes from ${cur_version}\n" if $banner;
+  return $entry;
+}
+
+# Accumulate the new entry, split by major components.
+my $text = "## ${fut_version} - TBD\n";  # new placeholder
+$text .= "\n## ${new_version} - ${year_month}\n";
+$text .= commits 'Bigtable', 'google/cloud/bigtable';
+$text .= commits 'Storage', 'google/cloud/storage';
+$text .= commits 'Spanner', 'google/cloud/spanner';
+$text .= commits 'Common libraries', 'google/cloud',
+                  map(":(exclude)google/cloud/$_",
+                      qw{bigtable storage spanner},  # handled above
+                      qw{bigquery firestore pubsub});  # unreleased
+
+if ($changelog eq '-') {
+  # Just write the new entry to stdout.
+  print $text;
+} else {
+  # Read the old CHANGELOG.md.
+  open CHANGELOG, '<', $changelog or fatal "${changelog}: $!\n";
+  my @changelog = <CHANGELOG>;
+  close CHANGELOG;
+
+  # Replace the old placeholder with the new entry.
+  my $oldtext = "## ${new_version} - TBD";
+  scalar(grep { s{^${oldtext}\n$}{${text}} } @changelog) == 1
+    or fatal "${changelog}: Could not find '${oldtext}'\n";
+
+  # Write the new CHANGELOG.md.
+  open CHANGELOG, '>', $changelog and
+  print CHANGELOG @changelog and
+  close CHANGELOG or fatal "${changelog}: $!";
+}
+
+exit 0;


### PR DESCRIPTION
Add a script to automatically update `CHANGELOG.md` with the PR
summaries since the last release.  chore/ci/test-tagged PRs are
always omitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4478)
<!-- Reviewable:end -->
