### PR TITLE
ci(macos): remove unused artifacts before exit

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -131,7 +131,20 @@ else
   exit 1
 fi
 
+io::log_yellow "post build cache upload + cleanup"
+
 gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/upload-cache.sh" \
   "${CACHE_FOLDER}" "${CACHE_NAME}" || true
+
+if [[ "${RUNNING_CI:-}" == "yes" ]] && [[ -n "${KOKORO_ARTIFACTS_DIR:-}" ]]; then
+  # Our CI system (Kokoro) syncs the data in this directory to somewhere after
+  # the build completes. Removing the cmake-out/ dir shaves minutes off this
+  # process. This is safe as long as we don't wish to save any build artifacts.
+  io::log_yellow "cleaning up artifacts."
+  find "${KOKORO_ARTIFACTS_DIR}" -name cmake-out -type d -prune -print0 |
+    xargs -0 -t rm -rf || true
+else
+  io::log_yellow "Not a CI build; skipping artifact cleanup"
+fi
 
 exit 0


### PR DESCRIPTION
By default Kokoro uploads the data from KOKORO_ARTIFACTS_DIR after
the build script exits. That can be a substantial amount of data, and
we do not use it. It is faster to just remove it.

Part of the work for #4507

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4508)
<!-- Reviewable:end -->
