### PR TITLE
test: enable running integration tests against a staging server

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -96,6 +96,12 @@ if should_run_integration_tests; then
   echo "================================================================"
   io::log "Running the integration tests"
 
+  if [[ -n "${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT:-}" ]]; then
+    bazel_args+=(
+      "--test_env=GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT=${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT}"
+    )
+  fi
+
   bazel_args+=(
     # Common configuration
     "--test_env=GOOGLE_APPLICATION_CREDENTIALS=/c/kokoro-run-key.json"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -524,6 +524,12 @@ if [[ -n "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-}" ]]; then
   docker_flags+=("--env" "KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH=${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-}")
 fi
 
+if [[ -n "${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT:-}" ]]; then
+  docker_flags+=(
+    "--env" "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT=${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT}"
+  )
+fi
+
 # Optionally allow the docker container to use the host's networking in order
 # to take advantage of potentially non-trivial network configurations (e.g.,
 # DNS cache) that might be a PITA to duplicate within the container itself.


### PR DESCRIPTION
Punch a hole in the docker and bazel environments wide enough to
override the default Spanner endpoint.

Fixes #4459.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4704)
<!-- Reviewable:end -->
