### PR TITLE
ci: pin vcpkg version to workaround build problems

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -58,7 +58,7 @@ if ($RunningCI -and (Test-Path "${vcpkg_dir}")) {
 }
 if (-not (Test-Path ${vcpkg_dir})) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cloning vcpkg repository."
-    git clone --quiet --depth 10 https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+    git clone --quiet --depth 10 --branch 2020.06 https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red `
             "vcpkg git setup failed with exit code $LastExitCode"


### PR DESCRIPTION
The current (as of 2020-07-24) version of vcpkg is not able to build our
dependencies. Pinning to the previous version seems to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4681)
<!-- Reviewable:end -->
