### PR TITLE
ci: restore bazel caching for *san builds

### DIFF
--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -48,10 +48,11 @@ cache_download_tarball() {
   activate_service_account_keyfile "${CACHE_KEYFILE}"
 
   echo "================================================================"
+  io::log "gsutil configuration"
+  gsutil version -l
   io::log "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
     gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
-    -o GSUtil:sliced_object_download_threshold=256M \
     cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
 }
 
@@ -77,6 +78,8 @@ cache_upload_tarball() {
   local -r GCS_FOLDER="$3"
 
   echo "================================================================"
+  io::log "gsutil configuration"
+  gsutil version -l
   io::log "Uploading build cache ${FILENAME} to ${GCS_FOLDER}"
 
   trap cache_gcloud_cleanup RETURN
@@ -84,7 +87,6 @@ cache_upload_tarball() {
   activate_service_account_keyfile "${CACHE_KEYFILE}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
     gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
-    -o GSUtil:parallel_composite_upload_threshold=256M \
     cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
 
   io::log "Upload completed"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -555,6 +555,9 @@ readonly CACHE_FOLDER
 CACHE_NAME="cache-${DOCKER_IMAGE_BASENAME}-${BUILD_NAME}"
 readonly CACHE_NAME
 
+echo "================================================================"
+io::log_yellow "Downloading build cache."
+
 "${PROJECT_ROOT}/ci/kokoro/docker/download-cache.sh" \
   "${CACHE_FOLDER}" "${CACHE_NAME}" "${BUILD_HOME}" || true
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -115,9 +115,6 @@ CACHE_NAME="cache-macos-${BUILD_NAME}"
 readonly CACHE_NAME
 
 echo "================================================================"
-io::log_yellow "install crcmod to speed up gsutil."
-sudo pip3 install -U crcmod
-
 gtimeout 1200 "${PROJECT_ROOT}/ci/kokoro/macos/download-cache.sh" \
   "${CACHE_FOLDER}" "${CACHE_NAME}" || true
 


### PR DESCRIPTION
Don't do any slicing or parallel uploads, the crcmod installed on the
Kokoro machines is too slow to support objects with multiple components.

Fixes #4524 but may need a full PR -> Full Build -> PR cycle before it has
any effect.

<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4526)
<!-- Reviewable:end -->
