### PR TITLE
feat(pubsub): implement UpdateSnapshot()

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -153,6 +153,17 @@ StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::GetSnapshot(
       context, request, __func__, tracing_options_);
 }
 
+StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::UpdateSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::UpdateSnapshotRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::UpdateSnapshotRequest const& request) {
+        return child_->UpdateSnapshot(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 Status SubscriberLogging::DeleteSnapshot(
     grpc::ClientContext& context,
     google::pubsub::v1::DeleteSnapshotRequest const& request) {

--- a/google/cloud/pubsub/internal/subscriber_logging.h
+++ b/google/cloud/pubsub/internal/subscriber_logging.h
@@ -79,6 +79,10 @@ class SubscriberLogging : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ListSnapshotsRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::UpdateSnapshotRequest const& request) override;
+
   Status DeleteSnapshot(
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSnapshotRequest const& request) override;

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -223,6 +223,18 @@ TEST_F(SubscriberLoggingTest, ListSnapshots) {
                              HasSubstr("test-project-name"))));
 }
 
+TEST_F(SubscriberLoggingTest, UpdateSnapshot) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, UpdateSnapshot)
+      .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  grpc::ClientContext context;
+  google::pubsub::v1::UpdateSnapshotRequest request;
+  auto status = stub.UpdateSnapshot(context, request);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("UpdateSnapshot")));
+}
+
 TEST_F(SubscriberLoggingTest, DeleteSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSnapshot).WillOnce(Return(Status{}));

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -152,6 +152,15 @@ class DefaultSubscriberStub : public SubscriberStub {
     return response;
   }
 
+  StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      grpc::ClientContext& context,
+      google::pubsub::v1::UpdateSnapshotRequest const& request) override {
+    google::pubsub::v1::Snapshot response;
+    auto status = grpc_stub_->UpdateSnapshot(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
   Status DeleteSnapshot(
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteSnapshotRequest const& request) override {

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -98,6 +98,11 @@ class SubscriberStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::ListSnapshotsRequest const& request) = 0;
 
+  /// Update an existing snapshot.
+  virtual StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::UpdateSnapshotRequest const& request) = 0;
+
   /// Delete a snapshot.
   virtual Status DeleteSnapshot(
       grpc::ClientContext& client_context,

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -272,6 +272,24 @@ void GetSnapshot(google::cloud::pubsub::SubscriptionAdminClient client,
   (std::move(client), argv.at(0), argv.at(1));
 }
 
+void UpdateSnapshot(google::cloud::pubsub::SubscriptionAdminClient client,
+                    std::vector<std::string> const& argv) {
+  //! [update-snapshot]
+  namespace pubsub = google::cloud::pubsub;
+  [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
+     std::string snapshot_id) {
+    auto snap = client.UpdateSnapshot(
+        pubsub::Snapshot(project_id, std::move(snapshot_id)),
+        pubsub::SnapshotMutationBuilder{}.add_label("samples-cpp", "gcp"));
+    if (!snap.ok()) return;  // TODO(#4792) - emulator lacks UpdateSnapshot()
+
+    std::cout << "The snapshot was successfully updated: "
+              << snap->DebugString() << "\n";
+  }
+  //! [update-snapshot]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
 void ListSnapshots(google::cloud::pubsub::SubscriptionAdminClient client,
                    std::vector<std::string> const& argv) {
   //! [list-snapshots]
@@ -611,6 +629,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning GetSnapshot() sample" << std::endl;
   GetSnapshot(subscription_admin_client, {project_id, snapshot_id});
 
+  std::cout << "\nRunning UpdateSnapshot() sample" << std::endl;
+  UpdateSnapshot(subscription_admin_client, {project_id, snapshot_id});
+
   std::cout << "\nRunning ListSnapshots() sample" << std::endl;
   ListSnapshots(subscription_admin_client, {project_id});
 
@@ -694,6 +715,8 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
           CreateSnapshot),
       CreateSubscriptionAdminCommand(
           "get-snapshot", {"project-id", "snapshot-id"}, GetSnapshot),
+      CreateSubscriptionAdminCommand(
+          "update-snapshot", {"project-id", "snapshot-id"}, UpdateSnapshot),
       CreateSubscriptionAdminCommand("list-snapshots", {"project-id"},
                                      ListSnapshots),
       CreateSubscriptionAdminCommand(

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -205,6 +205,24 @@ class SubscriptionAdminClient {
   }
 
   /**
+   * Update an existing snapshot.
+   *
+   * @par Idempotency
+   * This is not an idempotent operation and therefore it is never retried.
+   *
+   * @par Example
+   * @snippet samples.cc update-snapshot
+   *
+   * @param snapshot the name of the snapshot
+   * @param builder the changes applied to the snapshot
+   */
+  StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      Snapshot const& snapshot, SnapshotMutationBuilder builder) {
+    return connection_->UpdateSnapshot(
+        {std::move(builder).BuildUpdateMutation(snapshot)});
+  }
+
+  /**
    * List all the snapshots for a given project id.
    *
    * @par Idempotency

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -129,6 +129,12 @@ class SubscriptionAdminConnectionImpl
         });
   }
 
+  StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      UpdateSnapshotParams p) override {
+    grpc::ClientContext context;
+    return stub_->UpdateSnapshot(context, std::move(p.request));
+  }
+
   Status DeleteSnapshot(DeleteSnapshotParams p) override {
     google::pubsub::v1::DeleteSnapshotRequest request;
     request.set_snapshot(p.snapshot.FullName());

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -124,6 +124,11 @@ class SubscriptionAdminConnection {
     std::string project_id;
   };
 
+  /// Wrap the arguments for `UpdateSnapshot()`
+  struct UpdateSnapshotParams {
+    google::pubsub::v1::UpdateSnapshotRequest request;
+  };
+
   /// Wrap the arguments for `DeleteSnapshot()`
   struct DeleteSnapshotParams {
     Snapshot snapshot;
@@ -155,6 +160,10 @@ class SubscriptionAdminConnection {
   /// Defines the interface for `SnapshotAdminClient::GetSnapshot()`
   virtual StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
       GetSnapshotParams) = 0;
+
+  /// Defines the interface for `SnapshotAdminClient::UpdateSnapshot()`
+  virtual StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      UpdateSnapshotParams) = 0;
 
   /// Defines the interface for `SubscriptionAdminClient::ListSnapshots()`
   virtual ListSnapshotsRange ListSnapshots(ListSnapshotsParams) = 0;

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -20,7 +20,6 @@
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include <gmock/gmock.h>
-#include <atomic>
 
 namespace google {
 namespace cloud {
@@ -229,6 +228,30 @@ TEST(SubscriptionAdminConnectionTest, ListSnapshots) {
     names.push_back(t->name());
   }
   EXPECT_THAT(names, ElementsAre("test-snapshot-01", "test-snapshot-02"));
+}
+
+TEST(SubscriptionAdminConnectionTest, UpdateSnapshot) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  Topic const topic("test-project", "test-topic");
+  Subscription const subscription("test-project", "test-subscription");
+  Snapshot const snapshot("test-project", "test-snapshot-0001");
+  google::pubsub::v1::Snapshot expected;
+  expected.set_topic(topic.FullName());
+  expected.set_name(snapshot.FullName());
+
+  EXPECT_CALL(*mock, UpdateSnapshot)
+      .WillOnce([&](grpc::ClientContext&,
+                    google::pubsub::v1::UpdateSnapshotRequest const& request) {
+        EXPECT_EQ(snapshot.FullName(), request.snapshot().name());
+        return make_status_or(expected);
+      });
+
+  auto subscription_admin =
+      pubsub_internal::MakeSubscriptionAdminConnection({}, mock);
+  auto response = subscription_admin->UpdateSnapshot(
+      {SnapshotMutationBuilder{}.BuildUpdateMutation(snapshot)});
+  ASSERT_STATUS_OK(response);
+  EXPECT_THAT(*response, IsProtoEqual(expected));
 }
 
 TEST(SubscriptionAdminConnectionTest, DeleteSnapshot) {

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -90,6 +90,11 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                google::pubsub::v1::ListSnapshotsRequest const&),
               (override));
 
+  MOCK_METHOD(StatusOr<google::pubsub::v1::Snapshot>, UpdateSnapshot,
+              (grpc::ClientContext&,
+               google::pubsub::v1::UpdateSnapshotRequest const&),
+              (override));
+
   MOCK_METHOD(Status, DeleteSnapshot,
               (grpc::ClientContext&,
                google::pubsub::v1::DeleteSnapshotRequest const&),


### PR DESCRIPTION
Implemented the function in the *Stub, *Connection, and *Client classes.
Updated the unit tests, integration tests, and samples to include this
new function. I had to disable some of the tests when running against
the emulator because the emulator does not support this function. Filed
a bug and updated our tracker for emulator workarounds.

Fixes #4576

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4846)
<!-- Reviewable:end -->
