### PR TITLE
feat: handle invalid transactions in `ConnectionImpl` methods

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -470,6 +470,10 @@ ResultType ConnectionImpl::CommonQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
+  if (!s.ok()) {
+    return MakeStatusOnlyResult<ResultType>(s.status());
+  }
+
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
     return MakeStatusOnlyResult<ResultType>(std::move(prepare_status));
@@ -537,6 +541,9 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
+  if (!s.ok()) {
+    return s.status();
+  }
   auto function_name = __func__;
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -303,7 +303,9 @@ Status ConnectionImpl::PrepareSession(SessionHolder& session,
 RowStream ConnectionImpl::ReadImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     ReadParams params) {
-  // TODO(#4516): Handle !s.
+  if (!s.ok()) {
+    return MakeStatusOnlyResult<RowStream>(s.status());
+  }
 
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
@@ -367,7 +369,9 @@ RowStream ConnectionImpl::ReadImpl(
 StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     ReadParams const& params, PartitionOptions const& partition_options) {
-  // TODO(#4516): Handle !s.
+  if (!s.ok()) {
+    return s.status();
+  }
 
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
@@ -425,7 +429,9 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
         google::spanner::v1::ExecuteSqlRequest& request)> const&
         retry_resume_fn) {
-  // TODO(#4516): Handle !s.
+  if (!s.ok()) {
+    return s.status();
+  }
 
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(session->session_name());
@@ -595,7 +601,9 @@ StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     PartitionQueryParams const& params) {
-  // TODO(#4516): Handle !s.
+  if (!s.ok()) {
+    return s.status();
+  }
 
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
@@ -647,7 +655,9 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, ExecuteBatchDmlParams params) {
-  // TODO(#4516): Handle !s.
+  if (!s.ok()) {
+    return s.status();
+  }
 
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {
@@ -693,7 +703,9 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
 StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
     SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
     std::int64_t seqno, ExecutePartitionedDmlParams params) {
-  // TODO(#4516): Handle !s.
+  if (!s.ok()) {
+    return s.status();
+  }
 
   auto prepare_status = PrepareSession(session);
   if (!prepare_status.ok()) {

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -1536,8 +1536,8 @@ TEST(ConnectionImplTest, CommitCommitInvalidatedTransaction) {
 
   // Committing an invalidated transaction is a unilateral error.
   auto txn = MakeReadWriteTransaction();
-  SetTransactionInvalid(
-      txn, Status(Status(StatusCode::kAlreadyExists, "constraint error")));
+  SetTransactionInvalid(txn,
+                        Status(StatusCode::kAlreadyExists, "constraint error"));
 
   auto commit = conn->Commit({txn});
   EXPECT_FALSE(commit.ok());
@@ -1777,8 +1777,8 @@ TEST(ConnectionImplTest, RollbackInvalidatedTransaction) {
 
   // Rolling back an invalidated transaction is a unilateral success.
   auto txn = MakeReadWriteTransaction();
-  SetTransactionInvalid(
-      txn, Status(Status(StatusCode::kAlreadyExists, "constraint error")));
+  SetTransactionInvalid(txn,
+                        Status(StatusCode::kAlreadyExists, "constraint error"));
 
   auto rollback_status = conn->Rollback({txn});
   EXPECT_EQ(StatusCode::kAlreadyExists, rollback_status.code());
@@ -2486,8 +2486,8 @@ TEST(ConnectionImplTest, OperationsFailOnInvalidatedTransaction) {
 
   // Committing an invalidated transaction is a unilateral error.
   auto txn = MakeReadWriteTransaction();
-  SetTransactionInvalid(txn, Status(Status(StatusCode::kInvalidArgument,
-                                           "BeginTransaction failed")));
+  SetTransactionInvalid(
+      txn, Status(StatusCode::kInvalidArgument, "BeginTransaction failed"));
   // All operations on an invalid transaction should return the error that
   // invalidated it, without actually making a RPC.
 


### PR DESCRIPTION
this is a no-op because nothing yet sets a transaction invalid (aside
from the test).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4606)
<!-- Reviewable:end -->
