### PR TITLE
ci: deflake macOS cache updates

### DIFF
--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -50,7 +50,9 @@ cache_download_tarball() {
   echo "================================================================"
   io::log "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    gsutil -q cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
+    gsutil "${CACHE_GSUTIL_DEBUG:-q}" \
+    -o GSUtil:sliced_object_download_threshold=256M \
+    cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
 }
 
 cache_upload_enabled() {
@@ -81,7 +83,9 @@ cache_upload_tarball() {
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    gsutil -q cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
+    gsutil "${CACHE_GSUTIL_DEBUG:-q}" \
+    -o GSUtil:parallel_composite_upload_threshold=256M \
+    cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
 
   io::log "Upload completed"
 }

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -50,7 +50,7 @@ cache_download_tarball() {
   echo "================================================================"
   io::log "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    gsutil "${CACHE_GSUTIL_DEBUG:-q}" \
+    gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
     -o GSUtil:sliced_object_download_threshold=256M \
     cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
 }
@@ -83,7 +83,7 @@ cache_upload_tarball() {
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    gsutil "${CACHE_GSUTIL_DEBUG:-q}" \
+    gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
     -o GSUtil:parallel_composite_upload_threshold=256M \
     cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -116,10 +116,6 @@ readonly CACHE_NAME
 
 echo "================================================================"
 io::log_yellow "install crcmod to speed up gsutil."
-echo "DEBUG DEBUG DEBUG"
-gsutil version -l
-export CACHE_GSUTIL_DEBUG="-m"
-echo "DEBUG DEBUG DEBUG END"
 sudo pip3 install -U crcmod
 
 gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/download-cache.sh" \

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -114,7 +114,14 @@ readonly CACHE_FOLDER
 CACHE_NAME="cache-macos-${BUILD_NAME}"
 readonly CACHE_NAME
 
-"${PROJECT_ROOT}/ci/kokoro/macos/download-cache.sh" \
+echo "================================================================"
+io::log_yellow "install crcmod to speed up gsutil."
+echo "DEBUG DEBUG DEBUG"
+gsutil version -l
+echo "DEBUG DEBUG DEBUG END"
+sudo pip3 install -U crcmod
+
+gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/download-cache.sh" \
   "${CACHE_FOLDER}" "${CACHE_NAME}" || true
 
 echo "================================================================"
@@ -122,15 +129,12 @@ io::log_yellow "starting build script."
 
 if "${driver_script}" "${script_flags[@]+"${script_flags[@]}"}"; then
   io::log_green "build script was successful."
-  exit_status=0
 else
   io::log_red "build script reported errors."
-  exit_status=1
+  exit 1
 fi
 
-if [[ "${exit_status}" -eq 0 ]]; then
-  "${PROJECT_ROOT}/ci/kokoro/macos/upload-cache.sh" \
-    "${CACHE_FOLDER}" "${CACHE_NAME}" || true
-fi
+gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/upload-cache.sh" \
+  "${CACHE_FOLDER}" "${CACHE_NAME}" || true
 
-exit ${exit_status}
+exit 0

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -118,7 +118,7 @@ echo "================================================================"
 io::log_yellow "install crcmod to speed up gsutil."
 echo "DEBUG DEBUG DEBUG"
 gsutil version -l
-export CACHE_GSUTIL_DEBUG=""
+export CACHE_GSUTIL_DEBUG="-m"
 echo "DEBUG DEBUG DEBUG END"
 sudo pip3 install -U crcmod
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -118,6 +118,7 @@ echo "================================================================"
 io::log_yellow "install crcmod to speed up gsutil."
 echo "DEBUG DEBUG DEBUG"
 gsutil version -l
+export CACHE_GSUTIL_DEBUG=""
 echo "DEBUG DEBUG DEBUG END"
 sudo pip3 install -U crcmod
 


### PR DESCRIPTION
The last few failures for #3645 the build timed out because uploading or downloading the cache made no progress in 3600s.  With this change the upload and/or download of the cache may timeout, but that would not break the build because they run with a `|| true` at the end.

Whether the overall build will still timeout for other reason, or the 20 minutes consumed by the cache upload/download timeout proves too much, that remains to be seen. In any case, I believe this would help, if nothing else, it would give us more information as something else would fail.

Part of the work for #3645 

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4505)
<!-- Reviewable:end -->
