### PR TITLE
refactor: replace `EXPECT_TRUE(status.ok())` with `EXPECT_STATUS_OK()`

### DIFF
--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -50,7 +50,6 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncApply) {
   // case), but we need to wait before checking the results.
   Status status = fut.get();
   EXPECT_STATUS_OK(status);
-  EXPECT_TRUE(status.ok());
 
   // Validate that the newly created cells are actually in the server.
   std::vector<bigtable::Cell> expected{
@@ -140,7 +139,6 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowPass) {
   // case), but we need to wait before checking the results.
   auto status = fut.get();
   EXPECT_STATUS_OK(status);
-  EXPECT_TRUE(status.ok());
 
   std::vector<bigtable::Cell> expected{{key, kFamily, "c1", 0, "v1000"},
                                        {key, kFamily, "c2", 0, "v2000"}};
@@ -174,7 +172,6 @@ TEST_F(DataAsyncFutureIntegrationTest, TableAsyncCheckAndMutateRowFail) {
   // case), but we need to wait before checking the results.
   auto status = fut.get();
   EXPECT_STATUS_OK(status);
-  EXPECT_TRUE(status.ok());
 
   std::vector<bigtable::Cell> expected{{key, kFamily, "c1", 0, "v1000"},
                                        {key, kFamily, "c3", 0, "v3000"}};

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -367,7 +367,7 @@ TEST(ClientTest, RollbackSuccess) {
 
   auto txn = MakeReadWriteTransaction();
   auto rollback = client.Rollback(txn);
-  EXPECT_TRUE(rollback.ok());
+  EXPECT_STATUS_OK(rollback);
 }
 
 TEST(ClientTest, RollbackError) {

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -62,7 +62,7 @@ TEST(RowStream, IterateOverRows) {
   int num_rows = 0;
   for (auto const& row :
        StreamOf<std::tuple<std::int64_t, bool, std::string>>(rows)) {
-    EXPECT_TRUE(row.ok());
+    EXPECT_STATUS_OK(row);
     switch (num_rows++) {
       case 0:
         EXPECT_EQ(std::get<0>(*row), 5);
@@ -97,7 +97,7 @@ TEST(RowStream, IterateError) {
        StreamOf<std::tuple<std::int64_t, bool, std::string>>(rows)) {
     switch (num_rows++) {
       case 0:
-        EXPECT_TRUE(row.ok());
+        EXPECT_STATUS_OK(row);
         EXPECT_EQ(std::get<0>(*row), 5);
         EXPECT_EQ(std::get<1>(*row), true);
         EXPECT_EQ(std::get<2>(*row), "foo");

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -62,7 +62,7 @@ TEST(RowStream, IterateOverRows) {
   int num_rows = 0;
   for (auto const& row :
        StreamOf<std::tuple<std::int64_t, bool, std::string>>(rows)) {
-    EXPECT_STATUS_OK(row);
+    ASSERT_STATUS_OK(row);
     switch (num_rows++) {
       case 0:
         EXPECT_EQ(std::get<0>(*row), 5);
@@ -97,7 +97,7 @@ TEST(RowStream, IterateError) {
        StreamOf<std::tuple<std::int64_t, bool, std::string>>(rows)) {
     switch (num_rows++) {
       case 0:
-        EXPECT_STATUS_OK(row);
+        ASSERT_STATUS_OK(row);
         EXPECT_EQ(std::get<0>(*row), 5);
         EXPECT_EQ(std::get<1>(*row), true);
         EXPECT_EQ(std::get<2>(*row), "foo");

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -380,7 +380,7 @@ TEST(Value, MixingTypes) {
   using B = std::int64_t;
 
   Value a(A{});
-  EXPECT_TRUE(a.get<A>().ok());
+  EXPECT_STATUS_OK(a.get<A>());
   EXPECT_FALSE(a.get<B>().ok());
   EXPECT_FALSE(a.get<B>().ok());
 
@@ -391,7 +391,7 @@ TEST(Value, MixingTypes) {
   EXPECT_NE(null_a, a);
 
   Value b(B{});
-  EXPECT_TRUE(b.get<B>().ok());
+  EXPECT_STATUS_OK(b.get<B>());
   EXPECT_FALSE(b.get<A>().ok());
   EXPECT_FALSE(b.get<A>().ok());
 
@@ -414,14 +414,14 @@ TEST(Value, SpannerArray) {
   ArrayInt64 const empty = {};
   Value const ve(empty);
   EXPECT_EQ(ve, ve);
-  EXPECT_TRUE(ve.get<ArrayInt64>().ok());
+  EXPECT_STATUS_OK(ve.get<ArrayInt64>());
   EXPECT_FALSE(ve.get<ArrayDouble>().ok());
   EXPECT_EQ(empty, *ve.get<ArrayInt64>());
 
   ArrayInt64 const ai = {1, 2, 3};
   Value const vi(ai);
   EXPECT_EQ(vi, vi);
-  EXPECT_TRUE(vi.get<ArrayInt64>().ok());
+  EXPECT_STATUS_OK(vi.get<ArrayInt64>());
   EXPECT_FALSE(vi.get<ArrayDouble>().ok());
   EXPECT_EQ(ai, *vi.get<ArrayInt64>());
 
@@ -430,7 +430,7 @@ TEST(Value, SpannerArray) {
   EXPECT_EQ(vd, vd);
   EXPECT_NE(vi, vd);
   EXPECT_FALSE(vd.get<ArrayInt64>().ok());
-  EXPECT_TRUE(vd.get<ArrayDouble>().ok());
+  EXPECT_STATUS_OK(vd.get<ArrayDouble>());
   EXPECT_EQ(ad, *vd.get<ArrayDouble>());
 
   Value const null_vi = MakeNullValue<ArrayInt64>();
@@ -522,7 +522,7 @@ TEST(Value, SpannerStruct) {
   };
   using T4 = decltype(array_struct);
   Value v4(array_struct);
-  EXPECT_TRUE(v4.get<T4>().ok());
+  EXPECT_STATUS_OK(v4.get<T4>());
   EXPECT_FALSE(v4.get<T3>().ok());
   EXPECT_FALSE(v4.get<T2>().ok());
   EXPECT_FALSE(v4.get<T1>().ok());
@@ -533,7 +533,7 @@ TEST(Value, SpannerStruct) {
   auto empty = tuple<>{};
   using T5 = decltype(empty);
   Value v5(empty);
-  EXPECT_TRUE(v5.get<T5>().ok());
+  EXPECT_STATUS_OK(v5.get<T5>());
   EXPECT_FALSE(v5.get<T4>().ok());
   EXPECT_EQ(v5, v5);
   EXPECT_NE(v5, v4);
@@ -544,7 +544,7 @@ TEST(Value, SpannerStruct) {
   auto crazy = tuple<tuple<std::vector<optional<bool>>>>{};
   using T6 = decltype(crazy);
   Value v6(crazy);
-  EXPECT_TRUE(v6.get<T6>().ok());
+  EXPECT_STATUS_OK(v6.get<T6>());
   EXPECT_FALSE(v6.get<T5>().ok());
   EXPECT_EQ(v6, v6);
   EXPECT_NE(v6, v5);

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -148,7 +148,7 @@ TEST(GrpcResumableUploadSessionTest, Reset) {
 
   auto upload = session.UploadChunk(payload);
   EXPECT_EQ(size, session.next_expected_byte());
-  EXPECT_TRUE(upload.ok());
+  EXPECT_STATUS_OK(upload);
   upload = session.UploadChunk(payload);
   EXPECT_FALSE(upload.ok());
   EXPECT_EQ(StatusCode::kUnavailable, upload.status().code());

--- a/google/cloud/storage/internal/hmac_key_requests_test.cc
+++ b/google/cloud/storage/internal/hmac_key_requests_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hmac_key_requests.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -32,7 +33,7 @@ TEST(HmacKeyRequestsTest, ParseFailure) {
 
 TEST(HmacKeyRequestsTest, ParseEmpty) {
   auto actual = internal::HmacKeyMetadataParser::FromString("{}");
-  EXPECT_TRUE(actual.ok());
+  EXPECT_STATUS_OK(actual);
 }
 
 TEST(HmacKeyRequestsTest, Create) {

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -256,7 +256,7 @@ TEST_F(ErrorInjectionIntegrationTest, InjectRecvErrorOnRead) {
                    static_cast<int>(opts->download_buffer_size()) * 3 / 80);
   os.Close();
   EXPECT_TRUE(os);
-  EXPECT_TRUE(os.metadata().ok());
+  EXPECT_STATUS_OK(os.metadata());
 
   auto is = client.ReadObject(bucket_name_, object_name);
   std::vector<char> read_buf(opts->download_buffer_size() + 1);
@@ -294,7 +294,7 @@ TEST_F(ErrorInjectionIntegrationTest, InjectSendErrorOnRead) {
                    static_cast<int>(opts->download_buffer_size()) * 3 / 80);
   os.Close();
   EXPECT_TRUE(os);
-  EXPECT_TRUE(os.metadata().ok());
+  EXPECT_STATUS_OK(os.metadata());
 
   auto is = client.ReadObject(bucket_name_, object_name);
   std::vector<char> read_buf(opts->download_buffer_size() + 1);


### PR DESCRIPTION
just a small cleanup I noticed while working on another PR

I also found a couple cases that redundantly did both

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4485)
<!-- Reviewable:end -->
