### PR TITLE
test(pubsub): deflake SubscriptionSession test

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -84,8 +84,10 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
     auto pos = ids.find(std::this_thread::get_id());
     EXPECT_NE(ids.end(), pos);
     EXPECT_NE(main_id, std::this_thread::get_id());
-    std::move(h).ack();
+    // Increment the counter before acking, as the ack() may trigger a new call
+    // before this function gets to run.
     ++expected_message_id;
+    std::move(h).ack();
   };
 
   auto session =


### PR DESCRIPTION
There was a flake (5/1000 runs) in the test code.

Fixes #4716

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4717)
<!-- Reviewable:end -->
