### PR TITLE
cleanup: build with -Wconversion

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -143,13 +143,16 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   HEADER_FILTER_REGEX=$(clang-tidy -dump-config |
     sed -n "s/HeaderFilterRegex: *'\([^']*\)'/\1/p")
   SOURCE_FILTER_REGEX='google/cloud/.*\.cc$'
-  # We disable the misc-unused-using-decls check because it produces false
-  # positives when run on headers. For more details, see issue #4230.
+  # We disable the following checks:
+  #     misc-unused-using-decls
+  #     readability-redundant-declaration
+  # because they produce false positives when run on headers.
+  # For more details, see issue #4230.
   git diff --diff-filter=d --name-only "${TARGET_BRANCH}" |
     grep -E "(${HEADER_FILTER_REGEX})|(${SOURCE_FILTER_REGEX})" |
     grep -v google/cloud/bigtable/examples/opencensus |
     xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}" \
-      -checks="-misc-unused-using-decls"
+      -checks="-misc-unused-using-decls,-readability-redundant-declaration"
 fi
 
 echo "================================================================"

--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -23,6 +23,10 @@ mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_WERROR)
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wall GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
 check_cxx_compiler_flag(-Wextra GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
+check_cxx_compiler_flag(-Wconversion
+                        GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WCONVERSION)
+check_cxx_compiler_flag(-Wno-sign-conversion
+                        GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WNO_SIGN_CONVERSION)
 check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
 
 function (google_cloud_cpp_add_common_options target)
@@ -41,6 +45,12 @@ function (google_cloud_cpp_add_common_options target)
     endif ()
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
         target_compile_options(${target} PRIVATE "-Wextra")
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WCONVERSION)
+        target_compile_options(${target} PRIVATE "-Wconversion")
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WNO_SIGN_CONVERSION)
+        target_compile_options(${target} PRIVATE "-Wno-sign-conversion")
     endif ()
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR
         AND GOOGLE_CLOUD_CPP_ENABLE_WERROR)

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -50,13 +50,13 @@ std::string SystemInclude(absl::string_view header) {
 std::string CamelCaseToSnakeCase(absl::string_view input) {
   std::string output;
   for (auto i = 0U; i < input.size(); ++i) {
+    auto const uc = static_cast<unsigned char>(input[i]);
+    auto const lower = static_cast<char>(std::tolower(uc));
     if (input[i] != '_' && i + 2 < input.size()) {
       if (std::isupper(static_cast<unsigned char>(input[i + 1])) &&
           std::islower(static_cast<unsigned char>(input[i + 2]))) {
-        absl::StrAppend(
-            &output,
-            std::string(1, std::tolower(static_cast<unsigned char>(input[i]))),
-            "_");
+        output += lower;
+        output += '_';
         continue;
       }
     }
@@ -64,16 +64,12 @@ std::string CamelCaseToSnakeCase(absl::string_view input) {
       if ((std::islower(static_cast<unsigned char>(input[i])) ||
            std::isdigit(static_cast<unsigned char>(input[i]))) &&
           std::isupper(static_cast<unsigned char>(input[i + 1]))) {
-        absl::StrAppend(
-            &output,
-            std::string(1, std::tolower(static_cast<unsigned char>(input[i]))),
-            "_");
+        output += lower;
+        output += '_';
         continue;
       }
     }
-    absl::StrAppend(
-        &output,
-        std::string(1, std::tolower(static_cast<unsigned char>(input[i]))));
+    output += lower;
   }
   return output;
 }

--- a/google/cloud/bigquery/internal/streaming_read_result_source.cc
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.cc
@@ -55,7 +55,7 @@ StatusOr<absl::optional<Row>> StreamingReadResultSource::NextRow() {
   fraction_consumed_ =
       progress.at_response_start() +
       (progress.at_response_end() - progress.at_response_start()) *
-          static_cast<double>(offset_in_curr_response_) * 1.0 /
+          static_cast<double>(offset_in_curr_response_) /
           static_cast<double>(curr_->row_count());
 
   return absl::optional<Row>(Row());

--- a/google/cloud/bigquery/internal/streaming_read_result_source.cc
+++ b/google/cloud/bigquery/internal/streaming_read_result_source.cc
@@ -55,7 +55,8 @@ StatusOr<absl::optional<Row>> StreamingReadResultSource::NextRow() {
   fraction_consumed_ =
       progress.at_response_start() +
       (progress.at_response_end() - progress.at_response_start()) *
-          offset_in_curr_response_ * 1.0 / curr_->row_count();
+          static_cast<double>(offset_in_curr_response_) * 1.0 /
+          static_cast<double>(curr_->row_count());
 
   return absl::optional<Row>(Row());
 }

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -332,14 +332,16 @@ std::ostream& operator<<(std::ostream& os, FormatDuration duration) {
   // back is super tedious, so just use std::snprintf().
   if (nanos < std::chrono::milliseconds(1)) {
     char buf[32];
-    std::snprintf(buf, sizeof(buf), "%.03fus", nanos.count() / 1000.0);
+    std::snprintf(buf, sizeof(buf), "%.03fus",
+                  static_cast<double>(nanos.count()) / 1000.0);
     return os << buf;
   }
   // For sub-second values print 123.456ms, that is, the number of milliseconds.
   if (nanos < std::chrono::seconds(1)) {
     auto us = std::chrono::duration_cast<std::chrono::microseconds>(nanos);
     char buf[32];
-    std::snprintf(buf, sizeof(buf), "%.03fms", us.count() / 1000.0);
+    std::snprintf(buf, sizeof(buf), "%.03fms",
+                  static_cast<double>(us.count()) / 1000.0);
     return os << buf;
   }
 
@@ -363,7 +365,8 @@ std::ostream& operator<<(std::ostream& os, FormatDuration duration) {
     return os << ms.count() / 1000 << "s";
   }
   char buf[32];
-  std::snprintf(buf, sizeof(buf), "%.03fs", ms.count() / 1000.0);
+  std::snprintf(buf, sizeof(buf), "%.03fs",
+                static_cast<double>(ms.count()) / 1000.0);
   return os << buf;
 }
 

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -114,7 +114,8 @@ int main(int argc, char* argv[]) {
   }
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - latency_test_start);
-  auto throughput = 1000.0 * static_cast<double>(combined) / elapsed.count();
+  auto throughput = 1000.0 * static_cast<double>(combined) /
+                    static_cast<double>(elapsed.count());
   std::cout << "# DONE. Elapsed=" << FormatDuration(elapsed)
             << ", Ops=" << combined << ", Throughput: " << throughput
             << " ops/sec\n";

--- a/google/cloud/internal/backoff_policy.cc
+++ b/google/cloud/internal/backoff_policy.cc
@@ -46,8 +46,8 @@ std::chrono::milliseconds ExponentialBackoffPolicy::OnCompletion() {
   // Randomized sleep period because it is possible that after some time all
   // client have same sleep period if we use only exponential backoff policy.
   auto delay = microseconds(rng_distribution(*generator_));
-  current_delay_range_ = microseconds(
-      static_cast<microseconds::rep>(current_delay_range_.count() * scaling_));
+  current_delay_range_ = microseconds(static_cast<microseconds::rep>(
+      static_cast<double>(current_delay_range_.count()) * scaling_));
   if (current_delay_range_ >= maximum_delay_) {
     current_delay_range_ = maximum_delay_;
   }

--- a/google/cloud/internal/big_endian.h
+++ b/google/cloud/internal/big_endian.h
@@ -75,7 +75,7 @@ StatusOr<T> DecodeBigEndian(std::string const& value) {
   for (auto const& c : value) {
     auto const n = *reinterpret_cast<std::uint8_t const*>(&c);
     shift -= 8;
-    result |= unsigned_type{n} << shift;
+    result = static_cast<unsigned_type>(result | (unsigned_type{n} << shift));
   }
   return *reinterpret_cast<T*>(&result);
 }

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -1688,8 +1688,8 @@ void SimpleTimer::Stop() {
   cpu_time_ = utime + stime;
   double cpu_fraction = 0;
   if (elapsed_time_.count() != 0) {
-    cpu_fraction =
-        (cpu_time_).count() / static_cast<double>(elapsed_time_.count());
+    cpu_fraction = static_cast<double>(cpu_time_.count()) /
+                   static_cast<double>(elapsed_time_.count());
   }
   now.ru_minflt -= start_usage_.ru_minflt;
   now.ru_majflt -= start_usage_.ru_majflt;

--- a/google/cloud/spanner/bytes.cc
+++ b/google/cloud/spanner/bytes.cc
@@ -125,18 +125,18 @@ void Bytes::Decoder::Iterator::Fill() {
     auto i1 = kCharToIndexExcessOne[p1] - 1;
     if (p3 == kPadding) {
       if (p2 == kPadding) {
-        buf_[++len_] = i0 << 2 | i1 >> 4;
+        buf_[++len_] = static_cast<unsigned char>(i0 << 2 | i1 >> 4);
       } else {
         auto i2 = kCharToIndexExcessOne[p2] - 1;
-        buf_[++len_] = i1 << 4 | i2 >> 2;
-        buf_[++len_] = i0 << 2 | i1 >> 4;
+        buf_[++len_] = static_cast<unsigned char>(i1 << 4 | i2 >> 2);
+        buf_[++len_] = static_cast<unsigned char>(i0 << 2 | i1 >> 4);
       }
     } else {
       auto i2 = kCharToIndexExcessOne[p2] - 1;
       auto i3 = kCharToIndexExcessOne[p3] - 1;
-      buf_[++len_] = i2 << 6 | i3;
-      buf_[++len_] = i1 << 4 | i2 >> 2;
-      buf_[++len_] = i0 << 2 | i1 >> 4;
+      buf_[++len_] = static_cast<unsigned char>(i2 << 6 | i3);
+      buf_[++len_] = static_cast<unsigned char>(i1 << 4 | i2 >> 2);
+      buf_[++len_] = static_cast<unsigned char>(i0 << 2 | i1 >> 4);
     }
   }
 }

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -34,8 +34,8 @@ int flag_threads = 0;  // 0 means use the threads_per_core setting.
 int flag_threads_per_core = 4;
 
 struct Result {
-  std::int64_t failure_count = 0;
-  std::int64_t success_count = 0;
+  std::int32_t failure_count = 0;
+  std::int32_t success_count = 0;
 
   void Update(Status const& s) {
     if (!s.ok()) {
@@ -122,7 +122,9 @@ TEST_F(ClientStressTest, UpsertAndSelect) {
   }
 
   auto experiments_count = total.failure_count + total.success_count;
-  EXPECT_LE(total.failure_count, experiments_count * 0.001);
+  EXPECT_LE(total.failure_count * 1000, experiments_count)
+      << "total.failure_count=" << total.failure_count
+      << ", total.success_count=" << total.success_count;
 }
 
 /// @test Stress test the library using Read calls.

--- a/google/cloud/spanner/numeric.h
+++ b/google/cloud/spanner/numeric.h
@@ -214,11 +214,11 @@ StatusOr<T> ToInteger(Numeric const& n, int exponent = 0) {
   constexpr auto kMax = (std::numeric_limits<T>::max)();
   enum { kIntPart, kFracPart } state = kIntPart;
   for (auto const ch : rep) {
-    auto dp = std::strchr(kDigits, ch);
+    auto const* dp = std::strchr(kDigits, ch);
     if (state == kFracPart) {
       if (dp - kDigits >= 5) {  // dp != nullptr
         if (v == kMax) return internal::DataLoss(rep);
-        v += 1;
+        v = static_cast<T>(v + 1);
       }
       break;
     }
@@ -227,10 +227,10 @@ StatusOr<T> ToInteger(Numeric const& n, int exponent = 0) {
       state = kFracPart;  // ch == '.'
     } else {
       if (v > kMax / 10) return internal::DataLoss(rep);
-      v *= 10;
+      v = static_cast<T>(v * 10);
       auto d = static_cast<T>(dp - kDigits);
       if (v > kMax - d) return internal::DataLoss(rep);
-      v += d;
+      v = static_cast<T>(v + d);
     }
   }
   return v;
@@ -252,11 +252,11 @@ StatusOr<T> ToInteger(Numeric const& n, int exponent = 0) {
   bool negate = true;
   enum { kIntPart, kFracPart } state = kIntPart;
   for (auto const ch : rep) {
-    auto dp = std::strchr(kDigits, ch);
+    auto const* dp = std::strchr(kDigits, ch);
     if (state == kFracPart) {
       if (dp - kDigits >= 5) {  // dp != nullptr
         if (v == kMin) return internal::DataLoss(rep);
-        v -= 1;
+        v = static_cast<T>(v - 1);
       }
       break;
     }
@@ -268,16 +268,16 @@ StatusOr<T> ToInteger(Numeric const& n, int exponent = 0) {
       }
     } else {
       if (v < kMin / 10) return internal::DataLoss(rep);
-      v *= 10;
+      v = static_cast<T>(v * 10);
       auto d = static_cast<T>(dp - kDigits);
       if (v < kMin + d) return internal::DataLoss(rep);
-      v -= d;
+      v = static_cast<T>(v - d);
     }
   }
   if (!negate) return v;
   constexpr auto kMax = (std::numeric_limits<T>::max)();
   if (kMin != -kMax && v == kMin) return internal::DataLoss(rep);
-  return -v;
+  return static_cast<T>(-v);
 }
 ///@}
 

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -195,8 +195,8 @@ void SimpleTimer::Stop() {
   cpu_time_ = utime + stime;
   double cpu_fraction = 0;
   if (elapsed_time_.count() != 0) {
-    cpu_fraction =
-        (cpu_time_).count() / static_cast<double>(elapsed_time_.count());
+    cpu_fraction = static_cast<double>(cpu_time_.count()) /
+                   static_cast<double>(elapsed_time_.count());
   }
   now.ru_minflt -= start_usage_.ru_minflt;
   now.ru_majflt -= start_usage_.ru_majflt;
@@ -250,7 +250,7 @@ std::string FormatSize(std::uintmax_t size) {
       {kGiB, kMiB, "MiB"},
       {kTiB, kGiB, "GiB"},
   };
-  auto resolution = kTiB;
+  std::uintmax_t resolution = kTiB;
   char const* name = "TiB";
   for (auto const& r : ranges) {
     if (size < r.limit) {
@@ -262,7 +262,7 @@ std::string FormatSize(std::uintmax_t size) {
   std::ostringstream os;
   os.setf(std::ios::fixed);
   os.precision(1);
-  os << static_cast<double>(size) / resolution << name;
+  os << (static_cast<double>(size) / static_cast<double>(resolution)) << name;
   return os.str();
 }
 

--- a/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
@@ -163,9 +163,9 @@ int main(int argc, char* argv[]) {
     auto const r =
         RunOneIteration(generator, *options, bucket_name, object_names);
     std::cout << r.bytes << ',' << r.elapsed.count() << std::endl;
-    auto const mi_b = r.bytes / gcs_bm::kMiB;
-    auto const mi_bs =
-        mi_b * (1.0 * decltype(r.elapsed)::period::den) / r.elapsed.count();
+    auto const mi_b = static_cast<double>(r.bytes) / gcs_bm::kMiB;
+    auto const mi_bs = mi_b * (1.0 * decltype(r.elapsed)::period::den) /
+                       static_cast<double>(r.elapsed.count());
     mi_bs_sum += mi_bs;
   }
 

--- a/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
@@ -164,7 +164,7 @@ int main(int argc, char* argv[]) {
         RunOneIteration(generator, *options, bucket_name, object_names);
     std::cout << r.bytes << ',' << r.elapsed.count() << std::endl;
     auto const mi_b = static_cast<double>(r.bytes) / gcs_bm::kMiB;
-    auto const mi_bs = mi_b * (1.0 * decltype(r.elapsed)::period::den) /
+    auto const mi_bs = mi_b * decltype(r.elapsed)::period::den /
                        static_cast<double>(r.elapsed.count());
     mi_bs_sum += mi_bs;
   }

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -96,12 +96,12 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
       {"--minimum-sample-count",
        "continue the test until at least this number of samples are obtained",
        [&options](std::string const& val) {
-         options.minimum_sample_count = std::stol(val);
+         options.minimum_sample_count = std::stoi(val);
        }},
       {"--maximum-sample-count",
        "stop the test when this number of samples are obtained",
        [&options](std::string const& val) {
-         options.maximum_sample_count = std::stol(val);
+         options.maximum_sample_count = std::stoi(val);
        }},
       {"--enabled-apis", "enable a subset of the APIs for the test",
        [&options](std::string const& val) {

--- a/google/cloud/storage/internal/metadata_parser.cc
+++ b/google/cloud/storage/internal/metadata_parser.cc
@@ -54,7 +54,7 @@ std::int32_t ParseIntField(nlohmann::json const& json, char const* field_name) {
     return f.get<std::int32_t>();
   }
   if (f.is_string()) {
-    return std::stol(f.get_ref<std::string const&>());
+    return std::stoi(f.get_ref<std::string const&>());
   }
   std::ostringstream os;
   os << "Error parsing field <" << field_name
@@ -72,7 +72,10 @@ std::uint32_t ParseUnsignedIntField(nlohmann::json const& json,
     return f.get<std::uint32_t>();
   }
   if (f.is_string()) {
-    return std::stoul(f.get_ref<std::string const&>());
+    auto v = std::stoul(f.get_ref<std::string const&>());
+    if (v <= (std::numeric_limits<std::uint32_t>::max)()) {
+      return static_cast<std::uint32_t>(v);
+    }
   }
   std::ostringstream os;
   os << "Error parsing field <" << field_name

--- a/google/cloud/storage/internal/policy_document_request_test.cc
+++ b/google/cloud/storage/internal/policy_document_request_test.cc
@@ -63,7 +63,7 @@ TEST(PostPolicyV4EscapeTest, OnlyAscii) {
 TEST(PostPolicyV4EscapeTest, InvalidUtf) {
   // In UTF8 a byte larger than 0x7f indicates that there is a byte following
   // it. Here we truncate the string to cause the UTF parser to fail.
-  std::string invalid_utf8(1, 0x80);
+  std::string invalid_utf8(1, '\x80');
   EXPECT_EQ(StatusCode::kInvalidArgument,
             PostPolicyV4Escape(invalid_utf8).status().code());
 }


### PR DESCRIPTION
Enable `-Wconversion -Wno-sign-conversion` on the CMake builds. We
discussed this as maybe introducing too many casts, but also maybe
helping us catch stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4907)
<!-- Reviewable:end -->
