### PR TITLE
doc(pubsub): use pre-release numbers for Doxygen

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -16,7 +16,8 @@
 
 set(DOXYGEN_PROJECT_NAME "Google Cloud Pub/Sub C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Pub/Sub")
-set(DOXYGEN_PROJECT_NUMBER "${GOOGLE_CLOUD_CPP_VERSION}")
+# TODO(#4878) - restore the version number in the documents
+set(DOXYGEN_PROJECT_NUMBER "0.0.0 (dev)") # "${GOOGLE_CLOUD_CPP_VERSION}")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples)
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsub_internal" "pubsub_testing")
 set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_PUBSUB_NS=v1")


### PR DESCRIPTION
Change the generated Doxygen documentation to use a pre-release version
number. Our README file already states that the library is not GA, but I
want to publish the documentation, and putting a 1.x version number is
misleading.

Part of the work for #4874 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4881)
<!-- Reviewable:end -->
