### PR TITLE
refactor(GCS+gRPC): simplify resumable upload code

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -37,8 +37,6 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::size_t constexpr GrpcClient::kMaxInsertObjectWriteRequestSize;
-
 bool DirectPathEnabled() {
   auto const direct_path_settings =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH")
@@ -205,11 +203,8 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
   google::storage::v1::Object response;
   auto stream = stub_->InsertObject(&context, &response);
   auto proto_request = ToProto(request);
-  // This limit is for the *message*, not just the payload. It includes any
-  // additional information such as checksums. We need to use a stricter limit,
-  // a chunk quantum seems to work in practice.
   std::size_t const maximum_buffer_size =
-      kMaxInsertObjectWriteRequestSize - UploadChunkRequest::kChunkSizeQuantum;
+      google::storage::v1::ServiceConstants_Values_MAX_WRITE_CHUNK_BYTES;
   auto const& contents = request.contents();
 
   // This loop must run at least once because we need to send at least one
@@ -308,9 +303,11 @@ StatusOr<RewriteObjectResponse> GrpcClient::RewriteObject(
 
 StatusOr<std::unique_ptr<ResumableUploadSession>>
 GrpcClient::CreateResumableSession(ResumableUploadRequest const& request) {
-  auto session_id = request.GetOption<UseResumableUploadSession>().value_or("");
-  if (!session_id.empty()) {
-    return RestoreResumableSession(session_id);
+  if (request.HasOption<UseResumableUploadSession>()) {
+    auto session_id = request.GetOption<UseResumableUploadSession>().value();
+    if (!session_id.empty()) {
+      return RestoreResumableSession(session_id);
+    }
   }
 
   grpc::ClientContext context;

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -204,7 +204,7 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
   auto stream = stub_->InsertObject(&context, &response);
   auto proto_request = ToProto(request);
   std::size_t const maximum_buffer_size =
-      google::storage::v1::ServiceConstants_Values_MAX_WRITE_CHUNK_BYTES;
+      google::storage::v1::ServiceConstants::MAX_WRITE_CHUNK_BYTES;
   auto const& contents = request.contents();
 
   // This loop must run at least once because we need to send at least one

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -37,10 +37,6 @@ class GrpcClient : public RawClient,
   explicit GrpcClient(ClientOptions options);
   ~GrpcClient() override = default;
 
-  /// The gRPC server rejects messages that are larger than 4 MiB.
-  static std::size_t constexpr kMaxInsertObjectWriteRequestSize =
-      4 * 1024 * 1024L;
-
   //@{
   /// @name Implement the ResumableSession operations.
   // Note that these member functions are not inherited from RawClient, they are

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -94,8 +94,6 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
       google::storage::v1::ServiceConstants_Values_MAX_WRITE_CHUNK_BYTES;
   std::string chunk;
   auto flush_chunk = [&](bool has_more) {
-    std::cout << "chunk.size=" << chunk.size() << ", has_more=" << has_more
-              << ", final_chunk=" << final_chunk << "\n";
     if (chunk.size() < maximum_chunk_size && has_more) return true;
     if (chunk.empty() && !final_chunk) return true;
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -63,7 +63,11 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::ResetSession() {
   if (!last_response_) return last_response_;
 
   done_ = (last_response_->upload_state == ResumableUploadResponse::kDone);
-  next_expected_ = last_response_->last_committed_byte + 1;
+  if (last_response_->last_committed_byte == 0) {
+    next_expected_ = 0;
+  } else {
+    next_expected_ = last_response_->last_committed_byte + 1;
+  }
   return last_response_;
 }
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -95,7 +95,7 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
   std::string chunk;
   auto flush_chunk = [&](bool has_more) {
     std::cout << "chunk.size=" << chunk.size() << ", has_more=" << has_more
-        << ", final_chunk=" << final_chunk << "\n";
+              << ", final_chunk=" << final_chunk << "\n";
     if (chunk.size() < maximum_chunk_size && has_more) return true;
     if (chunk.empty() && !final_chunk) return true;
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -23,129 +23,48 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
+static_assert(
+    (google::storage::v1::ServiceConstants_Values_MAX_WRITE_CHUNK_BYTES %
+     UploadChunkRequest::kChunkSizeQuantum) == 0,
+    "Expected maximum insert request size to be a multiple of chunk quantum");
+static_assert(
+    google::storage::v1::ServiceConstants_Values_MAX_WRITE_CHUNK_BYTES >
+        UploadChunkRequest::kChunkSizeQuantum * 2,
+    "Expected maximum insert request size to be greater than twice "
+    "the chunk quantum");
+
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadChunk(
-    std::string const& buffer) {
-  CreateUploadWriter();
-
-  bool success = true;
-  // This loop must run at least once because we need to send at least one
-  // Write() call for empty objects.
-  std::size_t offset = 0;
-  do {
-    // This limit is for the *message*, not just the payload. It includes any
-    // additional information such as checksums. We need to use a stricter
-    // limit, a chunk quantum seems to work in practice.
-    std::size_t const maximum_buffer_size =
-        GrpcClient::kMaxInsertObjectWriteRequestSize -
-        UploadChunkRequest::kChunkSizeQuantum;
-
-    google::storage::v1::InsertObjectRequest request;
-    request.set_upload_id(session_id_);
-    request.set_write_offset(next_expected_);
-    request.set_finish_write(false);
-
-    auto& data = *request.mutable_checksummed_data();
-    auto const n = (std::min)(buffer.size() - offset, maximum_buffer_size);
-    data.set_content(buffer.substr(offset, n));
-    data.mutable_crc32c()->set_value(crc32c::Crc32c(data.content()));
-
-    success = upload_writer_->Write(request);
-
-    if (!success) break;
-    // After the first message, clear the object specification and checksums,
-    // there is no need to resend it.
-    request.clear_insert_object_spec();
-    request.clear_object_checksums();
-    offset += n;
-
-    auto result = ResumableUploadResponse{{},
-                                          next_expected_ + n - 1,
-                                          {},
-                                          ResumableUploadResponse::kInProgress,
-                                          {}};
-    Update(result);
-  } while (success && offset < buffer.size());
-  if (success) {
-    return ResumableUploadResponse{
-        {}, next_expected_ - 1, {}, ResumableUploadResponse::kInProgress, {}};
-  }
-  auto grpc_status = upload_writer_->Finish();
-  upload_writer_ = nullptr;
-  upload_context_ = nullptr;
-  if (!grpc_status.ok()) {
-    return google::cloud::MakeStatusFromRpcError(grpc_status);
-  }
-  return Status(StatusCode::kUnavailable,
-                "GrpcResumableUploadSession: stream closed unexpectedly");
+    std::string const& payload) {
+  return UploadGeneric(payload, false);
 }
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadFinalChunk(
-    std::string const& buffer, std::uint64_t) {
-  std::size_t const maximum_buffer_size =
-      GrpcClient::kMaxInsertObjectWriteRequestSize -
-      UploadChunkRequest::kChunkSizeQuantum;
-  static_assert(
-      GrpcClient::kMaxInsertObjectWriteRequestSize %
-              UploadChunkRequest::kChunkSizeQuantum ==
-          0,
-      "Expected maximum insert request size to be a multiple of chunk quantum");
-  static_assert(GrpcClient::kMaxInsertObjectWriteRequestSize >
-                    UploadChunkRequest::kChunkSizeQuantum * 2,
-                "Expected maximum insert request size to be greater than twice "
-                "the chunk quantum");
+    std::string const& payload, std::uint64_t) {
+  auto initial = UploadGeneric(payload, true);
+  if (!initial) return initial;
 
-  std::string trailer;
-  if (buffer.size() < maximum_buffer_size) {
-    trailer = buffer;
-  } else {
-    auto const last_full_chunk_pos = [&buffer] {
-      if (buffer.size() % UploadChunkRequest::kChunkSizeQuantum == 0) {
-        return buffer.size() - UploadChunkRequest::kChunkSizeQuantum;
-      }
-      return (buffer.size() / UploadChunkRequest::kChunkSizeQuantum) *
-             UploadChunkRequest::kChunkSizeQuantum;
-    }();
-    auto initial = UploadChunk(buffer.substr(0, last_full_chunk_pos));
-    if (!initial) return initial;
-    trailer = buffer.substr(last_full_chunk_pos);
-  }
-
-  CreateUploadWriter();
-  google::storage::v1::InsertObjectRequest request;
-  request.set_upload_id(session_id_);
-  request.set_write_offset(next_expected_);
-  request.set_finish_write(true);
-  request.mutable_checksummed_data()->set_content(trailer);
-  request.mutable_checksummed_data()->mutable_crc32c()->set_value(
-      crc32c::Crc32c(trailer));
-  // TODO(#4156) - compute the crc32c value inline and set it here
-  // TODO(#4157) - compute the MD5 hash value and set it here
-  auto success =
-      upload_writer_->Write(request, grpc::WriteOptions().set_last_message());
-  if (!success) {
-    return Status(
-        StatusCode::kUnavailable,
-        "GrpcResumableUploadSession: error writing last chunk to stream");
-  }
   auto status = upload_writer_->Finish();
   upload_writer_ = nullptr;
   upload_context_ = nullptr;
   if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
 
-  ResumableUploadResponse result{{},
-                                 next_expected_ + buffer.size() - 1,
+  done_ = true;
+  return ResumableUploadResponse{{},
+                                 next_expected_ - 1,
                                  GrpcClient::FromProto(upload_object_),
                                  ResumableUploadResponse::kDone,
                                  {}};
-  Update(result);
-  return result;
 }
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_);
   auto result = client_->QueryResumableUpload(request);
-  Update(result);
-  return result;
+  last_response_ = std::move(result);
+  if (!last_response_) return last_response_;
+
+  done_ = (last_response_->upload_state == ResumableUploadResponse::kDone);
+  next_expected_ = last_response_->last_committed_byte + 1;
+  return last_response_;
 }
 
 std::uint64_t GrpcResumableUploadSession::next_expected_byte() const {
@@ -163,6 +82,67 @@ GrpcResumableUploadSession::last_response() const {
   return last_response_;
 }
 
+StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
+    std::string const& payload, bool final_chunk) {
+  CreateUploadWriter();
+
+  std::size_t const maximum_chunk_size =
+      google::storage::v1::ServiceConstants_Values_MAX_WRITE_CHUNK_BYTES;
+  std::string chunk;
+  auto flush_chunk = [&chunk, final_chunk, this](bool has_more) {
+    if (chunk.size() < maximum_chunk_size && has_more) return true;
+    if (chunk.empty() && !final_chunk) return true;
+
+    google::storage::v1::InsertObjectRequest request;
+    request.set_upload_id(session_id_);
+    request.set_write_offset(next_expected_);
+    request.set_finish_write(false);
+
+    auto& data = *request.mutable_checksummed_data();
+    auto const n = chunk.size();
+    data.set_content(std::move(chunk));
+    chunk.clear();
+    data.mutable_crc32c()->set_value(crc32c::Crc32c(data.content()));
+
+    auto options = grpc::WriteOptions();
+    if (final_chunk && !has_more) {
+      // At this point we can set the full object checksums, there are two bugs
+      // for this:
+      // TODO(#4156) - compute the crc32c value inline
+      // TODO(#4157) - compute the MD5 hash value inline
+      request.set_finish_write(true);
+      options.set_last_message();
+    }
+
+    if (!upload_writer_->Write(request, options)) return false;
+    // After the first message, clear the object specification and checksums,
+    // there is no need to resend it.
+    request.clear_insert_object_spec();
+    request.clear_object_checksums();
+
+    next_expected_ += n;
+    return true;
+  };
+
+  std::size_t payload_offset = 0;
+  while (payload_offset != payload.size()) {
+    chunk.reserve(maximum_chunk_size);
+    // flush_chunk() guarantees that maximum_chunk_size < chunk.size()
+    auto capacity = maximum_chunk_size - chunk.size();
+    auto n = (std::min)(capacity, payload.size() - payload_offset);
+    char const* begin = payload.data() + payload_offset;
+    chunk.append(begin, begin + n);
+    payload_offset += n;
+
+    if (!flush_chunk(payload_offset != payload.size())) {
+      return HandleWriteError();
+    }
+  }
+
+  return ResumableUploadResponse{
+      {}, next_expected_ - 1, {}, ResumableUploadResponse::kInProgress, {}};
+}
+
 void GrpcResumableUploadSession::CreateUploadWriter() {
   if (upload_writer_) {
     return;
@@ -175,21 +155,17 @@ void GrpcResumableUploadSession::CreateUploadWriter() {
       client_->CreateUploadWriter(*upload_context_, upload_object_);
 }
 
-void GrpcResumableUploadSession::Update(
-    StatusOr<ResumableUploadResponse> const& result) {
-  last_response_ = result;
-  if (!result.ok()) {
-    return;
-  }
-  done_ = result->upload_state == ResumableUploadResponse::kDone;
-  if (result->last_committed_byte == 0) {
-    next_expected_ = 0;
-  } else {
-    next_expected_ = result->last_committed_byte + 1;
-  }
-  if (!result->upload_session_url.empty()) {
-    session_id_ = result->upload_session_url;
-  }
+StatusOr<ResumableUploadResponse>
+GrpcResumableUploadSession::HandleWriteError() {
+  auto grpc_status = upload_writer_->Finish();
+  upload_writer_ = nullptr;
+  upload_context_ = nullptr;
+  last_response_ =
+      grpc_status.ok()
+          ? Status(StatusCode::kUnavailable,
+                   "GrpcResumableUploadSession: stream closed unexpectedly")
+          : google::cloud::MakeStatusFromRpcError(grpc_status);
+  return last_response_;
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -32,10 +32,10 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
       : client_(std::move(client)), session_id_(std::move(session_id)) {}
 
   StatusOr<ResumableUploadResponse> UploadChunk(
-      std::string const& buffer) override;
+      std::string const& payload) override;
 
   StatusOr<ResumableUploadResponse> UploadFinalChunk(
-      std::string const& buffer, std::uint64_t upload_size) override;
+      std::string const& payload, std::uint64_t upload_size) override;
 
   StatusOr<ResumableUploadResponse> ResetSession() override;
 
@@ -48,8 +48,17 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
   StatusOr<ResumableUploadResponse> const& last_response() const override;
 
  private:
+  /**
+   * Uploads a multiple of the upload quantum bytes from @p buffers
+   *
+   * This function is used by both UploadChunk() and UploadFinalChunk()
+   */
+  StatusOr<ResumableUploadResponse> UploadGeneric(std::string const& payload,
+                                                  bool final_chunk);
+
   void CreateUploadWriter();
-  void Update(StatusOr<ResumableUploadResponse> const& result);
+
+  StatusOr<ResumableUploadResponse> HandleWriteError();
 
   std::shared_ptr<GrpcClient> client_;
   std::string session_id_;


### PR DESCRIPTION
The streaming uploads have a number of restrictions on message sizes,
chunk quantums, and final message flags. This refactors the code to keep
all this complexity in one place. It also dtakes advantage of the
`google.storage.v1.ServiceConstants` proto which did not exist or I
missed when we originally implemented this code. The code has more
conditional code now, but does not create more data copies than before.
Unfortunately a copy is more or less unavoidable because protos need to
own the payload and we cannot move it (both because we might need it on
a retry and because it is received as a `std::string const&`).

This will make other changes for #2664 much easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4488)
<!-- Reviewable:end -->
