### PR TITLE
ci(pubsub): use emulator for integration tests

### DIFF
--- a/ci/install-cloud-sdk.sh
+++ b/ci/install-cloud-sdk.sh
@@ -24,5 +24,5 @@ wget -q "${SITE}/${TARBALL}"
 
 echo "${GOOGLE_CLOUD_CPP_SDK_SHA256} ${TARBALL}" | sha256sum --check -
 tar x -C /usr/local -f "${TARBALL}"
-/usr/local/google-cloud-sdk/bin/gcloud \
-  --quiet components install cbt bigtable cloud-spanner-emulator beta
+/usr/local/google-cloud-sdk/bin/gcloud --quiet components install \
+  beta bigtable cbt cloud-spanner-emulator pubsub-emulator

--- a/ci/kokoro/docker/Dockerfile.centos
+++ b/ci/kokoro/docker/Dockerfile.centos
@@ -33,11 +33,13 @@ RUN echo 'root:' | chpasswd
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && \
     ln -sf /usr/bin/ctest3 /usr/bin/ctest
 
-# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
-# client.  They are used in the integration tests.
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN yum makecache && yum install -y java-latest-openjdk
 
 # Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -34,11 +34,13 @@ RUN pip3 install setuptools
 RUN pip3 install flask==1.1.1 Werkzeug==1.0.0 httpbin==0.7.0 \
     gevent==1.4.0 gunicorn==19.10.0 crc32c==2.0
 
-# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
-# client.  They are used in the integration tests.
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN dnf makecache && dnf install -y java-latest-openjdk
 
 # Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -114,11 +114,13 @@ RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
-# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
-# client.  They are used in the integration tests.
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN dnf makecache && dnf install -y java-latest-openjdk
 
 # Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -73,11 +73,13 @@ RUN cmake -Hlibcxx-8.0.0.src -B.build-libcxx -GNinja -Wno-dev \
 RUN cmake --build .build-libcxx --target cxx
 RUN cmake --build .build-libcxx --target install-cxx
 
-# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
-# client.  They are used in the integration tests.
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN dnf makecache && dnf install -y java-latest-openjdk
 
 # We need Bazel for this build.
 COPY . /var/tmp/ci

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -71,11 +71,13 @@ RUN pip3 install Jinja2==2.11.2 MarkupSafe==1.1.1 Werkzeug==1.0.0 \
     gunicorn==19.10.0 httpbin==0.7.0 itsdangerous==1.1.0 pycparser==2.20 \
     raven==6.10.0
 
-# Install the Cloud Bigtable emulator and the Cloud Bigtable command-line
-# client.  They are used in the integration tests.
+# Install the Cloud SDK and some of the emulators. We use the emulators to run
+# integration tests for the client libraries.
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
+# The Cloud Pub/Sub emulator needs Java :shrug:
+RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
 
 # Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -136,6 +136,11 @@ if should_run_integration_tests; then
   "${PROJECT_ROOT}/google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
     "${BAZEL_BIN}" "${bazel_args[@]}" --test_timeout=600
 
+  echo "================================================================"
+  io::log_yellow "running pubsub integration tests via Bazel+Emulator"
+  "${PROJECT_ROOT}/google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+    "${BAZEL_BIN}" "${bazel_args[@]}" --test_timeout=600
+
   # TODO(#441) - remove the for loops below.
   # Sometimes the integration tests manage to crash the Bigtable emulator.
   # Manually restarting the build clears up the problem, but that is just a
@@ -184,6 +189,9 @@ if should_run_integration_tests; then
 
     # The Storage integration tests were already run above
     "-//google/cloud/storage/..."
+
+    # The Pub/Sub integration tests were already run above
+    "-//google/cloud/pubsub/..."
   )
   for t in "${hmac_service_account_targets[@]}" "${access_token_targets[@]}"; do
     excluded_targets+=("-${t}")

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -187,6 +187,13 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
 
   if [[ "${RUN_INTEGRATION_TESTS:-}" != "no" ]]; then
     readonly EMULATOR_SCRIPT="run_integration_tests_emulator_cmake.sh"
+
+    echo
+    io::log_yellow "running pusub integration tests via CTest+Emulator"
+    echo
+    "${PROJECT_ROOT}/google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+      "${BINARY_DIR}" "${ctest_args[@]}" -L integration-test-emulator
+
     # TODO(#441) - remove the for loops below.
     # Sometimes the integration tests manage to crash the Bigtable emulator.
     # Manually restarting the build clears up the problem, but that is just a

--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make our include guard clean against set -o nounset.
+test -n "${GOOGLE_CLOUD_PUBSUB_CI_LIB_PUBSUB_EMULATOR_SH__:-}" || declare -i GOOGLE_CLOUD_PUBSUB_CI_LIB_PUBSUB_EMULATOR_SH__=0
+if ((GOOGLE_CLOUD_PUBSUB_CI_LIB_PUBSUB_EMULATOR_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module lib/io.sh
+
+# Global variable that holds the PID of the Pubsub emulator. This will be set
+# when the emulator is started, and it will be used to kill the emulator.
+PUBSUB_EMULATOR_PID=0
+
+# Outputs the port number that the emulator chose to listen on.
+function pubsub_emulator::internal::read_emulator_port() {
+  local -r logfile="$1"
+  shift
+
+  local emulator_port="0"
+  local -r expected=": Server started, listening on "
+  for attempt in $(seq 1 8); do
+    if grep -q "${expected}" "${logfile}"; then
+      # The port number is whatever is after 'listening on'.
+      emulator_port=$(grep "${expected}" "${logfile}" | awk -F' ' '{print $NF}')
+      break
+    fi
+    sleep 1
+  done
+  echo "${emulator_port}"
+}
+
+# Starts the Cloud Pub/Sub emulator. On success, exports the
+# PUBSUB_EMULATOR_HOST environment variable containing the host:port where the
+# emulator is listening.
+function pubsub_emulator::start() {
+  io::log "Launching Cloud Pub/Sub emulator in the background"
+  if [[ -z "${CLOUD_SDK_LOCATION:-}" ]]; then
+    echo 1>&2 "You must set CLOUD_SDK_LOCATION to find the emulator"
+    return 1
+  fi
+
+  # We cannot use `gcloud beta emulators pubsub start` because there is no way
+  # to kill the emulator at the end using that command.
+  readonly PUBSUB_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/gcloud"
+  readonly PUBSUB_EMULATOR_ARGS=(
+    "beta" "emulators" "pubsub" "start"
+    "--project=${GOOGLE_CLOUD_PROJECT:-fake-project}")
+  if [[ ! -x "${PUBSUB_EMULATOR_CMD}" ]]; then
+    echo 1>&2 "The Cloud Pub/Sub emulator does not seem to be installed, aborting"
+    cat emulator.log >&2
+    return 1
+  fi
+
+  # The tests typically run in a Docker container, where the ports are largely
+  # free; when using in manual tests, you can set EMULATOR_PORT.
+  "${PUBSUB_EMULATOR_CMD}" "${PUBSUB_EMULATOR_ARGS[@]}" >emulator.log 2>&1 </dev/null &
+  PUBSUB_EMULATOR_PID=$!
+
+  local -r emulator_port="$(pubsub_emulator::internal::read_emulator_port emulator.log)"
+  if [[ "${emulator_port}" = "0" ]]; then
+    echo "Cannot determine Cloud Pub/Sub emulator port." >&2
+    cat emulator.log >&2
+    pubsub_emulator::kill
+    return 1
+  fi
+
+  export PUBSUB_EMULATOR_HOST="localhost:${emulator_port}"
+  io::log "Cloud Pub/Sub emulator started at ${PUBSUB_EMULATOR_HOST}"
+}
+
+# Kills the running emulator.
+function pubsub_emulator::kill() {
+  if (("${PUBSUB_EMULATOR_PID}" > 0)); then
+    echo -n "Killing Pub/Sub Emulator [${PUBSUB_EMULATOR_PID}] "
+    kill "${PUBSUB_EMULATOR_PID}" || echo -n "-"
+    wait "${PUBSUB_EMULATOR_PID}" >/dev/null 2>&1 || echo -n "+"
+    echo -n "."
+    echo " done."
+    PUBSUB_EMULATOR_PID=0
+  fi
+}

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -49,13 +49,6 @@ for target in "${production_only_targets[@]}"; do
   excluded_targets+=("-${target}")
 done
 
-echo DEBUG DEBUG DEBUG "${BAZEL_BIN}" test "${bazel_test_args[@]}" \
-  --test_env="PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOST}" \
-  --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
-  --test_tag_filters="integration-test" -- \
-  "//google/cloud/pubsub/...:all" \
-  "${excluded_targets[@]}"
-
 "${BAZEL_BIN}" test "${bazel_test_args[@]}" \
   --test_env="PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOST}" \
   --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module etc/integration-tests-config.sh
+source module lib/pubsub_emulator.sh
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"
+  exit 1
+fi
+
+BAZEL_BIN="$1"
+shift
+bazel_test_args=("$@")
+
+# Configure run_emulators_utils.sh to find the instance admin emulator.
+# These can only run against production
+production_only_targets=()
+# Enable this command when there are any production targets to run
+#    "${BAZEL_BIN}" test "${bazel_test_args[@]}" \
+#      --test_tag_filters="integration-test" -- \
+#      "${production_only_targets[@]}"
+
+# Start the emulator and arranges to kill it, run in $HOME because
+# pubsub_emulator::start creates unsightly *.log files in the workspace
+# otherwise.
+pushd "${HOME}" >/dev/null
+pubsub_emulator::start
+popd
+trap pubsub_emulator::kill EXIT
+
+excluded_targets=()
+for target in "${production_only_targets[@]}"; do
+  excluded_targets+=("-${target}")
+done
+
+echo DEBUG DEBUG DEBUG "${BAZEL_BIN}" test "${bazel_test_args[@]}" \
+  --test_env="PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOST}" \
+  --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
+  --test_tag_filters="integration-test" -- \
+  "//google/cloud/pubsub/...:all" \
+  "${excluded_targets[@]}"
+
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" \
+  --test_env="PUBSUB_EMULATOR_HOST=${PUBSUB_EMULATOR_HOST}" \
+  --test_env="GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
+  --test_tag_filters="integration-test" -- \
+  "//google/cloud/pubsub/...:all" \
+  "${excluded_targets[@]}"

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../../../ci/lib/init.sh"
+source module etc/integration-tests-config.sh
+source module lib/pubsub_emulator.sh
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"
+  exit 1
+fi
+
+BINARY_DIR="$(
+  cd "${1}"
+  pwd
+)"
+readonly BINARY_DIR
+shift
+ctest_args=("$@")
+
+# Use the same configuration parameters as we use for testing against
+# production. Easier to maintain just one copy.
+export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
+
+cd "${BINARY_DIR}"
+# Start the emulator and arranges to kill it
+pubsub_emulator::start
+trap pubsub_emulator::kill EXIT
+
+ctest -R "^pubsub_" "${ctest_args[@]}"
+exit_status=$?
+
+exit "${exit_status}"

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -42,6 +42,3 @@ pubsub_emulator::start
 trap pubsub_emulator::kill EXIT
 
 ctest -R "^pubsub_" "${ctest_args[@]}"
-exit_status=$?
-
-exit "${exit_status}"


### PR DESCRIPTION
To do this we need to install the Java runtime environment in the images
that run integration tests, so there are downsides to this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4534)
<!-- Reviewable:end -->
