### PR TITLE
feat(pubsub): bootstrap snapshot CRUD

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -119,6 +119,28 @@ future<Status> SubscriberLogging::AsyncModifyAckDeadline(
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
+StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::CreateSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::CreateSnapshotRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::CreateSnapshotRequest const& request) {
+        return child_->CreateSnapshot(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
+Status SubscriberLogging::DeleteSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteSnapshotRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::DeleteSnapshotRequest const& request) {
+        return child_->DeleteSnapshot(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/subscriber_logging.h
+++ b/google/cloud/pubsub/internal/subscriber_logging.h
@@ -67,6 +67,14 @@ class SubscriberLogging : public SubscriberStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+
+  Status DeleteSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DeleteSnapshotRequest const& request) override;
+
  private:
   std::shared_ptr<SubscriberStub> child_;
   TracingOptions tracing_options_;

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -183,6 +183,29 @@ TEST_F(SubscriberLoggingTest, AsyncModifyAckDeadline) {
                              HasSubstr("test-subscription-name"))));
 }
 
+TEST_F(SubscriberLoggingTest, CreateSnapshot) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, CreateSnapshot)
+      .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  grpc::ClientContext context;
+  google::pubsub::v1::CreateSnapshotRequest request;
+  auto status = stub.CreateSnapshot(context, request);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("CreateSnapshot")));
+}
+
+TEST_F(SubscriberLoggingTest, DeleteSnapshot) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, DeleteSnapshot).WillOnce(Return(Status{}));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  grpc::ClientContext context;
+  google::pubsub::v1::DeleteSnapshotRequest request;
+  auto status = stub.DeleteSnapshot(context, request);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("DeleteSnapshot")));
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -125,6 +125,24 @@ class DefaultSubscriberStub : public SubscriberStub {
         });
   }
 
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override {
+    google::pubsub::v1::Snapshot response;
+    auto status = grpc_stub_->CreateSnapshot(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DeleteSnapshotRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = grpc_stub_->DeleteSnapshot(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return {};
+  }
+
  private:
   std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;
 };

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -82,6 +82,16 @@ class SubscriberStub {
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> client_context,
       google::pubsub::v1::ModifyAckDeadlineRequest const& request) = 0;
+
+  /// Create a new snapshot.
+  virtual StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) = 0;
+
+  /// Delete a snapshot.
+  virtual Status DeleteSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DeleteSnapshotRequest const& request) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -95,6 +95,19 @@ class SubscriptionAdminConnectionImpl
     return stub_->DeleteSubscription(context, request);
   }
 
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      CreateSnapshotParams p) override {
+    grpc::ClientContext context;
+    return stub_->CreateSnapshot(context, std::move(p.request));
+  }
+
+  Status DeleteSnapshot(DeleteSnapshotParams p) override {
+    google::pubsub::v1::DeleteSnapshotRequest request;
+    request.set_snapshot(p.snapshot.FullName());
+    grpc::ClientContext context;
+    return stub_->DeleteSnapshot(context, request);
+  }
+
  private:
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
 };

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
+#include "google/cloud/pubsub/snapshot.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/internal/pagination_range.h"
@@ -94,6 +95,16 @@ class SubscriptionAdminConnection {
   struct DeleteSubscriptionParams {
     Subscription subscription;
   };
+
+  /// Wrap the arguments for `CreateSnapshot()`
+  struct CreateSnapshotParams {
+    google::pubsub::v1::CreateSnapshotRequest request;
+  };
+
+  /// Wrap the arguments for `DeleteSnapshot()`
+  struct DeleteSnapshotParams {
+    Snapshot snapshot;
+  };
   //@}
 
   /// Defines the interface for `SubscriptionAdminClient::CreateSubscription()`
@@ -113,6 +124,13 @@ class SubscriptionAdminConnection {
 
   /// Defines the interface for `SubscriptionAdminClient::DeleteSubscription()`
   virtual Status DeleteSubscription(DeleteSubscriptionParams) = 0;
+
+  /// Defines the interface for `SnapshotAdminClient::CreateSnapshot()`
+  virtual StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      CreateSnapshotParams) = 0;
+
+  /// Defines the interface for `SnapshotAdminClient::DeleteSnapshot()`
+  virtual Status DeleteSnapshot(DeleteSnapshotParams) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -73,6 +73,16 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                std::unique_ptr<grpc::ClientContext>,
                google::pubsub::v1::ModifyAckDeadlineRequest const&),
               (override));
+
+  MOCK_METHOD(StatusOr<google::pubsub::v1::Snapshot>, CreateSnapshot,
+              (grpc::ClientContext&,
+               google::pubsub::v1::CreateSnapshotRequest const&),
+              (override));
+
+  MOCK_METHOD(Status, DeleteSnapshot,
+              (grpc::ClientContext&,
+               google::pubsub::v1::DeleteSnapshotRequest const&),
+              (override));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/testing/random_names.cc
+++ b/google/cloud/pubsub/testing/random_names.cc
@@ -23,6 +23,9 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::string RandomTopicId(google::cloud::internal::DefaultPRNG& generator,
                           std::string const& prefix) {
+  // The documentation says these should be between 3 and 255 characters, for
+  // our tests 32 characters is long enough.
+  //    https://cloud.google.com/pubsub/docs/admin#resource_names
   auto constexpr kMaxRandomTopicSuffixLength = 32;
   auto now = std::chrono::system_clock::now();
   std::string date = google::cloud::internal::FormatUtcDate(now);
@@ -35,10 +38,25 @@ std::string RandomTopicId(google::cloud::internal::DefaultPRNG& generator,
 std::string RandomSubscriptionId(
     google::cloud::internal::DefaultPRNG& generator,
     std::string const& prefix) {
+  // The documentation says these should be between 3 and 255 characters, for
+  // our tests 32 characters is long enough.
+  //    https://cloud.google.com/pubsub/docs/admin#resource_names
   auto constexpr kMaxRandomSubscriptionSuffixLength = 32;
   auto suffix = google::cloud::internal::Sample(
       generator, kMaxRandomSubscriptionSuffixLength,
       "abcdefghijklmnopqrstuvwxyz");
+  auto p = prefix.empty() ? "cloud-cpp" : prefix;
+  return p + "-" + suffix;
+}
+
+std::string RandomSnapshotId(google::cloud::internal::DefaultPRNG& generator,
+                             std::string const& prefix) {
+  // The documentation does not explicitly say how long this can be, but 32
+  // seems to work.
+  //    https://cloud.google.com/pubsub/docs/admin#resource_names
+  auto constexpr kMaxRandomSnapshotSuffixLength = 32;
+  auto suffix = google::cloud::internal::Sample(
+      generator, kMaxRandomSnapshotSuffixLength, "abcdefghijklmnopqrstuvwxyz");
   auto p = prefix.empty() ? "cloud-cpp" : prefix;
   return p + "-" + suffix;
 }

--- a/google/cloud/pubsub/testing/random_names.h
+++ b/google/cloud/pubsub/testing/random_names.h
@@ -32,6 +32,10 @@ std::string RandomSubscriptionId(
     google::cloud::internal::DefaultPRNG& generator,
     std::string const& prefix = {});
 
+/// Generate a random snapshot ID.
+std::string RandomSnapshotId(google::cloud::internal::DefaultPRNG& generator,
+                             std::string const& prefix = {});
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_testing
 }  // namespace cloud


### PR DESCRIPTION
Bootstrap the snapshot CRUD functions. I cannot start with just one
function, that is not really testable, and I really don't want to create
a giant PR with all of them. This is basically a minimal set to enable
an integration test.

To keep this PR small we do not add the new functions to
`pubsub::SubscriptionAdminClient`, nor do we add the examples for them.

Part of the work for #4575 and #4577

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4825)
<!-- Reviewable:end -->
