### PR TITLE
cleanup: restore inclusion of backwards-compatibility headers

### DIFF
--- a/google/cloud/bigquery/read_result.h
+++ b/google/cloud/bigquery/read_result.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/row_set.h"
 #include "google/cloud/bigquery/version.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 

--- a/google/cloud/bigquery/row_set.h
+++ b/google/cloud/bigquery/row_set.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigquery/row.h"
 #include "google/cloud/bigquery/version.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <functional>

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -28,6 +28,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -25,6 +25,7 @@
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <grpcpp/grpcpp.h>

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -35,6 +35,7 @@
 #include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/v1/spanner.pb.h>

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <string>

--- a/google/cloud/spanner/iam_updater.h
+++ b/google/cloud/spanner/iam_updater.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_IAM_UPDATER_H
 
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <google/iam/v1/policy.pb.h>
 #include <functional>

--- a/google/cloud/spanner/partition_options.h
+++ b/google/cloud/spanner/partition_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_PARTITION_OPTIONS_H
 
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <google/spanner/v1/spanner.pb.h>
 

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_QUERY_OPTIONS_H
 
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <string>
 

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <google/spanner/v1/spanner.pb.h>
 #include <memory>

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -16,11 +16,13 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H
 
 #include "google/cloud/spanner/bytes.h"
+#include "google/cloud/spanner/date.h"
 #include "google/cloud/spanner/internal/tuple_utils.h"
 #include "google/cloud/spanner/numeric.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/time/civil_time.h"
 #include "absl/types/optional.h"

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -21,6 +21,7 @@
 #include "google/cloud/storage/lifecycle_rule.h"
 #include "google/cloud/storage/object_access_control.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <map>
 #include <tuple>

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/storage_class.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/parse_rfc3339.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/time/civil_time.h"
 #include "absl/types/optional.h"

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <memory>
 #include <set>

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <condition_variable>
 #include <ctime>

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/complex_option.h"
 #include "google/cloud/storage/object_access_control.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <map>

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <algorithm>
 #include <cstdint>

--- a/google/cloud/storage/well_known_parameters.h
+++ b/google/cloud/storage/well_known_parameters.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/ios_flags_saver.h"
+#include "google/cloud/optional.h"
 #include "absl/types/optional.h"
 #include <cstdint>
 #include <iomanip>


### PR DESCRIPTION
Keep including `google/cloud/optional.h` and `google/cloud/spanner/date.h`
in our exported headers, even though the library does not need them. This
gives users who rely on transitive inclusion a chance to update references
from `google::cloud::optional` and `google::cloud::spanner::Date`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4621)
<!-- Reviewable:end -->
