### PR TITLE
cleanup(storage): fix typo in x-goog-* (was x-good-*)

### DIFF
--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -161,7 +161,7 @@ struct SignedUrlTimestamp
   // GCC <= 7.0 does not use the inherited default constructor, redeclare it
   // explicitly
   SignedUrlTimestamp() = default;
-  static char const* name() { return "x-good-date"; }
+  static char const* name() { return "x-goog-date"; }
 };
 
 /**

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -150,7 +150,7 @@ class GcsObjectVersion(object):
         :param request:flask.Request the http request.
         :param prefix: str the prefix shared by the encryption headers,
             typically 'x-goog-encryption', but for rewrite requests it can be
-            'x-good-copy-source-encryption'.
+            'x-goog-copy-source-encryption'.
         :rtype:NoneType
         """
         key_header = prefix + "-key"


### PR DESCRIPTION
Fixes #4762 

I thought about just removing this function, it is not used in the
library at all. But it is a public API, and seems unnecessary to
make a breaking change for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4763)
<!-- Reviewable:end -->
