### PR TITLE
feat(pubsub): a skeleton pubsub::Subscriber class

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(
     publisher_connection.h
     publisher_options.cc
     publisher_options.h
+    subscriber.h
     subscriber_connection.cc
     subscriber_connection.h
     subscription.cc
@@ -93,7 +94,8 @@ add_library(pubsub_client_mocks INTERFACE)
 target_sources(
     pubsub_client_mocks
     INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_ack_handler.h
-              ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_publisher_connection.h)
+              ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_publisher_connection.h
+              ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_subscriber_connection.h)
 target_link_libraries(
     pubsub_client_mocks
     INTERFACE googleapis-c++::pubsub_client google_cloud_cpp_testing
@@ -140,6 +142,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         publisher_option_test.cc
         publisher_test.cc
         subscriber_connection_test.cc
+        subscriber_test.cc
         subscription_test.cc
         topic_test.cc)
 

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher.h"
-#include "google/cloud/pubsub/subscriber_connection.h"
+#include "google/cloud/pubsub/subscriber.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/subscription_admin_client.h"
 #include "google/cloud/pubsub/testing/random_names.h"
@@ -60,7 +60,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
   ASSERT_STATUS_OK(subscription_metadata);
 
   auto publisher = Publisher(MakePublisherConnection(topic));
-  auto subscriber = MakeSubscriberConnection();
+  auto subscriber = Subscriber(MakeSubscriberConnection());
 
   std::mutex mu;
   std::vector<std::string> ids;
@@ -90,7 +90,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
     }
   };
 
-  auto result = subscriber->Subscribe({subscription.FullName(), handler});
+  auto result = subscriber.Subscribe(subscription, handler);
   // Wait until there are no more ids pending, then cancel the subscription and
   // get its status.
   ids_empty.get_future().get();

--- a/google/cloud/pubsub/mocks/mock_subscriber_connection.h
+++ b/google/cloud/pubsub/mocks/mock_subscriber_connection.h
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_MOCKS_MOCK_SUBSCRIBER_CONNECTION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_MOCKS_MOCK_SUBSCRIBER_CONNECTION_H
+
+#include "google/cloud/pubsub/subscriber_connection.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_mocks {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+class MockSubscriberConnection : public pubsub::SubscriberConnection {
+ public:
+  MOCK_METHOD(future<Status>, Subscribe,
+              (pubsub::SubscriberConnection::SubscribeParams), (override));
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_mocks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_MOCKS_MOCK_SUBSCRIBER_CONNECTION_H

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -29,6 +29,7 @@ pubsub_client_hdrs = [
     "publisher.h",
     "publisher_connection.h",
     "publisher_options.h",
+    "subscriber.h",
     "subscriber_connection.h",
     "subscription.h",
     "subscription_admin_client.h",

--- a/google/cloud/pubsub/pubsub_client_mocks.bzl
+++ b/google/cloud/pubsub/pubsub_client_mocks.bzl
@@ -19,6 +19,7 @@
 pubsub_client_mocks_hdrs = [
     "mocks/mock_ack_handler.h",
     "mocks/mock_publisher_connection.h",
+    "mocks/mock_subscriber_connection.h",
 ]
 
 pubsub_client_mocks_srcs = [

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -27,6 +27,7 @@ pubsub_client_unit_tests = [
     "publisher_option_test.cc",
     "publisher_test.cc",
     "subscriber_connection_test.cc",
+    "subscriber_test.cc",
     "subscription_test.cc",
     "topic_test.cc",
 ]

--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -1,0 +1,124 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIBER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIBER_H
+
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/subscriber_connection.h"
+#include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/status.h"
+#include <functional>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+/**
+ * Receive messages fromthe Cloud Pub/Sub service.
+ *
+ * This class is used to receive message from a given subscription, with a fixed
+ * configuration such as credentials, and background threads. Applications that
+ * receive messages from multiple subscriptions need to create separate
+ * instances of this class. Applications wanting to receive events with
+ * configuration parameters also need to create separate instances.
+ *
+ * @see https://cloud.google.com/pubsub for an overview of the Cloud Pub/Sub
+ *   service.
+ *
+ * @par Performance
+ *
+ * `Subscriber` objects are relatively cheap to create, copy, and move. However,
+ * each `Subscriber` object must be created with a
+ * `std::shared_ptr<SubscriberConnection>`, which itself is relatively expensive
+ * to create. Therefore, connection instances should be shared when possible.
+ * See the `MakeSubscriberConnection()` function and the `SubscriberConnection`
+ * interface for more details.
+ *
+ * @par Thread Safety
+ *
+ * Instances of this class created via copy-construction or copy-assignment
+ * share the underlying pool of connections. Access to these copies via multiple
+ * threads is guaranteed to work. Two threads operating on the same instance of
+ * this class is not guaranteed to work.
+ *
+ * @par Background Threads
+ *
+ * This class uses the background threads configured via `ConnectionOptions`.
+ * Applications can create their own pool of background threads by (a) creating
+ * their own #google::cloud::v1::CompletionQueue, (b) setting this completion
+ * queue in `pubsub::ConnectionOptions::DisableBackgroundThreads()`, and (c)
+ * attaching any number of threads to the completion queue.
+ *
+ * TODO(#4586) - add an example on how to do this.
+ *
+ * @par Asynchronous Functions
+ *
+ * Some of the member functions in this class return a `future<T>` (or
+ * `future<StatusOr<T>>`) object.  Readers are probably familiar with
+ * [`std::future<T>`][std-future-link], our version adds a `.then()` function to
+ * attach a callback to the future, which is invoked when the future is
+ * satisfied. This function returns a `future<U>` where `U` is the return value
+ * of the attached function. More details in the #google::cloud::v1::future
+ * documentation.
+ *
+ * @par Error Handling
+ *
+ * This class uses `StatusOr<T>` to report errors. When an operation fails to
+ * perform its work the returned `StatusOr<T>` contains the error details. If
+ * the `ok()` member function in the `StatusOr<T>` returns `true` then it
+ * contains the expected result. Please consult the #google::cloud::v1::StatusOr
+ * documentation for more details.
+ *
+ * @code
+ * namespace pubsub = ::google::cloud::pubsub;
+ *
+ * auto subscription = pubsub::Subscription("my-project", "my-subscription");
+ * auto subscriber = pubsub::Subscriber(MakeSubscriberConnection());
+ * subscriber->Subscribe(
+ *     subscription, [](Message m, AckHandler h) {
+ *         std::cout << "received " << m.message_id() << "\n";
+ *         std::move(h).ack();
+ *     }).then(
+ *     [](future<Status> f) {
+ *         auto s = f.get();
+ *         if (s) return;
+ *         std::cout << "unrecoverable error in subscription: " << s << "\n";
+ *     });
+ * @endcode
+ *
+ * [std-future-link]: https://en.cppreference.com/w/cpp/thread/future
+ */
+class Subscriber {
+ public:
+  explicit Subscriber(std::shared_ptr<SubscriberConnection> connection)
+      : connection_(std::move(connection)) {}
+
+  template <typename Callable>
+  future<Status> Subscribe(Subscription const& subscription, Callable&& cb) {
+    std::function<void(Message, AckHandler)> f(std::forward<Callable>(cb));
+    return connection_->Subscribe({subscription.FullName(), std::move(f)});
+  }
+
+ private:
+  std::shared_ptr<SubscriberConnection> connection_;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIBER_H

--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -68,7 +68,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  *
  * Some of the member functions in this class return a `future<T>` (or
  * `future<StatusOr<T>>`) object.  Readers are probably familiar with
- * [`std::future<T>`][std-future-link], our version adds a `.then()` function to
+ * [`std::future<T>`][std-future-link]. Our version adds a `.then()` function to
  * attach a callback to the future, which is invoked when the future is
  * satisfied. This function returns a `future<U>` where `U` is the return value
  * of the attached function. More details in the #google::cloud::v1::future

--- a/google/cloud/pubsub/subscriber_test.cc
+++ b/google/cloud/pubsub/subscriber_test.cc
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/pubsub/mocks/mock_ack_handler.h"
+#include "google/cloud/pubsub/mocks/mock_subscriber_connection.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::testing::_;
+
+/// @test Verify Subscriber::Subscribe() works, including mocks.
+TEST(SubscriberTest, SubscribeSimple) {
+  Subscription const subscription("test-project", "test-subscription");
+  auto mock = std::make_shared<pubsub_mocks::MockSubscriberConnection>();
+  EXPECT_CALL(*mock, Subscribe(_))
+      .WillOnce([&](SubscriberConnection::SubscribeParams const& p) {
+        EXPECT_EQ(subscription.FullName(), p.full_subscription_name);
+
+        {
+          auto ack = absl::make_unique<pubsub_mocks::MockAckHandler>();
+          EXPECT_CALL(*ack, ack()).Times(1);
+          p.callback(pubsub::MessageBuilder{}.SetData("do-ack").Build(),
+                     AckHandler(std::move(ack)));
+        }
+
+        {
+          auto ack = absl::make_unique<pubsub_mocks::MockAckHandler>();
+          EXPECT_CALL(*ack, nack()).Times(1);
+          p.callback(pubsub::MessageBuilder{}.SetData("do-nack").Build(),
+                     AckHandler(std::move(ack)));
+        }
+
+        return make_ready_future(Status{});
+      });
+
+  Subscriber subscriber(mock);
+  auto status = subscriber
+                    .Subscribe(subscription,
+                               [&](Message const& m, AckHandler h) {
+                                 if (m.data() == "do-nack") {
+                                   std::move(h).nack();
+                                 } else {
+                                   std::move(h).ack();
+                                 }
+                               })
+                    .get();
+  ASSERT_STATUS_OK(status);
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This PR implements a skeleton `Subscriber` class, with
enough functionality to be usable, but a fairly naive
implementation.

We also introduce a mock for `SubscriberConnection` and
a simple unit tests showing how to use it.

Fixes #4607 and fixes #3895

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4610)
<!-- Reviewable:end -->
