### PR TITLE
fix: use flag to prevent vcpkg lock timeout

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -57,7 +57,7 @@ fi
   cd "${vcpkg_dir}"
   ./bootstrap-vcpkg.sh
   ./vcpkg remove --outdated --recurse
-  ./vcpkg install google-cloud-cpp
+  ./vcpkg install --x-wait-for-lock google-cloud-cpp
 )
 # Use the new installed/ directory to create the cache.
 rm -fr "${HOME}/vcpkg-quickstart-cache"

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -56,7 +56,7 @@ fi
 (
   cd "${vcpkg_dir}"
   ./bootstrap-vcpkg.sh
-  ./vcpkg remove --outdated --recurse
+  ./vcpkg remove --x-wait-for-lock --outdated --recurse
   ./vcpkg install --x-wait-for-lock google-cloud-cpp
 )
 # Use the new installed/ directory to create the cache.

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -39,7 +39,7 @@ fi
 (
   cd "${vcpkg_dir}"
   ./bootstrap-vcpkg.sh
-  ./vcpkg remove --outdated --recurse
+  ./vcpkg remove --x-wait-for-lock --outdated --recurse
   ./vcpkg install --x-wait-for-lock google-cloud-cpp
 )
 # Use the new installed/ directory to create the cache.

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -40,7 +40,7 @@ fi
   cd "${vcpkg_dir}"
   ./bootstrap-vcpkg.sh
   ./vcpkg remove --outdated --recurse
-  ./vcpkg install google-cloud-cpp
+  ./vcpkg install --x-wait-for-lock google-cloud-cpp
 )
 # Use the new installed/ directory to create the cache.
 rm -fr "cmake-out/vcpkg-quickstart-cache"

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -123,7 +123,7 @@ if ($LastExitCode) {
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Building vcpkg package versions."
 foreach ($pkg in $packages) {
-    .\vcpkg.exe install ${vcpkg_flags} "${pkg}"
+    .\vcpkg.exe install --x-wait-for-lock ${vcpkg_flags} "${pkg}"
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "vcpkg install $pkg failed with exit code $LastExitCode"
         Exit ${LastExitCode}

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -115,7 +115,7 @@ if ($LastExitCode) {
 
 # Remove old versions of the packages.
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cleanup old vcpkg package versions."
-.\vcpkg.exe remove ${vcpkg_flags} --outdated --recurse
+.\vcpkg.exe remove --x-wait-for-lock ${vcpkg_flags} --outdated --recurse
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "vcpkg remove --outdated failed with exit code $LastExitCode"
     Exit ${LastExitCode}


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-cpp/issues/4487

The flag was implemented by Microsoft in
https://github.com/microsoft/vcpkg/pull/12227, thanks to @strega-nil!

I believe we were seeing this flake not because of multiple installs
happening at once, but rather because the machines that run our docker
tests were sometimes overloaded and running very slow and thus it
sometimes took more than 1.5 sec to acquire the lock. This is just a
hypothesis.

But regardless, we're now passing `--x-wait-for-lock` to all of our
`vcpkg install` invocations to avoid these flakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4495)
<!-- Reviewable:end -->
