### PR TITLE
fix(spanner): date formatting with negative years

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -374,7 +374,7 @@ google::protobuf::Value Value::MakeValueProto(absl::CivilDay d) {
   // absl::FormatCivilTime doesn't pad the year to 4-digits, which Spanner
   // needs as part of its RFC-3339 requirement.
   std::ostringstream ss;
-  ss << std::setfill('0') << std::setw(4) << d.year() << '-';
+  ss << std::internal << std::setfill('0') << std::setw(4) << d.year() << '-';
   ss << std::setfill('0') << std::setw(2) << d.month() << '-';
   ss << std::setfill('0') << std::setw(2) << d.day();
   v.set_string_value(std::move(ss).str());


### PR DESCRIPTION
Zero padding of years should be after the sign, not before it.

This broke a Spanner emulator test that expects `CivilDay(0, 0, 0)`
to produce `kInvalidArgument` on "-001-11-30" because the year is
less than 1, not `kFailedPrecondition` on "00-1-11-30" because the
string is syntactically illegal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4614)
<!-- Reviewable:end -->
