### PR TITLE
fix(pubsub): code now builds with MSVC 2019

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -128,7 +128,7 @@ void BatchingPublisherConnection::Flush(std::unique_lock<std::mutex> lk) {
   batch.waiters.reserve(pending_.size());
   google::pubsub::v1::PublishRequest request;
   request.set_topic(topic_full_name_);
-  request.mutable_messages()->Reserve(pending_.size());
+  request.mutable_messages()->Reserve(static_cast<int>(pending_.size()));
 
   for (auto& i : pending_) {
     batch.waiters.push_back(std::move(i.response));


### PR DESCRIPTION
Another case of `sizeof(int)` < `sizeof(std::size_t)` and protobuf using
`int` to index its vector-like things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4663)
<!-- Reviewable:end -->
