### PR TITLE
feat(pubsub): a builder for UpdateSubscriptionRequest

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(
     subscription_admin_client.h
     subscription_admin_connection.cc
     subscription_admin_connection.h
+    subscription_mutation_builder.cc
     subscription_mutation_builder.h
     subscription_options.h
     topic.cc

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -57,8 +57,8 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       [topic_admin, &topic]() mutable { topic_admin.DeleteTopic(topic); });
 
   auto subscription_metadata = subscription_admin.CreateSubscription(
-      SubscriptionMutationBuilder(subscription, topic)
-          .set_ack_deadline(std::chrono::seconds(10)));
+      topic, subscription,
+      SubscriptionMutationBuilder{}.set_ack_deadline(std::chrono::seconds(10)));
   ASSERT_STATUS_OK(subscription_metadata);
 
   auto publisher = Publisher(MakePublisherConnection(topic, {}));

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -74,8 +74,7 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   Cleanup cleanup_topic{
       [&publisher_client, &topic] { publisher_client.DeleteTopic(topic); }};
 
-  auto create_response = client.CreateSubscription(
-      SubscriptionMutationBuilder(subscription, topic));
+  auto create_response = client.CreateSubscription(topic, subscription);
   ASSERT_STATUS_OK(create_response);
 
   auto get_response = client.GetSubscription(subscription);
@@ -96,9 +95,9 @@ TEST(SubscriptionAdminIntegrationTest, CreateSubscriptionFailure) {
   // Use an invalid endpoint to force a connection error.
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
   auto client = SubscriptionAdminClient(MakeSubscriptionAdminConnection());
-  auto create_response = client.CreateSubscription(SubscriptionMutationBuilder(
-      Subscription("--invalid-project--", "--invalid-subscription--"),
-      Topic("--invalid-project--", "--invalid-topic--")));
+  auto create_response = client.CreateSubscription(
+      Topic("--invalid-project--", "--invalid-topic--"),
+      Subscription("--invalid-project--", "--invalid-subscription--"));
   ASSERT_FALSE(create_response.ok());
 }
 

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -67,6 +67,7 @@ pubsub_client_srcs = [
     "subscription.cc",
     "subscription_admin_client.cc",
     "subscription_admin_connection.cc",
+    "subscription_mutation_builder.cc",
     "topic.cc",
     "topic_admin_client.cc",
     "topic_admin_connection.cc",

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -93,10 +93,9 @@ void CreateSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   namespace pubsub = google::cloud::pubsub;
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& topic_id, std::string const& subscription_id) {
-    auto subscription =
-        client.CreateSubscription(pubsub::SubscriptionMutationBuilder(
-            pubsub::Subscription(project_id, std::move(subscription_id)),
-            pubsub::Topic(project_id, std::move(topic_id))));
+    auto subscription = client.CreateSubscription(
+        pubsub::Topic(project_id, std::move(topic_id)),
+        pubsub::Subscription(project_id, std::move(subscription_id)));
     if (!subscription)
       throw std::runtime_error(subscription.status().message());
 

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -78,11 +78,15 @@ class SubscriptionAdminClient {
    * @par Example
    * @snippet samples.cc create-subscription
    *
-   * @param builder the configuration for the new subscription.
+   * @param topic the topic that the subscription will attach to
+   * @param subscription the name for the subscription
+   * @param builder any additional configuration for the subscription
    */
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
-      SubscriptionMutationBuilder builder) {
-    return connection_->CreateSubscription({std::move(builder).as_proto()});
+      Topic const& topic, Subscription const& subscription,
+      SubscriptionMutationBuilder builder = {}) {
+    return connection_->CreateSubscription(
+        {std::move(builder).BuildCreateSubscription(topic, subscription)});
   }
 
   /**

--- a/google/cloud/pubsub/subscription_mutation_builder.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder.cc
@@ -27,8 +27,7 @@ SubscriptionMutationBuilder::BuildUpdateSubscription(
   request.mutable_subscription()->set_name(subscription.FullName());
   for (auto const& p : paths_) {
     google::protobuf::util::FieldMaskUtil::AddPathToFieldMask<
-        google::pubsub::v1::UpdateSubscriptionRequest>(
-        "subscription." + p, request.mutable_update_mask());
+        google::pubsub::v1::Subscription>(p, request.mutable_update_mask());
   }
   return request;
 }

--- a/google/cloud/pubsub/subscription_mutation_builder.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/subscription_mutation_builder.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+google::pubsub::v1::UpdateSubscriptionRequest
+SubscriptionMutationBuilder::BuildUpdateSubscription(
+    Subscription const& subscription) && {
+  google::pubsub::v1::UpdateSubscriptionRequest request;
+  *request.mutable_subscription() = std::move(proto_);
+  request.mutable_subscription()->set_name(subscription.FullName());
+  for (auto const& p : paths_) {
+    google::protobuf::util::FieldMaskUtil::AddPathToFieldMask<
+        google::pubsub::v1::UpdateSubscriptionRequest>(
+        "subscription." + p, request.mutable_update_mask());
+  }
+  return request;
+}
+
+google::pubsub::v1::Subscription
+SubscriptionMutationBuilder::BuildCreateSubscription(
+    Topic const& topic, Subscription const& subscription) && {
+  google::pubsub::v1::Subscription request = std::move(proto_);
+  request.set_topic(topic.FullName());
+  request.set_name(subscription.FullName());
+  return request;
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/subscription_mutation_builder.h
+++ b/google/cloud/pubsub/subscription_mutation_builder.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
+#include <google/protobuf/util/field_mask_util.h>
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <set>
 
@@ -92,23 +93,10 @@ class SubscriptionMutationBuilder {
   SubscriptionMutationBuilder() = default;
 
   google::pubsub::v1::UpdateSubscriptionRequest BuildUpdateSubscription(
-      Subscription const& subscription) && {
-    google::pubsub::v1::UpdateSubscriptionRequest request;
-    *request.mutable_subscription() = std::move(proto_);
-    request.mutable_subscription()->set_name(subscription.FullName());
-    for (auto const& p : paths_) {
-      request.mutable_update_mask()->add_paths(p);
-    }
-    return request;
-  }
+      Subscription const& subscription) &&;
 
   google::pubsub::v1::Subscription BuildCreateSubscription(
-      Topic const& topic, Subscription const& subscription) && {
-    google::pubsub::v1::Subscription request = std::move(proto_);
-    request.set_topic(topic.FullName());
-    request.set_name(subscription.FullName());
-    return request;
-  }
+      Topic const& topic, Subscription const& subscription) &&;
 
   SubscriptionMutationBuilder& set_push_config(PushConfigBuilder v) & {
     *proto_.mutable_push_config() = std::move(v.proto_);

--- a/google/cloud/pubsub/subscription_mutation_builder.h
+++ b/google/cloud/pubsub/subscription_mutation_builder.h
@@ -19,11 +19,13 @@
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <set>
 
 namespace google {
 namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+class SubscriptionMutationBuilder;
 
 /**
  * Helper class to create google::pubsub::v1::PushConfig protos.
@@ -32,6 +34,7 @@ class PushConfigBuilder {
  public:
   explicit PushConfigBuilder(std::string push_endpoint) {
     proto_.set_push_endpoint(std::move(push_endpoint));
+    paths_.insert("push_endpoint");
   }
 
   PushConfigBuilder& add_attribute(std::string const& key,
@@ -39,6 +42,7 @@ class PushConfigBuilder {
     proto_.mutable_attributes()->insert(
         google::protobuf::Map<std::string, std::string>::value_type(key,
                                                                     value));
+    paths_.insert("attributes");
     return *this;
   }
   PushConfigBuilder& set_attributes(
@@ -48,6 +52,7 @@ class PushConfigBuilder {
       attributes[kv.first] = std::move(kv.second);
     }
     proto_.mutable_attributes()->swap(attributes);
+    paths_.insert("attributes");
     return *this;
   }
 
@@ -69,14 +74,14 @@ class PushConfigBuilder {
   PushConfigBuilder& set_authentication(
       google::pubsub::v1::PushConfig::OidcToken token) {
     *proto_.mutable_oidc_token() = std::move(token);
+    paths_.insert("oidc_token");
     return *this;
   }
 
-  google::pubsub::v1::PushConfig as_proto() const& { return proto_; }
-  google::pubsub::v1::PushConfig&& as_proto() && { return std::move(proto_); }
-
  private:
+  friend class SubscriptionMutationBuilder;
   google::pubsub::v1::PushConfig proto_;
+  std::set<std::string> paths_;
 };
 
 /**
@@ -84,71 +89,135 @@ class PushConfigBuilder {
  */
 class SubscriptionMutationBuilder {
  public:
-  explicit SubscriptionMutationBuilder(Subscription const& subscription,
-                                       Topic const& topic) {
-    proto_.set_name(subscription.FullName());
-    proto_.set_topic(topic.FullName());
+  SubscriptionMutationBuilder() = default;
+
+  google::pubsub::v1::UpdateSubscriptionRequest BuildUpdateSubscription(
+      Subscription const& subscription) && {
+    google::pubsub::v1::UpdateSubscriptionRequest request;
+    *request.mutable_subscription() = std::move(proto_);
+    request.mutable_subscription()->set_name(subscription.FullName());
+    for (auto const& p : paths_) {
+      request.mutable_update_mask()->add_paths(p);
+    }
+    return request;
   }
 
-  SubscriptionMutationBuilder& set_push_config(
-      google::pubsub::v1::PushConfig v) {
-    *proto_.mutable_push_config() = std::move(v);
+  google::pubsub::v1::Subscription BuildCreateSubscription(
+      Topic const& topic, Subscription const& subscription) && {
+    google::pubsub::v1::Subscription request = std::move(proto_);
+    request.set_topic(topic.FullName());
+    request.set_name(subscription.FullName());
+    return request;
+  }
+
+  SubscriptionMutationBuilder& set_push_config(PushConfigBuilder v) & {
+    *proto_.mutable_push_config() = std::move(v.proto_);
+    for (auto const& s : v.paths_) {
+      paths_.insert("push_config." + s);
+    }
     return *this;
   }
+  SubscriptionMutationBuilder&& set_push_config(PushConfigBuilder v) && {
+    return std::move(set_push_config(std::move(v)));
+  }
 
-  SubscriptionMutationBuilder& set_ack_deadline(std::chrono::seconds v) {
+  SubscriptionMutationBuilder& set_ack_deadline(std::chrono::seconds v) & {
     proto_.set_ack_deadline_seconds(static_cast<std::int32_t>(v.count()));
+    paths_.insert("ack_deadline_seconds");
     return *this;
   }
+  SubscriptionMutationBuilder&& set_ack_deadline(std::chrono::seconds v) && {
+    return std::move(set_ack_deadline(v));
+  }
 
-  SubscriptionMutationBuilder& set_retain_acked_messages(bool v) {
+  SubscriptionMutationBuilder& set_retain_acked_messages(bool v) & {
     proto_.set_retain_acked_messages(v);
+    paths_.insert("retain_acked_messages");
     return *this;
+  }
+  SubscriptionMutationBuilder&& set_retain_acked_messages(bool v) && {
+    return std::move(set_retain_acked_messages(v));
   }
 
   template <typename Rep, typename Period>
   SubscriptionMutationBuilder& set_message_retention_duration(
-      std::chrono::duration<Rep, Period> d) {
+      std::chrono::duration<Rep, Period> d) & {
     *proto_.mutable_message_retention_duration() =
         ToDurationProto(std::move(d));
+    paths_.insert("message_retention_duration");
     return *this;
+  }
+  template <typename Rep, typename Period>
+  SubscriptionMutationBuilder&& set_message_retention_duration(
+      std::chrono::duration<Rep, Period> d) && {
+    return std::move(set_message_retention_duration(d));
   }
 
   SubscriptionMutationBuilder& add_label(std::string const& key,
-                                         std::string const& value) {
+                                         std::string const& value) & {
     using value_type = protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
+    paths_.insert("labels");
     return *this;
   }
+  SubscriptionMutationBuilder&& add_label(std::string const& key,
+                                          std::string const& value) && {
+    return std::move(add_label(key, value));
+  }
+
   SubscriptionMutationBuilder& set_labels(
-      std::vector<std::pair<std::string, std::string>> new_labels) {
+      std::vector<std::pair<std::string, std::string>> new_labels) & {
     google::protobuf::Map<std::string, std::string> labels;
     for (auto& kv : new_labels) {
       labels[kv.first] = std::move(kv.second);
     }
     proto_.mutable_labels()->swap(labels);
+    paths_.insert("labels");
     return *this;
   }
-  SubscriptionMutationBuilder& clear_labels() {
-    proto_.clear_labels();
-    return *this;
+  SubscriptionMutationBuilder&& set_labels(
+      std::vector<std::pair<std::string, std::string>> new_labels) && {
+    return std::move(set_labels(std::move(new_labels)));
   }
 
-  SubscriptionMutationBuilder& enable_message_ordering(bool v) {
-    proto_.set_enable_message_ordering(v);
+  SubscriptionMutationBuilder& clear_labels() & {
+    proto_.clear_labels();
+    paths_.insert("labels");
     return *this;
+  }
+  SubscriptionMutationBuilder&& clear_labels() && {
+    return std::move(clear_labels());
+  }
+
+  SubscriptionMutationBuilder& enable_message_ordering(bool v) & {
+    proto_.set_enable_message_ordering(v);
+    paths_.insert("enable_message_ordering");
+    return *this;
+  }
+  SubscriptionMutationBuilder&& enable_message_ordering(bool v) && {
+    return std::move(enable_message_ordering(v));
   }
 
   SubscriptionMutationBuilder& set_expiration_policy(
-      google::pubsub::v1::ExpirationPolicy v) {
+      google::pubsub::v1::ExpirationPolicy v) & {
     *proto_.mutable_expiration_policy() = std::move(v);
+    paths_.insert("expiration_policy");
     return *this;
+  }
+  SubscriptionMutationBuilder&& set_expiration_policy(
+      google::pubsub::v1::ExpirationPolicy v) && {
+    return std::move(set_expiration_policy(std::move(v)));
   }
 
   SubscriptionMutationBuilder& set_dead_letter_policy(
-      google::pubsub::v1::DeadLetterPolicy v) {
+      google::pubsub::v1::DeadLetterPolicy v) & {
     *proto_.mutable_dead_letter_policy() = std::move(v);
+    paths_.insert("dead_letter_policy");
     return *this;
+  }
+  SubscriptionMutationBuilder&& set_dead_letter_policy(
+      google::pubsub::v1::DeadLetterPolicy v) && {
+    return std::move(set_dead_letter_policy(std::move(v)));
   }
 
   template <typename Rep, typename Period>
@@ -160,15 +229,12 @@ class SubscriptionMutationBuilder {
   }
 
   static google::pubsub::v1::DeadLetterPolicy MakeDeadLetterPolicy(
-      Topic const& dead_letter_topic, std::int32_t max_delivery_attemps = 0) {
+      Topic const& dead_letter_topic, std::int32_t max_delivery_attempts = 0) {
     google::pubsub::v1::DeadLetterPolicy result;
     result.set_dead_letter_topic(dead_letter_topic.FullName());
-    result.set_max_delivery_attempts(max_delivery_attemps);
+    result.set_max_delivery_attempts(max_delivery_attempts);
     return result;
   }
-
-  google::pubsub::v1::Subscription as_proto() const& { return proto_; }
-  google::pubsub::v1::Subscription&& as_proto() && { return std::move(proto_); }
 
  private:
   template <typename Rep, typename Period>
@@ -184,6 +250,7 @@ class SubscriptionMutationBuilder {
   }
 
   google::pubsub::v1::Subscription proto_;
+  std::set<std::string> paths_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/subscription_mutation_builder_test.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder_test.cc
@@ -90,8 +90,7 @@ TEST(SubscriptionMutationBuilder, PushConfigBasic) {
     }
     update_mask { paths: "push_config.push_endpoint" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
-  EXPECT_THAT(actual, IsProtoEqual(expected))
-      << "actual=" << actual.DebugString();
+  EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
 TEST(SubscriptionMutationBuilder, PushConfigAddAttribute) {

--- a/google/cloud/pubsub/subscription_mutation_builder_test.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder_test.cc
@@ -88,7 +88,7 @@ TEST(SubscriptionMutationBuilder, PushConfigBasic) {
       name: "projects/test-project/subscriptions/test-subscription"
       push_config { push_endpoint: "https://endpoint.example.com" }
     }
-    update_mask { paths: "push_config.push_endpoint" })pb";
+    update_mask { paths: "subscription.push_config.push_endpoint" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -112,8 +112,8 @@ TEST(SubscriptionMutationBuilder, PushConfigAddAttribute) {
       }
     }
     update_mask {
-      paths: "push_config.attributes"
-      paths: "push_config.push_endpoint"
+      paths: "subscription.push_config.attributes"
+      paths: "subscription.push_config.push_endpoint"
     })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -138,8 +138,8 @@ TEST(SubscriptionMutationBuilder, PushConfigSetAttributes) {
       }
     }
     update_mask {
-      paths: "push_config.attributes"
-      paths: "push_config.push_endpoint"
+      paths: "subscription.push_config.attributes"
+      paths: "subscription.push_config.push_endpoint"
     })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -167,8 +167,8 @@ TEST(SubscriptionMutationBuilder, PushConfigSetAuthentication) {
       }
     }
     update_mask {
-      paths: "push_config.oidc_token"
-      paths: "push_config.push_endpoint"
+      paths: "subscription.push_config.oidc_token"
+      paths: "subscription.push_config.push_endpoint"
     })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -185,7 +185,7 @@ TEST(SubscriptionMutationBuilder, SetAckDeadline) {
       name: "projects/test-project/subscriptions/test-subscription"
       ack_deadline_seconds: 600
     }
-    update_mask { paths: "ack_deadline_seconds" })pb";
+    update_mask { paths: "subscription.ack_deadline_seconds" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -201,7 +201,7 @@ TEST(SubscriptionMutationBuilder, SetRetainAckedMessages) {
       name: "projects/test-project/subscriptions/test-subscription"
       retain_acked_messages: true
     }
-    update_mask { paths: "retain_acked_messages" })pb";
+    update_mask { paths: "subscription.retain_acked_messages" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -220,7 +220,7 @@ TEST(SubscriptionMutationBuilder, SetMessageRetentionDuration) {
       name: "projects/test-project/subscriptions/test-subscription"
       message_retention_duration { seconds: 62 nanos: 3000 }
     }
-    update_mask { paths: "message_retention_duration" })pb";
+    update_mask { paths: "subscription.message_retention_duration" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -237,7 +237,7 @@ TEST(SubscriptionMutationBuilder, SetPushConfig) {
       name: "projects/test-project/subscriptions/test-subscription"
       push_config { push_endpoint: "https://ep.example.com" }
     }
-    update_mask { paths: "push_config.push_endpoint" })pb";
+    update_mask { paths: "subscription.push_config.push_endpoint" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -255,7 +255,7 @@ TEST(SubscriptionMutationBuilder, AddLabels) {
       labels: { key: "key0", value: "label0" }
       labels: { key: "key1", value: "label1" }
     }
-    update_mask { paths: "labels" })pb";
+    update_mask { paths: "subscription.labels" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -273,7 +273,7 @@ TEST(SubscriptionMutationBuilder, SetLabels) {
       name: "projects/test-project/subscriptions/test-subscription"
       labels: { key: "key2", value: "label2" }
     }
-    update_mask { paths: "labels" })pb";
+    update_mask { paths: "subscription.labels" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -291,7 +291,7 @@ TEST(SubscriptionMutationBuilder, ClearLabels) {
       name: "projects/test-project/subscriptions/test-subscription"
       labels: { key: "key1", value: "label1" }
     }
-    update_mask { paths: "labels" })pb";
+    update_mask { paths: "subscription.labels" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -307,7 +307,7 @@ TEST(SubscriptionMutationBuilder, EnableMessageOrdering) {
       name: "projects/test-project/subscriptions/test-subscription"
       enable_message_ordering: true
     }
-    update_mask { paths: "enable_message_ordering" })pb";
+    update_mask { paths: "subscription.enable_message_ordering" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -326,7 +326,7 @@ TEST(SubscriptionMutationBuilder, SetExpirationPolicy) {
       name: "projects/test-project/subscriptions/test-subscription"
       expiration_policy { ttl { seconds: 7200 nanos: 3 } }
     }
-    update_mask { paths: "expiration_policy" })pb";
+    update_mask { paths: "subscription.expiration_policy" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -347,7 +347,7 @@ TEST(SubscriptionMutationBuilder, SetDeadLetterPolicy) {
         max_delivery_attempts: 3
       }
     }
-    update_mask { paths: "dead_letter_policy" })pb";
+    update_mask { paths: "subscription.dead_letter_policy" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }

--- a/google/cloud/pubsub/subscription_mutation_builder_test.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder_test.cc
@@ -88,7 +88,7 @@ TEST(SubscriptionMutationBuilder, PushConfigBasic) {
       name: "projects/test-project/subscriptions/test-subscription"
       push_config { push_endpoint: "https://endpoint.example.com" }
     }
-    update_mask { paths: "subscription.push_config.push_endpoint" })pb";
+    update_mask { paths: "push_config.push_endpoint" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -112,8 +112,8 @@ TEST(SubscriptionMutationBuilder, PushConfigAddAttribute) {
       }
     }
     update_mask {
-      paths: "subscription.push_config.attributes"
-      paths: "subscription.push_config.push_endpoint"
+      paths: "push_config.attributes"
+      paths: "push_config.push_endpoint"
     })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -138,8 +138,8 @@ TEST(SubscriptionMutationBuilder, PushConfigSetAttributes) {
       }
     }
     update_mask {
-      paths: "subscription.push_config.attributes"
-      paths: "subscription.push_config.push_endpoint"
+      paths: "push_config.attributes"
+      paths: "push_config.push_endpoint"
     })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -167,8 +167,8 @@ TEST(SubscriptionMutationBuilder, PushConfigSetAuthentication) {
       }
     }
     update_mask {
-      paths: "subscription.push_config.oidc_token"
-      paths: "subscription.push_config.push_endpoint"
+      paths: "push_config.oidc_token"
+      paths: "push_config.push_endpoint"
     })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -185,7 +185,7 @@ TEST(SubscriptionMutationBuilder, SetAckDeadline) {
       name: "projects/test-project/subscriptions/test-subscription"
       ack_deadline_seconds: 600
     }
-    update_mask { paths: "subscription.ack_deadline_seconds" })pb";
+    update_mask { paths: "ack_deadline_seconds" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -201,7 +201,7 @@ TEST(SubscriptionMutationBuilder, SetRetainAckedMessages) {
       name: "projects/test-project/subscriptions/test-subscription"
       retain_acked_messages: true
     }
-    update_mask { paths: "subscription.retain_acked_messages" })pb";
+    update_mask { paths: "retain_acked_messages" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -220,7 +220,7 @@ TEST(SubscriptionMutationBuilder, SetMessageRetentionDuration) {
       name: "projects/test-project/subscriptions/test-subscription"
       message_retention_duration { seconds: 62 nanos: 3000 }
     }
-    update_mask { paths: "subscription.message_retention_duration" })pb";
+    update_mask { paths: "message_retention_duration" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -237,7 +237,7 @@ TEST(SubscriptionMutationBuilder, SetPushConfig) {
       name: "projects/test-project/subscriptions/test-subscription"
       push_config { push_endpoint: "https://ep.example.com" }
     }
-    update_mask { paths: "subscription.push_config.push_endpoint" })pb";
+    update_mask { paths: "push_config.push_endpoint" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -255,7 +255,7 @@ TEST(SubscriptionMutationBuilder, AddLabels) {
       labels: { key: "key0", value: "label0" }
       labels: { key: "key1", value: "label1" }
     }
-    update_mask { paths: "subscription.labels" })pb";
+    update_mask { paths: "labels" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -273,7 +273,7 @@ TEST(SubscriptionMutationBuilder, SetLabels) {
       name: "projects/test-project/subscriptions/test-subscription"
       labels: { key: "key2", value: "label2" }
     }
-    update_mask { paths: "subscription.labels" })pb";
+    update_mask { paths: "labels" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -291,7 +291,7 @@ TEST(SubscriptionMutationBuilder, ClearLabels) {
       name: "projects/test-project/subscriptions/test-subscription"
       labels: { key: "key1", value: "label1" }
     }
-    update_mask { paths: "subscription.labels" })pb";
+    update_mask { paths: "labels" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -307,7 +307,7 @@ TEST(SubscriptionMutationBuilder, EnableMessageOrdering) {
       name: "projects/test-project/subscriptions/test-subscription"
       enable_message_ordering: true
     }
-    update_mask { paths: "subscription.enable_message_ordering" })pb";
+    update_mask { paths: "enable_message_ordering" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -326,7 +326,7 @@ TEST(SubscriptionMutationBuilder, SetExpirationPolicy) {
       name: "projects/test-project/subscriptions/test-subscription"
       expiration_policy { ttl { seconds: 7200 nanos: 3 } }
     }
-    update_mask { paths: "subscription.expiration_policy" })pb";
+    update_mask { paths: "expiration_policy" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -347,7 +347,7 @@ TEST(SubscriptionMutationBuilder, SetDeadLetterPolicy) {
         max_delivery_attempts: 3
       }
     }
-    update_mask { paths: "subscription.dead_letter_policy" })pb";
+    update_mask { paths: "dead_letter_policy" })pb";
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }


### PR DESCRIPTION
In this PR we change `pubsub::SubscriptionMutationBuilder` so it can
build both the protos for `CreateSubscription()` and
`UpdateSubscription()`.  I had to change the `pubsub::TopicAdminClient`
API in this change, I think it is now simpler in the common case.

Part of the work for #4572

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4774)
<!-- Reviewable:end -->
