### PR TITLE
feat(storage): new object lifecycle management features

### DIFF
--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -99,6 +99,15 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
       result.condition_.num_newer_versions.emplace(
           internal::ParseIntField(condition, "numNewerVersions"));
     }
+    if (condition.count("daysSinceNoncurrentTime") != 0) {
+      result.condition_.days_since_noncurrent_time.emplace(
+          internal::ParseIntField(condition, "daysSinceNoncurrentTime"));
+    }
+    if (condition.count("noncurrentTimeBefore") != 0) {
+      result.condition_.noncurrent_time_before.emplace(
+          google::cloud::internal::ParseRfc3339(
+              condition.value("noncurrentTimeBefore", "")));
+    }
   }
   return result;
 }

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -108,6 +108,15 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
           google::cloud::internal::ParseRfc3339(
               condition.value("noncurrentTimeBefore", "")));
     }
+    if (condition.count("daysSinceCustomTime") != 0) {
+      result.condition_.days_since_custom_time.emplace(
+          internal::ParseIntField(condition, "daysSinceCustomTime"));
+    }
+    if (condition.count("customTimeBefore") != 0) {
+      result.condition_.custom_time_before.emplace(
+          google::cloud::internal::ParseRfc3339(
+              condition.value("customTimeBefore", "")));
+    }
   }
   return result;
 }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/lifecycle_rule.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <algorithm>
 #include <iostream>
 
@@ -70,8 +71,8 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
     sep = ", ";
   }
   if (rhs.created_before.has_value()) {
-    os << sep
-       << "created_before=" << rhs.created_before->time_since_epoch().count();
+    os << sep << "created_before="
+       << google::cloud::internal::FormatRfc3339(*rhs.created_before);
     sep = ", ";
   }
   if (rhs.is_live.has_value()) {
@@ -92,6 +93,17 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
   }
   if (rhs.num_newer_versions.has_value()) {
     os << sep << "num_newer_versions=" << *rhs.num_newer_versions;
+    sep = ", ";
+  }
+  if (rhs.days_since_noncurrent_time.has_value()) {
+    os << sep
+       << "days_since_noncurrent_time=" << *rhs.days_since_noncurrent_time;
+    sep = ", ";
+  }
+  if (rhs.noncurrent_time_before.has_value()) {
+    os << sep << "noncurrent_time_before="
+       << google::cloud::internal::FormatRfc3339(*rhs.noncurrent_time_before);
+    sep = ", ";
   }
   return os << "}";
 }
@@ -150,6 +162,22 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
     } else {
       auto tmp = *rhs.num_newer_versions;
       result.num_newer_versions.emplace(std::forward<std::int32_t>(tmp));
+    }
+  }
+  if (rhs.days_since_noncurrent_time.has_value()) {
+    if (result.days_since_noncurrent_time.has_value()) {
+      *result.days_since_noncurrent_time = (std::max)(
+          *result.days_since_noncurrent_time, *rhs.days_since_noncurrent_time);
+    } else {
+      result.days_since_noncurrent_time = *rhs.days_since_noncurrent_time;
+    }
+  }
+  if (rhs.noncurrent_time_before.has_value()) {
+    if (result.noncurrent_time_before.has_value()) {
+      *result.noncurrent_time_before = (std::min)(
+          *result.noncurrent_time_before, *rhs.noncurrent_time_before);
+    } else {
+      result.noncurrent_time_before = *rhs.noncurrent_time_before;
     }
   }
 }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -105,6 +105,15 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
        << google::cloud::internal::FormatRfc3339(*rhs.noncurrent_time_before);
     sep = ", ";
   }
+  if (rhs.days_since_custom_time.has_value()) {
+    os << sep << "days_since_custom_time=" << *rhs.days_since_custom_time;
+    sep = ", ";
+  }
+  if (rhs.custom_time_before.has_value()) {
+    os << sep << "custom_time_before="
+       << google::cloud::internal::FormatRfc3339(*rhs.custom_time_before);
+    sep = ", ";
+  }
   return os << "}";
 }
 
@@ -178,6 +187,22 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
           *result.noncurrent_time_before, *rhs.noncurrent_time_before);
     } else {
       result.noncurrent_time_before = *rhs.noncurrent_time_before;
+    }
+  }
+  if (rhs.days_since_custom_time.has_value()) {
+    if (result.days_since_custom_time.has_value()) {
+      *result.days_since_custom_time = (std::max)(
+          *result.days_since_custom_time, *rhs.days_since_custom_time);
+    } else {
+      result.days_since_custom_time = *rhs.days_since_custom_time;
+    }
+  }
+  if (rhs.custom_time_before.has_value()) {
+    if (result.custom_time_before.has_value()) {
+      *result.custom_time_before =
+          (std::min)(*result.custom_time_before, *rhs.custom_time_before);
+    } else {
+      result.custom_time_before = *rhs.custom_time_before;
     }
   }
 }

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -83,6 +83,8 @@ struct LifecycleRuleCondition {
   google::cloud::optional<std::int32_t> num_newer_versions;
   optional<std::int32_t> days_since_noncurrent_time;
   optional<std::chrono::system_clock::time_point> noncurrent_time_before;
+  optional<std::int32_t> days_since_custom_time;
+  optional<std::chrono::system_clock::time_point> custom_time_before;
 };
 
 inline bool operator==(LifecycleRuleCondition const& lhs,
@@ -92,17 +94,21 @@ inline bool operator==(LifecycleRuleCondition const& lhs,
          lhs.matches_storage_class == rhs.matches_storage_class &&
          lhs.num_newer_versions == rhs.num_newer_versions &&
          lhs.days_since_noncurrent_time == rhs.days_since_noncurrent_time &&
-         lhs.noncurrent_time_before == rhs.noncurrent_time_before;
+         lhs.noncurrent_time_before == rhs.noncurrent_time_before &&
+         lhs.days_since_custom_time == rhs.days_since_custom_time &&
+         lhs.custom_time_before == rhs.custom_time_before;
 }
 
 inline bool operator<(LifecycleRuleCondition const& lhs,
                       LifecycleRuleCondition const& rhs) {
   return std::tie(lhs.age, lhs.created_before, lhs.is_live,
                   lhs.matches_storage_class, lhs.num_newer_versions,
-                  lhs.days_since_noncurrent_time, lhs.noncurrent_time_before) <
+                  lhs.days_since_noncurrent_time, lhs.noncurrent_time_before,
+                  lhs.days_since_custom_time, lhs.custom_time_before) <
          std::tie(rhs.age, rhs.created_before, rhs.is_live,
                   rhs.matches_storage_class, rhs.num_newer_versions,
-                  rhs.days_since_noncurrent_time, rhs.noncurrent_time_before);
+                  rhs.days_since_noncurrent_time, rhs.noncurrent_time_before,
+                  rhs.days_since_custom_time, rhs.custom_time_before);
 }
 
 inline bool operator!=(LifecycleRuleCondition const& lhs,
@@ -267,6 +273,23 @@ class LifecycleRule {
       std::string const& timestamp) {
     return NoncurrentTimeBefore(
         google::cloud::internal::ParseRfc3339(timestamp));
+  }
+
+  static LifecycleRuleCondition DaysSinceCustomTime(std::int32_t days) {
+    LifecycleRuleCondition result;
+    result.days_since_custom_time = days;
+    return result;
+  }
+
+  static LifecycleRuleCondition CustomTimeBefore(
+      std::chrono::system_clock::time_point tp) {
+    LifecycleRuleCondition result;
+    result.custom_time_before = tp;
+    return result;
+  }
+
+  static LifecycleRuleCondition CustomTimeBefore(std::string const& timestamp) {
+    return CustomTimeBefore(google::cloud::internal::ParseRfc3339(timestamp));
   }
   //@}
 


### PR DESCRIPTION
Implement "noncurrent time" and "custom time" conditions for object
lifecycle management.

This fixes #4432 and fixes #4275. I am putting both changes in one
PR because (a) we want them to become available simultaneously, and
(b) they are really conflict-prone as separate PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4544)
<!-- Reviewable:end -->
