### PR TITLE
feat(pubsub): implement basic data samples

### DIFF
--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -20,6 +20,54 @@ namespace cloud {
 namespace pubsub {
 namespace examples {
 
+google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
+    std::string const& name, std::vector<std::string> const& arg_names,
+    PublisherCommand const& command) {
+  auto adapter = [=](std::vector<std::string> argv) {
+    auto constexpr kFixedArguments = 2;
+    if ((argv.size() == 1 && argv[0] == "--help") ||
+        argv.size() != arg_names.size() + kFixedArguments) {
+      std::ostringstream os;
+      os << name << " <project-id> <topic-id>";
+      for (auto const& a : arg_names) {
+        os << " <" << a << ">";
+      }
+      throw google::cloud::testing_util::Usage{std::move(os).str()};
+    }
+    Topic const topic(argv.at(0), argv.at(1));
+    argv.erase(argv.begin(), argv.begin() + 2);
+    google::cloud::pubsub::Publisher client(
+        google::cloud::pubsub::MakePublisherConnection(topic, {}));
+    command(std::move(client), std::move(argv));
+  };
+  return google::cloud::testing_util::Commands::value_type{name,
+                                                           std::move(adapter)};
+}
+
+google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
+    std::string const& name, std::vector<std::string> const& arg_names,
+    SubscriberCommand const& command) {
+  auto adapter = [=](std::vector<std::string> argv) {
+    auto constexpr kFixedArguments = 2;
+    if ((argv.size() == 1 && argv[0] == "--help") ||
+        argv.size() != arg_names.size() + kFixedArguments) {
+      std::ostringstream os;
+      os << name << " <project-id> <subscription-id>";
+      for (auto const& a : arg_names) {
+        os << " <" << a << ">";
+      }
+      throw google::cloud::testing_util::Usage{std::move(os).str()};
+    }
+    google::cloud::pubsub::Subscriber client(
+        google::cloud::pubsub::MakeSubscriberConnection());
+    pubsub::Subscription subscription(argv.at(0), argv.at(1));
+    argv.erase(argv.begin(), argv.begin() + 2);
+    command(std::move(client), std::move(subscription), std::move(argv));
+  };
+  return google::cloud::testing_util::Commands::value_type{name,
+                                                           std::move(adapter)};
+}
+
 google::cloud::testing_util::Commands::value_type CreateTopicAdminCommand(
     std::string const& name, std::vector<std::string> const& arg_names,
     TopicAdminCommand const& command) {

--- a/google/cloud/pubsub/samples/pubsub_samples_common.h
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.h
@@ -15,6 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SAMPLES_PUBSUB_SAMPLES_COMMON_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SAMPLES_PUBSUB_SAMPLES_COMMON_H
 
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
 #include "google/cloud/pubsub/subscription_admin_client.h"
 #include "google/cloud/pubsub/topic_admin_client.h"
 #include "google/cloud/testing_util/example_driver.h"
@@ -24,16 +26,30 @@ namespace cloud {
 namespace pubsub {
 namespace examples {
 
-using TopicAdminCommand = std::function<void(
-    google::cloud::pubsub::TopicAdminClient, std::vector<std::string> const&)>;
+using PublisherCommand =
+    std::function<void(pubsub::Publisher, std::vector<std::string> const&)>;
+
+google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
+    std::string const& name, std::vector<std::string> const& arg_names,
+    PublisherCommand const& command);
+
+using SubscriberCommand = std::function<void(
+    pubsub::Subscriber, pubsub::Subscription const& subscription,
+    std::vector<std::string> const&)>;
+
+google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
+    std::string const& name, std::vector<std::string> const& arg_names,
+    SubscriberCommand const& command);
+
+using TopicAdminCommand = std::function<void(pubsub::TopicAdminClient,
+                                             std::vector<std::string> const&)>;
 
 google::cloud::testing_util::Commands::value_type CreateTopicAdminCommand(
     std::string const& name, std::vector<std::string> const& arg_names,
     TopicAdminCommand const& command);
 
-using SubscriptionAdminCommand =
-    std::function<void(google::cloud::pubsub::SubscriptionAdminClient,
-                       std::vector<std::string> const&)>;
+using SubscriptionAdminCommand = std::function<void(
+    pubsub::SubscriptionAdminClient, std::vector<std::string> const&)>;
 
 google::cloud::testing_util::Commands::value_type
 CreateSubscriptionAdminCommand(std::string const& name,

--- a/google/cloud/pubsub/samples/pubsub_samples_common_test.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common_test.cc
@@ -24,6 +24,71 @@ namespace {
 
 using ::testing::HasSubstr;
 
+TEST(PubSubSamplesCommon, PublisherCommand) {
+  using ::google::cloud::testing_util::Usage;
+
+  // Pretend we are using the emulator to avoid loading the default
+  // credentials from $HOME, which do not exist when running with Bazel.
+  google::cloud::testing_util::ScopedEnvironment emulator(
+      "PUBSUB_EMULATOR_HOST", "localhost:8085");
+  int call_count = 0;
+  auto command = [&call_count](pubsub::Publisher const&,
+                               std::vector<std::string> const& argv) {
+    ++call_count;
+    ASSERT_EQ(2, argv.size());
+    EXPECT_EQ("a", argv[0]);
+    EXPECT_EQ("b", argv[1]);
+  };
+  auto const actual =
+      CreatePublisherCommand("command-name", {"foo", "bar"}, command);
+  EXPECT_EQ("command-name", actual.first);
+  EXPECT_THROW(
+      try { actual.second({}); } catch (Usage const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("command-name"));
+        EXPECT_THAT(ex.what(), HasSubstr("foo"));
+        EXPECT_THAT(ex.what(), HasSubstr("bar"));
+        throw;
+      },
+      Usage);
+
+  ASSERT_NO_FATAL_FAILURE(
+      actual.second({"test-project", "test-topic", "a", "b"}));
+  EXPECT_EQ(1, call_count);
+}
+
+TEST(PubSubSamplesCommon, SubscriberCommand) {
+  using ::google::cloud::testing_util::Usage;
+
+  // Pretend we are using the emulator to avoid loading the default
+  // credentials from $HOME, which do not exist when running with Bazel.
+  google::cloud::testing_util::ScopedEnvironment emulator(
+      "PUBSUB_EMULATOR_HOST", "localhost:8085");
+  int call_count = 0;
+  auto command = [&call_count](pubsub::Subscriber const&,
+                               pubsub::Subscription const&,
+                               std::vector<std::string> const& argv) {
+    ++call_count;
+    ASSERT_EQ(2, argv.size());
+    EXPECT_EQ("a", argv[0]);
+    EXPECT_EQ("b", argv[1]);
+  };
+  auto const actual =
+      CreateSubscriberCommand("command-name", {"foo", "bar"}, command);
+  EXPECT_EQ("command-name", actual.first);
+  EXPECT_THROW(
+      try { actual.second({}); } catch (Usage const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("command-name"));
+        EXPECT_THAT(ex.what(), HasSubstr("foo"));
+        EXPECT_THAT(ex.what(), HasSubstr("bar"));
+        throw;
+      },
+      Usage);
+
+  ASSERT_NO_FATAL_FAILURE(
+      actual.second({"test-project", "test-subscription", "a", "b"}));
+  EXPECT_EQ(1, call_count);
+}
+
 TEST(PubSubSamplesCommon, TopicAdminCommand) {
   using ::google::cloud::testing_util::Usage;
 


### PR DESCRIPTION
`pubsub_publish` is the basic sample showing how to publish a message.
While `pubsub_subscriber_async_pull` shows how to receive messages.

Fixes #4662 and fixes #4660

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4664)
<!-- Reviewable:end -->
