### PR TITLE
cleanup(pubsub): cancel callback in SubscriptionSession

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -57,9 +57,8 @@ class SessionShutdownManager {
   SessionShutdownManager() = default;
   ~SessionShutdownManager();
 
-  // TODO(#4898) - I think a `.then()` call would work better here.
   /// Set the promise to signal when the shutdown has completed.
-  void Start(promise<Status> p) { done_ = std::move(p); }
+  future<Status> Start() { return done_.get_future(); }
 
   /**
    * Start an operation, using the current thread of control.


### PR DESCRIPTION
I did not like creating member objects that were discarded in the first
function call. This is all a bit complicated because we need to create a
promise<> to receive the session final status, but this promise also
needs to hold the cancellation callback (albeit that can be indirect).

Fixes #4898 