### PR TITLE
feat(pubsub): add batching example

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -82,6 +82,7 @@ void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
     FlushImpl(std::move(lk));
     return;
   }
+  // TODO(#4809) - use the same size algorithm as the pricing page
   auto const bytes = std::accumulate(
       pending_.begin(), pending_.end(), std::size_t{0},
       [](std::size_t a, Item const& b) { return a + b.message.data().size(); });

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -92,6 +92,9 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * });
  * @endcode
  *
+ * @par Batching Configuration Example
+ * @snippet samples.cc publisher-options
+ *
  * [std-future-link]: https://en.cppreference.com/w/cpp/thread/future
  */
 class Publisher {

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -24,15 +24,46 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-/// Batching configuration for a `Publisher`.
+/**
+ * Configure batching for a `Publisher` object.
+ *
+ * By default, the client library does not automatically batch messages, all
+ * messages have a maximum holding time of 0.
+ *
+ * @warning TODO(#4808) - we are planning to change this default.
+ *
+ * @note Applications developers may want to consider batching messages,
+ *     specially if their messages have small payloads. Consult the Cloud
+ *     Pub/Sub [pricing page][pubsub-pricing-link] for details.
+ *
+ * @par Example
+ * @snippet samples.cc publisher-options
+ *
+ * [pubsub-pricing-link]: https://cloud.google.com/pubsub/pricing
+ */
 class BatchingConfig {
  public:
   BatchingConfig();
 
+  /// The maximum hold time.
   std::chrono::microseconds maximum_hold_time() const {
     return maximum_hold_time_;
   }
 
+  /**
+   * Sets the maximum hold time for the messages.
+   *
+   * @note while this function accepts durations in arbitrary precision, the
+   *     implementation depends on the granularity of your OS timers. It is
+   *     possible that messages are held for slightly longer times than the
+   *     value set here.
+   *
+   * @note the first message in a batch starts the hold time counter. New
+   *     messages do not extend the life of the batch. For example, if you have
+   *     set the holding time to 10 milliseconds, start a batch with message 1,
+   *     and publish a second message 5 milliseconds later, the second message
+   *     will be flushed approximately 5 milliseconds after it is published.
+   */
   template <typename Rep, typename Period>
   BatchingConfig& set_maximum_hold_time(std::chrono::duration<Rep, Period> v) {
     maximum_hold_time_ =
@@ -58,7 +89,12 @@ class BatchingConfig {
   std::size_t maximum_batch_bytes_;
 };
 
-/// Configuration options for a `PublisherClient`
+/**
+ * Configuration options for a `Publisher`
+ *
+ * @par Example
+ * @snippet samples.cc publisher-options
+ */
 class PublisherOptions {
  public:
   PublisherOptions() = default;

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -340,6 +340,45 @@ void CustomThreadPoolPublisher(std::vector<std::string> const& argv) {
   (argv.at(0), argv.at(1));
 }
 
+void CustomBatchPublisher(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 2) {
+    throw examples::Usage{
+        "custom-thread-pool-publisher <project-id> <topic-id>"};
+  }
+  //! [START pubsub_publisher_batch_settings] [publisher-options]
+  namespace pubsub = google::cloud::pubsub;
+  using google::cloud::future;
+  using google::cloud::StatusOr;
+  [](std::string project_id, std::string topic_id) {
+    auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
+    auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+        std::move(topic),
+        pubsub::PublisherOptions{}.set_batching_config(
+            pubsub::BatchingConfig{}
+                .set_maximum_hold_time(std::chrono::milliseconds(10))
+                .set_maximum_batch_bytes(10 * 1024 * 1024L)
+                .set_maximum_message_count(100)),
+        pubsub::ConnectionOptions{}));
+
+    std::vector<future<void>> ids;
+    for (char const* data : {"1", "2", "3", "go!"}) {
+      ids.push_back(
+          publisher.Publish(pubsub::MessageBuilder().SetData(data).Build())
+              .then([data](future<StatusOr<std::string>> f) {
+                auto s = f.get();
+                if (!s) return;
+                std::cout << "Sent '" << data << "' (" << *s << ")\n";
+              }));
+    }
+    publisher.Flush();
+    // Block until they are actually sent.
+    for (auto& id : ids) id.get();
+  }
+  //! [END pubsub_publisher_batch_settings] [publisher-options]
+  (argv.at(0), argv.at(1));
+}
+
 void CustomThreadPoolSubscriber(std::vector<std::string> const& argv) {
   namespace examples = ::google::cloud::testing_util;
   if (argv.size() != 2) {
@@ -463,6 +502,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning the CustomThreadPoolPublisher() sample" << std::endl;
   CustomThreadPoolPublisher({project_id, topic_id});
 
+  std::cout << "\nRunning the CustomBatchPublisher() sample" << std::endl;
+  CustomBatchPublisher({project_id, topic_id});
+
   std::cout << "\nRunning the CustomThreadPoolSubscriber() sample" << std::endl;
   CustomThreadPoolSubscriber({project_id, subscription_id});
 
@@ -509,6 +551,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       CreatePublisherCommand("publish", {}, Publish),
       CreateSubscriberCommand("subscribe", {}, Subscribe),
       {"custom-thread-pool-publisher", CustomThreadPoolPublisher},
+      {"custom-batch-publisher", CustomBatchPublisher},
       {"custom-thread-pool-subscriber", CustomThreadPoolSubscriber},
       {"auto", AutoRun},
   });


### PR DESCRIPTION
This shows how to use `PublisherOptions` to configure batching. I also
updated a number of comments so the example could be referenced from our
Doxygen docs.

Fixes #4626 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4812)
<!-- Reviewable:end -->
