### PR TITLE
feat(pubsub): implement AckHandler::nack

### DIFF
--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
+#include <map>
 
 namespace google {
 namespace cloud {
@@ -56,21 +57,22 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       [topic_admin, &topic]() mutable { topic_admin.DeleteTopic(topic); });
 
   auto subscription_metadata = subscription_admin.CreateSubscription(
-      CreateSubscriptionBuilder(subscription, topic));
+      CreateSubscriptionBuilder(subscription, topic)
+          .set_ack_deadline(std::chrono::seconds(10)));
   ASSERT_STATUS_OK(subscription_metadata);
 
   auto publisher = Publisher(MakePublisherConnection(topic));
   auto subscriber = Subscriber(MakeSubscriberConnection());
 
   std::mutex mu;
-  std::vector<std::string> ids;
+  std::map<std::string, int> ids;
   for (auto const* data : {"message-0", "message-1", "message-2"}) {
     auto response =
         publisher.Publish(MessageBuilder{}.SetData(data).Build()).get();
     EXPECT_STATUS_OK(response);
     if (response) {
       std::lock_guard<std::mutex> lk(mu);
-      ids.push_back(*std::move(response));
+      ids.emplace(*std::move(response), 0);
     }
   }
   EXPECT_FALSE(ids.empty());
@@ -78,16 +80,22 @@ TEST(MessageIntegrationTest, PublishPullAck) {
   promise<void> ids_empty;
   auto handler = [&](pubsub::Message const& m, AckHandler h) {
     SCOPED_TRACE("Search for message " + m.message_id());
-    ASSERT_NO_FATAL_FAILURE(std::move(h).ack());
     std::lock_guard<std::mutex> lk(mu);
-    auto i = std::find(ids.begin(), ids.end(), m.message_id());
-    if (i != ids.end()) {
-      // Remember that Cloud Pub/Sub has "at least once" semantics, so a dup is
-      // perfectly possible, in that case the message would not be in the list
-      // of pending ids.
-      ids.erase(i);
-      if (ids.empty()) ids_empty.set_value();
+    auto i = ids.find(m.message_id());
+    // Remember that Cloud Pub/Sub has "at least once" semantics, so a dup is
+    // perfectly possible, in that case the message would not be in the map of
+    // of pending ids.
+    if (i == ids.end()) return;
+    // The first time just NACK the message to exercise that path, we expect
+    // Cloud Pub/Sub to retry.
+    if (i->second == 0) {
+      std::move(h).nack();
+      ++i->second;
+      return;
     }
+    std::move(h).ack();
+    ids.erase(i);
+    if (ids.empty()) ids_empty.set_value();
   };
 
   auto result = subscriber.Subscribe(subscription, handler);

--- a/google/cloud/pubsub/internal/default_ack_handler_impl.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.cc
@@ -28,7 +28,12 @@ void DefaultAckHandlerImpl::ack() {
 }
 
 void DefaultAckHandlerImpl::nack() {
-  // TODO(#4553) - implement nacks
+  grpc::ClientContext context;
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_subscription(std::move(subscription_));
+  request.add_ack_ids(std::move(ack_id_));
+  request.set_ack_deadline_seconds(0);
+  (void)stub_->ModifyAckDeadline(context, request);
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -80,6 +80,15 @@ class DefaultSubscriberStub : public SubscriberStub {
     return {};
   }
 
+  Status ModifyAckDeadline(
+      grpc::ClientContext& context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = grpc_stub_->ModifyAckDeadline(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return {};
+  }
+
  private:
   std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;
 };

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -64,6 +64,11 @@ class SubscriberStub {
   virtual Status Acknowledge(
       grpc::ClientContext& context,
       google::pubsub::v1::AcknowledgeRequest const& request) = 0;
+
+  /// Modify the ACK deadline.
+  virtual Status ModifyAckDeadline(
+      grpc::ClientContext& context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -54,6 +54,11 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
               (grpc::ClientContext&,
                google::pubsub::v1::AcknowledgeRequest const&),
               (override));
+
+  MOCK_METHOD(Status, ModifyAckDeadline,
+              (grpc::ClientContext&,
+               google::pubsub::v1::ModifyAckDeadlineRequest const&),
+              (override));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
With this PR applications can NACK a message early, allowing other
subscribers to handle the same message. Changed the integration test to
exercise this path.

Fixes #4553 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4641)
<!-- Reviewable:end -->
