### PR TITLE
fix(pubsub): workaround future<> bug in samples

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -520,7 +520,7 @@ void Subscribe(google::cloud::pubsub::Subscriber subscriber,
   [](pubsub::Subscriber subscriber, pubsub::Subscription const& subscription) {
     std::mutex mu;
     std::condition_variable cv;
-    bool done = true;
+    bool done = false;
     int message_count = 0;
     auto result = subscriber.Subscribe(
         subscription, [&](pubsub::Message const& m, pubsub::AckHandler h) {

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -528,8 +528,8 @@ void Subscribe(google::cloud::pubsub::Subscriber subscriber,
           std::unique_lock<std::mutex> lk(mu);
           ++message_count;
           done = true;
-          lk.unlock();
           cv.notify_one();
+          lk.unlock();
           std::move(h).ack();
         });
     // Wait until at least one message has been received.
@@ -571,8 +571,8 @@ void SubscribeErrorListener(
                          std::unique_lock<std::mutex> lk(mu);
                          ++message_count;
                          done = true;
-                         lk.unlock();
                          cv.notify_one();
+                         lk.unlock();
                          std::move(h).ack();
                        })
             // Setup an error handler for the subscription session
@@ -617,8 +617,8 @@ void SubscribeCustomAttributes(
           std::unique_lock<std::mutex> lk(mu);
           ++message_count;
           done = true;
-          lk.unlock();
           cv.notify_one();
+          lk.unlock();
           std::move(h).ack();
         });
     // Most applications would just release the `session` object at this point,


### PR DESCRIPTION
It seems there is a bug in `google::cloud::future<>` when setting a
continuation and getting satisfied at the same time. For now, avoid such
code in the samples, maybe they are easier to understand anyway.

Fixes #4921, I created #4928 to fix the underlying problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4929)
<!-- Reviewable:end -->
