### PR TITLE
cleanup(pubsub): use better naming in samples

### DIFF
--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -20,9 +20,9 @@ namespace cloud {
 namespace pubsub {
 namespace examples {
 
-google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
+google::cloud::testing_util::Commands::value_type CreateTopicAdminCommand(
     std::string const& name, std::vector<std::string> const& arg_names,
-    PublisherCommand const& command) {
+    TopicAdminCommand const& command) {
   auto adapter = [=](std::vector<std::string> const& argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         argv.size() != arg_names.size()) {
@@ -41,9 +41,10 @@ google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
                                                            std::move(adapter)};
 }
 
-google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
-    std::string const& name, std::vector<std::string> const& arg_names,
-    SubscriberCommand const& command) {
+google::cloud::testing_util::Commands::value_type
+CreateSubscriptionAdminCommand(std::string const& name,
+                               std::vector<std::string> const& arg_names,
+                               SubscriptionAdminCommand const& command) {
   auto adapter = [=](std::vector<std::string> const& argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         argv.size() != arg_names.size()) {

--- a/google/cloud/pubsub/samples/pubsub_samples_common.h
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.h
@@ -24,19 +24,21 @@ namespace cloud {
 namespace pubsub {
 namespace examples {
 
-using PublisherCommand = std::function<void(
+using TopicAdminCommand = std::function<void(
     google::cloud::pubsub::TopicAdminClient, std::vector<std::string> const&)>;
-using SubscriberCommand =
+
+google::cloud::testing_util::Commands::value_type CreateTopicAdminCommand(
+    std::string const& name, std::vector<std::string> const& arg_names,
+    TopicAdminCommand const& command);
+
+using SubscriptionAdminCommand =
     std::function<void(google::cloud::pubsub::SubscriptionAdminClient,
                        std::vector<std::string> const&)>;
 
-google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
-    std::string const& name, std::vector<std::string> const& arg_names,
-    PublisherCommand const& command);
-
-google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
-    std::string const& name, std::vector<std::string> const& arg_names,
-    SubscriberCommand const& command);
+google::cloud::testing_util::Commands::value_type
+CreateSubscriptionAdminCommand(std::string const& name,
+                               std::vector<std::string> const& arg_names,
+                               SubscriptionAdminCommand const& command);
 
 }  // namespace examples
 }  // namespace pubsub

--- a/google/cloud/pubsub/samples/pubsub_samples_common_test.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common_test.cc
@@ -24,7 +24,7 @@ namespace {
 
 using ::testing::HasSubstr;
 
-TEST(PubSubSamplesCommon, PublisherCommand) {
+TEST(PubSubSamplesCommon, TopicAdminCommand) {
   using ::google::cloud::testing_util::Usage;
 
   // Pretend we are using the emulator to avoid loading the default
@@ -40,7 +40,7 @@ TEST(PubSubSamplesCommon, PublisherCommand) {
     EXPECT_EQ("b", argv[1]);
   };
   auto const actual =
-      CreatePublisherCommand("command-name", {"foo", "bar"}, command);
+      CreateTopicAdminCommand("command-name", {"foo", "bar"}, command);
   EXPECT_EQ("command-name", actual.first);
   EXPECT_THROW(
       try { actual.second({}); } catch (Usage const& ex) {
@@ -55,7 +55,7 @@ TEST(PubSubSamplesCommon, PublisherCommand) {
   EXPECT_EQ(1, call_count);
 }
 
-TEST(PubSubSamplesCommon, SubscriberCommand) {
+TEST(PubSubSamplesCommon, SubscriptionAdminCommand) {
   using ::google::cloud::testing_util::Usage;
 
   // Pretend we are using the emulator to avoid loading the default
@@ -71,7 +71,7 @@ TEST(PubSubSamplesCommon, SubscriberCommand) {
     EXPECT_EQ("b", argv[1]);
   };
   auto const actual =
-      CreateSubscriberCommand("command-name", {"foo", "bar"}, command);
+      CreateSubscriptionAdminCommand("command-name", {"foo", "bar"}, command);
   EXPECT_EQ("command-name", actual.first);
   EXPECT_THROW(
       try { actual.second({}); } catch (Usage const& ex) {

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -210,24 +210,24 @@ void AutoRun(std::vector<std::string> const& argv) {
 }  // namespace
 
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
-  using ::google::cloud::pubsub::examples::CreatePublisherCommand;
-  using ::google::cloud::pubsub::examples::CreateSubscriberCommand;
+  using ::google::cloud::pubsub::examples::CreateSubscriptionAdminCommand;
+  using ::google::cloud::pubsub::examples::CreateTopicAdminCommand;
   using ::google::cloud::testing_util::Example;
 
   Example example({
-      CreatePublisherCommand("create-topic", {"project-id", "topic-id"},
-                             CreateTopic),
-      CreatePublisherCommand("list-topics", {"project-id"}, ListTopics),
-      CreatePublisherCommand("delete-topic", {"project-id", "topic-id"},
-                             DeleteTopic),
-      CreateSubscriberCommand("create-subscription",
-                              {"project-id", "topic-id", "subscription-id"},
-                              CreateSubscription),
-      CreateSubscriberCommand("list-subscriptions", {"project-id"},
-                              ListSubscriptions),
-      CreateSubscriberCommand("delete-subscription",
-                              {"project-id", "subscription-id"},
-                              DeleteSubscription),
+      CreateTopicAdminCommand("create-topic", {"project-id", "topic-id"},
+                              CreateTopic),
+      CreateTopicAdminCommand("list-topics", {"project-id"}, ListTopics),
+      CreateTopicAdminCommand("delete-topic", {"project-id", "topic-id"},
+                              DeleteTopic),
+      CreateSubscriptionAdminCommand(
+          "create-subscription", {"project-id", "topic-id", "subscription-id"},
+          CreateSubscription),
+      CreateSubscriptionAdminCommand("list-subscriptions", {"project-id"},
+                                     ListSubscriptions),
+      CreateSubscriptionAdminCommand("delete-subscription",
+                                     {"project-id", "subscription-id"},
+                                     DeleteSubscription),
       {"auto", AutoRun},
   });
   return example.Run(argc, argv);


### PR DESCRIPTION
Some of the helper functions needed better names after the `Publisher`
-> `TopicAdminClient` renaming. And I need the current names to start
writing publisher and subscription examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4643)
<!-- Reviewable:end -->
