### PR TITLE
ci: don't cache curl build actions

### DIFF
--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -44,6 +44,7 @@ genrule(
       fi >$@
     """,
     }),
+    tags = ["no-cache"],
 )
 
 CURL_WIN_COPTS = [
@@ -359,6 +360,7 @@ cc_library(
             "-lrt",
         ],
     }),
+    tags = ["no-cache"],
     visibility = ["//visibility:public"],
     deps = [
         # Use the same version of zlib that gRPC does.
@@ -475,6 +477,7 @@ cc_binary(
             "-Wno-string-plus-int",
         ],
     }),
+    tags = ["no-cache"],
     deps = [":curl"],
 )
 
@@ -745,4 +748,5 @@ genrule(
         "#endif  // EXTERNAL_CURL_INCLUDE_CURL_CONFIG_H_",
         "EOF",
     ]),
+    tags = ["no-cache"],
 )


### PR DESCRIPTION
We're seeing strange errors in our CI related to libcurl. It's possible
that we're using some cached artifacts that were compiled w/ the wrong
settings.

See also https://docs.bazel.build/versions/2.0.0/remote-caching.html#exclude-specific-targets-from-using-the-remote-cache

Related to PR https://github.com/googleapis/google-cloud-cpp/pull/4869

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4885)
<!-- Reviewable:end -->
