### PR TITLE
cleanup(pubsub): rename `Make*Connection`

### DIFF
--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -40,8 +40,9 @@ TEST(MessageIntegrationTest, PublishPullAck) {
   Subscription subscription(project_id,
                             pubsub_testing::RandomSubscriptionId(generator));
 
-  auto topic_admin = TopicAdminClient(MakePublisherConnection());
-  auto subscription_admin = SubscriptionAdminClient(MakeSubscriberConnection());
+  auto topic_admin = TopicAdminClient(MakeTopicAdminConnection());
+  auto subscription_admin =
+      SubscriptionAdminClient(MakeSubscriptionAdminConnection());
 
   auto topic_metadata = topic_admin.CreateTopic(CreateTopicBuilder(topic));
   ASSERT_STATUS_OK(topic_metadata);

--- a/google/cloud/pubsub/integration_tests/pubsub_install_test.cc
+++ b/google/cloud/pubsub/integration_tests/pubsub_install_test.cc
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) try {
             << google::cloud::version_string() << "\n";
 
   auto publisher = google::cloud::pubsub::TopicAdminClient(
-      google::cloud::pubsub::MakePublisherConnection());
+      google::cloud::pubsub::MakeTopicAdminConnection());
   std::cout << "Available topics in project " << project_id << ":\n";
   for (auto const& topic : publisher.ListTopics(project_id)) {
     if (!topic) throw std::runtime_error(topic.status().message());

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -54,8 +54,9 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   Subscription subscription(project_id,
                             pubsub_testing::RandomSubscriptionId(generator));
 
-  auto publisher_client = TopicAdminClient(MakePublisherConnection());
-  auto client = SubscriptionAdminClient(pubsub::MakeSubscriberConnection());
+  auto publisher_client = TopicAdminClient(MakeTopicAdminConnection());
+  auto client =
+      SubscriptionAdminClient(pubsub::MakeSubscriptionAdminConnection());
 
   EXPECT_THAT(subscription_names(client, project_id),
               Not(Contains(subscription.FullName())));
@@ -88,7 +89,7 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
 TEST(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriberConnection());
+  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection());
   auto create_response = client.CreateSubscription(CreateSubscriptionBuilder(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       Topic("--invalid-project--", "--invalid-topic--")));
@@ -98,7 +99,7 @@ TEST(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
 TEST(SubscriptionAdminIntegrationTest, ListSubscriptionsFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriberConnection());
+  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection());
   auto list = client.ListSubscriptions("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -108,7 +109,7 @@ TEST(SubscriptionAdminIntegrationTest, ListSubscriptionsFailure) {
 TEST(SubscriptionAdminIntegrationTest, DeleteSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto client = SubscriptionAdminClient(MakeSubscriberConnection());
+  auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection());
   auto delete_response = client.DeleteSubscription(
       Subscription("--invalid-project--", "--invalid-subscription--"));
   ASSERT_FALSE(delete_response.ok());

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -51,7 +51,7 @@ TEST(TopicAdminIntegrationTest, TopicCRUD) {
   Topic topic(project_id, pubsub_testing::RandomTopicId(generator));
 
   auto publisher =
-      TopicAdminClient(MakePublisherConnection(ConnectionOptions{}));
+      TopicAdminClient(MakeTopicAdminConnection(ConnectionOptions{}));
 
   EXPECT_THAT(topic_names(publisher, project_id),
               Not(Contains(topic.FullName())));
@@ -70,7 +70,7 @@ TEST(TopicAdminIntegrationTest, TopicCRUD) {
 
 TEST(TopicAdminIntegrationTest, CreateTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(MakePublisherConnection());
+  auto publisher = TopicAdminClient(MakeTopicAdminConnection());
   auto create_response = publisher.CreateTopic(
       CreateTopicBuilder(Topic("invalid-project", "invalid-topic")));
   ASSERT_FALSE(create_response);
@@ -78,7 +78,7 @@ TEST(TopicAdminIntegrationTest, CreateTopicFailure) {
 
 TEST(TopicAdminIntegrationTest, ListTopicsFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(MakePublisherConnection());
+  auto publisher = TopicAdminClient(MakeTopicAdminConnection());
   auto list = publisher.ListTopics("--invalid-project--");
   auto i = list.begin();
   EXPECT_FALSE(i == list.end());
@@ -87,7 +87,7 @@ TEST(TopicAdminIntegrationTest, ListTopicsFailure) {
 
 TEST(TopicAdminIntegrationTest, DeleteTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
-  auto publisher = TopicAdminClient(MakePublisherConnection());
+  auto publisher = TopicAdminClient(MakeTopicAdminConnection());
   auto delete_response =
       publisher.DeleteTopic(Topic("invalid-project", "invalid-topic"));
   ASSERT_FALSE(delete_response.ok());

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -34,7 +34,7 @@ google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
       throw google::cloud::testing_util::Usage{std::move(os).str()};
     }
     google::cloud::pubsub::TopicAdminClient client(
-        google::cloud::pubsub::MakePublisherConnection());
+        google::cloud::pubsub::MakeTopicAdminConnection());
     command(std::move(client), std::move(argv));
   };
   return google::cloud::testing_util::Commands::value_type{name,
@@ -55,7 +55,7 @@ google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
       throw google::cloud::testing_util::Usage{std::move(os).str()};
     }
     google::cloud::pubsub::SubscriptionAdminClient client(
-        google::cloud::pubsub::MakeSubscriberConnection());
+        google::cloud::pubsub::MakeSubscriptionAdminConnection());
     command(std::move(client), std::move(argv));
   };
   return google::cloud::testing_util::Commands::value_type{name,

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -157,9 +157,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto subscription_id = RandomSubscriptionId(generator);
 
   google::cloud::pubsub::TopicAdminClient publisher_client(
-      google::cloud::pubsub::MakePublisherConnection());
+      google::cloud::pubsub::MakeTopicAdminConnection());
   google::cloud::pubsub::SubscriptionAdminClient subscriber_client(
-      google::cloud::pubsub::MakeSubscriberConnection());
+      google::cloud::pubsub::MakeSubscriptionAdminConnection());
 
   std::cout << "\nRunning CreateTopic() sample\n";
   CreateTopic(publisher_client, {project_id, topic_id});

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -37,7 +37,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * However, each `SubscriberClient` object must be created with a
  * `std::shared_ptr<SubscriberConnection>`, which itself is relatively
  * expensive to create. Therefore, connection instances should be shared when
- * possible. See the `MakeSubscriberConnection()` function and the
+ * possible. See the `MakeSubscriptionAdminConnection()` function and the
  * `SubscriberConnection` interface for more details.
  *
  * @par Thread Safety

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -70,7 +70,7 @@ class SubscriptionAdminConnectionImpl : public SubscriptionAdminConnection {
 
 SubscriptionAdminConnection::~SubscriptionAdminConnection() = default;
 
-std::shared_ptr<SubscriptionAdminConnection> MakeSubscriberConnection(
+std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
     ConnectionOptions const& options) {
   auto stub =
       pubsub_internal::CreateDefaultSubscriberStub(options, /*channel_id=*/0);

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -54,7 +54,7 @@ using ListSubscriptionsRange = google::cloud::internal::PaginationRange<
  * use in their own tests.
  *
  * To create a concrete instance that connects you to the real Cloud Pub/Sub
- * service, see `MakeSubscriberConnection()`.
+ * service, see `MakeSubscriptionAdminConnection()`.
  */
 class SubscriptionAdminConnection {
  public:
@@ -108,7 +108,7 @@ class SubscriptionAdminConnection {
  * @param options (optional) configure the `SubscriberConnection` created by
  *     this function.
  */
-std::shared_ptr<SubscriptionAdminConnection> MakeSubscriberConnection(
+std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
     ConnectionOptions const& options = ConnectionOptions());
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -37,7 +37,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * each `PublisherClient` object must be created with a
  * `std::shared_ptr<PublisherConnection>`, which itself is relatively
  * expensive to create. Therefore, connection instances should be shared when
- * possible. See the `MakePublisherConnection()` function and the
+ * possible. See the `MakeTopicAdminConnection()` function and the
  * `PublisherConnection` interface for more details.
  *
  * @par Thread Safety

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -70,7 +70,7 @@ class TopicAdminConnectionImpl : public TopicAdminConnection {
 
 TopicAdminConnection::~TopicAdminConnection() = default;
 
-std::shared_ptr<TopicAdminConnection> MakePublisherConnection(
+std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
     ConnectionOptions const& options) {
   auto stub =
       pubsub_internal::CreateDefaultPublisherStub(options, /*channel_id=*/0);

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -52,7 +52,7 @@ using ListTopicsRange = google::cloud::internal::PaginationRange<
  * Mock object) in a `PublisherClient` object for use in their own tests.
  *
  * To create a concrete instance that connects you to the real Cloud Pub/Sub
- * service, see `MakePublisherConnection()`.
+ * service, see `MakeTopicAdminConnection()`.
  */
 class TopicAdminConnection {
  public:
@@ -106,7 +106,7 @@ class TopicAdminConnection {
  * @param options (optional) configure the `PublisherConnection` created by
  *     this function.
  */
-std::shared_ptr<TopicAdminConnection> MakePublisherConnection(
+std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
     ConnectionOptions const& options = ConnectionOptions());
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
I should have renamed the standalone `MakeSubscriberConnection` to
`MakeSubscriptionAdminConnection` when I renamed the corresponding
connection class. Same thing for `MakePublisherConnection`.