### PR TITLE
doc(pubsub): document publish batch limits

### DIFF
--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -75,6 +75,7 @@ class PublisherOptions {
   }
 
   std::size_t maximum_message_count() const { return maximum_message_count_; }
+
   /**
    * Set the maximum number of messages in a batch.
    *
@@ -91,6 +92,7 @@ class PublisherOptions {
   }
 
   std::size_t maximum_batch_bytes() const { return maximum_batch_bytes_; }
+
   /**
    * Set the maximum size for the messages in a batch.
    *

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -75,12 +75,32 @@ class PublisherOptions {
   }
 
   std::size_t maximum_message_count() const { return maximum_message_count_; }
+  /**
+   * Set the maximum number of messages in a batch.
+   *
+   * @note Application developers should keep in mind that Cloud Pub/Sub
+   *    sets [limits][pubsub-quota-link] on the size of a batch (1,000 messages)
+   *    The library makes no ttempt to validate the value provided in this
+   *    function.
+   *
+   * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
+   */
   PublisherOptions& set_maximum_message_count(std::size_t v) {
     maximum_message_count_ = v;
     return *this;
   }
 
   std::size_t maximum_batch_bytes() const { return maximum_batch_bytes_; }
+  /**
+   * Set the maximum size for the messages in a batch.
+   *
+   * @note Application developers should keep in mind that Cloud Pub/Sub
+   *    sets [limits][pubsub-quota-link] on the size of a batch (10MB). The
+   *    library makes no attempt to validate the value provided in this
+   *    function.
+   *
+   * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
+   */
   PublisherOptions& set_maximum_batch_bytes(std::size_t v) {
     maximum_batch_bytes_ = v;
     return *this;


### PR DESCRIPTION
Fixes #4671

As noted in the bug, originally I thought we should change the types, but after further thought, this is more of a documentation problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4873)
<!-- Reviewable:end -->
