### PR TITLE
ci: reduce root disk usage on Windows

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -132,26 +132,11 @@ Get-CimInstance -Class CIM_LogicalDisk | `
         @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
         @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
-$ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
-Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | `
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bazel Root (${bazel_root}) size"
+Get-Item -ErrorAction SilentlyContinue "${bazel_root}"  | `
+    Get-ChildItem -ErrorAction SilentlyContinue -Recurse | `
+    Measure-Object -ErrorAction SilentlyContinue -Sum Length | `
     Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-ChildItem "${bazel_root}"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length | `
-    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
-    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-$ErrorActionPreference = "Stop"
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
 
 $warning_flags = @(
     "--per_file_copt=^//google/cloud@-W3",
@@ -277,29 +262,13 @@ Get-CimInstance -Class CIM_LogicalDisk | `
         @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
         @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
-$ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
-Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | `
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bazel Root (${bazel_root}) size"
+Get-Item -ErrorAction SilentlyContinue "${bazel_root}"  | `
+    Get-ChildItem -ErrorAction SilentlyContinue -Recurse | `
+    Measure-Object -ErrorAction SilentlyContinue -Sum Length | `
     Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-ChildItem "${bazel_root}"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
-    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
-    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-$ErrorActionPreference = "Stop"
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
-
-# DEBUG DEBUG if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
-if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
+if ($RunningCI -and $IsCI -and $CacheConfigured -and $Has7z) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating Bazel cache"
     # We use 7z because it knows how to handle locked files better than Unix
     # tools like tar(1).
@@ -332,7 +301,7 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
             "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "uploading Bazel cache."
-        # DEBUG DEBUG gsutil -q cp "${download_dir}\${CACHE_BASENAME}.7z" "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.7z"
+        gsutil -q cp "${download_dir}\${CACHE_BASENAME}.7z" "gs://${CACHE_FOLDER}/${CACHE_BASENAME}.7z"
         if ($LastExitCode) {
             # Just report these errors and continue, caching failures should
             # not break the build.
@@ -350,26 +319,10 @@ Get-CimInstance -Class CIM_LogicalDisk | `
         @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
         @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
-$ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
-Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bazel Root (${bazel_root}) size"
+Get-Item -ErrorAction SilentlyContinue "${bazel_root}"  | `
+    Get-ChildItem -ErrorAction SilentlyContinue -Recurse | `
+    Measure-Object -ErrorAction SilentlyContinue -Sum Length | `
     Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-ChildItem "${bazel_root}"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
-    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
-    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-$ErrorActionPreference = "Stop"
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
-
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DONE"

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -126,11 +126,14 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     }
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk | `
+    Select-Object -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
-Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
 Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
@@ -265,11 +268,14 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Shutting down Bazel 
 bazel $common_flags shutdown
 bazel shutdown
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk | `
+    Select-Object -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
-Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
 Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
@@ -332,11 +338,14 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     }
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk | `
+    Select-Object -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
-Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
 Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -136,16 +136,19 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
-Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
 Get-ChildItem "${bazel_root}"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 $ErrorActionPreference = "Stop"
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
@@ -278,16 +281,19 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
-Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
 Get-ChildItem "${bazel_root}"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 $ErrorActionPreference = "Stop"
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
@@ -348,16 +354,19 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
-Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
 Get-ChildItem "${bazel_root}"
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
-Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length  | `
+    Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 $ErrorActionPreference = "Stop"
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -116,6 +116,24 @@ if ($RunningCI -and $IsPR -and $CacheConfigured -and $Has7z) {
     }
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG C:"
+$ErrorActionPreference = "SilentlyContinue"
+Get-ChildItem "C:\"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG T:"
+Get-ChildItem "T:\"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir ${download_dir}"
+Get-ChildItem "${download_dir}"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Download Dir"
+Get-Item "${download_dir}" | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
+Get-ChildItem "${bazel_root}"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG Bazel Root ${bazel_root}"
+Get-Item "${bazel_root}"   | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+$ErrorActionPreference = "Stop"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
+
 $warning_flags = @(
     "--per_file_copt=^//google/cloud@-W3",
     "--per_file_copt=^//google/cloud@-WX",

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -145,11 +145,21 @@ foreach ($pkg in $packages) {
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 .\vcpkg.exe list
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cleanup vcpkg buildtrees"
+Get-ChildItem -Recurse -File `
+        -ErrorAction SilentlyContinue `
+        -Path "buildtrees" | `
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+    Get-CimInstance -Class CIM_LogicalDisk | `
+        Select-Object -Property DeviceID, DriveType, VolumeName, `
+            @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+            @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
-Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
 Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
@@ -186,14 +196,18 @@ if ($True) {
       "HasBuildCache = $HasBuildCache."
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk | `
+    Select-Object -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
 $ErrorActionPreference = "SilentlyContinue"
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
-Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
-
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
 
 $ErrorActionPreference = "Stop"
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -147,8 +147,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and spa
 
 # Do not update the vcpkg cache on PRs, it might dirty the cache for any
 # PRs running in parallel, and it is a waste of time in most cases.
-# DEBUG DEBUG if ($RunningCI -and $IsCI -and $HasBuildCache) {
-if ($True) {
+if ($RunningCI -and $IsCI -and $HasBuildCache) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
       "zip vcpkg cache for upload."
     7z a vcpkg-installed.zip installed\ -bsp0
@@ -159,9 +158,9 @@ if ($True) {
     } else {
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "upload zip with vcpkg cache."
-        # DEBUG DEBUG gcloud auth activate-service-account `
-        # DEBUG DEBUG    --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
-        # DEBUG DEBUG gsutil -q cp vcpkg-installed.zip "${env:BUILD_CACHE}"
+        gcloud auth activate-service-account `
+           --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
+        gsutil -q cp vcpkg-installed.zip "${env:BUILD_CACHE}"
         if ($LastExitCode) {
             # Ignore errors, caching failures should not break the build.
             Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -99,18 +99,6 @@ if ($RunningCI -and $IsPR -and $HasBuildCache) {
     }
 }
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
-$ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
-Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
-
-$ErrorActionPreference = "Stop"
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
-
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bootstrap vcpkg."
 powershell -exec bypass scripts\bootstrap.ps1
 if ($LastExitCode) {
@@ -157,16 +145,6 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and spa
             @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
             @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
-$ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
-
-$ErrorActionPreference = "Stop"
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
-
 # Do not update the vcpkg cache on PRs, it might dirty the cache for any
 # PRs running in parallel, and it is a waste of time in most cases.
 # DEBUG DEBUG if ($RunningCI -and $IsCI -and $HasBuildCache) {
@@ -201,13 +179,3 @@ Get-CimInstance -Class CIM_LogicalDisk | `
     Select-Object -Property DeviceID, DriveType, VolumeName, `
         @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
         @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
-
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
-$ErrorActionPreference = "SilentlyContinue"
-
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
-Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, @{L="SizeGB";E={"{0:N2}" -f ($_.Sum / 1GB)}}
-
-$ErrorActionPreference = "Stop"
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -99,6 +99,18 @@ if ($RunningCI -and $IsPR -and $HasBuildCache) {
     }
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
+$ErrorActionPreference = "SilentlyContinue"
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
+Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+
+$ErrorActionPreference = "Stop"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bootstrap vcpkg."
 powershell -exec bypass scripts\bootstrap.ps1
 if ($LastExitCode) {
@@ -133,9 +145,22 @@ foreach ($pkg in $packages) {
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
 .\vcpkg.exe list
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
+$ErrorActionPreference = "SilentlyContinue"
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
+Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+
+$ErrorActionPreference = "Stop"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"
+
 # Do not update the vcpkg cache on PRs, it might dirty the cache for any
 # PRs running in parallel, and it is a waste of time in most cases.
-if ($RunningCI -and $IsCI -and $HasBuildCache) {
+# DEBUG DEBUG if ($RunningCI -and $IsCI -and $HasBuildCache) {
+if ($True) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
       "zip vcpkg cache for upload."
     7z a vcpkg-installed.zip installed\ -bsp0
@@ -146,9 +171,9 @@ if ($RunningCI -and $IsCI -and $HasBuildCache) {
     } else {
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "upload zip with vcpkg cache."
-        gcloud auth activate-service-account `
-            --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
-        gsutil -q cp vcpkg-installed.zip "${env:BUILD_CACHE}"
+        # DEBUG DEBUG gcloud auth activate-service-account `
+        # DEBUG DEBUG    --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
+        # DEBUG DEBUG gsutil -q cp vcpkg-installed.zip "${env:BUILD_CACHE}"
         if ($LastExitCode) {
             # Ignore errors, caching failures should not break the build.
             Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
@@ -160,3 +185,15 @@ if ($RunningCI -and $IsCI -and $HasBuildCache) {
       "vcpkg not updated IsCI = $IsCI, IsPR = $IsPR, " `
       "HasBuildCache = $HasBuildCache."
 }
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG"
+$ErrorActionPreference = "SilentlyContinue"
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG DISK SPACE"
+Get-CimInstance -Class CIM_LogicalDisk | Select-Object -Property DeviceID, DriveType, VolumeName, @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG DEBUG DEBUG cwd"
+Get-Item "." | Get-ChildItem -Recurse | Measure-Object -Sum Length | Select-Object Count, Sum
+
+$ErrorActionPreference = "Stop"
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DEBUG END"

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -105,6 +105,12 @@ if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
     $BuildScript = "build-quickstart-cmake.ps1"
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk | `
+    Select-Object -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
 $ScriptLocation = Split-Path $PSCommandPath -Parent
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Building dependencies for $BuildName build"
@@ -114,11 +120,25 @@ if ($LastExitCode) {
     Exit ${LastExitCode}
 }
 
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk -ErrorAction SilentlyContinue | `
+    Select-Object -ErrorAction SilentlyContinue `
+        -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running build script for $BuildName build"
 powershell -exec bypass "${ScriptLocation}/${BuildScript}"
 # Save the build exit code, we want to delete the artifacts
 # even if the build fails.
 $BuildExitCode = $LastExitCode
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Disk(s) size and space for troubleshooting"
+Get-CimInstance -Class CIM_LogicalDisk -ErrorAction SilentlyContinue | `
+    Select-Object -ErrorAction SilentlyContinue `
+        -Property DeviceID, DriveType, VolumeName, `
+        @{L='FreeSpaceGB';E={"{0:N2}" -f ($_.FreeSpace /1GB)}}, `
+        @{L="Capacity";E={"{0:N2}" -f ($_.Size/1GB)}}
 
 # Remove most things from the artifacts directory. Kokoro copies these files
 # *very* slowly on Windows, and then ignores most of them :shrug:


### PR DESCRIPTION
We are informed that the problems in #4363 might be caused
by the CI machine running out of space in the boot partition.
This change aims to reduce the chances of that happening,
and to improve our ability to troubleshoot for that case.

Remove temporary files after they are no longer used, for
example, when refreshing the `vcpkg` cache we may need to
create all the `.o` files for the dependencies, but once these
are installed the `.o` files are no longer needed. Likewise, the
tarball for the Bazel cache is not needed after it is extracted.

Add some logging to report how much disk space is left before
and after some of the steps that consume significant disk.


<!-- Reviewable:start -->
----
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4692)
<!-- Reviewable:end -->
