### PR TITLE
fix: handle `ExecuteBatchDml` returning OK with no results

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -792,9 +792,8 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
         },
         request, __func__);
     if (s->has_begin()) {
-      if (response.ok()) {
-        if (response->result_sets_size() < 1 ||
-            !response->result_sets(0).metadata().has_transaction()) {
+      if (response.ok() && response->result_sets_size() > 0) {
+        if (!response->result_sets(0).metadata().has_transaction()) {
           s = MissingTransactionStatus(__func__);
           return s.status();
         }

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -100,7 +100,7 @@ spanner_proto::TransactionOptions PartitionedDmlTransactionOptions() {
 Status MissingTransactionStatus(std::string const& operation) {
   return Status(StatusCode::kInternal,
                 "Begin transaction requested but no transaction returned (in " +
-                    operation + ").");
+                    operation + ")");
 }
 
 ConnectionImpl::ConnectionImpl(Database db,


### PR DESCRIPTION
I added a test and verifies it fails in the way we saw the emulator
tests fail without the code change:

```
[ RUN      ] ConnectionImplTest.ExecuteBatchDmlNoResultSets
google/cloud/spanner/internal/connection_impl_test.cc:1350: Failure
Value of: result
Expected: is OK
Actual: Begin transaction requested but no transaction returned (in ExecuteBatchDmlImpl). [INTERNAL]
```

Fixes #4723

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4724)
<!-- Reviewable:end -->
