### PR TITLE
ci: put current date in random bucket names

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
@@ -51,7 +51,7 @@ TEST(StorageBenchmarksUtilsTest, MakeRandomBucket) {
   EXPECT_EQ(0, d1.rfind("prefix-", 0));
   EXPECT_GE(63U, d1.size());
   EXPECT_EQ(std::string::npos,
-            d1.find_first_not_of("-abcdefghijklmnopqrstuvwxyz012456789"));
+            d1.find_first_not_of("-_abcdefghijklmnopqrstuvwxyz012456789"));
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "absl/time/civil_time.h"
 #include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include <sstream>
 
 namespace google {

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/internal/getenv.h"
+#include "absl/time/civil_time.h"
+#include "absl/time/clock.h"
 #include <sstream>
 
 namespace google {
@@ -31,13 +33,15 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix) {
   // The total length of a bucket name must be <= 63 characters,
   static std::size_t const kMaxBucketNameLength = 63;
-  std::size_t const max_random_characters =
-      kMaxBucketNameLength - prefix.size();
+  auto const date =
+      absl::FormatCivilTime(absl::ToCivilDay(absl::Now(), absl::UTCTimeZone()));
+  auto const full = prefix + date + "_";
+  std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
   // bucket names might also contain `-` and `_` characters, but we do not
   // *need* to use them.
-  return prefix + google::cloud::internal::Sample(
-                      gen, static_cast<int>(max_random_characters),
-                      "abcdefghijklmnopqrstuvwxyz012456789");
+  return full + google::cloud::internal::Sample(
+                    gen, static_cast<int>(max_random_characters),
+                    "abcdefghijklmnopqrstuvwxyz012456789");
 }
 
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,

--- a/google/cloud/storage/testing/random_names.cc
+++ b/google/cloud/storage/testing/random_names.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/testing/random_names.h"
 #include "absl/time/civil_time.h"
 #include "absl/time/clock.h"
+#include "absl/time/time.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/random_names.cc
+++ b/google/cloud/storage/testing/random_names.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/storage/testing/random_names.h"
+#include "absl/time/civil_time.h"
+#include "absl/time/clock.h"
 
 namespace google {
 namespace cloud {
@@ -23,11 +25,13 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix) {
   // The total length of this bucket name must be <= 63 characters,
   static std::size_t const kMaxBucketNameLength = 63;
-  std::size_t const max_random_characters =
-      kMaxBucketNameLength - prefix.size();
-  return prefix + google::cloud::internal::Sample(
-                      gen, static_cast<int>(max_random_characters),
-                      "abcdefghijklmnopqrstuvwxyz012456789");
+  auto const date =
+      absl::FormatCivilTime(absl::ToCivilDay(absl::Now(), absl::UTCTimeZone()));
+  auto const full = prefix + date + "_";
+  std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
+  return full + google::cloud::internal::Sample(
+                    gen, static_cast<int>(max_random_characters),
+                    "abcdefghijklmnopqrstuvwxyz012456789");
 }
 
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {


### PR DESCRIPTION
We create buckets with random names in our integration tests, when these
leak (either because the test crashes or we forget to cleanup) it is
nice to have the date in the name so we can tell which buckets are safe
to delete.  In a future PR we can automatically cleanup these buckets
too.

This will help with #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4908)
<!-- Reviewable:end -->
