### PR TITLE
ci: configure a Windows+MSVC+x86 build

### DIFF
--- a/ci/kokoro/windows/cmake-release-x86.cfg
+++ b/ci/kokoro/windows/cmake-release-x86.cfg
@@ -1,0 +1,16 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp/ci/kokoro/windows/build-32.bat"


### PR DESCRIPTION
No presubmit build because CMake builds on Windows simply take too long.

A separate internal will enable this build on Kokoro.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4530)
<!-- Reviewable:end -->
