### PR TITLE
feat(pubsub): batch messages in Publish()

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(
     connection_options.h
     create_subscription_builder.h
     create_topic_builder.h
+    internal/batching_publisher_connection.cc
+    internal/batching_publisher_connection.h
     internal/default_ack_handler_impl.cc
     internal/default_ack_handler_impl.h
     internal/emulator_overrides.cc
@@ -137,6 +139,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         ack_handler_test.cc
         create_subscription_builder_test.cc
         create_topic_builder_test.cc
+        internal/batching_publisher_connection_test.cc
         internal/default_ack_handler_impl_test.cc
         internal/emulator_overrides_test.cc
         internal/user_agent_prefix_test.cc

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -59,7 +59,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       CreateSubscriptionBuilder(subscription, topic));
   ASSERT_STATUS_OK(subscription_metadata);
 
-  auto publisher = Publisher(MakePublisherConnection(topic));
+  auto publisher = Publisher(MakePublisherConnection(topic, {}));
   auto subscriber = Subscriber(MakeSubscriberConnection());
 
   std::mutex mu;

--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -1,0 +1,146 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/batching_publisher_connection.h"
+#include <numeric>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+// A helper callable to handle a response, it is a bit large for a lambda, and
+// we need move-capture anyways.
+struct Batch {
+  // We are going to use the completion queue as an executor, so we might as
+  // well name it as one.
+  google::cloud::CompletionQueue executor;
+  std::vector<promise<StatusOr<std::string>>> waiters;
+
+  void operator()(future<StatusOr<google::pubsub::v1::PublishResponse>> f) {
+    auto response = f.get();
+    if (!response) {
+      SatisfyAllWaiters(response.status());
+      return;
+    }
+    if (static_cast<std::size_t>(response->message_ids_size()) !=
+        waiters.size()) {
+      SatisfyAllWaiters(
+          Status(StatusCode::kUnknown, "mismatched message id count"));
+      return;
+    }
+    struct SetValue {
+      promise<StatusOr<std::string>> waiter;
+      std::string value;
+      void operator()() { waiter.set_value(std::move(value)); }
+    };
+    int idx = 0;
+    for (auto& w : waiters) {
+      executor.RunAsync(SetValue{std::move(w), response->message_ids(idx++)});
+    }
+  }
+
+  void SatisfyAllWaiters(Status const& status) {
+    struct SetStatus {
+      promise<StatusOr<std::string>> waiter;
+      Status status;
+      void operator()() { waiter.set_value(std::move(status)); }
+    };
+    for (auto& w : waiters) {
+      executor.RunAsync(SetStatus{std::move(w), status});
+    }
+  }
+};
+
+future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
+    PublishParams p) {
+  promise<StatusOr<std::string>> promise;
+  auto f = promise.get_future();
+  std::unique_lock<std::mutex> lk(mu_);
+  pending_.push_back(Item{std::move(promise), std::move(p.message)});
+  MaybeFlush(std::move(lk));
+  return f;
+}
+
+void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
+  if (pending_.size() >= batching_config_.maximum_message_count()) {
+    Flush(std::move(lk));
+    return;
+  }
+  auto const bytes = std::accumulate(
+      pending_.begin(), pending_.end(), std::size_t{0},
+      [](std::size_t a, Item const& b) { return a + b.message.data().size(); });
+  if (bytes >= batching_config_.maximum_batch_bytes()) {
+    Flush(std::move(lk));
+    return;
+  }
+  // If the batch is empty obviously we do not need a timer, and if it has more
+  // than one element then we already have setup a timer previously.
+  if (pending_.size() == 1U) {
+    batch_expiration_ =
+        std::chrono::system_clock::now() + batching_config_.maximum_hold_time();
+    lk.unlock();
+    // We need a weak_ptr<> because this class owns the completion queue,
+    // creating a lambda with a shared_ptr<> owning this class would create a
+    // cycle.  Unfortunately some older compiler/libraries lack
+    // `weak_from_this()`.
+    auto weak = std::weak_ptr<BatchingPublisherConnection>(shared_from_this());
+    // Note that at this point the lock is released, so whether the timer
+    // schedules later on schedules in this thread has no effect.
+    cq_.MakeDeadlineTimer(batch_expiration_)
+        .then([weak](future<StatusOr<std::chrono::system_clock::time_point>>) {
+          auto self = weak.lock();
+          if (!self) return;
+          self->OnTimer();
+        });
+  }
+}
+
+void BatchingPublisherConnection::OnTimer() {
+  std::unique_lock<std::mutex> lk(mu_);
+  if (std::chrono::system_clock::now() < batch_expiration_) {
+    // We may get many "old" timers for batches that have already flushed due to
+    // size. Trying to cancel these timers is a bit hopeless, they might trigger
+    // even if we attempt to cancel them. This test is more robust.
+    return;
+  }
+  Flush(std::move(lk));
+}
+
+void BatchingPublisherConnection::Flush(std::unique_lock<std::mutex> lk) {
+  if (pending_.empty()) return;
+
+  auto context = absl::make_unique<grpc::ClientContext>();
+
+  Batch batch;
+  batch.executor = cq_;
+  batch.waiters.reserve(pending_.size());
+  google::pubsub::v1::PublishRequest request;
+  request.set_topic(topic_full_name_);
+  request.mutable_messages()->Reserve(pending_.size());
+
+  for (auto& i : pending_) {
+    batch.waiters.push_back(std::move(i.response));
+    *request.add_messages() = pubsub_internal::ToProto(std::move(i.message));
+  }
+  pending_.clear();
+  lk.unlock();
+
+  stub_->AsyncPublish(cq_, std::move(context), request).then(std::move(batch));
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_BATCHING_PUBLISHER_CONNECTION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_BATCHING_PUBLISHER_CONNECTION_H
+
+#include "google/cloud/pubsub/publisher_connection.h"
+#include "google/cloud/pubsub/version.h"
+#include <mutex>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+class BatchingPublisherConnection
+    : public pubsub::PublisherConnection,
+      public std::enable_shared_from_this<BatchingPublisherConnection> {
+ public:
+  static std::shared_ptr<BatchingPublisherConnection> Create(
+      pubsub::Topic topic, pubsub::BatchingConfig batching_config,
+      std::shared_ptr<pubsub_internal::PublisherStub> stub,
+      pubsub::ConnectionOptions const& connection_options) {
+    return std::shared_ptr<BatchingPublisherConnection>(
+        new BatchingPublisherConnection(std::move(topic),
+                                        std::move(batching_config),
+                                        std::move(stub), connection_options));
+  }
+
+  future<StatusOr<std::string>> Publish(PublishParams p) override;
+
+ private:
+  explicit BatchingPublisherConnection(
+      pubsub::Topic topic, pubsub::BatchingConfig batching_config,
+      std::shared_ptr<pubsub_internal::PublisherStub> stub,
+      pubsub::ConnectionOptions const& connection_options)
+      : topic_(std::move(topic)),
+        topic_full_name_(topic_.FullName()),
+        batching_config_(std::move(batching_config)),
+        stub_(std::move(stub)),
+        background_(connection_options.background_threads_factory()()),
+        cq_(background_->cq()) {}
+
+  void OnTimer();
+  void MaybeFlush(std::unique_lock<std::mutex> lk);
+  void Flush(std::unique_lock<std::mutex> lk);
+
+  pubsub::Topic topic_;
+  std::string topic_full_name_;
+  pubsub::BatchingConfig batching_config_;
+  std::shared_ptr<pubsub_internal::PublisherStub> stub_;
+  std::unique_ptr<BackgroundThreads> background_;
+  google::cloud::CompletionQueue cq_;
+
+  std::mutex mu_;
+  struct Item {
+    promise<StatusOr<std::string>> response;
+    pubsub::Message message;
+  };
+  std::vector<Item> pending_;
+  std::chrono::system_clock::time_point batch_expiration_;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_BATCHING_PUBLISHER_CONNECTION_H

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -1,0 +1,286 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/batching_publisher_connection.h"
+#include "google/cloud/pubsub/testing/mock_publisher_stub.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/mock_completion_queue.h"
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::testing::_;
+using ::testing::HasSubstr;
+
+TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const& request) {
+        EXPECT_EQ(topic.FullName(), request.topic());
+        EXPECT_EQ(1, request.messages_size());
+        EXPECT_EQ("test-data-0", request.messages(0).data());
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        return make_ready_future(make_status_or(response));
+      })
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const& request) {
+        EXPECT_EQ(topic.FullName(), request.topic());
+        EXPECT_EQ(1, request.messages_size());
+        EXPECT_EQ("test-data-1", request.messages(0).data());
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-1");
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic, pubsub::BatchingConfig{}, mock,
+      pubsub::ConnectionOptions{grpc::InsecureChannelCredentials()});
+
+  // We expect the responses to be satisfied in the context of the completion
+  // queue threads. This is an important property, the processing of any
+  // responses should be scheduled with any other work.
+  auto const main_thread = std::this_thread::get_id();
+  publisher->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+      .then([&](future<StatusOr<std::string>> f) {
+        auto r = f.get();
+        ASSERT_STATUS_OK(r);
+        EXPECT_EQ("test-message-id-0", *r);
+        EXPECT_NE(main_thread, std::this_thread::get_id());
+      })
+      .get();
+  publisher->Publish({pubsub::MessageBuilder{}.SetData("test-data-1").Build()})
+      .then([&](future<StatusOr<std::string>> f) {
+        auto r = f.get();
+        ASSERT_STATUS_OK(r);
+        EXPECT_EQ("test-message-id-1", *r);
+        EXPECT_NE(main_thread, std::this_thread::get_id());
+      })
+      .get();
+}
+
+TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const& request) {
+        EXPECT_EQ(topic.FullName(), request.topic());
+        EXPECT_EQ(2, request.messages_size());
+        EXPECT_EQ("test-data-0", request.messages(0).data());
+        EXPECT_EQ("test-data-1", request.messages(1).data());
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        response.add_message_ids("test-message-id-1");
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic, pubsub::BatchingConfig{}.set_maximum_message_count(2), mock,
+      pubsub::ConnectionOptions{grpc::InsecureChannelCredentials()});
+  auto r0 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+          .then([](future<StatusOr<std::string>> f) {
+            auto r = f.get();
+            ASSERT_STATUS_OK(r);
+            EXPECT_EQ("test-message-id-0", *r);
+          });
+  auto r1 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-1").Build()})
+          .then([](future<StatusOr<std::string>> f) {
+            auto r = f.get();
+            ASSERT_STATUS_OK(r);
+            EXPECT_EQ("test-message-id-1", *r);
+          });
+
+  r0.get();
+  r1.get();
+}
+
+TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const& request) {
+        EXPECT_EQ(topic.FullName(), request.topic());
+        EXPECT_EQ(2, request.messages_size());
+        EXPECT_EQ("test-data-0", request.messages(0).data());
+        EXPECT_EQ("test-data-1", request.messages(1).data());
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        response.add_message_ids("test-message-id-1");
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto constexpr kMaxMessageBytes = sizeof("test-data-N") + 2;
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::BatchingConfig{}
+          .set_maximum_message_count(4)
+          .set_maximum_batch_bytes(kMaxMessageBytes),
+      mock, pubsub::ConnectionOptions{grpc::InsecureChannelCredentials()});
+  auto r0 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+          .then([](future<StatusOr<std::string>> f) {
+            auto r = f.get();
+            ASSERT_STATUS_OK(r);
+            EXPECT_EQ("test-message-id-0", *r);
+          });
+  auto r1 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-1").Build()})
+          .then([](future<StatusOr<std::string>> f) {
+            auto r = f.get();
+            ASSERT_STATUS_OK(r);
+            EXPECT_EQ("test-message-id-1", *r);
+          });
+
+  r0.get();
+  r1.get();
+}
+
+TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const& request) {
+        EXPECT_EQ(topic.FullName(), request.topic());
+        EXPECT_EQ(2, request.messages_size());
+        EXPECT_EQ("test-data-0", request.messages(0).data());
+        EXPECT_EQ("test-data-1", request.messages(1).data());
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        response.add_message_ids("test-message-id-1");
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::BatchingConfig{}
+          .set_maximum_message_count(4)
+          .set_maximum_hold_time(std::chrono::milliseconds(500)),
+      mock, pubsub::ConnectionOptions{grpc::InsecureChannelCredentials()});
+  auto r0 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+          .then([](future<StatusOr<std::string>> f) {
+            auto r = f.get();
+            ASSERT_STATUS_OK(r);
+            EXPECT_EQ("test-message-id-0", *r);
+          });
+  auto r1 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-1").Build()})
+          .then([](future<StatusOr<std::string>> f) {
+            auto r = f.get();
+            ASSERT_STATUS_OK(r);
+            EXPECT_EQ("test-message-id-1", *r);
+          });
+
+  r0.get();
+  r1.get();
+}
+
+TEST(BatchingPublisherConnectionTest, HandleError) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  auto const error_status = Status(StatusCode::kPermissionDenied, "uh-oh");
+  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const&) {
+        return make_ready_future(
+            StatusOr<google::pubsub::v1::PublishResponse>(error_status));
+      });
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic, pubsub::BatchingConfig{}.set_maximum_message_count(2), mock,
+      pubsub::ConnectionOptions{grpc::InsecureChannelCredentials()});
+  auto check_status = [&](future<StatusOr<std::string>> f) {
+    auto r = f.get();
+    EXPECT_EQ(error_status, r.status());
+  };
+  auto r0 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+          .then(check_status);
+  auto r1 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-1").Build()})
+          .then(check_status);
+
+  r0.get();
+  r1.get();
+}
+
+TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+      .WillOnce([&](google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext>,
+                    google::pubsub::v1::PublishRequest const&) {
+        google::pubsub::v1::PublishResponse response;
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic, pubsub::BatchingConfig{}.set_maximum_message_count(2), mock,
+      pubsub::ConnectionOptions{grpc::InsecureChannelCredentials()});
+  auto check_status = [&](future<StatusOr<std::string>> f) {
+    auto r = f.get();
+    EXPECT_EQ(StatusCode::kUnknown, r.status().code());
+    EXPECT_THAT(r.status().message(), HasSubstr("mismatched message id count"));
+  };
+  auto r0 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+          .then(check_status);
+  auto r1 =
+      publisher
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-1").Build()})
+          .then(check_status);
+
+  r0.get();
+  r1.get();
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher_connection.h"
+#include "google/cloud/pubsub/internal/batching_publisher_connection.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include <memory>
 
@@ -24,11 +25,13 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 PublisherConnection::~PublisherConnection() = default;
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
-    Topic topic, ConnectionOptions const& options) {
-  auto stub =
-      pubsub_internal::CreateDefaultPublisherStub(options, /*channel_id=*/0);
-  return pubsub_internal::MakePublisherConnection(std::move(topic),
-                                                  std::move(stub), options);
+    Topic topic, PublisherOptions options,
+    ConnectionOptions const& connection_options) {
+  auto stub = pubsub_internal::CreateDefaultPublisherStub(connection_options,
+                                                          /*channel_id=*/0);
+  return pubsub_internal::MakePublisherConnection(
+      std::move(topic), std::move(options), std::move(stub),
+      connection_options);
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -36,50 +39,16 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
-namespace {
-class PublisherConnectionImpl : public pubsub::PublisherConnection {
- public:
-  explicit PublisherConnectionImpl(
-      pubsub::Topic topic, std::shared_ptr<pubsub_internal::PublisherStub> stub,
-      pubsub::ConnectionOptions const& options)
-      : topic_(std::move(topic)),
-        topic_full_name_(topic_.FullName()),
-        stub_(std::move(stub)),
-        background_(options.background_threads_factory()()),
-        cq_(background_->cq()) {}
-
-  future<StatusOr<std::string>> Publish(PublishParams p) override {
-    auto context = absl::make_unique<grpc::ClientContext>();
-    google::pubsub::v1::PublishRequest request;
-    request.set_topic(topic_full_name_);
-    *request.add_messages() = pubsub_internal::ToProto(std::move(p.message));
-    return stub_->AsyncPublish(cq_, std::move(context), request)
-        .then([](future<StatusOr<google::pubsub::v1::PublishResponse>> f)
-                  -> StatusOr<std::string> {
-          auto response = f.get();
-          if (!response) return std::move(response).status();
-          if (response->message_ids_size() != 1) {
-            return Status(StatusCode::kUnknown, "mismatched message id count");
-          }
-          return std::move(*response->mutable_message_ids(0));
-        });
-  }
-
- private:
-  pubsub::Topic topic_;
-  std::string topic_full_name_;
-  std::shared_ptr<pubsub_internal::PublisherStub> stub_;
-  std::unique_ptr<BackgroundThreads> background_;
-  google::cloud::CompletionQueue cq_;
-};
-}  // namespace
 
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, std::shared_ptr<PublisherStub> stub,
-    pubsub::ConnectionOptions const& options) {
-  return std::make_shared<PublisherConnectionImpl>(std::move(topic),
-                                                   std::move(stub), options);
+    pubsub::Topic topic, pubsub::PublisherOptions options,
+    std::shared_ptr<PublisherStub> stub,
+    pubsub::ConnectionOptions const& connection_options) {
+  return BatchingPublisherConnection::Create(
+      std::move(topic), options.batching_config(), std::move(stub),
+      connection_options);
 }
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/publisher_options.h"
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/future.h"
@@ -53,11 +54,14 @@ class PublisherConnection {
  *
  * @param topic the Cloud Pub/Sub topic used by the returned
  *     `PublisherConnection`.
- * @param options (optional) configure the `PublisherConnection` created by
- *     this function.
+ * @param options configure the batching policy and other parameters in the
+ *     returned connection.
+ * @param connection_options (optional) general configuration for this
+ *    connection, this type is also used to configure `pubsub::Subscriber`.
  */
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
-    Topic topic, ConnectionOptions const& options = ConnectionOptions());
+    Topic topic, PublisherOptions options,
+    ConnectionOptions const& connection_options = ConnectionOptions());
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
@@ -65,8 +69,9 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, std::shared_ptr<PublisherStub> stub,
-    pubsub::ConnectionOptions const& options);
+    pubsub::Topic topic, pubsub::PublisherOptions options,
+    std::shared_ptr<PublisherStub> stub,
+    pubsub::ConnectionOptions const& connection_options);
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -45,7 +45,7 @@ TEST(PublisherConnectionTest, Basic) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
+      topic, {}, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
           .get();
@@ -66,7 +66,7 @@ TEST(PublisherConnectionTest, HandleInvalidResponse) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
+      topic, {}, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
           .get();
@@ -91,7 +91,7 @@ TEST(PublisherConnectionTest, HandleError) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
+      topic, {}, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
           .get();

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -21,6 +21,7 @@ pubsub_client_hdrs = [
     "connection_options.h",
     "create_subscription_builder.h",
     "create_topic_builder.h",
+    "internal/batching_publisher_connection.h",
     "internal/default_ack_handler_impl.h",
     "internal/emulator_overrides.h",
     "internal/publisher_stub.h",
@@ -45,6 +46,7 @@ pubsub_client_hdrs = [
 pubsub_client_srcs = [
     "ack_handler.cc",
     "connection_options.cc",
+    "internal/batching_publisher_connection.cc",
     "internal/default_ack_handler_impl.cc",
     "internal/emulator_overrides.cc",
     "internal/publisher_stub.cc",

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -20,6 +20,7 @@ pubsub_client_unit_tests = [
     "ack_handler_test.cc",
     "create_subscription_builder_test.cc",
     "create_topic_builder_test.cc",
+    "internal/batching_publisher_connection_test.cc",
     "internal/default_ack_handler_impl_test.cc",
     "internal/emulator_overrides_test.cc",
     "internal/user_agent_prefix_test.cc",


### PR DESCRIPTION
With this PR messages are batched in the `PublisherConnection()` layer
before making a `AsyncPublish()` call.  The application can request that
messages are flushed based on message count, total data size, or time.

Each future returned by `Publish()` is satisfied as its own work item in
the completion queue, effectively this means the messages are sent in
order, but the responses are handled in an unspecified order.

Part of the work for #4581 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4616)
<!-- Reviewable:end -->
