### PR TITLE
refactor(pubsub): move default AckHandler

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -32,6 +32,8 @@ add_library(
     connection_options.h
     create_subscription_builder.h
     create_topic_builder.h
+    internal/default_ack_handler_impl.cc
+    internal/default_ack_handler_impl.h
     internal/emulator_overrides.cc
     internal/emulator_overrides.h
     internal/publisher_stub.cc
@@ -135,6 +137,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         ack_handler_test.cc
         create_subscription_builder_test.cc
         create_topic_builder_test.cc
+        internal/default_ack_handler_impl_test.cc
         internal/emulator_overrides_test.cc
         internal/user_agent_prefix_test.cc
         message_test.cc

--- a/google/cloud/pubsub/internal/default_ack_handler_impl.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.cc
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/default_ack_handler_impl.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+void DefaultAckHandlerImpl::ack() {
+  grpc::ClientContext context;
+  google::pubsub::v1::AcknowledgeRequest request;
+  request.set_subscription(std::move(subscription_));
+  request.add_ack_ids(std::move(ack_id_));
+  (void)stub_->Acknowledge(context, request);
+}
+
+void DefaultAckHandlerImpl::nack() {
+  // TODO(#4553) - implement nacks
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/default_ack_handler_impl.h
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.h
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULT_ACK_HANDLER_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULT_ACK_HANDLER_IMPL_H
+
+#include "google/cloud/pubsub/ack_handler.h"
+#include "google/cloud/pubsub/internal/subscriber_stub.h"
+#include "google/cloud/pubsub/version.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+class DefaultAckHandlerImpl : public pubsub::AckHandler::Impl {
+ public:
+  DefaultAckHandlerImpl(std::shared_ptr<pubsub_internal::SubscriberStub> s,
+                        std::string subscription, std::string ack_id)
+      : stub_(std::move(s)),
+        subscription_(std::move(subscription)),
+        ack_id_(std::move(ack_id)) {}
+
+  ~DefaultAckHandlerImpl() override = default;
+
+  void ack() override;
+  void nack() override;
+
+  std::string ack_id() const override { return ack_id_; }
+
+ private:
+  std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
+  std::string subscription_;
+  std::string ack_id_;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULT_ACK_HANDLER_IMPL_H

--- a/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/default_ack_handler_impl.h"
+#include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::testing::_;
+
+TEST(DefaultAckHandlerTest, Basic) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, Acknowledge(_, _))
+      .WillOnce([](grpc::ClientContext&,
+                   google::pubsub::v1::AcknowledgeRequest const& request) {
+        EXPECT_EQ("test-subscription", request.subscription());
+        EXPECT_EQ(1, request.ack_ids_size());
+        EXPECT_EQ("test-ack-id", request.ack_ids(0));
+        return Status{};
+      });
+
+  DefaultAckHandlerImpl handler(mock, "test-subscription", "test-ack-id");
+  EXPECT_EQ("test-ack-id", handler.ack_id());
+  ASSERT_NO_FATAL_FAILURE(handler.ack());
+  ASSERT_NO_FATAL_FAILURE(handler.nack());
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -21,6 +21,7 @@ pubsub_client_hdrs = [
     "connection_options.h",
     "create_subscription_builder.h",
     "create_topic_builder.h",
+    "internal/default_ack_handler_impl.h",
     "internal/emulator_overrides.h",
     "internal/publisher_stub.h",
     "internal/subscriber_stub.h",
@@ -44,6 +45,7 @@ pubsub_client_hdrs = [
 pubsub_client_srcs = [
     "ack_handler.cc",
     "connection_options.cc",
+    "internal/default_ack_handler_impl.cc",
     "internal/emulator_overrides.cc",
     "internal/publisher_stub.cc",
     "internal/subscriber_stub.cc",

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -20,6 +20,7 @@ pubsub_client_unit_tests = [
     "ack_handler_test.cc",
     "create_subscription_builder_test.cc",
     "create_topic_builder_test.cc",
+    "internal/default_ack_handler_impl_test.cc",
     "internal/emulator_overrides_test.cc",
     "internal/user_agent_prefix_test.cc",
     "message_test.cc",


### PR DESCRIPTION
Move `pubsub_internal::DefaultAckHandlerImpl` to its own file, this is a
bit of an overkill right now. I am about to add more functionality,
which would be easier to test with this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4619)
<!-- Reviewable:end -->
