### PR TITLE
feat(storage): add a function to delete resumable upload in client

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1256,6 +1256,7 @@ class Client {
    * This operation is always idempotent because it only acts on a specific
    * `upload_id`.
    */
+  template <typename... Options>
   Status DeleteResumableUpload(std::string const& bucket_name,
                                std::string const& object_name,
                                std::string const& upload_id,

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1246,23 +1246,19 @@ class Client {
   /**
    * Cancel a resumable upload.
    *
-   * @param bucket_name the name of the bucket that contains the object.
-   * @param object_name the name of the object that is uploading.
-   * @param upload_id the id of the resumable upload.
+   * @param upload_session_url the url of the upload session. Returned by
+   * `ObjectWriteStream::resumable_session_id`.
    * @param options a list of optional query parameters and/or request headers.
    *   Valid types for this operation include `UserProject`.
    *
    * @par Idempotency
    * This operation is always idempotent because it only acts on a specific
-   * `upload_id`.
+   * `upload_session_url`.
    */
   template <typename... Options>
-  Status DeleteResumableUpload(std::string const& bucket_name,
-                               std::string const& object_name,
-                               std::string const& upload_id,
+  Status DeleteResumableUpload(std::string const& upload_session_url,
                                Options&&... options) {
-    internal::DeleteResumableUploadRequest request(bucket_name, object_name,
-                                                   upload_id);
+    internal::DeleteResumableUploadRequest request(upload_session_url);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->DeleteResumableUpload(request).status();
   }

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1249,15 +1249,20 @@ class Client {
    * @param bucket_name the name of the bucket that contains the object.
    * @param object_name the name of the object that is uploading.
    * @param upload_id the id of the resumable upload.
+   * @param options a list of optional query parameters and/or request headers.
+   *   Valid types for this operation include `UserProject`.
    *
    * @par Idempotency
-   * This operation is idempotent.
+   * This operation is always idempotent because it only acts on a specific
+   * `upload_id`.
    */
   Status DeleteResumableUpload(std::string const& bucket_name,
                                std::string const& object_name,
-                               std::string const& upload_id) {
+                               std::string const& upload_id,
+                               Options&&... options) {
     internal::DeleteResumableUploadRequest request(bucket_name, object_name,
                                                    upload_id);
+    request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->DeleteResumableUpload(request).status();
   }
 

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1244,6 +1244,24 @@ class Client {
   }
 
   /**
+   * Cancel a resumable upload.
+   *
+   * @param bucket_name the name of the bucket that contains the object.
+   * @param object_name the name of the object that is uploading.
+   * @param upload_id the id of the resumable upload.
+   *
+   * @par Idempotency
+   * This operation is idempotent.
+   */
+  Status DeleteResumableUpload(std::string const& bucket_name,
+                               std::string const& object_name,
+                               std::string const& upload_id) {
+    internal::DeleteResumableUploadRequest request(bucket_name, object_name,
+                                                   upload_id);
+    return raw_client_->DeleteResumableUpload(request).status();
+  }
+
+  /**
    * Downloads a Cloud Storage object to a file.
    *
    * @param bucket_name the name of the bucket that contains the object.

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -707,14 +707,11 @@ CurlClient::RestoreResumableSession(std::string const& session_id) {
 
 StatusOr<EmptyResponse> CurlClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
-  CurlRequestBuilder builder(
-      upload_endpoint_ + "/b/" + request.bucket_name() + "/o", upload_factory_);
+  CurlRequestBuilder builder(request.upload_session_url(), upload_factory_);
   auto status = SetupBuilderCommon(builder, "DELETE");
   if (!status.ok()) {
     return status;
   }
-  builder.AddQueryParameter("uploadType", "resumable");
-  builder.AddQueryParameter("upload_id", request.upload_id());
   auto response = builder.BuildRequest().MakeRequest(std::string{});
   if (!response.ok()) {
     return std::move(response).status();

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -715,7 +715,15 @@ StatusOr<EmptyResponse> CurlClient::DeleteResumableUpload(
   }
   builder.AddQueryParameter("uploadType", "resumable");
   builder.AddQueryParameter("upload_id", request.upload_id());
-  return ReturnEmptyResponse(builder.BuildRequest().MakeRequest(std::string{}));
+  auto response = builder.BuildRequest().MakeRequest(std::string{});
+  if (!response.ok()) {
+    return std::move(response).status();
+  }
+  if (response->status_code >= HttpStatusCode::kMinNotSuccess &&
+      response->status_code != 499) {
+    return AsStatus(*response);
+  }
+  return EmptyResponse{};
 }
 
 StatusOr<ListBucketAclResponse> CurlClient::ListBucketAcl(

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -396,8 +396,8 @@ TEST_P(CurlClientTest, CreateResumableSession) {
 
 TEST_P(CurlClientTest, DeleteResumableUpload) {
   auto actual = client_
-                    ->DeleteResumableUpload(DeleteResumableUploadRequest(
-                        "test-bucket", "test-object", "test-upload-id"))
+                    ->DeleteResumableUpload(
+                        DeleteResumableUploadRequest("test-upload-session-url"))
                     .status();
   CheckStatus(actual);
 }

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -584,6 +584,7 @@ std::ostream& operator<<(std::ostream& os,
                          DeleteResumableUploadRequest const& r) {
   os << "DeleteResumableUploadRequest={bucket_name=" << r.bucket_name()
      << ", object_name=" << r.object_name() << ", upload_id=" << r.upload_id();
+  r.DumpOptions(os, ", ");
   return os << "}";
 }
 

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -582,8 +582,8 @@ std::ostream& operator<<(std::ostream& os, ResumableUploadRequest const& r) {
 
 std::ostream& operator<<(std::ostream& os,
                          DeleteResumableUploadRequest const& r) {
-  os << "DeleteResumableUploadRequest={bucket_name=" << r.bucket_name()
-     << ", object_name=" << r.object_name() << ", upload_id=" << r.upload_id();
+  os << "DeleteResumableUploadRequest={upload_session_url="
+     << r.upload_session_url();
   r.DumpOptions(os, ", ");
   return os << "}";
 }

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -382,7 +382,7 @@ std::ostream& operator<<(std::ostream& os, ResumableUploadRequest const& r);
  * A request to cancel a resumable upload.
  */
 class DeleteResumableUploadRequest
-    : public GenericObjectRequest<DeleteResumableUploadRequest> {
+    : public GenericObjectRequest<DeleteResumableUploadRequest, UserProject> {
  public:
   DeleteResumableUploadRequest() = default;
 

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -382,19 +382,16 @@ std::ostream& operator<<(std::ostream& os, ResumableUploadRequest const& r);
  * A request to cancel a resumable upload.
  */
 class DeleteResumableUploadRequest
-    : public GenericObjectRequest<DeleteResumableUploadRequest, UserProject> {
+    : public GenericRequest<DeleteResumableUploadRequest, UserProject> {
  public:
   DeleteResumableUploadRequest() = default;
+  explicit DeleteResumableUploadRequest(std::string upload_session_url)
+      : upload_session_url_(std::move(upload_session_url)) {}
 
-  DeleteResumableUploadRequest(std::string bucket_name, std::string object_name,
-                               std::string upload_id)
-      : GenericObjectRequest(std::move(bucket_name), std::move(object_name)),
-        upload_id_(std::move(upload_id)) {}
-
-  std::string const& upload_id() const { return upload_id_; }
+  std::string const& upload_session_url() const { return upload_session_url_; }
 
  private:
-  std::string upload_id_;
+  std::string upload_session_url_;
 };
 
 std::ostream& operator<<(std::ostream& os,

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -505,18 +505,13 @@ TEST(ObjectRequestsTest, ResumableUpload) {
 }
 
 TEST(ObjectRequestsTest, DeleteResumableUpload) {
-  DeleteResumableUploadRequest request("source-bucket", "source-object",
-                                       "source-upload-id");
-  EXPECT_EQ("source-bucket", request.bucket_name());
-  EXPECT_EQ("source-object", request.object_name());
-  EXPECT_EQ("source-upload-id", request.upload_id());
+  DeleteResumableUploadRequest request("source-upload-session-url");
+  EXPECT_EQ("source-upload-session-url", request.upload_session_url());
 
   std::ostringstream os;
   os << request;
   std::string actual = os.str();
-  EXPECT_THAT(actual, HasSubstr("source-bucket"));
-  EXPECT_THAT(actual, HasSubstr("source-object"));
-  EXPECT_THAT(actual, HasSubstr("source-upload-id"));
+  EXPECT_THAT(actual, HasSubstr("source-upload-session-url"));
 }
 
 TEST(ObjectRequestsTest, UploadChunk) {

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -835,6 +835,25 @@ def resumable_upload_chunk(bucket_name):
     return bucket.receive_upload_chunk(gcs_url, flask.request)
 
 
+@upload.route("/b/<bucket_name>/o", methods=["DELETE"])
+def delete_resumable_upload(bucket_name):
+    upload_type = flask.request.args.get("uploadType")
+    if upload_type != "resumable":
+        raise error_response.ErrorResponse(
+            "testbench can delete resumable uploadType only", status_code=400
+        )
+    upload_id = flask.request.args.get("upload_id")
+    if upload_id is None:
+        raise error_response.ErrorResponse(
+            "missing upload_id in delete_resumable_upload", status_code=400
+        )
+    bucket = testbench_utils.lookup_bucket(bucket_name)
+    if upload_id not in bucket.resumable_uploads:
+        raise error_response.ErrorResponse("upload_id does not exist", status_code=404)
+    bucket.resumable_uploads.pop(upload_id)
+    return testbench_utils.filtered_response(flask.request, {})
+
+
 # Define the WSGI application to handle (a few) requests in the XML API.
 XMLAPI_HANDLER_PATH = "/xmlapi"
 xmlapi = flask.Flask(__name__)

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -805,6 +805,34 @@ TEST_F(ObjectIntegrationTest, DeleteAccessControlFailure) {
   ASSERT_FALSE(status.ok());
 }
 
+TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto object_name = MakeRandomObjectName();
+  auto stream = client->WriteObject(bucket_name_, object_name,
+                                    NewResumableUploadSession());
+  auto session_id = stream.resumable_session_id();
+  auto upload_id =
+      session_id.substr(session_id.find("upload_id=") + strlen("upload_id="));
+
+  stream << "This data will not get uploaded, it is too small\n";
+  std::move(stream).Suspend();
+
+  auto status =
+      client->DeleteResumableUpload(bucket_name_, object_name, upload_id);
+  EXPECT_STATUS_OK(status);
+
+  auto client_options = ClientOptions::CreateDefaultClientOptions();
+  ASSERT_STATUS_OK(client_options);
+  Client client_resumable(client_options->set_maximum_simple_upload_size(0));
+  auto stream_resumable = client_resumable.WriteObject(
+      bucket_name_, object_name, RestoreResumableUploadSession(session_id));
+  stream_resumable << LoremIpsum();
+  stream_resumable.Close();
+  EXPECT_FALSE(stream_resumable.metadata().status().ok());
+}
+
 }  // anonymous namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -813,14 +813,11 @@ TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
   auto stream = client->WriteObject(bucket_name_, object_name,
                                     NewResumableUploadSession());
   auto session_id = stream.resumable_session_id();
-  auto upload_id =
-      session_id.substr(session_id.find("upload_id=") + strlen("upload_id="));
 
   stream << "This data will not get uploaded, it is too small\n";
   std::move(stream).Suspend();
 
-  auto status =
-      client->DeleteResumableUpload(bucket_name_, object_name, upload_id);
+  auto status = client->DeleteResumableUpload(session_id);
   EXPECT_STATUS_OK(status);
 
   auto client_options = ClientOptions::CreateDefaultClientOptions();


### PR DESCRIPTION
This PR is a part of #4404 

It seems that it is impossible to implement a test for this function.
- I dont know how to get the `upload_id` from `Object: insert`
- I dont know how to send a signal to interrupt a resumable upload so we can delete that resumable upload.

I think we should implement a function to return the `upload_id` to user. With that function we could actually resume a resumable upload ( if there is an interruption ) and write test for `DeleteResumableUpload`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4696)
<!-- Reviewable:end -->
