### PR TITLE
test(pubsub): better handling for retry errors

### DIFF
--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -64,7 +64,9 @@ TEST(MessageIntegrationTest, PublishPullAck) {
   auto subscription_metadata = subscription_admin.CreateSubscription(
       topic, subscription,
       SubscriptionMutationBuilder{}.set_ack_deadline(std::chrono::seconds(10)));
-  ASSERT_STATUS_OK(subscription_metadata);
+  ASSERT_THAT(
+      subscription_metadata,
+      AnyOf(StatusIs(StatusCode::kOk), StatusIs(StatusCode::kAlreadyExists)));
 
   auto publisher = Publisher(MakePublisherConnection(topic, {}));
   auto subscriber = Subscriber(MakeSubscriberConnection());
@@ -112,7 +114,8 @@ TEST(MessageIntegrationTest, PublishPullAck) {
   EXPECT_STATUS_OK(result.get());
 
   auto delete_response = subscription_admin.DeleteSubscription(subscription);
-  ASSERT_STATUS_OK(delete_response);
+  EXPECT_THAT(delete_response, AnyOf(StatusIs(StatusCode::kOk),
+                                     StatusIs(StatusCode::kNotFound)));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_admin_integration_test.cc
@@ -102,7 +102,8 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
       topic, subscription,
       SubscriptionMutationBuilder{}.set_push_config(
           PushConfigBuilder{}.set_push_endpoint(endpoint)));
-  ASSERT_STATUS_OK(create_response);
+  ASSERT_THAT(create_response, AnyOf(StatusIs(StatusCode::kOk),
+                                     StatusIs(StatusCode::kAlreadyExists)));
 
   auto get_response = subscription_admin.GetSubscription(subscription);
   ASSERT_STATUS_OK(get_response);
@@ -185,7 +186,8 @@ TEST(SubscriptionAdminIntegrationTest, SubscriptionCRUD) {
   //  }
 
   auto delete_response = subscription_admin.DeleteSubscription(subscription);
-  ASSERT_STATUS_OK(delete_response);
+  EXPECT_THAT(delete_response, AnyOf(StatusIs(StatusCode::kOk),
+                                     StatusIs(StatusCode::kNotFound)));
 
   EXPECT_THAT(subscription_names(subscription_admin, project_id),
               Not(Contains(subscription.FullName())));

--- a/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/topic_admin_integration_test.cc
@@ -91,7 +91,8 @@ TEST(TopicAdminIntegrationTest, TopicCRUD) {
   // complicate this test with little benefit.
 
   auto delete_response = publisher.DeleteTopic(topic);
-  ASSERT_STATUS_OK(delete_response);
+  EXPECT_THAT(delete_response, AnyOf(StatusIs(StatusCode::kOk),
+                                     StatusIs(StatusCode::kNotFound)));
   EXPECT_THAT(topic_names(publisher, project_id),
               Not(Contains(topic.FullName())));
 }


### PR DESCRIPTION
Now that the admin APIs retry (almost all) requests we need to handle
errors caused by duplicate `Create*()` or `Delete*()` requests.

Fixes #4328

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4962)
<!-- Reviewable:end -->
