### PR TITLE
feat(storage): HTTP requests with many buffers

### DIFF
--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -80,6 +80,7 @@ cc_library(
         "@com_github_curl_curl//:curl",
         "@com_github_google_crc32c//:crc32c",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -33,7 +33,64 @@ extern "C" size_t CurlRequestOnHeaderData(char* contents, size_t size,
   return request->OnHeaderData(contents, size, nitems);
 }
 
+class WriteVector {
+ public:
+  explicit WriteVector(std::vector<absl::Span<char const>> w)
+      : writev_(std::move(w)) {}
+
+  bool empty() const { return writev_.empty(); }
+
+  std::size_t OnRead(char* ptr, std::size_t size, std::size_t nitems) {
+    std::size_t offset = 0;
+    auto capacity = size * nitems;
+    while (capacity > 0 && !writev_.empty()) {
+      auto& f = writev_.front();
+      auto n = (std::min)(capacity, writev_.front().size());
+      std::copy(f.data(), f.data() + n, ptr + offset);
+      offset += n;
+      capacity -= n;
+      writev_.front() = absl::Span<char const>(f.data() + n, f.size() - n);
+      if (writev_.front().empty()) {
+        writev_.erase(writev_.begin());
+      }
+    }
+    return offset;
+  }
+
+ private:
+  std::vector<absl::Span<char const>> writev_;
+};
+
+extern "C" std::size_t CurlRequestOnReadData(char* ptr, std::size_t size,
+                                             std::size_t nitems,
+                                             void* userdata) {
+  auto* v = reinterpret_cast<WriteVector*>(userdata);
+  return v->OnRead(ptr, size, nitems);
+}
+
 StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
+  handle_.SetOption(CURLOPT_UPLOAD, 0L);
+  if (!payload.empty()) {
+    handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
+    handle_.SetOption(CURLOPT_POSTFIELDS, payload.c_str());
+  }
+  return MakeRequestImpl();
+}
+
+StatusOr<HttpResponse> CurlRequest::MakeUploadRequest(
+    std::vector<absl::Span<char const>> payload) {
+  WriteVector writev{std::move(payload)};
+  if (!writev.empty()) {
+    handle_.SetOption(CURLOPT_READFUNCTION, &CurlRequestOnReadData);
+    handle_.SetOption(CURLOPT_READDATA, &writev);
+    handle_.SetOption(CURLOPT_UPLOAD, 1L);
+  } else {
+    handle_.SetOption(CURLOPT_UPLOAD, 0L);
+  }
+  return MakeRequestImpl();
+}
+
+StatusOr<HttpResponse> CurlRequest::MakeRequestImpl() {
   // We get better performance using a slightly larger buffer (128KiB) than the
   // default buffer size set by libcurl (16KiB)
   auto constexpr kDefaultBufferSize = 128 * 1024L;
@@ -44,7 +101,6 @@ StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
   handle_.SetOption(CURLOPT_NOSIGNAL, 1);
-  handle_.SetOption(CURLOPT_UPLOAD, 0L);
   handle_.SetOption(CURLOPT_TCP_KEEPALIVE, 1L);
   handle_.EnableLogging(logging_enabled_);
   handle_.SetSocketCallback(socket_options_);
@@ -52,10 +108,6 @@ StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
   handle_.SetOption(CURLOPT_WRITEDATA, this);
   handle_.SetOption(CURLOPT_HEADERFUNCTION, &CurlRequestOnHeaderData);
   handle_.SetOption(CURLOPT_HEADERDATA, this);
-  if (!payload.empty()) {
-    handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
-    handle_.SetOption(CURLOPT_POSTFIELDS, payload.c_str());
-  }
   auto status = handle_.EasyPerform();
   if (!status.ok()) {
     return status;

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -51,6 +51,10 @@ class WriteVector {
       capacity -= n;
       writev_.front() = absl::Span<char const>(f.data() + n, f.size() - n);
       if (writev_.front().empty()) {
+        // In practice this is expected to be cheap, most vectors will contain 1
+        // or 2 elements. And, if you are really lucky, your compiler turns this
+        // into a memmove():
+        //     https://godbolt.org/z/jw5VDd
         writev_.erase(writev_.begin());
       }
     }

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -19,6 +19,8 @@
 #include "google/cloud/storage/internal/curl_handle_factory.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
+#include "absl/types/span.h"
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -49,7 +51,12 @@ class CurlRequest {
    */
   StatusOr<HttpResponse> MakeRequest(std::string const& payload);
 
+  StatusOr<HttpResponse> MakeUploadRequest(
+      std::vector<absl::Span<char const>> payload);
+
  private:
+  StatusOr<HttpResponse> MakeRequestImpl();
+
   friend class CurlRequestBuilder;
   friend size_t CurlRequestOnWriteData(char* ptr, size_t size, size_t nmemb,
                                        void* userdata);

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -51,6 +51,7 @@ class CurlRequest {
    */
   StatusOr<HttpResponse> MakeRequest(std::string const& payload);
 
+  /// @copydoc MakeRequest(std::string const&)
   StatusOr<HttpResponse> MakeUploadRequest(
       std::vector<absl::Span<char const>> payload);
 

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -40,6 +40,7 @@ load(
         "//google/cloud/storage:storage_client",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in storage_client_integration_tests]

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ foreach (fname ${storage_client_integration_tests})
                 GTest::gtest
                 CURL::libcurl
                 Threads::Threads
+                absl::strings
                 nlohmann_json)
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 #include <cstdlib>
 #include <vector>
@@ -29,6 +30,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 
 std::string HttpBinEndpoint() {
@@ -166,6 +168,42 @@ TEST(CurlRequestTest, MultiBufferEmptyPUT) {
   EXPECT_EQ(200, response->status_code);
   nl::json parsed = nl::json::parse(response->payload);
   EXPECT_TRUE(parsed["data"].get<std::string>().empty());
+}
+
+TEST(CurlRequestTest, MultiBufferLargePUT) {
+  storage::internal::CurlRequestBuilder request(
+      HttpBinEndpoint() + "/put",
+      storage::internal::GetDefaultCurlHandleFactory());
+  request.SetMethod("PUT");
+
+  std::vector<std::string> lines;
+  auto constexpr kLineSize = 1024;
+  // libcurl's CURLOPT_READFUNCTION provides at most CURL_MAX_READ_SIZE bytes,
+  // use enough buffers to ensure we get more than one read callback.
+  auto constexpr kLineCount = (2 * CURL_MAX_READ_SIZE) / kLineSize;
+  for (int i = 0; i != kLineCount; ++i) {
+    std::string line = std::to_string(i);
+    line += ": ";
+    line += std::string(kLineSize, '=');
+    lines.push_back(std::move(line));
+  }
+  std::vector<absl::Span<char const>> data;
+  std::string nl = "\n";
+  for (auto const& p : lines) {
+    data.emplace_back(p.data(), p.size());
+    data.emplace_back(nl.data(), nl.size());
+  }
+  request.AddHeader("Accept: application/json");
+  request.AddHeader("Content-Type: application/octet-stream");
+  request.AddHeader("charsets: utf-8");
+
+  auto response = request.BuildRequest().MakeUploadRequest(data);
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+  nl::json parsed = nl::json::parse(response->payload);
+  std::vector<std::string> const actual = absl::StrSplit(
+      parsed["data"].get<std::string>(), '\n', absl::SkipEmpty());
+  EXPECT_THAT(actual, ElementsAreArray(lines));
 }
 
 TEST(CurlRequestTest, Handle404) {

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -151,6 +151,23 @@ TEST(CurlRequestTest, MultiBufferPUT) {
   EXPECT_EQ("line 1\nline 2\nline 3\n", parsed["data"]);
 }
 
+TEST(CurlRequestTest, MultiBufferEmptyPUT) {
+  storage::internal::CurlRequestBuilder request(
+      HttpBinEndpoint() + "/put",
+      storage::internal::GetDefaultCurlHandleFactory());
+  request.SetMethod("PUT");
+
+  request.AddHeader("Accept: application/json");
+  request.AddHeader("Content-Type: application/octet-stream");
+  request.AddHeader("charsets: utf-8");
+
+  auto response = request.BuildRequest().MakeUploadRequest({});
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(200, response->status_code);
+  nl::json parsed = nl::json::parse(response->payload);
+  EXPECT_TRUE(parsed["data"].get<std::string>().empty());
+}
+
 TEST(CurlRequestTest, Handle404) {
   storage::internal::CurlRequestBuilder request(
       HttpBinEndpoint() + "/status/404",


### PR DESCRIPTION
Add a function to make HTTP requests gathering data from multiple
buffers. I expect to use this function in reducing the amount of data
copying during uploads, using (when possible) the buffer provided by the
application without any additional copying.

Part of the work for #2664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4480)
<!-- Reviewable:end -->
