### PR TITLE
feat(pubsub): align default batching configuration

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(
     publisher.h
     publisher_connection.cc
     publisher_connection.h
+    publisher_options.cc
     publisher_options.h
     retry_policy.h
     snapshot.cc

--- a/google/cloud/pubsub/publisher_options.cc
+++ b/google/cloud/pubsub/publisher_options.cc
@@ -13,33 +13,16 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher_options.h"
-#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
-namespace {
 
-TEST(PublisherOptions, Setters) {
-  auto const b0 = PublisherOptions{};
-  EXPECT_NE(0, b0.maximum_hold_time().count());
-  EXPECT_FALSE(b0.message_ordering());
+std::chrono::milliseconds constexpr PublisherOptions::kDefaultMaximumHoldTime;
+std::size_t constexpr PublisherOptions::kDefaultMaximumMessageCount;
+std::size_t constexpr PublisherOptions::kDefaultMaximumMessageSize;
 
-  auto const b = PublisherOptions{}
-                     .set_maximum_hold_time(std::chrono::seconds(12))
-                     .set_maximum_batch_bytes(123)
-                     .set_maximum_message_count(10)
-                     .enable_message_ordering();
-  EXPECT_EQ(10, b.maximum_message_count());
-  EXPECT_EQ(123, b.maximum_batch_bytes());
-  auto const expected = std::chrono::duration_cast<std::chrono::microseconds>(
-      std::chrono::seconds(12));
-  EXPECT_EQ(expected, b.maximum_hold_time());
-  EXPECT_TRUE(b.message_ordering());
-}
-
-}  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
 }  // namespace cloud

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -119,9 +119,13 @@ class PublisherOptions {
   }
 
  private:
-  std::chrono::microseconds maximum_hold_time_{0};
-  std::size_t maximum_message_count_{(std::numeric_limits<std::size_t>::max)()};
-  std::size_t maximum_batch_bytes_{(std::numeric_limits<std::size_t>::max)()};
+  static auto constexpr kDefaultMaximumHoldTime = std::chrono::milliseconds(10);
+  static std::size_t constexpr kDefaultMaximumMessageCount = 100;
+  static std::size_t constexpr kDefaultMaximumMessageSize = 1024 * 1024L;
+
+  std::chrono::microseconds maximum_hold_time_ = kDefaultMaximumHoldTime;
+  std::size_t maximum_message_count_ = kDefaultMaximumMessageCount;
+  std::size_t maximum_batch_bytes_ = kDefaultMaximumMessageSize;
   bool message_ordering_{false};
 };
 

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -78,6 +78,7 @@ pubsub_client_srcs = [
     "message.cc",
     "publisher.cc",
     "publisher_connection.cc",
+    "publisher_options.cc",
     "snapshot.cc",
     "snapshot_mutation_builder.cc",
     "subscriber_connection.cc",


### PR DESCRIPTION
Make the default batching configuration match the settings for the
client libraries in other languages.

Fixes #4808

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4966)
<!-- Reviewable:end -->
