### PR TITLE
feat(pubsub): implement SubscriptionAdmin::UpdateSubcription

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -47,6 +47,15 @@ class DefaultSubscriberStub : public SubscriberStub {
     return response;
   }
 
+  StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
+      grpc::ClientContext& context,
+      google::pubsub::v1::UpdateSubscriptionRequest const& request) override {
+    google::pubsub::v1::Subscription response;
+    auto status = grpc_stub_->UpdateSubscription(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
   StatusOr<google::pubsub::v1::ListSubscriptionsResponse> ListSubscriptions(
       grpc::ClientContext& context,
       google::pubsub::v1::ListSubscriptionsRequest const& request) override {

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -49,6 +49,11 @@ class SubscriberStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::GetSubscriptionRequest const& request) = 0;
 
+  /// Update an existing subscription.
+  virtual StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::UpdateSubscriptionRequest const& request) = 0;
+
   /// List existing subscriptions.
   virtual StatusOr<google::pubsub::v1::ListSubscriptionsResponse>
   ListSubscriptions(

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -123,6 +123,25 @@ void GetSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   (std::move(client), argv.at(0), argv.at(1));
 }
 
+void UpdateSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
+                        std::vector<std::string> const& argv) {
+  //! [update-subscription]
+  namespace pubsub = google::cloud::pubsub;
+  [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
+     std::string const& subscription_id) {
+    auto s = client.UpdateSubscription(
+        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::SubscriptionMutationBuilder{}.set_ack_deadline(
+            std::chrono::seconds(60)));
+    if (!s) throw std::runtime_error(s.status().message());
+
+    std::cout << "The subscription has been updated to: " << s->DebugString()
+              << "\n";
+  }
+  //! [update-subscription]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
 void ListSubscriptions(google::cloud::pubsub::SubscriptionAdminClient client,
                        std::vector<std::string> const& argv) {
   //! [START pubsub_list_subscriptions] [list-subscriptions]
@@ -375,6 +394,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning GetSubscription() sample" << std::endl;
   GetSubscription(subscription_admin_client, {project_id, subscription_id});
 
+  std::cout << "\nRunning UpdateSubscription() sample" << std::endl;
+  UpdateSubscription(subscription_admin_client, {project_id, subscription_id});
+
   std::cout << "\nRunning ListSubscriptions() sample" << std::endl;
   ListSubscriptions(subscription_admin_client, {project_id});
 
@@ -430,6 +452,9 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       CreateSubscriptionAdminCommand("get-subscription",
                                      {"project-id", "subscription-id"},
                                      GetSubscription),
+      CreateSubscriptionAdminCommand("update-subscription",
+                                     {"project-id", "subscription-id"},
+                                     UpdateSubscription),
       CreateSubscriptionAdminCommand("list-subscriptions", {"project-id"},
                                      ListSubscriptions),
       CreateSubscriptionAdminCommand("delete-subscription",

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -105,6 +105,24 @@ class SubscriptionAdminClient {
   }
 
   /**
+   * Update an existing subscription in Cloud Pub/Sub.
+   *
+   * @par Idempotency
+   * This is not an idempotent operation and therefore it is never retried.
+   *
+   * @par Example
+   * @snippet samples.cc update-subscription
+   *
+   * @param subscription the name for the subscription
+   * @param builder any additional configuration for the subscription
+   */
+  StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
+      Subscription const& subscription, SubscriptionMutationBuilder builder) {
+    return connection_->UpdateSubscription(
+        {std::move(builder).BuildUpdateSubscription(subscription)});
+  }
+
+  /**
    * List all the subscriptions for a given project id.
    *
    * @par Idempotency

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -44,6 +44,12 @@ class SubscriptionAdminConnectionImpl : public SubscriptionAdminConnection {
     return stub_->GetSubscription(context, request);
   }
 
+  StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
+      UpdateSubscriptionParams p) override {
+    grpc::ClientContext context;
+    return stub_->UpdateSubscription(context, p.request);
+  }
+
   ListSubscriptionsRange ListSubscriptions(ListSubscriptionsParams p) override {
     google::pubsub::v1::ListSubscriptionsRequest request;
     request.set_project(std::move(p.project_id));

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -79,6 +79,11 @@ class SubscriptionAdminConnection {
     Subscription subscription;
   };
 
+  /// Wrap the arguments for `UpdateSubscription()`
+  struct UpdateSubscriptionParams {
+    google::pubsub::v1::UpdateSubscriptionRequest request;
+  };
+
   /// Wrap the arguments for `ListSubscription()`
   struct ListSubscriptionsParams {
     std::string project_id;
@@ -97,6 +102,10 @@ class SubscriptionAdminConnection {
   /// Defines the interface for `SubscriptionAdminClient::GetSubscription()`
   virtual StatusOr<google::pubsub::v1::Subscription> GetSubscription(
       GetSubscriptionParams) = 0;
+
+  /// Defines the interface for `SubscriptionAdminClient::UpdateSubscription()`
+  virtual StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
+      UpdateSubscriptionParams) = 0;
 
   /// Defines the interface for `SubscriptionAdminClient::ListSubscriptions()`
   virtual ListSubscriptionsRange ListSubscriptions(ListSubscriptionsParams) = 0;

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -40,6 +40,11 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                google::pubsub::v1::GetSubscriptionRequest const&),
               (override));
 
+  MOCK_METHOD(StatusOr<google::pubsub::v1::Subscription>, UpdateSubscription,
+              (grpc::ClientContext&,
+               google::pubsub::v1::UpdateSubscriptionRequest const&),
+              (override));
+
   MOCK_METHOD(StatusOr<google::pubsub::v1::ListSubscriptionsResponse>,
               ListSubscriptions,
               (grpc::ClientContext&,


### PR DESCRIPTION
Now that we have a builder for the `UpdateSubscription()` proto, we can
implement the function, an integration test, and an example.

This fixes #4572 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4777)
<!-- Reviewable:end -->
