### PR TITLE
feat(pubsub): use asynchronous RPC for Publish

### DIFF
--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/version.h"
+#include "google/cloud/completion_queue.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.grpc.pb.h>
 
@@ -55,8 +56,9 @@ class PublisherStub {
       google::pubsub::v1::DeleteTopicRequest const& request) = 0;
 
   /// Publish a batch of messages.
-  virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& client_context,
+  virtual future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> client_context,
       google::pubsub::v1::PublishRequest const& request) = 0;
 };
 

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -28,7 +28,7 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
   auto stub =
       pubsub_internal::CreateDefaultPublisherStub(options, /*channel_id=*/0);
   return pubsub_internal::MakePublisherConnection(std::move(topic),
-                                                  std::move(stub));
+                                                  std::move(stub), options);
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -40,37 +40,45 @@ namespace {
 class PublisherConnectionImpl : public pubsub::PublisherConnection {
  public:
   explicit PublisherConnectionImpl(
-      pubsub::Topic topic, std::shared_ptr<pubsub_internal::PublisherStub> stub)
+      pubsub::Topic topic, std::shared_ptr<pubsub_internal::PublisherStub> stub,
+      pubsub::ConnectionOptions const& options)
       : topic_(std::move(topic)),
         topic_full_name_(topic_.FullName()),
-        stub_(std::move(stub)) {}
+        stub_(std::move(stub)),
+        background_(options.background_threads_factory()()),
+        cq_(background_->cq()) {}
 
   future<StatusOr<std::string>> Publish(PublishParams p) override {
-    grpc::ClientContext context;
+    auto context = absl::make_unique<grpc::ClientContext>();
     google::pubsub::v1::PublishRequest request;
     request.set_topic(topic_full_name_);
     *request.add_messages() = pubsub_internal::ToProto(std::move(p.message));
-    auto r = stub_->Publish(context, request);
-    using Result = StatusOr<std::string>;
-    if (!r) return make_ready_future<Result>(std::move(r).status());
-    if (r->message_ids_size() != 1) {
-      return make_ready_future<Result>(
-          Status(StatusCode::kUnknown, "mismatched message id count"));
-    }
-    return make_ready_future<Result>(std::move(*r->mutable_message_ids(0)));
+    return stub_->AsyncPublish(cq_, std::move(context), request)
+        .then([](future<StatusOr<google::pubsub::v1::PublishResponse>> f)
+                  -> StatusOr<std::string> {
+          auto response = f.get();
+          if (!response) return std::move(response).status();
+          if (response->message_ids_size() != 1) {
+            return Status(StatusCode::kUnknown, "mismatched message id count");
+          }
+          return std::move(*response->mutable_message_ids(0));
+        });
   }
 
  private:
   pubsub::Topic topic_;
   std::string topic_full_name_;
   std::shared_ptr<pubsub_internal::PublisherStub> stub_;
+  std::unique_ptr<BackgroundThreads> background_;
+  google::cloud::CompletionQueue cq_;
 };
 }  // namespace
 
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, std::shared_ptr<PublisherStub> stub) {
+    pubsub::Topic topic, std::shared_ptr<PublisherStub> stub,
+    pubsub::ConnectionOptions const& options) {
   return std::make_shared<PublisherConnectionImpl>(std::move(topic),
-                                                   std::move(stub));
+                                                   std::move(stub), options);
 }
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -65,7 +65,8 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, std::shared_ptr<PublisherStub> stub);
+    pubsub::Topic topic, std::shared_ptr<PublisherStub> stub,
+    pubsub::ConnectionOptions const& options);
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/testing/mock_publisher_stub.h
+++ b/google/cloud/pubsub/testing/mock_publisher_stub.h
@@ -45,8 +45,11 @@ class MockPublisherStub : public pubsub_internal::PublisherStub {
                google::pubsub::v1::DeleteTopicRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::PublishResponse>, Publish,
-              (grpc::ClientContext&, google::pubsub::v1::PublishRequest const&),
+  MOCK_METHOD(future<StatusOr<google::pubsub::v1::PublishResponse>>,
+              AsyncPublish,
+              (google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::pubsub::v1::PublishRequest const&),
               (override));
 };
 


### PR DESCRIPTION
Change `pubsub_internal::PublisherStub` to use an asynchronous RPC for
`Publish()`, adjust the unit tests to use the new functions. Change the
default `pubsub::PublisherConnection` to use the configuration in
`pubsub::ConnectionOptions` to either use a completion queue provided by
the application (which must be serviced by one or more threads also provided
by the application), or to create its own completion queue and a (at the moment)
single background thread.

Fixes #4604

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4608)
<!-- Reviewable:end -->
