### PR TITLE
ci: enable warnings-as-errors for Windows+MSVC+Bazel

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -146,6 +146,7 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   # positives when run on headers. For more details, see issue #4230.
   git diff --diff-filter=d --name-only "${TARGET_BRANCH}" |
     grep -E "(${HEADER_FILTER_REGEX})|(${SOURCE_FILTER_REGEX})" |
+    grep -v google/cloud/bigtable/examples/opencensus |
     xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}" \
       -checks="-misc-unused-using-decls"
 fi

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -128,7 +128,7 @@ $test_flags = @("--test_output=errors",
                 "--keep_going")
 $test_flags += $warning_flags
 $build_flags = @("--keep_going")
-$build_flags += $build_flags
+$build_flags += $warning_flags
 
 if (${env:BUILD_NAME} -eq "bazel-release") {
     $test_flags+=("-c", "opt")

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -116,10 +116,19 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     }
 }
 
+$warning_flags = @(
+    "--per_file_copt=^//google/cloud@-W3",
+    "--per_file_copt=^//google/cloud@-WX",
+    "--per_file_copt=^//google/cloud@-experimental:external",
+    "--per_file_copt=^//google/cloud@-external:W0",
+    "--per_file_copt=^//google/cloud@-external:anglebrackets"
+)
 $test_flags = @("--test_output=errors",
                 "--verbose_failures=true",
                 "--keep_going")
+$test_flags += $warning_flags
 $build_flags = @("--keep_going")
+$build_flags += $build_flags
 
 if (${env:BUILD_NAME} -eq "bazel-release") {
     $test_flags+=("-c", "opt")

--- a/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
+++ b/google/cloud/bigtable/examples/opencensus/bigtable_opencensus.cc
@@ -16,6 +16,11 @@
 
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
+// OpenCensus generates too many warnings with MSVC
+#include "google/cloud/internal/diagnostics_push.inc"
+#if _MSC_VER
+#pragma warning(disable : 4081; disable : 4267)
+#endif  // _MSC_VER
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/stats/stdout/stdout_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
@@ -23,6 +28,8 @@
 #include "opencensus/stats/stats.h"
 #include "opencensus/trace/sampler.h"
 #include "opencensus/trace/trace_config.h"
+// Restore warnings after the OpenCensus includes
+#include "google/cloud/internal/diagnostics_pop.inc"
 #include <grpcpp/opencensus.h>
 
 int main(int argc, char* argv[]) try {

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -919,7 +919,7 @@ google::storage::v1::Bucket::Cors GrpcClient::ToProto(CorsEntry const& rhs) {
     result.add_response_header(v);
   }
   if (rhs.max_age_seconds.has_value()) {
-    result.set_max_age_seconds(*rhs.max_age_seconds);
+    result.set_max_age_seconds(static_cast<std::int32_t>(*rhs.max_age_seconds));
   }
   return result;
 }


### PR DESCRIPTION
Use `--per_file_copt` (TIL: thanks @devjgm) to enable warnings-as-errors
(aka `/WX`) on the Windows+MSVC+Bazel builds. We already use these flags
in the Windows+MSVC+CMake builds, but those do not run on PRs and
missed a couple of files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4676)
<!-- Reviewable:end -->
