### PR TITLE
fix: avoid unnecessary chunk to finalize uploads

### DIFF
--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -283,8 +283,6 @@ ObjectReadStreambuf::pos_type ObjectReadStreambuf::seekoff(
 }
 
 StatusOr<ResumableUploadResponse> ObjectWriteStreambuf::Close() {
-  pubsync();
-  GCP_LOG(INFO) << __func__ << "()";
   FlushFinal();
   return last_response_;
 }

--- a/google/cloud/storage/internal/object_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_streambuf_test.cc
@@ -601,20 +601,11 @@ TEST(ObjectWriteStreambufTest, Pubsync) {
                                     {},
                                     ResumableUploadResponse::kInProgress,
                                     {}});
-      })
-      .WillOnce([&](ConstBufferSequence const& p) {
-        EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
-        mock_next_byte += TotalBytes(p);
-        return make_status_or(
-            ResumableUploadResponse{"",
-                                    mock_next_byte - 1,
-                                    {},
-                                    ResumableUploadResponse::kInProgress,
-                                    {}});
       });
   EXPECT_CALL(*mock, UploadFinalChunk(_, _))
       .WillOnce([&](ConstBufferSequence const& p, std::uint64_t) {
-        EXPECT_EQ(0, TotalBytes(p));
+        EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
+        mock_next_byte += TotalBytes(p);
         mock_is_done = true;
         return make_status_or(ResumableUploadResponse{
             "", mock_next_byte - 1, {}, ResumableUploadResponse::kDone, {}});


### PR DESCRIPTION
When closing a stream we need to send a chunk to finalize the upload. If
there was more than one upload quantum in the put area we first flushed
that data with one chunk, and then sent the finalization chunk, with
many zero bytes. It is more efficient to avoid the flush and send a
single finalization chunk.

Fixes #4499

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4504)
<!-- Reviewable:end -->
