### PR TITLE
feat(pubsub): enable logging for Subs*Connection

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -162,6 +162,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         publisher_test.cc
         subscriber_connection_test.cc
         subscriber_test.cc
+        subscription_admin_connection_test.cc
         subscription_mutation_builder_test.cc
         subscription_test.cc
         topic_admin_connection_test.cc

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -33,6 +33,7 @@ pubsub_client_unit_tests = [
     "publisher_test.cc",
     "subscriber_connection_test.cc",
     "subscriber_test.cc",
+    "subscription_admin_connection_test.cc",
     "subscription_mutation_builder_test.cc",
     "subscription_test.cc",
     "topic_admin_connection_test.cc",

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/subscriber_connection.h"
+#include "google/cloud/pubsub/internal/subscriber_logging.h"
 #include "google/cloud/pubsub/internal/subscription_session.h"
+#include "google/cloud/log.h"
 #include <algorithm>
 #include <memory>
 
@@ -62,6 +64,11 @@ class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
     std::shared_ptr<SubscriberStub> stub,
     pubsub::ConnectionOptions const& options) {
+  if (options.tracing_enabled("rpc")) {
+    GCP_LOG(INFO) << "Enabled logging for gRPC calls";
+    stub = std::make_shared<pubsub_internal::SubscriberLogging>(
+        std::move(stub), options.tracing_options());
+  }
   return std::make_shared<SubscriberConnectionImpl>(std::move(stub), options);
 }
 

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_SUBSCRIPTION_ADMIN_CONNECTION_H
 
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -132,6 +133,16 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
+
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+std::shared_ptr<pubsub::SubscriptionAdminConnection>
+MakeSubscriptionAdminConnection(pubsub::ConnectionOptions const& options,
+                                std::shared_ptr<SubscriberStub> stub);
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -1,0 +1,165 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/subscription_admin_connection.h"
+#include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
+#include <gmock/gmock.h>
+#include <atomic>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::testing::Contains;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+
+TEST(SubscriptionAdminConnectionTest, Create) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  Subscription const subscription("test-project", "test-subscription");
+
+  EXPECT_CALL(*mock, CreateSubscription)
+      .WillOnce([&](grpc::ClientContext&,
+                    google::pubsub::v1::Subscription const& request) {
+        EXPECT_EQ(subscription.FullName(), request.name());
+        return make_status_or(request);
+      });
+
+  auto subscription_admin =
+      pubsub_internal::MakeSubscriptionAdminConnection({}, mock);
+  google::pubsub::v1::Subscription expected;
+  expected.set_topic("test-topic-name");
+  expected.set_name(subscription.FullName());
+  auto response = subscription_admin->CreateSubscription({expected});
+  ASSERT_STATUS_OK(response);
+  EXPECT_THAT(*response, IsProtoEqual(expected));
+}
+
+TEST(SubscriptionAdminConnectionTest, List) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+
+  EXPECT_CALL(*mock, ListSubscriptions)
+      .WillOnce(
+          [&](grpc::ClientContext&,
+              google::pubsub::v1::ListSubscriptionsRequest const& request) {
+            EXPECT_EQ("projects/test-project-id", request.project());
+            EXPECT_TRUE(request.page_token().empty());
+            google::pubsub::v1::ListSubscriptionsResponse response;
+            response.add_subscriptions()->set_name("test-subscription-01");
+            response.add_subscriptions()->set_name("test-subscription-02");
+            return make_status_or(response);
+          });
+
+  auto subscription_admin =
+      pubsub_internal::MakeSubscriptionAdminConnection({}, mock);
+  std::vector<std::string> topic_names;
+  for (auto& t :
+       subscription_admin->ListSubscriptions({"projects/test-project-id"})) {
+    ASSERT_STATUS_OK(t);
+    topic_names.push_back(t->name());
+  }
+  EXPECT_THAT(topic_names,
+              ElementsAre("test-subscription-01", "test-subscription-02"));
+}
+
+TEST(SubscriptionAdminConnectionTest, Get) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  Subscription const subscription("test-project", "test-subscription");
+  google::pubsub::v1::Subscription expected;
+  expected.set_topic("test-topic-name");
+  expected.set_name(subscription.FullName());
+
+  EXPECT_CALL(*mock, GetSubscription)
+      .WillOnce([&](grpc::ClientContext&,
+                    google::pubsub::v1::GetSubscriptionRequest const& request) {
+        EXPECT_EQ(subscription.FullName(), request.subscription());
+        return make_status_or(expected);
+      });
+
+  auto subscription_admin =
+      pubsub_internal::MakeSubscriptionAdminConnection({}, mock);
+  auto response = subscription_admin->GetSubscription({subscription});
+  ASSERT_STATUS_OK(response);
+  EXPECT_THAT(*response, IsProtoEqual(expected));
+}
+
+TEST(SubscriptionAdminConnectionTest, Update) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  Subscription const subscription("test-project", "test-subscription");
+
+  EXPECT_CALL(*mock, UpdateSubscription)
+      .WillOnce(
+          [&](grpc::ClientContext&,
+              google::pubsub::v1::UpdateSubscriptionRequest const& request) {
+            EXPECT_EQ(subscription.FullName(), request.subscription().name());
+            EXPECT_THAT(request.update_mask().paths(),
+                        Contains("ack_deadline_seconds"));
+            return make_status_or(request.subscription());
+          });
+
+  auto subscription_admin =
+      pubsub_internal::MakeSubscriptionAdminConnection({}, mock);
+  google::pubsub::v1::Subscription expected;
+  expected.set_name(subscription.FullName());
+  expected.set_ack_deadline_seconds(1);
+
+  google::pubsub::v1::UpdateSubscriptionRequest request;
+  *request.mutable_subscription() = expected;
+  request.mutable_update_mask()->add_paths("ack_deadline_seconds");
+  auto response = subscription_admin->UpdateSubscription({request});
+  ASSERT_STATUS_OK(response);
+  EXPECT_THAT(*response, IsProtoEqual(expected));
+}
+
+/**
+ * @test Verify DeleteTopic() and logging works.
+ *
+ * We use this test for both DeleteTopic and logging. DeleteTopic has a simple
+ * return type, so it is a good candidate to do the logging test too.
+ */
+TEST(SubscriptionAdminConnectionTest, DeleteWithLogging) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  Subscription const subscription("test-project", "test-subscription");
+  auto backend =
+      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  EXPECT_CALL(*mock, DeleteSubscription)
+      .WillOnce(
+          [&](grpc::ClientContext&,
+              google::pubsub::v1::DeleteSubscriptionRequest const& request) {
+            EXPECT_EQ(subscription.FullName(), request.subscription());
+            return Status{};
+          });
+
+  auto subscription_admin = pubsub_internal::MakeSubscriptionAdminConnection(
+      ConnectionOptions{}.enable_tracing("rpc"), mock);
+  auto response = subscription_admin->DeleteSubscription({subscription});
+  ASSERT_STATUS_OK(response);
+
+  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("DeleteSubscription")));
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
If configured, use the `SubscriberLogging` decorator for both
`SubscriptionAdminConnection` and `SubscriberConnection`.

Fixes #4561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4789)
<!-- Reviewable:end -->
