### PR TITLE
cleanup(spanner): use the correct form of the NUMERIC type code

### DIFF
--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -677,7 +677,7 @@ TEST(Value, ProtoConversionNumeric) {
     Value const v(x);
     auto const p = internal::ToProto(v);
     EXPECT_EQ(v, internal::FromProto(p.first, p.second));
-    EXPECT_EQ(google::spanner::v1::TypeCode::STRUCT + 1, p.first.code());
+    EXPECT_EQ(google::spanner::v1::TypeCode::NUMERIC, p.first.code());
     EXPECT_EQ(x.ToString(), p.second.string_value());
   }
 }


### PR DESCRIPTION
I missed updating one instance of TypeCode "STRUCT + 1", which was
used during the development of `spanner::Numeric`.  Oops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4864)
<!-- Reviewable:end -->
