### PR TITLE
feat(pubsub): auto refresh ack deadline

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(
     subscription_admin_client.h
     subscription_admin_connection.cc
     subscription_admin_connection.h
+    subscription_options.h
     topic.cc
     topic.h
     topic_admin_client.cc

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -32,25 +32,31 @@ class NotifyWhenMessageHandled : public pubsub::AckHandler::Impl {
   ~NotifyWhenMessageHandled() override = default;
 
   void ack() override {
+    auto id = ack_id();
     child_->ack();
-    NotifySession();
+    NotifySession(id);
   }
   void nack() override {
+    auto id = ack_id();
     child_->nack();
-    NotifySession();
+    NotifySession(id);
   }
   std::string ack_id() const override { return child_->ack_id(); }
 
  private:
-  void NotifySession() {
+  void NotifySession(std::string const& id) {
     auto session = session_.lock();
-    if (session) session->MessageHandled(message_size_);
+    if (session) session->MessageHandled(id, message_size_);
   }
 
   std::weak_ptr<SubscriptionSession> session_;
   std::unique_ptr<pubsub::AckHandler::Impl> child_;
   std::size_t message_size_;
 };
+
+int constexpr SubscriptionSession::kMinimumAckDeadlineSeconds;
+int constexpr SubscriptionSession::kMaximumAckDeadlineSeconds;
+int constexpr SubscriptionSession::kAckDeadlineSlackSeconds;
 
 future<Status> SubscriptionSession::Start() {
   auto self = shared_from_this();
@@ -64,7 +70,10 @@ future<Status> SubscriptionSession::Start() {
   return result_.get_future();
 }
 
-void SubscriptionSession::MessageHandled(std::size_t) {
+void SubscriptionSession::MessageHandled(std::string const& ack_id,
+                                         std::size_t) {
+  std::unique_lock<std::mutex> lk(mu_);
+  ack_deadlines_.erase(ack_id);
   auto self = shared_from_this();
   // After the callback re-schedule ourselves.
   // TODO(#4652) - support parallel scheduling of callbacks
@@ -74,6 +83,7 @@ void SubscriptionSession::MessageHandled(std::size_t) {
 void SubscriptionSession::Cancel() {
   std::lock_guard<std::mutex> lk(mu_);
   shutdown_ = true;
+  if (refresh_timer_.valid()) refresh_timer_.cancel();
 }
 
 void SubscriptionSession::PullOne() {
@@ -103,22 +113,32 @@ void SubscriptionSession::PullOne() {
 
 void SubscriptionSession::OnPull(StatusOr<google::pubsub::v1::PullResponse> r) {
   if (!r) {
+    // TODO(#4699) - retry on transient failures
     result_.set_value(std::move(r).status());
     return;
   }
 
   std::unique_lock<std::mutex> lk(mu_);
+  auto const now = std::chrono::system_clock::now();
+  auto const estimated_server_deadline = now + std::chrono::seconds(10);
+  auto const handling_deadline = now + params_.options.max_deadline_time();
+  for (auto const& rm : r->received_messages()) {
+    ack_deadlines_.emplace(
+        rm.ack_id(), AckStatus{estimated_server_deadline, handling_deadline});
+  }
   std::move(r->mutable_received_messages()->begin(),
             r->mutable_received_messages()->end(),
             std::back_inserter(messages_));
-  lk.unlock();
-
+  if (refresh_timer_.valid()) {
+    refresh_timer_.cancel();
+    refresh_timer_ = {};
+  }
   auto self = shared_from_this();
   executor_.RunAsync([self] { self->HandleQueue(); });
-}
 
-void SubscriptionSession::HandleQueue() {
-  HandleQueue(std::unique_lock<std::mutex>(mu_));
+  StartRefreshAckDeadlinesTimer(
+      std::move(lk), std::chrono::system_clock::now() +
+                         std::chrono::seconds(kMinimumAckDeadlineSeconds));
 }
 
 void SubscriptionSession::HandleQueue(std::unique_lock<std::mutex> lk) {
@@ -135,12 +155,84 @@ void SubscriptionSession::HandleQueue(std::unique_lock<std::mutex> lk) {
       absl::make_unique<DefaultAckHandlerImpl>(executor_, stub_,
                                                params_.full_subscription_name,
                                                std::move(*m.mutable_ack_id()));
-  // TODO(#...) - use a better estimation for the message size.
+  // TODO(#4645) - use a better estimation for the message size.
   auto const message_size = m.message().data().size();
   handler = absl::make_unique<NotifyWhenMessageHandled>(
       self, std::move(handler), message_size);
   params_.callback(FromProto(std::move(*m.mutable_message())),
                    pubsub::AckHandler(std::move(handler)));
+}
+
+void SubscriptionSession::RefreshAckDeadlines(std::unique_lock<std::mutex> lk) {
+  if (ack_deadlines_.empty() || refreshing_deadlines_) return;
+  google::pubsub::v1::ModifyAckDeadlineRequest request;
+  auto const now = std::chrono::system_clock::now();
+  request.set_subscription(params_.full_subscription_name);
+  using seconds = std::chrono::seconds;
+  auto extension = seconds(kMaximumAckDeadlineSeconds);
+  for (auto const& kv : ack_deadlines_) {
+    // This message cannot be extended any further, and we do not want to send
+    // an extension of 0 seconds because that is a nack.
+    if (kv.second.handling_deadline < now + seconds(1)) continue;
+    auto const message_extension =
+        std::chrono::duration_cast<seconds>(kv.second.handling_deadline - now);
+    extension = (std::min)(extension, message_extension);
+    request.add_ack_ids(kv.first);
+  }
+  auto const new_deadline = now + extension;
+  if (request.ack_ids().empty()) {
+    StartRefreshAckDeadlinesTimer(std::move(lk), new_deadline);
+    return;
+  }
+  request.set_ack_deadline_seconds(
+      static_cast<std::int32_t>(extension.count()));
+  refreshing_deadlines_ = true;
+  auto context = absl::make_unique<grpc::ClientContext>();
+  auto weak = std::weak_ptr<SubscriptionSession>(shared_from_this());
+  lk.unlock();
+  stub_->AsyncModifyAckDeadline(executor_, std::move(context), request)
+      .then([weak, request, new_deadline](future<Status>) {
+        auto self = weak.lock();
+        if (!self) return;
+        self->OnRefreshAckDeadlines(request, new_deadline);
+      });
+}
+
+void SubscriptionSession::OnRefreshAckDeadlines(
+    google::pubsub::v1::ModifyAckDeadlineRequest const& request,
+    std::chrono::system_clock::time_point new_server_deadline) {
+  std::unique_lock<std::mutex> lk(mu_);
+  for (auto const& ack : request.ack_ids()) {
+    auto i = ack_deadlines_.find(ack);
+    if (i == ack_deadlines_.end()) continue;
+    i->second.estimated_server_deadline = new_server_deadline;
+  }
+  StartRefreshAckDeadlinesTimer(std::move(lk), new_server_deadline);
+}
+
+void SubscriptionSession::StartRefreshAckDeadlinesTimer(
+    std::unique_lock<std::mutex>,
+    std::chrono::system_clock::time_point new_server_deadline) {
+  if (shutdown_) return;
+  auto weak = std::weak_ptr<SubscriptionSession>(shared_from_this());
+  auto deadline =
+      new_server_deadline - std::chrono::seconds(kAckDeadlineSlackSeconds);
+  if (test_refresh_period_.count() != 0) {
+    deadline = std::chrono::system_clock::now() + test_refresh_period_;
+  }
+  refresh_timer_ = executor_.MakeDeadlineTimer(deadline).then(
+      [weak](future<StatusOr<std::chrono::system_clock::time_point>> f) {
+        auto self = weak.lock();
+        if (!self || !f.get()) return;
+        self->OnRefreshAckDeadlinesTimer();
+      });
+}
+
+void SubscriptionSession::OnRefreshAckDeadlinesTimer() {
+  std::unique_lock<std::mutex> lk(mu_);
+  refreshing_deadlines_ = false;
+  refresh_timer_ = {};
+  RefreshAckDeadlines(std::move(lk));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -32,6 +32,11 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 class SubscriptionSession
     : public std::enable_shared_from_this<SubscriptionSession> {
  public:
+  static auto constexpr kMinimumAckDeadlineSeconds = 10;
+  static auto constexpr kMaximumAckDeadlineSeconds = 600;
+  static auto constexpr kAckDeadlineSlackSeconds = 2;
+
+  /// The constructor is private to prevent accidents with hared_from_this()
   static std::shared_ptr<SubscriptionSession> Create(
       std::shared_ptr<pubsub_internal::SubscriberStub> s,
       google::cloud::CompletionQueue executor,
@@ -40,9 +45,16 @@ class SubscriptionSession
         std::move(s), std::move(executor), std::move(p)));
   }
 
+  /// Start running the subscription, pull the first batch of messages.
   future<Status> Start();
 
-  void MessageHandled(std::size_t message_size);
+  /// Discard any information about @p ack_id and stop refreshing its deadline.
+  void MessageHandled(std::string const& ack_id, std::size_t message_size);
+
+  /// Test-only, speed up the deadline refreshes to keep tests snappy.
+  void SetTestRefreshPeriod(std::chrono::milliseconds d) {
+    test_refresh_period_ = d;
+  }
 
  private:
   SubscriptionSession(std::shared_ptr<pubsub_internal::SubscriberStub> s,
@@ -50,17 +62,43 @@ class SubscriptionSession
                       pubsub::SubscriberConnection::SubscribeParams p)
       : stub_(std::move(s)),
         executor_(std::move(executor)),
-        params_(std::move(p)) {}
+        params_(std::move(p)),
+        test_refresh_period_(0) {}
 
+  /// Stop fetching message batchines and stop updating any deadlines
   void Cancel();
 
+  /// Asynchronously fetch one batch of messages
   void PullOne();
 
+  /// Called when a batch of messages is received.
   void OnPull(StatusOr<google::pubsub::v1::PullResponse> r);
 
-  void HandleQueue();
+  void HandleQueue() { HandleQueue(std::unique_lock<std::mutex>(mu_)); }
 
+  /// Handle the queue of messages, invoking `callback_` on the next message.
   void HandleQueue(std::unique_lock<std::mutex> lk);
+
+  /// Start the loop to keep ack deadlines refreshed
+  void StartAckDeadlineLoop() {
+    RefreshAckDeadlines(std::unique_lock<std::mutex>(mu_));
+  }
+
+  /// If needed asynchronous update the ack deadlines in the server.
+  void RefreshAckDeadlines(std::unique_lock<std::mutex> lk);
+
+  /// Invoked when the asynchronous RPC to update ack deadlines completes.
+  void OnRefreshAckDeadlines(
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request,
+      std::chrono::system_clock::time_point new_server_deadline);
+
+  /// Start the timer to update ack deadlines.
+  void StartRefreshAckDeadlinesTimer(
+      std::unique_lock<std::mutex> lk,
+      std::chrono::system_clock::time_point new_server_deadline);
+
+  /// The timer to update ack deadlines has triggered.
+  void OnRefreshAckDeadlinesTimer();
 
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   google::cloud::CompletionQueue executor_;
@@ -68,7 +106,16 @@ class SubscriptionSession
   std::mutex mu_;
   bool shutdown_ = false;
   std::deque<google::pubsub::v1::ReceivedMessage> messages_;
+  struct AckStatus {
+    std::chrono::system_clock::time_point estimated_server_deadline;
+    std::chrono::system_clock::time_point handling_deadline;
+  };
+  std::map<std::string, AckStatus> ack_deadlines_;
   promise<Status> result_;
+  bool refreshing_deadlines_ = false;
+  future<void> refresh_timer_;
+
+  std::chrono::milliseconds test_refresh_period_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -325,9 +325,6 @@ TEST(SubscriptionSessionTest, UpdateAckDeadlines) {
       .WillOnce(generate_ack_response)
       .WillOnce(generate_ack_response)
       .WillOnce(generate_ack_response);
-//  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
-//      .After(modify_ack_2)
-//      .WillRepeatedly(ignore_modify_ack_deadline);
 
   promise<void> enough_messages;
   std::atomic<int> expected_message_id{0};

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -29,7 +29,6 @@ using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Expectation;
 using ::testing::InSequence;
-using ::testing::StartsWith;
 
 /// @test Verify callbacks are scheduled in the background threads.
 TEST(SubscriptionSessionTest, ScheduleCallbacks) {

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -27,8 +27,6 @@ namespace {
 
 using ::testing::_;
 using ::testing::AtLeast;
-using ::testing::ElementsAre;
-using ::testing::Expectation;
 using ::testing::InSequence;
 
 /// @test Verify callbacks are scheduled in the background threads.

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/pubsub/internal/subscription_session.h"
 #include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/mock_completion_queue.h"
 #include <gmock/gmock.h>
 #include <atomic>
 
@@ -27,6 +28,7 @@ namespace {
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::InSequence;
+using ::testing::StartsWith;
 
 /// @test Verify callbacks are scheduled in the background threads.
 TEST(SubscriptionSessionTest, ScheduleCallbacks) {
@@ -67,6 +69,12 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
             }
             return make_ready_future(Status{});
           });
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
+      .WillRepeatedly([](google::cloud::CompletionQueue&,
+                         std::unique_ptr<grpc::ClientContext>,
+                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        return make_ready_future(Status{});
+      });
 
   google::cloud::CompletionQueue cq;
   std::vector<std::thread> tasks;
@@ -90,8 +98,8 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
     std::move(h).ack();
   };
 
-  auto session =
-      SubscriptionSession::Create(mock, cq, {subscription.FullName(), handler});
+  auto session = SubscriptionSession::Create(
+      mock, cq, {subscription.FullName(), handler, {}});
   auto response = session->Start();
   while (expected_ack_id.load() < 100) {
     auto s = response.wait_for(std::chrono::milliseconds(5));
@@ -127,6 +135,12 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
     return make_ready_future(make_status_or(response));
   };
 
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
+      .WillRepeatedly([](google::cloud::CompletionQueue&,
+                         std::unique_ptr<grpc::ClientContext>,
+                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        return make_ready_future(Status{});
+      });
   {
     InSequence sequence;
 
@@ -175,8 +189,8 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
 
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
-  auto session =
-      SubscriptionSession::Create(mock, cq, {subscription.FullName(), handler});
+  auto session = SubscriptionSession::Create(
+      mock, cq, {subscription.FullName(), handler, {}});
   auto response = session->Start();
   enough_messages.get_future()
       .then([&](future<void>) { response.cancel(); })
@@ -186,6 +200,170 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
   cq.Shutdown();
   t.join();
 }
+
+/// @test Verify callbacks are scheduled in sequence.
+TEST(SubscriptionSessionTest, UpdateAckDeadlines) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  pubsub::Subscription const subscription("test-project", "test-subscription");
+
+  std::mutex mu;
+  int count = 0;
+  auto generate_3 = [&](google::cloud::CompletionQueue&,
+                        std::unique_ptr<grpc::ClientContext>,
+                        google::pubsub::v1::PullRequest const& request) {
+    EXPECT_EQ(subscription.FullName(), request.subscription());
+    google::pubsub::v1::PullResponse response;
+    for (int i = 0; i != 3; ++i) {
+      auto& m = *response.add_received_messages();
+      std::lock_guard<std::mutex> lk(mu);
+      m.set_ack_id("test-ack-id-" + std::to_string(count));
+      m.mutable_message()->set_message_id("test-message-id-" +
+                                          std::to_string(count));
+      ++count;
+    }
+    return make_ready_future(make_status_or(response));
+  };
+  auto generate_ack_response =
+      [](google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+         google::pubsub::v1::AcknowledgeRequest const&) {
+        return make_ready_future(Status{});
+      };
+
+  promise<void> deadline_0_updated;
+  promise<void> deadline_1_updated;
+  promise<void> deadline_2_updated;
+  {
+    InSequence sequence;
+
+    EXPECT_CALL(*mock, AsyncPull(_, _, _)).WillOnce(generate_3);
+    // This may happen 0 or more times, depending on timing.
+    EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
+        .WillRepeatedly(
+            [&](google::cloud::CompletionQueue&,
+                std::unique_ptr<grpc::ClientContext>,
+                google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+              EXPECT_GE(3, request.ack_ids_size());
+              for (auto const& a : request.ack_ids()) {
+                EXPECT_THAT(a, StartsWith("test-ack-id-"));
+              }
+              return make_ready_future(Status{});
+            });
+
+    EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+        .Times(2)
+        .WillRepeatedly(generate_ack_response);
+    // After 2 acks the handler will block, which will (eventually) expire the
+    // timer and create a update on the AckDeadline and trigger this
+    // expectation. Here we release the handler to wait on the next event.
+    EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
+        .WillOnce(
+            [&](google::cloud::CompletionQueue&,
+                std::unique_ptr<grpc::ClientContext>,
+                google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+              EXPECT_EQ(1, request.ack_ids_size());
+              if (request.ack_ids_size() == 1) {
+                EXPECT_EQ("test-ack-id-2", request.ack_ids(0));
+              }
+              // Allow callback to make progress.
+              deadline_0_updated.set_value();
+              return make_ready_future(Status{});
+            })
+        .WillRepeatedly(
+            [&](google::cloud::CompletionQueue&,
+                std::unique_ptr<grpc::ClientContext>,
+                google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+              // Rarely we will get additional timers triggered and this
+              // function will be called, that is fine.
+              return make_ready_future(Status{});
+            });
+    EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+        .WillOnce(generate_ack_response);
+    EXPECT_CALL(*mock, AsyncPull(_, _, _)).WillOnce(generate_3);
+    EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+        .Times(2)
+        .WillRepeatedly(generate_ack_response);
+    // Here the handler blocks for two deadline updates
+    EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
+        .WillOnce(
+            [&](google::cloud::CompletionQueue&,
+                std::unique_ptr<grpc::ClientContext>,
+                google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+              EXPECT_EQ(1, request.ack_ids_size());
+              if (request.ack_ids_size() == 1) {
+                EXPECT_EQ("test-ack-id-5", request.ack_ids(0));
+              }
+              // Allow callback to make progress.
+              deadline_1_updated.set_value();
+              return make_ready_future(Status{});
+            })
+        .WillOnce(
+            [&](google::cloud::CompletionQueue&,
+                std::unique_ptr<grpc::ClientContext>,
+                google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+              EXPECT_EQ(1, request.ack_ids_size());
+              if (request.ack_ids_size() == 1) {
+                EXPECT_EQ("test-ack-id-5", request.ack_ids(0));
+              }
+              // Allow callback to make progress.
+              deadline_2_updated.set_value();
+              return make_ready_future(Status{});
+            })
+        .WillRepeatedly(
+            [&](google::cloud::CompletionQueue&,
+                std::unique_ptr<grpc::ClientContext>,
+                google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+              // Rarely we will get additional timers triggered and this
+              // function will be called, that is fine.
+              return make_ready_future(Status{});
+            });
+    EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+        .WillOnce(generate_ack_response);
+    EXPECT_CALL(*mock, AsyncPull(_, _, _)).WillOnce(generate_3);
+    EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+        .Times(3)
+        .WillRepeatedly(generate_ack_response);
+  }
+
+  promise<void> enough_messages;
+  std::atomic<int> expected_message_id{0};
+  auto constexpr kMaximumMessages = 9;
+  auto handler = [&](pubsub::Message const&, pubsub::AckHandler h) {
+    auto const id = expected_message_id.load();
+    if (id == 2) {
+      deadline_0_updated.get_future().get();
+    }
+    if (id == 5) {
+      deadline_1_updated.get_future().get();
+      deadline_2_updated.get_future().get();
+    }
+    if (++expected_message_id == kMaximumMessages) {
+      enough_messages.set_value();
+    }
+    std::move(h).ack();
+  };
+
+  google::cloud::CompletionQueue cq;
+  std::vector<std::thread> pool;
+  // we need more than one thread because `handler()` blocks and the CQ needs to
+  // make progress.
+  std::generate_n(std::back_inserter(pool), 4,
+                  [&cq] { return std::thread{[&cq] { cq.Run(); }}; });
+
+  auto session = SubscriptionSession::Create(
+      mock, cq,
+      {subscription.FullName(), handler,
+       pubsub::SubscriptionOptions{}.set_max_deadline_time(
+           std::chrono::seconds(60))});
+  session->SetTestRefreshPeriod(std::chrono::milliseconds(50));
+  auto response = session->Start();
+  enough_messages.get_future()
+      .then([&](future<void>) { response.cancel(); })
+      .get();
+  EXPECT_STATUS_OK(response.get());
+
+  cq.Shutdown();
+  for (auto& t : pool) t.join();
+}  // namespace
 
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -38,6 +38,7 @@ pubsub_client_hdrs = [
     "subscription.h",
     "subscription_admin_client.h",
     "subscription_admin_connection.h",
+    "subscription_options.h",
     "topic.h",
     "topic_admin_client.h",
     "topic_admin_connection.h",

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -20,6 +20,7 @@
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/pubsub/subscription_options.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/status_or.h"
 #include <functional>
@@ -42,6 +43,7 @@ class SubscriberConnection {
   struct SubscribeParams {
     std::string full_subscription_name;
     CallbackType callback;
+    SubscriptionOptions options;
   };
   virtual future<Status> Subscribe(SubscribeParams p) = 0;
 };

--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -1,0 +1,67 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_OPTIONS_H
+
+#include "google/cloud/pubsub/version.h"
+#include <chrono>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/**
+ * Configure how a subscription handles incoming messages.
+ */
+class SubscriptionOptions {
+ public:
+  SubscriptionOptions() = default;
+
+  /**
+   * The maximum deadline for each incoming message.
+   *
+   * Configure how long does the application have to respond (ACK or NACK) an
+   * incoming message. Note that this might be longer, or shorter, than the
+   * deadline configured in the server-side subcription.
+   *
+   * The value `0` is reserved to leave the deadline unmodified and just use the
+   * server-side configuration.
+   *
+   * @note The deadline applies to each message as it is delivered to the
+   *     application, thus, if the library receives a batch of N messages their
+   *     deadline for all the messages is extended repeatedly. Only once the
+   *     message is delivered to a callback does the deadline become immutable.
+   */
+  std::chrono::seconds max_deadline_time() const { return max_deadline_time_; }
+
+  /// Set the maximum deadline for incoming messages.
+  SubscriptionOptions& set_max_deadline_time(std::chrono::seconds d) {
+    max_deadline_time_ = std::chrono::duration_cast<std::chrono::seconds>(d);
+    return *this;
+  }
+
+  // TODO(#4645) - add options for flow control
+
+ private:
+  std::chrono::seconds max_deadline_time_ = std::chrono::seconds(0);
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_OPTIONS_H


### PR DESCRIPTION
Automatically update the Ack deadline for all the events still being
processed (that is, those where the application has neither called
`ack()` nor `nack()`). The application can set a maximum ACK deadline
when the subscription is created, and this applies to the full batch of
messages received by the application even if the messages are
serialized. This is consitent with the golang implementation.

Several tests have different expectations because we avoid sending an
initial `AsyncModifyAckDeadline()` RPC until needed. We expect many
applications to process messages in the initial 10 seconds, so saving
the call seems worthwhile.

Fixes #4583

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4719)
<!-- Reviewable:end -->
