### PR TITLE
refactor(pubsub): rename CreateTopicBuilder

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -30,7 +30,6 @@ add_library(
     ack_handler.h
     connection_options.cc
     connection_options.h
-    create_topic_builder.h
     internal/batching_publisher_connection.cc
     internal/batching_publisher_connection.h
     internal/default_ack_handler_impl.cc
@@ -77,6 +76,7 @@ add_library(
     topic_admin_client.h
     topic_admin_connection.cc
     topic_admin_connection.h
+    topic_mutation_builder.h
     version.h
     version_info.h)
 target_include_directories(
@@ -147,7 +147,6 @@ function (google_cloud_cpp_pubsub_client_define_tests)
     set(pubsub_client_unit_tests
         # cmake-format: sort
         ack_handler_test.cc
-        create_topic_builder_test.cc
         internal/batching_publisher_connection_test.cc
         internal/default_ack_handler_impl_test.cc
         internal/emulator_overrides_test.cc
@@ -165,6 +164,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         subscription_mutation_builder_test.cc
         subscription_test.cc
         topic_admin_connection_test.cc
+        topic_mutation_builder_test.cc
         topic_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -45,7 +45,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
   auto subscription_admin =
       SubscriptionAdminClient(MakeSubscriptionAdminConnection());
 
-  auto topic_metadata = topic_admin.CreateTopic(CreateTopicBuilder(topic));
+  auto topic_metadata = topic_admin.CreateTopic(TopicMutationBuilder(topic));
   ASSERT_STATUS_OK(topic_metadata);
 
   struct Cleanup {

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -63,7 +63,8 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   EXPECT_THAT(subscription_names(client, project_id),
               Not(Contains(subscription.FullName())));
 
-  auto topic_metadata = publisher_client.CreateTopic(CreateTopicBuilder(topic));
+  auto topic_metadata =
+      publisher_client.CreateTopic(TopicMutationBuilder(topic));
   ASSERT_STATUS_OK(topic_metadata);
 
   struct Cleanup {

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -58,7 +58,7 @@ TEST(TopicAdminIntegrationTest, TopicCRUD) {
   EXPECT_THAT(topic_names(publisher, project_id),
               Not(Contains(topic.FullName())));
 
-  auto create_response = publisher.CreateTopic(CreateTopicBuilder(topic));
+  auto create_response = publisher.CreateTopic(TopicMutationBuilder(topic));
   ASSERT_STATUS_OK(create_response);
 
   auto get_response = publisher.GetTopic(topic);
@@ -79,7 +79,7 @@ TEST(TopicAdminIntegrationTest, CreateTopicFailure) {
   ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
   auto publisher = TopicAdminClient(MakeTopicAdminConnection());
   auto create_response = publisher.CreateTopic(
-      CreateTopicBuilder(Topic("invalid-project", "invalid-topic")));
+      TopicMutationBuilder(Topic("invalid-project", "invalid-topic")));
   ASSERT_FALSE(create_response);
 }
 

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -19,7 +19,6 @@
 pubsub_client_hdrs = [
     "ack_handler.h",
     "connection_options.h",
-    "create_topic_builder.h",
     "internal/batching_publisher_connection.h",
     "internal/default_ack_handler_impl.h",
     "internal/emulator_overrides.h",
@@ -44,6 +43,7 @@ pubsub_client_hdrs = [
     "topic.h",
     "topic_admin_client.h",
     "topic_admin_connection.h",
+    "topic_mutation_builder.h",
     "version.h",
     "version_info.h",
 ]

--- a/google/cloud/pubsub/pubsub_client_unit_tests.bzl
+++ b/google/cloud/pubsub/pubsub_client_unit_tests.bzl
@@ -18,7 +18,6 @@
 
 pubsub_client_unit_tests = [
     "ack_handler_test.cc",
-    "create_topic_builder_test.cc",
     "internal/batching_publisher_connection_test.cc",
     "internal/default_ack_handler_impl_test.cc",
     "internal/emulator_overrides_test.cc",
@@ -36,5 +35,6 @@ pubsub_client_unit_tests = [
     "subscription_mutation_builder_test.cc",
     "subscription_test.cc",
     "topic_admin_connection_test.cc",
+    "topic_mutation_builder_test.cc",
     "topic_test.cc",
 ]

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -41,7 +41,7 @@ void CreateTopic(google::cloud::pubsub::TopicAdminClient client,
   namespace pubsub = google::cloud::pubsub;
   [](pubsub::TopicAdminClient client, std::string project_id,
      std::string topic_id) {
-    auto topic = client.CreateTopic(pubsub::CreateTopicBuilder(
+    auto topic = client.CreateTopic(pubsub::TopicMutationBuilder(
         pubsub::Topic(std::move(project_id), std::move(topic_id))));
     if (!topic) throw std::runtime_error(topic.status().message());
 

--- a/google/cloud/pubsub/subscription_mutation_builder_test.cc
+++ b/google/cloud/pubsub/subscription_mutation_builder_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "subscription_mutation_builder.h"
-#include "google/cloud/pubsub/create_topic_builder.h"
+#include "google/cloud/pubsub/topic_mutation_builder.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_ADMIN_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_ADMIN_CLIENT_H
 
-#include "google/cloud/pubsub/create_topic_builder.h"
 #include "google/cloud/pubsub/topic_admin_connection.h"
+#include "google/cloud/pubsub/topic_mutation_builder.h"
 #include "google/cloud/pubsub/version.h"
 #include <memory>
 
@@ -79,7 +79,8 @@ class TopicAdminClient {
    *
    * @param builder the configuration for the new topic.
    */
-  StatusOr<google::pubsub::v1::Topic> CreateTopic(CreateTopicBuilder builder) {
+  StatusOr<google::pubsub::v1::Topic> CreateTopic(
+      TopicMutationBuilder builder) {
     return connection_->CreateTopic({std::move(builder).as_proto()});
   }
 

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/topic_admin_connection.h"
-#include "google/cloud/pubsub/create_topic_builder.h"
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
+#include "google/cloud/pubsub/topic_mutation_builder.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
@@ -43,7 +43,7 @@ TEST(TopicAdminConnectionTest, Create) {
           });
 
   auto topic_admin = pubsub_internal::MakeTopicAdminConnection({}, mock);
-  auto const expected = CreateTopicBuilder(topic).as_proto();
+  auto const expected = TopicMutationBuilder(topic).as_proto();
   auto response = topic_admin->CreateTopic({expected});
   ASSERT_STATUS_OK(response);
   EXPECT_THAT(*response, IsProtoEqual(expected));

--- a/google/cloud/pubsub/topic_mutation_builder.h
+++ b/google/cloud/pubsub/topic_mutation_builder.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_TOPIC_BUILDER_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_TOPIC_BUILDER_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_MUTATION_BUILDER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_MUTATION_BUILDER_H
 
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
@@ -27,36 +27,36 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 /**
  * Create a Cloud Pub/Sub topic configuration.
  */
-class CreateTopicBuilder {
+class TopicMutationBuilder {
  public:
-  explicit CreateTopicBuilder(Topic const& topic) {
+  explicit TopicMutationBuilder(Topic const& topic) {
     proto_.set_name(topic.FullName());
   }
 
-  CreateTopicBuilder& add_label(std::string const& key,
-                                std::string const& value) {
+  TopicMutationBuilder& add_label(std::string const& key,
+                                  std::string const& value) {
     using value_type = protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
     return *this;
   }
 
-  CreateTopicBuilder& clear_labels() {
+  TopicMutationBuilder& clear_labels() {
     proto_.clear_labels();
     return *this;
   }
 
-  CreateTopicBuilder& add_allowed_persistence_region(std::string region) {
+  TopicMutationBuilder& add_allowed_persistence_region(std::string region) {
     proto_.mutable_message_storage_policy()->add_allowed_persistence_regions(
         std::move(region));
     return *this;
   }
-  CreateTopicBuilder& clear_allowed_persistence_regions() {
+  TopicMutationBuilder& clear_allowed_persistence_regions() {
     proto_.mutable_message_storage_policy()
         ->clear_allowed_persistence_regions();
     return *this;
   }
 
-  CreateTopicBuilder& set_kms_key_name(std::string key_name) {
+  TopicMutationBuilder& set_kms_key_name(std::string key_name) {
     proto_.set_kms_key_name(std::move(key_name));
     return *this;
   }
@@ -73,4 +73,4 @@ class CreateTopicBuilder {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_CREATE_TOPIC_BUILDER_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_MUTATION_BUILDER_H

--- a/google/cloud/pubsub/topic_mutation_builder_test.cc
+++ b/google/cloud/pubsub/topic_mutation_builder_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/pubsub/create_topic_builder.h"
+#include "google/cloud/pubsub/topic_mutation_builder.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -29,7 +29,7 @@ using ::google::protobuf::TextFormat;
 
 TEST(Topic, TopicOnly) {
   auto const actual =
-      CreateTopicBuilder(Topic("test-project", "test-topic")).as_proto();
+      TopicMutationBuilder(Topic("test-project", "test-topic")).as_proto();
   google::pubsub::v1::Topic expected;
   std::string const text = R"pb(
     name: "projects/test-project/topics/test-topic"
@@ -39,7 +39,7 @@ TEST(Topic, TopicOnly) {
 }
 
 TEST(Topic, AddLabel) {
-  auto const actual = CreateTopicBuilder(Topic("test-project", "test-topic"))
+  auto const actual = TopicMutationBuilder(Topic("test-project", "test-topic"))
                           .add_label("key0", "label0")
                           .add_label("key1", "label1")
                           .as_proto();
@@ -54,7 +54,7 @@ TEST(Topic, AddLabel) {
 }
 
 TEST(Topic, ClearLabel) {
-  auto const actual = CreateTopicBuilder(Topic("test-project", "test-topic"))
+  auto const actual = TopicMutationBuilder(Topic("test-project", "test-topic"))
                           .add_label("key0", "label0")
                           .clear_labels()
                           .add_label("key1", "label1")
@@ -69,7 +69,7 @@ TEST(Topic, ClearLabel) {
 }
 
 TEST(Topic, AddAllowedPersistenceRegion) {
-  auto const actual = CreateTopicBuilder(Topic("test-project", "test-topic"))
+  auto const actual = TopicMutationBuilder(Topic("test-project", "test-topic"))
                           .add_allowed_persistence_region("us-central1")
                           .add_allowed_persistence_region("us-west1")
                           .as_proto();
@@ -86,7 +86,7 @@ TEST(Topic, AddAllowedPersistenceRegion) {
 }
 
 TEST(Topic, ClearAllowedPersistenceRegions) {
-  auto const actual = CreateTopicBuilder(Topic("test-project", "test-topic"))
+  auto const actual = TopicMutationBuilder(Topic("test-project", "test-topic"))
                           .add_allowed_persistence_region("us-central1")
                           .clear_allowed_persistence_regions()
                           .add_allowed_persistence_region("us-west1")
@@ -101,7 +101,7 @@ TEST(Topic, ClearAllowedPersistenceRegions) {
 }
 
 TEST(Topic, SetKmsKeyName) {
-  auto const actual = CreateTopicBuilder(Topic("test-project", "test-topic"))
+  auto const actual = TopicMutationBuilder(Topic("test-project", "test-topic"))
                           .set_kms_key_name("projects/.../test-only-string")
                           .as_proto();
   google::pubsub::v1::Topic expected;
@@ -114,7 +114,7 @@ TEST(Topic, SetKmsKeyName) {
 }
 
 TEST(Topic, MoveProto) {
-  auto builder = CreateTopicBuilder(Topic("test-project", "test-topic"))
+  auto builder = TopicMutationBuilder(Topic("test-project", "test-topic"))
                      .add_label("key0", "label0")
                      .add_label("key1", "label1")
                      .add_allowed_persistence_region("us-central1")


### PR DESCRIPTION
Rename `pubsub::CreateTopicBuilder` to `pubsub::TopicMutationBuilder`,
we will need basically the same builder for both `CreateTopic()` and
`UpdateTopic()`. This PR is just about renaming, the new functionality
will come in a future PR.

Part of the work for #4566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4790)
<!-- Reviewable:end -->
