### PR TITLE
doc(bigtable): restore quickstart's region tags

### DIFF
--- a/ci/generate-markdown/generate-bigtable-readme.sh
+++ b/ci/generate-markdown/generate-bigtable-readme.sh
@@ -63,10 +63,10 @@ _EOF_
 
 # Dumps the contents of quickstart.cc starting at the first #include, so we
 # skip the license header comment.
-sed -n '/^#/,$p' "${BINDIR}/../../google/cloud/bigtable/quickstart/quickstart.cc"
+sed -n -e '/END bigtable_quickstart/,$d' -e '/^#/,$p' "${BINDIR}/../../google/cloud/bigtable/quickstart/quickstart.cc"
 
 cat <<'_EOF_'
-````
+```
 
 ## Contributing changes
 

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -80,7 +80,6 @@ int main(int argc, char* argv[]) try {
   std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
   return 1;
 }
-
 ```
 
 ## Contributing changes

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -80,7 +80,8 @@ int main(int argc, char* argv[]) try {
   std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
   return 1;
 }
-````
+
+```
 
 ## Contributing changes
 

--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -59,5 +59,4 @@ int main(int argc, char* argv[]) try {
   std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
   return 1;
 }
-
 // [END bigtable_quickstart]

--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START bigtable_quickstart]
+
 #include "google/cloud/bigtable/table.h"
 
 int main(int argc, char* argv[]) try {
@@ -57,3 +59,5 @@ int main(int argc, char* argv[]) try {
   std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
   return 1;
 }
+
+// [END bigtable_quickstart]

--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START bigtable_quickstart]
-
 #include "google/cloud/bigtable/table.h"
 
 int main(int argc, char* argv[]) try {


### PR DESCRIPTION
Thanks to @cshaff0524 for the original PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4525)
<!-- Reviewable:end -->
