### PR TITLE
feat: add google-cloud-resource-prefix to non-admin operations

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -481,7 +481,7 @@ class ExperimentImpl {
       clients.emplace_back(
           spanner::Client(spanner::MakeConnection(database, options)));
       stubs.emplace_back(spanner::internal::CreateDefaultSpannerStub(
-          options, /*channel_id=*/0));
+          database, options, /*channel_id=*/0));
       std::cout << '.' << std::flush;
     }
     std::cout << " DONE\n";

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -336,7 +336,7 @@ std::shared_ptr<Connection> MakeConnection(
   stubs.reserve(num_channels);
   for (int channel_id = 0; channel_id < num_channels; ++channel_id) {
     stubs.push_back(
-        internal::CreateDefaultSpannerStub(connection_options, channel_id));
+        internal::CreateDefaultSpannerStub(db, connection_options, channel_id));
   }
   return internal::MakeConnection(
       db, std::move(stubs), connection_options, std::move(session_pool_options),

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -54,7 +54,8 @@ TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
   auto const db = GetDatabase();
-  auto stub = CreateDefaultSpannerStub(ConnectionOptions{}, /*channel_id=*/0);
+  auto stub =
+      CreateDefaultSpannerStub(db, ConnectionOptions{}, /*channel_id=*/0);
   auto session_pool =
       MakeSessionPool(db, {stub}, SessionPoolOptions{}, cq,
                       LimitedTimeRetryPolicy(std::chrono::minutes(5)).clone(),

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -26,10 +26,10 @@ namespace internal {
 namespace spanner_proto = ::google::spanner::v1;
 
 MetadataSpannerStub::MetadataSpannerStub(std::shared_ptr<SpannerStub> child,
-                                         std::string db_resource_header)
+                                         std::string resource_prefix_header)
     : child_(std::move(child)),
       api_client_header_(ApiClientHeader()),
-      db_resource_header_(std::move(db_resource_header)) {}
+      resource_prefix_header_(std::move(resource_prefix_header)) {}
 
 StatusOr<spanner_proto::Session> MetadataSpannerStub::CreateSession(
     grpc::ClientContext& client_context,
@@ -166,7 +166,7 @@ void MetadataSpannerStub::SetMetadata(grpc::ClientContext& context,
                                       std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);
   context.AddMetadata("x-goog-api-client", api_client_header_);
-  context.AddMetadata("google-cloud-resource-prefix", db_resource_header_);
+  context.AddMetadata("google-cloud-resource-prefix", resource_prefix_header_);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -25,8 +25,11 @@ namespace internal {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-MetadataSpannerStub::MetadataSpannerStub(std::shared_ptr<SpannerStub> child)
-    : child_(std::move(child)), api_client_header_(ApiClientHeader()) {}
+MetadataSpannerStub::MetadataSpannerStub(std::shared_ptr<SpannerStub> child,
+                                         std::string db_resource_header)
+    : child_(std::move(child)),
+      api_client_header_(ApiClientHeader()),
+      db_resource_header_(std::move(db_resource_header)) {}
 
 StatusOr<spanner_proto::Session> MetadataSpannerStub::CreateSession(
     grpc::ClientContext& client_context,
@@ -163,6 +166,7 @@ void MetadataSpannerStub::SetMetadata(grpc::ClientContext& context,
                                       std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);
   context.AddMetadata("x-goog-api-client", api_client_header_);
+  context.AddMetadata("google-cloud-resource-prefix", db_resource_header_);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -30,7 +30,7 @@ namespace internal {
 class MetadataSpannerStub : public SpannerStub {
  public:
   explicit MetadataSpannerStub(std::shared_ptr<SpannerStub> child,
-                               std::string db_resource_header);
+                               std::string resource_prefix_header);
   ~MetadataSpannerStub() override = default;
 
   StatusOr<google::spanner::v1::Session> CreateSession(
@@ -101,7 +101,7 @@ class MetadataSpannerStub : public SpannerStub {
 
   std::shared_ptr<SpannerStub> child_;
   std::string api_client_header_;
-  std::string db_resource_header_;
+  std::string resource_prefix_header_;
 };
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -29,7 +29,8 @@ namespace internal {
  */
 class MetadataSpannerStub : public SpannerStub {
  public:
-  explicit MetadataSpannerStub(std::shared_ptr<SpannerStub> child);
+  explicit MetadataSpannerStub(std::shared_ptr<SpannerStub> child,
+                               std::string db_resource_header);
   ~MetadataSpannerStub() override = default;
 
   StatusOr<google::spanner::v1::Session> CreateSession(
@@ -100,6 +101,7 @@ class MetadataSpannerStub : public SpannerStub {
 
   std::shared_ptr<SpannerStub> child_;
   std::string api_client_header_;
+  std::string db_resource_header_;
 };
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -99,10 +99,7 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::CreateSessionRequest request;
-  request.set_database(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id");
+  request.set_database(db_.FullName());
   auto status = stub.CreateSession(context, request);
   EXPECT_EQ(TransientError(), status.status());
 }
@@ -113,17 +110,14 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
                        spanner_proto::BatchCreateSessionsRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.BatchCreateSessions",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return TransientError();
       });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::BatchCreateSessionsRequest request;
-  request.set_database(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id");
+  request.set_database(db_.FullName());
   request.set_session_count(3);
   auto status = stub.BatchCreateSessions(context, request);
   EXPECT_EQ(TransientError(), status.status());
@@ -135,7 +129,7 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
                        spanner_proto::GetSessionRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.GetSession",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return TransientError();
       });
 
@@ -157,17 +151,14 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
                        spanner_proto::ListSessionsRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.ListSessions",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return TransientError();
       });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::ListSessionsRequest request;
-  request.set_database(
-      "projects/test-project-id/"
-      "instances/test-instance-id/"
-      "databases/test-database-id");
+  request.set_database(db_.FullName());
   auto status = stub.ListSessions(context, request);
   EXPECT_EQ(TransientError(), status.status());
 }
@@ -178,7 +169,7 @@ TEST_F(MetadataSpannerStubTest, DeleteSession) {
                        spanner_proto::DeleteSessionRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.DeleteSession",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return TransientError();
       });
 
@@ -204,7 +195,7 @@ TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
                        spanner_proto::ExecuteSqlRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.ExecuteStreamingSql",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return std::unique_ptr<
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
       });
@@ -231,7 +222,7 @@ TEST_F(MetadataSpannerStubTest, StreamingRead) {
                        spanner_proto::ReadRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.StreamingRead",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return std::unique_ptr<
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
       });

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/metadata_spanner_stub.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/internal/api_client_header.h"
 #include "google/cloud/spanner/testing/mock_spanner_stub.h"
 #include "google/cloud/spanner/testing/validate_metadata.h"
@@ -38,7 +39,6 @@ class MetadataSpannerStubTest : public ::testing::Test {
  protected:
   void SetUp() override {
     mock_ = std::make_shared<spanner_testing::MockSpannerStub>();
-    MetadataSpannerStub stub(mock_);
     expected_api_client_header_ = ApiClientHeader();
   }
 
@@ -65,11 +65,11 @@ class MetadataSpannerStubTest : public ::testing::Test {
         [this, rpc_name](grpc::ClientContext& context, Request const&) {
           EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
               context, "google.spanner.v1.Spanner." + rpc_name,
-              expected_api_client_header_));
+              expected_api_client_header_, db_.FullName()));
           return TransientError();
         });
 
-    MetadataSpannerStub stub(mock_);
+    MetadataSpannerStub stub(mock_, db_.FullName());
     grpc::ClientContext context;
     Request request;
     request.set_session(
@@ -83,6 +83,7 @@ class MetadataSpannerStubTest : public ::testing::Test {
 
   std::shared_ptr<spanner_testing::MockSpannerStub> mock_;
   std::string expected_api_client_header_;
+  Database db_{"test-project", "test-instance", "test-database"};
 };
 
 TEST_F(MetadataSpannerStubTest, CreateSession) {
@@ -91,11 +92,11 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
                        spanner_proto::CreateSessionRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.CreateSession",
-            expected_api_client_header_));
+            expected_api_client_header_, db_.FullName()));
         return TransientError();
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::CreateSessionRequest request;
   request.set_database(
@@ -116,7 +117,7 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
         return TransientError();
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::BatchCreateSessionsRequest request;
   request.set_database(
@@ -138,7 +139,7 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
         return TransientError();
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::GetSessionRequest request;
   request.set_name(
@@ -160,7 +161,7 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
         return TransientError();
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::ListSessionsRequest request;
   request.set_database(
@@ -181,7 +182,7 @@ TEST_F(MetadataSpannerStubTest, DeleteSession) {
         return TransientError();
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::DeleteSessionRequest request;
   request.set_name(
@@ -208,7 +209,7 @@ TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::ExecuteSqlRequest request;
   request.set_session(
@@ -235,7 +236,7 @@ TEST_F(MetadataSpannerStubTest, StreamingRead) {
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
       });
 
-  MetadataSpannerStub stub(mock_);
+  MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
   spanner_proto::ReadRequest request;
   request.set_session(

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -284,7 +284,8 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
 
 }  // namespace
 
-std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(ConnectionOptions options,
+std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(Database const& db,
+                                                      ConnectionOptions options,
                                                       int channel_id) {
   options = internal::EmulatorOverrides(std::move(options));
 
@@ -299,7 +300,7 @@ std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(ConnectionOptions options,
 
   std::shared_ptr<SpannerStub> stub =
       std::make_shared<DefaultSpannerStub>(std::move(spanner_grpc_stub));
-  stub = std::make_shared<MetadataSpannerStub>(std::move(stub));
+  stub = std::make_shared<MetadataSpannerStub>(std::move(stub), db.FullName());
 
   if (options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_SPANNER_STUB_H
 
 #include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/status.h"
@@ -122,7 +123,8 @@ class SpannerStub {
  * @p channel_id should be unique among all stubs in the same Connection pool,
  * to ensure they use different underlying connections.
  */
-std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(ConnectionOptions options,
+std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(Database const& db,
+                                                      ConnectionOptions options,
                                                       int channel_id);
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -27,7 +27,8 @@ namespace {
 using ::testing::AnyOf;
 
 TEST(SpannerStub, CreateDefaultStub) {
-  auto stub = CreateDefaultSpannerStub(ConnectionOptions(), /*channel_id=*/0);
+  auto stub = CreateDefaultSpannerStub(Database("foo", "bar", "baz"),
+                                       ConnectionOptions(), /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 }
 
@@ -37,6 +38,7 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
   auto id = google::cloud::LogSink::Instance().AddBackend(backend);
 
   auto stub = CreateDefaultSpannerStub(
+      Database("foo", "bar", "baz"),
       ConnectionOptions(grpc::InsecureChannelCredentials())
           .set_endpoint("localhost:1")
           .enable_tracing("rpc"),

--- a/google/cloud/spanner/testing/validate_metadata.h
+++ b/google/cloud/spanner/testing/validate_metadata.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status.h"
+#include "absl/types/optional.h"
 #include <grpcpp/client_context.h>
 #include <string>
 
@@ -37,14 +38,18 @@ inline namespace SPANNER_CLIENT_NS {
  * @param method a gRPC method which which this context will be passed to
  * @param api_client_header expected value for the x-goog-api-client metadata
  *     header.
+ * @param resource_prefix_header if specified, this is the expected value for
+ *     the google-cloud-resource-prefix metadata header.
  *
  * @warning the `context` will be destroyed and shouldn't be used after passing
  *     it to this function.
  *
  * @return an OK status if the `context` is properly set up
  */
-Status IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        std::string const& api_client_header);
+Status IsContextMDValid(
+    grpc::ClientContext& context, std::string const& method,
+    std::string const& api_client_header,
+    absl::optional<std::string> resource_prefix_header = {});
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_testing


### PR DESCRIPTION
Fixes: #4546

This PR gives the `MetadataSpannerStub` knowledge of the full database
resource name, which it then adds as a metadata (aka, a "header") using
the name "google-cloud-resource-prefix" to the `grpc::ClientContext` for
all non-admin calls. Admin operations will not use this header, though
they may in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4703)
<!-- Reviewable:end -->
