### PR TITLE
ci: make libcurl cacheable on Linux builds

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -49,6 +49,12 @@ if [[ -n "${BAZEL_CONFIG}" ]]; then
   bazel_args+=("--config" "${BAZEL_CONFIG}")
 fi
 
+if [[ -r "/etc/pki/tls/certs/ca-bundle.crt" ]]; then
+  bazel_args+=("--define" "ca_bundle_style=redhat")
+elif [[ -r "/etc/ssl/certs/ca-certificates.crt" ]]; then
+  bazel_args+=("--define" "ca_bundle_style=debian")
+fi
+
 readonly TEST_KEY_FILE_JSON="/c/kokoro-run-key.json"
 readonly TEST_KEY_FILE_P12="/c/kokoro-run-key.p12"
 readonly GOOGLE_APPLICATION_CREDENTIALS="/c/kokoro-run-key.json"
@@ -75,6 +81,7 @@ io::log "Fetching dependencies"
 
 echo "================================================================"
 io::log "Compiling and running unit tests"
+echo "bazel test" "${bazel_args[@]}"
 "${BAZEL_BIN}" test \
   "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 


### PR DESCRIPTION
Make libcurl cacheable on CI builds, though it remains very much
not cache-friendly for manual builds. The build uses a `--define`
Bazel flag to configure the `CURL_CA_BUNDLE` macro, if the
`--define` flag is not provided we default to guessing the location
as before.

I think this is a reasonable tradeoff: the build works by default,
without special flags, but it is not cache-friendly. The CI builds
work more efficiently, but require a special flag.

Fixes #4902 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4911)
<!-- Reviewable:end -->
