### PR TITLE
cleanup(pubsub): remove redundant duration_cast<>

### DIFF
--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -49,7 +49,7 @@ class SubscriptionOptions {
 
   /// Set the maximum deadline for incoming messages.
   SubscriptionOptions& set_max_deadline_time(std::chrono::seconds d) {
-    max_deadline_time_ = std::chrono::duration_cast<std::chrono::seconds>(d);
+    max_deadline_time_ = d;
     return *this;
   }
 


### PR DESCRIPTION
Thanks to @devbww for noticing this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4730)
<!-- Reviewable:end -->
