### PR TITLE
feat(storage): custom_time in ObjectMetadata

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -806,6 +806,7 @@ ObjectMetadata GrpcClient::FromProto(google::storage::v1::Object object) {
         google::cloud::internal::ToChronoTimePoint(
             object.time_storage_class_updated());
   }
+  // TODO(#4893) - support customTime for GCS+gRPC
 
   return metadata;
 }

--- a/google/cloud/storage/object_metadata.cc
+++ b/google/cloud/storage/object_metadata.cc
@@ -22,6 +22,9 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+
+using ::google::cloud::internal::FormatRfc3339;
+
 bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
   return static_cast<internal::CommonMetadata<ObjectMetadata> const&>(lhs) ==
              rhs &&
@@ -42,7 +45,7 @@ bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
          lhs.temporary_hold_ == rhs.temporary_hold_ &&
          lhs.time_deleted_ == rhs.time_deleted_ &&
          lhs.time_storage_class_updated_ == rhs.time_storage_class_updated_ &&
-         lhs.size_ == rhs.size_;
+         lhs.size_ == rhs.size_ && lhs.custom_time_ == rhs.custom_time_;
 }
 
 std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
@@ -85,7 +88,7 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
   }
 
   os << ", retention_expiration_time="
-     << google::cloud::internal::FormatRfc3339(rhs.retention_expiration_time())
+     << FormatRfc3339(rhs.retention_expiration_time())
      << ", self_link=" << rhs.self_link() << ", size=" << rhs.size()
      << ", storage_class=" << rhs.storage_class()
      << ", temporary_hold=" << std::boolalpha << rhs.temporary_hold()
@@ -93,8 +96,11 @@ std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs) {
      << ", time_deleted=" << rhs.time_deleted().time_since_epoch().count()
      << ", time_storage_class_updated="
      << rhs.time_storage_class_updated().time_since_epoch().count()
-     << ", updated=" << rhs.updated().time_since_epoch().count() << "}";
-  return os;
+     << ", updated=" << rhs.updated().time_since_epoch().count();
+  if (rhs.has_custom_time()) {
+    os << ", custom_time=" << FormatRfc3339(rhs.custom_time());
+  }
+  return os << "}";
 }
 
 std::string ObjectMetadataPatchBuilder::BuildPatch() const {
@@ -241,6 +247,18 @@ ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetTemporaryHold(
 
 ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetTemporaryHold() {
   impl_.RemoveField("temporaryHold");
+  return *this;
+}
+
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::SetCustomTime(
+    std::chrono::system_clock::time_point tp) {
+  impl_.SetStringField("customTime",
+                       google::cloud::internal::FormatRfc3339(tp));
+  return *this;
+}
+
+ObjectMetadataPatchBuilder& ObjectMetadataPatchBuilder::ResetCustomTime() {
+  impl_.RemoveField("customTime");
   return *this;
 }
 

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -230,6 +230,19 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
 
   using CommonMetadata::updated;
 
+  bool has_custom_time() const { return custom_time_.has_value(); }
+  std::chrono::system_clock::time_point custom_time() const {
+    return custom_time_.value_or(std::chrono::system_clock::time_point{});
+  }
+  ObjectMetadata& set_custom_time(std::chrono::system_clock::time_point v) {
+    custom_time_ = v;
+    return *this;
+  }
+  ObjectMetadata& reset_custom_time() {
+    custom_time_.reset();
+    return *this;
+  }
+
   friend bool operator==(ObjectMetadata const& lhs, ObjectMetadata const& rhs);
   friend bool operator!=(ObjectMetadata const& lhs, ObjectMetadata const& rhs) {
     return !(lhs == rhs);
@@ -262,6 +275,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   bool temporary_hold_{false};
   std::chrono::system_clock::time_point time_deleted_;
   std::chrono::system_clock::time_point time_storage_class_updated_;
+  absl::optional<std::chrono::system_clock::time_point> custom_time_;
 };
 
 std::ostream& operator<<(std::ostream& os, ObjectMetadata const& rhs);
@@ -313,6 +327,16 @@ class ObjectMetadataPatchBuilder {
 
   ObjectMetadataPatchBuilder& SetTemporaryHold(bool v);
   ObjectMetadataPatchBuilder& ResetTemporaryHold();
+
+  /**
+   * Change the `custom_time` field.
+   *
+   * @par Example
+   * @snippet storage_object_samples.cc object custom time
+   */
+  ObjectMetadataPatchBuilder& SetCustomTime(
+      std::chrono::system_clock::time_point tp);
+  ObjectMetadataPatchBuilder& ResetCustomTime();
 
  private:
   internal::PatchBuilder impl_;

--- a/google/cloud/storage/testbench/gcs_object.py
+++ b/google/cloud/storage/testbench/gcs_object.py
@@ -428,8 +428,12 @@ class GcsObject(object):
             "metadata",
             "temporaryHold",
             "storageClass",
+            "customTime",
         }
-        for key in metadata.keys():
+        # Cannot change `metadata` while we are iterating over it, so we make
+        # a copy
+        keys = [key for key in metadata.keys()]
+        for key in keys:
             if key not in writeable_keys:
                 metadata.pop(key, None)
         return metadata


### PR DESCRIPTION
Support the `customTime` field in `gcs::ObjectMetadata`. This is a
timestamp field, so it is represented by
`std::chrono::system_clock::timestamp` and the name in C++ is
`custom_time`. Because this field can be changed, we need support for it
in `Patch` and `Update`. I also wrote an example.

Fixes #4886

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4901)
<!-- Reviewable:end -->
