### PR TITLE
feat(pubsub): implement Publisher::Flush()

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -39,6 +39,7 @@ class BatchingPublisherConnection
   }
 
   future<StatusOr<std::string>> Publish(PublishParams p) override;
+  void Flush(FlushParams) override;
 
  private:
   explicit BatchingPublisherConnection(
@@ -53,7 +54,7 @@ class BatchingPublisherConnection
 
   void OnTimer();
   void MaybeFlush(std::unique_lock<std::mutex> lk);
-  void Flush(std::unique_lock<std::mutex> lk);
+  void FlushImpl(std::unique_lock<std::mutex> lk);
 
   pubsub::Topic topic_;
   std::string topic_full_name_;

--- a/google/cloud/pubsub/mocks/mock_publisher_connection.h
+++ b/google/cloud/pubsub/mocks/mock_publisher_connection.h
@@ -27,6 +27,8 @@ class MockPublisherConnection : public pubsub::PublisherConnection {
  public:
   MOCK_METHOD(future<StatusOr<std::string>>, Publish,
               (pubsub::PublisherConnection::PublishParams), (override));
+  MOCK_METHOD(void, Flush, (pubsub::PublisherConnection::FlushParams),
+              (override));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -120,6 +120,19 @@ class Publisher {
     return connection_->Publish({std::move(m)});
   }
 
+  /**
+   * Flush any unpublished messages.
+   *
+   * As applications can configure a `Publisher` to buffer messages, it is
+   * sometimes useful to flush them before any of the normal criteria to send
+   * the RPCs is met.
+   *
+   * @note This function does not return any status or error codes, the
+   *     application can use the `future<StatusOr<std::string>>` returned in
+   *     each `Publish()` call to find out what the results are.
+   */
+  void Flush() { connection_->Flush({}); }
+
  private:
   std::shared_ptr<PublisherConnection> connection_;
 };

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -33,6 +33,7 @@ class ContainingPublisherConnection : public PublisherConnection {
   future<StatusOr<std::string>> Publish(PublishParams p) override {
     return child_->Publish(std::move(p));
   }
+  void Flush(FlushParams p) override { child_->Flush(std::move(p)); }
 
  private:
   std::shared_ptr<BackgroundThreads> background_;

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -40,6 +40,9 @@ class PublisherConnection {
     Message message;
   };
   virtual future<StatusOr<std::string>> Publish(PublishParams p) = 0;
+
+  struct FlushParams {};
+  virtual void Flush(FlushParams) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/publisher_test.cc
+++ b/google/cloud/pubsub/publisher_test.cc
@@ -32,8 +32,10 @@ TEST(PublisherTest, PublishSimple) {
         EXPECT_EQ("test-data-0", p.message.data());
         return make_ready_future(StatusOr<std::string>("test-id-0"));
       });
+  EXPECT_CALL(*mock, Flush(_)).Times(1);
 
   Publisher publisher(mock);
+  publisher.Flush();
   auto id =
       publisher.Publish(pubsub::MessageBuilder{}.SetData("test-data-0").Build())
           .get();


### PR DESCRIPTION
This function allows applications to flush any messages sitting in the
`pubsub::PublisherConnection` buffers.

Part of the work for #4581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4654)
<!-- Reviewable:end -->
