### PR TITLE
feat(pubsub): implement TopicAdminClient::UpdateTopic

### DIFF
--- a/google/cloud/pubsub/internal/publisher_logging.cc
+++ b/google/cloud/pubsub/internal/publisher_logging.cc
@@ -43,6 +43,17 @@ StatusOr<google::pubsub::v1::Topic> PublisherLogging::GetTopic(
       context, request, __func__, tracing_options_);
 }
 
+StatusOr<google::pubsub::v1::Topic> PublisherLogging::UpdateTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::UpdateTopicRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::UpdateTopicRequest const& request) {
+        return child_->UpdateTopic(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 StatusOr<google::pubsub::v1::ListTopicsResponse> PublisherLogging::ListTopics(
     grpc::ClientContext& context,
     google::pubsub::v1::ListTopicsRequest const& request) {

--- a/google/cloud/pubsub/internal/publisher_logging.h
+++ b/google/cloud/pubsub/internal/publisher_logging.h
@@ -38,6 +38,9 @@ class PublisherLogging : public PublisherStub {
   StatusOr<google::pubsub::v1::Topic> GetTopic(
       grpc::ClientContext& context,
       google::pubsub::v1::GetTopicRequest const& request) override;
+  StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::UpdateTopicRequest const& request) override;
   StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicsRequest const& request) override;

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -79,6 +79,19 @@ TEST_F(PublisherLoggingTest, GetTopic) {
   EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("GetTopic")));
 }
 
+TEST_F(PublisherLoggingTest, UpdateTopic) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  EXPECT_CALL(*mock, UpdateTopic)
+      .WillOnce(Return(make_status_or(google::pubsub::v1::Topic{})));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  grpc::ClientContext context;
+  google::pubsub::v1::UpdateTopicRequest request;
+  request.mutable_topic()->set_name("test-topic-name");
+  auto status = stub.UpdateTopic(context, request);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("UpdateTopic")));
+}
+
 TEST_F(PublisherLoggingTest, ListTopics) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, ListTopics)

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -48,6 +48,15 @@ class DefaultPublisherStub : public PublisherStub {
     return response;
   }
 
+  StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      grpc::ClientContext& context,
+      google::pubsub::v1::UpdateTopicRequest const& request) override {
+    google::pubsub::v1::Topic response;
+    auto status = grpc_stub_->UpdateTopic(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
   StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& context,
       google::pubsub::v1::ListTopicsRequest const& request) override {

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -50,6 +50,11 @@ class PublisherStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::GetTopicRequest const& request) = 0;
 
+  /// Update the configuration of an existing topic.
+  virtual StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::UpdateTopicRequest const& request) = 0;
+
   /// List existing topics.
   virtual StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
       grpc::ClientContext& client_context,

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -69,6 +69,25 @@ void GetTopic(google::cloud::pubsub::TopicAdminClient client,
   (std::move(client), argv.at(0), argv.at(1));
 }
 
+void UpdateTopic(google::cloud::pubsub::TopicAdminClient client,
+                 std::vector<std::string> const& argv) {
+  //! [update-topic]
+  namespace pubsub = google::cloud::pubsub;
+  [](pubsub::TopicAdminClient client, std::string project_id,
+     std::string topic_id) {
+    auto topic = client.UpdateTopic(
+        pubsub::TopicMutationBuilder(
+            pubsub::Topic(std::move(project_id), std::move(topic_id)))
+            .add_label("test-key", "test-value"));
+    if (!topic) return;  // TODO(#4792) - emulator lacks UpdateTopic()
+
+    std::cout << "The topic was successfully updated: " << topic->DebugString()
+              << "\n";
+  }
+  //! [update-topic]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
 void ListTopics(google::cloud::pubsub::TopicAdminClient client,
                 std::vector<std::string> const& argv) {
   //! [START pubsub_list_topics] [list-topics]
@@ -401,6 +420,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning GetTopic() sample" << std::endl;
   GetTopic(topic_admin_client, {project_id, topic_id});
 
+  std::cout << "\nRunning UpdateTopic() sample" << std::endl;
+  UpdateTopic(topic_admin_client, {project_id, topic_id});
+
   std::cout << "\nRunning the StatusOr example" << std::endl;
   ExampleStatusOr(topic_admin_client, {project_id});
 
@@ -465,6 +487,8 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
                               CreateTopic),
       CreateTopicAdminCommand("get-topic", {"project-id", "topic-id"},
                               GetTopic),
+      CreateTopicAdminCommand("update-topic", {"project-id", "topic-id"},
+                              UpdateTopic),
       CreateTopicAdminCommand("list-topics", {"project-id"}, ListTopics),
       CreateTopicAdminCommand("delete-topic", {"project-id", "topic-id"},
                               DeleteTopic),

--- a/google/cloud/pubsub/testing/mock_publisher_stub.h
+++ b/google/cloud/pubsub/testing/mock_publisher_stub.h
@@ -40,6 +40,11 @@ class MockPublisherStub : public pubsub_internal::PublisherStub {
                google::pubsub::v1::GetTopicRequest const&),
               (override));
 
+  MOCK_METHOD(StatusOr<google::pubsub::v1::Topic>, UpdateTopic,
+              (grpc::ClientContext&,
+               google::pubsub::v1::UpdateTopicRequest const&),
+              (override));
+
   MOCK_METHOD(StatusOr<google::pubsub::v1::ListTopicsResponse>, ListTopics,
               (grpc::ClientContext&,
                google::pubsub::v1::ListTopicsRequest const&),

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -98,6 +98,22 @@ class TopicAdminClient {
   }
 
   /**
+   * Update the configuration of an existing Cloud Pub/Sub topic.
+   *
+   * @par Idempotency
+   * This is not an idempotent operation and therefore it is never retried.
+   *
+   * @par Example
+   * @snippet samples.cc update-topic
+   *
+   * @param builder the configuration for the new topic, includes the name.
+   */
+  StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      TopicMutationBuilder builder) {
+    return connection_->UpdateTopic({std::move(builder).BuildUpdateMutation()});
+  }
+
+  /**
    * List all the topics for a given project id.
    *
    * @par Idempotency

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -45,6 +45,12 @@ class TopicAdminConnectionImpl : public TopicAdminConnection {
     return stub_->GetTopic(context, request);
   }
 
+  StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      UpdateTopicParams p) override {
+    grpc::ClientContext context;
+    return stub_->UpdateTopic(context, p.request);
+  }
+
   ListTopicsRange ListTopics(ListTopicsParams p) override {
     google::pubsub::v1::ListTopicsRequest request;
     request.set_project(std::move(p.project_id));

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -78,6 +78,11 @@ class TopicAdminConnection {
     Topic topic;
   };
 
+  /// Wrap the arguments for `UpdateTopic()`
+  struct UpdateTopicParams {
+    google::pubsub::v1::UpdateTopicRequest request;
+  };
+
   /// Wrap the arguments for `ListTopics`
   struct ListTopicsParams {
     std::string project_id;
@@ -95,6 +100,10 @@ class TopicAdminConnection {
 
   /// Defines the interface for `Client::GetTopic()`
   virtual StatusOr<google::pubsub::v1::Topic> GetTopic(GetTopicParams) = 0;
+
+  /// Defines the interface for `Client::UpdateTopic()`
+  virtual StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      UpdateTopicParams) = 0;
 
   /// Defines the interface for `Client::ListTopics()`
   virtual ListTopicsRange ListTopics(ListTopicsParams) = 0;


### PR DESCRIPTION
Add the function to the stub, connection, mocks, and decorators. Add a
simple example for Doxygen, the typical unit tests, and include this
function in the integration test. The emulator does not support this
function, so we need some workarounds which are labeled with TODO
entries.

Fixes #4566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4800)
<!-- Reviewable:end -->
