### PR TITLE
feat(pubsub): Subscriber::Subscribe() takes options

### DIFF
--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -115,6 +115,8 @@ class Subscriber {
    * @param subscription the Cloud Pub/Sub subscription to receive messages from
    * @param cb an object usable to construct a
    *     `std::function<void(pubsub::Message, pubsub::AckHandler)>`
+   * @param options configure the subscription's flow control, maximum message
+   *     lease time and other parameters, see `SubscriptionOptions` for details
    * @return a future that is satisfied when the session will no longer receive
    *     messages. For example because there was an unrecoverable error trying
    *     to receive data. Calling `.cancel()` in this object will (eventually)
@@ -124,9 +126,11 @@ class Subscriber {
    * https://en.cppreference.com/w/cpp/utility/functional/function
    */
   template <typename Callable>
-  future<Status> Subscribe(Subscription const& subscription, Callable&& cb) {
+  future<Status> Subscribe(Subscription const& subscription, Callable&& cb,
+                           SubscriptionOptions options = {}) {
     std::function<void(Message, AckHandler)> f(std::forward<Callable>(cb));
-    return connection_->Subscribe({subscription.FullName(), std::move(f), {}});
+    return connection_->Subscribe(
+        {subscription.FullName(), std::move(f), std::move(options)});
   }
 
  private:

--- a/google/cloud/pubsub/subscriber_test.cc
+++ b/google/cloud/pubsub/subscriber_test.cc
@@ -74,18 +74,11 @@ TEST(SubscriberTest, SubscribeWithOptions) {
       .WillOnce([&](SubscriberConnection::SubscribeParams const& p) {
         EXPECT_EQ(subscription.FullName(), p.full_subscription_name);
         EXPECT_EQ(7200, p.options.max_deadline_time().count());
-
         return make_ready_future(Status{});
       });
 
   Subscriber subscriber(mock);
-  auto handler = [&](Message const& m, AckHandler h) {
-    if (m.data() == "do-nack") {
-      std::move(h).nack();
-    } else {
-      std::move(h).ack();
-    }
-  };
+  auto handler = [&](Message const&, AckHandler const&) {};
   auto status = subscriber
                     .Subscribe(subscription, std::move(handler),
                                SubscriptionOptions{}.set_max_deadline_time(

--- a/google/cloud/pubsub/subscriber_test.cc
+++ b/google/cloud/pubsub/subscriber_test.cc
@@ -66,6 +66,34 @@ TEST(SubscriberTest, SubscribeSimple) {
   ASSERT_STATUS_OK(status);
 }
 
+/// @test Verify Subscriber::Subscribe() works, including mocks.
+TEST(SubscriberTest, SubscribeWithOptions) {
+  Subscription const subscription("test-project", "test-subscription");
+  auto mock = std::make_shared<pubsub_mocks::MockSubscriberConnection>();
+  EXPECT_CALL(*mock, Subscribe(_))
+      .WillOnce([&](SubscriberConnection::SubscribeParams const& p) {
+        EXPECT_EQ(subscription.FullName(), p.full_subscription_name);
+        EXPECT_EQ(7200, p.options.max_deadline_time().count());
+
+        return make_ready_future(Status{});
+      });
+
+  Subscriber subscriber(mock);
+  auto handler = [&](Message const& m, AckHandler h) {
+    if (m.data() == "do-nack") {
+      std::move(h).nack();
+    } else {
+      std::move(h).ack();
+    }
+  };
+  auto status = subscriber
+                    .Subscribe(subscription, std::move(handler),
+                               SubscriptionOptions{}.set_max_deadline_time(
+                                   std::chrono::hours(2)))
+                    .get();
+  ASSERT_STATUS_OK(status);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub


### PR DESCRIPTION
The options will be needed to setup flow and concurrency control.

Fixes #4735

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4845)
<!-- Reviewable:end -->
