### PR TITLE
feat: automatically create background thread pools

### DIFF
--- a/google/cloud/connection_options.cc
+++ b/google/cloud/connection_options.cc
@@ -42,8 +42,10 @@ TracingOptions DefaultTracingOptions() {
   return TracingOptions{}.SetOptions(*tracing_options);
 }
 
-std::unique_ptr<BackgroundThreads> DefaultBackgroundThreads() {
-  return absl::make_unique<AutomaticallyCreatedBackgroundThreads>();
+std::unique_ptr<BackgroundThreads> DefaultBackgroundThreads(
+    std::size_t thread_pool_size) {
+  return absl::make_unique<AutomaticallyCreatedBackgroundThreads>(
+      thread_pool_size);
 }
 
 }  // namespace internal

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/connection_options.h"
+#include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_environment.h"
@@ -222,8 +223,14 @@ TEST(ConnectionOptionsTest, DefaultTracingOptionsWithValue) {
 }
 
 TEST(ConnectionOptionsTest, DefaultBackgroundThreads) {
-  auto actual = internal::DefaultBackgroundThreads();
-  EXPECT_TRUE(actual);
+  auto constexpr kThreadCount = 4;
+  auto options = TestConnectionOptions(grpc::InsecureChannelCredentials())
+                     .set_background_thread_pool_size(kThreadCount);
+  auto background = options.background_threads_factory()();
+  auto* tp = dynamic_cast<internal::AutomaticallyCreatedBackgroundThreads*>(
+      background.get());
+  ASSERT_NE(nullptr, tp);
+  EXPECT_EQ(kThreadCount, tp->pool_size());
 }
 
 }  // namespace

--- a/google/cloud/internal/background_threads_impl.cc
+++ b/google/cloud/internal/background_threads_impl.cc
@@ -25,13 +25,12 @@ AutomaticallyCreatedBackgroundThreads::AutomaticallyCreatedBackgroundThreads()
 
 AutomaticallyCreatedBackgroundThreads::AutomaticallyCreatedBackgroundThreads(
     std::size_t thread_count)
-    : AutomaticallyCreatedBackgroundThreads(
-          thread_count == 0 ? 1 : thread_count, {}) {}
+    : AutomaticallyCreatedBackgroundThreads(thread_count, {}) {}
 
 AutomaticallyCreatedBackgroundThreads::AutomaticallyCreatedBackgroundThreads(
-    std::size_t thread_count, Normalized)
-    : pool_(thread_count) {
-  std::generate_n(pool_.begin(), thread_count, [this] {
+    std::size_t thread_count, NormalizeTag)
+    : pool_(thread_count == 0 ? 1 : thread_count) {
+  std::generate_n(pool_.begin(), pool_.size(), [this] {
     return std::thread([](CompletionQueue cq) { cq.Run(); }, cq_);
   });
 }

--- a/google/cloud/internal/background_threads_impl.h
+++ b/google/cloud/internal/background_threads_impl.h
@@ -19,6 +19,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/version.h"
 #include <thread>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -42,14 +43,18 @@ class CustomerSuppliedBackgroundThreads : public BackgroundThreads {
 class AutomaticallyCreatedBackgroundThreads : public BackgroundThreads {
  public:
   AutomaticallyCreatedBackgroundThreads();
+  explicit AutomaticallyCreatedBackgroundThreads(std::size_t thread_count);
   ~AutomaticallyCreatedBackgroundThreads() override;
 
   CompletionQueue cq() const override { return cq_; }
   void Shutdown();
+  std::size_t pool_size() const { return pool_.size(); }
 
  private:
+  struct Normalized {};
+  AutomaticallyCreatedBackgroundThreads(std::size_t thread_count, Normalized);
   CompletionQueue cq_;
-  std::thread runner_;
+  std::vector<std::thread> pool_;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/background_threads_impl.h
+++ b/google/cloud/internal/background_threads_impl.h
@@ -51,8 +51,9 @@ class AutomaticallyCreatedBackgroundThreads : public BackgroundThreads {
   std::size_t pool_size() const { return pool_.size(); }
 
  private:
-  struct Normalized {};
-  AutomaticallyCreatedBackgroundThreads(std::size_t thread_count, Normalized);
+  struct NormalizeTag {};
+  AutomaticallyCreatedBackgroundThreads(std::size_t thread_count, NormalizeTag);
+
   CompletionQueue cq_;
   std::vector<std::thread> pool_;
 };

--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -22,6 +22,8 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
+using ::testing::Contains;
+using ::testing::Not;
 using testing_util::ScopedThread;
 
 /// @test Verify we can create and use a CustomerSuppliedBackgroundThreads
@@ -72,10 +74,42 @@ TEST(CustomerSuppliedBackgroundThreads, SharesCompletionQueue) {
 /// @test Verify that automatically created completion queues are usable.
 TEST(AutomaticallyCreatedBackgroundThreads, IsActive) {
   AutomaticallyCreatedBackgroundThreads actual;
+  EXPECT_EQ(1, actual.pool_size());
 
   promise<std::thread::id> bg;
   actual.cq().RunAsync([&bg] { bg.set_value(std::this_thread::get_id()); });
   EXPECT_NE(std::this_thread::get_id(), bg.get_future().get());
+}
+
+/// @test Verify that automatically created completion queues are usable.
+TEST(AutomaticallyCreatedBackgroundThreads, NoEmptyPools) {
+  AutomaticallyCreatedBackgroundThreads actual(0);
+  EXPECT_EQ(1, actual.pool_size());
+
+  promise<std::thread::id> bg;
+  actual.cq().RunAsync([&bg] { bg.set_value(std::this_thread::get_id()); });
+  EXPECT_NE(std::this_thread::get_id(), bg.get_future().get());
+}
+
+/// @test Verify that automatically created completion queues work.
+TEST(AutomaticallyCreatedBackgroundThreads, ManyThreads) {
+  auto constexpr kThreadCount = 4;
+  AutomaticallyCreatedBackgroundThreads actual(kThreadCount);
+  EXPECT_EQ(kThreadCount, actual.pool_size());
+
+  std::vector<promise<std::thread::id>> promises(100 * kThreadCount);
+  for (auto& p : promises) {
+    actual.cq().RunAsync([&p] {
+      p.set_value(std::this_thread::get_id());
+      // Keep the thread busy for a bit so the other functors schedule in a
+      // different thread.
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    });
+  }
+  std::set<std::thread::id> ids;
+  for (auto& p : promises) ids.insert(p.get_future().get());
+  EXPECT_LE(2, ids.size());
+  EXPECT_THAT(ids, Not(Contains(std::this_thread::get_id())));
 }
 
 }  // namespace

--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -99,16 +99,12 @@ TEST(AutomaticallyCreatedBackgroundThreads, ManyThreads) {
 
   std::vector<promise<std::thread::id>> promises(100 * kThreadCount);
   for (auto& p : promises) {
-    actual.cq().RunAsync([&p] {
-      p.set_value(std::this_thread::get_id());
-      // Keep the thread busy for a bit so the other functors schedule in a
-      // different thread.
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    });
+    actual.cq().RunAsync([&p] { p.set_value(std::this_thread::get_id()); });
   }
   std::set<std::thread::id> ids;
   for (auto& p : promises) ids.insert(p.get_future().get());
-  EXPECT_LE(2, ids.size());
+  EXPECT_FALSE(ids.empty());
+  EXPECT_GE(kThreadCount, ids.size());
   EXPECT_THAT(ids, Not(Contains(std::this_thread::get_id())));
 }
 


### PR DESCRIPTION
Make the size of the background thread pool created by
google::cloud::ConnectionOptions` configurable. A future change will
set the default size to something more sensible than "one", though this
would need to be by service, for example, a subscription or publisher
*should* use several threads, but the admin APIs are probably fine with
one.

Fixes #4650

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4936)
<!-- Reviewable:end -->
