### PR TITLE
ci: use warnings-as-errors on Windows+MSVC+Bazel

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -24,5 +24,5 @@ config_setting(
     },
     values = {
         "cpu": "x64_windows",
-    }
+    },
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -15,3 +15,14 @@
 licenses(["notice"])  # Apache v2
 
 package(default_visibility = ["//:__subpackages__"])
+
+# Determine if the code should be compiled with -Wall -Werror
+config_setting(
+    name = "msvc_werror",
+    define_values = {
+        "GOOGLE_CLOUD_CPP_ENABLE_WERROR": "ON",
+    },
+    values = {
+        "cpu": "x64_windows",
+    }
+)

--- a/bazel/werror_copts.bzl
+++ b/bazel/werror_copts.bzl
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
-
-licenses(["notice"])  # Apache 2.0
-
-load("//bazel:werror_copts.bzl", "WERROR_COPTS")
-
-cc_test(
-    name = "common_install_test",
-    srcs = ["common_install_test.cc"],
-    copts = WERROR_COPTS,
-    deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
-        "//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
-        "@com_google_googletest//:gtest_main",
+# These are the flags used to compile the library in our builds. They might
+# be too strict for most applications, but are helpful for us. We do not
+# require that applications use them, and are only enabled if Bazel if
+# invoked with `--define GOOGLE_CLOUD_CPP_ENABLE_WERROR=ON` on Windows.
+WERROR_COPTS = select({
+    "//bazel:msvc_werror": [
+        "/W3",
+        "/WX",
+        "/experimental:external",
+        "/external:W0",
+        "/external:anglebrackets",
     ],
-)
+    "//conditions:default": [
+    ],
+})

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -118,12 +118,13 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
 
 $test_flags = @("--test_output=errors",
                 "--verbose_failures=true",
-                "--keep_going")
-$build_flags = @("--keep_going")
+                "--keep_going",
+                "--define", "GOOGLE_CLOUD_CPP_ENABLE_WERROR=ON")
+$build_flags = @("--keep_going", "--define", "GOOGLE_CLOUD_CPP_ENABLE_WERROR=ON")
 
 if (${env:BUILD_NAME} -eq "bazel-release") {
     $test_flags+=("-c", "opt")
-    $build_flags+=("-c", "opt")
+    $build_flags+=("-c", "opt", "--define")
 }
 
 $env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"

--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -16,6 +16,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
+
 genrule(
     name = "generate_build_info",
     srcs = ["internal/build_info.cc.in"],
@@ -38,6 +40,7 @@ cc_library(
     name = "google_cloud_cpp_common",
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/types:optional",
@@ -52,6 +55,7 @@ load(
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],
@@ -70,6 +74,7 @@ load(":google_cloud_cpp_common_benchmarks.bzl", "google_cloud_cpp_common_benchma
 [cc_test(
     name = benchmark.replace("/", "_").replace(".cc", ""),
     srcs = [benchmark],
+    copts = WERROR_COPTS,
     tags = ["benchmark"],
     deps = [
         ":google_cloud_cpp_common",
@@ -89,6 +94,7 @@ cc_library(
         for header in google_cloud_cpp_grpc_utils_hdrs
         if not "grpc_utils/" in header
     ],
+    copts = WERROR_COPTS,
     deps = [
         ":google_cloud_cpp_common",
         "@com_github_grpc_grpc//:grpc++",
@@ -104,6 +110,7 @@ load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":google_cloud_cpp_common",
         ":google_cloud_cpp_grpc_utils",

--- a/google/cloud/bigquery/BUILD
+++ b/google/cloud/bigquery/BUILD
@@ -14,12 +14,14 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":bigquery_client.bzl", "bigquery_client_hdrs", "bigquery_client_srcs")
 
 cc_library(
     name = "bigquery_client",
     srcs = bigquery_client_srcs,
     hdrs = bigquery_client_hdrs,
+    copts = WERROR_COPTS,
     # Do not sort: grpc++ must come last
     deps = [
         "//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
@@ -35,6 +37,7 @@ cc_library(
     name = "bigquery_client_testing",
     srcs = bigquery_client_testing_srcs,
     hdrs = bigquery_client_testing_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         ":bigquery_client",
         "//google/cloud:google_cloud_cpp_common",
@@ -48,6 +51,7 @@ load(":bigquery_client_unit_tests.bzl", "bigquery_client_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":bigquery_client",
         ":bigquery_client_testing",

--- a/google/cloud/bigquery/samples/BUILD
+++ b/google/cloud/bigquery/samples/BUILD
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
+
 cc_binary(
     name = "read",
     srcs = [
         "read.cc",
     ],
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud/bigquery:bigquery_client",
     ],

--- a/google/cloud/bigtable/BUILD
+++ b/google/cloud/bigtable/BUILD
@@ -19,12 +19,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":bigtable_client.bzl", "bigtable_client_hdrs", "bigtable_client_srcs")
 
 cc_library(
     name = "bigtable_client",
     srcs = bigtable_client_srcs,
     hdrs = bigtable_client_hdrs,
+    copts = WERROR_COPTS,
     # Do not sort: grpc++ must come last
     deps = [
         "//google/cloud:google_cloud_cpp_common",
@@ -44,6 +46,7 @@ cc_library(
     name = "bigtable_client_testing",
     srcs = bigtable_client_testing_srcs,
     hdrs = bigtable_client_testing_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         ":bigtable_client",
         "//google/cloud:google_cloud_cpp_common",
@@ -59,6 +62,7 @@ load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":bigtable_client",
         ":bigtable_client_testing",
@@ -77,6 +81,7 @@ cc_test(
         "internal/readrowsparser_acceptance_tests.inc",
         "internal/readrowsparser_test.cc",
     ],
+    copts = WERROR_COPTS,
     deps = [
         ":bigtable_client",
         ":bigtable_client_testing",

--- a/google/cloud/bigtable/benchmarks/BUILD
+++ b/google/cloud/bigtable/benchmarks/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":bigtable_benchmark_common.bzl", "bigtable_benchmark_common_hdrs", "bigtable_benchmark_common_srcs")
 
 cc_library(
     name = "bigtable_benchmark_common",
     srcs = bigtable_benchmark_common_srcs,
     hdrs = bigtable_benchmark_common_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/bigtable:bigtable_client",
@@ -33,6 +35,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],
@@ -52,6 +55,7 @@ load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],

--- a/google/cloud/bigtable/examples/BUILD
+++ b/google/cloud/bigtable/examples/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":bigtable_examples_common.bzl", "bigtable_examples_common_hdrs", "bigtable_examples_common_srcs")
 
 cc_library(
     name = "bigtable_examples_common",
     srcs = bigtable_examples_common_srcs,
     hdrs = bigtable_examples_common_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
@@ -37,6 +39,7 @@ load(":bigtable_examples_unit_tests.bzl", "bigtable_examples_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":bigtable_examples_common",
         "//google/cloud:google_cloud_cpp_common",
@@ -53,6 +56,7 @@ load(":bigtable_examples.bzl", "bigtable_examples")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],

--- a/google/cloud/bigtable/tests/BUILD
+++ b/google/cloud/bigtable/tests/BUILD
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(
     ":bigtable_client_integration_tests.bzl",
     "bigtable_client_integration_tests",
@@ -25,6 +26,7 @@ load(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],
@@ -41,6 +43,7 @@ load(
 cc_binary(
     name = "instance_admin_emulator",
     srcs = ["instance_admin_emulator.cc"],
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud/bigtable:bigtable_client",
     ],

--- a/google/cloud/examples/BUILD
+++ b/google/cloud/examples/BUILD
@@ -16,9 +16,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
+
 cc_binary(
     name = "gcs2cbt",
     srcs = ["gcs2cbt.cc"],
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud/bigtable:bigtable_client",
         "//google/cloud/storage:storage_client",

--- a/google/cloud/firestore/BUILD
+++ b/google/cloud/firestore/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":firestore_client.bzl", "firestore_client_hdrs", "firestore_client_srcs")
 
 cc_library(
     name = "firestore_client",
     srcs = firestore_client_srcs,
     hdrs = firestore_client_hdrs,
+    copts = WERROR_COPTS,
     deps = [],
 )
 
@@ -30,6 +32,7 @@ load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],

--- a/google/cloud/grpc_utils/BUILD
+++ b/google/cloud/grpc_utils/BUILD
@@ -16,6 +16,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
+
 # TODO(googleapis/google-cloud-cpp-common#171) - remove the backwards
 #     compatibility target.
 cc_library(
@@ -27,6 +29,7 @@ cc_library(
         "grpc_error_delegate.h",
         "version.h",
     ],
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",

--- a/google/cloud/pubsub/BUILD
+++ b/google/cloud/pubsub/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":pubsub_client.bzl", "pubsub_client_hdrs", "pubsub_client_srcs")
 
 cc_library(
     name = "pubsub_client",
     srcs = pubsub_client_srcs,
     hdrs = pubsub_client_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
@@ -35,6 +37,7 @@ cc_library(
     name = "pubsub_client_testing",
     srcs = pubsub_client_testing_srcs,
     hdrs = pubsub_client_testing_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         ":pubsub_client",
         "//google/cloud:google_cloud_cpp_common",
@@ -49,6 +52,7 @@ cc_library(
     name = "pubsub_client_mocks",
     srcs = pubsub_client_mocks_srcs,
     hdrs = pubsub_client_mocks_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         ":pubsub_client",
         "//google/cloud:google_cloud_cpp_common",
@@ -62,6 +66,7 @@ load(":pubsub_client_unit_tests.bzl", "pubsub_client_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":pubsub_client",
         ":pubsub_client_mocks",

--- a/google/cloud/pubsub/integration_tests/BUILD
+++ b/google/cloud/pubsub/integration_tests/BUILD
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":pubsub_client_integration_tests.bzl", "pubsub_client_integration_tests")
 load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
 
@@ -23,6 +24,7 @@ load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],
@@ -38,6 +40,7 @@ load(":pubsub_client_install_tests.bzl", "pubsub_client_install_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],

--- a/google/cloud/pubsub/samples/BUILD
+++ b/google/cloud/pubsub/samples/BUILD
@@ -18,12 +18,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":pubsub_samples_common.bzl", "pubsub_samples_common_hdrs", "pubsub_samples_common_srcs")
 
 cc_library(
     name = "pubsub_samples_common",
     srcs = pubsub_samples_common_srcs,
     hdrs = pubsub_samples_common_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/pubsub:pubsub_client",
@@ -37,6 +39,7 @@ load(":pubsub_samples_unit_tests.bzl", "pubsub_samples_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":pubsub_samples_common",
         "//google/cloud:google_cloud_cpp_common",
@@ -53,6 +56,7 @@ load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],
@@ -67,6 +71,7 @@ load(":pubsub_client_unit_samples.bzl", "pubsub_client_unit_samples")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":pubsub_samples_common",
         "//google/cloud:google_cloud_cpp_common",

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -19,12 +19,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":spanner_client.bzl", "spanner_client_hdrs", "spanner_client_srcs")
 
 cc_library(
     name = "spanner_client",
     srcs = spanner_client_srcs,
     hdrs = spanner_client_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
@@ -45,6 +47,7 @@ cc_library(
     name = "spanner_client_mocks",
     srcs = spanner_client_mocks_srcs,
     hdrs = spanner_client_mocks_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         ":spanner_client",
         "//google/cloud:google_cloud_cpp_common",
@@ -59,6 +62,7 @@ cc_library(
     name = "spanner_client_testing",
     srcs = spanner_client_testing_srcs,
     hdrs = spanner_client_testing_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         ":spanner_client",
         ":spanner_client_mocks",
@@ -73,6 +77,7 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":spanner_client",
         ":spanner_client_mocks",
@@ -91,6 +96,7 @@ load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks")
 [cc_test(
     name = benchmark.replace("/", "_").replace(".cc", ""),
     srcs = [benchmark],
+    copts = WERROR_COPTS,
     tags = ["benchmark"],
     deps = [
         ":spanner_client",

--- a/google/cloud/spanner/benchmarks/BUILD
+++ b/google/cloud/spanner/benchmarks/BUILD
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks_hdrs", "spanner_client_benchmarks_srcs")
 load(":spanner_client_benchmark_programs.bzl", "spanner_client_benchmark_programs")
 
@@ -23,6 +24,7 @@ cc_library(
     name = "spanner_client_benchmarks",
     srcs = spanner_client_benchmarks_srcs,
     hdrs = spanner_client_benchmarks_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client",
@@ -37,6 +39,7 @@ cc_library(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -18,6 +18,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":spanner_client_integration_samples.bzl", "spanner_client_integration_samples")
 load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 
@@ -25,6 +26,7 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],
@@ -40,6 +42,7 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client",

--- a/google/cloud/storage/BUILD
+++ b/google/cloud/storage/BUILD
@@ -19,6 +19,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
+
 GOOGLE_CLOUD_STORAGE_WIN_COPTS = [
     "/DWIN32_LEAN_AND_MEAN",
 ]
@@ -47,7 +49,7 @@ cc_library(
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
-    }),
+    }) + WERROR_COPTS,
     defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     deps = [
         ":nlohmann_json",
@@ -72,7 +74,7 @@ cc_library(
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
-    }),
+    }) + WERROR_COPTS,
     deps = [
         ":nlohmann_json",
         "//google/cloud:google_cloud_cpp_common",
@@ -97,7 +99,7 @@ cc_library(
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
-    }),
+    }) + WERROR_COPTS,
     deps = [
         ":nlohmann_json",
         ":storage_client",
@@ -119,7 +121,7 @@ load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
-    }),
+    }) + WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],
@@ -146,7 +148,7 @@ load(":storage_client_grpc_unit_tests.bzl", "storage_client_grpc_unit_tests")
     copts = select({
         "@bazel_tools//src/conditions:windows": GOOGLE_CLOUD_STORAGE_WIN_COPTS,
         "//conditions:default": [],
-    }),
+    }) + WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],

--- a/google/cloud/storage/benchmarks/BUILD
+++ b/google/cloud/storage/benchmarks/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":storage_benchmarks.bzl", "storage_benchmarks_hdrs", "storage_benchmarks_srcs")
 
 cc_library(
     name = "storage_benchmarks",
     srcs = storage_benchmarks_srcs,
     hdrs = storage_benchmarks_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
@@ -41,6 +43,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],
@@ -67,6 +70,7 @@ load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": ["-lpthread"],

--- a/google/cloud/storage/examples/BUILD
+++ b/google/cloud/storage/examples/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":storage_examples_common.bzl", "storage_examples_common_hdrs", "storage_examples_common_srcs")
 
 cc_library(
     name = "storage_examples_common",
     srcs = storage_examples_common_srcs,
     hdrs = storage_examples_common_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client",
@@ -34,6 +36,7 @@ load(":storage_examples_unit_tests.bzl", "storage_examples_unit_tests")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":storage_examples_common",
         "//google/cloud:google_cloud_cpp_common",
@@ -49,6 +52,7 @@ load(":storage_examples.bzl", "storage_examples")
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     tags = [
         "integration-test",
     ],

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -919,7 +919,7 @@ google::storage::v1::Bucket::Cors GrpcClient::ToProto(CorsEntry const& rhs) {
     result.add_response_header(v);
   }
   if (rhs.max_age_seconds.has_value()) {
-    result.set_max_age_seconds(*rhs.max_age_seconds);
+    result.set_max_age_seconds(static_cast<std::int32_t>(*rhs.max_age_seconds));
   }
   return result;
 }

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -16,6 +16,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(
     ":storage_client_integration_tests.bzl",
     "storage_client_integration_tests",
@@ -25,6 +26,7 @@ load(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
+    copts = WERROR_COPTS,
     linkopts = select({
         "@bazel_tools//src/conditions:windows": [],
         "//conditions:default": [

--- a/google/cloud/testing_util/BUILD
+++ b/google/cloud/testing_util/BUILD
@@ -16,12 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+load("//bazel:werror_copts.bzl", "WERROR_COPTS")
 load(":google_cloud_cpp_testing.bzl", "google_cloud_cpp_testing_hdrs", "google_cloud_cpp_testing_srcs")
 
 cc_library(
     name = "google_cloud_cpp_testing",
     srcs = google_cloud_cpp_testing_srcs,
     hdrs = google_cloud_cpp_testing_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "@com_google_absl//absl/debugging:failure_signal_handler",
@@ -35,6 +37,7 @@ load(":google_cloud_cpp_testing_unit_tests.bzl", "google_cloud_cpp_testing_unit_
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":google_cloud_cpp_testing",
         "//google/cloud:google_cloud_cpp_common",
@@ -48,6 +51,7 @@ cc_library(
     name = "google_cloud_cpp_testing_grpc",
     srcs = google_cloud_cpp_testing_grpc_srcs,
     hdrs = google_cloud_cpp_testing_grpc_hdrs,
+    copts = WERROR_COPTS,
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "@com_google_googletest//:gtest_main",
@@ -60,6 +64,7 @@ load(":google_cloud_cpp_testing_grpc_unit_tests.bzl", "google_cloud_cpp_testing_
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
+    copts = WERROR_COPTS,
     deps = [
         ":google_cloud_cpp_testing_grpc",
         "//google/cloud:google_cloud_cpp_common",


### PR DESCRIPTION
Enable most warnings (/W3) and treat warnings as errors (/WX) on the
Windows+MSVC+Bazel builds. We already do this on the Windows+MSVC+CMake
builds, but those are post-submit and therefore break from time to time.
Note that only the CMake builds compile for x86, so there are some
warnings we miss anyway.

The change is more intrusive than just adding some --copt options
because we only want *our* code compiled with these options, we do not
want to hear about warnings in our dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4673)
<!-- Reviewable:end -->
