### PR TITLE
feat(pubsub): retry loop for TopicAdminConnection

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
     pubsub_client # cmake-format: sort
     ack_handler.cc
     ack_handler.h
+    backoff_policy.h
     connection_options.cc
     connection_options.h
     internal/batching_publisher_connection.cc
@@ -64,6 +65,7 @@ add_library(
     publisher_connection.cc
     publisher_connection.h
     publisher_options.h
+    retry_policy.h
     snapshot.cc
     snapshot.h
     snapshot_mutation_builder.cc

--- a/google/cloud/pubsub/backoff_policy.h
+++ b/google/cloud/pubsub/backoff_policy.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_BACKOFF_POLICY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_BACKOFF_POLICY_H
+
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/backoff_policy.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/// The base class for backoff policies.
+using BackoffPolicy = google::cloud::internal::BackoffPolicy;
+
+/// A truncated exponential backoff policy with randomized periods.
+using ExponentialBackoffPolicy =
+    google::cloud::internal::ExponentialBackoffPolicy;
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_BACKOFF_POLICY_H

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <map>
 
@@ -30,6 +31,9 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::AnyOf;
 
 TEST(MessageIntegrationTest, PublishPullAck) {
   auto project_id =
@@ -46,7 +50,8 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       SubscriptionAdminClient(MakeSubscriptionAdminConnection());
 
   auto topic_metadata = topic_admin.CreateTopic(TopicMutationBuilder(topic));
-  ASSERT_STATUS_OK(topic_metadata);
+  ASSERT_THAT(topic_metadata, AnyOf(StatusIs(StatusCode::kOk),
+                                    StatusIs(StatusCode::kAlreadyExists)));
 
   struct Cleanup {
     std::function<void()> action;

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -33,6 +34,8 @@ namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::ScopedEnvironment;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::AnyOf;
 using ::testing::Contains;
 using ::testing::Not;
 
@@ -80,7 +83,8 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
               Not(Contains(subscription.FullName())));
 
   auto topic_metadata = topic_admin.CreateTopic(TopicMutationBuilder(topic));
-  ASSERT_STATUS_OK(topic_metadata);
+  ASSERT_THAT(topic_metadata, AnyOf(StatusIs(StatusCode::kOk),
+                                    StatusIs(StatusCode::kAlreadyExists)));
 
   struct Cleanup {
     std::function<void()> action;

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -18,6 +18,7 @@
 
 pubsub_client_hdrs = [
     "ack_handler.h",
+    "backoff_policy.h",
     "connection_options.h",
     "internal/batching_publisher_connection.h",
     "internal/default_ack_handler_impl.h",
@@ -36,6 +37,7 @@ pubsub_client_hdrs = [
     "publisher.h",
     "publisher_connection.h",
     "publisher_options.h",
+    "retry_policy.h",
     "snapshot.h",
     "snapshot_mutation_builder.h",
     "subscriber.h",

--- a/google/cloud/pubsub/retry_policy.h
+++ b/google/cloud/pubsub/retry_policy.h
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_RETRY_POLICY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_RETRY_POLICY_H
+
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/retry_policy.h"
+#include "google/cloud/status.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+/// Define the gRPC status code semantics for retrying requests.
+struct RetryTraits {
+  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+    return status.code() != StatusCode::kOk &&
+           status.code() != StatusCode::kAborted &&
+           status.code() != StatusCode::kDeadlineExceeded &&
+           status.code() != StatusCode::kInternal &&
+           status.code() != StatusCode::kUnavailable &&
+           status.code() != StatusCode::kResourceExhausted;
+  }
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+/// The base class for retry policies.
+using RetryPolicy = google::cloud::internal::TraitBasedRetryPolicy<
+    pubsub_internal::RetryTraits>;
+
+/// A retry policy that limits based on time.
+using LimitedTimeRetryPolicy = google::cloud::internal::LimitedTimeRetryPolicy<
+    pubsub_internal::RetryTraits>;
+
+/// A retry policy that limits the number of times a request can fail.
+using LimitedErrorCountRetryPolicy =
+    google::cloud::internal::LimitedErrorCountRetryPolicy<
+        pubsub_internal::RetryTraits>;
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_RETRY_POLICY_H

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -48,6 +48,7 @@ void CreateTopic(google::cloud::pubsub::TopicAdminClient client,
      std::string topic_id) {
     auto topic = client.CreateTopic(pubsub::TopicMutationBuilder(
         pubsub::Topic(std::move(project_id), std::move(topic_id))));
+    // Note that kAlreadyExist is a possible error when the library retries.
     if (!topic) throw std::runtime_error(topic.status().message());
 
     std::cout << "The topic was successfully created: " << topic->DebugString()
@@ -121,6 +122,7 @@ void DeleteTopic(google::cloud::pubsub::TopicAdminClient client,
      std::string const& topic_id) {
     auto status = client.DeleteTopic(
         pubsub::Topic(std::move(project_id), std::move(topic_id)));
+    // Note that kNotFound is a possible error when the library retries.
     if (!status.ok()) throw std::runtime_error(status.message());
 
     std::cout << "The topic was successfully deleted\n";
@@ -849,14 +851,7 @@ void AutoRun(std::vector<std::string> const& argv) {
       google::cloud::pubsub::MakeSubscriptionAdminConnection());
 
   std::cout << "\nRunning CreateTopic() sample" << std::endl;
-  try {
-    CreateTopic(topic_admin_client, {project_id, topic_id});
-  } catch (std::runtime_error const& ex) {
-    // Ignore errors caused by duplicate calls to CreateTopic().
-    auto get = topic_admin_client.GetTopic(
-        google::cloud::pubsub::Topic(project_id, topic_id));
-    if (!get) throw;
-  }
+  CreateTopic(topic_admin_client, {project_id, topic_id});
 
   std::cout << "\nRunning GetTopic() sample" << std::endl;
   GetTopic(topic_admin_client, {project_id, topic_id});

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -443,7 +443,7 @@ void ExampleStatusOr(google::cloud::pubsub::TopicAdminClient client,
     // google::cloud::StatusOr<google::pubsub::v1::Topic>, but
     // we expect it'll most often be declared with auto like this.
     for (auto const& topic : client.ListTopics(project_id)) {
-      // Use `topic` like a smart pointer; check it before dereferencing
+      // Use `topic` like a smart pointer; check it before de-referencing
       if (!topic) {
         // `topic` doesn't contain a value, so `.status()` will contain error
         // info
@@ -849,7 +849,14 @@ void AutoRun(std::vector<std::string> const& argv) {
       google::cloud::pubsub::MakeSubscriptionAdminConnection());
 
   std::cout << "\nRunning CreateTopic() sample" << std::endl;
-  CreateTopic(topic_admin_client, {project_id, topic_id});
+  try {
+    CreateTopic(topic_admin_client, {project_id, topic_id});
+  } catch (std::runtime_error const& ex) {
+    // Ignore errors caused by duplicate calls to CreateTopic().
+    auto get = topic_admin_client.GetTopic(
+        google::cloud::pubsub::Topic(project_id, topic_id));
+    if (!get) throw;
+  }
 
   std::cout << "\nRunning GetTopic() sample" << std::endl;
   GetTopic(topic_admin_client, {project_id, topic_id});

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -73,7 +73,9 @@ class TopicAdminClient {
    * Create a new topic in Cloud Pub/Sub.
    *
    * @par Idempotency
-   * This is not an idempotent operation and therefore it is never retried.
+   * This operation is idempotent, as it succeeds only once, therefore the
+   * library retries the call. It might return a status code of
+   * `kAlreadyExists` if successful more than one time.
    *
    * @par Example
    * @snippet samples.cc create-topic
@@ -102,7 +104,8 @@ class TopicAdminClient {
    * Update the configuration of an existing Cloud Pub/Sub topic.
    *
    * @par Idempotency
-   * This is not an idempotent operation and therefore it is never retried.
+   * This operation is idempotent, the state of the system is the same after one
+   * or several calls, and thefeore it is always retried.
    *
    * @par Example
    * @snippet samples.cc update-topic
@@ -118,8 +121,7 @@ class TopicAdminClient {
    * List all the topics for a given project id.
    *
    * @par Idempotency
-   * This operation is read-only and therefore it is always treated as
-   * idempotent.
+   * This is a read-only operation and therefore always idempotent and retried.
    *
    * @par Example
    * @snippet samples.cc list-topics
@@ -132,7 +134,8 @@ class TopicAdminClient {
    * Delete an existing topic in Cloud Pub/Sub.
    *
    * @par Idempotency
-   * This is not an idempotent operation and therefore it is never retried.
+   * This operation is idempotent, the state of the system is the same after one
+   * or several calls, and therefore it is always retried.
    *
    * @par Example
    * @snippet samples.cc delete-topic
@@ -154,7 +157,8 @@ class TopicAdminClient {
    *   project in an early access program.
    *
    * @par Idempotency
-   * This is not an idempotent operation and therefore it is never retried.
+   * This operation is idempotent, the state of the system is the same after one
+   * or several calls, and therefore it is always retried.
    *
    * @par Example
    * @snippet samples.cc detach-subscription
@@ -175,8 +179,7 @@ class TopicAdminClient {
    * need to parse these names to use with other APIs.
    *
    * @par Idempotency
-   * This operation is read-only and therefore it is always treated as
-   * idempotent.
+   * This is a read-only operation and therefore always idempotent and retried.
    *
    * @par Example
    * @snippet samples.cc list-topic-subscriptions
@@ -194,8 +197,7 @@ class TopicAdminClient {
    * need to parse these names to use with other APIs.
    *
    * @par Idempotency
-   * This operation is read-only and therefore it is always treated as
-   * idempotent.
+   * This is a read-only operation and therefore always idempotent and retried.
    *
    * @par Example
    * @snippet samples.cc list-topic-snapshots

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -15,8 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_ADMIN_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TOPIC_ADMIN_CONNECTION_H
 
+#include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
+#include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
@@ -70,14 +72,13 @@ using ListTopicSnapshotsRange = google::cloud::internal::PaginationRange<
     google::pubsub::v1::ListTopicSnapshotsResponse>;
 
 /**
- * A connection to Cloud Pub/Sub.
+ * A connection to Cloud Pub/Sub for topic-related administrative operations.
  *
  * This interface defines pure-virtual methods for each of the user-facing
- * overload sets in `PublisherClient`. That is, all of `PublisherClient`'s
- * `Publish()` overloads will forward to the one pure-virtual `Publish()` method
- * declared in this interface, and similar for `PublisherClient`'s other
- * methods. This allows users to inject custom behavior (e.g., with a Google
- * Mock object) in a `PublisherClient` object for use in their own tests.
+ * overload sets in `TopicAdminClient`. That is, all of `TopicAdminClient`'s
+ * overloads will forward to the one pure-virtual method declared in this
+ * interface. This allows users to inject custom behavior (e.g., with a Google
+ * Mock object) in a `TopicAdminClient` object for use in their own tests.
  *
  * To create a concrete instance that connects you to the real Cloud Pub/Sub
  * service, see `MakeTopicAdminConnection()`.
@@ -88,6 +89,8 @@ class TopicAdminConnection {
 
   //@{
   /**
+   * @name The parameter wrapper types.
+   *
    * Define the arguments for each member function.
    *
    * Applications may define classes derived from `PublisherConnection`, for
@@ -95,6 +98,7 @@ class TopicAdminConnection {
    * derived classes when we change the number or type of the arguments to the
    * member functions we define light weight structures to pass the arguments.
    */
+
   /// Wrap the arguments for `CreateTopic()`
   struct CreateTopicParams {
     google::pubsub::v1::Topic topic;
@@ -167,20 +171,25 @@ class TopicAdminConnection {
 };
 
 /**
- * Returns an PublisherConnection object to work with Cloud Pub/Sub publisher
- * APIs.
+ * Returns a `TopicAdminConnection` object to work with `TopicAdminClient`.
  *
- * The `PublisherConnection` class is not intended for direct use in
- * applications, it is provided for applications wanting to mock the
- * `PublisherClient` behavior in their tests.
+ * The `TopicAdminConnection` class is provided for applications wanting to mock
+ * the `TopicAdminClient` behavior in their tests. It is not intended for direct
+ * use.
  *
- * @see `PublisherConnection`
+ * @see `TopicAdminClient`
  *
  * @param options (optional) configure the `PublisherConnection` created by
  *     this function.
+ * @param retry_policy control for how long (or how many times) are retryable
+ *     RPCs attempted.
+ * @param backoff_policy controls the backoff behavior between retry attempts,
+ *     typically some form of exponential backoff with jitter.
  */
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
-    ConnectionOptions const& options = ConnectionOptions());
+    ConnectionOptions const& options = ConnectionOptions(),
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
@@ -190,7 +199,9 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::TopicAdminConnection> MakeTopicAdminConnection(
     pubsub::ConnectionOptions const& options,
-    std::shared_ptr<PublisherStub> stub);
+    std::shared_ptr<PublisherStub> stub,
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal


### PR DESCRIPTION
Add retry loops for `pubsub::TopicAdminConnection`, and consequently for
`pubsub::TopicAdminClient`. In Cloud Pub/Sub all topic admin operations
are idempotent.

Fixes #4580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4959)
<!-- Reviewable:end -->
