### PR TITLE
feat(pubsub): support updates in TopicMutationBuilder

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(
     topic_admin_client.h
     topic_admin_connection.cc
     topic_admin_connection.h
+    topic_mutation_builder.cc
     topic_mutation_builder.h
     version.h
     version_info.h)

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -73,4 +73,5 @@ pubsub_client_srcs = [
     "topic.cc",
     "topic_admin_client.cc",
     "topic_admin_connection.cc",
+    "topic_mutation_builder.cc",
 ]

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -77,11 +77,11 @@ class TopicAdminClient {
    * @par Example
    * @snippet samples.cc create-topic
    *
-   * @param builder the configuration for the new topic.
+   * @param builder the configuration for the new topic, includes the name.
    */
   StatusOr<google::pubsub::v1::Topic> CreateTopic(
       TopicMutationBuilder builder) {
-    return connection_->CreateTopic({std::move(builder).as_proto()});
+    return connection_->CreateTopic({std::move(builder).BuildCreateMutation()});
   }
 
   /**

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -43,7 +43,7 @@ TEST(TopicAdminConnectionTest, Create) {
           });
 
   auto topic_admin = pubsub_internal::MakeTopicAdminConnection({}, mock);
-  auto const expected = TopicMutationBuilder(topic).as_proto();
+  auto const expected = TopicMutationBuilder(topic).BuildCreateMutation();
   auto response = topic_admin->CreateTopic({expected});
   ASSERT_STATUS_OK(response);
   EXPECT_THAT(*response, IsProtoEqual(expected));

--- a/google/cloud/pubsub/topic_mutation_builder.cc
+++ b/google/cloud/pubsub/topic_mutation_builder.cc
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/topic_mutation_builder.h"
+#include <google/protobuf/util/field_mask_util.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+google::pubsub::v1::Topic TopicMutationBuilder::BuildCreateMutation() && {
+  return std::move(proto_);
+}
+
+google::pubsub::v1::UpdateTopicRequest
+TopicMutationBuilder::BuildUpdateMutation() && {
+  google::pubsub::v1::UpdateTopicRequest request;
+  *request.mutable_topic() = std::move(proto_);
+  for (auto const& p : paths_) {
+    google::protobuf::util::FieldMaskUtil::AddPathToFieldMask<
+        google::pubsub::v1::Topic>(p, request.mutable_update_mask());
+  }
+  return request;
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/topic_mutation_builder.h
+++ b/google/cloud/pubsub/topic_mutation_builder.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <set>
 
 namespace google {
 namespace cloud {
@@ -33,39 +34,61 @@ class TopicMutationBuilder {
     proto_.set_name(topic.FullName());
   }
 
+  google::pubsub::v1::Topic BuildCreateMutation() &&;
+
+  google::pubsub::v1::UpdateTopicRequest BuildUpdateMutation() &&;
+
   TopicMutationBuilder& add_label(std::string const& key,
-                                  std::string const& value) {
+                                  std::string const& value) & {
     using value_type = protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
+    paths_.insert("labels");
     return *this;
   }
+  TopicMutationBuilder&& add_label(std::string const& key,
+                                   std::string const& value) && {
+    return std::move(add_label(key, value));
+  }
 
-  TopicMutationBuilder& clear_labels() {
+  TopicMutationBuilder& clear_labels() & {
     proto_.clear_labels();
+    paths_.insert("labels");
     return *this;
   }
+  TopicMutationBuilder&& clear_labels() && { return std::move(clear_labels()); }
 
-  TopicMutationBuilder& add_allowed_persistence_region(std::string region) {
+  TopicMutationBuilder& add_allowed_persistence_region(std::string region) & {
     proto_.mutable_message_storage_policy()->add_allowed_persistence_regions(
         std::move(region));
+    paths_.insert("message_storage_policy");
     return *this;
   }
-  TopicMutationBuilder& clear_allowed_persistence_regions() {
+  TopicMutationBuilder&& add_allowed_persistence_region(std::string region) && {
+    return std::move(add_allowed_persistence_region(std::move(region)));
+  }
+
+  TopicMutationBuilder& clear_allowed_persistence_regions() & {
     proto_.mutable_message_storage_policy()
         ->clear_allowed_persistence_regions();
+    paths_.insert("message_storage_policy");
     return *this;
   }
+  TopicMutationBuilder&& clear_allowed_persistence_regions() && {
+    return std::move(clear_allowed_persistence_regions());
+  }
 
-  TopicMutationBuilder& set_kms_key_name(std::string key_name) {
+  TopicMutationBuilder& set_kms_key_name(std::string key_name) & {
     proto_.set_kms_key_name(std::move(key_name));
+    paths_.insert("kms_key_name");
     return *this;
   }
-
-  google::pubsub::v1::Topic as_proto() const& { return proto_; }
-  google::pubsub::v1::Topic&& as_proto() && { return std::move(proto_); }
+  TopicMutationBuilder&& set_kms_key_name(std::string key_name) && {
+    return std::move(set_kms_key_name(std::move(key_name)));
+  }
 
  private:
   google::pubsub::v1::Topic proto_;
+  std::set<std::string> paths_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
Adds support for updates in `pubsub::TopicMutationBuilder`, though this
is not used beyond the unit test at this point.

Part of the work for #4566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4794)
<!-- Reviewable:end -->
