### PR TITLE
ci: with Bazel use only the GCS cache on Linux

### DIFF
--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -45,7 +45,7 @@ cache_download_tarball "${CACHE_FOLDER}" "${HOME_DIR}" "${CACHE_NAME}.tar.gz"
 # into the future :shrug:
 echo "================================================================"
 io::log "Extracting build cache"
-tar -zxf "${HOME_DIR}/${CACHE_NAME}.tar.gz" 2>&1 | grep -E -v 'tar:.*in the future'
+tar -zxf "${HOME_DIR}/${CACHE_NAME}.tar.gz" 2>&1
 io::log "Extraction completed"
 
 exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -43,9 +43,6 @@ maybe_dirs=(
   # directory, but we have to separate it from the other files in `vcpkg` or
   # things like `git clone` do not work as expected.
   "${HOME_DIR}/vcpkg-quickstart-cache"
-
-  # Bazel, when running inside the Docker container, puts its cache here:
-  "${HOME_DIR}/.cache"
 )
 
 dirs=()


### PR DESCRIPTION
Now that the libcurl build is cache-friendly we can disable the tarball
caches. That yields simpler code in our scripts and better performance
for PR rebuilds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4925)
<!-- Reviewable:end -->
