### PR TITLE
ci: speed up full builds for Windows+CMake

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -76,7 +76,7 @@ Set-Location "${vcpkg_dir}"
 
 # If BUILD_CACHE is set (which typically is on Kokoro builds), try
 # to download and extract the build cache.
-if ($RunningCI -and $IsPR -and $HasBuildCache) {
+if ($RunningCI -and $HasBuildCache) {
     gcloud auth activate-service-account `
         --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `


### PR DESCRIPTION
While normally we do not care about the time for a full build (as
opposed to PRs) in this case I think we should: we have limited
bandwidth for Windows builds, and these are taking between 1 and 2
hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4697)
<!-- Reviewable:end -->
