### PR TITLE
feat(pubsub): support move-only message callbacks

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -159,8 +159,8 @@ void SubscriptionSession::HandleQueue(std::unique_lock<std::mutex> lk) {
   auto const message_size = m.message().data().size();
   handler = absl::make_unique<NotifyWhenMessageHandled>(
       self, std::move(handler), message_size);
-  params_.callback(FromProto(std::move(*m.mutable_message())),
-                   pubsub::AckHandler(std::move(handler)));
+  params_.callback->exec(FromProto(std::move(*m.mutable_message())),
+                         pubsub::AckHandler(std::move(handler)));
 }
 
 void SubscriptionSession::RefreshAckDeadlines(std::unique_lock<std::mutex> lk) {

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -98,7 +98,10 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
   };
 
   auto session = SubscriptionSession::Create(
-      mock, cq, {subscription.FullName(), handler, {}});
+      mock, cq,
+      {subscription.FullName(),
+       pubsub_internal::MakeSubscriberCallback(std::move(handler)),
+       {}});
   auto response = session->Start();
   while (expected_ack_id.load() < 100) {
     auto s = response.wait_for(std::chrono::milliseconds(5));
@@ -189,7 +192,10 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
   auto session = SubscriptionSession::Create(
-      mock, cq, {subscription.FullName(), handler, {}});
+      mock, cq,
+      {subscription.FullName(),
+       pubsub_internal::MakeSubscriberCallback(std::move(handler)),
+       {}});
   auto response = session->Start();
   enough_messages.get_future()
       .then([&](future<void>) { response.cancel(); })
@@ -312,7 +318,8 @@ TEST(SubscriptionSessionTest, UpdateAckDeadlines) {
 
   auto session = SubscriptionSession::Create(
       mock, cq,
-      {subscription.FullName(), handler,
+      {subscription.FullName(),
+       pubsub_internal::MakeSubscriberCallback(std::move(handler)),
        pubsub::SubscriptionOptions{}.set_max_deadline_time(
            std::chrono::seconds(60))});
   session->SetTestRefreshPeriod(std::chrono::milliseconds(50));

--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -108,8 +108,10 @@ class Subscriber {
 
   template <typename Callable>
   future<Status> Subscribe(Subscription const& subscription, Callable&& cb) {
-    std::function<void(Message, AckHandler)> f(std::forward<Callable>(cb));
-    return connection_->Subscribe({subscription.FullName(), std::move(f), {}});
+    return connection_->Subscribe(
+        {subscription.FullName(),
+         pubsub_internal::MakeSubscriberCallback(std::forward<Callable>(cb)),
+         {}});
   }
 
  private:

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -78,7 +78,10 @@ TEST(SubscriberConnectionTest, Basic) {
     waiter.set_value();
   };
   std::thread t([&cq] { cq.Run(); });
-  auto response = subscriber->Subscribe({subscription.FullName(), handler, {}});
+  auto response = subscriber->Subscribe(
+      {subscription.FullName(),
+       pubsub_internal::MakeSubscriberCallback(std::move(handler)),
+       {}});
   waiter.get_future().wait();
   response.cancel();
   ASSERT_STATUS_OK(response.get());
@@ -107,7 +110,10 @@ TEST(SubscriberConnectionTest, PullFailure) {
   auto subscriber = pubsub_internal::MakeSubscriberConnection(
       mock, ConnectionOptions{grpc::InsecureChannelCredentials()});
   auto handler = [&](Message const&, AckHandler const&) {};
-  auto response = subscriber->Subscribe({subscription.FullName(), handler, {}});
+  auto response = subscriber->Subscribe(
+      {subscription.FullName(),
+       pubsub_internal::MakeSubscriberCallback(std::move(handler)),
+       {}});
   EXPECT_EQ(expected, response.get());
 }
 

--- a/google/cloud/pubsub/subscriber_test.cc
+++ b/google/cloud/pubsub/subscriber_test.cc
@@ -92,6 +92,7 @@ TEST(SubscriberTest, SubscribeMoveOnly) {
       });
 
   struct MoveOnly {
+    MoveOnly() = default;
     MoveOnly(MoveOnly const&) = delete;
     MoveOnly& operator=(MoveOnly const&) = delete;
     MoveOnly(MoveOnly&&) noexcept = default;
@@ -106,7 +107,7 @@ TEST(SubscriberTest, SubscribeMoveOnly) {
     }
   };
   Subscriber subscriber(mock);
-  auto status = subscriber.Subscribe(subscription, MoveOnly{}).get();
+  auto status = subscriber.Subscribe(subscription, MoveOnly()).get();
   ASSERT_STATUS_OK(status);
 }
 


### PR DESCRIPTION
The previous implementation used `std::function<>` to type-erase the
callable provided by the application, which (AFAIK) requires the
callable to be copy constructible.

Fixes #4556

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4728)
<!-- Reviewable:end -->
