### PR TITLE
feat: support moving a Transaction into an error state

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -241,7 +241,7 @@ StatusOr<CommitResult> Client::Commit(
       // Marks the session bad and creates a new Transaction for the next loop.
       internal::Visit(
           txn, [](internal::SessionHolder& s,
-                  StatusOr<google::spanner::v1::TransactionSelector> const&,
+                  optional<google::spanner::v1::TransactionSelector> const&,
                   std::int64_t) {
             if (s) s->set_bad();
             return true;

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -239,12 +239,13 @@ StatusOr<CommitResult> Client::Commit(
     }
     if (internal::IsSessionNotFound(status)) {
       // Marks the session bad and creates a new Transaction for the next loop.
-      internal::Visit(txn, [](internal::SessionHolder& s,
-                              google::spanner::v1::TransactionSelector const&,
-                              std::int64_t) {
-        if (s) s->set_bad();
-        return true;
-      });
+      internal::Visit(
+          txn, [](internal::SessionHolder& s,
+                  StatusOr<google::spanner::v1::TransactionSelector> const&,
+                  std::int64_t) {
+            if (s) s->set_bad();
+            return true;
+          });
       txn = MakeReadWriteTransaction();
     } else {
       // Create a new transaction for the next loop, but reuse the session

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -825,7 +825,9 @@ Status ConnectionImpl::RollbackImpl(
   }
   if (s->has_begin()) {
     // There is nothing to rollback if a transaction id has not yet been
-    // assigned, so we just succeed without making an RPC.
+    // assigned, so we just succeed without making an RPC. But we also cause
+    // all future (non-rollback) operations on the transaction to fail.
+    s.reset();
     return Status();
   }
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -303,6 +303,8 @@ Status ConnectionImpl::PrepareSession(SessionHolder& session,
 RowStream ConnectionImpl::ReadImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     ReadParams params) {
+  // TODO(#4516): Handle !s.ok().
+
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return MakeStatusOnlyResult<RowStream>(std::move(prepare_status));
@@ -365,6 +367,8 @@ RowStream ConnectionImpl::ReadImpl(
 StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     ReadParams const& params, PartitionOptions const& partition_options) {
+  // TODO(#4516): Handle !s.ok().
+
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
   auto prepare_status = PrepareSession(session, /*dissociate_from_pool=*/true);
@@ -421,6 +425,8 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
         google::spanner::v1::ExecuteSqlRequest& request)> const&
         retry_resume_fn) {
+  // TODO(#4516): Handle !s.ok().
+
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(session->session_name());
   *request.mutable_transaction() = *s;
@@ -589,6 +595,8 @@ StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     PartitionQueryParams const& params) {
+  // TODO(#4516): Handle !s.ok().
+
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
   auto prepare_status = PrepareSession(session, /*dissociate_from_pool=*/true);
@@ -639,6 +647,8 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, ExecuteBatchDmlParams params) {
+  // TODO(#4516): Handle !s.ok().
+
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return prepare_status;
@@ -683,6 +693,8 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
 StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, ExecutePartitionedDmlParams params) {
+  // TODO(#4516): Handle !s.ok().
+
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return prepare_status;

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -108,7 +108,8 @@ RowStream ConnectionImpl::Read(ReadParams params) {
   return internal::Visit(
       std::move(params.transaction),
       [this, &params](SessionHolder& session,
-                      spanner_proto::TransactionSelector& s, std::int64_t) {
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t) {
         return ReadImpl(session, s, std::move(params));
       });
 }
@@ -118,60 +119,61 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
   return internal::Visit(
       std::move(params.read_params.transaction),
       [this, &params](SessionHolder& session,
-                      spanner_proto::TransactionSelector& s, std::int64_t) {
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t) {
         return PartitionReadImpl(session, s, params.read_params,
                                  params.partition_options);
       });
 }
 
 RowStream ConnectionImpl::ExecuteQuery(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ExecuteQueryImpl(session, s, seqno,
-                                                   std::move(params));
-                         });
+  return internal::Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t seqno) {
+        return ExecuteQueryImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<DmlResult> ConnectionImpl::ExecuteDml(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ExecuteDmlImpl(session, s, seqno,
-                                                 std::move(params));
-                         });
+  return internal::Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t seqno) {
+        return ExecuteDmlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQuery(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ProfileQueryImpl(session, s, seqno,
-                                                   std::move(params));
-                         });
+  return internal::Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t seqno) {
+        return ProfileQueryImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ProfileDmlImpl(session, s, seqno,
-                                                 std::move(params));
-                         });
+  return internal::Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t seqno) {
+        return ProfileDmlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return AnalyzeSqlImpl(session, s, seqno,
-                                                 std::move(params));
-                         });
+  return internal::Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t seqno) {
+        return AnalyzeSqlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
@@ -179,7 +181,7 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
   auto txn = MakeReadOnlyTransaction();
   return internal::Visit(
       txn, [this, &params](SessionHolder& session,
-                           spanner_proto::TransactionSelector& s,
+                           StatusOr<spanner_proto::TransactionSelector>& s,
                            std::int64_t seqno) {
         return ExecutePartitionedDmlImpl(session, s, seqno, std::move(params));
       });
@@ -190,27 +192,29 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
   return internal::Visit(
       std::move(params.transaction),
       [this, &params](SessionHolder& session,
-                      spanner_proto::TransactionSelector& s, std::int64_t) {
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t) {
         return PartitionQueryImpl(session, s, params);
       });
 }
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
     ExecuteBatchDmlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ExecuteBatchDmlImpl(session, s, seqno,
-                                                      std::move(params));
-                         });
+  return internal::Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t seqno) {
+        return ExecuteBatchDmlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<CommitResult> ConnectionImpl::Commit(CommitParams params) {
   return internal::Visit(
       std::move(params.transaction),
       [this, &params](SessionHolder& session,
-                      spanner_proto::TransactionSelector& s, std::int64_t) {
+                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      std::int64_t) {
         return this->CommitImpl(session, s, std::move(params));
       });
 }
@@ -218,7 +222,8 @@ StatusOr<CommitResult> ConnectionImpl::Commit(CommitParams params) {
 Status ConnectionImpl::Rollback(RollbackParams params) {
   return internal::Visit(
       std::move(params.transaction),
-      [this](SessionHolder& session, spanner_proto::TransactionSelector& s,
+      [this](SessionHolder& session,
+             StatusOr<spanner_proto::TransactionSelector>& s,
              std::int64_t) { return this->RollbackImpl(session, s); });
 }
 
@@ -295,9 +300,9 @@ Status ConnectionImpl::PrepareSession(SessionHolder& session,
   return Status();
 }
 
-RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
-                                   spanner_proto::TransactionSelector& s,
-                                   ReadParams params) {
+RowStream ConnectionImpl::ReadImpl(
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    ReadParams params) {
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return MakeStatusOnlyResult<RowStream>(std::move(prepare_status));
@@ -305,7 +310,7 @@ RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
 
   spanner_proto::ReadRequest request;
   request.set_session(session->session_name());
-  *request.mutable_transaction() = s;
+  *request.mutable_transaction() = *s;
   request.set_table(std::move(params.table));
   request.set_index(std::move(params.read_options.index_name));
   for (auto&& column : params.columns) {
@@ -344,7 +349,7 @@ RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
     if (internal::IsSessionNotFound(status)) session->set_bad();
     return MakeStatusOnlyResult<RowStream>(std::move(status));
   }
-  if (s.has_begin()) {
+  if (s->has_begin()) {
     auto metadata = (*reader)->Metadata();
     if (!metadata || metadata->transaction().id().empty()) {
       return MakeStatusOnlyResult<RowStream>(
@@ -352,13 +357,13 @@ RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
                  "Begin transaction requested but no transaction returned (in "
                  "Read)."));
     }
-    s.set_id(metadata->transaction().id());
+    s->set_id(metadata->transaction().id());
   }
   return RowStream(*std::move(reader));
 }
 
 StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     ReadParams const& params, PartitionOptions const& partition_options) {
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
@@ -369,7 +374,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
 
   spanner_proto::PartitionReadRequest request;
   request.set_session(session->session_name());
-  *request.mutable_transaction() = s;
+  *request.mutable_transaction() = *s;
   request.set_table(params.table);
   request.set_index(params.read_options.index_name);
   for (auto const& column : params.columns) {
@@ -393,8 +398,8 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
     return status;
   }
 
-  if (s.has_begin()) {
-    s.set_id(response->transaction().id());
+  if (s->has_begin()) {
+    s->set_id(response->transaction().id());
   }
 
   std::vector<ReadPartition> read_partitions;
@@ -410,7 +415,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
 
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
-    SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
@@ -418,7 +423,7 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
         retry_resume_fn) {
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(session->session_name());
-  *request.mutable_transaction() = s;
+  *request.mutable_transaction() = *s;
   auto sql_statement = internal::ToProto(std::move(params.statement));
   request.set_sql(std::move(*sql_statement.mutable_sql()));
   *request.mutable_params() = std::move(*sql_statement.mutable_params());
@@ -437,20 +442,20 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
   if (!reader.ok()) {
     return std::move(reader).status();
   }
-  if (s.has_begin()) {
+  if (s->has_begin()) {
     auto metadata = (*reader)->Metadata();
     if (!metadata || metadata->transaction().id().empty()) {
       return Status(StatusCode::kInternal,
                     "Begin transaction requested but no transaction returned.");
     }
-    s.set_id(metadata->transaction().id());
+    s->set_id(metadata->transaction().id());
   }
   return ResultType(std::move(*reader));
 }
 
 template <typename ResultType>
 ResultType ConnectionImpl::CommonQueryImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   auto prepare_status = PrepareSession(session);
@@ -501,14 +506,14 @@ ResultType ConnectionImpl::CommonQueryImpl(
 }
 
 RowStream ConnectionImpl::ExecuteQueryImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<RowStream>(session, s, seqno, std::move(params),
                                     spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
-    SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<ProfileQueryResult>(
       session, s, seqno, std::move(params),
@@ -517,7 +522,7 @@ ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
 
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   auto function_name = __func__;
@@ -555,14 +560,14 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
 }
 
 StatusOr<DmlResult> ConnectionImpl::ExecuteDmlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<DmlResult>(session, s, seqno, std::move(params),
                                   spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
-    SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<ProfileDmlResult>(
       session, s, seqno, std::move(params),
@@ -570,7 +575,7 @@ StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
 }
 
 StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
-    SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params) {
   auto result =
       CommonDmlImpl<ProfileDmlResult>(session, s, seqno, std::move(params),
@@ -582,7 +587,7 @@ StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 }
 
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     PartitionQueryParams const& params) {
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
@@ -593,7 +598,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
 
   spanner_proto::PartitionQueryRequest request;
   request.set_session(session->session_name());
-  *request.mutable_transaction() = s;
+  *request.mutable_transaction() = *s;
   auto sql_statement = internal::ToProto(params.statement);
   request.set_sql(std::move(*sql_statement.mutable_sql()));
   *request.mutable_params() = std::move(*sql_statement.mutable_params());
@@ -617,8 +622,8 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
     return status;
   }
 
-  if (s.has_begin()) {
-    s.set_id(response->transaction().id());
+  if (s->has_begin()) {
+    s->set_id(response->transaction().id());
   }
 
   std::vector<QueryPartition> query_partitions;
@@ -632,7 +637,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
 }
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, ExecuteBatchDmlParams params) {
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
@@ -642,7 +647,7 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
   spanner_proto::ExecuteBatchDmlRequest request;
   request.set_session(session->session_name());
   request.set_seqno(seqno);
-  *request.mutable_transaction() = s;
+  *request.mutable_transaction() = *s;
   for (auto& sql : params.statements) {
     *request.add_statements() = internal::ToProto(std::move(sql));
   }
@@ -662,8 +667,8 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
     return status;
   }
 
-  if (response->result_sets_size() > 0 && s.has_begin()) {
-    s.set_id(response->result_sets(0).metadata().transaction().id());
+  if (response->result_sets_size() > 0 && s->has_begin()) {
+    s->set_id(response->result_sets(0).metadata().transaction().id());
   }
 
   BatchDmlResult result;
@@ -676,7 +681,7 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
 }
 
 StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, ExecutePartitionedDmlParams params) {
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
@@ -701,11 +706,11 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
     if (internal::IsSessionNotFound(status)) session->set_bad();
     return status;
   }
-  s.set_id(begin_response->id());
+  s->set_id(begin_response->id());
 
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(session->session_name());
-  *request.mutable_transaction() = s;
+  *request.mutable_transaction() = *s;
   auto sql_statement = internal::ToProto(std::move(params.statement));
   request.set_sql(std::move(*sql_statement.mutable_sql()));
   *request.mutable_params() = std::move(*sql_statement.mutable_params());
@@ -734,8 +739,13 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
 }
 
 StatusOr<CommitResult> ConnectionImpl::CommitImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     CommitParams params) {
+  if (!s) {
+    // Fail the commit if the transaction has been invalidated.
+    return s.status();
+  }
+
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return prepare_status;
@@ -747,10 +757,10 @@ StatusOr<CommitResult> ConnectionImpl::CommitImpl(
     *request.add_mutations() = std::move(m).as_proto();
   }
 
-  if (s.selector_case() != spanner_proto::TransactionSelector::kId) {
+  if (s->selector_case() != spanner_proto::TransactionSelector::kId) {
     spanner_proto::BeginTransactionRequest begin;
     begin.set_session(session->session_name());
-    *begin.mutable_options() = s.has_begin() ? s.begin() : s.single_use();
+    *begin.mutable_options() = s->has_begin() ? s->begin() : s->single_use();
     auto stub = session_pool_->GetStub(*session);
     auto response = internal::RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
@@ -765,9 +775,9 @@ StatusOr<CommitResult> ConnectionImpl::CommitImpl(
       if (internal::IsSessionNotFound(status)) session->set_bad();
       return status;
     }
-    s.set_id(response->id());
+    s->set_id(response->id());
   }
-  request.set_transaction_id(s.id());
+  request.set_transaction_id(s->id());
 
   auto stub = session_pool_->GetStub(*session);
   auto response = internal::RetryLoop(
@@ -789,25 +799,31 @@ StatusOr<CommitResult> ConnectionImpl::CommitImpl(
   return r;
 }
 
-Status ConnectionImpl::RollbackImpl(SessionHolder& session,
-                                    spanner_proto::TransactionSelector& s) {
+Status ConnectionImpl::RollbackImpl(
+    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s) {
+  if (!s) {
+    // There is nothing to rollback if the transaction has been invalidated,
+    // so we just succeed without making an RPC.
+    return Status();
+  }
+  if (s->has_single_use()) {
+    return Status(StatusCode::kInvalidArgument,
+                  "Cannot rollback a single-use transaction");
+  }
+  if (s->has_begin()) {
+    // There is nothing to rollback if a transaction id has not yet been
+    // assigned, so we just succeed without making an RPC.
+    return Status();
+  }
+
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return prepare_status;
   }
 
-  if (s.has_single_use()) {
-    return Status(StatusCode::kInvalidArgument,
-                  "Cannot rollback a single-use transaction");
-  }
-  if (s.has_begin()) {
-    // There is nothing to rollback if a transaction id has not yet been
-    // assigned, so we just succeed without making an RPC.
-    return Status();
-  }
   spanner_proto::RollbackRequest request;
   request.set_session(session->session_name());
-  request.set_transaction_id(s.id());
+  request.set_transaction_id(s->id());
   auto stub = session_pool_->GetStub(*session);
   auto status = internal::RetryLoop(
       retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -99,56 +99,67 @@ class ConnectionImpl : public Connection {
                         bool dissociate_from_pool = false);
 
   RowStream ReadImpl(SessionHolder& session,
-                     google::spanner::v1::TransactionSelector& s,
+                     StatusOr<google::spanner::v1::TransactionSelector>& s,
                      ReadParams params);
 
   StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
       ReadParams const& params, PartitionOptions const& partition_options);
 
-  RowStream ExecuteQueryImpl(SessionHolder& session,
-                             google::spanner::v1::TransactionSelector& s,
-                             std::int64_t seqno, SqlParams params);
+  RowStream ExecuteQueryImpl(
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params);
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   ProfileQueryResult ProfileQueryImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params);
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<ProfileDmlResult> ProfileDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params);
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<ExecutionPlan> AnalyzeSqlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params);
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecutePartitionedDmlParams params);
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      ExecutePartitionedDmlParams params);
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
       PartitionQueryParams const& params);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteBatchDmlParams params);
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      ExecuteBatchDmlParams params);
 
-  StatusOr<CommitResult> CommitImpl(SessionHolder& session,
-                                    google::spanner::v1::TransactionSelector& s,
-                                    CommitParams params);
+  StatusOr<CommitResult> CommitImpl(
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      CommitParams params);
 
   Status RollbackImpl(SessionHolder& session,
-                      google::spanner::v1::TransactionSelector& s);
+                      StatusOr<google::spanner::v1::TransactionSelector>& s);
 
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params,
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
       std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
           google::spanner::v1::ExecuteSqlRequest& request)> const&
@@ -156,13 +167,15 @@ class ConnectionImpl : public Connection {
 
   template <typename ResultType>
   ResultType CommonQueryImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params,
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
   template <typename ResultType>
   StatusOr<ResultType> CommonDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, SqlParams params,
+      SessionHolder& session,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   Database db_;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -99,66 +99,66 @@ class ConnectionImpl : public Connection {
                         bool dissociate_from_pool = false);
 
   RowStream ReadImpl(SessionHolder& session,
-                     StatusOr<google::spanner::v1::TransactionSelector>& s,
+                     optional<google::spanner::v1::TransactionSelector>& s,
                      ReadParams params);
 
   StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      optional<google::spanner::v1::TransactionSelector>& s,
       ReadParams const& params, PartitionOptions const& partition_options);
 
   RowStream ExecuteQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params);
 
   ProfileQueryResult ProfileQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params);
 
   StatusOr<ProfileDmlResult> ProfileDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params);
 
   StatusOr<ExecutionPlan> AnalyzeSqlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       ExecutePartitionedDmlParams params);
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      optional<google::spanner::v1::TransactionSelector>& s,
       PartitionQueryParams const& params);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       ExecuteBatchDmlParams params);
 
   StatusOr<CommitResult> CommitImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s,
+      optional<google::spanner::v1::TransactionSelector>& s,
       CommitParams params);
 
   Status RollbackImpl(SessionHolder& session,
-                      StatusOr<google::spanner::v1::TransactionSelector>& s);
+                      optional<google::spanner::v1::TransactionSelector>& s);
 
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
       std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
@@ -168,13 +168,13 @@ class ConnectionImpl : public Connection {
   template <typename ResultType>
   ResultType CommonQueryImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
   template <typename ResultType>
   StatusOr<ResultType> CommonDmlImpl(
       SessionHolder& session,
-      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      optional<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
       SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -90,11 +90,12 @@ MATCHER_P(BatchCreateSessionsRequestHasDatabase, database,
   return arg.database() == database.FullName();
 }
 
-// Matches a spanner::Transaction that is marked "is_bad()"
+// Matches a spanner::Transaction that is bound to a "bad" session"
 MATCHER(HasBadSession, "bound to a session that's marked bad") {
   return internal::Visit(
-      arg, [&](internal::SessionHolder& session,
-               google::spanner::v1::TransactionSelector&, std::int64_t) {
+      arg,
+      [&](internal::SessionHolder& session,
+          StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t) {
         if (!session) {
           *result_listener << "has no session";
           return false;
@@ -107,12 +108,24 @@ MATCHER(HasBadSession, "bound to a session that's marked bad") {
       });
 }
 
-// Helper to set the Transaction's ID.
+// Helper to set the Transaction's ID. Requires selector.ok().
 void SetTransactionId(Transaction& txn, std::string tid) {
+  internal::Visit(txn,
+                  [&tid](SessionHolder&,
+                         StatusOr<spanner_proto::TransactionSelector>& selector,
+                         std::int64_t) {
+                    selector->set_id(std::move(tid));
+                    return 0;
+                  });
+}
+
+// Helper to mark the Transaction as invalid. Requires !status.ok().
+void SetTransactionInvalid(Transaction& txn, Status status) {
   internal::Visit(
-      txn, [&tid](SessionHolder&, spanner_proto::TransactionSelector& selector,
-                  std::int64_t) {
-        selector.set_id(std::move(tid));
+      txn, [&status](SessionHolder&,
+                     StatusOr<spanner_proto::TransactionSelector>& selector,
+                     std::int64_t) {
+        selector = std::move(status);
         return 0;
       });
 }
@@ -1504,6 +1517,26 @@ TEST(ConnectionImplTest, CommitCommitTooManyTransientFailures) {
   EXPECT_THAT(commit.status().message(), HasSubstr("uh-oh in Commit"));
 }
 
+TEST(ConnectionImplTest, CommitCommitInvalidatedTransaction) {
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  auto conn = MakeConnection(
+      db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _)).Times(0);
+  EXPECT_CALL(*mock, BeginTransaction(_, _)).Times(0);
+  EXPECT_CALL(*mock, Commit(_, _)).Times(0);
+
+  // Committing an invalidated transaction is a unilateral error.
+  auto txn = MakeReadWriteTransaction();
+  SetTransactionInvalid(
+      txn, Status(Status(StatusCode::kAlreadyExists, "constraint error")));
+
+  auto commit = conn->Commit({txn});
+  EXPECT_EQ(StatusCode::kAlreadyExists, commit.status().code());
+  EXPECT_THAT(commit.status().message(), HasSubstr("constraint error"));
+}
+
 TEST(ConnectionImplTest, CommitCommitIdempotentTransientSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
@@ -1594,6 +1627,7 @@ TEST(ConnectionImplTest, RollbackGetSessionFailure) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
   auto txn = MakeReadWriteTransaction();
+  SetTransactionId(txn, "test-txn-id");
   auto rollback = conn->Rollback({txn});
   EXPECT_EQ(StatusCode::kPermissionDenied, rollback.code());
   EXPECT_THAT(rollback.message(), HasSubstr("uh-oh in GetSession"));
@@ -1604,13 +1638,7 @@ TEST(ConnectionImplTest, RollbackBeginTransaction) {
   std::string const session_name = "test-session-name";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([&db, &session_name](
-                    grpc::ClientContext&,
-                    spanner_proto::BatchCreateSessionsRequest const& request) {
-        EXPECT_EQ(db.FullName(), request.database());
-        return MakeSessionsResponse({session_name});
-      });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _)).Times(0);
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
   auto conn = MakeConnection(
@@ -1625,13 +1653,7 @@ TEST(ConnectionImplTest, RollbackSingleUseTransaction) {
   std::string const session_name = "test-session-name";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([&db, &session_name](
-                    grpc::ClientContext&,
-                    spanner_proto::BatchCreateSessionsRequest const& request) {
-        EXPECT_EQ(db.FullName(), request.database());
-        return MakeSessionsResponse({session_name});
-      });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _)).Times(0);
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
   auto conn = MakeConnection(
@@ -1731,6 +1753,24 @@ TEST(ConnectionImplTest, RollbackSuccess) {
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, transaction_id);
+  auto rollback = conn->Rollback({txn});
+  EXPECT_STATUS_OK(rollback);
+}
+
+TEST(ConnectionImplTest, RollbackSuccessInvalidatedTransaction) {
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  auto conn = MakeConnection(
+      db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _)).Times(0);
+  EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
+
+  // Rolling back an invalidated transaction is a unilateral success.
+  auto txn = MakeReadWriteTransaction();
+  SetTransactionInvalid(
+      txn, Status(Status(StatusCode::kAlreadyExists, "constraint error")));
+
   auto rollback = conn->Rollback({txn});
   EXPECT_STATUS_OK(rollback);
 }

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -125,7 +125,7 @@ void SetTransactionInvalid(Transaction& txn) {
       txn,
       [](SessionHolder&, optional<spanner_proto::TransactionSelector>& selector,
          std::int64_t) {
-        selector = {};
+        selector.reset();
         return 0;
       });
 }

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -19,7 +19,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/port_platform.h"
-#include "google/cloud/status_or.h"
+#include "google/cloud/optional.h"
 #include <google/spanner/v1/transaction.pb.h>
 #include <condition_variable>
 #include <cstdint>
@@ -35,7 +35,7 @@ namespace internal {
 template <typename Functor>
 using VisitInvokeResult = ::google::cloud::internal::invoke_result_t<
     Functor, SessionHolder&,
-    StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t>;
+    optional<google::spanner::v1::TransactionSelector>&, std::int64_t>;
 
 /**
  * The internal representation of a google::cloud::spanner::Transaction.
@@ -80,7 +80,7 @@ class TransactionImpl {
   VisitInvokeResult<Functor> Visit(Functor&& f) {
     static_assert(google::cloud::internal::is_invocable<
                       Functor, SessionHolder&,
-                      StatusOr<google::spanner::v1::TransactionSelector>&,
+                      optional<google::spanner::v1::TransactionSelector>&,
                       std::int64_t>::value,
                   "TransactionImpl::Visit() functor has incompatible type.");
     std::int64_t seqno;
@@ -102,8 +102,8 @@ class TransactionImpl {
       bool done = false;
       {
         std::lock_guard<std::mutex> lock(mu_);
-        state_ = selector_.ok() && selector_->has_begin() ? State::kBegin
-                                                          : State::kDone;
+        state_ =
+            selector_ && selector_->has_begin() ? State::kBegin : State::kDone;
         done = (state_ == State::kDone);
       }
       if (done) {
@@ -135,7 +135,7 @@ class TransactionImpl {
   std::mutex mu_;
   std::condition_variable cond_;
   SessionHolder session_;
-  StatusOr<google::spanner::v1::TransactionSelector> selector_;
+  optional<google::spanner::v1::TransactionSelector> selector_;
   std::int64_t seqno_;
 };
 

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/port_platform.h"
+#include "google/cloud/status_or.h"
 #include <google/spanner/v1/transaction.pb.h>
 #include <condition_variable>
 #include <cstdint>
@@ -33,8 +34,8 @@ namespace internal {
 
 template <typename Functor>
 using VisitInvokeResult = ::google::cloud::internal::invoke_result_t<
-    Functor, SessionHolder&, google::spanner::v1::TransactionSelector&,
-    std::int64_t>;
+    Functor, SessionHolder&,
+    StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t>;
 
 /**
  * The internal representation of a google::cloud::spanner::Transaction.
@@ -53,7 +54,7 @@ class TransactionImpl {
       : session_(std::move(session)),
         selector_(std::move(selector)),
         seqno_(0) {
-    state_ = selector_.has_begin() ? State::kBegin : State::kDone;
+    state_ = selector_->has_begin() ? State::kBegin : State::kDone;
   }
 
   ~TransactionImpl();
@@ -64,18 +65,24 @@ class TransactionImpl {
   // If the SessionHolder is not nullptr, the functor must use the session.
   // Otherwise it must allocate a session and assign to the SessionHolder.
   //
-  // If initially selector.has_begin(), and the operation successfully allocates
-  // a transaction ID, then the functor should selector.set_id(id). Otherwise
-  // the functor should not modify the selector.
+  // If the TransactionSelector is in the "begin" state and the operation
+  // successfully allocates a transaction ID, then the functor must assign
+  // that ID to the selector. If the functor fails to allocate a transaction
+  // ID then it should place the selector into an error state. All of this
+  // is independent of whether the functor itself succeeds.
+  //
+  // If the TransactionSelector is not in the "begin" state then the functor
+  // must not modify it. Rather it should use either the transaction ID or
+  // the error state in a manner appropriate for the operation.
   //
   // A monotonically-increasing sequence number is also passed to the functor.
   template <typename Functor>
   VisitInvokeResult<Functor> Visit(Functor&& f) {
-    static_assert(
-        google::cloud::internal::is_invocable<
-            Functor, SessionHolder&, google::spanner::v1::TransactionSelector&,
-            std::int64_t>::value,
-        "TransactionImpl::Visit() functor has incompatible type.");
+    static_assert(google::cloud::internal::is_invocable<
+                      Functor, SessionHolder&,
+                      StatusOr<google::spanner::v1::TransactionSelector>&,
+                      std::int64_t>::value,
+                  "TransactionImpl::Visit() functor has incompatible type.");
     std::int64_t seqno;
     {
       std::unique_lock<std::mutex> lock(mu_);
@@ -87,7 +94,7 @@ class TransactionImpl {
       }
       state_ = State::kPending;
     }
-    // selector_.has_begin(), but only one visitor active at a time.
+    // selector_->has_begin(), but only one visitor active at a time.
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
@@ -95,7 +102,8 @@ class TransactionImpl {
       bool done = false;
       {
         std::lock_guard<std::mutex> lock(mu_);
-        state_ = selector_.has_begin() ? State::kBegin : State::kDone;
+        state_ = selector_.ok() && selector_->has_begin() ? State::kBegin
+                                                          : State::kDone;
         done = (state_ == State::kDone);
       }
       if (done) {
@@ -127,7 +135,7 @@ class TransactionImpl {
   std::mutex mu_;
   std::condition_variable cond_;
   SessionHolder session_;
-  google::spanner::v1::TransactionSelector selector_;
+  StatusOr<google::spanner::v1::TransactionSelector> selector_;
   std::int64_t seqno_;
 };
 

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -44,9 +44,13 @@ class ResultSet {};
 // operation that does nothing but track the expected transaction callbacks.
 class Client {
  public:
-  Client() = default;
-  explicit Client(Status s)
-      : mode_(Mode::kReadFails), txn_status_(std::move(s)) {}
+  enum class Mode {
+    kReadSucceeds,  // and assigns a transaction ID
+    kReadFailsAndTxnRemainsBegin,
+    kReadFailsAndTxnInvalidated,
+  };
+
+  explicit Client(Mode mode) : mode_(mode) {}
 
   // Set the `read_timestamp` we expect to see, and the `session_id` and
   // `txn_id` we want to use during the upcoming `Read()` calls.
@@ -71,7 +75,7 @@ class Client {
                  std::vector<std::string> const& columns) {
     auto read = [this, &table, &keys, &columns](
                     SessionHolder& session,
-                    StatusOr<TransactionSelector>& selector,
+                    optional<TransactionSelector>& selector,
                     std::int64_t seqno) {
       return this->Read(session, selector, seqno, table, keys, columns);
     };
@@ -87,18 +91,12 @@ class Client {
   }
 
  private:
-  enum class Mode {
-    kReadSucceeds,
-    kReadFails,
-  };
-
   ResultSet Read(SessionHolder& session,
-                 StatusOr<TransactionSelector>& selector, std::int64_t seqno,
+                 optional<TransactionSelector>& selector, std::int64_t seqno,
                  std::string const& table, KeySet const& keys,
                  std::vector<std::string> const& columns);
 
-  Mode mode_{Mode::kReadSucceeds};
-  Status txn_status_;
+  Mode mode_;
   Timestamp read_timestamp_;
   std::string session_id_;
   std::string txn_id_;
@@ -112,27 +110,23 @@ class Client {
 // switch the selector to use the allocated transaction ID.  Here we use
 // the pre-assigned transaction ID after checking the read timestamp.
 ResultSet Client::Read(SessionHolder& session,
-                       StatusOr<TransactionSelector>& selector,
+                       optional<TransactionSelector>& selector,
                        std::int64_t seqno, std::string const&, KeySet const&,
                        std::vector<std::string> const&) {
+  bool fail_with_throw = false;
   if (!selector) {
-    EXPECT_EQ(selector.status(), txn_status_);
     std::unique_lock<std::mutex> lock(mu_);
     switch (mode_) {
       case Mode::kReadSucceeds:  // visits never valid
         break;
-      case Mode::kReadFails:  // visits always valid
+      case Mode::kReadFailsAndTxnRemainsBegin:  // visits always valid
+      case Mode::kReadFailsAndTxnInvalidated:
         ++valid_visits_;
-        if (valid_visits_ % 2 == 0) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-          throw "1201 Program Alarm - Executive Overflow - No Core Sets.";
-#endif
-        }
+        fail_with_throw = (valid_visits_ % 2 == 0);
         break;
     }
   } else if (selector->has_begin()) {
     EXPECT_THAT(session, IsNull());
-    bool fail_with_throw = false;
     if (selector->begin().has_read_only() &&
         selector->begin().read_only().has_read_timestamp()) {
       auto const& proto = selector->begin().read_only().read_timestamp();
@@ -142,7 +136,8 @@ ResultSet Client::Read(SessionHolder& session,
           case Mode::kReadSucceeds:  // first visit valid
             if (valid_visits_ == 0) ++valid_visits_;
             break;
-          case Mode::kReadFails:  // visits always valid
+          case Mode::kReadFailsAndTxnRemainsBegin:  // visits always valid
+          case Mode::kReadFailsAndTxnInvalidated:
             ++valid_visits_;
             fail_with_throw = (valid_visits_ % 2 == 0);
             break;
@@ -156,18 +151,12 @@ ResultSet Client::Read(SessionHolder& session,
         session = internal::MakeDissociatedSessionHolder(session_id_);
         selector->set_id(txn_id_);
         break;
-      case Mode::kReadFails:
-        if (txn_status_.ok()) {
-          // leave as `begin`, calls stay serialized
-        } else {
-          // `begin` -> `error`, calls now parallelized
-          selector = txn_status_;
-        }
-        if (fail_with_throw) {
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-          throw "1202 Program Alarm - Executive Overflow - No VAC Areas.";
-#endif
-        }
+      case Mode::kReadFailsAndTxnRemainsBegin:
+        // leave as `begin`, calls stay serialized
+        break;
+      case Mode::kReadFailsAndTxnInvalidated:
+        // `begin` -> `error`, calls now parallelized
+        selector = {};
         break;
     }
   } else {
@@ -179,11 +168,19 @@ ResultSet Client::Read(SessionHolder& session,
         case Mode::kReadSucceeds:  // non-initial visits valid
           if (valid_visits_ != 0 && seqno > begin_seqno_) ++valid_visits_;
           break;
-        case Mode::kReadFails:  // visits never valid
+        case Mode::kReadFailsAndTxnRemainsBegin:  // visits never valid
+        case Mode::kReadFailsAndTxnInvalidated:
           break;
       }
     }
   }
+  if (fail_with_throw) {
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+    throw "1202 Program Alarm - Executive Overflow - No VAC Areas.";
+#endif
+  }
+  // kReadSucceeds -v- kReadFailsAnd* is all about whether we assign a
+  // transaction ID, not about what we return here (which is never used).
   return {};
 }
 
@@ -228,21 +225,21 @@ int MultiThreadedRead(int n_threads, Client* client, std::time_t read_time,
 }
 
 TEST(InternalTransaction, ReadSucceeds) {
-  Client client;
+  Client client(Client::Mode::kReadSucceeds);
   EXPECT_EQ(1, MultiThreadedRead(1, &client, 1562359982, "sess0", "txn0"));
   EXPECT_EQ(64, MultiThreadedRead(64, &client, 1562360571, "sess1", "txn1"));
   EXPECT_EQ(128, MultiThreadedRead(128, &client, 1562361252, "sess2", "txn2"));
 }
 
-TEST(InternalTransaction, ReadFailsTxnBegin) {
-  Client client{Status()};  // OK
+TEST(InternalTransaction, ReadFailsAndTxnRemainsBegin) {
+  Client client(Client::Mode::kReadFailsAndTxnRemainsBegin);
   EXPECT_EQ(1, MultiThreadedRead(1, &client, 1562359982, "sess0", "txn0"));
   EXPECT_EQ(64, MultiThreadedRead(64, &client, 1562360571, "sess1", "txn1"));
   EXPECT_EQ(128, MultiThreadedRead(128, &client, 1562361252, "sess2", "txn2"));
 }
 
-TEST(InternalTransaction, ReadFailsTxnBad) {
-  Client client{Status(StatusCode::kInternal, "Bad transaction")};
+TEST(InternalTransaction, ReadFailsAndTxnInvalidated) {
+  Client client(Client::Mode::kReadFailsAndTxnInvalidated);
   EXPECT_EQ(1, MultiThreadedRead(1, &client, 1562359982, "sess0", "txn0"));
   EXPECT_EQ(64, MultiThreadedRead(64, &client, 1562360571, "sess1", "txn1"));
   EXPECT_EQ(128, MultiThreadedRead(128, &client, 1562361252, "sess2", "txn2"));

--- a/google/cloud/spanner/row.cc
+++ b/google/cloud/spanner/row.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <algorithm>
-#include <cassert>
 #include <iterator>
 #include <utility>
 

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -42,8 +42,9 @@ MATCHER_P2(
     HasSessionAndTransactionId, session_id, transaction_id,
     "Verifies a Transaction has the expected Session and Transaction IDs") {
   return google::cloud::spanner::internal::Visit(
-      arg, [&](google::cloud::spanner::internal::SessionHolder& session,
-               google::spanner::v1::TransactionSelector& s, std::int64_t) {
+      arg,
+      [&](google::cloud::spanner::internal::SessionHolder& session,
+          StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
         bool result = true;
         if (!session) {
           *result_listener << "Session ID missing (expected " << session_id
@@ -54,8 +55,13 @@ MATCHER_P2(
                            << " != " << session_id;
           result = false;
         }
-        if (s.id() != transaction_id) {
-          *result_listener << "Transaction ID mismatch: " << s.id()
+        if (!s) {
+          *result_listener << "Transaction ID missing (expected "
+                           << transaction_id << " but found status "
+                           << s.status() << ")";
+          result = false;
+        } else if (s->id() != transaction_id) {
+          *result_listener << "Transaction ID mismatch: " << s->id()
                            << " != " << transaction_id;
           result = false;
         }

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -44,7 +44,7 @@ MATCHER_P2(
   return google::cloud::spanner::internal::Visit(
       arg,
       [&](google::cloud::spanner::internal::SessionHolder& session,
-          StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
+          optional<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
         bool result = true;
         if (!session) {
           *result_listener << "Session ID missing (expected " << session_id
@@ -56,9 +56,8 @@ MATCHER_P2(
           result = false;
         }
         if (!s) {
-          *result_listener << "Transaction ID missing (expected "
-                           << transaction_id << " but found status "
-                           << s.status() << ")";
+          *result_listener << "Transaction invalid (expected " << transaction_id
+                           << ")";
           result = false;
         } else if (s->id() != transaction_id) {
           *result_listener << "Transaction ID mismatch: " << s->id()

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -80,7 +80,7 @@ TEST(Transaction, Visit) {
   std::int64_t a_seqno;
   internal::Visit(
       a, [&a_seqno](internal::SessionHolder& /*session*/,
-                    StatusOr<google::spanner::v1::TransactionSelector>& s,
+                    optional<google::spanner::v1::TransactionSelector>& s,
                     std::int64_t seqno) {
         EXPECT_TRUE(s->has_begin());
         EXPECT_TRUE(s->begin().has_read_only());
@@ -90,7 +90,7 @@ TEST(Transaction, Visit) {
       });
   internal::Visit(
       a, [a_seqno](internal::SessionHolder& /*session*/,
-                   StatusOr<google::spanner::v1::TransactionSelector>& s,
+                   optional<google::spanner::v1::TransactionSelector>& s,
                    std::int64_t seqno) {
         EXPECT_EQ("test-txn-id", s->id());
         EXPECT_GT(seqno, a_seqno);
@@ -103,7 +103,7 @@ TEST(Transaction, SessionAffinity) {
   Transaction a = MakeReadWriteTransaction();
   internal::Visit(
       a, [&a_session](internal::SessionHolder& session,
-                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      optional<google::spanner::v1::TransactionSelector>& s,
                       std::int64_t) {
         EXPECT_FALSE(session);
         EXPECT_TRUE(s->has_begin());
@@ -114,7 +114,7 @@ TEST(Transaction, SessionAffinity) {
   Transaction b = MakeReadWriteTransaction(a);
   internal::Visit(
       b, [&a_session](internal::SessionHolder& session,
-                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      optional<google::spanner::v1::TransactionSelector>& s,
                       std::int64_t) {
         EXPECT_EQ(a_session, session);  // session affinity
         EXPECT_TRUE(s->has_begin());    // but a new transaction

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -78,44 +78,48 @@ TEST(Transaction, RegularSemantics) {
 TEST(Transaction, Visit) {
   Transaction a = MakeReadOnlyTransaction();
   std::int64_t a_seqno;
-  internal::Visit(a, [&a_seqno](internal::SessionHolder& /*session*/,
-                                google::spanner::v1::TransactionSelector& s,
-                                std::int64_t seqno) {
-    EXPECT_TRUE(s.has_begin());
-    EXPECT_TRUE(s.begin().has_read_only());
-    s.set_id("test-txn-id");
-    a_seqno = seqno;
-    return 0;
-  });
-  internal::Visit(a, [a_seqno](internal::SessionHolder& /*session*/,
-                               google::spanner::v1::TransactionSelector& s,
-                               std::int64_t seqno) {
-    EXPECT_EQ("test-txn-id", s.id());
-    EXPECT_GT(seqno, a_seqno);
-    return 0;
-  });
+  internal::Visit(
+      a, [&a_seqno](internal::SessionHolder& /*session*/,
+                    StatusOr<google::spanner::v1::TransactionSelector>& s,
+                    std::int64_t seqno) {
+        EXPECT_TRUE(s->has_begin());
+        EXPECT_TRUE(s->begin().has_read_only());
+        s->set_id("test-txn-id");
+        a_seqno = seqno;
+        return 0;
+      });
+  internal::Visit(
+      a, [a_seqno](internal::SessionHolder& /*session*/,
+                   StatusOr<google::spanner::v1::TransactionSelector>& s,
+                   std::int64_t seqno) {
+        EXPECT_EQ("test-txn-id", s->id());
+        EXPECT_GT(seqno, a_seqno);
+        return 0;
+      });
 }
 
 TEST(Transaction, SessionAffinity) {
   auto a_session = internal::MakeDissociatedSessionHolder("SessionAffinity");
   Transaction a = MakeReadWriteTransaction();
-  internal::Visit(a, [&a_session](internal::SessionHolder& session,
-                                  google::spanner::v1::TransactionSelector& s,
-                                  std::int64_t) {
-    EXPECT_FALSE(session);
-    EXPECT_TRUE(s.has_begin());
-    session = a_session;
-    s.set_id("a-txn-id");
-    return 0;
-  });
+  internal::Visit(
+      a, [&a_session](internal::SessionHolder& session,
+                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      std::int64_t) {
+        EXPECT_FALSE(session);
+        EXPECT_TRUE(s->has_begin());
+        session = a_session;
+        s->set_id("a-txn-id");
+        return 0;
+      });
   Transaction b = MakeReadWriteTransaction(a);
-  internal::Visit(b, [&a_session](internal::SessionHolder& session,
-                                  google::spanner::v1::TransactionSelector& s,
-                                  std::int64_t) {
-    EXPECT_EQ(a_session, session);  // session affinity
-    EXPECT_TRUE(s.has_begin());     // but a new transaction
-    return 0;
-  });
+  internal::Visit(
+      b, [&a_session](internal::SessionHolder& session,
+                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      std::int64_t) {
+        EXPECT_EQ(a_session, session);  // session affinity
+        EXPECT_TRUE(s->has_begin());    // but a new transaction
+        return 0;
+      });
 }
 
 }  // namespace


### PR DESCRIPTION
Change the signature of the transaction `Visit()` functor to take a
`StatusOr<TransactionSelector>&` instead of a `TransactionSelector&`.

This allows a functor that failed to allocate a transaction ID to
move the transaction into an error state (with a `Status`) instead
of leaving it as a "begin", for the use of future visitors like
`Commit()`.

Only `ConnectionImpl::CommitImpl()` and `RollbackImpl()` have been
modified to check for the error state.  Every other `ConnectionImpl`
transaction visitor currently assumes there is no error (which is OK
as no one currently imposes one).

Part of #4516.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4545)
<!-- Reviewable:end -->
