### PR TITLE
chore: remove no-longer-needed docker mount

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -510,7 +510,6 @@ docker_flags=(
   # in your workstation.
   "--volume" "/v/cmake-out/home"
   "--volume" "/v/cmake-out"
-  "--volume" "/v/cmake-build-debug"
   "--volume" "${PWD}/${BUILD_OUTPUT}:/v/${BUILD_OUTPUT}"
 
   # No need to preserve the container.


### PR DESCRIPTION
It looks like since our check-style.sh script now uses `git ls-files`
we probably don't need to mount the cmake-build-debug/ directory, which
CLion uses by default. The only downside is that this directory is
created in everyone's repo dir (even if they don't use clion) as a dir
owned by root. So if we don't need it, and our CLion users' workflows
still work, it seems good to get rid of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4679)
<!-- Reviewable:end -->
