### PR TITLE
feat(pubsub): expose delivery_attempt field

### DIFF
--- a/google/cloud/pubsub/ack_handler.h
+++ b/google/cloud/pubsub/ack_handler.h
@@ -55,6 +55,10 @@ class AckHandler {
   /// The Cloud Pub/Sub acknowledge ID, useful for debugging and logging.
   std::string ack_id() const { return impl_->ack_id(); }
 
+  /// The approximate number of times that Cloud Pub/Sub has attempted to
+  /// deliver the associated message to a subscriber.
+  std::int32_t delivery_attempt() const { return impl_->delivery_attempt(); }
+
   /// Allow applications to mock an `AckHandler`.
   class Impl {
    public:
@@ -65,6 +69,8 @@ class AckHandler {
     virtual void nack() = 0;
     /// The implementation for `AckHandler::ack_id()`
     virtual std::string ack_id() const = 0;
+    /// The implementation for `AckHandler::delivery_attempt()`
+    virtual std::int32_t delivery_attempt() const = 0;
   };
 
   /**

--- a/google/cloud/pubsub/ack_handler_test.cc
+++ b/google/cloud/pubsub/ack_handler_test.cc
@@ -49,6 +49,14 @@ TEST(AckHandlerTest, AckId) {
   EXPECT_EQ("test-id", handler.ack_id());
 }
 
+TEST(AckHandlerTest, DeliveryAttempts) {
+  auto mock = absl::make_unique<pubsub_mocks::MockAckHandler>();
+  EXPECT_CALL(*mock, delivery_attempt()).WillOnce(Return(42));
+  EXPECT_CALL(*mock, nack()).Times(1);
+  AckHandler handler(std::move(mock));
+  EXPECT_EQ(42, handler.delivery_attempt());
+}
+
 TEST(AckHandlerTest, Ack) {
   auto mock = absl::make_unique<pubsub_mocks::MockAckHandler>();
   EXPECT_CALL(*mock, ack()).Times(1);

--- a/google/cloud/pubsub/internal/default_ack_handler_impl.h
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl.h
@@ -28,11 +28,13 @@ class DefaultAckHandlerImpl : public pubsub::AckHandler::Impl {
  public:
   DefaultAckHandlerImpl(google::cloud::CompletionQueue cq,
                         std::shared_ptr<pubsub_internal::SubscriberStub> s,
-                        std::string subscription, std::string ack_id)
+                        std::string subscription, std::string ack_id,
+                        std::int32_t delivery_attempt)
       : cq_(std::move(cq)),
         stub_(std::move(s)),
         subscription_(std::move(subscription)),
-        ack_id_(std::move(ack_id)) {}
+        ack_id_(std::move(ack_id)),
+        delivery_attempt_(delivery_attempt) {}
 
   ~DefaultAckHandlerImpl() override = default;
 
@@ -40,12 +42,14 @@ class DefaultAckHandlerImpl : public pubsub::AckHandler::Impl {
   void nack() override;
 
   std::string ack_id() const override { return ack_id_; }
+  std::int32_t delivery_attempt() const override { return delivery_attempt_; }
 
  private:
   google::cloud::CompletionQueue cq_;
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   std::string subscription_;
   std::string ack_id_;
+  std::int32_t delivery_attempt_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
+++ b/google/cloud/pubsub/internal/default_ack_handler_impl_test.cc
@@ -22,11 +22,9 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::testing::_;
-
 TEST(DefaultAckHandlerTest, Ack) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
-  EXPECT_CALL(*mock, AsyncAcknowledge(_, _, _))
+  EXPECT_CALL(*mock, AsyncAcknowledge)
       .WillOnce([](google::cloud::CompletionQueue&,
                    std::unique_ptr<grpc::ClientContext>,
                    google::pubsub::v1::AcknowledgeRequest const& request) {
@@ -37,14 +35,16 @@ TEST(DefaultAckHandlerTest, Ack) {
       });
 
   google::cloud::CompletionQueue cq;
-  DefaultAckHandlerImpl handler(cq, mock, "test-subscription", "test-ack-id");
+  DefaultAckHandlerImpl handler(cq, mock, "test-subscription", "test-ack-id",
+                                123);
   EXPECT_EQ("test-ack-id", handler.ack_id());
+  EXPECT_EQ(123, handler.delivery_attempt());
   ASSERT_NO_FATAL_FAILURE(handler.ack());
 }
 
 TEST(DefaultAckHandlerTest, Nack) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(_, _, _))
+  EXPECT_CALL(*mock, AsyncModifyAckDeadline)
       .WillOnce(
           [](google::cloud::CompletionQueue&,
              std::unique_ptr<grpc::ClientContext>,
@@ -57,7 +57,8 @@ TEST(DefaultAckHandlerTest, Nack) {
           });
 
   google::cloud::CompletionQueue cq;
-  DefaultAckHandlerImpl handler(cq, mock, "test-subscription", "test-ack-id");
+  DefaultAckHandlerImpl handler(cq, mock, "test-subscription", "test-ack-id",
+                                0);
   EXPECT_EQ("test-ack-id", handler.ack_id());
   ASSERT_NO_FATAL_FAILURE(handler.nack());
 }

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -42,6 +42,9 @@ class NotifyWhenMessageHandled : public pubsub::AckHandler::Impl {
     NotifySession(id);
   }
   std::string ack_id() const override { return child_->ack_id(); }
+  std::int32_t delivery_attempt() const override {
+    return child_->delivery_attempt();
+  }
 
  private:
   void NotifySession(std::string const& id) {
@@ -152,9 +155,9 @@ void SubscriptionSession::HandleQueue(std::unique_lock<std::mutex> lk) {
   lk.unlock();
 
   std::unique_ptr<pubsub::AckHandler::Impl> handler =
-      absl::make_unique<DefaultAckHandlerImpl>(executor_, stub_,
-                                               params_.full_subscription_name,
-                                               std::move(*m.mutable_ack_id()));
+      absl::make_unique<DefaultAckHandlerImpl>(
+          executor_, stub_, params_.full_subscription_name,
+          std::move(*m.mutable_ack_id()), m.delivery_attempt());
   // TODO(#4645) - use a better estimation for the message size.
   auto const message_size = m.message().data().size();
   handler = absl::make_unique<NotifyWhenMessageHandled>(

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -47,6 +47,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
           auto& m = *response.add_received_messages();
           std::lock_guard<std::mutex> lk(mu);
           m.set_ack_id("test-ack-id-" + std::to_string(count));
+          m.set_delivery_attempt(42);
           m.mutable_message()->set_message_id("test-message-id-" +
                                               std::to_string(count));
           ++count;
@@ -86,6 +87,7 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
 
   std::atomic<int> expected_message_id{0};
   auto handler = [&](pubsub::Message const& m, pubsub::AckHandler h) {
+    EXPECT_EQ(42, h.delivery_attempt());
     EXPECT_EQ("test-message-id-" + std::to_string(expected_message_id),
               m.message_id());
     auto pos = ids.find(std::this_thread::get_id());

--- a/google/cloud/pubsub/mocks/mock_ack_handler.h
+++ b/google/cloud/pubsub/mocks/mock_ack_handler.h
@@ -28,6 +28,7 @@ class MockAckHandler : public pubsub::AckHandler::Impl {
   MOCK_METHOD0(ack, void());
   MOCK_METHOD0(nack, void());
   MOCK_CONST_METHOD0(ack_id, std::string());
+  MOCK_CONST_METHOD0(delivery_attempt, std::int32_t());
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
When using dead-letter queues (DLQ, an upcoming feature for Cloud
Pub/Sub) the message might include a "delivery attempt" counter, which
approximately tell us how many times has Pub/Sub tried to deliver a
message. We need to expose this field, and choose to expose it as part
of the `AckHandler`, like we do for `ack_id()`.

Fixes #4799

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4807)
<!-- Reviewable:end -->
