### PR TITLE
fix: use the updated transaction id in `ReadImpl`

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -379,7 +379,7 @@ RowStream ConnectionImpl::ReadImpl(
   auto stub = session_pool_->GetStub(*session);
   auto const tracing_enabled = rpc_stream_tracing_enabled_;
   auto const tracing_options = tracing_options_;
-  auto factory = [stub, request, tracing_enabled,
+  auto factory = [stub, &request, tracing_enabled,
                   tracing_options](std::string const& resume_token) mutable {
     request.set_resume_token(resume_token);
     auto context = absl::make_unique<grpc::ClientContext>();

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -436,13 +436,15 @@ TEST(ConnectionImplTest, ReadImplicitBeginTransactionPermanentFailure) {
             EXPECT_EQ(db.FullName(), request.database());
             return MakeSessionsResponse({"test-session-name"});
           });
-  EXPECT_CALL(*mock, StreamingRead(_, _))
+  EXPECT_CALL(*mock, StreamingRead(_, ReadRequestHasSessionAndBeginTransaction(
+                                          "test-session-name")))
       .InSequence(s)
       .WillOnce(Return(ByMove(std::move(reader1))));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .InSequence(s)
-      .WillOnce(Return(MakeTestTransaction()));
-  EXPECT_CALL(*mock, StreamingRead(_, _))
+      .WillOnce(Return(MakeTestTransaction("FEDCBA98")));
+  EXPECT_CALL(*mock, StreamingRead(_, ReadRequestHasSessionAndTransactionId(
+                                          "test-session-name", "FEDCBA98")))
       .InSequence(s)
       .WillOnce(Return(ByMove(std::move(reader2))));
 


### PR DESCRIPTION
The test cases were not checking the transaction state on the
`StreamingRead` operations, so they missed this. Confirmed the new test
fails without the code change and passes with it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4722)
<!-- Reviewable:end -->
