### PR TITLE
ci: log when integration tests against production start

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -206,6 +206,9 @@ if should_run_integration_tests; then
   # Run the integration tests using Bazel to drive them. Some of the tests and
   # examples require environment variables with dynamic values, so we run them
   # below to avoid invalidating the cached test results for all the other tests.
+  echo "================================================================"
+  io::log_yellow "running integration tests against production:" \
+    "spanner=${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT:-default}"
   "${BAZEL_BIN}" test \
     "${bazel_args[@]}" \
     "--test_tag_filters=integration-test" \


### PR DESCRIPTION
This just makes the output a little clearer. Include any override
setting for the Spanner endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4793)
<!-- Reviewable:end -->
