### PR TITLE
feat(pubsub): use CQ to run subscription callbacks

### DIFF
--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -36,10 +36,12 @@ class SubscriberConnection {
  public:
   virtual ~SubscriberConnection() = 0;
 
+  // TODO(#4556) - consider a lighter weight type-erasure
+  using CallbackType = std::function<void(Message, AckHandler)>;
+
   struct SubscribeParams {
     std::string full_subscription_name;
-    // TODO(#4556) - consider a lighter weight type-erasure
-    std::function<void(Message, AckHandler)> callback;
+    CallbackType callback;
   };
   virtual future<Status> Subscribe(SubscribeParams p) = 0;
 };
@@ -67,7 +69,8 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    std::shared_ptr<SubscriberStub> stub);
+    std::shared_ptr<SubscriberStub> stub,
+    pubsub::ConnectionOptions const& options);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -25,13 +25,14 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::testing::_;
+using ::testing::AtLeast;
 
 TEST(SubscriberConnectionTest, Basic) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   Subscription const subscription("test-project", "test-subscription");
 
   EXPECT_CALL(*mock, Pull(_, _))
-      .Times(testing::AtLeast(1))
+      .Times(AtLeast(1))
       .WillRepeatedly([&](grpc::ClientContext&,
                           google::pubsub::v1::PullRequest const& request) {
         EXPECT_EQ(subscription.FullName(), request.subscription());
@@ -42,7 +43,7 @@ TEST(SubscriberConnectionTest, Basic) {
         return make_status_or(response);
       });
   EXPECT_CALL(*mock, Acknowledge(_, _))
-      .Times(testing::AtLeast(1))
+      .Times(AtLeast(1))
       .WillRepeatedly(
           [&](grpc::ClientContext&,
               google::pubsub::v1::AcknowledgeRequest const& request) {
@@ -54,7 +55,7 @@ TEST(SubscriberConnectionTest, Basic) {
             return Status{};
           });
 
-  auto subscriber = pubsub_internal::MakeSubscriberConnection(mock);
+  auto subscriber = pubsub_internal::MakeSubscriberConnection(mock, {});
   std::atomic_flag received_one{false};
   promise<void> waiter;
   auto handler = [&](Message const& m, AckHandler h) {
@@ -76,17 +77,87 @@ TEST(SubscriberConnectionTest, PullFailure) {
 
   auto const expected = Status(StatusCode::kPermissionDenied, "uh-oh");
   EXPECT_CALL(*mock, Pull(_, _))
-      .Times(testing::AtLeast(1))
+      .Times(AtLeast(1))
       .WillRepeatedly([&](grpc::ClientContext&,
                           google::pubsub::v1::PullRequest const& request) {
         EXPECT_EQ(subscription.FullName(), request.subscription());
         return StatusOr<google::pubsub::v1::PullResponse>(expected);
       });
 
-  auto subscriber = pubsub_internal::MakeSubscriberConnection(mock);
+  auto subscriber = pubsub_internal::MakeSubscriberConnection(mock, {});
   auto handler = [&](Message const&, AckHandler const&) {};
   auto response = subscriber->Subscribe({subscription.FullName(), handler});
   EXPECT_EQ(expected, response.get());
+}
+
+/// @test Verify callbacks are scheduled in the background threads.
+TEST(SubscriberConnectionTest, ScheduleCallbacks) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  Subscription const subscription("test-project", "test-subscription");
+
+  std::mutex mu;
+  int count = 0;
+  EXPECT_CALL(*mock, Pull(_, _))
+      .Times(AtLeast(1))
+      .WillRepeatedly([&](grpc::ClientContext&,
+                          google::pubsub::v1::PullRequest const& request) {
+        EXPECT_EQ(subscription.FullName(), request.subscription());
+        google::pubsub::v1::PullResponse response;
+        for (int i = 0; i != 2; ++i) {
+          auto& m = *response.add_received_messages();
+          std::lock_guard<std::mutex> lk(mu);
+          m.set_ack_id("test-ack-id-" + std::to_string(count));
+          m.mutable_message()->set_message_id("test-message-id-" +
+                                              std::to_string(count));
+          ++count;
+        }
+        return make_status_or(response);
+      });
+
+  std::atomic<int> expected_ack_id{0};
+  EXPECT_CALL(*mock, Acknowledge(_, _))
+      .Times(AtLeast(1))
+      .WillRepeatedly(
+          [&](grpc::ClientContext&,
+              google::pubsub::v1::AcknowledgeRequest const& request) {
+            EXPECT_EQ(subscription.FullName(), request.subscription());
+            for (auto const& a : request.ack_ids()) {
+              EXPECT_EQ("test-ack-id-" + std::to_string(expected_ack_id), a);
+              ++expected_ack_id;
+            }
+            return Status{};
+          });
+
+  google::cloud::CompletionQueue cq;
+  auto subscriber = pubsub_internal::MakeSubscriberConnection(
+      mock, ConnectionOptions{grpc::InsecureChannelCredentials()}
+                .DisableBackgroundThreads(cq));
+
+  std::vector<std::thread> tasks;
+  std::generate_n(std::back_inserter(tasks), 4,
+                  [&] { return std::thread([&cq] { cq.Run(); }); });
+  std::set<std::thread::id> ids;
+  std::transform(tasks.begin(), tasks.end(), std::inserter(ids, ids.end()),
+                 [](std::thread const& t) { return t.get_id(); });
+
+  std::atomic<int> expected_message_id{0};
+  auto handler = [&](Message const& m, AckHandler h) {
+    EXPECT_EQ("test-message-id-" + std::to_string(expected_message_id),
+              m.message_id());
+    std::move(h).ack();
+    ++expected_message_id;
+  };
+  auto response = subscriber->Subscribe({subscription.FullName(), handler});
+
+  while (expected_ack_id.load() < 100) {
+    auto s = response.wait_for(std::chrono::milliseconds(5));
+    if (s != std::future_status::timeout) break;
+  }
+  response.cancel();
+  EXPECT_STATUS_OK(response.get());
+
+  cq.Shutdown();
+  for (auto& t : tasks) t.join();
 }
 
 }  // namespace


### PR DESCRIPTION
With this change there are no magic threads to run each subscriber.
Instead the work is executed in the background threads. To avoid
blocking for a long time while handling a large response the code the
library uses a different RunAsync() to execute each callback. For now
these are sequenced to work well with ordering keys. A future change
will allow applications to choose out of order execution.

Fixes #4555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4653)
<!-- Reviewable:end -->
