### PR TITLE
fix(pubsub): correct ownership of background threads

### DIFF
--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -70,8 +70,7 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
     pubsub::Topic topic, pubsub::PublisherOptions options,
-    std::shared_ptr<PublisherStub> stub,
-    pubsub::ConnectionOptions const& connection_options);
+    std::shared_ptr<PublisherStub> stub, google::cloud::CompletionQueue cq);
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -44,8 +44,9 @@ TEST(PublisherConnectionTest, Basic) {
         return make_ready_future(make_status_or(response));
       });
 
-  auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
+  auto publisher =
+      pubsub_internal::MakePublisherConnection(topic, {}, mock, bg.cq());
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
           .get();
@@ -65,8 +66,9 @@ TEST(PublisherConnectionTest, HandleInvalidResponse) {
         return make_ready_future(make_status_or(response));
       });
 
-  auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
+  auto publisher =
+      pubsub_internal::MakePublisherConnection(topic, {}, mock, bg.cq());
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
           .get();
@@ -90,8 +92,9 @@ TEST(PublisherConnectionTest, HandleError) {
             Status(StatusCode::kPermissionDenied, "uh-oh")));
       });
 
-  auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
+  auto publisher =
+      pubsub_internal::MakePublisherConnection(topic, {}, mock, bg.cq());
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
           .get();


### PR DESCRIPTION
I shall write 100 times on the blackboard: "Cannot have crazy cycles in
thread ownership or you shall suffer evil deadlocks at shutdown".

FWIW, the test used to crash about 1 in 1000 times before, the same
test ran 100,000 times successfully after this change.

Fixes #4672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4675)
<!-- Reviewable:end -->
