### PR TITLE
feat(pubsub): sequence message handle on ack/nack

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -42,6 +42,8 @@ class SubscriptionSession
 
   future<Status> Start();
 
+  void MessageHandled(std::size_t message_size);
+
  private:
   SubscriptionSession(std::shared_ptr<pubsub_internal::SubscriberStub> s,
                       google::cloud::CompletionQueue executor,

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -26,6 +26,7 @@ namespace {
 
 using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::AtMost;
 
 /// @test Verify callbacks are scheduled in the background threads.
 TEST(SubscriptionSessionTest, ScheduleCallbacks) {
@@ -99,6 +100,74 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
 
   cq.Shutdown();
   for (auto& t : tasks) t.join();
+}
+
+/// @test Verify callbacks are scheduled in sequence.
+TEST(SubscriptionSessionTest, SequencedCallbacks) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  pubsub::Subscription const subscription("test-project", "test-subscription");
+
+  std::mutex mu;
+  int count = 0;
+  auto generate_3 = [&](google::cloud::CompletionQueue&,
+                        std::unique_ptr<grpc::ClientContext>,
+                        google::pubsub::v1::PullRequest const& request) {
+    EXPECT_EQ(subscription.FullName(), request.subscription());
+    google::pubsub::v1::PullResponse response;
+    for (int i = 0; i != 3; ++i) {
+      auto& m = *response.add_received_messages();
+      std::lock_guard<std::mutex> lk(mu);
+      m.set_ack_id("test-ack-id-" + std::to_string(count));
+      m.mutable_message()->set_message_id("test-message-id-" +
+                                          std::to_string(count));
+      ++count;
+    }
+    return make_ready_future(make_status_or(response));
+  };
+  EXPECT_CALL(*mock, AsyncPull(_, _, _)).WillOnce(generate_3);
+
+  // This receives a message, verify that it is the next message in the sequence
+  // and then sets up the expectations for the next set of calls (mostly
+  // AsyncPull).
+  std::atomic<int> expected_message_id{0};
+  auto handler = [&](pubsub::Message const& m, pubsub::AckHandler h) {
+    SCOPED_TRACE("Running for message" + m.message_id());
+    EXPECT_EQ("test-message-id-" + std::to_string(expected_message_id),
+              m.message_id());
+    auto ack_id = "test-ack-id-" + std::to_string(expected_message_id);
+    EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+        .WillOnce(
+            [ack_id](google::cloud::CompletionQueue&,
+                     std::unique_ptr<grpc::ClientContext>,
+                     google::pubsub::v1::AcknowledgeRequest const& request) {
+              for (auto const& a : request.ack_ids()) {
+                EXPECT_EQ(ack_id, a);
+              }
+              return make_ready_future(Status{});
+            });
+    if (expected_message_id > 0 && expected_message_id % 3 == 2) {
+      EXPECT_CALL(*mock, AsyncPull(_, _, _))
+          .Times(AtMost(1))
+          .WillRepeatedly(generate_3);
+    }
+    std::move(h).ack();
+    ++expected_message_id;
+  };
+
+  google::cloud::CompletionQueue cq;
+  std::thread t([&cq] { cq.Run(); });
+  auto session =
+      SubscriptionSession::Create(mock, cq, {subscription.FullName(), handler});
+  auto response = session->Start();
+  while (expected_message_id.load() < 50) {
+    auto s = response.wait_for(std::chrono::milliseconds(5));
+    if (s != std::future_status::timeout) break;
+  }
+  response.cancel();
+  EXPECT_STATUS_OK(response.get());
+
+  cq.Shutdown();
+  t.join();
 }
 
 }  // namespace


### PR DESCRIPTION
So far we have been using the return from the subscription handler to
schedule the next event. This is not correct if we want to limit the
number of messages being handled and support handlers that use some kind
of thread pool.

This is part of the work for #4583 but just because it makes testing easier.
I believe it will also help with #4645 but that remains to be seen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4711)
<!-- Reviewable:end -->
