### PR TITLE
feat(pubsub): implement DetachSubscription()

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -158,6 +158,12 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   EXPECT_THAT(snapshot_names(subscription_admin, project_id),
               Not(Contains(snapshot.FullName())));
 
+  // TODO(#4792) - the emulator does not support DetachSubscription()
+  if (!UsingEmulator()) {
+    auto detach_response = topic_admin.DetachSubscription(subscription);
+    ASSERT_STATUS_OK(detach_response);
+  }
+
   auto delete_response = subscription_admin.DeleteSubscription(subscription);
   ASSERT_STATUS_OK(delete_response);
 

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -159,10 +159,11 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
               Not(Contains(snapshot.FullName())));
 
   // TODO(#4792) - the emulator does not support DetachSubscription()
-  if (!UsingEmulator()) {
-    auto detach_response = topic_admin.DetachSubscription(subscription);
-    ASSERT_STATUS_OK(detach_response);
-  }
+  // TODO(#4850) - completely disabled as we are not in the EAP
+  //  if (!UsingEmulator()) {
+  //    auto detach_response = topic_admin.DetachSubscription(subscription);
+  //    ASSERT_STATUS_OK(detach_response);
+  //  }
 
   auto delete_response = subscription_admin.DeleteSubscription(subscription);
   ASSERT_STATUS_OK(delete_response);

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -77,10 +77,11 @@ TEST(TopicAdminIntegrationTest, TopicCRUD) {
     ASSERT_STATUS_OK(update_response);
   }
 
-  // The integration tests for ListTopicSubscriptions() and ListTopicSnapshots()
-  // are found in subscription_admin_integration_test.cc. The tests are
-  // uninteresting until one creates a subscription and a snapshot, and doing so
-  // here would just complicate this test with little benefit.
+  // The integration tests for ListTopicSubscriptions(), DetachSubscription()
+  // and ListTopicSnapshots() are found in
+  // subscription_admin_integration_test.cc. The tests are uninteresting until
+  // one creates a subscription and a snapshot, and doing so here would just
+  // complicate this test with little benefit.
 
   auto delete_response = publisher.DeleteTopic(topic);
   ASSERT_STATUS_OK(delete_response);
@@ -126,6 +127,14 @@ TEST(TopicAdminIntegrationTest, DeleteTopicFailure) {
   auto delete_response =
       publisher.DeleteTopic(Topic("invalid-project", "invalid-topic"));
   ASSERT_FALSE(delete_response.ok());
+}
+
+TEST(TopicAdminIntegrationTest, DetachSubscriptionFailure) {
+  ScopedEnvironment env("PUBSUB_EMULATOR_HOST", "localhost:1");
+  auto publisher = TopicAdminClient(MakeTopicAdminConnection());
+  auto response = publisher.DetachSubscription(
+      Subscription("invalid-project", "invalid-subscription"));
+  ASSERT_FALSE(response.ok());
 }
 
 TEST(TopicAdminIntegrationTest, ListTopicSubscriptionsFailure) {

--- a/google/cloud/pubsub/internal/publisher_logging.cc
+++ b/google/cloud/pubsub/internal/publisher_logging.cc
@@ -76,6 +76,18 @@ Status PublisherLogging::DeleteTopic(
       context, request, __func__, tracing_options_);
 }
 
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+PublisherLogging::DetachSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DetachSubscriptionRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::DetachSubscriptionRequest const& request) {
+        return child_->DetachSubscription(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
 PublisherLogging::ListTopicSubscriptions(
     grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/publisher_logging.h
+++ b/google/cloud/pubsub/internal/publisher_logging.h
@@ -52,6 +52,10 @@ class PublisherLogging : public PublisherStub {
       grpc::ClientContext& context,
       google::pubsub::v1::DeleteTopicRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
+
   StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -122,6 +122,22 @@ TEST_F(PublisherLoggingTest, DeleteTopic) {
       Contains(AllOf(HasSubstr("DeleteTopic"), HasSubstr("test-topic-name"))));
 }
 
+TEST_F(PublisherLoggingTest, DetachSubscription) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  EXPECT_CALL(*mock, DetachSubscription)
+      .WillOnce(Return(
+          make_status_or(google::pubsub::v1::DetachSubscriptionResponse{})));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  grpc::ClientContext context;
+  google::pubsub::v1::DetachSubscriptionRequest request;
+  request.set_subscription("test-subscription-name");
+  auto status = stub.DetachSubscription(context, request);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(backend_->log_lines,
+              Contains(AllOf(HasSubstr("DetachSubscription"),
+                             HasSubstr("test-subscription-name"))));
+}
+
 TEST_F(PublisherLoggingTest, ListTopicSubscriptions) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, ListTopicSubscriptions)

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -75,6 +75,15 @@ class DefaultPublisherStub : public PublisherStub {
     return {};
   }
 
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override {
+    google::pubsub::v1::DetachSubscriptionResponse response;
+    auto status = grpc_stub_->DetachSubscription(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
   StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -65,6 +65,12 @@ class PublisherStub {
       grpc::ClientContext& client_context,
       google::pubsub::v1::DeleteTopicRequest const& request) = 0;
 
+  /// Detach a subscription.
+  virtual StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+  DetachSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) = 0;
+
   /// List subscriptions for a topic.
   virtual StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
   ListTopicSubscriptions(

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -128,6 +128,23 @@ void DeleteTopic(google::cloud::pubsub::TopicAdminClient client,
   (std::move(client), argv.at(0), argv.at(1));
 }
 
+void DetachSubscription(google::cloud::pubsub::TopicAdminClient client,
+                        std::vector<std::string> const& argv) {
+  //! [START pubsub_subscription_detachment] [detach-subscription]
+  namespace pubsub = google::cloud::pubsub;
+  [](pubsub::TopicAdminClient client, std::string project_id,
+     std::string subscription_id) {
+    auto response = client.DetachSubscription(pubsub::Subscription(
+        std::move(project_id), std::move(subscription_id)));
+    if (!response.ok()) return;  // TODO(#4792) - not implemented in emulator
+
+    std::cout << "The subscription was successfully detached: "
+              << response->DebugString() << "\n";
+  }
+  //! [END pubsub_subscription_detachment] [detach-subscription]
+  (std::move(client), argv.at(0), argv.at(1));
+}
+
 void ListTopicSubscriptions(google::cloud::pubsub::TopicAdminClient client,
                             std::vector<std::string> const& argv) {
   //! [START pubsub_list_topic_subscriptions] [list-topic-subscriptions]
@@ -688,6 +705,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning the CustomThreadPoolSubscriber() sample" << std::endl;
   CustomThreadPoolSubscriber({project_id, subscription_id});
 
+  std::cout << "\nRunning DetachSubscription() sample" << std::endl;
+  DetachSubscription(topic_admin_client, {project_id, subscription_id});
+
   std::cout << "\nRunning DeleteSubscription() sample" << std::endl;
   DeleteSubscription(subscription_admin_client, {project_id, subscription_id});
 
@@ -714,6 +734,9 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       CreateTopicAdminCommand("list-topics", {"project-id"}, ListTopics),
       CreateTopicAdminCommand("delete-topic", {"project-id", "topic-id"},
                               DeleteTopic),
+      CreateTopicAdminCommand("detach-subscription",
+                              {"project-id", "subscription-id"},
+                              DetachSubscription),
       CreateTopicAdminCommand("list-topic-subscriptions",
                               {"project-id", "topic-id"},
                               ListTopicSubscriptions),

--- a/google/cloud/pubsub/testing/mock_publisher_stub.h
+++ b/google/cloud/pubsub/testing/mock_publisher_stub.h
@@ -55,6 +55,12 @@ class MockPublisherStub : public pubsub_internal::PublisherStub {
                google::pubsub::v1::DeleteTopicRequest const& request),
               (override));
 
+  MOCK_METHOD(StatusOr<google::pubsub::v1::DetachSubscriptionResponse>,
+              DetachSubscription,
+              (grpc::ClientContext&,
+               google::pubsub::v1::DetachSubscriptionRequest const& request),
+              (override));
+
   MOCK_METHOD(StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>,
               ListTopicSubscriptions,
               (grpc::ClientContext&,

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -143,6 +143,26 @@ class TopicAdminClient {
   }
 
   /**
+   * Detaches an existing subscription.
+   *
+   * This operation stops the subscription from receiving any further messages,
+   * it drops any messages still retained by the subscription, and any
+   * outstanding pull requests will fail with `FAILED_PRECONDITION`.
+   *
+   * @par Idempotency
+   * This is not an idempotent operation and therefore it is never retried.
+   *
+   * @par Example
+   * @snippet samples.cc detach-subscription
+   *
+   * @param subscription the name of the subscription to detach.
+   */
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      Subscription subscription) {
+    return connection_->DetachSubscription({std::move(subscription)});
+  }
+
+  /**
    * List all the subscription names for a given topic.
    *
    * @note

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -149,6 +149,9 @@ class TopicAdminClient {
    * it drops any messages still retained by the subscription, and any
    * outstanding pull requests will fail with `FAILED_PRECONDITION`.
    *
+   * @warning this feature is **not GA** and may require registering your
+   *   project in an early access program.
+   *
    * @par Idempotency
    * This is not an idempotent operation and therefore it is never retried.
    *

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -79,6 +79,14 @@ class TopicAdminConnectionImpl : public TopicAdminConnection {
     return stub_->DeleteTopic(context, request);
   }
 
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      DetachSubscriptionParams p) override {
+    google::pubsub::v1::DetachSubscriptionRequest request;
+    request.set_subscription(p.subscription.FullName());
+    grpc::ClientContext context;
+    return stub_->DetachSubscription(context, request);
+  }
+
   ListTopicSubscriptionsRange ListTopicSubscriptions(
       ListTopicSubscriptionsParams p) override {
     google::pubsub::v1::ListTopicSubscriptionsRequest request;

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -120,6 +120,11 @@ class TopicAdminConnection {
     Topic topic;
   };
 
+  /// Wrap the arguments for `DetachSubscription()`
+  struct DetachSubscriptionParams {
+    Subscription subscription;
+  };
+
   /// Wrap the arguments for `ListTopicSubscriptions()`
   struct ListTopicSubscriptionsParams {
     std::string topic_full_name;
@@ -147,6 +152,10 @@ class TopicAdminConnection {
 
   /// Defines the interface for `TopicAdminClient::DeleteTopic()`
   virtual Status DeleteTopic(DeleteTopicParams) = 0;
+
+  /// Defines the interface for `TopicAdminClient::DetachSubscriptions()`
+  virtual StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+      DetachSubscription(DetachSubscriptionParams) = 0;
 
   /// Defines the interface for `TopicAdminClient::ListTopicSubscriptions()`
   virtual ListTopicSubscriptionsRange ListTopicSubscriptions(


### PR DESCRIPTION
Implement the function in the *Stub, *Connection, and *Client classes.
Modify the unit tests, integration tests, and samples to include this
function. The emulator does not support this function so we need some
workarounds in the integration tests and samples.

Fixes #4570 and fixes #4639

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4849)
<!-- Reviewable:end -->
