### PR TITLE
feat(pubsub): skeleton stubs to push/pull messages

### DIFF
--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -23,7 +23,8 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
 
     set(pubsub_client_integration_tests
         # cmake-format: sortable
-        subscription_admin_integration_test.cc topic_admin_integration_test.cc)
+        message_integration_test.cc subscription_admin_integration_test.cc
+        topic_admin_integration_test.cc)
     set(pubsub_client_install_tests pubsub_install_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -1,0 +1,150 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/publisher_stub.h"
+#include "google/cloud/pubsub/internal/subscriber_stub.h"
+#include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/pubsub/subscription_admin_client.h"
+#include "google/cloud/pubsub/testing/random_names.h"
+#include "google/cloud/pubsub/topic_admin_client.h"
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+TEST(MessageIntegrationTest, PublishPullAck) {
+  auto project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  ASSERT_FALSE(project_id.empty());
+
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  Topic topic(project_id, pubsub_testing::RandomTopicId(generator));
+  Subscription subscription(project_id,
+                            pubsub_testing::RandomSubscriptionId(generator));
+
+  auto topic_admin = TopicAdminClient(MakePublisherConnection());
+  auto subscription_admin = SubscriptionAdminClient(MakeSubscriberConnection());
+
+  auto topic_metadata = topic_admin.CreateTopic(CreateTopicBuilder(topic));
+  ASSERT_STATUS_OK(topic_metadata);
+
+  struct Cleanup {
+    std::function<void()> action;
+    explicit Cleanup(std::function<void()> a) : action(std::move(a)) {}
+    ~Cleanup() { action(); }
+  };
+  Cleanup cleanup_topic(
+      [topic_admin, &topic]() mutable { topic_admin.DeleteTopic(topic); });
+
+  auto subscription_metadata = subscription_admin.CreateSubscription(
+      CreateSubscriptionBuilder(subscription, topic));
+  ASSERT_STATUS_OK(subscription_metadata);
+
+  auto publisher =
+      pubsub_internal::CreateDefaultPublisherStub(ConnectionOptions{}, 0);
+  auto subscriber =
+      pubsub_internal::CreateDefaultSubscriberStub(ConnectionOptions{}, 0);
+
+  auto publish = [&]() -> StatusOr<std::vector<std::string>> {
+    grpc::ClientContext context;
+    google::pubsub::v1::PublishRequest request;
+    request.set_topic(topic.FullName());
+    *request.add_messages() = [] {
+      google::pubsub::v1::PubsubMessage m;
+      m.set_message_id("message-0");
+      m.set_data("foo");
+      return m;
+    }();
+    *request.add_messages() = [] {
+      google::pubsub::v1::PubsubMessage m;
+      m.set_message_id("message-1");
+      m.set_data("bar");
+      return m;
+    }();
+    *request.add_messages() = [] {
+      google::pubsub::v1::PubsubMessage m;
+      m.set_message_id("message-2");
+      m.set_data("baz");
+      return m;
+    }();
+
+    auto response = publisher->Publish(context, request);
+    if (!response) return std::move(response).status();
+
+    std::vector<std::string> ids;
+    ids.reserve(response->message_ids_size());
+    for (auto& i : *response->mutable_message_ids()) {
+      ids.push_back(std::move(i));
+    }
+    return ids;
+  };
+
+  auto pull =
+      [&]() -> StatusOr<std::vector<google::pubsub::v1::ReceivedMessage>> {
+    grpc::ClientContext context;
+    google::pubsub::v1::PullRequest request;
+    request.set_subscription(subscription.FullName());
+    request.set_max_messages(5);
+    auto response = subscriber->Pull(context, request);
+    if (!response) return std::move(response).status();
+    std::vector<google::pubsub::v1::ReceivedMessage> messages;
+    messages.reserve(response->received_messages_size());
+    for (auto& m : *response->mutable_received_messages()) {
+      messages.push_back(std::move(m));
+    }
+    return messages;
+  };
+
+  auto ack = [&](std::string const& id) -> Status {
+    grpc::ClientContext context;
+    google::pubsub::v1::AcknowledgeRequest request;
+    request.set_subscription(subscription.FullName());
+    request.add_ack_ids(id);
+    return subscriber->Acknowledge(context, request);
+  };
+
+  auto ids = publish();
+  ASSERT_STATUS_OK(ids);
+
+  while (!ids->empty()) {
+    auto messages = pull();
+    ASSERT_STATUS_OK(messages);
+
+    for (auto const& m : *messages) {
+      SCOPED_TRACE("Search for message " + m.DebugString());
+      auto i = std::find_if(
+          ids->begin(), ids->end(),
+          [&m](std::string const& x) { return m.message().message_id() == x; });
+      EXPECT_STATUS_OK(ack(m.ack_id()));
+      EXPECT_NE(i, ids->end());
+      ids->erase(i);
+    }
+  }
+
+  auto delete_response = subscription_admin.DeleteSubscription(subscription);
+  ASSERT_STATUS_OK(delete_response);
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -130,12 +130,13 @@ TEST(MessageIntegrationTest, PublishPullAck) {
 
     for (auto const& m : *messages) {
       SCOPED_TRACE("Search for message " + m.DebugString());
-      auto i = std::find_if(
-          ids->begin(), ids->end(),
-          [&m](std::string const& x) { return m.message().message_id() == x; });
+      auto i = std::find(ids->begin(), ids->end(), m.message().message_id());
       EXPECT_STATUS_OK(ack(m.ack_id()));
-      EXPECT_NE(i, ids->end());
-      ids->erase(i);
+      if (i != ids->end()) {
+        EXPECT_NE(i, ids->end());
+      } else {
+        ids->erase(i);
+      }
     }
   }
 

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -133,9 +133,10 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       auto i = std::find(ids->begin(), ids->end(), m.message().message_id());
       EXPECT_STATUS_OK(ack(m.ack_id()));
       if (i != ids->end()) {
-        EXPECT_NE(i, ids->end());
-      } else {
         ids->erase(i);
+      } else {
+        FAIL() << "Cannot find message id=" << m.message().message_id()
+               << " to erase";
       }
     }
   }

--- a/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
+++ b/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 pubsub_client_integration_tests = [
+    "message_integration_test.cc",
     "subscription_admin_integration_test.cc",
     "topic_admin_integration_test.cc",
 ]

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -62,6 +62,15 @@ class DefaultPublisherStub : public PublisherStub {
     return {};
   }
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override {
+    google::pubsub::v1::PublishResponse response;
+    auto status = grpc_stub_->Publish(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
  private:
   std::unique_ptr<google::pubsub::v1::Publisher::StubInterface> grpc_stub_;
 };

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -53,6 +53,11 @@ class PublisherStub {
   virtual Status DeleteTopic(
       grpc::ClientContext& client_context,
       google::pubsub::v1::DeleteTopicRequest const& request) = 0;
+
+  /// Publish a batch of messages.
+  virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::PublishRequest const& request) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -62,6 +62,24 @@ class DefaultSubscriberStub : public SubscriberStub {
     return {};
   }
 
+  StatusOr<google::pubsub::v1::PullResponse> Pull(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PullRequest const& request) override {
+    google::pubsub::v1::PullResponse response;
+    auto status = grpc_stub_->Pull(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status Acknowledge(
+      grpc::ClientContext& context,
+      google::pubsub::v1::AcknowledgeRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = grpc_stub_->Acknowledge(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return {};
+  }
+
  private:
   std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;
 };

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -54,6 +54,16 @@ class SubscriberStub {
   virtual Status DeleteSubscription(
       grpc::ClientContext& client_context,
       google::pubsub::v1::DeleteSubscriptionRequest const& request) = 0;
+
+  /// Pull a batch of messages.
+  virtual StatusOr<google::pubsub::v1::PullResponse> Pull(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::PullRequest const& request) = 0;
+
+  /// Acknowledge one or more messages.
+  virtual Status Acknowledge(
+      grpc::ClientContext& context,
+      google::pubsub::v1::AcknowledgeRequest const& request) = 0;
 };
 
 /**


### PR DESCRIPTION
Implement the blocking, synchronous, non-streaming RPCs to publish and
pull messages. That will let us implement skeletons for
`pubsub::Publisher` and `pubsub::Subscriber`.

Part of the work for #3895 and #3896 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4538)
<!-- Reviewable:end -->
