### PR TITLE
ci: use GCS Bazel cache for macOS

### DIFF
--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -85,6 +85,7 @@ done
 echo
 echo "================================================================"
 io::log_yellow "build and run unit tests."
+echo "bazel test " "${bazel_args[@]}"
 "${BAZEL_BIN}" test \
   "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -48,8 +48,9 @@ echo "================================================================"
 io::log "Extracting build cache"
 # Ignore timestamp warnings, Bazel has files with timestamps 10 years
 # into the future :shrug:
-tar -C / -zxf "${DOWNLOAD}/${CACHE_NAME}.tar.gz" 2>&1 |
-  grep -E -v 'tar:.*in the future'
+# DEBUG DEBUG Only extract ${HOME}/.ccache, we need this to test the
+# PR build before the cache gets updated.
+tar -C / -zxf "${DOWNLOAD}/${CACHE_NAME}.tar.gz" "${HOME}/.ccache"
 io::log "Extraction completed"
 
 exit 0

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -46,11 +46,7 @@ cache_download_tarball "${CACHE_FOLDER}" "${DOWNLOAD}" "${CACHE_NAME}.tar.gz"
 
 echo "================================================================"
 io::log "Extracting build cache"
-# Ignore timestamp warnings, Bazel has files with timestamps 10 years
-# into the future :shrug:
-# DEBUG DEBUG Only extract ${HOME}/.ccache, we need this to test the
-# PR build before the cache gets updated.
-tar -C / -zxf "${DOWNLOAD}/${CACHE_NAME}.tar.gz" "${HOME}/.ccache"
+tar -C / -zxf "${DOWNLOAD}/${CACHE_NAME}.tar.gz"
 io::log "Extraction completed"
 
 exit 0

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -49,21 +49,6 @@ maybe_dirs=(
   "${PROJECT_ROOT}/cmake-out/upload/vcpkg-installed"
 )
 
-readonly BAZEL_BIN="$HOME/bin/bazel"
-if [[ -x "${BAZEL_BIN}" ]]; then
-  maybe_dirs+=("$("${BAZEL_BIN}" info repository_cache)")
-  maybe_dirs+=("$("${BAZEL_BIN}" info output_base)")
-  "${BAZEL_BIN}" shutdown
-
-  for library in $(quickstart::libraries); do
-    cd "${PROJECT_ROOT}/google/cloud/${library}/quickstart"
-    maybe_dirs+=("$("${BAZEL_BIN}" info repository_cache)")
-    maybe_dirs+=("$("${BAZEL_BIN}" info output_base)")
-    "${BAZEL_BIN}" shutdown
-  done
-  cd "${PROJECT_ROOT}"
-fi
-
 dirs=()
 for dir in "${maybe_dirs[@]}"; do
   if [[ -d "${dir}" ]]; then dirs+=("${dir}"); fi


### PR DESCRIPTION
Now that libcurl is cache-friendly with macOS we do not need the tarball
cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4924)
<!-- Reviewable:end -->
