### PR TITLE
test: add StatusIs and IsOk matchers

### DIFF
--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_spanner_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
@@ -54,6 +55,7 @@ namespace {
 #endif
 
 using ::google::cloud::spanner_testing::HasSessionAndTransactionId;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;
@@ -107,12 +109,6 @@ MATCHER(HasBadSession, "bound to a session that's marked bad") {
         }
         return true;
       });
-}
-
-MATCHER_P2(StatusContains, code, message_substr,
-           "Status has expected code and message substring") {
-  return arg.code() == code &&
-         arg.message().find(message_substr) != std::string::npos;
 }
 
 // Helper to set the Transaction's ID. Requires selector.ok().
@@ -2514,49 +2510,52 @@ TEST(ConnectionImplTest, OperationsFailOnInvalidatedTransaction) {
 
   EXPECT_THAT(
       conn->Read({txn, "table", KeySet::All(), {"Column"}}).begin()->status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+      StatusIs(StatusCode::kInvalidArgument,
+               HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->PartitionRead({{txn, "table", KeySet::All(), {"Column"}}}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->PartitionRead({{txn, "table", KeySet::All(), {"Column"}}}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
   EXPECT_THAT(
       conn->ExecuteQuery({txn, SqlStatement("select 1")}).begin()->status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+      StatusIs(StatusCode::kInvalidArgument,
+               HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->ExecuteDml({txn, SqlStatement("delete * from table")}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->ExecuteDml({txn, SqlStatement("delete * from table")}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
   EXPECT_THAT(
       conn->ProfileQuery({txn, SqlStatement("select 1")}).begin()->status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+      StatusIs(StatusCode::kInvalidArgument,
+               HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->ProfileDml({txn, SqlStatement("delete * from table")}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->ProfileDml({txn, SqlStatement("delete * from table")}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->AnalyzeSql({txn, SqlStatement("select * from table")}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->AnalyzeSql({txn, SqlStatement("select * from table")}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
   // ExecutePartitionedDml creates its own transaction so it's not tested here.
 
-  EXPECT_THAT(
-      conn->PartitionQuery({txn, SqlStatement("select * from table")}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->PartitionQuery({txn, SqlStatement("select * from table")}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->ExecuteBatchDml({txn}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->ExecuteBatchDml({txn}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->Commit({txn}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->Commit({txn}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(
-      conn->Rollback({txn}),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->Rollback({txn}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 }
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -1476,15 +1476,15 @@ TEST(ConnectionImplTest, CommitBeginTransactionPermanentFailure) {
       .WillOnce(Return(
           Status(StatusCode::kInvalidArgument, "BeginTransaction failed")));
   auto txn = MakeReadWriteTransaction();
-  EXPECT_THAT(
-      conn->Commit({txn}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->Commit({txn}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 
   // Retrying the operation should also fail with the same error, without making
   // an additional `BeginTransaction` call.
-  EXPECT_THAT(
-      conn->Commit({txn}).status(),
-      StatusContains(StatusCode::kInvalidArgument, "BeginTransaction failed"));
+  EXPECT_THAT(conn->Commit({txn}),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("BeginTransaction failed")));
 }
 
 TEST(ConnectionImplTest, CommitCommitPermanentFailure) {

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -33,6 +33,7 @@ if (BUILD_TESTING)
         scoped_environment.cc
         scoped_environment.h
         scoped_thread.h
+        status_matchers.h
         testing_types.cc
         testing_types.h)
     target_link_libraries(
@@ -46,7 +47,7 @@ if (BUILD_TESTING)
     set(google_cloud_cpp_testing_unit_tests
         # cmake-format: sort
         assert_ok_test.cc crash_handler_test.cc example_driver_test.cc
-        scoped_environment_test.cc)
+        scoped_environment_test.cc status_matchers_test.cc)
 
     # Export the list of unit tests so the Bazel BUILD file can pick it up.
     export_list_to_bazel("google_cloud_cpp_testing_unit_tests.bzl"

--- a/google/cloud/testing_util/google_cloud_cpp_testing.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing.bzl
@@ -27,6 +27,7 @@ google_cloud_cpp_testing_hdrs = [
     "expect_future_error.h",
     "scoped_environment.h",
     "scoped_thread.h",
+    "status_matchers.h",
     "testing_types.h",
 ]
 

--- a/google/cloud/testing_util/google_cloud_cpp_testing_unit_tests.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_unit_tests.bzl
@@ -21,4 +21,5 @@ google_cloud_cpp_testing_unit_tests = [
     "crash_handler_test.cc",
     "example_driver_test.cc",
     "scoped_environment_test.cc",
+    "status_matchers_test.cc",
 ]

--- a/google/cloud/testing_util/status_matchers.h
+++ b/google/cloud/testing_util/status_matchers.h
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_STATUS_MATCHERS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_STATUS_MATCHERS_H
+
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+namespace internal {
+// Allows the matchers to work with `Status` or `StatusOr<T>`
+inline const ::google::cloud::Status& GetStatus(
+    const ::google::cloud::Status& status) {
+  return status;
+}
+
+template <typename T>
+inline const ::google::cloud::Status& GetStatus(
+    const ::google::cloud::StatusOr<T>& status) {
+  return status.status();
+}
+}  // namespace internal
+
+/**
+ * Match the `code` and `message` of a `google::cloud::Status`.
+ *
+ * example:
+ *
+ * ```
+ * Status status = ...;
+ * EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument,
+ *                              testing::HasSubstr("message substring"));
+ * ```
+ */
+// NOLINTNEXTLINE(readability-redundant-string-init)
+MATCHER_P2(StatusIs, code_matcher, message_matcher, "") {
+  ::testing::StringMatchResultListener code_listener;
+  auto const& status = ::google::cloud::testing_util::internal::GetStatus(arg);
+  bool result = true;
+  if (!::testing::MatcherCast<::google::cloud::StatusCode const&>(code_matcher)
+           .MatchAndExplain(status.code(), &code_listener)) {
+    std::string code_explanation = code_listener.str();
+    if (code_explanation.empty()) {
+      code_explanation = "does not match expected value";
+    }
+    result = false;
+    *result_listener << "code " << status.code() << " " << code_explanation;
+  }
+  ::testing::StringMatchResultListener message_listener;
+  if (!::testing::MatcherCast<std::string const&>(message_matcher)
+           .MatchAndExplain(status.message(), &message_listener)) {
+    if (!result) {
+      *result_listener << "; ";
+    }
+    result = false;
+    std::string message_explanation = message_listener.str();
+    if (message_explanation.empty()) {
+      message_explanation = "does not match expected value";
+    }
+    *result_listener << "message '" << status.message() << "' "
+                     << message_explanation;
+  }
+  return result;
+}
+
+/// Match the `code` of a `google::cloud::Status`, disregarding the message
+// NOLINTNEXTLINE(readability-redundant-string-init)
+MATCHER_P(StatusIs, code_matcher, "") {
+  auto const& status = ::google::cloud::testing_util::internal::GetStatus(arg);
+  return ::testing::MatcherCast<::google::cloud::Status const&>(
+             StatusIs(code_matcher, ::testing::_))
+      .MatchAndExplain(status, result_listener);
+}
+
+/// Shorthand for `StatusIs(StatusCode::kOk)`
+// NOLINTNEXTLINE(readability-redundant-string-init)
+MATCHER(IsOk, "") {
+  auto const& status = ::google::cloud::testing_util::internal::GetStatus(arg);
+  return ::testing::MatcherCast<::google::cloud::Status const&>(
+             StatusIs(::google::cloud::StatusCode::kOk, ::testing::_))
+      .MatchAndExplain(status, result_listener);
+}
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_STATUS_MATCHERS_H

--- a/google/cloud/testing_util/status_matchers_test.cc
+++ b/google/cloud/testing_util/status_matchers_test.cc
@@ -1,0 +1,117 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
+#include <gtest/gtest.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+using ::testing::_;
+using ::testing::AnyOf;
+using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+TEST(StatusIsTest, OkStatus) {
+  Status status;
+  EXPECT_THAT(status, IsOk());
+  EXPECT_THAT(status, StatusIs(StatusCode::kOk));
+  EXPECT_THAT(status, StatusIs(_));
+  EXPECT_THAT(status, StatusIs(StatusCode::kOk, IsEmpty()));
+  EXPECT_THAT(status, StatusIs(_, _));
+}
+
+TEST(StatusIsTest, FailureStatus) {
+  Status status(StatusCode::kUnknown, "hello");
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, "hello"));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, Eq("hello")));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, HasSubstr("ello")));
+  EXPECT_THAT(status, StatusIs(_, AnyOf("hello", "goodbye")));
+  EXPECT_THAT(status,
+              StatusIs(AnyOf(StatusCode::kAborted, StatusCode::kUnknown), _));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, _));
+  EXPECT_THAT(status, StatusIs(_, "hello"));
+  EXPECT_THAT(status, StatusIs(_, _));
+}
+
+TEST(StatusIsTest, FailureStatusNegation) {
+  Status status(StatusCode::kNotFound, "not found");
+
+  // code doesn't match
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kUnknown, "not found")));
+
+  // message doesn't match
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kNotFound, "found")));
+
+  // both don't match
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kCancelled, "goodbye")));
+
+  // combine with a few other matchers
+  EXPECT_THAT(status, Not(StatusIs(AnyOf(StatusCode::kInvalidArgument,
+                                         StatusCode::kInternal))));
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kUnknown, Eq("goodbye"))));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kUnknown), Not(IsEmpty())));
+}
+
+TEST(StatusIsTest, OkStatusOr) {
+  StatusOr<std::string> status("StatusOr string value");
+  EXPECT_THAT(status, IsOk());
+  EXPECT_THAT(status, StatusIs(StatusCode::kOk));
+  EXPECT_THAT(status, StatusIs(_));
+  EXPECT_THAT(status, StatusIs(StatusCode::kOk, IsEmpty()));
+  EXPECT_THAT(status, StatusIs(_, _));
+}
+
+TEST(StatusIsTest, FailureStatusOr) {
+  StatusOr<int> status(Status(StatusCode::kUnknown, "hello"));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, "hello"));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, Eq("hello")));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, HasSubstr("ello")));
+  EXPECT_THAT(status, StatusIs(_, AnyOf("hello", "goodbye")));
+  EXPECT_THAT(status,
+              StatusIs(AnyOf(StatusCode::kAborted, StatusCode::kUnknown), _));
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnknown, _));
+  EXPECT_THAT(status, StatusIs(_, "hello"));
+  EXPECT_THAT(status, StatusIs(_, _));
+}
+
+TEST(StatusIsTest, FailureStatusOrNegation) {
+  StatusOr<float> status(Status(StatusCode::kNotFound, "not found"));
+
+  // code doesn't match
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kUnknown, "not found")));
+
+  // message doesn't match
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kNotFound, "found")));
+
+  // both don't match
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kCancelled, "goodbye")));
+
+  // combine with a few other matchers
+  EXPECT_THAT(status, Not(StatusIs(AnyOf(StatusCode::kInvalidArgument,
+                                         StatusCode::kInternal))));
+  EXPECT_THAT(status, Not(StatusIs(StatusCode::kUnknown, Eq("goodbye"))));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kUnknown), Not(IsEmpty())));
+}
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
I replaced the `StatusContains` matcher I recently introduced with this.
It would be nice to do a LSC, not sure how easy it would be to automate.
There also might be an opportunity to consolidate assert_ok.

Part of #4693

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4694)
<!-- Reviewable:end -->
