### PR TITLE
feat(pubsub): use emulator environment variable

### DIFF
--- a/google/cloud/pubsub/BUILD
+++ b/google/cloud/pubsub/BUILD
@@ -37,6 +37,7 @@ load(":pubsub_client_unit_tests.bzl", "pubsub_client_unit_tests")
     deps = [
         ":pubsub_client",
         "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",
     ],

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -28,6 +28,8 @@ add_library(
     connection_options.h
     create_subscription_builder.h
     create_topic_builder.h
+    internal/emulator_overrides.cc
+    internal/emulator_overrides.h
     internal/publisher_stub.cc
     internal/publisher_stub.h
     internal/subscriber_stub.cc
@@ -79,8 +81,12 @@ function (google_cloud_cpp_pubsub_client_define_tests)
 
     set(pubsub_client_unit_tests
         # cmake-format: sort
-        create_subscription_builder_test.cc create_topic_builder_test.cc
-        internal/user_agent_prefix_test.cc subscription_test.cc topic_test.cc)
+        create_subscription_builder_test.cc
+        create_topic_builder_test.cc
+        internal/emulator_overrides_test.cc
+        internal/user_agent_prefix_test.cc
+        subscription_test.cc
+        topic_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -27,6 +28,7 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
+using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::Contains;
 using ::testing::Not;
 
@@ -100,10 +102,8 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
 
 TEST(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
-  auto connection_options =
-      ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1");
-  auto client = SubscriptionAdminClient(pubsub::MakeSubscriberConnection());
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto client = SubscriptionAdminClient(MakeSubscriberConnection());
   auto create_response = client.CreateSubscription(CreateSubscriptionBuilder(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       Topic("--invalid-project--", "--invalid-topic--")));
@@ -112,10 +112,8 @@ TEST(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
 
 TEST(SubscriptionAdminIntegrationTest, ListSubscriptionsFailure) {
   // Use an invalid endpoint to force a connection error.
-  auto connection_options =
-      ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1");
-  auto client = SubscriptionAdminClient(pubsub::MakeSubscriberConnection());
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto client = SubscriptionAdminClient(MakeSubscriberConnection());
   auto list = client.ListSubscriptions("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -124,10 +122,8 @@ TEST(SubscriptionAdminIntegrationTest, ListSubscriptionsFailure) {
 
 TEST(SubscriptionAdminIntegrationTest, DeleteSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
-  auto connection_options =
-      ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1");
-  auto client = SubscriptionAdminClient(pubsub::MakeSubscriberConnection());
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto client = SubscriptionAdminClient(MakeSubscriberConnection());
   auto delete_response = client.DeleteSubscription(
       Subscription("--invalid-project--", "--invalid-subscription--"));
   ASSERT_FALSE(delete_response.ok());

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -25,6 +26,7 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
+using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::Contains;
 using ::testing::Not;
 
@@ -74,22 +76,16 @@ TEST(TopicAdminIntegrationTest, TopicCRUD) {
 }
 
 TEST(TopicAdminIntegrationTest, CreateTopicFailure) {
-  auto connection_options =
-      ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1");
-  auto publisher =
-      TopicAdminClient(MakePublisherConnection(connection_options));
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto publisher = TopicAdminClient(MakePublisherConnection());
   auto create_response = publisher.CreateTopic(
       CreateTopicBuilder(Topic("invalid-project", "invalid-topic")));
   ASSERT_FALSE(create_response);
 }
 
 TEST(TopicAdminIntegrationTest, ListTopicsFailure) {
-  auto connection_options =
-      ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1");
-  auto publisher =
-      TopicAdminClient(MakePublisherConnection(connection_options));
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto publisher = TopicAdminClient(MakePublisherConnection());
   auto list = publisher.ListTopics("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -97,11 +93,8 @@ TEST(TopicAdminIntegrationTest, ListTopicsFailure) {
 }
 
 TEST(TopicAdminIntegrationTest, DeleteTopicFailure) {
-  auto connection_options =
-      ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1");
-  auto publisher =
-      TopicAdminClient(MakePublisherConnection(connection_options));
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto publisher = TopicAdminClient(MakePublisherConnection());
   auto delete_response =
       publisher.DeleteTopic(Topic("invalid-project", "invalid-topic"));
   ASSERT_FALSE(delete_response.ok());

--- a/google/cloud/pubsub/internal/emulator_overrides.cc
+++ b/google/cloud/pubsub/internal/emulator_overrides.cc
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/emulator_overrides.h"
+#include "google/cloud/internal/getenv.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+// Override connection endpoint and credentials with values appropriate for
+// an emulated backend. This should be done after any user code that could
+// also override the default values (i.e., immediately before establishing
+// the connection).
+pubsub::ConnectionOptions EmulatorOverrides(pubsub::ConnectionOptions options) {
+  auto emulator_addr = google::cloud::internal::GetEnv("PUBSUB_EMULATOR_HOST");
+  if (emulator_addr.has_value()) {
+    options.set_endpoint(*emulator_addr)
+        .set_credentials(grpc::InsecureChannelCredentials());
+  }
+  return options;
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/emulator_overrides.h
+++ b/google/cloud/pubsub/internal/emulator_overrides.h
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_EMULATOR_OVERRIDES_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_EMULATOR_OVERRIDES_H
+
+#include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/version.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/**
+ * Apply any emulator overrides to @p options.
+ */
+google::cloud::pubsub::ConnectionOptions EmulatorOverrides(
+    google::cloud::pubsub::ConnectionOptions options);
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_EMULATOR_OVERRIDES_H

--- a/google/cloud/pubsub/internal/emulator_overrides_test.cc
+++ b/google/cloud/pubsub/internal/emulator_overrides_test.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/emulator_overrides.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::google::cloud::testing_util::ScopedEnvironment;
+
+TEST(EmulatorOverridesTest, NotSet) {
+  ScopedEnvironment emulator("PUBSUB_EMULATOR_HOST", {});
+  auto options = EmulatorOverrides(
+      pubsub::ConnectionOptions(grpc::InsecureChannelCredentials())
+          .set_endpoint("invalid-test-only"));
+  EXPECT_EQ("invalid-test-only", options.endpoint());
+}
+
+TEST(EmulatorOverridesTest, Set) {
+  ScopedEnvironment emulator("PUBSUB_EMULATOR_HOST",
+                             "invalid-testing-override");
+  auto options = EmulatorOverrides(
+      pubsub::ConnectionOptions(grpc::InsecureChannelCredentials())
+          .set_endpoint("invalid-test-only"));
+  EXPECT_EQ("invalid-testing-override", options.endpoint());
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/publisher_stub.h"
+#include "google/cloud/pubsub/internal/emulator_overrides.h"
 #include "google/cloud/grpc_error_delegate.h"
 
 namespace google {
@@ -66,7 +67,8 @@ class DefaultPublisherStub : public PublisherStub {
 };
 
 std::shared_ptr<PublisherStub> CreateDefaultPublisherStub(
-    pubsub::ConnectionOptions const& options, int channel_id) {
+    pubsub::ConnectionOptions options, int channel_id) {
+  options = EmulatorOverrides(std::move(options));
   auto channel_arguments = options.CreateChannelArguments();
   // Newer versions of gRPC include a macro (`GRPC_ARG_CHANNEL_ID`) but use
   // its value here to allow compiling against older versions.

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -62,7 +62,7 @@ class PublisherStub {
  * to ensure they use different underlying connections.
  */
 std::shared_ptr<PublisherStub> CreateDefaultPublisherStub(
-    pubsub::ConnectionOptions const& options, int channel_id);
+    pubsub::ConnectionOptions options, int channel_id);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
+#include "google/cloud/pubsub/internal/emulator_overrides.h"
 #include "google/cloud/grpc_error_delegate.h"
 
 namespace google {
@@ -66,7 +67,8 @@ class DefaultSubscriberStub : public SubscriberStub {
 };
 
 std::shared_ptr<SubscriberStub> CreateDefaultSubscriberStub(
-    pubsub::ConnectionOptions const& options, int channel_id) {
+    pubsub::ConnectionOptions options, int channel_id) {
+  options = EmulatorOverrides(std::move(options));
   auto channel_arguments = options.CreateChannelArguments();
   // Newer versions of gRPC include a macro (`GRPC_ARG_CHANNEL_ID`) but use
   // its value here to allow compiling against older versions.

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -63,7 +63,7 @@ class SubscriberStub {
  * to ensure they use different underlying connections.
  */
 std::shared_ptr<SubscriberStub> CreateDefaultSubscriberStub(
-    pubsub::ConnectionOptions const& options, int channel_id);
+    pubsub::ConnectionOptions options, int channel_id);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -20,6 +20,7 @@ pubsub_client_hdrs = [
     "connection_options.h",
     "create_subscription_builder.h",
     "create_topic_builder.h",
+    "internal/emulator_overrides.h",
     "internal/publisher_stub.h",
     "internal/subscriber_stub.h",
     "internal/user_agent_prefix.h",
@@ -35,6 +36,7 @@ pubsub_client_hdrs = [
 
 pubsub_client_srcs = [
     "connection_options.cc",
+    "internal/emulator_overrides.cc",
     "internal/publisher_stub.cc",
     "internal/subscriber_stub.cc",
     "internal/user_agent_prefix.cc",

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -19,6 +19,7 @@
 pubsub_client_unit_tests = [
     "create_subscription_builder_test.cc",
     "create_topic_builder_test.cc",
+    "internal/emulator_overrides_test.cc",
     "internal/user_agent_prefix_test.cc",
     "subscription_test.cc",
     "topic_test.cc",


### PR DESCRIPTION
The `PUBSUB_EMULATOR_HOST` environment variable can be used to override
any default or application-defined endpoint in the *Connection objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4529)
<!-- Reviewable:end -->
