### PR TITLE
cleanup: prefer matchers over std::count_if

### DIFF
--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -25,13 +25,16 @@
 #include <deque>
 #include <initializer_list>
 
-using testing::_;
-using testing::DoAll;
-using testing::Eq;
-using testing::Matcher;
-using testing::Property;
-using testing::Return;
-using testing::SetArgPointee;
+using ::testing::_;
+using ::testing::Contains;
+using ::testing::DoAll;
+using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::Matcher;
+using ::testing::Not;
+using ::testing::Property;
+using ::testing::Return;
+using ::testing::SetArgPointee;
 
 using google::bigtable::v2::ReadRowsRequest;
 using google::bigtable::v2::ReadRowsResponse_CellChunk;
@@ -721,15 +724,10 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 
-  std::string const expected_message =
-      "RowReader has an error, and the error status was not retrieved";
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [&expected_message](std::string const& line) {
-                      return line.find(expected_message) != std::string::npos;
-                    });
-  EXPECT_EQ(0, count) << "Unexpected log captured: "
-                      << backend->log_lines.front();
+  EXPECT_THAT(
+      backend->log_lines,
+      Not(Contains(HasSubstr(
+          "RowReader has an error, and the error status was not retrieved"))));
 }
 
 TEST_F(RowReaderTest, RowReaderConstructorDoesNotCallRpc) {

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -28,6 +28,8 @@ namespace internal {
 namespace {
 
 using ::testing::_;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::Return;
 namespace gcsa = ::google::spanner::admin::database::v1;
 
@@ -50,12 +52,7 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
   }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count) << "expected to find line with " << contents;
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
   std::shared_ptr<spanner_testing::MockDatabaseAdminStub> mock_;

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -28,6 +28,8 @@ namespace internal {
 namespace {
 
 using ::testing::_;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::Return;
 namespace gcsa = ::google::spanner::admin::instance::v1;
 
@@ -50,12 +52,7 @@ class InstanceAdminLoggingTest : public ::testing::Test {
   }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count) << "expected to find line with " << contents;
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
   std::shared_ptr<spanner_testing::MockInstanceAdminStub> mock_;

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -28,6 +28,8 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::Contains;
+using ::testing::HasSubstr;
 namespace spanner_proto = ::google::spanner::v1;
 
 class LoggingResultSetReaderTest : public ::testing::Test {
@@ -46,12 +48,7 @@ class LoggingResultSetReaderTest : public ::testing::Test {
   void ClearLogCapture() { backend_->log_lines.clear(); }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count);
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
  private:

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -28,6 +28,8 @@ namespace internal {
 namespace {
 
 using ::testing::_;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::Return;
 namespace spanner_proto = ::google::spanner::v1;
 
@@ -50,12 +52,7 @@ class LoggingSpannerStubTest : public ::testing::Test {
   }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count) << contents;
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
   std::shared_ptr<spanner_testing::MockSpannerStub> mock_;

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -25,6 +25,8 @@ namespace internal {
 namespace {
 
 using ::testing::AnyOf;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 
 TEST(SpannerStub, CreateDefaultStub) {
   auto stub = CreateDefaultSpannerStub(Database("foo", "bar", "baz"),
@@ -54,12 +56,8 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
               AnyOf(StatusCode::kUnavailable, StatusCode::kInvalidArgument,
                     StatusCode::kDeadlineExceeded));
 
-  auto const& lines = backend->log_lines;
-  auto count = std::count_if(
-      lines.begin(), lines.end(), [&session](std::string const& line) {
-        return line.find(session.status().message()) != std::string::npos;
-      });
-  EXPECT_NE(0, count);
+  EXPECT_THAT(backend->log_lines,
+              Contains(HasSubstr(session.status().message())));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
+#include <algorithm>
 #include <chrono>
 #include <string>
 #include <thread>
@@ -124,6 +125,15 @@ CountMatchingEntities(std::vector<AccessControlResource> const& acl,
       acl.begin(), acl.end(), [&expected](AccessControlResource const& x) {
         return x.entity() == expected.entity() && x.role() == expected.role();
       });
+}
+
+template <typename AccessControlResource>
+std::vector<std::string> AclEntityNames(
+    std::vector<AccessControlResource> const& acl) {
+  std::vector<std::string> names(acl.size());
+  std::transform(acl.begin(), acl.end(), names.begin(),
+                 [](AccessControlResource const& x) { return x.entity(); });
+  return names;
 }
 
 }  // namespace testing

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -27,8 +27,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::AclEntityNames;
+using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 class BucketIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -67,18 +70,16 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto buckets = client->ListBucketsForProject(project_id_);
-  std::vector<BucketMetadata> initial_buckets;
-  for (auto&& b : buckets) {
-    initial_buckets.emplace_back(std::move(b).value());
-  }
-  auto name_counter = [](std::string const& name,
-                         std::vector<BucketMetadata> const& list) {
-    return std::count_if(
-        list.begin(), list.end(),
-        [name](BucketMetadata const& m) { return m.name() == name; });
+  auto list_bucket_names = [&client, this] {
+    std::vector<std::string> names;
+    for (auto b : client->ListBucketsForProject(project_id_)) {
+      EXPECT_STATUS_OK(b);
+      if (!b) break;
+      names.push_back(b->name());
+    }
+    return names;
   };
-  ASSERT_EQ(0, name_counter(bucket_name, initial_buckets))
+  EXPECT_THAT(list_bucket_names(), Not(Contains(bucket_name)))
       << "Test aborted. The bucket <" << bucket_name << "> already exists."
       << " This is unexpected as the test generates a random bucket name.";
 
@@ -86,13 +87,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
                                                     BucketMetadata());
   ASSERT_STATUS_OK(insert_meta);
   EXPECT_EQ(bucket_name, insert_meta->name());
-
-  buckets = client->ListBucketsForProject(project_id_);
-  std::vector<BucketMetadata> current_buckets;
-  for (auto&& b : buckets) {
-    current_buckets.emplace_back(std::move(b).value());
-  }
-  EXPECT_EQ(1, name_counter(bucket_name, current_buckets));
+  EXPECT_THAT(list_bucket_names(), Contains(bucket_name));
 
   StatusOr<BucketMetadata> get_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(get_meta);
@@ -138,12 +133,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
 
   auto status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
-  buckets = client->ListBucketsForProject(project_id_);
-  current_buckets.clear();
-  for (auto&& b : buckets) {
-    current_buckets.emplace_back(std::move(b).value());
-  }
-  EXPECT_EQ(0, name_counter(bucket_name, current_buckets));
+  EXPECT_THAT(list_bucket_names(), Not(Contains(bucket_name)));
 }
 
 TEST_F(BucketIntegrationTest, CreatePredefinedAcl) {
@@ -353,10 +343,8 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   ASSERT_STATUS_OK(patched);
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
-  EXPECT_EQ(1, std::count_if(patched->acl().begin(), patched->acl().end(),
-                             [](BucketAccessControl const& x) {
-                               return x.entity() == "allAuthenticatedUsers";
-                             }));
+  EXPECT_THAT(AclEntityNames(patched->acl()),
+              Contains("allAuthenticatedUsers"));
 
   // billing()
   EXPECT_EQ(desired_state.billing_as_optional(),
@@ -367,11 +355,8 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 
   // default_acl() - cannot compare for equality because many fields are updated
   // with unknown values (entity_id, etag, etc)
-  EXPECT_EQ(1, std::count_if(patched->default_acl().begin(),
-                             patched->default_acl().end(),
-                             [](ObjectAccessControl const& x) {
-                               return x.entity() == "allAuthenticatedUsers";
-                             }));
+  EXPECT_THAT(AclEntityNames(patched->default_acl()),
+              Contains("allAuthenticatedUsers"));
 
   // encryption() - TODO(#1003) - verify the key was correctly used.
 
@@ -618,18 +603,10 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
 
   auto entity_name = MakeEntityName();
 
-  auto name_counter = [](std::string const& name,
-                         std::vector<ObjectAccessControl> const& list) {
-    auto name_matcher = [](std::string const& name) {
-      return
-          [name](ObjectAccessControl const& m) { return m.entity() == name; };
-    };
-    return std::count_if(list.begin(), list.end(), name_matcher(name));
-  };
   ASSERT_FALSE(meta->default_acl().empty())
       << "Test aborted. Empty ACL returned from newly created bucket <"
       << bucket_name << "> even though we requested the <full> projection.";
-  ASSERT_EQ(0, name_counter(entity_name, meta->default_acl()))
+  EXPECT_THAT(AclEntityNames(meta->default_acl()), Not(Contains(entity_name)))
       << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
       << "> in its ACL.  This is unexpected because the bucket was just"
       << " created with a predefine ACL which should preclude this result.";
@@ -645,7 +622,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   // Search using the entity name returned by the request, because we use
   // 'project-editors-<project_id_>' this different than the original entity
   // name, the server "translates" the project id to a project number.
-  EXPECT_EQ(1, name_counter(result->entity(), *current_acl));
+  EXPECT_THAT(AclEntityNames(meta->default_acl()), Contains(result->entity()));
 
   auto get_result = client->GetDefaultObjectAcl(bucket_name, entity_name);
   ASSERT_STATUS_OK(get_result);
@@ -673,7 +650,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
 
   current_acl = client->ListDefaultObjectAcl(bucket_name);
   ASSERT_STATUS_OK(current_acl);
-  EXPECT_EQ(0, name_counter(result->entity(), *current_acl));
+  EXPECT_THAT(AclEntityNames(meta->default_acl()), Not(Contains(entity_name)));
 
   status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
@@ -689,9 +666,14 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
                                              BucketMetadata());
   ASSERT_STATUS_OK(meta);
 
-  auto current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_STATUS_OK(current_notifications);
-  EXPECT_TRUE(current_notifications->empty())
+  auto notification_ids = [&client, bucket_name] {
+    std::vector<std::string> ids;
+    auto list = client->ListNotifications(bucket_name);
+    EXPECT_STATUS_OK(list);
+    for (auto const& notification : *list) ids.push_back(notification.id());
+    return ids;
+  };
+  EXPECT_TRUE(notification_ids().empty())
       << "Test aborted. Non-empty notification list returned from newly"
       << " created bucket <" << bucket_name
       << ">. This is unexpected because the bucket name is chosen at random.";
@@ -703,15 +685,8 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
 
   EXPECT_EQ(payload_format::JsonApiV1(), create->payload_format());
   EXPECT_THAT(create->topic(), HasSubstr(topic_name_));
-
-  current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_STATUS_OK(current_notifications);
-  auto count = std::count_if(current_notifications->begin(),
-                             current_notifications->end(),
-                             [create](NotificationMetadata const& x) {
-                               return x.id() == create->id();
-                             });
-  EXPECT_EQ(1, count) << "create=" << *create;
+  EXPECT_THAT(notification_ids(), Contains(create->id()))
+      << "create=" << *create;
 
   auto get = client->GetNotification(bucket_name, create->id());
   ASSERT_STATUS_OK(get);
@@ -719,15 +694,8 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
 
   auto status = client->DeleteNotification(bucket_name, create->id());
   ASSERT_STATUS_OK(status);
-
-  current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_STATUS_OK(current_notifications);
-  count = std::count_if(current_notifications->begin(),
-                        current_notifications->end(),
-                        [create](NotificationMetadata const& x) {
-                          return x.id() == create->id();
-                        });
-  EXPECT_EQ(0, count) << "create=" << *create;
+  EXPECT_THAT(notification_ids(), Not(Contains(create->id())))
+      << "create=" << *create;
 
   status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -34,6 +34,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::testing::Contains;
+using ::testing::Not;
 using ObjectBasicCRUDIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
@@ -42,21 +44,18 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto objects = client->ListObjects(bucket_name_);
-  std::vector<ObjectMetadata> initial_list;
-  for (auto&& o : objects) {
-    initial_list.emplace_back(std::move(o).value());
-  }
-
-  auto name_counter = [](std::string const& name,
-                         std::vector<ObjectMetadata> const& list) {
-    return std::count_if(
-        list.begin(), list.end(),
-        [name](ObjectMetadata const& m) { return m.name() == name; });
+  auto list_object_names = [&client, this] {
+    std::vector<std::string> names;
+    for (auto o : client->ListObjects(bucket_name_)) {
+      EXPECT_STATUS_OK(o);
+      if (!o) break;
+      names.push_back(o->name());
+    }
+    return names;
   };
 
   auto object_name = MakeRandomObjectName();
-  ASSERT_EQ(0, name_counter(object_name, initial_list))
+  EXPECT_THAT(list_object_names(), Not(Contains(object_name)))
       << "Test aborted. The object <" << object_name << "> already exists."
       << "This is unexpected as the test generates a random object name.";
 
@@ -65,14 +64,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
       client->InsertObject(bucket_name_, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection("full"));
   ASSERT_STATUS_OK(insert_meta);
-
-  objects = client->ListObjects(bucket_name_);
-
-  std::vector<ObjectMetadata> current_list;
-  for (auto&& o : objects) {
-    current_list.emplace_back(std::move(o).value());
-  }
-  EXPECT_EQ(1, name_counter(object_name, current_list));
+  EXPECT_THAT(list_object_names(), Contains(object_name));
 
   StatusOr<ObjectMetadata> get_meta = client->GetObjectMetadata(
       bucket_name_, object_name, Generation(insert_meta->generation()),
@@ -137,14 +129,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
-
-  objects = client->ListObjects(bucket_name_);
-  current_list.clear();
-  for (auto&& o : objects) {
-    current_list.emplace_back(std::move(o).value());
-  }
-
-  EXPECT_EQ(0, name_counter(object_name, current_list));
+  EXPECT_THAT(list_object_names(), Not(Contains(object_name)));
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -358,13 +358,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
   ASSERT_STATUS_OK(meta);
   LogSink::Instance().RemoveBackend(id);
 
-  auto count = std::count_if(
-      backend->log_lines.begin(), backend->log_lines.end(),
-      [file_name](std::string const& line) {
-        return line.find(file_name) != std::string::npos &&
-               line.find("not a regular file") != std::string::npos;
-      });
-  EXPECT_NE(0U, count);
+  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("not a regular file")));
 
   t.join();
   auto status = client->DeleteObject(bucket_name_, object_name);

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -30,6 +30,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::testing::HasSubstr;
+using ::testing::StartsWith;
 
 class ObjectHashIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -62,13 +63,8 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [](std::string const& line) {
-                      return line.rfind("x-goog-hash: md5=", 0) == 0;
-                    });
-  // The count should be 0 because there is no MD5Hash computation.
-  EXPECT_EQ(0, count);
+  EXPECT_THAT(backend->log_lines,
+              Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -91,18 +87,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count = std::count_if(
-      backend->log_lines.begin(), backend->log_lines.end(),
-      [](std::string const& line) {
-        // This is a big indirect, we detect if the upload changed to
-        // multipart/related, and if so, we assume the hash value is being used.
-        // Unfortunately I (@coryan) cannot think of a way to examine the upload
-        // contents.
-        return line.rfind("content-type: multipart/related; boundary=", 0) == 0;
-      });
-  // The count should be greater then 0 because there is Crc32cChecksum
-  // computations.
-  EXPECT_LE(1, count);
+  // This is a big indirect, we detect if the upload changed to
+  // multipart/related, and if so, we assume the hash value is being used.
+  // Unfortunately I (@coryan) cannot think of a way to examine the upload
+  // contents.
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
     // When running against the testbench, we have some more information to
@@ -133,12 +124,8 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [](std::string const& line) {
-                      return line.rfind("x-goog-hash: md5=", 0) == 0;
-                    });
-  EXPECT_EQ(0, count);
+  EXPECT_THAT(backend->log_lines,
+              Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -162,18 +149,13 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count = std::count_if(
-      backend->log_lines.begin(), backend->log_lines.end(),
-      [](std::string const& line) {
-        // This is a big indirect, we detect if the upload changed to
-        // multipart/related, and if so, we assume the hash value is being used.
-        // Unfortunately I (@coryan) cannot think of a way to examine the upload
-        // contents.
-        return line.rfind("content-type: multipart/related; boundary=", 0) == 0;
-      });
-  // The count should be greater then 0 because there is Crc32cChecksum
-  // computations.
-  EXPECT_LE(1, count);
+  // This is a big indirect, we detect if the upload changed to
+  // multipart/related, and if so, we assume the hash value is being used.
+  // Unfortunately I (@coryan) cannot think of a way to examine the upload
+  // contents.
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
     // When running against the testbench, we have some more information to

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -30,6 +30,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::testing::AllOf;
+using ::testing::HasSubstr;
 
 class ObjectInsertIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest,
@@ -60,17 +62,6 @@ class ObjectInsertIntegrationTest
   ::google::cloud::testing_util::ScopedEnvironment application_credentials_;
   std::string bucket_name_;
 };
-
-std::string GetLinesWith(testing_util::CaptureLogLinesBackend const& backend,
-                         std::string const& text) {
-  std::string msg;
-  for (auto const& l : backend.log_lines) {
-    if (l.find(text) == std::string::npos) continue;
-    msg += l;
-    msg += "\n";
-  }
-  return msg;
-}
 
 TEST_P(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   StatusOr<Client> client = MakeIntegrationTestClient();
@@ -567,15 +558,10 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto predicate = [this](std::string const& line) {
-    return line.find(" POST ") != std::string::npos &&
-           line.find("/b/" + bucket_name_ + "/o") != std::string::npos &&
-           line.find("quotaUser=test-quota-user") != std::string::npos;
-  };
-  auto count = std::count_if(backend->log_lines.begin(),
-                             backend->log_lines.end(), predicate);
-  EXPECT_LT(0, count) << ", logs matching POST="
-                      << GetLinesWith(*backend, " POST ") << "\n";
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr(" POST "),
+                             HasSubstr("/b/" + bucket_name_ + "/o"),
+                             HasSubstr("quotaUser=test-quota-user"))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -607,15 +593,10 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto predicate = [this](std::string const& line) {
-    return line.find(" POST ") != std::string::npos &&
-           line.find("/b/" + bucket_name_ + "/o") != std::string::npos &&
-           line.find("userIp=127.0.0.1") != std::string::npos;
-  };
-  auto count = std::count_if(backend->log_lines.begin(),
-                             backend->log_lines.end(), predicate);
-  EXPECT_LT(0, count) << ", logs matching POST="
-                      << GetLinesWith(*backend, " POST ") << "\n";
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr(" POST "),
+                             HasSubstr("/b/" + bucket_name_ + "/o"),
+                             HasSubstr("userIp=127.0.0.1"))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -659,15 +640,10 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto predicate = [this](std::string const& line) {
-    return line.find(" POST ") != std::string::npos &&
-           line.find("/b/" + bucket_name_ + "/o") != std::string::npos &&
-           line.find("userIp=") != std::string::npos;
-  };
-  auto count = std::count_if(backend->log_lines.begin(),
-                             backend->log_lines.end(), predicate);
-  EXPECT_LT(0, count) << ", logs matching POST="
-                      << GetLinesWith(*backend, " POST ") << "\n";
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr(" POST "),
+                             HasSubstr("/b/" + bucket_name_ + "/o"),
+                             HasSubstr("userIp="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);


### PR DESCRIPTION
Cleaned up most uses of `std::count_if()` in the tests in factor of a
`Contains()` or `Not(Contains())` matcher over the collection. The
matchers produce better error messages, and (maybe) better express what
we are testing for.

This was motivated by a obscure error message in a failed build (see #4904).
I punted on some changes in Bigtable, left that for somebody else who feels
like doing some cleanup work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4906)
<!-- Reviewable:end -->
