### PR TITLE
feat: a LogWrapper for future<Status>

### DIFF
--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -54,6 +54,11 @@ struct IsFutureStatusOr : public std::false_type {};
 template <typename T>
 struct IsFutureStatusOr<future<StatusOr<T>>> : public std::true_type {};
 
+template <typename T>
+struct IsFutureStatus : public std::false_type {};
+template <>
+struct IsFutureStatus<future<Status>> : public std::true_type {};
+
 template <
     typename Functor, typename Request,
     typename Result = google::cloud::internal::invoke_result_t<
@@ -174,6 +179,33 @@ Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
       GCP_LOG(DEBUG) << prefix
                      << " >> response=" << DebugString(*response, options);
     }
+    return response;
+  });
+}
+
+template <typename Functor, typename Request,
+          typename Result = google::cloud::internal::invoke_result_t<
+              Functor, google::cloud::CompletionQueue&,
+              std::unique_ptr<grpc::ClientContext>, Request const&>,
+          typename std::enable_if<IsFutureStatus<Result>::value, int>::type = 0>
+Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
+                  std::unique_ptr<grpc::ClientContext> context,
+                  Request const& request, char const* where,
+                  TracingOptions const& options) {
+  // Because this is an asynchronous request we need a unique identifier so
+  // applications can match the request and response in the log.
+  auto prefix = std::string(where) + "(" + RequestIdForLogging() + ")";
+  GCP_LOG(DEBUG) << prefix << " << " << DebugString(request, options);
+  auto response = functor(cq, std::move(context), request);
+  // Ideally we would have an ID to match the request with the asynchronous
+  // response, but for functions with this signature there is nothing that comes
+  // to mind.
+  GCP_LOG(DEBUG) << prefix << " >> future_status="
+                 << DebugFutureStatus(
+                        response.wait_for(std::chrono::microseconds(0)));
+  return response.then([prefix, options](future<Status> f) {
+    auto response = f.get();
+    GCP_LOG(DEBUG) << prefix << " >> response=" << response;
     return response;
   });
 }


### PR DESCRIPTION
This is yet another overload for `g::c::internal::LogWrapper` this time
for functions that return `future<Status>`. We will need this overload
in the log decorator for `pubsub::PublisherStub`.

Part of the work for #4561 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4772)
<!-- Reviewable:end -->
