### PR TITLE
ci: restore github.io uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ compile_commands.json
 .idea/
 cmake-build-*/
 
-# This is a staging directory used to upload the documents to gihub.io
-github-io-staging/
-
 # Ignore Visual Studio Code files
 .vsbuild/
 .vscode/

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -584,10 +584,10 @@ fi
 if [[ "${BUILD_NAME}" == "publish-refdocs" ]]; then
   "${PROJECT_ROOT}/ci/kokoro/docker/publish-refdocs.sh"
   exit_status=$?
-else
+elif [[ "${RUNNING_CI:-}" == "yes" ]]; then
   # Note that only the `clang-tidy` build config contains the token needed
   # to actually upload the docs, otherwise this has no effect.
-  "${PROJECT_ROOT}/ci/kokoro/docker/upload-docs.sh" "${BRANCH}"
+  "${PROJECT_ROOT}/ci/kokoro/docker/upload-docs.sh" "${BRANCH}" "${BUILD_OUTPUT}"
 fi
 
 "${PROJECT_ROOT}/ci/kokoro/docker/upload-coverage.sh" \


### PR DESCRIPTION
On CI builds only (not when running locally) upload the Doxygen docs to `googleapis.github.io/google-cloud-cpp`.

Fixed the upload script to be able to test it manually, so one can do:

```sh
GENERATE_DOCS=yes ./ci/kokoro/docker/upload-docs.sh master cmake-out/ci-fedora-install-31-clang-tidy/
```

and upload the documents to `$USER.github.io/google-cloud-cpp/`, for example see:

https://coryan.github.io/google-cloud-cpp/latest/pubsub/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4882)
<!-- Reviewable:end -->
