### PR TITLE
cleanup: prefer matchers over std::count_if

### DIFF
--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -25,13 +25,16 @@
 #include <deque>
 #include <initializer_list>
 
-using testing::_;
-using testing::DoAll;
-using testing::Eq;
-using testing::Matcher;
-using testing::Property;
-using testing::Return;
-using testing::SetArgPointee;
+using ::testing::_;
+using ::testing::Contains;
+using ::testing::DoAll;
+using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::Matcher;
+using ::testing::Not;
+using ::testing::Property;
+using ::testing::Return;
+using ::testing::SetArgPointee;
 
 using google::bigtable::v2::ReadRowsRequest;
 using google::bigtable::v2::ReadRowsResponse_CellChunk;
@@ -721,15 +724,10 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 
-  std::string const expected_message =
-      "RowReader has an error, and the error status was not retrieved";
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [&expected_message](std::string const& line) {
-                      return line.find(expected_message) != std::string::npos;
-                    });
-  EXPECT_EQ(0, count) << "Unexpected log captured: "
-                      << backend->log_lines.front();
+  EXPECT_THAT(
+      backend->log_lines,
+      Not(Contains(HasSubstr(
+          "RowReader has an error, and the error status was not retrieved"))));
 }
 
 TEST_F(RowReaderTest, RowReaderConstructorDoesNotCallRpc) {

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -149,11 +149,29 @@ class TableIntegrationTest : public ::testing::Test {
     return TableTestEnvironment::UsingCloudBigtableEmulator();
   }
 
- protected:
+  static std::vector<std::string> TableNames(
+      std::vector<google::bigtable::admin::v2::Table> const& tables) {
+    std::vector<std::string> names(tables.size());
+    std::transform(
+        tables.begin(), tables.end(), names.begin(),
+        [](google::bigtable::admin::v2::Table const& x) { return x.name(); });
+    return names;
+  }
+
+  static std::vector<std::string> BackupNames(
+      std::vector<google::bigtable::admin::v2::Backup> const& backups) {
+    std::vector<std::string> names(backups.size());
+    std::transform(
+        backups.begin(), backups.end(), names.begin(),
+        [](google::bigtable::admin::v2::Backup const& x) { return x.name(); });
+    return names;
+  }
+
   std::shared_ptr<bigtable::AdminClient> admin_client_;
   std::unique_ptr<bigtable::TableAdmin> table_admin_;
   std::shared_ptr<bigtable::DataClient> data_client_;
 };
+
 }  // namespace testing
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -141,7 +141,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, CreateListGetDeleteTableTest) {
           .then([&](future<StatusOr<std::vector<btadmin::Table>>> fut) {
             StatusOr<std::vector<btadmin::Table>> result = fut.get();
             EXPECT_STATUS_OK(result);
-            EXPECT_THAT(TableNames(*result),
+            ASSERT_THAT(TableNames(*result),
                         Not(Contains(table_admin_->instance_name() +
                                      "/tables/" + table_id)))
                 << "Table (" << table_id << ") already exists."

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -82,7 +82,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
     EXPECT_THAT(
-        TableNames(*previous_table_list),
+        TableNames(*current_table_list),
         ContainsOnce(table_admin_->instance_name() + "/tables/" + table_id));
   }
   for (auto const& table_id : expected_table_list) {
@@ -93,7 +93,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
     EXPECT_THAT(
-        TableNames(*previous_table_list),
+        TableNames(*current_table_list),
         Not(Contains(table_admin_->instance_name() + "/tables/" + table_id)));
   }
 }

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -18,14 +18,22 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
+#include "google/cloud/testing_util/contains_once.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <string>
 #include <vector>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 namespace {
+
+using ::google::cloud::testing_util::ContainsOnce;
+using ::testing::Contains;
+using ::testing::Not;
 namespace btadmin = google::bigtable::admin::v2;
-namespace bigtable = google::cloud::bigtable;
 
 class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
  protected:
@@ -46,17 +54,6 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
     table_admin_ = absl::make_unique<bigtable::TableAdmin>(
         admin_client, bigtable::testing::TableTestEnvironment::instance_id());
   }
-
-  int CountMatchingTables(std::string const& table_id,
-                          std::vector<btadmin::Table> const& tables) {
-    std::string table_name =
-        table_admin_->instance_name() + "/tables/" + table_id;
-    auto count = std::count_if(tables.begin(), tables.end(),
-                               [&table_name](btadmin::Table const& t) {
-                                 return table_name == t.name();
-                               });
-    return static_cast<int>(count);
-  }
 };
 
 TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
@@ -71,10 +68,11 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
   int constexpr kTableCount = 5;
   for (int index = 0; index < kTableCount; ++index) {
     std::string table_id = RandomTableId();
-    auto previous_count = CountMatchingTables(table_id, *previous_table_list);
-    ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
-                                 << " This is unexpected, as the table ids are"
-                                 << " generated at random.";
+    ASSERT_THAT(
+        TableNames(*previous_table_list),
+        Not(Contains(table_admin_->instance_name() + "/tables/" + table_id)))
+        << "Table (" << table_id << ") already exists."
+        << " This is unexpected, as the table ids are generated at random.";
     EXPECT_STATUS_OK(table_admin_->CreateTable(table_id, table_config));
 
     expected_table_list.emplace_back(table_id);
@@ -83,7 +81,9 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
   ASSERT_STATUS_OK(current_table_list);
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
-    EXPECT_EQ(1, CountMatchingTables(table_id, *current_table_list));
+    EXPECT_THAT(
+        TableNames(*previous_table_list),
+        ContainsOnce(table_admin_->instance_name() + "/tables/" + table_id));
   }
   for (auto const& table_id : expected_table_list) {
     EXPECT_STATUS_OK(table_admin_->DeleteTable(table_id));
@@ -92,7 +92,9 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
   ASSERT_STATUS_OK(current_table_list);
   // Delete the tables so future tests have a clean slate.
   for (auto const& table_id : expected_table_list) {
-    EXPECT_EQ(0, CountMatchingTables(table_id, *current_table_list));
+    EXPECT_THAT(
+        TableNames(*previous_table_list),
+        Not(Contains(table_admin_->instance_name() + "/tables/" + table_id)));
   }
 }
 
@@ -161,10 +163,12 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTable) {
   auto previous_table_list =
       table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(previous_table_list);
-  auto previous_count = CountMatchingTables(table_id, *previous_table_list);
-  ASSERT_EQ(0, previous_count) << "Table (" << table_id << ") already exists."
-                               << " This is unexpected, as the table ids are"
-                               << " generated at random.";
+  ASSERT_THAT(
+      TableNames(*previous_table_list),
+      Not(Contains(table_admin_->instance_name() + "/tables/" + table_id)))
+      << "Table (" << table_id << ") already exists."
+      << " This is unexpected, as the table ids are generated at random.";
+
   // create table config
   bigtable::TableConfig table_config(
       {{"fam", GC::MaxNumVersions(5)},
@@ -221,8 +225,9 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTable) {
   // List to verify it is no longer there
   auto current_table_list = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(current_table_list);
-  auto table_count = CountMatchingTables(table_id, *current_table_list);
-  EXPECT_EQ(0, table_count);
+  EXPECT_THAT(
+      TableNames(*current_table_list),
+      Not(Contains(table_admin_->instance_name() + "/tables/" + table_id)));
 }
 
 /// @test Verify that `bigtable::TableAdmin` WaitForConsistencyCheck works as
@@ -309,11 +314,14 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 }
 
 }  // namespace
-// Test Cases Finished
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable::testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -388,9 +388,9 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   };
 
   EXPECT_THAT(profile_names(*initial_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id1))));
+              Not(Contains(EndsWith("/appProfiles/" + id1))));
   EXPECT_THAT(profile_names(*initial_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id2))));
+              Not(Contains(EndsWith("/appProfiles/" + id2))));
 
   auto profile_1 = instance_admin_
                        ->AsyncCreateAppProfile(
@@ -409,9 +409,9 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
       instance_admin_->AsyncListAppProfiles(cq, instance_id).get();
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_THAT(profile_names(*current_profiles),
-              ContainsOnce(EndsWith("/appProfiles" + id1)));
+              ContainsOnce(EndsWith("/appProfiles/" + id1)));
   EXPECT_THAT(profile_names(*current_profiles),
-              ContainsOnce(EndsWith("/appProfiles" + id2)));
+              ContainsOnce(EndsWith("/appProfiles/" + id2)));
 
   auto detail_1 =
       instance_admin_->AsyncGetAppProfile(cq, instance_id, id1).get();
@@ -445,9 +445,9 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_THAT(profile_names(*current_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id1))));
+              Not(Contains(EndsWith("/appProfiles/" + id1))));
   EXPECT_THAT(profile_names(*current_profiles),
-              ContainsOnce(EndsWith("/appProfiles" + id2)));
+              ContainsOnce(EndsWith("/appProfiles/" + id2)));
 
   ASSERT_STATUS_OK(instance_admin_
                        ->AsyncDeleteAppProfile(cq, instance_id, id2,
@@ -456,9 +456,9 @@ TEST_F(InstanceAdminAsyncFutureIntegrationTest, AsyncListAppProfilesTest) {
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_THAT(profile_names(*current_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id1))));
+              Not(Contains(EndsWith("/appProfiles/" + id1))));
   EXPECT_THAT(profile_names(*current_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id2))));
+              Not(Contains(EndsWith("/appProfiles/" + id2))));
 
   EXPECT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
 

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -177,9 +177,9 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   };
 
   EXPECT_THAT(profile_names(*initial_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id1))));
+              Not(Contains(EndsWith("/appProfiles/" + id1))));
   EXPECT_THAT(profile_names(*initial_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id2))));
+              Not(Contains(EndsWith("/appProfiles/" + id2))));
 
   auto profile_1 = instance_admin_->CreateAppProfile(
       instance_id, bigtable::AppProfileConfig::MultiClusterUseAny(id1));
@@ -191,9 +191,9 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   auto current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_THAT(profile_names(*current_profiles),
-              ContainsOnce(EndsWith("/appProfiles" + id1)));
+              ContainsOnce(EndsWith("/appProfiles/" + id1)));
   EXPECT_THAT(profile_names(*current_profiles),
-              ContainsOnce(EndsWith("/appProfiles" + id2)));
+              ContainsOnce(EndsWith("/appProfiles/" + id2)));
 
   auto detail_1 = instance_admin_->GetAppProfile(instance_id, id1);
   ASSERT_STATUS_OK(detail_1);
@@ -221,17 +221,17 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_THAT(profile_names(*current_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id1))));
+              Not(Contains(EndsWith("/appProfiles/" + id1))));
   EXPECT_THAT(profile_names(*current_profiles),
-              ContainsOnce(EndsWith("/appProfiles" + id2)));
+              ContainsOnce(EndsWith("/appProfiles/" + id2)));
 
   ASSERT_STATUS_OK(instance_admin_->DeleteAppProfile(instance_id, id2, true));
   current_profiles = instance_admin_->ListAppProfiles(instance_id);
   ASSERT_STATUS_OK(current_profiles);
   EXPECT_THAT(profile_names(*current_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id1))));
+              Not(Contains(EndsWith("/appProfiles/" + id1))));
   EXPECT_THAT(profile_names(*current_profiles),
-              Not(Contains(EndsWith("/appProfiles" + id2))));
+              Not(Contains(EndsWith("/appProfiles/" + id2))));
 
   ASSERT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
 }

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -28,6 +28,8 @@ namespace internal {
 namespace {
 
 using ::testing::_;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::Return;
 namespace gcsa = ::google::spanner::admin::database::v1;
 
@@ -50,12 +52,7 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
   }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count) << "expected to find line with " << contents;
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
   std::shared_ptr<spanner_testing::MockDatabaseAdminStub> mock_;

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -28,6 +28,8 @@ namespace internal {
 namespace {
 
 using ::testing::_;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::Return;
 namespace gcsa = ::google::spanner::admin::instance::v1;
 
@@ -50,12 +52,7 @@ class InstanceAdminLoggingTest : public ::testing::Test {
   }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count) << "expected to find line with " << contents;
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
   std::shared_ptr<spanner_testing::MockInstanceAdminStub> mock_;

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -28,6 +28,8 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::Contains;
+using ::testing::HasSubstr;
 namespace spanner_proto = ::google::spanner::v1;
 
 class LoggingResultSetReaderTest : public ::testing::Test {
@@ -46,12 +48,7 @@ class LoggingResultSetReaderTest : public ::testing::Test {
   void ClearLogCapture() { backend_->log_lines.clear(); }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count);
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
  private:

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -28,6 +28,8 @@ namespace internal {
 namespace {
 
 using ::testing::_;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 using ::testing::Return;
 namespace spanner_proto = ::google::spanner::v1;
 
@@ -50,12 +52,7 @@ class LoggingSpannerStubTest : public ::testing::Test {
   }
 
   void HasLogLineWith(std::string const& contents) {
-    auto count =
-        std::count_if(backend_->log_lines.begin(), backend_->log_lines.end(),
-                      [&contents](std::string const& line) {
-                        return std::string::npos != line.find(contents);
-                      });
-    EXPECT_NE(0, count) << contents;
+    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
   }
 
   std::shared_ptr<spanner_testing::MockSpannerStub> mock_;

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -25,6 +25,8 @@ namespace internal {
 namespace {
 
 using ::testing::AnyOf;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 
 TEST(SpannerStub, CreateDefaultStub) {
   auto stub = CreateDefaultSpannerStub(Database("foo", "bar", "baz"),
@@ -54,12 +56,8 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
               AnyOf(StatusCode::kUnavailable, StatusCode::kInvalidArgument,
                     StatusCode::kDeadlineExceeded));
 
-  auto const& lines = backend->log_lines;
-  auto count = std::count_if(
-      lines.begin(), lines.end(), [&session](std::string const& line) {
-        return line.find(session.status().message()) != std::string::npos;
-      });
-  EXPECT_NE(0, count);
+  EXPECT_THAT(backend->log_lines,
+              Contains(HasSubstr(session.status().message())));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/contains_once.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 
@@ -28,6 +29,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::CaptureLogLinesBackend;
+using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::_;
 using ::testing::Contains;
 using ::testing::ElementsAre;
@@ -89,9 +91,11 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_EQ("uh oh", result.status().message());
 
+  EXPECT_THAT(
+      log_backend_->log_lines,
+      ContainsOnce(HasSubstr("upload_size=" + std::to_string(513 * 1024))));
   EXPECT_THAT(log_backend_->log_lines,
-              Contains(HasSubstr("upload_size=" + std::to_string(513 * 1024))));
-  EXPECT_THAT(log_backend_->log_lines, Contains(HasSubstr("[UNAVAILABLE]")));
+              ContainsOnce(HasSubstr("[UNAVAILABLE]")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
@@ -109,7 +113,7 @@ TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
   EXPECT_EQ("uh oh", result.status().message());
 
   EXPECT_THAT(log_backend_->log_lines,
-              Contains(HasSubstr("[FAILED_PRECONDITION]")));
+              ContainsOnce(HasSubstr("[FAILED_PRECONDITION]")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, NextExpectedByte) {
@@ -125,7 +129,7 @@ TEST_F(LoggingResumableUploadSessionTest, NextExpectedByte) {
   EXPECT_EQ(512 * 1024, result);
 
   EXPECT_THAT(log_backend_->log_lines,
-              Contains(HasSubstr(std::to_string(512 * 1024))));
+              ContainsOnce(HasSubstr(std::to_string(512 * 1024))));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, LastResponseOk) {
@@ -140,8 +144,8 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseOk) {
   auto result = session.last_response();
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result.value(), last_response.value());
-  EXPECT_THAT(log_backend_->log_lines, Contains(HasSubstr("upload url")));
-  EXPECT_THAT(log_backend_->log_lines, Contains(HasSubstr("payload={}")));
+  EXPECT_THAT(log_backend_->log_lines, ContainsOnce(HasSubstr("upload url")));
+  EXPECT_THAT(log_backend_->log_lines, ContainsOnce(HasSubstr("payload={}")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
@@ -158,7 +162,7 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
   EXPECT_EQ("something bad", result.status().message());
 
   EXPECT_THAT(log_backend_->log_lines,
-              Contains(HasSubstr("[FAILED_PRECONDITION]")));
+              ContainsOnce(HasSubstr("[FAILED_PRECONDITION]")));
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -31,7 +31,6 @@ namespace {
 using ::google::cloud::testing_util::CaptureLogLinesBackend;
 using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::_;
-using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::ReturnRef;
@@ -70,7 +69,8 @@ TEST_F(LoggingResumableUploadSessionTest, UploadChunk) {
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_EQ("uh oh", result.status().message());
 
-  EXPECT_THAT(log_backend_->log_lines, Contains(HasSubstr("[UNAVAILABLE]")));
+  EXPECT_THAT(log_backend_->log_lines,
+              ContainsOnce(HasSubstr("[UNAVAILABLE]")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
+#include <algorithm>
 #include <chrono>
 #include <string>
 #include <thread>
@@ -124,6 +125,15 @@ CountMatchingEntities(std::vector<AccessControlResource> const& acl,
       acl.begin(), acl.end(), [&expected](AccessControlResource const& x) {
         return x.entity() == expected.entity() && x.role() == expected.role();
       });
+}
+
+template <typename AccessControlResource>
+std::vector<std::string> AclEntityNames(
+    std::vector<AccessControlResource> const& acl) {
+  std::vector<std::string> names(acl.size());
+  std::transform(acl.begin(), acl.end(), names.begin(),
+                 [](AccessControlResource const& x) { return x.entity(); });
+  return names;
 }
 
 }  // namespace testing

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -79,7 +79,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
     }
     return names;
   };
-  EXPECT_THAT(list_bucket_names(), Not(Contains(bucket_name)))
+  ASSERT_THAT(list_bucket_names(), Not(Contains(bucket_name)))
       << "Test aborted. The bucket <" << bucket_name << "> already exists."
       << " This is unexpected as the test generates a random bucket name.";
 
@@ -606,7 +606,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   ASSERT_FALSE(meta->default_acl().empty())
       << "Test aborted. Empty ACL returned from newly created bucket <"
       << bucket_name << "> even though we requested the <full> projection.";
-  EXPECT_THAT(AclEntityNames(meta->default_acl()), Not(Contains(entity_name)))
+  ASSERT_THAT(AclEntityNames(meta->default_acl()), Not(Contains(entity_name)))
       << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
       << "> in its ACL.  This is unexpected because the bucket was just"
       << " created with a predefine ACL which should preclude this result.";

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -27,8 +27,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::storage::testing::AclEntityNames;
+using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 class BucketIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -67,18 +70,16 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto buckets = client->ListBucketsForProject(project_id_);
-  std::vector<BucketMetadata> initial_buckets;
-  for (auto&& b : buckets) {
-    initial_buckets.emplace_back(std::move(b).value());
-  }
-  auto name_counter = [](std::string const& name,
-                         std::vector<BucketMetadata> const& list) {
-    return std::count_if(
-        list.begin(), list.end(),
-        [name](BucketMetadata const& m) { return m.name() == name; });
+  auto list_bucket_names = [&client, this] {
+    std::vector<std::string> names;
+    for (auto b : client->ListBucketsForProject(project_id_)) {
+      EXPECT_STATUS_OK(b);
+      if (!b) break;
+      names.push_back(b->name());
+    }
+    return names;
   };
-  ASSERT_EQ(0, name_counter(bucket_name, initial_buckets))
+  EXPECT_THAT(list_bucket_names(), Not(Contains(bucket_name)))
       << "Test aborted. The bucket <" << bucket_name << "> already exists."
       << " This is unexpected as the test generates a random bucket name.";
 
@@ -86,13 +87,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
                                                     BucketMetadata());
   ASSERT_STATUS_OK(insert_meta);
   EXPECT_EQ(bucket_name, insert_meta->name());
-
-  buckets = client->ListBucketsForProject(project_id_);
-  std::vector<BucketMetadata> current_buckets;
-  for (auto&& b : buckets) {
-    current_buckets.emplace_back(std::move(b).value());
-  }
-  EXPECT_EQ(1, name_counter(bucket_name, current_buckets));
+  EXPECT_THAT(list_bucket_names(), Contains(bucket_name));
 
   StatusOr<BucketMetadata> get_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(get_meta);
@@ -138,12 +133,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
 
   auto status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
-  buckets = client->ListBucketsForProject(project_id_);
-  current_buckets.clear();
-  for (auto&& b : buckets) {
-    current_buckets.emplace_back(std::move(b).value());
-  }
-  EXPECT_EQ(0, name_counter(bucket_name, current_buckets));
+  EXPECT_THAT(list_bucket_names(), Not(Contains(bucket_name)));
 }
 
 TEST_F(BucketIntegrationTest, CreatePredefinedAcl) {
@@ -353,10 +343,8 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   ASSERT_STATUS_OK(patched);
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
-  EXPECT_EQ(1, std::count_if(patched->acl().begin(), patched->acl().end(),
-                             [](BucketAccessControl const& x) {
-                               return x.entity() == "allAuthenticatedUsers";
-                             }));
+  EXPECT_THAT(AclEntityNames(patched->acl()),
+              Contains("allAuthenticatedUsers"));
 
   // billing()
   EXPECT_EQ(desired_state.billing_as_optional(),
@@ -367,11 +355,8 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 
   // default_acl() - cannot compare for equality because many fields are updated
   // with unknown values (entity_id, etag, etc)
-  EXPECT_EQ(1, std::count_if(patched->default_acl().begin(),
-                             patched->default_acl().end(),
-                             [](ObjectAccessControl const& x) {
-                               return x.entity() == "allAuthenticatedUsers";
-                             }));
+  EXPECT_THAT(AclEntityNames(patched->default_acl()),
+              Contains("allAuthenticatedUsers"));
 
   // encryption() - TODO(#1003) - verify the key was correctly used.
 
@@ -618,18 +603,10 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
 
   auto entity_name = MakeEntityName();
 
-  auto name_counter = [](std::string const& name,
-                         std::vector<ObjectAccessControl> const& list) {
-    auto name_matcher = [](std::string const& name) {
-      return
-          [name](ObjectAccessControl const& m) { return m.entity() == name; };
-    };
-    return std::count_if(list.begin(), list.end(), name_matcher(name));
-  };
   ASSERT_FALSE(meta->default_acl().empty())
       << "Test aborted. Empty ACL returned from newly created bucket <"
       << bucket_name << "> even though we requested the <full> projection.";
-  ASSERT_EQ(0, name_counter(entity_name, meta->default_acl()))
+  EXPECT_THAT(AclEntityNames(meta->default_acl()), Not(Contains(entity_name)))
       << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
       << "> in its ACL.  This is unexpected because the bucket was just"
       << " created with a predefine ACL which should preclude this result.";
@@ -645,7 +622,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   // Search using the entity name returned by the request, because we use
   // 'project-editors-<project_id_>' this different than the original entity
   // name, the server "translates" the project id to a project number.
-  EXPECT_EQ(1, name_counter(result->entity(), *current_acl));
+  EXPECT_THAT(AclEntityNames(meta->default_acl()), Contains(result->entity()));
 
   auto get_result = client->GetDefaultObjectAcl(bucket_name, entity_name);
   ASSERT_STATUS_OK(get_result);
@@ -673,7 +650,7 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
 
   current_acl = client->ListDefaultObjectAcl(bucket_name);
   ASSERT_STATUS_OK(current_acl);
-  EXPECT_EQ(0, name_counter(result->entity(), *current_acl));
+  EXPECT_THAT(AclEntityNames(meta->default_acl()), Not(Contains(entity_name)));
 
   status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);
@@ -689,9 +666,14 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
                                              BucketMetadata());
   ASSERT_STATUS_OK(meta);
 
-  auto current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_STATUS_OK(current_notifications);
-  EXPECT_TRUE(current_notifications->empty())
+  auto notification_ids = [&client, bucket_name] {
+    std::vector<std::string> ids;
+    auto list = client->ListNotifications(bucket_name);
+    EXPECT_STATUS_OK(list);
+    for (auto const& notification : *list) ids.push_back(notification.id());
+    return ids;
+  };
+  EXPECT_TRUE(notification_ids().empty())
       << "Test aborted. Non-empty notification list returned from newly"
       << " created bucket <" << bucket_name
       << ">. This is unexpected because the bucket name is chosen at random.";
@@ -703,15 +685,8 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
 
   EXPECT_EQ(payload_format::JsonApiV1(), create->payload_format());
   EXPECT_THAT(create->topic(), HasSubstr(topic_name_));
-
-  current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_STATUS_OK(current_notifications);
-  auto count = std::count_if(current_notifications->begin(),
-                             current_notifications->end(),
-                             [create](NotificationMetadata const& x) {
-                               return x.id() == create->id();
-                             });
-  EXPECT_EQ(1, count) << "create=" << *create;
+  EXPECT_THAT(notification_ids(), Contains(create->id()))
+      << "create=" << *create;
 
   auto get = client->GetNotification(bucket_name, create->id());
   ASSERT_STATUS_OK(get);
@@ -719,15 +694,8 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
 
   auto status = client->DeleteNotification(bucket_name, create->id());
   ASSERT_STATUS_OK(status);
-
-  current_notifications = client->ListNotifications(bucket_name);
-  ASSERT_STATUS_OK(current_notifications);
-  count = std::count_if(current_notifications->begin(),
-                        current_notifications->end(),
-                        [create](NotificationMetadata const& x) {
-                          return x.id() == create->id();
-                        });
-  EXPECT_EQ(0, count) << "create=" << *create;
+  EXPECT_THAT(notification_ids(), Not(Contains(create->id())))
+      << "create=" << *create;
 
   status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(status);

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/contains_once.h"
 #include <gmock/gmock.h>
 #include <chrono>
 #include <thread>
@@ -28,6 +29,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::AclEntityNames;
+using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::Contains;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
@@ -87,7 +89,7 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
                                                     BucketMetadata());
   ASSERT_STATUS_OK(insert_meta);
   EXPECT_EQ(bucket_name, insert_meta->name());
-  EXPECT_THAT(list_bucket_names(), Contains(bucket_name));
+  EXPECT_THAT(list_bucket_names(), ContainsOnce(bucket_name));
 
   StatusOr<BucketMetadata> get_meta = client->GetBucketMetadata(bucket_name);
   ASSERT_STATUS_OK(get_meta);
@@ -344,7 +346,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
   EXPECT_THAT(AclEntityNames(patched->acl()),
-              Contains("allAuthenticatedUsers"));
+              ContainsOnce("allAuthenticatedUsers"));
 
   // billing()
   EXPECT_EQ(desired_state.billing_as_optional(),
@@ -356,7 +358,7 @@ TEST_F(BucketIntegrationTest, FullPatch) {
   // default_acl() - cannot compare for equality because many fields are updated
   // with unknown values (entity_id, etag, etc)
   EXPECT_THAT(AclEntityNames(patched->default_acl()),
-              Contains("allAuthenticatedUsers"));
+              ContainsOnce("allAuthenticatedUsers"));
 
   // encryption() - TODO(#1003) - verify the key was correctly used.
 
@@ -622,7 +624,8 @@ TEST_F(BucketIntegrationTest, DefaultObjectAccessControlCRUD) {
   // Search using the entity name returned by the request, because we use
   // 'project-editors-<project_id_>' this different than the original entity
   // name, the server "translates" the project id to a project number.
-  EXPECT_THAT(AclEntityNames(meta->default_acl()), Contains(result->entity()));
+  EXPECT_THAT(AclEntityNames(meta->default_acl()),
+              ContainsOnce(result->entity()));
 
   auto get_result = client->GetDefaultObjectAcl(bucket_name, entity_name);
   ASSERT_STATUS_OK(get_result);
@@ -685,7 +688,7 @@ TEST_F(BucketIntegrationTest, NotificationsCRUD) {
 
   EXPECT_EQ(payload_format::JsonApiV1(), create->payload_format());
   EXPECT_THAT(create->topic(), HasSubstr(topic_name_));
-  EXPECT_THAT(notification_ids(), Contains(create->id()))
+  EXPECT_THAT(notification_ids(), ContainsOnce(create->id()))
       << "create=" << *create;
 
   auto get = client->GetNotification(bucket_name, create->id());

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/expect_exception.h"
 #include <gmock/gmock.h>
 #include <sys/types.h>
@@ -34,6 +35,7 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::Contains;
 using ::testing::Not;
 using ObjectBasicCRUDIntegrationTest =
@@ -64,7 +66,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
       client->InsertObject(bucket_name_, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection("full"));
   ASSERT_STATUS_OK(insert_meta);
-  EXPECT_THAT(list_object_names(), Contains(object_name));
+  EXPECT_THAT(list_object_names(), ContainsOnce(object_name));
 
   StatusOr<ObjectMetadata> get_meta = client->GetObjectMetadata(
       bucket_name_, object_name, Generation(insert_meta->generation()),

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -55,7 +55,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
   };
 
   auto object_name = MakeRandomObjectName();
-  EXPECT_THAT(list_object_names(), Not(Contains(object_name)))
+  ASSERT_THAT(list_object_names(), Not(Contains(object_name)))
       << "Test aborted. The object <" << object_name << "> already exists."
       << "This is unexpected as the test generates a random object name.";
 

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -34,6 +34,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
 
+using ::testing::Contains;
+using ::testing::Not;
 using ObjectBasicCRUDIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
@@ -42,21 +44,18 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto objects = client->ListObjects(bucket_name_);
-  std::vector<ObjectMetadata> initial_list;
-  for (auto&& o : objects) {
-    initial_list.emplace_back(std::move(o).value());
-  }
-
-  auto name_counter = [](std::string const& name,
-                         std::vector<ObjectMetadata> const& list) {
-    return std::count_if(
-        list.begin(), list.end(),
-        [name](ObjectMetadata const& m) { return m.name() == name; });
+  auto list_object_names = [&client, this] {
+    std::vector<std::string> names;
+    for (auto o : client->ListObjects(bucket_name_)) {
+      EXPECT_STATUS_OK(o);
+      if (!o) break;
+      names.push_back(o->name());
+    }
+    return names;
   };
 
   auto object_name = MakeRandomObjectName();
-  ASSERT_EQ(0, name_counter(object_name, initial_list))
+  EXPECT_THAT(list_object_names(), Not(Contains(object_name)))
       << "Test aborted. The object <" << object_name << "> already exists."
       << "This is unexpected as the test generates a random object name.";
 
@@ -65,14 +64,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
       client->InsertObject(bucket_name_, object_name, LoremIpsum(),
                            IfGenerationMatch(0), Projection("full"));
   ASSERT_STATUS_OK(insert_meta);
-
-  objects = client->ListObjects(bucket_name_);
-
-  std::vector<ObjectMetadata> current_list;
-  for (auto&& o : objects) {
-    current_list.emplace_back(std::move(o).value());
-  }
-  EXPECT_EQ(1, name_counter(object_name, current_list));
+  EXPECT_THAT(list_object_names(), Contains(object_name));
 
   StatusOr<ObjectMetadata> get_meta = client->GetObjectMetadata(
       bucket_name_, object_name, Generation(insert_meta->generation()),
@@ -137,14 +129,7 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
 
   auto status = client->DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
-
-  objects = client->ListObjects(bucket_name_);
-  current_list.clear();
-  for (auto&& o : objects) {
-    current_list.emplace_back(std::move(o).value());
-  }
-
-  EXPECT_EQ(0, name_counter(object_name, current_list));
+  EXPECT_THAT(list_object_names(), Not(Contains(object_name)));
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -358,13 +358,7 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
   ASSERT_STATUS_OK(meta);
   LogSink::Instance().RemoveBackend(id);
 
-  auto count = std::count_if(
-      backend->log_lines.begin(), backend->log_lines.end(),
-      [file_name](std::string const& line) {
-        return line.find(file_name) != std::string::npos &&
-               line.find("not a regular file") != std::string::npos;
-      });
-  EXPECT_NE(0U, count);
+  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("not a regular file")));
 
   t.join();
   auto status = client->DeleteObject(bucket_name_, object_name);

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -30,6 +30,7 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::testing::HasSubstr;
+using ::testing::StartsWith;
 
 class ObjectHashIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -62,13 +63,8 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [](std::string const& line) {
-                      return line.rfind("x-goog-hash: md5=", 0) == 0;
-                    });
-  // The count should be 0 because there is no MD5Hash computation.
-  EXPECT_EQ(0, count);
+  EXPECT_THAT(backend->log_lines,
+              Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -91,18 +87,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count = std::count_if(
-      backend->log_lines.begin(), backend->log_lines.end(),
-      [](std::string const& line) {
-        // This is a big indirect, we detect if the upload changed to
-        // multipart/related, and if so, we assume the hash value is being used.
-        // Unfortunately I (@coryan) cannot think of a way to examine the upload
-        // contents.
-        return line.rfind("content-type: multipart/related; boundary=", 0) == 0;
-      });
-  // The count should be greater then 0 because there is Crc32cChecksum
-  // computations.
-  EXPECT_LE(1, count);
+  // This is a big indirect, we detect if the upload changed to
+  // multipart/related, and if so, we assume the hash value is being used.
+  // Unfortunately I (@coryan) cannot think of a way to examine the upload
+  // contents.
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
     // When running against the testbench, we have some more information to
@@ -133,12 +124,8 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count =
-      std::count_if(backend->log_lines.begin(), backend->log_lines.end(),
-                    [](std::string const& line) {
-                      return line.rfind("x-goog-hash: md5=", 0) == 0;
-                    });
-  EXPECT_EQ(0, count);
+  EXPECT_THAT(backend->log_lines,
+              Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -162,18 +149,13 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto count = std::count_if(
-      backend->log_lines.begin(), backend->log_lines.end(),
-      [](std::string const& line) {
-        // This is a big indirect, we detect if the upload changed to
-        // multipart/related, and if so, we assume the hash value is being used.
-        // Unfortunately I (@coryan) cannot think of a way to examine the upload
-        // contents.
-        return line.rfind("content-type: multipart/related; boundary=", 0) == 0;
-      });
-  // The count should be greater then 0 because there is Crc32cChecksum
-  // computations.
-  EXPECT_LE(1, count);
+  // This is a big indirect, we detect if the upload changed to
+  // multipart/related, and if so, we assume the hash value is being used.
+  // Unfortunately I (@coryan) cannot think of a way to examine the upload
+  // contents.
+  EXPECT_THAT(
+      backend->log_lines,
+      Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
     // When running against the testbench, we have some more information to

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -30,6 +30,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::CountMatchingEntities;
+using ::testing::AllOf;
+using ::testing::HasSubstr;
 
 class ObjectInsertIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest,
@@ -60,17 +62,6 @@ class ObjectInsertIntegrationTest
   ::google::cloud::testing_util::ScopedEnvironment application_credentials_;
   std::string bucket_name_;
 };
-
-std::string GetLinesWith(testing_util::CaptureLogLinesBackend const& backend,
-                         std::string const& text) {
-  std::string msg;
-  for (auto const& l : backend.log_lines) {
-    if (l.find(text) == std::string::npos) continue;
-    msg += l;
-    msg += "\n";
-  }
-  return msg;
-}
 
 TEST_P(ObjectInsertIntegrationTest, SimpleInsertWithNonUrlSafeName) {
   StatusOr<Client> client = MakeIntegrationTestClient();
@@ -567,15 +558,10 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto predicate = [this](std::string const& line) {
-    return line.find(" POST ") != std::string::npos &&
-           line.find("/b/" + bucket_name_ + "/o") != std::string::npos &&
-           line.find("quotaUser=test-quota-user") != std::string::npos;
-  };
-  auto count = std::count_if(backend->log_lines.begin(),
-                             backend->log_lines.end(), predicate);
-  EXPECT_LT(0, count) << ", logs matching POST="
-                      << GetLinesWith(*backend, " POST ") << "\n";
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr(" POST "),
+                             HasSubstr("/b/" + bucket_name_ + "/o"),
+                             HasSubstr("quotaUser=test-quota-user"))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -607,15 +593,10 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto predicate = [this](std::string const& line) {
-    return line.find(" POST ") != std::string::npos &&
-           line.find("/b/" + bucket_name_ + "/o") != std::string::npos &&
-           line.find("userIp=127.0.0.1") != std::string::npos;
-  };
-  auto count = std::count_if(backend->log_lines.begin(),
-                             backend->log_lines.end(), predicate);
-  EXPECT_LT(0, count) << ", logs matching POST="
-                      << GetLinesWith(*backend, " POST ") << "\n";
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr(" POST "),
+                             HasSubstr("/b/" + bucket_name_ + "/o"),
+                             HasSubstr("userIp=127.0.0.1"))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
@@ -659,15 +640,10 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  auto predicate = [this](std::string const& line) {
-    return line.find(" POST ") != std::string::npos &&
-           line.find("/b/" + bucket_name_ + "/o") != std::string::npos &&
-           line.find("userIp=") != std::string::npos;
-  };
-  auto count = std::count_if(backend->log_lines.begin(),
-                             backend->log_lines.end(), predicate);
-  EXPECT_LT(0, count) << ", logs matching POST="
-                      << GetLinesWith(*backend, " POST ") << "\n";
+  EXPECT_THAT(backend->log_lines,
+              Contains(AllOf(HasSubstr(" POST "),
+                             HasSubstr("/b/" + bucket_name_ + "/o"),
+                             HasSubstr("userIp="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -105,7 +105,7 @@ TEST_F(ObjectIntegrationTest, FullPatch) {
   // acl() - cannot compare for equality because many fields are updated with
   // unknown values (entity_id, etag, etc)
   EXPECT_THAT(AclEntityNames(patched->acl()),
-              Contains("allAuthenticatedUsers"));
+              ContainsOnce("allAuthenticatedUsers"));
 
   EXPECT_EQ(desired.cache_control(), patched->cache_control());
   EXPECT_EQ(desired.content_disposition(), patched->content_disposition());

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -515,8 +515,7 @@ TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
   StatusOr<std::vector<ObjectAccessControl>> initial_acl =
       client->ListObjectAcl(bucket_name_, object_name);
   ASSERT_STATUS_OK(initial_acl);
-
-  EXPECT_THAT(AclEntityNames(*initial_acl), Not(Contains(entity_name)))
+  ASSERT_THAT(AclEntityNames(*initial_acl), Not(Contains(entity_name)))
       << "Test aborted. The entity <" << entity_name << "> already exists."
       << "This is unexpected as the test generates a random object name.";
 

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/expect_exception.h"
 #include <gmock/gmock.h>
 #include <sys/types.h>
@@ -36,6 +37,7 @@ namespace {
 
 using ::google::cloud::storage::testing::AclEntityNames;
 using ::google::cloud::storage::testing::TestPermanentFailure;
+using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::AnyOf;
 using ::testing::Contains;
 using ::testing::Eq;
@@ -528,7 +530,7 @@ TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
   // Search using the entity name returned by the request, because we use
   // 'project-editors-<project_id>' this different than the original entity
   // name, the server "translates" the project id to a project number.
-  EXPECT_THAT(AclEntityNames(*current_acl), Contains(result->entity()));
+  EXPECT_THAT(AclEntityNames(*current_acl), ContainsOnce(result->entity()));
 
   auto get_result =
       client->GetObjectAcl(bucket_name_, object_name, entity_name);


### PR DESCRIPTION
Cleaned up most uses of `std::count_if()` in the tests in factor of a
`Contains()` or `Not(Contains())` matcher over the collection. The
matchers produce better error messages, and (maybe) better express what
we are testing for.

Thanks to @devbww for creating `ContainsOnce()` and for the review
in an earlier incarnation of this PR.
