### PR TITLE
feat(pubsub): another region tag for publish sample

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -459,6 +459,7 @@ void ExampleStatusOr(google::cloud::pubsub::TopicAdminClient client,
 
 void Publish(google::cloud::pubsub::Publisher publisher,
              std::vector<std::string> const&) {
+  //! [START pubsub_publish_messages_error_handler]
   //! [START pubsub_publish_with_error_handler]
   //! [START pubsub_publish] [publish]
   namespace pubsub = google::cloud::pubsub;
@@ -477,6 +478,7 @@ void Publish(google::cloud::pubsub::Publisher publisher,
   }
   //! [END pubsub_publish] [publish]
   //! [END pubsub_publish_with_error_handler]
+  //! [END pubsub_publish_messages_error_handler]
   (std::move(publisher));
 }
 


### PR DESCRIPTION
The existing `Publish()` example can be used for the
`pubsub_publish_messages_error_handler` region tag. Seems like there are
duplicate / synonym tags for this service :shrug:

Fixes #4666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4949)
<!-- Reviewable:end -->
