### PR TITLE
feat(pubsub): automatically nack messages

### DIFF
--- a/google/cloud/pubsub/ack_handler.cc
+++ b/google/cloud/pubsub/ack_handler.cc
@@ -29,6 +29,10 @@ static_assert(std::is_move_assignable<AckHandler>::value,
 static_assert(std::is_move_constructible<AckHandler>::value,
               "AckHandler should be MoveConstructible");
 
+AckHandler::~AckHandler() {
+  if (impl_) impl_->nack();
+}
+
 AckHandler::Impl::~Impl() = default;
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/ack_handler.h
+++ b/google/cloud/pubsub/ack_handler.h
@@ -35,6 +35,11 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  */
 class AckHandler {
  public:
+  ~AckHandler();
+
+  AckHandler(AckHandler&&) noexcept = default;
+  AckHandler& operator=(AckHandler&&) noexcept = default;
+
   /// Acknowledge the message and return any (unrecoverablee) RPC errors
   void ack() && {
     auto impl = std::move(impl_);


### PR DESCRIPTION
The application may fail to nack or ack a message in the subscription
handler. In this case the library will automatically nack the message.

Fixes #4709

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4710)
<!-- Reviewable:end -->
