### PR TITLE
ci: remove inconvenient convenience symlinks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,10 @@
 #   [1]: https://github.com/bazelbuild/bazel/issues/4341
 build --copt=-DGRPC_BAZEL_BUILD
 
+# Do not create the convenience links, they are incovenient when the build runs
+# inside a docker image.
+build --experimental_convenience_symlinks=ignore
+
 # Clang Sanitizers, use with (for example):
 #
 # --client_env=CXX=clang++ --client_env=CC=clang --config asan


### PR DESCRIPTION
Bazel creates "convenience" links in %workspace% pointing to the
location of several interesting directories. These links are wrong when
created inside a Docker container, which is the case for most of our
builds, better to not generate the links in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4933)
<!-- Reviewable:end -->
