### PR TITLE
feat(storage): noncurrent and custom time OLM

### DIFF
--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -120,6 +120,20 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
       }
       result.condition_.noncurrent_time_before.emplace(std::move(day));
     }
+    if (condition.count("daysSinceCustomTime") != 0) {
+      result.condition_.days_since_custom_time.emplace(
+          internal::ParseIntField(condition, "daysSinceCustomTime"));
+    }
+    if (condition.count("customTimeBefore") != 0) {
+      auto const date = condition.value("customTimeBefore", "");
+      absl::CivilDay day;
+      if (!absl::ParseCivilTime(date, &day)) {
+        return Status(
+            StatusCode::kInvalidArgument,
+            "Cannot parse customTimeBefore value (" + date + ") as a date");
+      }
+      result.condition_.custom_time_before.emplace(std::move(day));
+    }
   }
   return result;
 }

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -85,8 +85,9 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
       auto const date = condition.value("createdBefore", "");
       absl::CivilDay day;
       if (!absl::ParseCivilTime(date, &day)) {
-        return Status(StatusCode::kInvalidArgument,
-                      "Cannot parse " + date + " as a date");
+        return Status(
+            StatusCode::kInvalidArgument,
+            "Cannot parse createdBefore value (" + date + "( as a date");
       }
       result.condition_.created_before.emplace(std::move(day));
     }
@@ -104,6 +105,20 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
     if (condition.count("numNewerVersions") != 0) {
       result.condition_.num_newer_versions.emplace(
           internal::ParseIntField(condition, "numNewerVersions"));
+    }
+    if (condition.count("daysSinceNoncurrentTime") != 0) {
+      result.condition_.days_since_noncurrent_time.emplace(
+          internal::ParseIntField(condition, "daysSinceNoncurrentTime"));
+    }
+    if (condition.count("noncurrentTimeBefore") != 0) {
+      auto const date = condition.value("noncurrentTimeBefore", "");
+      absl::CivilDay day;
+      if (!absl::ParseCivilTime(date, &day)) {
+        return Status(
+            StatusCode::kInvalidArgument,
+            "Cannot parse noncurrentTimeBefore value (" + date + ") as a date");
+      }
+      result.condition_.noncurrent_time_before.emplace(std::move(day));
     }
   }
   return result;

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -87,7 +87,7 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
       if (!absl::ParseCivilTime(date, &day)) {
         return Status(
             StatusCode::kInvalidArgument,
-            "Cannot parse createdBefore value (" + date + "( as a date");
+            "Cannot parse createdBefore value (" + date + ") as a date");
       }
       result.condition_.created_before.emplace(std::move(day));
     }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -90,6 +90,16 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
   }
   if (rhs.num_newer_versions.has_value()) {
     os << sep << "num_newer_versions=" << *rhs.num_newer_versions;
+    sep = ", ";
+  }
+  if (rhs.days_since_noncurrent_time.has_value()) {
+    os << sep
+       << "days_since_noncurrent_time=" << *rhs.days_since_noncurrent_time;
+    sep = ", ";
+  }
+  if (rhs.noncurrent_time_before.has_value()) {
+    os << sep << "noncurrent_time_before=" << *rhs.noncurrent_time_before;
+    sep = ", ";
   }
   return os << "}";
 }
@@ -146,6 +156,22 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
     } else {
       auto tmp = *rhs.num_newer_versions;
       result.num_newer_versions.emplace(std::forward<std::int32_t>(tmp));
+    }
+  }
+  if (rhs.days_since_noncurrent_time.has_value()) {
+    if (result.days_since_noncurrent_time.has_value()) {
+      *result.days_since_noncurrent_time = (std::max)(
+          *result.days_since_noncurrent_time, *rhs.days_since_noncurrent_time);
+    } else {
+      result.days_since_noncurrent_time = *rhs.days_since_noncurrent_time;
+    }
+  }
+  if (rhs.noncurrent_time_before.has_value()) {
+    if (result.noncurrent_time_before.has_value()) {
+      *result.noncurrent_time_before = (std::min)(
+          *result.noncurrent_time_before, *rhs.noncurrent_time_before);
+    } else {
+      result.noncurrent_time_before = *rhs.noncurrent_time_before;
     }
   }
 }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -101,6 +101,14 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
     os << sep << "noncurrent_time_before=" << *rhs.noncurrent_time_before;
     sep = ", ";
   }
+  if (rhs.days_since_custom_time.has_value()) {
+    os << sep << "days_since_custom_time=" << *rhs.days_since_custom_time;
+    sep = ", ";
+  }
+  if (rhs.custom_time_before.has_value()) {
+    os << sep << "custom_time_before=" << *rhs.custom_time_before;
+    sep = ", ";
+  }
   return os << "}";
 }
 
@@ -172,6 +180,22 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
           *result.noncurrent_time_before, *rhs.noncurrent_time_before);
     } else {
       result.noncurrent_time_before = *rhs.noncurrent_time_before;
+    }
+  }
+  if (rhs.days_since_custom_time.has_value()) {
+    if (result.days_since_custom_time.has_value()) {
+      *result.days_since_custom_time = (std::max)(
+          *result.days_since_custom_time, *rhs.days_since_custom_time);
+    } else {
+      result.days_since_custom_time = *rhs.days_since_custom_time;
+    }
+  }
+  if (rhs.custom_time_before.has_value()) {
+    if (result.custom_time_before.has_value()) {
+      *result.custom_time_before =
+          (std::min)(*result.custom_time_before, *rhs.custom_time_before);
+    } else {
+      result.custom_time_before = *rhs.custom_time_before;
     }
   }
 }

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -116,7 +116,7 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
                                     LifecycleRuleCondition const& rhs) {
   if (rhs.age.has_value()) {
     if (result.age.has_value()) {
-      *result.age = std::min(*result.age, *rhs.age);
+      result.age = std::min(*result.age, *rhs.age);
     } else {
       auto tmp = *rhs.age;
       result.age.emplace(std::forward<std::int32_t>(tmp));
@@ -124,7 +124,7 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
   }
   if (rhs.created_before.has_value()) {
     if (result.created_before.has_value()) {
-      *result.created_before =
+      result.created_before =
           std::max(*result.created_before, *rhs.created_before);
     } else {
       result.created_before.emplace(std::move(*rhs.created_before));
@@ -159,7 +159,7 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
   }
   if (rhs.num_newer_versions.has_value()) {
     if (result.num_newer_versions.has_value()) {
-      *result.num_newer_versions =
+      result.num_newer_versions =
           std::max(*result.num_newer_versions, *rhs.num_newer_versions);
     } else {
       auto tmp = *rhs.num_newer_versions;
@@ -168,7 +168,7 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
   }
   if (rhs.days_since_noncurrent_time.has_value()) {
     if (result.days_since_noncurrent_time.has_value()) {
-      *result.days_since_noncurrent_time = (std::max)(
+      result.days_since_noncurrent_time = (std::max)(
           *result.days_since_noncurrent_time, *rhs.days_since_noncurrent_time);
     } else {
       result.days_since_noncurrent_time = *rhs.days_since_noncurrent_time;
@@ -176,23 +176,23 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
   }
   if (rhs.noncurrent_time_before.has_value()) {
     if (result.noncurrent_time_before.has_value()) {
-      *result.noncurrent_time_before = (std::min)(
-          *result.noncurrent_time_before, *rhs.noncurrent_time_before);
+      result.noncurrent_time_before = (std::min)(*result.noncurrent_time_before,
+                                                 *rhs.noncurrent_time_before);
     } else {
       result.noncurrent_time_before = *rhs.noncurrent_time_before;
     }
   }
   if (rhs.days_since_custom_time.has_value()) {
     if (result.days_since_custom_time.has_value()) {
-      *result.days_since_custom_time = (std::max)(
-          *result.days_since_custom_time, *rhs.days_since_custom_time);
+      result.days_since_custom_time = (std::max)(*result.days_since_custom_time,
+                                                 *rhs.days_since_custom_time);
     } else {
       result.days_since_custom_time = *rhs.days_since_custom_time;
     }
   }
   if (rhs.custom_time_before.has_value()) {
     if (result.custom_time_before.has_value()) {
-      *result.custom_time_before =
+      result.custom_time_before =
           (std::min)(*result.custom_time_before, *rhs.custom_time_before);
     } else {
       result.custom_time_before = *rhs.custom_time_before;

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -85,6 +85,8 @@ struct LifecycleRuleCondition {
   absl::optional<std::int32_t> num_newer_versions;
   absl::optional<std::int32_t> days_since_noncurrent_time;
   absl::optional<absl::CivilDay> noncurrent_time_before;
+  absl::optional<std::int32_t> days_since_custom_time;
+  absl::optional<absl::CivilDay> custom_time_before;
 };
 
 inline bool operator==(LifecycleRuleCondition const& lhs,
@@ -94,17 +96,21 @@ inline bool operator==(LifecycleRuleCondition const& lhs,
          lhs.matches_storage_class == rhs.matches_storage_class &&
          lhs.num_newer_versions == rhs.num_newer_versions &&
          lhs.days_since_noncurrent_time == rhs.days_since_noncurrent_time &&
-         lhs.noncurrent_time_before == rhs.noncurrent_time_before;
+         lhs.noncurrent_time_before == rhs.noncurrent_time_before &&
+         lhs.days_since_custom_time == rhs.days_since_custom_time &&
+         lhs.custom_time_before == rhs.custom_time_before;
 }
 
 inline bool operator<(LifecycleRuleCondition const& lhs,
                       LifecycleRuleCondition const& rhs) {
   return std::tie(lhs.age, lhs.created_before, lhs.is_live,
                   lhs.matches_storage_class, lhs.num_newer_versions,
-                  lhs.days_since_noncurrent_time, lhs.noncurrent_time_before) <
+                  lhs.days_since_noncurrent_time, lhs.noncurrent_time_before,
+                  lhs.days_since_custom_time, lhs.custom_time_before) <
          std::tie(rhs.age, rhs.created_before, rhs.is_live,
                   rhs.matches_storage_class, rhs.num_newer_versions,
-                  rhs.days_since_noncurrent_time, rhs.noncurrent_time_before);
+                  rhs.days_since_noncurrent_time, rhs.noncurrent_time_before,
+                  rhs.days_since_custom_time, rhs.custom_time_before);
 }
 
 inline bool operator!=(LifecycleRuleCondition const& lhs,
@@ -253,6 +259,18 @@ class LifecycleRule {
   static LifecycleRuleCondition NoncurrentTimeBefore(absl::CivilDay date) {
     LifecycleRuleCondition result;
     result.noncurrent_time_before = date;
+    return result;
+  }
+
+  static LifecycleRuleCondition DaysSinceCustomTime(std::int32_t days) {
+    LifecycleRuleCondition result;
+    result.days_since_custom_time = days;
+    return result;
+  }
+
+  static LifecycleRuleCondition CustomTimeBefore(absl::CivilDay date) {
+    LifecycleRuleCondition result;
+    result.custom_time_before = date;
     return result;
   }
   //@}

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -83,6 +83,8 @@ struct LifecycleRuleCondition {
   absl::optional<bool> is_live;
   absl::optional<std::vector<std::string>> matches_storage_class;
   absl::optional<std::int32_t> num_newer_versions;
+  absl::optional<std::int32_t> days_since_noncurrent_time;
+  absl::optional<absl::CivilDay> noncurrent_time_before;
 };
 
 inline bool operator==(LifecycleRuleCondition const& lhs,
@@ -90,15 +92,19 @@ inline bool operator==(LifecycleRuleCondition const& lhs,
   return lhs.age == rhs.age && lhs.created_before == rhs.created_before &&
          lhs.is_live == rhs.is_live &&
          lhs.matches_storage_class == rhs.matches_storage_class &&
-         lhs.num_newer_versions == rhs.num_newer_versions;
+         lhs.num_newer_versions == rhs.num_newer_versions &&
+         lhs.days_since_noncurrent_time == rhs.days_since_noncurrent_time &&
+         lhs.noncurrent_time_before == rhs.noncurrent_time_before;
 }
 
 inline bool operator<(LifecycleRuleCondition const& lhs,
                       LifecycleRuleCondition const& rhs) {
   return std::tie(lhs.age, lhs.created_before, lhs.is_live,
-                  lhs.matches_storage_class, lhs.num_newer_versions) <
+                  lhs.matches_storage_class, lhs.num_newer_versions,
+                  lhs.days_since_noncurrent_time, lhs.noncurrent_time_before) <
          std::tie(rhs.age, rhs.created_before, rhs.is_live,
-                  rhs.matches_storage_class, rhs.num_newer_versions);
+                  rhs.matches_storage_class, rhs.num_newer_versions,
+                  rhs.days_since_noncurrent_time, rhs.noncurrent_time_before);
 }
 
 inline bool operator!=(LifecycleRuleCondition const& lhs,
@@ -235,6 +241,18 @@ class LifecycleRule {
   static LifecycleRuleCondition NumNewerVersions(std::int32_t days) {
     LifecycleRuleCondition result;
     result.num_newer_versions.emplace(std::move(days));
+    return result;
+  }
+
+  static LifecycleRuleCondition DaysSinceNoncurrentTime(std::int32_t days) {
+    LifecycleRuleCondition result;
+    result.days_since_noncurrent_time = days;
+    return result;
+  }
+
+  static LifecycleRuleCondition NoncurrentTimeBefore(absl::CivilDay date) {
+    LifecycleRuleCondition result;
+    result.noncurrent_time_before = date;
     return result;
   }
   //@}

--- a/google/cloud/storage/lifecycle_rule_test.cc
+++ b/google/cloud/storage/lifecycle_rule_test.cc
@@ -30,7 +30,9 @@ LifecycleRule CreateLifecycleRuleForTest() {
         "createdBefore": "2018-07-23",
         "isLive": true,
         "matchesStorageClass": [ "STANDARD" ],
-        "numNewerVersions": 7
+        "numNewerVersions": 7,
+        "daysSinceNoncurrentTime": 3,
+        "noncurrentTimeBefore": "2020-07-22"
       },
       "action": {
         "type": "SetStorageClass",
@@ -239,6 +241,37 @@ TEST(LifecycleRuleTest, NumNewerVersions) {
   EXPECT_EQ(7, condition.num_newer_versions.value());
 }
 
+/// @test Verify that LifecycleRule::DaysSinceNoncurrent() works as expected.
+TEST(LifecycleRuleTest, DaysSinceNoncurrentTime) {
+  auto const c1 = LifecycleRule::DaysSinceNoncurrentTime(3);
+  ASSERT_TRUE(c1.days_since_noncurrent_time.has_value());
+  EXPECT_EQ(3, c1.days_since_noncurrent_time.value());
+  EXPECT_EQ(c1, c1);
+  auto const c2 = LifecycleRule::DaysSinceNoncurrentTime(4);
+  EXPECT_NE(c1, c2);
+  EXPECT_LT(c1, c2);
+  auto const empty = LifecycleRuleCondition{};
+  EXPECT_NE(c1, empty);
+}
+
+/// @test Verify that LifecycleRule::NoncurrentTimeBefore() works as expected.
+TEST(LifecycleRuleTest, NoncurrentTimeBefore) {
+  auto const c1 =
+      LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 22));
+  ASSERT_TRUE(c1.noncurrent_time_before.has_value());
+  EXPECT_EQ(c1, c1);
+  auto const c2 =
+      LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 23));
+  ASSERT_TRUE(c2.noncurrent_time_before.has_value());
+  EXPECT_EQ(c2, c2);
+
+  EXPECT_NE(c1, c2);
+  EXPECT_LT(c1, c2);
+
+  auto const empty = LifecycleRuleCondition{};
+  EXPECT_NE(c1, empty);
+}
+
 /// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
 TEST(LifecycleRuleTest, ConditionConjunctionAge) {
   auto c1 = LifecycleRule::MaxAge(7);
@@ -318,6 +351,26 @@ TEST(LifecycleRuleTest, ConditionConjunctionNumNewerVersions) {
 }
 
 /// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
+TEST(LifecycleRuleTest, ConditionConjunctionDaysSinceNoncurrentTime) {
+  auto const c1 = LifecycleRule::DaysSinceNoncurrentTime(7);
+  auto const c2 = LifecycleRule::DaysSinceNoncurrentTime(42);
+  auto const condition = LifecycleRule::ConditionConjunction(c1, c2);
+  ASSERT_TRUE(condition.days_since_noncurrent_time.has_value());
+  EXPECT_EQ(42, *condition.days_since_noncurrent_time);
+}
+
+/// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
+TEST(LifecycleRuleTest, ConditionConjunctionNoncurrentTimeBefore) {
+  auto const c1 =
+      LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 22));
+  auto const c2 =
+      LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 23));
+  auto const condition = LifecycleRule::ConditionConjunction(c1, c2);
+  ASSERT_TRUE(condition.noncurrent_time_before.has_value());
+  EXPECT_EQ(absl::CivilDay(2020, 7, 22), *condition.noncurrent_time_before);
+}
+
+/// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
 TEST(LifecycleRuleTest, ConditionConjunctionMultiple) {
   auto c1 = LifecycleRule::NumNewerVersions(7);
   auto c2 = LifecycleRule::MaxAge(42);
@@ -348,7 +401,9 @@ TEST(LifecycleRuleTest, Parsing) {
           LifecycleRule::CreatedBefore(absl::CivilDay(2018, 7, 23)),
           LifecycleRule::IsLive(true),
           LifecycleRule::MatchesStorageClassStandard(),
-          LifecycleRule::NumNewerVersions(7));
+          LifecycleRule::NumNewerVersions(7),
+          LifecycleRule::DaysSinceNoncurrentTime(3),
+          LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 22)));
   EXPECT_EQ(expected_condition, actual.condition());
 
   LifecycleRuleAction expected_action =

--- a/google/cloud/storage/lifecycle_rule_test.cc
+++ b/google/cloud/storage/lifecycle_rule_test.cc
@@ -32,7 +32,9 @@ LifecycleRule CreateLifecycleRuleForTest() {
         "matchesStorageClass": [ "STANDARD" ],
         "numNewerVersions": 7,
         "daysSinceNoncurrentTime": 3,
-        "noncurrentTimeBefore": "2020-07-22"
+        "noncurrentTimeBefore": "2020-07-22",
+        "daysSinceCustomTime": 30,
+        "customTimeBefore": "2020-07-23"
       },
       "action": {
         "type": "SetStorageClass",
@@ -272,6 +274,35 @@ TEST(LifecycleRuleTest, NoncurrentTimeBefore) {
   EXPECT_NE(c1, empty);
 }
 
+/// @test Verify that LifecycleRule::DaysSinceCustomTime() works as expected.
+TEST(LifecycleRuleTest, DaysSinceCustomTime) {
+  auto const c1 = LifecycleRule::DaysSinceCustomTime(3);
+  ASSERT_TRUE(c1.days_since_custom_time.has_value());
+  EXPECT_EQ(3, c1.days_since_custom_time.value());
+  EXPECT_EQ(c1, c1);
+  auto const c2 = LifecycleRule::DaysSinceCustomTime(4);
+  EXPECT_NE(c1, c2);
+  EXPECT_LT(c1, c2);
+  auto const empty = LifecycleRuleCondition{};
+  EXPECT_NE(c1, empty);
+}
+
+/// @test Verify that LifecycleRule::NoncurrentTimeBefore() works as expected.
+TEST(LifecycleRuleTest, CustomTimeBefore) {
+  auto const c1 = LifecycleRule::CustomTimeBefore(absl::CivilDay(2020, 7, 23));
+  ASSERT_TRUE(c1.custom_time_before.has_value());
+  EXPECT_EQ(c1, c1);
+  auto const c2 = LifecycleRule::CustomTimeBefore(absl::CivilDay(2020, 7, 24));
+  ASSERT_TRUE(c2.custom_time_before.has_value());
+  EXPECT_EQ(c2, c2);
+
+  EXPECT_NE(c1, c2);
+  EXPECT_LT(c1, c2);
+
+  auto const empty = LifecycleRuleCondition{};
+  EXPECT_NE(c1, empty);
+}
+
 /// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
 TEST(LifecycleRuleTest, ConditionConjunctionAge) {
   auto c1 = LifecycleRule::MaxAge(7);
@@ -371,6 +402,24 @@ TEST(LifecycleRuleTest, ConditionConjunctionNoncurrentTimeBefore) {
 }
 
 /// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
+TEST(LifecycleRuleTest, ConditionConjunctionDaysSinceCustomTime) {
+  auto const c1 = LifecycleRule::DaysSinceCustomTime(7);
+  auto const c2 = LifecycleRule::DaysSinceCustomTime(42);
+  auto const condition = LifecycleRule::ConditionConjunction(c1, c2);
+  ASSERT_TRUE(condition.days_since_custom_time.has_value());
+  EXPECT_EQ(42, *condition.days_since_custom_time);
+}
+
+/// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
+TEST(LifecycleRuleTest, ConditionConjunctionCustomTimeBefore) {
+  auto const c1 = LifecycleRule::CustomTimeBefore(absl::CivilDay(2020, 7, 23));
+  auto const c2 = LifecycleRule::CustomTimeBefore(absl::CivilDay(2020, 7, 24));
+  auto const condition = LifecycleRule::ConditionConjunction(c1, c2);
+  ASSERT_TRUE(condition.custom_time_before.has_value());
+  EXPECT_EQ(absl::CivilDay(2020, 7, 23), *condition.custom_time_before);
+}
+
+/// @test Verify that LifecycleRule::ConditionConjunction() works as expected.
 TEST(LifecycleRuleTest, ConditionConjunctionMultiple) {
   auto c1 = LifecycleRule::NumNewerVersions(7);
   auto c2 = LifecycleRule::MaxAge(42);
@@ -403,7 +452,9 @@ TEST(LifecycleRuleTest, Parsing) {
           LifecycleRule::MatchesStorageClassStandard(),
           LifecycleRule::NumNewerVersions(7),
           LifecycleRule::DaysSinceNoncurrentTime(3),
-          LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 22)));
+          LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2020, 7, 22)),
+          LifecycleRule::DaysSinceCustomTime(30),
+          LifecycleRule::CustomTimeBefore(absl::CivilDay(2020, 7, 23)));
   EXPECT_EQ(expected_condition, actual.condition());
 
   LifecycleRuleAction expected_action =
@@ -419,6 +470,8 @@ TEST(LifecycleRuleTest, LifecycleRuleStream) {
   auto actual = os.str();
   EXPECT_THAT(actual, ::testing::HasSubstr("age=42"));
   EXPECT_THAT(actual, ::testing::HasSubstr("NEARLINE"));
+  EXPECT_THAT(actual, ::testing::HasSubstr("days_since_custom_time="));
+  EXPECT_THAT(actual, ::testing::HasSubstr("custom_time_before="));
 }
 
 }  // namespace


### PR DESCRIPTION
Implement new Object Lifecycle Management (OLM) conditions
based on:

- "noncurrent time", i.e., the time since the object version is
"archived" or no longer the "current" version.
- "custom time", i.e., a custom field in the object metadata.

This fixes #4275 and fixes #4432

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4871)
<!-- Reviewable:end -->
