### PR TITLE
feat: store a Status when invalidating Transactions

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -240,10 +240,9 @@ StatusOr<CommitResult> Client::Commit(
     if (internal::IsSessionNotFound(status)) {
       // Marks the session bad and creates a new Transaction for the next loop.
       internal::Visit(
-          txn,
-          [](internal::SessionHolder& s,
-             StatusOr<google::spanner::v1::TransactionSelector> const&,
-             std::int64_t) {
+          txn, [](internal::SessionHolder& s,
+                  StatusOr<google::spanner::v1::TransactionSelector> const&,
+                  std::int64_t) {
             if (s) s->set_bad();
             return true;
           });

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -242,7 +242,7 @@ StatusOr<CommitResult> Client::Commit(
       internal::Visit(
           txn,
           [](internal::SessionHolder& s,
-             absl::optional<google::spanner::v1::TransactionSelector> const&,
+             StatusOr<google::spanner::v1::TransactionSelector> const&,
              std::int64_t) {
             if (s) s->set_bad();
             return true;

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "absl/memory/memory.h"
+#include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <array>
@@ -700,7 +701,7 @@ TEST(ClientTest, CommitMutations) {
 MATCHER(DoesNotHaveSession, "not bound to a session") {
   return internal::Visit(
       arg, [&](internal::SessionHolder& session,
-               absl::optional<google::spanner::v1::TransactionSelector>&,
+               StatusOr<google::spanner::v1::TransactionSelector>&,
                std::int64_t) {
         if (session) {
           *result_listener << "has session " << session->session_name();
@@ -713,7 +714,7 @@ MATCHER(DoesNotHaveSession, "not bound to a session") {
 MATCHER_P(HasSession, name, "bound to expected session") {
   return internal::Visit(
       arg, [&](internal::SessionHolder& session,
-               absl::optional<google::spanner::v1::TransactionSelector>&,
+               StatusOr<google::spanner::v1::TransactionSelector>&,
                std::int64_t) {
         if (!session) {
           *result_listener << "has no session but expected " << name;
@@ -731,10 +732,10 @@ MATCHER_P(HasSession, name, "bound to expected session") {
 MATCHER(HasBegin, "not bound to a transaction-id nor invalidated") {
   return internal::Visit(
       arg, [&](internal::SessionHolder&,
-               absl::optional<google::spanner::v1::TransactionSelector>& s,
+               StatusOr<google::spanner::v1::TransactionSelector>& s,
                std::int64_t) {
         if (!s) {
-          *result_listener << "has been invalidated";
+          *result_listener << "has status " << s.status();
           return false;
         }
         if (!s->has_begin()) {
@@ -752,7 +753,7 @@ MATCHER(HasBegin, "not bound to a transaction-id nor invalidated") {
 bool SetSessionName(Transaction const& txn, std::string name) {
   return internal::Visit(
       txn, [&name](internal::SessionHolder& session,
-                   absl::optional<google::spanner::v1::TransactionSelector>&,
+                   StatusOr<google::spanner::v1::TransactionSelector>&,
                    std::int64_t) {
         session = internal::MakeDissociatedSessionHolder(std::move(name));
         return true;
@@ -762,7 +763,7 @@ bool SetSessionName(Transaction const& txn, std::string name) {
 bool SetTransactionId(Transaction const& txn, std::string id) {
   return internal::Visit(
       txn, [&id](internal::SessionHolder&,
-                 absl::optional<google::spanner::v1::TransactionSelector>& s,
+                 StatusOr<google::spanner::v1::TransactionSelector>& s,
                  std::int64_t) {
         s->set_id(std::move(id));  // only valid when s.ok()
         return true;

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -700,9 +700,9 @@ TEST(ClientTest, CommitMutations) {
 
 MATCHER(DoesNotHaveSession, "not bound to a session") {
   return internal::Visit(
-      arg, [&](internal::SessionHolder& session,
-               StatusOr<google::spanner::v1::TransactionSelector>&,
-               std::int64_t) {
+      arg,
+      [&](internal::SessionHolder& session,
+          StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t) {
         if (session) {
           *result_listener << "has session " << session->session_name();
           return false;
@@ -713,9 +713,9 @@ MATCHER(DoesNotHaveSession, "not bound to a session") {
 
 MATCHER_P(HasSession, name, "bound to expected session") {
   return internal::Visit(
-      arg, [&](internal::SessionHolder& session,
-               StatusOr<google::spanner::v1::TransactionSelector>&,
-               std::int64_t) {
+      arg,
+      [&](internal::SessionHolder& session,
+          StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t) {
         if (!session) {
           *result_listener << "has no session but expected " << name;
           return false;
@@ -731,9 +731,9 @@ MATCHER_P(HasSession, name, "bound to expected session") {
 
 MATCHER(HasBegin, "not bound to a transaction-id nor invalidated") {
   return internal::Visit(
-      arg, [&](internal::SessionHolder&,
-               StatusOr<google::spanner::v1::TransactionSelector>& s,
-               std::int64_t) {
+      arg,
+      [&](internal::SessionHolder&,
+          StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
         if (!s) {
           *result_listener << "has status " << s.status();
           return false;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -27,7 +27,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include "absl/types/optional.h"
 #include <google/spanner/v1/spanner.pb.h>
 #include <cstdint>
 #include <memory>
@@ -99,70 +98,68 @@ class ConnectionImpl : public Connection {
   Status PrepareSession(SessionHolder& session,
                         bool dissociate_from_pool = false);
 
-  RowStream ReadImpl(
-      SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      ReadParams params);
+  RowStream ReadImpl(SessionHolder& session,
+                     StatusOr<google::spanner::v1::TransactionSelector>& s,
+                     ReadParams params);
 
   StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
       ReadParams const& params, PartitionOptions const& partition_options);
 
   RowStream ExecuteQueryImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   ProfileQueryResult ProfileQueryImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<ProfileDmlResult> ProfileDmlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<ExecutionPlan> AnalyzeSqlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, ExecutePartitionedDmlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      ExecutePartitionedDmlParams params);
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
       PartitionQueryParams const& params);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, ExecuteBatchDmlParams params);
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      ExecuteBatchDmlParams params);
 
   StatusOr<CommitResult> CommitImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
+      StatusOr<google::spanner::v1::TransactionSelector>& s,
       CommitParams params);
 
-  Status RollbackImpl(
-      SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s);
+  Status RollbackImpl(SessionHolder& session,
+                      StatusOr<google::spanner::v1::TransactionSelector>& s);
 
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
       std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
           google::spanner::v1::ExecuteSqlRequest& request)> const&
@@ -171,14 +168,14 @@ class ConnectionImpl : public Connection {
   template <typename ResultType>
   ResultType CommonQueryImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
   template <typename ResultType>
   StatusOr<ResultType> CommonDmlImpl(
       SessionHolder& session,
-      absl::optional<google::spanner::v1::TransactionSelector>& s,
-      std::int64_t seqno, SqlParams params,
+      StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t seqno,
+      SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   Database db_;

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -94,9 +94,9 @@ MATCHER_P(BatchCreateSessionsRequestHasDatabase, database,
 // Matches a spanner::Transaction that is bound to a "bad" session"
 MATCHER(HasBadSession, "bound to a session that's marked bad") {
   return internal::Visit(
-      arg, [&](internal::SessionHolder& session,
-               StatusOr<google::spanner::v1::TransactionSelector>&,
-               std::int64_t) {
+      arg,
+      [&](internal::SessionHolder& session,
+          StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t) {
         if (!session) {
           *result_listener << "has no session";
           return false;
@@ -111,13 +111,13 @@ MATCHER(HasBadSession, "bound to a session that's marked bad") {
 
 // Helper to set the Transaction's ID. Requires selector.ok().
 void SetTransactionId(Transaction& txn, std::string tid) {
-  internal::Visit(
-      txn, [&tid](SessionHolder&,
-                  StatusOr<spanner_proto::TransactionSelector>& selector,
-                  std::int64_t) {
-        selector->set_id(std::move(tid));
-        return 0;
-      });
+  internal::Visit(txn,
+                  [&tid](SessionHolder&,
+                         StatusOr<spanner_proto::TransactionSelector>& selector,
+                         std::int64_t) {
+                    selector->set_id(std::move(tid));
+                    return 0;
+                  });
 }
 
 // Helper to mark the Transaction as invalid.

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -68,9 +68,9 @@ class TransactionImpl {
   // If the TransactionSelector is in the "begin" state and the operation
   // successfully allocates a transaction ID, then the functor must assign
   // that ID to the selector. If the functor fails to allocate a transaction
-  // ID then it should assign the status of the failing operation to the
-  // selector. All of this is independent of whether the functor itself
-  // succeeds.
+  // ID then it must assign a `Status` that indicates why transaction
+  // allocation failed (i.e. the result of `BeginTransaction`) to the parameter.
+  // All of this is independent of whether the functor itself succeeds.
   //
   // If the TransactionSelector is not in the "begin" state then the functor
   // must not modify it. Rather it should use either the transaction ID or

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -19,7 +19,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/port_platform.h"
-#include "absl/types/optional.h"
+#include "google/cloud/status_or.h"
 #include <google/spanner/v1/transaction.pb.h>
 #include <condition_variable>
 #include <cstdint>
@@ -35,7 +35,7 @@ namespace internal {
 template <typename Functor>
 using VisitInvokeResult = ::google::cloud::internal::invoke_result_t<
     Functor, SessionHolder&,
-    absl::optional<google::spanner::v1::TransactionSelector>&, std::int64_t>;
+    StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t>;
 
 /**
  * The internal representation of a google::cloud::spanner::Transaction.
@@ -68,8 +68,9 @@ class TransactionImpl {
   // If the TransactionSelector is in the "begin" state and the operation
   // successfully allocates a transaction ID, then the functor must assign
   // that ID to the selector. If the functor fails to allocate a transaction
-  // ID then it should place the selector into an error state. All of this
-  // is independent of whether the functor itself succeeds.
+  // ID then it should assign the status of the failing operation to the
+  // selector. All of this is independent of whether the functor itself
+  // succeeds.
   //
   // If the TransactionSelector is not in the "begin" state then the functor
   // must not modify it. Rather it should use either the transaction ID or
@@ -80,7 +81,7 @@ class TransactionImpl {
   VisitInvokeResult<Functor> Visit(Functor&& f) {
     static_assert(google::cloud::internal::is_invocable<
                       Functor, SessionHolder&,
-                      absl::optional<google::spanner::v1::TransactionSelector>&,
+                      StatusOr<google::spanner::v1::TransactionSelector>&,
                       std::int64_t>::value,
                   "TransactionImpl::Visit() functor has incompatible type.");
     std::int64_t seqno;
@@ -135,7 +136,7 @@ class TransactionImpl {
   std::mutex mu_;
   std::condition_variable cond_;
   SessionHolder session_;
-  absl::optional<google::spanner::v1::TransactionSelector> selector_;
+  StatusOr<google::spanner::v1::TransactionSelector> selector_;
   std::int64_t seqno_;
 };
 

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -92,9 +92,9 @@ class Client {
 
  private:
   ResultSet Read(SessionHolder& session,
-                 StatusOr<TransactionSelector>& selector,
-                 std::int64_t seqno, std::string const& table,
-                 KeySet const& keys, std::vector<std::string> const& columns);
+                 StatusOr<TransactionSelector>& selector, std::int64_t seqno,
+                 std::string const& table, KeySet const& keys,
+                 std::vector<std::string> const& columns);
 
   Mode mode_;
   const Status failed_txn_status_{StatusCode::kInternal, "Bad transaction"};

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -43,9 +43,9 @@ MATCHER_P2(
     HasSessionAndTransactionId, session_id, transaction_id,
     "Verifies a Transaction has the expected Session and Transaction IDs") {
   return google::cloud::spanner::internal::Visit(
-      arg, [&](google::cloud::spanner::internal::SessionHolder& session,
-               StatusOr<google::spanner::v1::TransactionSelector>& s,
-               std::int64_t) {
+      arg,
+      [&](google::cloud::spanner::internal::SessionHolder& session,
+          StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
         bool result = true;
         if (!session) {
           *result_listener << "Session ID missing (expected " << session_id

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -57,8 +57,10 @@ MATCHER_P2(
           result = false;
         }
         if (!s) {
-          *result_listener << "Transaction invalid (expected " << transaction_id
-                           << ")";
+          *result_listener << "Transaction ID missing (expected "
+                           << transaction_id << " but found status "
+                           << s.status() << ")";
+
           result = false;
         } else if (s->id() != transaction_id) {
           *result_listener << "Transaction ID mismatch: " << s->id()

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/status_or.h"
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 #include <cstdint>
@@ -43,7 +44,7 @@ MATCHER_P2(
     "Verifies a Transaction has the expected Session and Transaction IDs") {
   return google::cloud::spanner::internal::Visit(
       arg, [&](google::cloud::spanner::internal::SessionHolder& session,
-               absl::optional<google::spanner::v1::TransactionSelector>& s,
+               StatusOr<google::spanner::v1::TransactionSelector>& s,
                std::int64_t) {
         bool result = true;
         if (!session) {

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -80,7 +80,7 @@ TEST(Transaction, Visit) {
   std::int64_t a_seqno;
   internal::Visit(
       a, [&a_seqno](internal::SessionHolder& /*session*/,
-                    absl::optional<google::spanner::v1::TransactionSelector>& s,
+                    StatusOr<google::spanner::v1::TransactionSelector>& s,
                     std::int64_t seqno) {
         EXPECT_TRUE(s->has_begin());
         EXPECT_TRUE(s->begin().has_read_only());
@@ -90,7 +90,7 @@ TEST(Transaction, Visit) {
       });
   internal::Visit(
       a, [a_seqno](internal::SessionHolder& /*session*/,
-                   absl::optional<google::spanner::v1::TransactionSelector>& s,
+                   StatusOr<google::spanner::v1::TransactionSelector>& s,
                    std::int64_t seqno) {
         EXPECT_EQ("test-txn-id", s->id());
         EXPECT_GT(seqno, a_seqno);
@@ -104,7 +104,7 @@ TEST(Transaction, SessionAffinity) {
   internal::Visit(
       a,
       [&a_session](internal::SessionHolder& session,
-                   absl::optional<google::spanner::v1::TransactionSelector>& s,
+                   StatusOr<google::spanner::v1::TransactionSelector>& s,
                    std::int64_t) {
         EXPECT_FALSE(session);
         EXPECT_TRUE(s->has_begin());
@@ -116,7 +116,7 @@ TEST(Transaction, SessionAffinity) {
   internal::Visit(
       b,
       [&a_session](internal::SessionHolder& session,
-                   absl::optional<google::spanner::v1::TransactionSelector>& s,
+                   StatusOr<google::spanner::v1::TransactionSelector>& s,
                    std::int64_t) {
         EXPECT_EQ(a_session, session);  // session affinity
         EXPECT_TRUE(s->has_begin());    // but a new transaction

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -102,10 +102,9 @@ TEST(Transaction, SessionAffinity) {
   auto a_session = internal::MakeDissociatedSessionHolder("SessionAffinity");
   Transaction a = MakeReadWriteTransaction();
   internal::Visit(
-      a,
-      [&a_session](internal::SessionHolder& session,
-                   StatusOr<google::spanner::v1::TransactionSelector>& s,
-                   std::int64_t) {
+      a, [&a_session](internal::SessionHolder& session,
+                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      std::int64_t) {
         EXPECT_FALSE(session);
         EXPECT_TRUE(s->has_begin());
         session = a_session;
@@ -114,10 +113,9 @@ TEST(Transaction, SessionAffinity) {
       });
   Transaction b = MakeReadWriteTransaction(a);
   internal::Visit(
-      b,
-      [&a_session](internal::SessionHolder& session,
-                   StatusOr<google::spanner::v1::TransactionSelector>& s,
-                   std::int64_t) {
+      b, [&a_session](internal::SessionHolder& session,
+                      StatusOr<google::spanner::v1::TransactionSelector>& s,
+                      std::int64_t) {
         EXPECT_EQ(a_session, session);  // session affinity
         EXPECT_TRUE(s->has_begin());    // but a new transaction
         return 0;


### PR DESCRIPTION
after further discussion, @devbww and I reversed the decision in #4545
to use `optional` to mark a `Transaction` invalid, and instead we will
store and propagate the `Status` of the failed `BeginTransaction`.

we also discussed how `Rollback` should function in various failure
scenarios, and I did some testing making manual RPCs to spanner.
When `Rollback` is called with an invalid `Transaction` it now
propagates the `Status` instead of returning `OK`. I also left a TODO
to change the behavior in the `has_begin` case to better match backend
behavior.

part of #4516

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4670)
<!-- Reviewable:end -->
