### PR TITLE
feat(pubsub): higher default for subscription concurrency

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -137,7 +137,9 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
   };
 
   auto session = SubscriptionSession::Create(
-      mock, cq, {subscription.FullName(), handler, {}});
+      mock, cq,
+      {subscription.FullName(), handler,
+       pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, 1)});
   auto response = session->Start();
   while (expected_ack_id.load() < 100) {
     auto s = response.wait_for(std::chrono::milliseconds(5));
@@ -228,7 +230,9 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
   auto session = SubscriptionSession::Create(
-      mock, cq, {subscription.FullName(), handler, {}});
+      mock, cq,
+      {subscription.FullName(), handler,
+       pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, 1)});
   auto response = session->Start();
   enough_messages.get_future()
       .then([&](future<void>) { response.cancel(); })
@@ -352,8 +356,9 @@ TEST(SubscriptionSessionTest, UpdateAckDeadlines) {
   auto session = SubscriptionSession::Create(
       mock, cq,
       {subscription.FullName(), handler,
-       pubsub::SubscriptionOptions{}.set_max_deadline_time(
-           std::chrono::seconds(60))});
+       pubsub::SubscriptionOptions{}
+           .set_concurrency_watermarks(0, 1)
+           .set_max_deadline_time(std::chrono::seconds(60))});
   session->SetTestRefreshPeriod(std::chrono::milliseconds(50));
   auto response = session->Start();
   enough_messages.get_future()
@@ -421,8 +426,9 @@ TEST(SubscriptionSessionTest, ShutdownNackCallbacks) {
   auto session = SubscriptionSession::Create(
       mock, cq,
       {subscription.FullName(), handler,
-       pubsub::SubscriptionOptions{}.set_max_deadline_time(
-           std::chrono::seconds(60))});
+       pubsub::SubscriptionOptions{}
+           .set_concurrency_watermarks(0, 1)
+           .set_max_deadline_time(std::chrono::seconds(60))});
   session->SetTestRefreshPeriod(std::chrono::milliseconds(50));
   auto response = session->Start();
   // Setup the system to cancel after the second message.

--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/version.h"
 #include <chrono>
+#include <thread>
 
 namespace google {
 namespace cloud {
@@ -91,9 +92,15 @@ class SubscriptionOptions {
   std::size_t concurrency_hwm() const { return concurrency_hwm_; }
 
  private:
+  static std::size_t DefaultConcurrencyHwm() {
+    auto constexpr kDefaultHwm = 4;
+    auto const n = std::thread::hardware_concurrency();
+    return n == 0 ? kDefaultHwm : n;
+  }
+
   std::chrono::seconds max_deadline_time_ = std::chrono::seconds(0);
   std::size_t concurrency_lwm_ = 0;
-  std::size_t concurrency_hwm_ = 1;
+  std::size_t concurrency_hwm_ = DefaultConcurrencyHwm();
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
This aligns the client with the defaults for other languages, increasing
the number of parallel callbacks allowed by default.

Part of the work for #4645

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4951)
<!-- Reviewable:end -->
