### PR TITLE
fix: warnings under Windows+MSVC+x86

### DIFF
--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -40,11 +40,6 @@ $cmake_flags += "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET"
 $cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"
 $cmake_flags += "-DCMAKE_CXX_COMPILER=cl.exe"
 
-if ("${env:VCPKG_TRIPLET}" -like "x86*") {
-    # TODO(#4501) - cannot use /WX (aka -Werror) on MSVC+Windows+x86
-    $cmake_flags += "-DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF"
-}
-
 # Configure CMake and create the build directory.
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Configuring CMake with $cmake_flags"
 cmake $cmake_flags

--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -113,9 +113,9 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
          c.maximum_clients = std::stoi(v);
        }},
       {"--table-size=",
-       [](Config& c, std::string const& v) { c.table_size = std::stol(v); }},
+       [](Config& c, std::string const& v) { c.table_size = std::stoi(v); }},
       {"--query-size=",
-       [](Config& c, std::string const& v) { c.query_size = std::stol(v); }},
+       [](Config& c, std::string const& v) { c.query_size = std::stoi(v); }},
 
       {"--use-only-stubs",
        [](Config& c, std::string const&) { c.use_only_stubs = true; }},

--- a/google/cloud/spanner/benchmarks/benchmarks_config.h
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.h
@@ -42,8 +42,8 @@ struct Config {
   int minimum_clients = 1;
   int maximum_clients = 1;
 
-  std::int64_t table_size = 1000 * 1000L;
-  std::int64_t query_size = 1000;
+  std::int32_t table_size = 1000 * 1000L;
+  std::int32_t query_size = 1000;
 
   bool use_only_clients = false;
   bool use_only_stubs = false;

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -532,7 +532,7 @@ class ExperimentImpl {
     auto flush_as_needed = [&maybe_flush] { return maybe_flush(false); };
 
     auto const report_period =
-        (std::max)(static_cast<std::int64_t>(2), config.table_size / 50);
+        (std::max)(static_cast<std::int32_t>(2), config.table_size / 50);
     for (std::int64_t key = 0; key != config.table_size; ++key) {
       // Each thread does a fraction of the key space.
       if (key % task_count != task_id) continue;
@@ -662,7 +662,8 @@ class ReadExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread. Use that to estimate
     // the size of the vector.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     std::vector<std::string> const columns{"Key",   "Data0", "Data1", "Data2",
                                            "Data3", "Data4", "Data5", "Data6",
                                            "Data7", "Data8", "Data9"};
@@ -745,7 +746,8 @@ class ReadExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread, so allocate enough
     // memory to start.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {
@@ -881,7 +883,8 @@ class SelectExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread. Use that to estimate
     // the size of the vector.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     auto const statement = CreateStatement();
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
@@ -965,7 +968,8 @@ class SelectExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread, so allocate enough
     // memory to start.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {
@@ -1120,7 +1124,8 @@ class UpdateExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread. Use that to estimate
     // the size of the vector.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {
@@ -1215,7 +1220,8 @@ class UpdateExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread, so allocate enough
     // memory to start.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {
@@ -1388,7 +1394,8 @@ class MutationExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread. Use that to estimate
     // the size of the vector.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {
@@ -1469,7 +1476,8 @@ class MutationExperiment : public Experiment {
     std::vector<RowCpuSample> samples;
     // We expect about 50 reads per second per thread, so allocate enough
     // memory to start.
-    samples.reserve(config.iteration_duration.count() * 50);
+    samples.reserve(
+        static_cast<std::size_t>(config.iteration_duration.count() * 50));
     for (auto start = std::chrono::steady_clock::now(),
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -190,7 +190,7 @@ void FillTableTask(Config const& config, spanner::Client client, std::mutex& mu,
   auto flush_as_needed = [&maybe_flush] { maybe_flush(false); };
 
   auto const report_period =
-      (std::max)(static_cast<std::int64_t>(2), config.table_size / 50);
+      (std::max)(static_cast<std::int32_t>(2), config.table_size / 50);
   for (std::int64_t key = 0; key != config.table_size; ++key) {
     // Each thread does a fraction of the key space.
     if (key % task_count != task_id) continue;

--- a/google/cloud/spanner/internal/time_format.cc
+++ b/google/cloud/spanner/internal/time_format.cc
@@ -176,7 +176,7 @@ std::size_t ParseTime(char const* fmt, std::string const& s, std::tm* tm) {
   input >> std::get_time(tm, fmt);
   if (!input) return std::string::npos;
   auto const pos = input.tellg();
-  if (pos >= 0) return pos;
+  if (pos >= 0) return static_cast<std::size_t>(pos);
   return s.size();
 #endif
 }

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -21,8 +21,15 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+// TODO(#4501) - fix by doing #include <absl/...>
+#include "google/cloud/internal/diagnostics_push.inc"
+#if _MSC_VER
+#pragma warning(disable : 4244)
+#endif  // _MSC_VER
 #include "absl/algorithm/container.h"
 #include "absl/strings/str_join.h"
+// TODO(#4501) - end
+#include "google/cloud/internal/diagnostics_pop.inc"
 #include <future>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
Remove any remaining warnings under Windows+MSVC+x86, now the examples,
tests and benchmarks compile cleanly in 32-bit mode. I think we are
actually using the correct types, not just silencing warnings with
`static_cast<>` too.

To enable `/WX` (treat warnings as errors) I had to disable warnings
around an Abseil include, there is a TODO for a better fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4515)
<!-- Reviewable:end -->
