### PR TITLE
fix(storage): GCE credentials response handling

### DIFF
--- a/google/cloud/storage/internal/compute_engine_util.cc
+++ b/google/cloud/storage/internal/compute_engine_util.cc
@@ -23,12 +23,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
 std::string GceMetadataHostname() {
-  auto maybe_hostname =
-      google::cloud::internal::GetEnv(GceMetadataHostnameEnvVar());
-  if (maybe_hostname.has_value()) {
-    return *maybe_hostname;
-  }
-  return "metadata.google.internal";
+  return google::cloud::internal::GetEnv(GceMetadataHostnameEnvVar())
+      .value_or("metadata.google.internal");
 }
 
 }  // namespace internal

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -33,16 +33,16 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     auto payload =
         response.payload +
         "Could not find all required fields in response (email, scopes).";
-    return AsStatus(storage::internal::HttpResponse{response.status_code,
-                                                    payload, response.headers});
+    return AsStatus(storage::internal::HttpResponse{
+        storage::internal::HttpStatusCode::kMinInvalidCode, payload,
+        response.headers});
   }
   ServiceAccountMetadata metadata;
   // Do not update any state until all potential errors are handled.
   metadata.email = response_body.value("email", "");
   // We need to call the .get<>() helper because the conversion is ambiguous
   // otherwise.
-  metadata.scopes =
-      response_body["scopes"].template get<std::set<std::string>>();
+  metadata.scopes = response_body["scopes"].get<std::set<std::string>>();
   return metadata;
 }
 

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/mock_http_request.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <chrono>
 #include <cstring>
@@ -36,8 +37,10 @@ using ::google::cloud::storage::internal::HttpResponse;
 using ::google::cloud::storage::testing::FakeClock;
 using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::HasSubstr;
+using ::testing::Not;
 using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::UnorderedElementsAre;
@@ -177,18 +180,16 @@ TEST_F(ComputeEngineCredentialsTest, ParseMetadataServerResponseMissingFields) {
   })""";
 
   auto status =
-      ParseMetadataServerResponse(HttpResponse{400, svc_acct_info_resp, {}});
-  EXPECT_FALSE(status);
-  EXPECT_EQ(status.status().code(), StatusCode::kInvalidArgument);
-  EXPECT_THAT(status.status().message(),
-              ::testing::HasSubstr("Could not find all required fields"));
+      ParseMetadataServerResponse(HttpResponse{200, svc_acct_info_resp, {}});
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk),
+                       HasSubstr("Could not find all required fields")));
 
   status =
       ParseMetadataServerResponse(HttpResponse{400, svc_acct_info_resp2, {}});
-  EXPECT_FALSE(status);
-  EXPECT_EQ(status.status().code(), StatusCode::kInvalidArgument);
-  EXPECT_THAT(status.status().message(),
-              ::testing::HasSubstr("Could not find all required fields"));
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk),
+                       HasSubstr("Could not find all required fields")));
 }
 
 /// @test Parsing a metadata server response yields a ServiceAccountMetadata.


### PR DESCRIPTION
Sometimes a thing pretending to be the GCE metadata server responds
with invalid contents but with a success HTTP status code. We were
crashing in this case because we tried to create a StatusOr with an OK
status.

Fixes #4729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4739)
<!-- Reviewable:end -->
