### PR TITLE
feat(pubsub): subscriber concurrency control sample

### DIFF
--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -74,6 +74,9 @@ class SubscriptionOptions {
    * callbacks) allows applications, for example, to ensure that at most `K`
    * threads in the pool are used by any given subscription.
    *
+   * @par Example
+   * @snippet samples.cc subscriber-concurrency
+   *
    * @note applications that want to have a single outstanding callback can set
    *     these parameters to `lwm==0` and `hwm==1`.
    *


### PR DESCRIPTION
Implement an example showing how to control the number of threads in the
I/O pool and the number of concurrent callbacks from a subscription.

Fixes #4657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4948)
<!-- Reviewable:end -->
