### PR TITLE
doc: update region tags for bigtable quickstart

### DIFF
--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-[START bigtable_quickstart]
+// [START bigtable_quickstart]
 
 #include "google/cloud/bigtable/table.h"
 
@@ -60,4 +60,4 @@ int main(int argc, char* argv[]) try {
   return 1;
 }
 
-[END bigtable_quickstart]
+// [END bigtable_quickstart]

--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+[START bigtable_quickstart]
+
 #include "google/cloud/bigtable/table.h"
 
 int main(int argc, char* argv[]) try {
@@ -57,3 +59,5 @@ int main(int argc, char* argv[]) try {
   std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
   return 1;
 }
+
+[END bigtable_quickstart]


### PR DESCRIPTION
Re-add region tags that were removed when this page was refactored and moved. Region tags are required to pull the quickstart code in to the client libraries overview page in the Cloud Bigtable docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4522)
<!-- Reviewable:end -->
