### PR TITLE
ci: simplify bazel targets to consistently use `...` to build everything

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -34,7 +34,7 @@ readonly TIMEFORMAT="... %R seconds"
 problems=""
 printf "%-30s" "Running check-include-guards:"
 time {
-  if ! find google/cloud generator -name '*.h' -print0 |
+  if ! git ls-files -z | grep -zE '\.h$' |
     xargs -0 awk -f "ci/check-include-guards.gawk"; then
     problems="${problems} include-guards"
   fi

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -53,21 +53,18 @@ echo "================================================================"
 io::log "Fetching dependencies"
 # retry up to 3 times with exponential backoff, initial interval 120s
 "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
-  "${BAZEL_BIN}" fetch -- //google/cloud/...:all //generator/...:all
+  "${BAZEL_BIN}" fetch ...
 
 echo "================================================================"
 io::log "Compiling and running unit tests"
 "${BAZEL_BIN}" test \
-  "${bazel_args[@]}" "--test_tag_filters=-integration-test" \
-  -- //google/cloud/...:all //generator/...:all
+  "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 
 echo "================================================================"
 io::log "Compiling all the code, including integration tests"
 # Then build everything else (integration tests, examples, etc). So we can run
 # them next.
-"${BAZEL_BIN}" build \
-  "${bazel_args[@]}" \
-  -- //google/cloud/...:all //generator/...:all
+"${BAZEL_BIN}" build "${bazel_args[@]}" ...
 
 readonly TEST_KEY_FILE_JSON="/c/kokoro-run-key.json"
 readonly TEST_KEY_FILE_P12="/c/kokoro-run-key.p12"
@@ -212,7 +209,7 @@ if should_run_integration_tests; then
   "${BAZEL_BIN}" test \
     "${bazel_args[@]}" \
     "--test_tag_filters=integration-test" \
-    -- //google/cloud/...:all "${excluded_targets[@]}"
+    -- ... "${excluded_targets[@]}"
 
   # Changing the PATH disables the Bazel cache, so use an absolute path.
   readonly GCLOUD="/usr/local/google-cloud-sdk/bin/gcloud"

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -64,11 +64,11 @@ build_quickstart() {
   io::log "fetch dependencies for ${library}'s quickstart"
   # retry up to 3 times with exponential backoff, initial interval 120s
   "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
-    "${BAZEL_BIN}" fetch -- ...
+    "${BAZEL_BIN}" fetch ...
 
   echo
   io::log_yellow "Compiling ${library}'s quickstart"
-  "${BAZEL_BIN}" build "${bazel_args[@]}" -- ...
+  "${BAZEL_BIN}" build "${bazel_args[@]}" ...
 
   if [[ -r "/c/kokoro-run-key.json" ]]; then
     echo

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -58,7 +58,7 @@ echo
 echo "================================================================"
 for repeat in 1 2 3; do
   io::log_yellow "Fetch bazel dependencies [${repeat}/3]."
-  if "${BAZEL_BIN}" fetch -- //google/cloud/...; then
+  if "${BAZEL_BIN}" fetch ...; then
     break
   else
     io::log_yellow "bazel fetch failed with $?"
@@ -69,14 +69,12 @@ echo
 echo "================================================================"
 io::log_yellow "build and run unit tests."
 "${BAZEL_BIN}" test \
-  "${bazel_args[@]}" "--test_tag_filters=-integration-test" \
-  -- //google/cloud/...:all
+  "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 
 echo
 echo "================================================================"
 io::log_yellow "build all targets."
-"${BAZEL_BIN}" build \
-  "${bazel_args[@]}" -- //google/cloud/...:all
+"${BAZEL_BIN}" build "${bazel_args[@]}" ...
 
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly TEST_KEY_FILE_JSON="${CONFIG_DIR}/kokoro-run-key.json"
@@ -132,7 +130,7 @@ if should_run_integration_tests; then
   "${BAZEL_BIN}" test \
     "${bazel_args[@]}" \
     "--test_tag_filters=integration-test" \
-    -- //google/cloud/...:all \
+    -- ... \
     -//google/cloud/bigtable/examples:bigtable_grpc_credentials \
     -//google/cloud/storage/examples:storage_service_account_samples \
     -//google/cloud/storage/tests:service_account_integration_test

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -78,7 +78,7 @@ build_quickstart() {
   for repeat in 1 2 3; do
     echo
     io::log_yellow "Fetching deps for ${library}'s quickstart [${repeat}/3]."
-    if "${BAZEL_BIN}" fetch -- ...; then
+    if "${BAZEL_BIN}" fetch ...; then
       break
     else
       io::log_yellow "bazel fetch failed with $?"

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -161,23 +161,21 @@ $env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
 
 ForEach($_ in (1, 2, 3)) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Fetch dependencies [$_]"
-    bazel $common_flags fetch -- //google/cloud/...:all
+    bazel $common_flags fetch ...
     if ($LastExitCode -eq 0) {
         break
     }
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling and running unit tests"
-bazel $common_flags test $test_flags `
-  --test_tag_filters=-integration-test `
-  -- //google/cloud/...:all
+bazel $common_flags test $test_flags --test_tag_filters=-integration-test ...
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "bazel test failed with exit code ${LastExitCode}."
     Exit ${LastExitCode}
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling extra programs"
-bazel $common_flags build $build_flags -- //google/cloud/...:all
+bazel $common_flags build $build_flags ...
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "bazel test failed with exit code ${LastExitCode}."
     Exit ${LastExitCode}
@@ -238,7 +236,7 @@ if (Integration-Tests-Enabled) {
     )
     bazel $common_flags test $test_flags $integration_flags `
         "--test_tag_filters=integration-test" `
-        -- //google/cloud/...:all `
+        -- ... `
         -//google/cloud/bigtable/examples:bigtable_grpc_credentials `
         -//google/cloud/storage/examples:storage_service_account_samples `
         -//google/cloud/storage/tests:service_account_integration_test

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -141,7 +141,7 @@ ForEach($library in ("bigtable", "storage", "spanner")) {
     ForEach($_ in (1, 2, 3)) {
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "Fetch dependencies for ${library} [$_]"
-        bazel $common_flags fetch -- ...:all
+        bazel $common_flags fetch ...
         if ($LastExitCode -eq 0) {
             break
         }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/4819

This simplifies our build scripts and future-proofs them so that our bazel builds always build everything. In bazel world `...` is the way to specify that (the trailing `:all` is unnecessary)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4824)
<!-- Reviewable:end -->
