### PR TITLE
doc(pubsub): a custom thread pool example

### DIFF
--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -60,7 +60,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * queue in `pubsub::ConnectionOptions::DisableBackgroundThreads()`, and (c)
  * attaching any number of threads to the completion queue.
  *
- * TODO(#4586) - add an example on how to do this.
+ * @snippet samples.cc custom-thread-pool-publisher
  *
  * @par Asynchronous Functions
  *

--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -62,7 +62,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * queue in `pubsub::ConnectionOptions::DisableBackgroundThreads()`, and (c)
  * attaching any number of threads to the completion queue.
  *
- * TODO(#4586) - add an example on how to do this.
+ * @snippet samples.cc custom-thread-pool-subscriber
  *
  * @par Asynchronous Functions
  *

--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -109,7 +109,7 @@ class Subscriber {
   template <typename Callable>
   future<Status> Subscribe(Subscription const& subscription, Callable&& cb) {
     std::function<void(Message, AckHandler)> f(std::forward<Callable>(cb));
-    return connection_->Subscribe({subscription.FullName(), std::move(f)});
+    return connection_->Subscribe({subscription.FullName(), std::move(f), {}});
   }
 
  private:


### PR DESCRIPTION
Show how to setup a custom thread pool for `pubsub::Publisher` and
`pubsub::Subscriber`.

Fixes #4586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4726)
<!-- Reviewable:end -->
