### PR TITLE
refactor(pubsub): rename CreateSubscriptionBuilder

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -30,7 +30,6 @@ add_library(
     ack_handler.h
     connection_options.cc
     connection_options.h
-    create_subscription_builder.h
     create_topic_builder.h
     internal/batching_publisher_connection.cc
     internal/batching_publisher_connection.h
@@ -65,6 +64,7 @@ add_library(
     subscription_admin_client.h
     subscription_admin_connection.cc
     subscription_admin_connection.h
+    subscription_mutation_builder.h
     subscription_options.h
     topic.cc
     topic.h
@@ -142,7 +142,6 @@ function (google_cloud_cpp_pubsub_client_define_tests)
     set(pubsub_client_unit_tests
         # cmake-format: sort
         ack_handler_test.cc
-        create_subscription_builder_test.cc
         create_topic_builder_test.cc
         internal/batching_publisher_connection_test.cc
         internal/default_ack_handler_impl_test.cc
@@ -156,6 +155,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         publisher_test.cc
         subscriber_connection_test.cc
         subscriber_test.cc
+        subscription_mutation_builder_test.cc
         subscription_test.cc
         topic_test.cc)
 

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -57,7 +57,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       [topic_admin, &topic]() mutable { topic_admin.DeleteTopic(topic); });
 
   auto subscription_metadata = subscription_admin.CreateSubscription(
-      CreateSubscriptionBuilder(subscription, topic)
+      SubscriptionMutationBuilder(subscription, topic)
           .set_ack_deadline(std::chrono::seconds(10)));
   ASSERT_STATUS_OK(subscription_metadata);
 

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -74,8 +74,8 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   Cleanup cleanup_topic{
       [&publisher_client, &topic] { publisher_client.DeleteTopic(topic); }};
 
-  auto create_response =
-      client.CreateSubscription(CreateSubscriptionBuilder(subscription, topic));
+  auto create_response = client.CreateSubscription(
+      SubscriptionMutationBuilder(subscription, topic));
   ASSERT_STATUS_OK(create_response);
 
   auto get_response = client.GetSubscription(subscription);
@@ -96,7 +96,7 @@ TEST(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
   auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection());
-  auto create_response = client.CreateSubscription(CreateSubscriptionBuilder(
+  auto create_response = client.CreateSubscription(SubscriptionMutationBuilder(
       Subscription("--invalid-project--", "--invalid-subscription--"),
       Topic("--invalid-project--", "--invalid-topic--")));
   ASSERT_FALSE(create_response.ok());

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -19,7 +19,6 @@
 pubsub_client_hdrs = [
     "ack_handler.h",
     "connection_options.h",
-    "create_subscription_builder.h",
     "create_topic_builder.h",
     "internal/batching_publisher_connection.h",
     "internal/default_ack_handler_impl.h",
@@ -38,6 +37,7 @@ pubsub_client_hdrs = [
     "subscription.h",
     "subscription_admin_client.h",
     "subscription_admin_connection.h",
+    "subscription_mutation_builder.h",
     "subscription_options.h",
     "topic.h",
     "topic_admin_client.h",

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -18,7 +18,6 @@
 
 pubsub_client_unit_tests = [
     "ack_handler_test.cc",
-    "create_subscription_builder_test.cc",
     "create_topic_builder_test.cc",
     "internal/batching_publisher_connection_test.cc",
     "internal/default_ack_handler_impl_test.cc",
@@ -32,6 +31,7 @@ pubsub_client_unit_tests = [
     "publisher_test.cc",
     "subscriber_connection_test.cc",
     "subscriber_test.cc",
+    "subscription_mutation_builder_test.cc",
     "subscription_test.cc",
     "topic_test.cc",
 ]

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -94,7 +94,7 @@ void CreateSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& topic_id, std::string const& subscription_id) {
     auto subscription =
-        client.CreateSubscription(pubsub::CreateSubscriptionBuilder(
+        client.CreateSubscription(pubsub::SubscriptionMutationBuilder(
             pubsub::Subscription(project_id, std::move(subscription_id)),
             pubsub::Topic(project_id, std::move(topic_id))));
     if (!subscription)

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_ADMIN_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_ADMIN_CLIENT_H
 
-#include "google/cloud/pubsub/create_subscription_builder.h"
 #include "google/cloud/pubsub/subscription_admin_connection.h"
+#include "google/cloud/pubsub/subscription_mutation_builder.h"
 #include "google/cloud/pubsub/version.h"
 #include <memory>
 
@@ -81,7 +81,7 @@ class SubscriptionAdminClient {
    * @param builder the configuration for the new subscription.
    */
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
-      CreateSubscriptionBuilder builder) {
+      SubscriptionMutationBuilder builder) {
     return connection_->CreateSubscription({std::move(builder).as_proto()});
   }
 

--- a/google/cloud/pubsub/subscription_mutation_builder.h
+++ b/google/cloud/pubsub/subscription_mutation_builder.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_SUBSCRIPTION_BUILDER_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_SUBSCRIPTION_BUILDER_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_MUTATION_BUILDER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_MUTATION_BUILDER_H
 
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/topic.h"
@@ -82,44 +82,45 @@ class PushConfigBuilder {
 /**
  * Create a Cloud Pub/Sub subscription configuration.
  */
-class CreateSubscriptionBuilder {
+class SubscriptionMutationBuilder {
  public:
-  explicit CreateSubscriptionBuilder(Subscription const& subscription,
-                                     Topic const& topic) {
+  explicit SubscriptionMutationBuilder(Subscription const& subscription,
+                                       Topic const& topic) {
     proto_.set_name(subscription.FullName());
     proto_.set_topic(topic.FullName());
   }
 
-  CreateSubscriptionBuilder& set_push_config(google::pubsub::v1::PushConfig v) {
+  SubscriptionMutationBuilder& set_push_config(
+      google::pubsub::v1::PushConfig v) {
     *proto_.mutable_push_config() = std::move(v);
     return *this;
   }
 
-  CreateSubscriptionBuilder& set_ack_deadline(std::chrono::seconds v) {
+  SubscriptionMutationBuilder& set_ack_deadline(std::chrono::seconds v) {
     proto_.set_ack_deadline_seconds(static_cast<std::int32_t>(v.count()));
     return *this;
   }
 
-  CreateSubscriptionBuilder& set_retain_acked_messages(bool v) {
+  SubscriptionMutationBuilder& set_retain_acked_messages(bool v) {
     proto_.set_retain_acked_messages(v);
     return *this;
   }
 
   template <typename Rep, typename Period>
-  CreateSubscriptionBuilder& set_message_retention_duration(
+  SubscriptionMutationBuilder& set_message_retention_duration(
       std::chrono::duration<Rep, Period> d) {
     *proto_.mutable_message_retention_duration() =
         ToDurationProto(std::move(d));
     return *this;
   }
 
-  CreateSubscriptionBuilder& add_label(std::string const& key,
-                                       std::string const& value) {
+  SubscriptionMutationBuilder& add_label(std::string const& key,
+                                         std::string const& value) {
     using value_type = protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
     return *this;
   }
-  CreateSubscriptionBuilder& set_labels(
+  SubscriptionMutationBuilder& set_labels(
       std::vector<std::pair<std::string, std::string>> new_labels) {
     google::protobuf::Map<std::string, std::string> labels;
     for (auto& kv : new_labels) {
@@ -128,23 +129,23 @@ class CreateSubscriptionBuilder {
     proto_.mutable_labels()->swap(labels);
     return *this;
   }
-  CreateSubscriptionBuilder& clear_labels() {
+  SubscriptionMutationBuilder& clear_labels() {
     proto_.clear_labels();
     return *this;
   }
 
-  CreateSubscriptionBuilder& enable_message_ordering(bool v) {
+  SubscriptionMutationBuilder& enable_message_ordering(bool v) {
     proto_.set_enable_message_ordering(v);
     return *this;
   }
 
-  CreateSubscriptionBuilder& set_expiration_policy(
+  SubscriptionMutationBuilder& set_expiration_policy(
       google::pubsub::v1::ExpirationPolicy v) {
     *proto_.mutable_expiration_policy() = std::move(v);
     return *this;
   }
 
-  CreateSubscriptionBuilder& set_dead_letter_policy(
+  SubscriptionMutationBuilder& set_dead_letter_policy(
       google::pubsub::v1::DeadLetterPolicy v) {
     *proto_.mutable_dead_letter_policy() = std::move(v);
     return *this;
@@ -190,4 +191,4 @@ class CreateSubscriptionBuilder {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_SUBSCRIPTION_BUILDER_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_MUTATION_BUILDER_H

--- a/google/cloud/pubsub/subscription_mutation_builder_test.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "create_subscription_builder.h"
+#include "subscription_mutation_builder.h"
 #include "google/cloud/pubsub/create_topic_builder.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
@@ -28,7 +28,7 @@ namespace {
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 
-TEST(CreateSubscriptionBuilder, MakeOidcToken) {
+TEST(SubscriptionMutationBuilder, MakeOidcToken) {
   auto const actual =
       PushConfigBuilder::MakeOidcToken("test-account@example.com");
   google::pubsub::v1::PushConfig::OidcToken expected;
@@ -39,7 +39,7 @@ TEST(CreateSubscriptionBuilder, MakeOidcToken) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, MakeOidcTokenWithAudience) {
+TEST(SubscriptionMutationBuilder, MakeOidcTokenWithAudience) {
   auto const actual = PushConfigBuilder::MakeOidcToken(
       "test-account@example.com", "test-audience");
   google::pubsub::v1::PushConfig::OidcToken expected;
@@ -51,7 +51,7 @@ TEST(CreateSubscriptionBuilder, MakeOidcTokenWithAudience) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, PushConfigBasic) {
+TEST(SubscriptionMutationBuilder, PushConfigBasic) {
   auto const actual =
       PushConfigBuilder("https://endpoint.example.com").as_proto();
   google::pubsub::v1::PushConfig expected;
@@ -62,7 +62,7 @@ TEST(CreateSubscriptionBuilder, PushConfigBasic) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, PushConfigAddAttribute) {
+TEST(SubscriptionMutationBuilder, PushConfigAddAttribute) {
   auto const actual = PushConfigBuilder("https://endpoint.example.com")
                           .add_attribute("key0", "label0")
                           .add_attribute("key1", "label1")
@@ -77,7 +77,7 @@ TEST(CreateSubscriptionBuilder, PushConfigAddAttribute) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, PushConfigSetAttributes) {
+TEST(SubscriptionMutationBuilder, PushConfigSetAttributes) {
   auto const actual = PushConfigBuilder("https://endpoint.example.com")
                           .add_attribute("key0", "label0")
                           .add_attribute("key1", "label1")
@@ -92,7 +92,7 @@ TEST(CreateSubscriptionBuilder, PushConfigSetAttributes) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, PushConfigSetAuthentication) {
+TEST(SubscriptionMutationBuilder, PushConfigSetAuthentication) {
   auto const actual =
       PushConfigBuilder("https://endpoint.example.com")
           .set_authentication(PushConfigBuilder::MakeOidcToken(
@@ -110,8 +110,8 @@ TEST(CreateSubscriptionBuilder, PushConfigSetAuthentication) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, Basic) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, Basic) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .as_proto();
@@ -124,8 +124,8 @@ TEST(CreateSubscriptionBuilder, Basic) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetAckDeadline) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, SetAckDeadline) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .set_ack_deadline(std::chrono::seconds(600))
@@ -140,8 +140,8 @@ TEST(CreateSubscriptionBuilder, SetAckDeadline) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetRetainAckedMessages) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, SetRetainAckedMessages) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .set_retain_acked_messages(true)
@@ -156,9 +156,9 @@ TEST(CreateSubscriptionBuilder, SetRetainAckedMessages) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetMessageRetentionDuration) {
+TEST(SubscriptionMutationBuilder, SetMessageRetentionDuration) {
   auto const actual =
-      CreateSubscriptionBuilder(
+      SubscriptionMutationBuilder(
           Subscription("test-project", "test-subscription"),
           Topic("test-project", "test-topic"))
           .set_message_retention_duration(std::chrono::minutes(1) +
@@ -175,9 +175,9 @@ TEST(CreateSubscriptionBuilder, SetMessageRetentionDuration) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetPushConfig) {
+TEST(SubscriptionMutationBuilder, SetPushConfig) {
   auto const actual =
-      CreateSubscriptionBuilder(
+      SubscriptionMutationBuilder(
           Subscription("test-project", "test-subscription"),
           Topic("test-project", "test-topic"))
           .set_push_config(
@@ -193,8 +193,8 @@ TEST(CreateSubscriptionBuilder, SetPushConfig) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, AddLabels) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, AddLabels) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .add_label("key0", "label0")
@@ -211,8 +211,8 @@ TEST(CreateSubscriptionBuilder, AddLabels) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetLabels) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, SetLabels) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .add_label("key0", "label0")
@@ -229,8 +229,8 @@ TEST(CreateSubscriptionBuilder, SetLabels) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, ClearLabels) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, ClearLabels) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .add_label("key0", "label0")
@@ -247,8 +247,8 @@ TEST(CreateSubscriptionBuilder, ClearLabels) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, EnableMessageOrdering) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, EnableMessageOrdering) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .enable_message_ordering(true)
@@ -263,13 +263,13 @@ TEST(CreateSubscriptionBuilder, EnableMessageOrdering) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetExpirationPolicy) {
+TEST(SubscriptionMutationBuilder, SetExpirationPolicy) {
   auto const actual =
-      CreateSubscriptionBuilder(
+      SubscriptionMutationBuilder(
           Subscription("test-project", "test-subscription"),
           Topic("test-project", "test-topic"))
           .set_expiration_policy(
-              CreateSubscriptionBuilder::MakeExpirationPolicy(
+              SubscriptionMutationBuilder::MakeExpirationPolicy(
                   std::chrono::hours(2) + std::chrono::nanoseconds(3)))
           .as_proto();
   google::pubsub::v1::Subscription expected;
@@ -282,12 +282,12 @@ TEST(CreateSubscriptionBuilder, SetExpirationPolicy) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, SetDeadLetterPolicy) {
-  auto const actual = CreateSubscriptionBuilder(
+TEST(SubscriptionMutationBuilder, SetDeadLetterPolicy) {
+  auto const actual = SubscriptionMutationBuilder(
                           Subscription("test-project", "test-subscription"),
                           Topic("test-project", "test-topic"))
                           .set_dead_letter_policy(
-                              CreateSubscriptionBuilder::MakeDeadLetterPolicy(
+                              SubscriptionMutationBuilder::MakeDeadLetterPolicy(
                                   Topic("test-project", "dead-letter"), 3))
                           .as_proto();
   google::pubsub::v1::Subscription expected;
@@ -306,13 +306,13 @@ TEST(CreateSubscriptionBuilder, SetDeadLetterPolicy) {
 template <typename Duration>
 void CheckMakeExpirationPolicy(Duration d,
                                std::string const& expected_as_text) {
-  auto const actual = CreateSubscriptionBuilder::MakeExpirationPolicy(d);
+  auto const actual = SubscriptionMutationBuilder::MakeExpirationPolicy(d);
   google::pubsub::v1::ExpirationPolicy expected;
   ASSERT_TRUE(TextFormat::ParseFromString(expected_as_text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
-TEST(CreateSubscriptionBuilder, MakeExpirationPolicy) {
+TEST(SubscriptionMutationBuilder, MakeExpirationPolicy) {
   using std::chrono::hours;
   using std::chrono::nanoseconds;
   using std::chrono::seconds;


### PR DESCRIPTION
I will soon need a `*Builder` class for `UpdateSubscription` and this
would have been almost a copy of `CreateSubscriptionBuilder`. In this PR
I am just renaming the class to `SubcriptionMutationBuilder`, a future
PR will add the functionality to support both `Create...` and
`Update...` operations.

Part of the work for #4572

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4771)
<!-- Reviewable:end -->
