### PR TITLE
feat: update to new version of googleapis protos

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -75,10 +75,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/abd6b709a5533ba5d0bc435189ffda7f2445cd4b.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/59f97e6044a1275f83427ab7962a154c00d915b5.tar.gz",
             ],
-            strip_prefix = "googleapis-abd6b709a5533ba5d0bc435189ffda7f2445cd4b",
-            sha256 = "c45d0e135ac7ad54c34546404d5338e4980d0b397f093e1e2cb185ec8813430f",
+            strip_prefix = "googleapis-59f97e6044a1275f83427ab7962a154c00d915b5",
+            sha256 = "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -19,10 +19,10 @@ cmake_minimum_required(VERSION 3.5)
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-    "https://github.com/googleapis/googleapis/archive/abd6b709a5533ba5d0bc435189ffda7f2445cd4b.tar.gz"
+    "https://github.com/googleapis/googleapis/archive/59f97e6044a1275f83427ab7962a154c00d915b5.tar.gz"
 )
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-    "c45d0e135ac7ad54c34546404d5338e4980d0b397f093e1e2cb185ec8813430f")
+    "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073")
 
 set(GOOGLEAPIS_CPP_SOURCE
     "${CMAKE_BINARY_DIR}/external/googleapis/src/googleapis_download")


### PR DESCRIPTION
Update from the 2020-05-16 https://github.com/googleapis/googleapis,
most notably to pick up support for the Spanner NUMERIC type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4517)
<!-- Reviewable:end -->
