### PR TITLE
ci: use GCS Bazel cache for Linux and macOS

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -81,7 +81,7 @@ io::log "Fetching dependencies"
 
 echo "================================================================"
 io::log "Compiling and running unit tests"
-echo "bazel test" "${bazel_args[@]}"
+echo "bazel test " "${bazel_args[@]}"
 "${BAZEL_BIN}" test \
   "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -46,6 +46,11 @@ cache_download_tarball "${CACHE_FOLDER}" "${HOME_DIR}" "${CACHE_NAME}.tar.gz"
 echo "================================================================"
 io::log "Extracting build cache"
 tar -zxf "${HOME_DIR}/${CACHE_NAME}.tar.gz" 2>&1 | grep -E -v 'tar:.*in the future'
+# DEBUG DEBUG DO NOT MERGE
+# Remove the Bazel cache to verify the PR builds are fast, just before this is
+# merged we can remove this hack as the full CI build will cleanup the tarballs
+rm -fr "${HOME_DIR}/.cache"
+# END EBUG DEBUG
 io::log "Extraction completed"
 
 exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -43,9 +43,6 @@ maybe_dirs=(
   # directory, but we have to separate it from the other files in `vcpkg` or
   # things like `git clone` do not work as expected.
   "${HOME_DIR}/vcpkg-quickstart-cache"
-
-  # Bazel, when running inside the Docker container, puts its cache here:
-  "${HOME_DIR}/.cache"
 )
 
 dirs=()

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -85,6 +85,7 @@ done
 echo
 echo "================================================================"
 io::log_yellow "build and run unit tests."
+echo "bazel test " "${bazel_args[@]}"
 "${BAZEL_BIN}" test \
   "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -49,21 +49,6 @@ maybe_dirs=(
   "${PROJECT_ROOT}/cmake-out/upload/vcpkg-installed"
 )
 
-readonly BAZEL_BIN="$HOME/bin/bazel"
-if [[ -x "${BAZEL_BIN}" ]]; then
-  maybe_dirs+=("$("${BAZEL_BIN}" info repository_cache)")
-  maybe_dirs+=("$("${BAZEL_BIN}" info output_base)")
-  "${BAZEL_BIN}" shutdown
-
-  for library in $(quickstart::libraries); do
-    cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
-    maybe_dirs+=("$("${BAZEL_BIN}" info repository_cache)")
-    maybe_dirs+=("$("${BAZEL_BIN}" info output_base)")
-    "${BAZEL_BIN}" shutdown
-  done
-  cd "${PROJECT_ROOT}"
-fi
-
 dirs=()
 for dir in "${maybe_dirs[@]}"; do
   if [[ -d "${dir}" ]]; then dirs+=("${dir}"); fi


### PR DESCRIPTION
We do not need the tarball Bazel cache for macOS nor Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4920)
<!-- Reviewable:end -->
