### PR TITLE
feat(pubsub): flow control configuration parameters

### DIFF
--- a/google/cloud/pubsub/subscription_options.cc
+++ b/google/cloud/pubsub/subscription_options.cc
@@ -20,6 +20,20 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
+SubscriptionOptions& SubscriptionOptions::set_message_count_watermarks(
+    std::size_t lwm, std::size_t hwm) {
+  message_count_hwm_ = (std::max<std::size_t>)(1, hwm);
+  message_count_lwm_ = (std::min)(message_count_hwm_, lwm);
+  return *this;
+}
+
+SubscriptionOptions& SubscriptionOptions::set_message_size_watermarks(
+    std::size_t lwm, std::size_t hwm) {
+  message_size_hwm_ = (std::max<std::size_t>)(1, hwm);
+  message_size_lwm_ = (std::min)(message_size_hwm_, lwm);
+  return *this;
+}
+
 SubscriptionOptions& SubscriptionOptions::set_concurrency_watermarks(
     std::size_t lwm, std::size_t hwm) {
   concurrency_hwm_ = (std::max<std::size_t>)(1, hwm);

--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -54,7 +54,56 @@ class SubscriptionOptions {
     return *this;
   }
 
-  // TODO(#4645) - add options for flow control
+  /**
+   * Set the parameters for message-count-based flow control.
+   *
+   * The Cloud Pub/Sub C++ client library will pull more messages from a
+   * subscription as long as the number of pending messages (that is received,
+   * but not fully processed is less than the high watermark (@p hwm). Once the
+   * @p hwm value is reached the client will not pull more messages until the
+   * number of pending messages is at or below the low watermark (@p lwm).
+   *
+   * @par Example
+   * TODO(#4644) - add a working example of this setting.
+   *
+   * @note applications that want to have a single pull request at a time, can
+   *     set these parameters to `lwm==0` and `hwm==1`.
+   *
+   * @param hwm the high watermark, if this parameter is `0` the high watermark
+   *     is set to `1`, to avoid starvation
+   * @param lwm the low watermark, if this parameter greater than @p hwm then
+   *    the low watermark is set to the same value as the high watermark
+   */
+  SubscriptionOptions& set_message_count_watermarks(std::size_t lwm,
+                                                    std::size_t hwm);
+  std::size_t message_count_lwm() const { return message_count_lwm_; }
+  std::size_t message_count_hwm() const { return message_count_hwm_; }
+
+  /**
+   * Set the parameters for message-size-based flow control.
+   *
+   * The Cloud Pub/Sub C++ client library will pull more messages from a
+   * subscription as long as the total size of the pending messages (that is
+   * received, but not fully processed is less than the high watermark (@p hwm).
+   * Once the @p hwm value is reached the client will not pull more messages
+   * until the total size of the pending messages is at or below the low
+   * watermark (@p lwm).
+   *
+   * @par Example
+   * TODO(#4644) - add a working example of this setting.
+   *
+   * @note applications that want to have a single pull request at a time, can
+   *     set these parameters to `lwm==0` and `hwm==1`.
+   *
+   * @param hwm the high watermark, if this parameter is `0` the high watermark
+   *     is set to `1`, to avoid starvation
+   * @param lwm the low watermark, if this parameter greater than @p hwm then
+   *    the low watermark is set to the same value as the high watermark
+   */
+  SubscriptionOptions& set_message_size_watermarks(std::size_t lwm,
+                                                   std::size_t hwm);
+  std::size_t message_size_lwm() const { return message_size_lwm_; }
+  std::size_t message_size_hwm() const { return message_size_hwm_; }
 
   /**
    * Set the high watermark and low watermarks for callback concurrency.
@@ -99,6 +148,10 @@ class SubscriptionOptions {
   }
 
   std::chrono::seconds max_deadline_time_ = std::chrono::seconds(0);
+  std::size_t message_count_lwm_ = 0;
+  std::size_t message_count_hwm_ = 1000;
+  std::size_t message_size_lwm_ = 0;
+  std::size_t message_size_hwm_ = 100 * 1024 * 1024L;
   std::size_t concurrency_lwm_ = 0;
   std::size_t concurrency_hwm_ = DefaultConcurrencyHwm();
 };

--- a/google/cloud/pubsub/subscription_options_test.cc
+++ b/google/cloud/pubsub/subscription_options_test.cc
@@ -23,8 +23,40 @@ namespace {
 
 TEST(SubscriptionOptionsTest, Default) {
   SubscriptionOptions const options{};
+  EXPECT_LE(options.message_count_lwm(), options.message_count_hwm());
+  EXPECT_LT(0, options.message_count_hwm());
+  EXPECT_LE(options.message_size_lwm(), options.message_size_hwm());
+  EXPECT_LT(0, options.message_size_hwm());
   EXPECT_LE(options.concurrency_lwm(), options.concurrency_hwm());
   EXPECT_LT(0, options.concurrency_hwm());
+}
+
+TEST(SubscriptionOptionsTest, SetMessageCount) {
+  auto options = SubscriptionOptions{}.set_message_count_watermarks(8, 16);
+  EXPECT_EQ(16, options.message_count_hwm());
+  EXPECT_EQ(8, options.message_count_lwm());
+
+  options.set_message_count_watermarks(0, 0);
+  EXPECT_EQ(1, options.message_count_hwm());
+  EXPECT_EQ(0, options.message_count_lwm());
+
+  options.set_message_count_watermarks(10, 5);
+  EXPECT_EQ(5, options.message_count_hwm());
+  EXPECT_EQ(5, options.message_count_lwm());
+}
+
+TEST(SubscriptionOptionsTest, SetMessageSize) {
+  auto options = SubscriptionOptions{}.set_message_size_watermarks(8, 16);
+  EXPECT_EQ(16, options.message_size_hwm());
+  EXPECT_EQ(8, options.message_size_lwm());
+
+  options.set_message_size_watermarks(0, 0);
+  EXPECT_EQ(1, options.message_size_hwm());
+  EXPECT_EQ(0, options.message_size_lwm());
+
+  options.set_message_size_watermarks(10, 5);
+  EXPECT_EQ(5, options.message_size_hwm());
+  EXPECT_EQ(5, options.message_size_lwm());
 }
 
 TEST(SubscriptionOptionsTest, SetConcurrency) {


### PR DESCRIPTION
This just adds the configuration parameters for flow control (when to
ask for more messages), they are unused except in tests.

Part of the work for #4645

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4953)
<!-- Reviewable:end -->
