### PR TITLE
feat(pubsub): better defaults for thread pool size

### DIFF
--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -64,17 +64,19 @@ class PublisherConnection {
  */
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, PublisherOptions options,
-    ConnectionOptions const& connection_options = ConnectionOptions());
+    ConnectionOptions connection_options = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
 
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
     pubsub::Topic topic, pubsub::PublisherOptions options,
-    pubsub::ConnectionOptions const& connection_options,
+    pubsub::ConnectionOptions connection_options,
     std::shared_ptr<PublisherStub> stub);
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -61,7 +61,7 @@ class SubscriberConnection {
  *     this function.
  */
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
-    ConnectionOptions const& options = ConnectionOptions());
+    ConnectionOptions options = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
@@ -70,8 +70,7 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    std::shared_ptr<SubscriberStub> stub,
-    pubsub::ConnectionOptions const& options);
+    std::shared_ptr<SubscriberStub> stub, pubsub::ConnectionOptions options);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal


### PR DESCRIPTION
For `pubsub::Publisher` and `pubsub::Subscriber` we need larger thread
pool sizes by default. If `std::thread::hardware_concurrency()` returns
`0` we use 4 threads, otherwise using the value returned by this
function, this is aligned with the libraries for other languages.

Fixes #4946

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4947)
<!-- Reviewable:end -->
