### PR TITLE
fix(storage): avoid chunked transfer encoding

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -262,6 +262,10 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   builder.AddHeader("Content-Type: application/octet-stream");
   builder.AddHeader("Content-Length: " +
                     std::to_string(request.payload_size()));
+  // We need to explicitly disable chunked transfer encoding. libcurl uses is by
+  // default (at least in this case), and that wastes bandwidth as the content
+  // length is known.
+  builder.AddHeader("Transfer-Encoding:");
   auto response = builder.BuildRequest().MakeUploadRequest(request.payload());
   if (!response.ok()) {
     return std::move(response).status();

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -82,6 +82,7 @@ StatusOr<HttpResponse> CurlRequest::MakeUploadRequest(
     handle_.SetOption(CURLOPT_POSTFIELDS, payload[0].data());
     return MakeRequestImpl();
   }
+
   WriteVector writev{std::move(payload)};
   handle_.SetOption(CURLOPT_READFUNCTION, &CurlRequestOnReadData);
   handle_.SetOption(CURLOPT_READDATA, &writev);


### PR DESCRIPTION
In some (we think relatively rare) cases we were using chunked
transfer encoding, which wastes bandwidth when the size of the transfer
is known (as it is in our case).

The problem only manifested itself when an upload stream had some data
in its buffers and the application provided a large enough call in
`.write()` to fill an upload chunk.

This change adds some metadata in the testbench to detect the transfer
encodings used for an upload, that seems better than examining the log
of the upload.

Fixes #4498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4506)
<!-- Reviewable:end -->
