### PR TITLE
ci(pubsub): really disable tests against production

### DIFF
--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -56,7 +56,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-test;integration-test-production")
+                                 "integration-test;integration-tests-emulator")
         add_dependencies(pubsub-client-integration-tests ${target})
     endforeach ()
 
@@ -72,7 +72,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
         add_test(NAME ${target} COMMAND ${target})
         set_tests_properties(
             ${target} PROPERTIES LABELS
-                                 "integration-test;integration-test-production")
+                                 "integration-test;integration-test-emulator")
     endforeach ()
 endfunction ()
 


### PR DESCRIPTION
The labels in these tests always force running against production, fixed
now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4551)
<!-- Reviewable:end -->
