### PR TITLE
ci: workaround build failure on MSVC+x86

### DIFF
--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -54,7 +54,9 @@ if ($LastExitCode) {
 # bug, and this seems to workaround it.
 $workaround_targets=(
     # Failed around 2020-07-29
-    "storage_internal_tuple_filter_test"
+    "storage_internal_tuple_filter_test",
+    # Failed around 2020-08-10
+    "storage_well_known_parameters_test"
 )
 ForEach($target IN $workaround_targets) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling $target with CMake $env:CONFIG"


### PR DESCRIPTION
Fix build / link problem with `storage_well_known_parameters_test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4847)
<!-- Reviewable:end -->
