### PR TITLE
test(pubsub): accommodate protobuf fields of type `bytes`

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -259,7 +259,7 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
         EXPECT_EQ(topic.FullName(), request.topic());
         google::pubsub::v1::PublishResponse response;
         for (auto const& m : request.messages()) {
-          response.add_message_ids("ack-for-" + m.data());
+          response.add_message_ids("ack-for-" + std::string(m.data()));
         }
         return make_ready_future(make_status_or(response));
       });

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection_test.cc
@@ -44,7 +44,8 @@ TEST(OrderingKeyPublisherConnectionTest, Publish) {
             [ordering_key](
                 pubsub::PublisherConnection::PublishParams const& p) {
               EXPECT_EQ(ordering_key, p.message.ordering_key());
-              auto ack_id = p.message.ordering_key() + "#" + p.message.data();
+              auto ack_id = p.message.ordering_key() + "#" +
+                            std::string(p.message.data());
               return make_ready_future(make_status_or(ack_id));
             });
     EXPECT_CALL(*mock, Flush(_)).Times(2);


### PR DESCRIPTION
A `bytes` field may not be a `std::string` in some environments,
but it is convertible to one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4720)
<!-- Reviewable:end -->
