### PR TITLE
feat(pubsub): tag sample with publish_with_error_handler

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -239,6 +239,7 @@ void ExampleStatusOr(google::cloud::pubsub::TopicAdminClient client,
 
 void Publish(google::cloud::pubsub::Publisher publisher,
              std::vector<std::string> const&) {
+  //! [START pubsub_publish_with_error_handler]
   //! [START pubsub_publish] [publish]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
@@ -255,6 +256,7 @@ void Publish(google::cloud::pubsub::Publisher publisher,
     done.get();
   }
   //! [END pubsub_publish] [publish]
+  //! [END pubsub_publish_with_error_handler]
   (std::move(publisher));
 }
 


### PR DESCRIPTION
Our existing sample to publish messages already shows how to handle
errors, I am adding the region tag to it.

Fixes #4655

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4813)
<!-- Reviewable:end -->
