### PR TITLE
feat(pubsub): orderly shutdown subscription sessions

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -29,6 +29,96 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
+/**
+ * A helper class to track (and debug) `SubscriptionSession`'s shutdown process
+ *
+ * The `SubscriptionSession` class needs to implement an orderly shutdown when
+ * the application requests it (via a `future<>::cancel()` call) or when the
+ * session fails, i.e., the `AsyncPull()` fails and we have exhausted the retry
+ * policies.
+ *
+ * Once the shutdown is initiated we need to stop any operation that would
+ * create more work, including:
+ * - New callbacks to the application
+ * - Making new calls to `AsyncPull()`
+ * - Handling any responses from `AsyncPull()`
+ * - Creating any new timers to update message leases.
+ * - Creating any new `AsyncModifyAckDeadline()` requests to update message
+ *   leases.
+ *
+ * When the shutdown is requested we should also cancel any pending timers, as
+ * these can be long and we do not want to wait until they expire. We should
+ * also make a best effort attempt to `nack()` any pending messages that are
+ * not being handled by the application, as well as any messages that are not
+ * being handled by a callback.
+ */
+class SessionShutdownManager {
+ public:
+  SessionShutdownManager() = default;
+  ~SessionShutdownManager();
+
+  // TODO(#4898) - I think a `.then()` call would work better here.
+  /// Set the promise to signal when the shutdown has completed.
+  void Start(promise<Status> p) { done_ = std::move(p); }
+
+  /**
+   * Start an operation, using the current thread of control.
+   *
+   * If the shutdown process has not started, this function calls @p op and
+   * increments the count of outstanding functions.
+   *
+   * Note that this function takes parameters to trace the activity, but this
+   * tracing is typically disabled at compile-time.
+   */
+  template <typename Operation>
+  void StartOperation(char const* caller, char const* name, Operation&& op) {
+    std::unique_lock<std::mutex> lk(mu_);
+    LogStart(caller, name);
+    if (shutdown_) return;
+    ++outstanding_operations_;
+    lk.unlock();
+    op();
+  }
+
+  /**
+   * Start an asynchronous operation using @p executor.
+   *
+   * If the shutdown process has not started, this function calls @p op using
+   * one of the threads associated with @p executor, and increments the count
+   * of outstanding functions.
+   *
+   * Note that this function takes parameters to trace the activity, but this
+   * tracing is typically disabled at compile-time.
+   */
+  template <typename Operation>
+  void StartAsyncOperation(char const* caller, char const* name,
+                           CompletionQueue& executor, Operation&& op) {
+    std::unique_lock<std::mutex> lk(mu_);
+    LogStart(caller, name);
+    if (shutdown_) return;
+    ++outstanding_operations_;
+    lk.unlock();
+    executor.RunAsync(std::forward<Operation>(op));
+  }
+
+  /// Record an operation completion
+  bool FinishedOperation(char const* name);
+
+  // Start the shutdown process
+  void MarkAsShutdown(char const* caller, Status status);
+
+ private:
+  void LogStart(char const* caller, char const* name);
+  void SignalOnShutdown(std::unique_lock<std::mutex> lk);
+
+  std::mutex mu_;
+  bool shutdown_ = false;
+  bool signaled_ = false;
+  int outstanding_operations_ = 0;
+  Status result_;
+  promise<Status> done_;
+};
+
 class SubscriptionSession
     : public std::enable_shared_from_this<SubscriptionSession> {
  public:
@@ -79,11 +169,7 @@ class SubscriptionSession
   /// Handle the queue of messages, invoking `callback_` on the next message.
   void HandleQueue(std::unique_lock<std::mutex> lk);
 
-  /// Start the loop to keep ack deadlines refreshed
-  void StartAckDeadlineLoop() {
-    RefreshAckDeadlines(std::unique_lock<std::mutex>(mu_));
-  }
-
+  // TODO(#4899) - rename these functions to *MessageLeases()
   /// If needed asynchronous update the ack deadlines in the server.
   void RefreshAckDeadlines(std::unique_lock<std::mutex> lk);
 
@@ -98,20 +184,41 @@ class SubscriptionSession
       std::chrono::system_clock::time_point new_server_deadline);
 
   /// The timer to update ack deadlines has triggered.
-  void OnRefreshAckDeadlinesTimer();
+  void OnRefreshAckDeadlinesTimer(bool restart);
+
+  template <typename Iterator>
+  void NackAll(std::unique_lock<std::mutex> const& lk, Iterator begin,
+               Iterator end) {
+    google::pubsub::v1::ModifyAckDeadlineRequest request;
+    for (auto m = begin; m != end; ++m) {
+      request.add_ack_ids(m->ack_id());
+    }
+    NackAll(lk, std::move(request));
+  }
+  void NackAll(std::unique_lock<std::mutex> const&,
+               google::pubsub::v1::ModifyAckDeadlineRequest request);
+
+  /// Estimate the size of a message.
+  static std::size_t MessageSize(google::pubsub::v1::PubsubMessage const& m);
 
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   google::cloud::CompletionQueue executor_;
   pubsub::SubscriberConnection::SubscribeParams params_;
   std::mutex mu_;
-  bool shutdown_ = false;
+
+  // Used to signal the application when all activity has ceased.
+  SessionShutdownManager shutdown_manager_;
+
+  // The queue of messages waiting to be delivered to the application callback.
   std::deque<google::pubsub::v1::ReceivedMessage> messages_;
+
+  // A collection of message ack_ids to maintain the message leases.
   struct AckStatus {
     std::chrono::system_clock::time_point estimated_server_deadline;
     std::chrono::system_clock::time_point handling_deadline;
   };
   std::map<std::string, AckStatus> ack_deadlines_;
-  promise<Status> result_;
+
   bool refreshing_deadlines_ = false;
   future<void> refresh_timer_;
 


### PR DESCRIPTION
So far it has been easy to shutdown subscription sessions as the number
of operations outstanding is 1 or 2 (including the timers). As we
increase the concurrency we will need better code to handle potentially
multiple callbacks in flight, and maybe even multiple calls to
`AsynPull()` in flight. We also want to nack any pending messages that
will not be delivered to a callback as early as possible.

This change creates a helper class to track all asynchronous operations.
Recall that subscription sessions are just represented by a
`future<Status>`. When this future is canceled that starts the orderly
shutdown process. First, a helper class stops scheduling any additional
work. Next, the timer for the session is canceled. A helper class tracks
how many operations are pending, when the counter reaches 0 the future
is satisfied.

Once the shutdown process is started, any responses to `AsyncPull()`
create a fire+forget asynchronous function to nack the messages received
in that pull request. Should that fire+forget operation fail then Cloud
Pub/Sub will timeout the lease for these messages anyway, so they would
be nacked later, but no data is at risk.

Fixes #4862

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4900)
<!-- Reviewable:end -->
