### PR TITLE
test: use the "common" `IsProtoEqual` in spanner

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -329,6 +329,7 @@ function (spanner_client_define_tests)
                     absl::numeric
                     googleapis-c++::spanner_client
                     google_cloud_cpp_testing
+                    google_cloud_cpp_testing_grpc
                     GTest::gmock_main
                     GTest::gmock
                     GTest::gtest)

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -17,11 +17,11 @@
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/results.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
@@ -42,7 +42,7 @@ namespace spanner_proto = ::google::spanner::v1;
 
 using ::google::cloud::spanner_mocks::MockConnection;
 using ::google::cloud::spanner_mocks::MockResultSetSource;
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AnyNumber;

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mocks/mock_database_admin_connection.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "absl/types/optional.h"
 #include <gmock/gmock.h>
 
@@ -27,7 +27,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/database_admin_connection.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_database_admin_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -25,8 +25,8 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
 using ::google::cloud::spanner_testing::MockDatabaseAdminStub;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/spanner/instance_admin_connection.h"
 #include "google/cloud/spanner/create_instance_request_builder.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_instance_admin_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -26,7 +26,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -31,6 +31,7 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
         "//google/cloud/spanner:spanner_client_mocks",
         "//google/cloud/spanner:spanner_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
+        "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_integration_tests]

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -45,8 +45,12 @@ function (spanner_client_define_integration_tests)
         google_cloud_cpp_add_executable(target "spanner" "${fname}")
         target_link_libraries(
             ${target}
-            PRIVATE googleapis-c++::spanner_client spanner_client_testing
-                    google_cloud_cpp_testing GTest::gmock_main GTest::gmock
+            PRIVATE googleapis-c++::spanner_client
+                    spanner_client_testing
+                    google_cloud_cpp_testing_grpc
+                    google_cloud_cpp_testing
+                    GTest::gmock_main
+                    GTest::gmock
                     GTest::gtest)
         google_cloud_cpp_add_common_options(${target})
 

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -14,12 +14,12 @@
 
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -28,7 +28,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::EndsWith;
 
 /// @test Verify the basic CRUD operations for databases work.

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_spanner_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
@@ -55,6 +56,7 @@ namespace {
 #endif
 
 using ::google::cloud::spanner_testing::HasSessionAndTransactionId;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
@@ -556,7 +558,7 @@ TEST(ConnectionImplTest, QueryOptions) {
   for (auto const& version : optimizer_versions) {
     spanner_proto::ExecuteSqlRequest::QueryOptions qo;
     if (version) qo.set_optimizer_version(*version);
-    auto m = Property(kQueryOptionsProp, spanner_testing::IsProtoEqual(qo));
+    auto m = Property(kQueryOptionsProp, IsProtoEqual(qo));
     auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
     EXPECT_CALL(*mock, BatchCreateSessions(_, _))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -749,7 +751,7 @@ TEST(ConnectionImplTest, ProfileQuerySuccess) {
 
   auto plan = result.ExecutionPlan();
   ASSERT_TRUE(plan);
-  EXPECT_THAT(*plan, spanner_testing::IsProtoEqual(expected_plan));
+  EXPECT_THAT(*plan, IsProtoEqual(expected_plan));
 
   std::vector<std::pair<const std::string, std::string>> expected_stats;
   expected_stats.emplace_back("elapsed_time", "42 secs");
@@ -874,7 +876,7 @@ TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
 
   auto plan = result->ExecutionPlan();
   ASSERT_TRUE(plan);
-  EXPECT_THAT(*plan, spanner_testing::IsProtoEqual(expected_plan));
+  EXPECT_THAT(*plan, IsProtoEqual(expected_plan));
 
   std::vector<std::pair<const std::string, std::string>> expected_stats;
   expected_stats.emplace_back("elapsed_time", "42 secs");
@@ -973,7 +975,7 @@ TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kTextExpectedPlan, &expected_plan));
 
   ASSERT_STATUS_OK(result);
-  EXPECT_THAT(*result, spanner_testing::IsProtoEqual(expected_plan));
+  EXPECT_THAT(*result, IsProtoEqual(expected_plan));
 }
 
 TEST(ConnectionImplTest, AnalyzeSqlGetSessionFailure) {
@@ -1840,9 +1842,8 @@ TEST(ConnectionImplTest, PartitionReadSuccess) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTextPartitionRequest, &partition_request));
 
-  EXPECT_CALL(
-      *mock_spanner_stub,
-      PartitionRead(_, spanner_testing::IsProtoEqual(partition_request)))
+  EXPECT_CALL(*mock_spanner_stub,
+              PartitionRead(_, IsProtoEqual(partition_request)))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(partition_response));
 
@@ -1948,9 +1949,8 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
   google::spanner::v1::PartitionQueryRequest partition_request;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTextPartitionRequest, &partition_request));
-  EXPECT_CALL(
-      *mock_spanner_stub,
-      PartitionQuery(_, spanner_testing::IsProtoEqual(partition_request)))
+  EXPECT_CALL(*mock_spanner_stub,
+              PartitionQuery(_, IsProtoEqual(partition_request)))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(partition_response));
 

--- a/google/cloud/spanner/internal/merge_chunk_test.cc
+++ b/google/cloud/spanner/internal/merge_chunk_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/merge_chunk.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/struct.pb.h>
 #include <gmock/gmock.h>
 #include <string>
@@ -27,7 +27,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 
 //
 // MakeProtoValue() is an overloaded helper function for creating

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/partial_result_set_resume.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_partial_result_set_reader.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -33,8 +33,8 @@ namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -14,10 +14,10 @@
 
 #include "google/cloud/spanner/internal/partial_result_set_source.h"
 #include "google/cloud/spanner/row.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_partial_result_set_reader.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -34,8 +34,8 @@ namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::HasSubstr;
 using ::testing::Return;

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/keys.h"
-#include "google/cloud/spanner/testing/matchers.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
 #include <google/spanner/v1/keys.pb.h>
 #include <gmock/gmock.h>
@@ -25,6 +25,8 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
+
+using ::google::cloud::testing_util::IsProtoEqual;
 
 TEST(KeyTest, ConstructionCopyAssign) {
   Key key1;
@@ -121,7 +123,7 @@ TEST(KeySetTest, NoKeys) {
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString("", &expected));
   KeySet no_keys;
   ::google::spanner::v1::KeySet result = internal::ToProto(no_keys);
-  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
+  EXPECT_THAT(result, IsProtoEqual(expected));
   EXPECT_EQ(internal::FromProto(expected), no_keys);
 }
 
@@ -133,7 +135,7 @@ TEST(KeySetTest, AllKeys) {
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &expected));
   auto all_keys = KeySet::All();
   ::google::spanner::v1::KeySet result = internal::ToProto(all_keys);
-  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
+  EXPECT_THAT(result, IsProtoEqual(expected));
   EXPECT_EQ(internal::FromProto(expected), all_keys);
 }
 

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/keys.h"
-#include "google/cloud/spanner/testing/matchers.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
@@ -35,7 +35,7 @@ namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::HasSubstr;
 

--- a/google/cloud/spanner/read_partition_test.cc
+++ b/google/cloud/spanner/read_partition_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/read_partition.h"
 #include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -47,6 +48,7 @@ class ReadPartitionTester {
 namespace {
 
 using ::google::cloud::spanner_testing::HasSessionAndTransactionId;
+using ::google::cloud::testing_util::IsProtoEqual;
 
 TEST(ReadPartitionTest, MakeReadPartition) {
   std::string partition_token("token");
@@ -64,7 +66,7 @@ TEST(ReadPartitionTest, MakeReadPartition) {
   EXPECT_EQ(session_id, actual_partition.SessionId());
   EXPECT_EQ(table_name, actual_partition.TableName());
   EXPECT_THAT(actual_partition.KeySet(),
-              spanner_testing::IsProtoEqual(internal::ToProto(KeySet::All())));
+              IsProtoEqual(internal::ToProto(KeySet::All())));
   EXPECT_EQ(column_names, actual_partition.ColumnNames());
 }
 
@@ -86,7 +88,7 @@ TEST(ReadPartitionTest, Constructor) {
   EXPECT_EQ(session_id, actual_partition.SessionId());
   EXPECT_EQ(table_name, actual_partition.TableName());
   EXPECT_THAT(actual_partition.KeySet(),
-              spanner_testing::IsProtoEqual(internal::ToProto(KeySet::All())));
+              IsProtoEqual(internal::ToProto(KeySet::All())));
   EXPECT_EQ(column_names, actual_partition.ColumnNames());
   EXPECT_EQ(read_options, actual_partition.ReadOptions());
 }
@@ -135,7 +137,7 @@ TEST(ReadPartitionTest, SerializeDeserialize) {
   EXPECT_EQ(expected_partition.SessionId(), actual_partition.SessionId());
   EXPECT_EQ(expected_partition.TableName(), actual_partition.TableName());
   EXPECT_THAT(actual_partition.KeySet(),
-              spanner_testing::IsProtoEqual(expected_partition.KeySet()));
+              IsProtoEqual(expected_partition.KeySet()));
   EXPECT_EQ(expected_partition.ColumnNames(), actual_partition.ColumnNames());
   EXPECT_EQ(expected_partition.ReadOptions(), actual_partition.ReadOptions());
 }

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -14,9 +14,9 @@
 
 #include "google/cloud/spanner/results.h"
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -33,6 +33,7 @@ namespace {
 namespace spanner_proto = ::google::spanner::v1;
 
 using ::google::cloud::spanner_mocks::MockResultSetSource;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::Eq;
 using ::testing::Return;
@@ -196,8 +197,7 @@ TEST(ProfileQueryResult, ExecutionPlan) {
   EXPECT_CALL(*mock_source, Stats()).WillRepeatedly(Return(stats));
 
   ProfileQueryResult query_result(std::move(mock_source));
-  EXPECT_THAT(*query_result.ExecutionPlan(),
-              spanner_testing::IsProtoEqual(stats.query_plan()));
+  EXPECT_THAT(*query_result.ExecutionPlan(), IsProtoEqual(stats.query_plan()));
 }
 
 TEST(DmlResult, RowsModified) {

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/sql_statement.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -24,7 +24,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::AnyOf;
 using ::testing::Eq;

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -19,7 +19,6 @@
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
-#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 #include <cstdint>
 #include <memory>
@@ -28,15 +27,6 @@ namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
-
-MATCHER_P(IsProtoEqual, value, "Checks whether protos are equal") {
-  std::string delta;
-  google::protobuf::util::MessageDifferencer differencer;
-  differencer.ReportDifferencesToString(&delta);
-  auto const result = differencer.Compare(arg, value);
-  *result_listener << "\n" << delta;
-  return result;
-}
 
 /// Verifies a `Transaction` has the expected Session and Transaction IDs
 MATCHER_P2(

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/value.h"
-#include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -33,7 +33,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::spanner_testing::IsProtoEqual;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::Not;
 
 std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>


### PR DESCRIPTION
Spanner had its own (identical) implementation - eliminate it and update
all references.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4695)
<!-- Reviewable:end -->
