### PR TITLE
doc(pubsub): link the resource name restrictions

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -18,6 +18,7 @@ set(DOXYGEN_PROJECT_NAME "Google Cloud Pub/Sub C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Pub/Sub")
 set(DOXYGEN_PROJECT_NUMBER "${GOOGLE_CLOUD_CPP_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples)
+set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_PUBSUB_NS=v1")
 
 include(GoogleCloudCppCommon)
 

--- a/google/cloud/pubsub/subscription.h
+++ b/google/cloud/pubsub/subscription.h
@@ -25,6 +25,13 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 /**
  * Objects of this class identify a Cloud Pub/Sub subscription.
+ *
+ * @note
+ * This class makes no effort to validate the ids provided. The application
+ * should verify that any ids passed to this application conform to the
+ * Cloud Pub/Sub [resource name][name-link] restrictions.
+ *
+ * [name-link]: https://cloud.google.com/pubsub/docs/admin#resource_names
  */
 class Subscription {
  public:

--- a/google/cloud/pubsub/topic.h
+++ b/google/cloud/pubsub/topic.h
@@ -25,6 +25,13 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 /**
  * Objects of this class identify a Cloud Pub/Sub topic.
+ *
+ * @note
+ * This class makes no effort to validate the ids provided. The application
+ * should verify that any ids passed to this application conform to the
+ * Cloud Pub/Sub [resource name][name-link] restrictions.
+ *
+ * [name-link]: https://cloud.google.com/pubsub/docs/admin#resource_names
  */
 class Topic {
  public:


### PR DESCRIPTION
There are restrictions on the size of a topic and/or subscription id. I
included links to them from the `pubsub::Topic` and
`pubsub::Subscription` class. Also fixed the inline namespace to be the
"Right Thing"[tm].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4535)
<!-- Reviewable:end -->
