### PR TITLE
feat: log the result for future<StatusOr<T>>

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/internal/log_wrapper.h"
 #include <google/protobuf/text_format.h>
+#include <atomic>
 #include <sstream>
-#include <thread>
 
 namespace google {
 namespace cloud {
@@ -35,10 +35,8 @@ std::string DebugString(google::protobuf::Message const& m,
 }
 
 std::string RequestIdForLogging() {
-  static std::atomic<int> generator{0};
-  std::ostringstream os;
-  os << std::this_thread::get_id() << ":" << ++generator;
-  return std::move(os).str();
+  static std::atomic<std::uint64_t> generator{0};
+  return std::to_string(++generator);
 }
 
 char const* DebugFutureStatus(std::future_status status) {

--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -35,7 +35,7 @@ std::string DebugString(google::protobuf::Message const& m,
 }
 
 std::string RequestIdForLogging() {
-  thread_local std::uint64_t generator = 0;
+  static std::atomic<int> generator{0};
   std::ostringstream os;
   os << std::this_thread::get_id() << ":" << ++generator;
   return std::move(os).str();

--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/internal/log_wrapper.h"
 #include <google/protobuf/text_format.h>
 #include <atomic>
-#include <sstream>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/internal/log_wrapper.h"
 #include <google/protobuf/text_format.h>
+#include <sstream>
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -30,6 +32,32 @@ std::string DebugString(google::protobuf::Message const& m,
       options.truncate_string_field_longer_than());
   p.PrintToString(m, &str);
   return str;
+}
+
+std::string RequestIdForLogging() {
+  thread_local std::uint64_t generator = 0;
+  std::ostringstream os;
+  os << std::this_thread::get_id() << ":" << ++generator;
+  return std::move(os).str();
+}
+
+char const* DebugFutureStatus(std::future_status status) {
+  // We cannot log the value of the future, even when it is available, because
+  // the value can only be extracted once. But we can log if the future is
+  // satisfied.
+  char const* msg = "<invalid>";
+  switch (status) {
+    case std::future_status::ready:
+      msg = "ready";
+      break;
+    case std::future_status::timeout:
+      msg = "timeout";
+      break;
+    case std::future_status::deferred:
+      msg = "deferred";
+      break;
+  }
+  return msg;
 }
 
 }  // namespace internal

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/log_wrapper.h"
+#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/tracing_options.h"
 #include <google/protobuf/text_format.h>
 #include <google/spanner/v1/mutation.pb.h>
@@ -23,6 +24,10 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
+
+using ::testing::AllOf;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 
 google::spanner::v1::Mutation MakeMutation() {
   auto constexpr kText = R"pb(
@@ -125,6 +130,124 @@ TEST(LogWrapper, Truncate) {
             R"pb(} )pb";
   // clang-format on
   EXPECT_EQ(text, internal::DebugString(MakeMutation(), tracing_options));
+}
+
+TEST(LogWrapper, FutureStatus) {
+  struct Case {
+    std::future_status actual;
+    std::string expected;
+  } cases[] = {
+      {std::future_status::deferred, "deferred"},
+      {std::future_status::timeout, "timeout"},
+      {std::future_status::ready, "ready"},
+  };
+  for (auto const& c : cases) {
+    EXPECT_EQ(c.expected, DebugFutureStatus(c.actual));
+  }
+}
+
+/// @test the overload for functions returning FutureStatusOr
+TEST(LogWrapper, FutureStatusOrValue) {
+  auto mock = [](google::spanner::v1::Mutation m) {
+    return make_ready_future(make_status_or(std::move(m)));
+  };
+
+  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  LogWrapper(mock, MakeMutation(), "in-test", {});
+
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
+  EXPECT_THAT(backend->log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                                 HasSubstr(" >> response="))));
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+}
+
+/// @test the overload for functions returning FutureStatusOr
+TEST(LogWrapper, FutureStatusOrError) {
+  auto mock = [](google::spanner::v1::Mutation const&) {
+    return make_ready_future(StatusOr<google::spanner::v1::Mutation>(
+        Status(StatusCode::kPermissionDenied, "uh-oh")));
+  };
+
+  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  LogWrapper(mock, MakeMutation(), "in-test", {});
+
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> status="))));
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr("uh-oh"))));
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+}
+
+/// @test the overload for functions returning FutureStatusOr and using
+/// CompletionQueue as input
+TEST(LogWrapper, FutureStatusOrValueWithContextAndCQ) {
+  auto mock = [](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext>,
+                 google::spanner::v1::Mutation m) {
+    return make_ready_future(make_status_or(std::move(m)));
+  };
+
+  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context;
+  LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
+
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
+  EXPECT_THAT(backend->log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                                 HasSubstr(" >> response="))));
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+}
+
+/// @test the overload for functions returning FutureStatusOr and using
+/// CompletionQueue as input
+TEST(LogWrapper, FutureStatusOrErrorWithContextAndCQ) {
+  auto mock = [](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext>,
+                 google::spanner::v1::Mutation const&) {
+    return make_ready_future(StatusOr<google::spanner::v1::Mutation>(
+        Status(StatusCode::kPermissionDenied, "uh-oh")));
+  };
+
+  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  CompletionQueue cq;
+  std::unique_ptr<grpc::ClientContext> context;
+  LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
+
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> status="))));
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr("uh-oh"))));
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 
 }  // namespace


### PR DESCRIPTION
When a function returns `future<StatusOr<T>>` we cannot log the results
immediately, they may not even exist! Previously we just logged whether
the returned future was ready, now we attach a callback to the future
which logs the value whenever it becomes available.

Because this may be much later in the log, the application might need a
token to match the request and response pairs. I am using a per-thread
counter and the thread id as an identifier.

Part of the work for #4561 and #3900

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4746)
<!-- Reviewable:end -->
