### PR TITLE
feat(pubsub): use async RPCs for subscribers

### DIFF
--- a/google/cloud/pubsub/internal/default_ack_handler_impl.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/default_ack_handler_impl.h"
+#include "absl/memory/memory.h"
 
 namespace google {
 namespace cloud {
@@ -20,20 +21,20 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 void DefaultAckHandlerImpl::ack() {
-  grpc::ClientContext context;
   google::pubsub::v1::AcknowledgeRequest request;
   request.set_subscription(std::move(subscription_));
   request.add_ack_ids(std::move(ack_id_));
-  (void)stub_->Acknowledge(context, request);
+  (void)stub_->AsyncAcknowledge(cq_, absl::make_unique<grpc::ClientContext>(),
+                                request);
 }
 
 void DefaultAckHandlerImpl::nack() {
-  grpc::ClientContext context;
   google::pubsub::v1::ModifyAckDeadlineRequest request;
   request.set_subscription(std::move(subscription_));
   request.add_ack_ids(std::move(ack_id_));
   request.set_ack_deadline_seconds(0);
-  (void)stub_->ModifyAckDeadline(context, request);
+  (void)stub_->AsyncModifyAckDeadline(
+      cq_, absl::make_unique<grpc::ClientContext>(), request);
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/default_ack_handler_impl.h
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.h
@@ -40,6 +40,7 @@ class DefaultAckHandlerImpl : public pubsub::AckHandler::Impl {
   std::string ack_id() const override { return ack_id_; }
 
  private:
+  google::cloud::CompletionQueue cq_;
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   std::string subscription_;
   std::string ack_id_;

--- a/google/cloud/pubsub/internal/default_ack_handler_impl.h
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.h
@@ -26,9 +26,11 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 class DefaultAckHandlerImpl : public pubsub::AckHandler::Impl {
  public:
-  DefaultAckHandlerImpl(std::shared_ptr<pubsub_internal::SubscriberStub> s,
+  DefaultAckHandlerImpl(google::cloud::CompletionQueue cq,
+                        std::shared_ptr<pubsub_internal::SubscriberStub> s,
                         std::string subscription, std::string ack_id)
-      : stub_(std::move(s)),
+      : cq_(std::move(cq)),
+        stub_(std::move(s)),
         subscription_(std::move(subscription)),
         ack_id_(std::move(ack_id)) {}
 

--- a/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
@@ -36,7 +36,8 @@ TEST(DefaultAckHandlerTest, Ack) {
         return make_ready_future(Status{});
       });
 
-  DefaultAckHandlerImpl handler(mock, "test-subscription", "test-ack-id");
+  google::cloud::CompletionQueue cq;
+  DefaultAckHandlerImpl handler(cq, mock, "test-subscription", "test-ack-id");
   EXPECT_EQ("test-ack-id", handler.ack_id());
   ASSERT_NO_FATAL_FAILURE(handler.ack());
 }
@@ -55,7 +56,8 @@ TEST(DefaultAckHandlerTest, Nack) {
             return make_ready_future(Status{});
           });
 
-  DefaultAckHandlerImpl handler(mock, "test-subscription", "test-ack-id");
+  google::cloud::CompletionQueue cq;
+  DefaultAckHandlerImpl handler(cq, mock, "test-subscription", "test-ack-id");
   EXPECT_EQ("test-ack-id", handler.ack_id());
   ASSERT_NO_FATAL_FAILURE(handler.nack());
 }

--- a/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
@@ -26,13 +26,14 @@ using ::testing::_;
 
 TEST(DefaultAckHandlerTest, Ack) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
-  EXPECT_CALL(*mock, Acknowledge(_, _))
-      .WillOnce([](grpc::ClientContext&,
+  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+      .WillOnce([](google::cloud::CompletionQueue&,
+                   std::unique_ptr<grpc::ClientContext>,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
         EXPECT_EQ("test-subscription", request.subscription());
         EXPECT_EQ(1, request.ack_ids_size());
         EXPECT_EQ("test-ack-id", request.ack_ids(0));
-        return Status{};
+        return make_ready_future(Status{});
       });
 
   DefaultAckHandlerImpl handler(mock, "test-subscription", "test-ack-id");
@@ -42,15 +43,16 @@ TEST(DefaultAckHandlerTest, Ack) {
 
 TEST(DefaultAckHandlerTest, Nack) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
-  EXPECT_CALL(*mock, ModifyAckDeadline(_, _))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
       .WillOnce(
-          [](grpc::ClientContext&,
+          [](google::cloud::CompletionQueue&,
+             std::unique_ptr<grpc::ClientContext>,
              google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
             EXPECT_EQ("test-subscription", request.subscription());
             EXPECT_EQ(1, request.ack_ids_size());
             EXPECT_EQ("test-ack-id", request.ack_ids(0));
             EXPECT_EQ(0, request.ack_deadline_seconds());
-            return Status{};
+            return make_ready_future(Status{});
           });
 
   DefaultAckHandlerImpl handler(mock, "test-subscription", "test-ack-id");

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -56,18 +56,21 @@ class SubscriberStub {
       google::pubsub::v1::DeleteSubscriptionRequest const& request) = 0;
 
   /// Pull a batch of messages.
-  virtual StatusOr<google::pubsub::v1::PullResponse> Pull(
-      grpc::ClientContext& client_context,
+  virtual future<StatusOr<google::pubsub::v1::PullResponse>> AsyncPull(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> client_context,
       google::pubsub::v1::PullRequest const& request) = 0;
 
   /// Acknowledge one or more messages.
-  virtual Status Acknowledge(
-      grpc::ClientContext& context,
+  virtual future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> client_context,
       google::pubsub::v1::AcknowledgeRequest const& request) = 0;
 
   /// Modify the ACK deadline.
-  virtual Status ModifyAckDeadline(
-      grpc::ClientContext& context,
+  virtual future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> client_context,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
 };
 

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -80,28 +80,27 @@ class SubscriptionSession
       return;
     }
 
-    // TODO(#4554) - use the completion queue and asynchronous requests
     auto self = shared_from_this();
     lk.unlock();
 
-    grpc::ClientContext context;
-    context.set_deadline(std::chrono::system_clock::now() +
-                         std::chrono::milliseconds(500));
+    auto context = absl::make_unique<grpc::ClientContext>();
     google::pubsub::v1::PullRequest request;
     request.set_subscription(params_.full_subscription_name);
     request.set_max_messages(1);
-    auto r = stub_->Pull(context, request);
-    // TODO(#4554) - for now we poll every 500ms to close the session gracefully
-    if (r.status().code() == StatusCode::kDeadlineExceeded) {
-      executor_.RunAsync([self] { self->PullOne(); });
-      return;
-    }
+    stub_->AsyncPull(executor_, std::move(context), request)
+        .then([self](future<StatusOr<google::pubsub::v1::PullResponse>> f) {
+          self->OnPull(f.get());
+        });
+  }
+
+  void OnPull(StatusOr<google::pubsub::v1::PullResponse> r) {
+    auto self = shared_from_this();
     if (!r) {
       result_.set_value(std::move(r).status());
       return;
     }
 
-    lk.lock();
+    std::unique_lock<std::mutex> lk(mu_);
     std::move(r->mutable_received_messages()->begin(),
               r->mutable_received_messages()->end(),
               std::back_inserter(messages_));

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -46,17 +46,21 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                google::pubsub::v1::DeleteSubscriptionRequest const& request),
               (override));
 
-  MOCK_METHOD(StatusOr<google::pubsub::v1::PullResponse>, Pull,
-              (grpc::ClientContext&, google::pubsub::v1::PullRequest const&),
+  MOCK_METHOD(future<StatusOr<google::pubsub::v1::PullResponse>>, AsyncPull,
+              (google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::pubsub::v1::PullRequest const&),
               (override));
 
-  MOCK_METHOD(Status, Acknowledge,
-              (grpc::ClientContext&,
+  MOCK_METHOD(future<Status>, AsyncAcknowledge,
+              (google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
                google::pubsub::v1::AcknowledgeRequest const&),
               (override));
 
-  MOCK_METHOD(Status, ModifyAckDeadline,
-              (grpc::ClientContext&,
+  MOCK_METHOD(future<Status>, AsyncModifyAckDeadline,
+              (google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
                google::pubsub::v1::ModifyAckDeadlineRequest const&),
               (override));
 };


### PR DESCRIPTION
With this change we use `AsyncPull()` to pull messages, and
`AsyncAcknowledgement()` and `AsyncModifyAckDeadline()` to ACK and NACK
the messages.

Fixes #4554

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4687)
<!-- Reviewable:end -->
