### PR TITLE
cleanup: remove unused+undefined function

### DIFF
--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -94,7 +94,6 @@ class EmbeddedServerTestFixture : public ::testing::Test {
   void StartServer();
   void SetUp() override;
   void TearDown() override;
-  void ResetChannel();
 
   static char const kProjectId[];
   static char const kInstanceId[];


### PR DESCRIPTION
Since there was at least one undefined function (see #4674) I decided to go looking for any others. This is all I found with the exception of functions intentionally undefined in some template meta programming crazy sauce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4685)
<!-- Reviewable:end -->
