### PR TITLE
feat(storage): reduce data copies in uploads

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -23,7 +23,7 @@ option(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC
        "Enable compilation for the GCS gRPC plugin (EXPERIMENTAL)" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
 
-set(DOXYGEN_PROJECT_NAME "Google Cloud Storage C++ ªClient")
+set(DOXYGEN_PROJECT_NAME "Google Cloud Storage C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Storage")
 set(DOXYGEN_PROJECT_NUMBER
     "${GOOGLE_CLOUD_CPP_VERSION_MAJOR}.${GOOGLE_CLOUD_CPP_VERSION_MINOR}.${GOOGLE_CLOUD_CPP_VERSION_PATCH}"
@@ -40,7 +40,7 @@ set(DOXYGEN_EXCLUDE_PATTERNS
     "*/google/cloud/storage/testing/*"
     "*/google/cloud/storage/tests/*"
     "*/google/cloud/storage/*_test.cc")
-set(DOXYGEN_EXCLUDE_SYMBOLS "internal")
+set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "storage_benchmarks")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_request.h"
+#include "google/cloud/log.h"
 #include <iostream>
 
 namespace google {
@@ -65,6 +66,9 @@ extern "C" std::size_t CurlRequestOnReadData(char* ptr, std::size_t size,
 }
 
 StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
+  if (logging_enabled_) {
+    GCP_LOG(DEBUG) << __func__ << "() << payload.size=" << payload.size();
+  }
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (!payload.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
@@ -75,6 +79,10 @@ StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
 
 StatusOr<HttpResponse> CurlRequest::MakeUploadRequest(
     ConstBufferSequence payload) {
+  if (logging_enabled_) {
+    GCP_LOG(DEBUG) << __func__ << "() << payload.size=" << payload.size()
+                   << ", payload.bytes=" << TotalBytes(payload);
+  }
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (payload.empty()) return MakeRequestImpl();
   if (payload.size() == 1) {

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_request.h"
-#include "google/cloud/log.h"
 #include <iostream>
 
 namespace google {

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -66,9 +66,6 @@ extern "C" std::size_t CurlRequestOnReadData(char* ptr, std::size_t size,
 }
 
 StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
-  if (logging_enabled_) {
-    GCP_LOG(DEBUG) << __func__ << "() << payload.size=" << payload.size();
-  }
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (!payload.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload.length());
@@ -79,10 +76,6 @@ StatusOr<HttpResponse> CurlRequest::MakeRequest(std::string const& payload) {
 
 StatusOr<HttpResponse> CurlRequest::MakeUploadRequest(
     ConstBufferSequence payload) {
-  if (logging_enabled_) {
-    GCP_LOG(DEBUG) << __func__ << "() << payload.size=" << payload.size()
-                   << ", payload.bytes=" << TotalBytes(payload);
-  }
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
   if (payload.empty()) return MakeRequestImpl();
   if (payload.size() == 1) {

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -329,13 +329,14 @@ std::streamsize ObjectWriteStreambuf::xsputn(char const* s,
 ObjectWriteStreambuf::int_type ObjectWriteStreambuf::overflow(int_type ch) {
   // For ch == EOF this function must do nothing and return any value != EOF.
   if (traits_type::eq_int_type(ch, traits_type::eof())) return 0;
+  if (!IsOpen()) return traits_type::eof();
 
   // assert pptr() != epptr()
   *pptr() = traits_type::to_char_type(ch);
   pbump(1);
   auto actual_size = static_cast<std::size_t>(pptr() - pbase());
   if (actual_size >= max_buffer_size_) Flush();
-  return last_response_ ? traits_type::eof() : ch;
+  return last_response_ ? ch : traits_type::eof();
 }
 
 void ObjectWriteStreambuf::FlushFinal() {

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -285,7 +285,8 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
 StatusOr<ResumableUploadResponse> ObjectWriteStreambuf::Close() {
   pubsync();
   GCP_LOG(INFO) << __func__ << "()";
-  return FlushFinal();
+  FlushFinal();
+  return last_response_;
 }
 
 bool ObjectWriteStreambuf::IsOpen() const {
@@ -299,139 +300,142 @@ bool ObjectWriteStreambuf::ValidateHash(ObjectMetadata const& meta) {
 }
 
 int ObjectWriteStreambuf::sync() {
-  auto result = Flush();
-  if (!result.ok()) {
-    return traits_type::eof();
-  }
-  return 0;
+  Flush();
+  return !last_response_ ? traits_type::eof() : 0;
 }
 
 std::streamsize ObjectWriteStreambuf::xsputn(char const* s,
                                              std::streamsize count) {
-  if (!IsOpen()) {
-    return traits_type::eof();
-  }
+  if (!IsOpen()) return traits_type::eof();
 
-  std::streamsize bytes_copied = 0;
-  while (bytes_copied != count) {
-    std::streamsize remaining_buffer_size = epptr() - pptr();
-    std::streamsize bytes_to_copy =
-        std::min(count - bytes_copied, remaining_buffer_size);
-    std::copy(s, s + bytes_to_copy, pptr());
-    pbump(static_cast<int>(bytes_to_copy));
-    bytes_copied += bytes_to_copy;
-    s += bytes_to_copy;
-    last_response_ = Flush();
-    // Upload failures are irrecoverable because the internal buffer is opaque
-    // to the caller, so there is no way to know what byte range to specify
-    // next.  Replace it with a SessionError so next_expected_byte and
-    // resumable_session_id can still be retrieved.
-    if (!last_response_.ok()) {
-      upload_session_ = std::unique_ptr<ResumableUploadSession>(
-          new ResumableUploadSessionError(last_response_.status(),
-                                          next_expected_byte(),
-                                          resumable_session_id()));
-      return traits_type::eof();
+  auto internal_buffer_size = static_cast<std::size_t>(pptr() - pbase());
+  if (count + internal_buffer_size >= max_buffer_size_) {
+    if (internal_buffer_size == 0) {
+      FlushRoundChunk({ConstBuffer(s, count)});
+    } else {
+      FlushRoundChunk({
+          ConstBuffer(pbase(), internal_buffer_size),
+          ConstBuffer(s, count),
+      });
     }
+    if (!last_response_) return traits_type::eof();
+  } else {
+    std::copy(s, s + count, pptr());
+    pbump(static_cast<int>(count));
   }
   return count;
 }
 
 ObjectWriteStreambuf::int_type ObjectWriteStreambuf::overflow(int_type ch) {
-  if (!IsOpen()) {
-    return traits_type::eof();
-  }
-  if (traits_type::eq_int_type(ch, traits_type::eof())) {
-    // For ch == EOF this function must do nothing and return any value != EOF.
-    return 0;
-  }
-  // If the buffer is full flush it immediately.
-  auto result = Flush();
-  if (!result.ok()) {
-    return traits_type::eof();
-  }
-  // Make sure there is now room in the buffer for the char.
-  if (pptr() == epptr()) {
-    return traits_type::eof();
-  }
-  // Push the character into the current buffer.
+  // For ch == EOF this function must do nothing and return any value != EOF.
+  if (traits_type::eq_int_type(ch, traits_type::eof())) return 0;
+
+  // assert pptr() != epptr()
   *pptr() = traits_type::to_char_type(ch);
   pbump(1);
-  return ch;
+  auto actual_size = static_cast<std::size_t>(pptr() - pbase());
+  if (actual_size >= max_buffer_size_) Flush();
+  return last_response_ ? traits_type::eof() : ch;
 }
 
-StatusOr<ResumableUploadResponse> ObjectWriteStreambuf::FlushFinal() {
-  if (!IsOpen()) {
-    return last_response_;
-  }
-  // Shorten the buffer to the actual used size.
+void ObjectWriteStreambuf::FlushFinal() {
+  if (!IsOpen()) return;
+
+  // Calculate the portion of the buffer that needs to be uploaded, if any.
   auto actual_size = static_cast<std::size_t>(pptr() - pbase());
   std::size_t upload_size = upload_session_->next_expected_byte() + actual_size;
   hash_validator_->Update(pbase(), actual_size);
 
   last_response_ = upload_session_->UploadFinalChunk(
       {ConstBuffer(pbase(), actual_size)}, upload_size);
-  if (!last_response_) {
-    // This was an unrecoverable error, time to store status and signal an
-    // error.
-    return last_response_;
-  }
+
   // Reset the iostream put area with valid pointers, but empty.
   current_ios_buffer_.resize(1);
   auto pbeg = current_ios_buffer_.data();
   setp(pbeg, pbeg);
 
+  // Close the stream
   upload_session_.reset();
-
-  return last_response_;
 }
 
-StatusOr<ResumableUploadResponse> ObjectWriteStreambuf::Flush() {
-  if (!IsOpen()) {
-    return last_response_;
-  }
+void ObjectWriteStreambuf::Flush() {
+  if (!IsOpen()) return;
 
   auto actual_size = static_cast<std::size_t>(pptr() - pbase());
-  if (actual_size < max_buffer_size_) {
-    return last_response_;
+  if (actual_size < UploadChunkRequest::kChunkSizeQuantum) return;
+
+  ConstBufferSequence payload{ConstBuffer(pbase(), pptr() - pbase())};
+  FlushRoundChunk(payload);
+}
+
+void ObjectWriteStreambuf::FlushRoundChunk(ConstBufferSequence buffers) {
+  auto actual_size = TotalBytes(buffers);
+  auto chunk_count = actual_size / UploadChunkRequest::kChunkSizeQuantum;
+  auto rounded_size = chunk_count * UploadChunkRequest::kChunkSizeQuantum;
+
+  // Trim the buffers to the rounded chunk we will actually upload.
+  auto payload = buffers;
+  while (actual_size > rounded_size && !payload.empty()) {
+    auto const n =
+        (std::min)(actual_size - rounded_size, payload.back().size());
+    payload.back().remove_suffix(n);
+    actual_size -= n;
+    if (payload.back().empty()) payload.pop_back();
   }
 
-  auto chunk_count = actual_size / UploadChunkRequest::kChunkSizeQuantum;
-  auto chunk_size = chunk_count * UploadChunkRequest::kChunkSizeQuantum;
+  for (auto const& b : payload) {
+    hash_validator_->Update(b.data(), b.size());
+  }
+
   // GCS upload returns an updated range header that sets the next expected
   // byte. Check to make sure it remains consistent with the bytes stored in the
   // buffer.
-  auto expected_next_byte = upload_session_->next_expected_byte() + chunk_size;
+  auto first_buffered_byte = upload_session_->next_expected_byte();
+  auto expected_next_byte = upload_session_->next_expected_byte() + actual_size;
+  last_response_ = upload_session_->UploadChunk(payload);
 
-  hash_validator_->Update(pbase(), chunk_size);
-  StatusOr<ResumableUploadResponse> result;
-  last_response_ =
-      upload_session_->UploadChunk({ConstBuffer{pbase(), chunk_size}});
-  if (!last_response_) {
-    return last_response_;
-  }
-  auto actual_next_byte = upload_session_->next_expected_byte();
-  auto bytes_uploaded = static_cast<int64_t>(chunk_size);
-  if (actual_next_byte < expected_next_byte) {
-    bytes_uploaded -= expected_next_byte - actual_next_byte;
-    if (bytes_uploaded < 0) {
+  if (last_response_) {
+    // Reset the internal buffer and copy any trailing bytes from `buffers` to
+    // it.
+    auto pbeg = current_ios_buffer_.data();
+    setp(pbeg, pbeg + current_ios_buffer_.size());
+    PopFrontBytes(buffers, rounded_size);
+    for (auto const& b : buffers) {
+      std::copy(b.begin(), b.end(), pptr());
+      pbump(static_cast<int>(b.size()));
+    }
+
+    // We cannot use the last committed byte in `last_response_` because when
+    // using X-Upload-Content-Length GCS returns 0 when the upload completed
+    // even if no "final chunk" is sent.  The resumable upload classes know how
+    // to deal with this mess, so let's not duplicate that code here.
+    auto actual_next_byte = upload_session_->next_expected_byte();
+    if (actual_next_byte < expected_next_byte &&
+        actual_next_byte < first_buffered_byte) {
       std::ostringstream error_message;
       error_message << "Could not continue upload stream. GCS requested byte "
                     << actual_next_byte << " which has already been uploaded.";
-      return Status(StatusCode::kAborted, error_message.str());
+      last_response_ = Status(StatusCode::kAborted, error_message.str());
+    } else if (actual_next_byte > expected_next_byte) {
+      std::ostringstream error_message;
+      error_message << "Could not continue upload stream. "
+                    << "GCS requested unexpected byte. (expected: "
+                    << expected_next_byte << ", actual: " << actual_next_byte
+                    << ")";
+      last_response_ = Status(StatusCode::kAborted, error_message.str());
     }
-  } else if (actual_next_byte > expected_next_byte) {
-    std::ostringstream error_message;
-    error_message << "Could not continue upload stream. "
-                  << "GCS requested unexpected byte. (expected: "
-                  << expected_next_byte << ", actual: " << actual_next_byte
-                  << ")";
-    return Status(StatusCode::kAborted, error_message.str());
   }
-  std::copy(pbase() + bytes_uploaded, epptr(), pbase());
-  setp(pbase(), epptr());
-  pbump(static_cast<int>(actual_size - bytes_uploaded));
-  return last_response_;
+
+  // Upload failures are irrecoverable because the internal buffer is opaque
+  // to the caller, so there is no way to know what byte range to specify
+  // next.  Replace it with a SessionError so next_expected_byte and
+  // resumable_session_id can still be retrieved.
+  if (!last_response_.ok()) {
+    upload_session_ =
+        std::unique_ptr<ResumableUploadSession>(new ResumableUploadSessionError(
+            last_response_.status(), next_expected_byte(),
+            resumable_session_id()));
+  }
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -331,11 +331,10 @@ ObjectWriteStreambuf::int_type ObjectWriteStreambuf::overflow(int_type ch) {
   if (traits_type::eq_int_type(ch, traits_type::eof())) return 0;
   if (!IsOpen()) return traits_type::eof();
 
-  // assert pptr() != epptr()
-  *pptr() = traits_type::to_char_type(ch);
-  pbump(1);
   auto actual_size = static_cast<std::size_t>(pptr() - pbase());
   if (actual_size >= max_buffer_size_) Flush();
+  *pptr() = traits_type::to_char_type(ch);
+  pbump(1);
   return last_response_ ? ch : traits_type::eof();
 }
 

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -140,11 +140,14 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   int_type overflow(int_type ch) override;
 
  private:
-  /// Flush any data if possible.
-  StatusOr<ResumableUploadResponse> Flush();
+  /// Flush any data if possible, returns the bytes written.
+  void Flush();
 
-  /// Flush any remaining data and commit the upload.
-  StatusOr<ResumableUploadResponse> FlushFinal();
+  /// Flush any remaining data and finalize the upload.
+  void FlushFinal();
+
+  /// Upload a round chunk
+  void FlushRoundChunk(ConstBufferSequence buffers);
 
   std::unique_ptr<ResumableUploadSession> upload_session_;
 

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -140,7 +140,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   int_type overflow(int_type ch) override;
 
  private:
-  /// Flush any data if possible, returns the bytes written.
+  /// Flush any data if possible.
   void Flush();
 
   /// Flush any remaining data and finalize the upload.
@@ -148,6 +148,9 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
 
   /// Upload a round chunk
   void FlushRoundChunk(ConstBufferSequence buffers);
+
+  /// The current used bytes in the put area (aka current_ios_buffer_)
+  std::size_t put_area_size() const { return pptr() - pbase(); }
 
   std::unique_ptr<ResumableUploadSession> upload_session_;
 

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -31,6 +31,7 @@ using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::InSequence;
 using ::testing::InvokeWithoutArgs;
+using ::testing::NiceMock;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -489,7 +490,8 @@ TEST(ObjectWriteStreambufTest, ErroneousStream) {
 
 /// @test Verify that last error status is accessible for large payloads.
 TEST(ObjectWriteStreambufTest, ErrorInLargePayload) {
-  auto mock = absl::make_unique<testing::MockResumableUploadSession>();
+  auto mock =
+      absl::make_unique<NiceMock<testing::MockResumableUploadSession>>();
   EXPECT_CALL(*mock, done).WillRepeatedly(Return(false));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
@@ -497,6 +499,7 @@ TEST(ObjectWriteStreambufTest, ErrorInLargePayload) {
   std::string const payload_2("trailer");
   std::string const session_id = "upload_id";
 
+  ON_CALL(*mock, next_expected_byte()).WillByDefault(Return(0));
   EXPECT_CALL(*mock, UploadChunk(_))
       .WillOnce([&](ConstBufferSequence const& p) {
         EXPECT_EQ(3 * quantum, TotalBytes(p));

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -200,9 +200,9 @@ TEST(ObjectWriteStreambufTest, FlushAfterFullQuantum) {
       .WillOnce([&](ConstBufferSequence const& p) {
         ++count;
         EXPECT_EQ(1, count);
-        auto expected =
-            payload_1 + payload_2.substr(0, quantum - payload_1.size());
-        EXPECT_THAT(p, ElementsAre(ConstBuffer{expected}));
+        auto trailer = payload_2.substr(0, quantum - payload_1.size());
+        EXPECT_THAT(p,
+                    ElementsAre(ConstBuffer{payload_1}, ConstBuffer{trailer}));
         next_byte += TotalBytes(p);
         return make_status_or(ResumableUploadResponse{
             "", quantum - 1, {}, ResumableUploadResponse::kInProgress, {}});
@@ -288,34 +288,25 @@ TEST(ObjectWriteStreambufTest, SomeBytesNotAccepted) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
-  std::string const payload = std::string(quantum, '*') + "abcde";
+  std::string const payload = std::string(quantum - 2, '*') + "abcde";
 
   size_t next_byte = 0;
-  uint64_t const bytes_uploaded_first_try = quantum - 1;
   EXPECT_CALL(*mock, UploadChunk(_))
       .WillOnce([&](ConstBufferSequence const& p) {
         auto expected = payload.substr(0, quantum);
         EXPECT_THAT(p, ElementsAre(ConstBuffer{expected}));
-        next_byte += bytes_uploaded_first_try;
-        return make_status_or(
-            ResumableUploadResponse{"",
-                                    bytes_uploaded_first_try - 1,
-                                    {},
-                                    ResumableUploadResponse::kInProgress,
-                                    {}});
+        next_byte += quantum;
+        return make_status_or(ResumableUploadResponse{
+            "", next_byte - 1, {}, ResumableUploadResponse::kInProgress, {}});
       });
   EXPECT_CALL(*mock, UploadFinalChunk(_, _))
       .WillOnce([&](ConstBufferSequence const& p, std::uint64_t s) {
-        auto const content = payload.substr(bytes_uploaded_first_try);
+        auto const content = payload.substr(quantum);
         EXPECT_THAT(p, ElementsAre(ConstBuffer{content}));
         EXPECT_EQ(payload.size(), s);
-        auto last_committed_byte = payload.size() - 1;
-        return make_status_or(
-            ResumableUploadResponse{"{}",
-                                    last_committed_byte,
-                                    {},
-                                    ResumableUploadResponse::kInProgress,
-                                    {}});
+        next_byte += content.size();
+        return make_status_or(ResumableUploadResponse{
+            "{}", next_byte - 1, {}, ResumableUploadResponse::kInProgress, {}});
       });
   EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly([&]() {
     return next_byte;
@@ -342,9 +333,11 @@ TEST(ObjectWriteStreambufTest, NextExpectedByteJumpsAhead) {
   size_t next_byte = 0;
   EXPECT_CALL(*mock, UploadChunk(_))
       .WillOnce([&](ConstBufferSequence const& p) {
-        next_byte += quantum * 2;
-        auto expected = payload.substr(0, quantum);
+        auto expected = payload.substr(0, 2 * quantum);
         EXPECT_THAT(p, ElementsAre(ConstBuffer{expected}));
+        // Simulate a condition where the server reports more bytes committed
+        // than expected
+        next_byte += quantum * 3;
         return make_status_or(ResumableUploadResponse{
             "", next_byte - 1, {}, ResumableUploadResponse::kInProgress, {}});
       });
@@ -408,9 +401,9 @@ TEST(ObjectWriteStreambufTest, MixPutcPutn) {
       .WillOnce([&](ConstBufferSequence const& p) {
         ++count;
         EXPECT_EQ(1, count);
-        auto expected =
-            payload_1 + payload_2.substr(0, quantum - payload_1.size());
-        EXPECT_THAT(p, ElementsAre(ConstBuffer{expected}));
+        auto expected = payload_2.substr(0, quantum - payload_1.size());
+        EXPECT_THAT(p,
+                    ElementsAre(ConstBuffer{payload_1}, ConstBuffer{expected}));
         next_byte += TotalBytes(p);
         return make_status_or(ResumableUploadResponse{
             "", quantum - 1, {}, ResumableUploadResponse::kInProgress, {}});
@@ -505,8 +498,8 @@ TEST(ObjectWriteStreambufTest, ErrorInLargePayload) {
   std::string const session_id = "upload_id";
 
   EXPECT_CALL(*mock, UploadChunk(_))
-      .WillOnce([&quantum](ConstBufferSequence const& p) {
-        EXPECT_EQ(quantum, TotalBytes(p));
+      .WillOnce([&](ConstBufferSequence const& p) {
+        EXPECT_EQ(3 * quantum, TotalBytes(p));
         return Status(StatusCode::kInvalidArgument, "Invalid Argument");
       });
   EXPECT_CALL(*mock, session_id).WillOnce(ReturnRef(session_id));
@@ -525,6 +518,59 @@ TEST(ObjectWriteStreambufTest, ErrorInLargePayload) {
   auto response = streambuf.Close();
   EXPECT_EQ(StatusCode::kInvalidArgument, response.status().code())
       << ", status=" << response.status();
+}
+
+/// @test Verify that uploads of known size work.
+TEST(ObjectWriteStreambufTEst, KnownSizeUpload) {
+  auto mock = absl::make_unique<testing::MockResumableUploadSession>();
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(2 * quantum, '*');
+
+  std::size_t mock_next_byte = 0;
+  EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly([&]() {
+    return mock_next_byte;
+  });
+  bool mock_is_done = false;
+  EXPECT_CALL(*mock, done()).WillRepeatedly([&]() { return mock_is_done; });
+  std::string const mock_session_id = "session-id";
+  EXPECT_CALL(*mock, session_id()).WillRepeatedly(ReturnRef(mock_session_id));
+  EXPECT_CALL(*mock, UploadChunk(_))
+      .WillOnce([&](ConstBufferSequence const& p) {
+        EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
+        mock_next_byte += TotalBytes(p);
+        return make_status_or(ResumableUploadResponse{
+            "", 2 * quantum - 1, {}, ResumableUploadResponse::kInProgress, {}});
+      })
+      .WillOnce([&](ConstBufferSequence const& p) {
+        EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
+        mock_next_byte += TotalBytes(p);
+        return make_status_or(ResumableUploadResponse{
+            "", 4 * quantum - 1, {}, ResumableUploadResponse::kInProgress, {}});
+      })
+      .WillOnce([&](ConstBufferSequence const& p) {
+        EXPECT_THAT(p, ElementsAre(ConstBuffer{payload.data(), quantum}));
+        mock_next_byte += TotalBytes(p);
+        // When using X-Upload-Content-Length GCS finalizes the upload when
+        // enough data is sent, regardless of whether we use UploadChunk() or
+        // UploadFinalChunk(). Furthermore the response has a last committed
+        // byte of "0".
+        mock_is_done = true;
+        return make_status_or(ResumableUploadResponse{
+            "", 0, {}, ResumableUploadResponse::kDone, {}});
+      });
+
+  ObjectWriteStreambuf streambuf(std::move(mock), quantum,
+                                 absl::make_unique<NullHashValidator>());
+
+  streambuf.sputn(payload.data(), 2 * quantum);
+  streambuf.sputn(payload.data(), 2 * quantum);
+  streambuf.sputn(payload.data(), quantum);
+  EXPECT_EQ(5 * quantum, streambuf.next_expected_byte());
+  EXPECT_FALSE(streambuf.IsOpen());
+  EXPECT_STATUS_OK(streambuf.last_status());
+  auto response = streambuf.Close();
+  EXPECT_STATUS_OK(response);
 }
 
 TEST(ObjectReadStreambufTest, FailedTellg) {

--- a/google/cloud/storage/internal/resumable_upload_session.cc
+++ b/google/cloud/storage/internal/resumable_upload_session.cc
@@ -103,7 +103,10 @@ std::ostream& operator<<(std::ostream& os, ResumableUploadResponse const& r) {
   } else {
     os << "{}";
   }
-  return os << ", upload_state=" << r.upload_state
+  return os << ", upload_state="
+            << (r.upload_state == ResumableUploadResponse::kDone
+                    ? "kDone"
+                    : "kInProgress")
             << ", annotations=" << r.annotations << "}";
 }
 

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -673,6 +673,7 @@ class GcsBucket(object):
         end = next_byte + len(request.data)
         total = end
         final_chunk = False
+        payload = testbench_utils.extract_media(request)
         content_range = request.headers.get("content-range")
         if content_range is not None:
             if content_range.startswith("bytes */*"):
@@ -711,14 +712,14 @@ class GcsBucket(object):
                         % (next_byte, begin),
                         status_code=400,
                     )
-                if len(request.data) != end - begin + 1:
+                if len(payload) != end - begin + 1:
                     raise error_response.ErrorResponse(
-                        "Mismatched data range (%d) vs. content-length (%d)"
-                        % (end - begin + 1, len(request.data)),
+                        "Mismatched data range (%d) vs. received data (%d)"
+                        % (end - begin + 1, len(payload)),
                         status_code=400,
                     )
 
-        upload["media"] = upload.get("media", b"") + request.data
+        upload["media"] = upload.get("media", b"") + payload
         next_byte = len(upload.get("media", ""))
         upload["next_byte"] = next_byte
         response_payload = ""


### PR DESCRIPTION
With this change it is possible to avoid all copies of upload data until
the libcurl/openssl layer (at which point a copy is unavoidable). We say
"possible" because there are cases where some amount of data copies are
necessary (more on these later).

Some background first: resumable uploads in GCS work by uploading
"chunks". The size of these chunks (except the last one) must be
multiples of the upload quantum (256KiB). Uploading a chunk that is not
a multiple of the quantum implicitly finalizes the upload.

This means that any data smaller than a quantum *must* be buffered.
Applications should consider always providing buffers that are a
multiple of the quantum to avoid such buffering.

With that said, many applications upload data by calling
`std::ostream::write()` repeatedly, as long as the buffer provided in
these calls is larger than `clientOptions::upload_buffer_size()` the
buffer will be passed without additional copies to libcurl. Any portion
that is not a multiple of the quantum is not uploaded and buffered.

As an additional improvement this change fixes `sync()` to actually
flush data if the buffer contains at least one multiple of the upload
quantum (256KiB). Smaller buffers cannot be flushed because GCS
finalizes an upload on the first chunk that is not a multiple of the
quantum.

The cases where copying are unavoidable include:

- Data provided via operator<<() is always buffered before copying.
- Buffers smaller than the GCS upload quantum need to be copied.
- Buffers that are not a multiple of the upload quantum are partially
  copied.

Also fixed the testbench to work with chunked (these are HTTP chunks,
not GCS chunks) transfer encoding for resumable uploads.

Fixes #2664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4496)
<!-- Reviewable:end -->
