### PR TITLE
ci: do not remove build script on cleanup

### DIFF
--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -126,7 +126,7 @@ if (Test-Path env:KOKORO_ARTIFACTS_DIR) {
     try {
         $ErrorActionPreference = "SilentlyContinue"
         Get-ChildItem -Recurse -File `
-            -Exclude test.xml,sponge_log.xml,build.bat `
+            -Exclude test.xml,sponge_log.xml,build.bat,build-32.bat,build.ps1 `
             -ErrorAction SilentlyContinue `
             -Path "${env:KOKORO_ARTIFACTS_DIR}" | `
             Remove-Item -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
At the end of the Windows build we cleanup the artifacts directory, and
accidentally remove the build script itself in that process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4533)
<!-- Reviewable:end -->
