### PR TITLE
ci: workaround Windows+CMake+x86 build problems

### DIFF
--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -60,7 +60,7 @@ $workaround_targets=(
 )
 ForEach($target IN $workaround_targets) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling $target with CMake $env:CONFIG"
-    cmake --build "${binary_dir}" --config $env:CONFIG --target "storage_internal_tuple_filter_test"
+    cmake --build "${binary_dir}" --config $env:CONFIG --target "${target}"
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling with CMake $env:CONFIG"

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -48,6 +48,21 @@ if ($LastExitCode) {
     Exit ${LastExitCode}
 }
 
+# Workaround some flaky / broken tests in the CI builds, some of the
+# tests where (reported) successfully created during the build,
+# only to be missing when runing the tests. This is probably a toolchain
+# bug, and this seems to workaround it.
+$workaround_targets=(
+    # Failed around 2020-07-29
+    "storage_internal_tuple_filter_test",
+    # Failed around 2020-07-15
+    "storage_internal_nljson_use_third_party_test"
+)
+ForEach($target IN $workaround_targets) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling $target with CMake $env:CONFIG"
+    cmake --build "${binary_dir}" --config $env:CONFIG --target "storage_internal_tuple_filter_test"
+}
+
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling with CMake $env:CONFIG"
 cmake --build "${binary_dir}" --config $env:CONFIG
 if ($LastExitCode) {


### PR DESCRIPTION
Our builds are failing because one executable is reportedly created by
the CMake step, but the executable is no longer present by the time we
get to the CTest step.  Creating the executable first with CMake, and
then building everything else *seems* to workaround whatever the problem
is. This is a obviously brittle, but the best answer we have at the
moment.

This should reduce the incidence of #4539, but I do not claim it is a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4734)
<!-- Reviewable:end -->
