### PR TITLE
fix: builds on 64-bit Windows

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator.cc
@@ -102,7 +102,7 @@ std::vector<int> BulkMutatorState::OnRead(
       res.push_back(annotation.original_index);
       continue;
     }
-    auto& original = *mutations_.mutable_entries(index);
+    auto& original = *mutations_.mutable_entries(static_cast<int>(index));
     // Failed responses are handled according to the current policies.
     if (SafeGrpcRetry::IsTransientFailure(code) && annotation.is_idempotent) {
       // Retryable requests are saved in the pending mutations, along with the


### PR DESCRIPTION
Ironically I broke the 64-bit builds when fixing the 32-bit builds for
Windows. Tested both this time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4523)
<!-- Reviewable:end -->
