### PR TITLE
feat: retry loop for asynchronous RPCs

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -342,6 +342,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         grpc_utils/grpc_error_delegate.h
         grpc_utils/version.h
         internal/async_read_stream_impl.h
+        internal/async_retry_loop.h
         internal/async_retry_unary_rpc.h
         internal/background_threads_impl.cc
         internal/background_threads_impl.h
@@ -350,8 +351,9 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/log_wrapper.cc
         internal/log_wrapper.h
         internal/pagination_range.h
-        internal/retry_loop.cc
         internal/retry_loop.h
+        internal/retry_loop_helpers.cc
+        internal/retry_loop_helpers.h
         internal/time_utils.cc
         internal/time_utils.h)
     target_link_libraries(
@@ -381,6 +383,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             completion_queue_test.cc
             connection_options_test.cc
             grpc_error_delegate_test.cc
+            internal/async_retry_loop_test.cc
             internal/async_retry_unary_rpc_test.cc
             internal/background_threads_impl_test.cc
             internal/log_wrapper_test.cc

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -27,12 +27,14 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "grpc_utils/grpc_error_delegate.h",
     "grpc_utils/version.h",
     "internal/async_read_stream_impl.h",
+    "internal/async_retry_loop.h",
     "internal/async_retry_unary_rpc.h",
     "internal/background_threads_impl.h",
     "internal/completion_queue_impl.h",
     "internal/log_wrapper.h",
     "internal/pagination_range.h",
     "internal/retry_loop.h",
+    "internal/retry_loop_helpers.h",
     "internal/time_utils.h",
 ]
 
@@ -43,6 +45,6 @@ google_cloud_cpp_grpc_utils_srcs = [
     "internal/background_threads_impl.cc",
     "internal/completion_queue_impl.cc",
     "internal/log_wrapper.cc",
-    "internal/retry_loop.cc",
+    "internal/retry_loop_helpers.cc",
     "internal/time_utils.cc",
 ]

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "completion_queue_test.cc",
     "connection_options_test.cc",
     "grpc_error_delegate_test.cc",
+    "internal/async_retry_loop_test.cc",
     "internal/async_retry_unary_rpc_test.cc",
     "internal/background_threads_impl_test.cc",
     "internal/log_wrapper_test.cc",

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -1,0 +1,179 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_RETRY_LOOP_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_RETRY_LOOP_H
+
+#include "google/cloud/backoff_policy.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/retry_loop_helpers.h"
+#include "google/cloud/internal/retry_policy.h"
+#include "google/cloud/version.h"
+#include "absl/meta/type_traits.h"
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+template <typename T>
+struct FutureValueType;
+
+template <typename T>
+struct FutureValueType<future<T>> {
+  using value_type = T;
+};
+
+/**
+ * Implement an asynchronous retry loop for wrapped gRPC requests.
+ *
+ * In newer libraries the stubs wrap asynchronous RPCs to match this signature:
+ *
+ * @code
+ * class MyStub { public:
+ *   virtual future<StatusOr<ResponseProto>> AsyncRpcName(
+ *      google::cloud::CompletionQueue& cq,
+ *      std::unique_ptr<grpc::ClientContext> context,
+ *      RequestProto const& request) = 0;
+ * };
+ * @endcode
+ *
+ * stubs with such a signature are easier to mock and test. In most mocks all
+ * we need to do is return a future satisfied immediately. And writing the
+ * implementation of these stubs is very easy too.
+ *
+ * This class implements the retry loop for such an RPC.
+ */
+template <typename Functor, typename Request>
+class AsyncRetryLoopImpl : public std::enable_shared_from_this<
+                               AsyncRetryLoopImpl<Functor, Request>> {
+ public:
+  AsyncRetryLoopImpl(std::unique_ptr<RetryPolicy> retry_policy,
+                     std::unique_ptr<BackoffPolicy> backoff_policy,
+                     bool is_idempotent, google::cloud::CompletionQueue cq,
+                     Functor&& functor, Request request, char const* location)
+      : retry_policy_(std::move(retry_policy)),
+        backoff_policy_(std::move(backoff_policy)),
+        is_idempotent_(is_idempotent),
+        cq_(std::move(cq)),
+        functor_(std::forward<Functor>(functor)),
+        request_(std::move(request)),
+        location_(location) {}
+
+  using ReturnType = google::cloud::internal::invoke_result_t<
+      Functor, google::cloud::CompletionQueue&,
+      std::unique_ptr<grpc::ClientContext>, Request const&>;
+  using T = typename FutureValueType<ReturnType>::value_type;
+
+  future<T> Start() {
+    StartAttempt();
+    return result_.get_future();
+  }
+
+ private:
+  void StartAttempt() {
+    if (retry_policy_->IsExhausted()) {
+      result_.set_value(
+          RetryLoopError("Retry policy exhausted in", location_, last_status_));
+      return;
+    }
+    auto self = this->shared_from_this();
+    functor_(cq_, absl::make_unique<grpc::ClientContext>(), request_)
+        .then([self](future<T> f) { self->OnAttempt(f.get()); });
+  }
+
+  void OnAttempt(T result) {
+    // A successful attempt, set the value and finish the loop.
+    if (result.ok()) {
+      result_.set_value(std::move(result));
+      return;
+    }
+    // Some kind of failure, first verify that it is retryable.
+    last_status_ = GetResultStatus(std::move(result));
+    if (!is_idempotent_) {
+      result_.set_value(RetryLoopError("Error in non-idempotent operation",
+                                       location_, last_status_));
+      return;
+    }
+    if (!retry_policy_->OnFailure(last_status_)) {
+      if (retry_policy_->IsPermanentFailure(last_status_)) {
+        result_.set_value(
+            RetryLoopError("Permanent error in", location_, last_status_));
+      } else {
+        result_.set_value(RetryLoopError("Retry policy exhausted in", location_,
+                                         last_status_));
+      }
+      return;
+    }
+    auto self = this->shared_from_this();
+    cq_.MakeRelativeTimer(backoff_policy_->OnCompletion())
+        .then(
+            [self](future<StatusOr<std::chrono::system_clock::time_point>> f) {
+              self->OnBackoffTimer(f.get());
+            });
+  }
+
+  void OnBackoffTimer(StatusOr<std::chrono::system_clock::time_point> tp) {
+    if (!tp) {
+      // some kind of error in the CompletionQueue, probably shutting down.
+      result_.set_value(RetryLoopError("Timer failure in", location_,
+                                       std::move(tp).status()));
+      return;
+    }
+    StartAttempt();
+  }
+
+  std::unique_ptr<RetryPolicy> retry_policy_;
+  std::unique_ptr<BackoffPolicy> backoff_policy_;
+  bool is_idempotent_ = false;
+  google::cloud::CompletionQueue cq_;
+  absl::decay_t<Functor> functor_;
+  Request request_;
+  char const* location_ = "unknown";
+  Status last_status_ = Status(StatusCode::kUnknown, "Retry policy exhausted");
+  promise<T> result_;
+};
+
+/**
+ * Create the right AsyncRetryLoopImpl object and start the retry loop on it.
+ */
+template <typename Functor, typename Request,
+          typename std::enable_if<
+              google::cloud::internal::is_invocable<
+                  Functor, google::cloud::CompletionQueue&,
+                  std::unique_ptr<grpc::ClientContext>, Request const&>::value,
+              int>::type = 0>
+auto AsyncRetryLoop(std::unique_ptr<RetryPolicy> retry_policy,
+                    std::unique_ptr<BackoffPolicy> backoff_policy,
+                    bool is_idempotent, google::cloud::CompletionQueue cq,
+                    Functor&& functor, Request request, char const* location)
+    -> google::cloud::internal::invoke_result_t<
+        Functor, google::cloud::CompletionQueue&,
+        std::unique_ptr<grpc::ClientContext>, Request const&> {
+  auto loop = std::make_shared<AsyncRetryLoopImpl<Functor, Request>>(
+      std::move(retry_policy), std::move(backoff_policy), is_idempotent,
+      std::move(cq), std::forward<Functor>(functor), std::move(request),
+      location);
+  return loop->Start();
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_RETRY_LOOP_H

--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -1,0 +1,197 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/async_retry_loop.h"
+#include "google/cloud/internal/background_threads_impl.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::AllOf;
+using ::testing::HasSubstr;
+using ::testing::Return;
+
+struct TestRetryablePolicy {
+  static bool IsPermanentFailure(google::cloud::Status const& s) {
+    return !s.ok() &&
+           (s.code() == google::cloud::StatusCode::kPermissionDenied);
+  }
+};
+
+auto constexpr kMaxRetries = 5;
+std::unique_ptr<RetryPolicy> TestRetryPolicy() {
+  return LimitedErrorCountRetryPolicy<TestRetryablePolicy>(kMaxRetries).clone();
+}
+
+std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {
+  return ExponentialBackoffPolicy(std::chrono::microseconds(1),
+                                  std::chrono::microseconds(5), 2.0)
+      .clone();
+}
+
+TEST(AsyncRetryLoopTest, Success) {
+  AutomaticallyCreatedBackgroundThreads background;
+  StatusOr<int> actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), TestBackoffPolicy(), true, background.cq(),
+          [](google::cloud::CompletionQueue&,
+             std::unique_ptr<grpc::ClientContext>,
+             int request) -> future<StatusOr<int>> {
+            return make_ready_future(StatusOr<int>(2 * request));
+          },
+          42, "error message")
+          .get();
+  ASSERT_THAT(actual.status(), StatusIs(StatusCode::kOk));
+  EXPECT_EQ(84, *actual);
+}
+
+TEST(AsyncRetryLoopTest, TransientThenSuccess) {
+  int counter = 0;
+  AutomaticallyCreatedBackgroundThreads background;
+  StatusOr<int> actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), TestBackoffPolicy(), true, background.cq(),
+          [&](google::cloud::CompletionQueue&,
+              std::unique_ptr<grpc::ClientContext>, int request) {
+            if (++counter < 3) {
+              return make_ready_future(
+                  StatusOr<int>(Status(StatusCode::kUnavailable, "try again")));
+            }
+            return make_ready_future(StatusOr<int>(2 * request));
+          },
+          42, "error message")
+          .get();
+  ASSERT_THAT(actual.status(), StatusIs(StatusCode::kOk));
+  EXPECT_EQ(84, *actual);
+}
+
+TEST(AsyncRetryLoopTest, ReturnJustStatus) {
+  int counter = 0;
+  AutomaticallyCreatedBackgroundThreads background;
+  Status actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), TestBackoffPolicy(), true, background.cq(),
+          [&](google::cloud::CompletionQueue&,
+              std::unique_ptr<grpc::ClientContext>, int) {
+            if (++counter <= 3) {
+              return make_ready_future(
+                  Status(StatusCode::kResourceExhausted, "slow-down"));
+            }
+            return make_ready_future(Status());
+          },
+          42, "error message")
+          .get();
+  ASSERT_THAT(actual, StatusIs(StatusCode::kOk));
+}
+
+class MockBackoffPolicy : public BackoffPolicy {
+ public:
+  MOCK_CONST_METHOD0(clone, std::unique_ptr<BackoffPolicy>());
+  MOCK_METHOD0(OnCompletion, std::chrono::milliseconds());
+};
+
+/// @test Verify the backoff policy is queried after each failure.
+TEST(AsyncRetryLoopTest, UsesBackoffPolicy) {
+  using ms = std::chrono::milliseconds;
+
+  std::unique_ptr<MockBackoffPolicy> mock(new MockBackoffPolicy);
+  EXPECT_CALL(*mock, OnCompletion()).Times(3).WillRepeatedly(Return(ms(1)));
+
+  int counter = 0;
+  std::vector<ms> sleep_for;
+  AutomaticallyCreatedBackgroundThreads background;
+  StatusOr<int> actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), std::move(mock), true, background.cq(),
+          [&](google::cloud::CompletionQueue&,
+              std::unique_ptr<grpc::ClientContext>, int request) {
+            if (++counter <= 3) {
+              return make_ready_future(
+                  StatusOr<int>(Status(StatusCode::kUnavailable, "try again")));
+            }
+            return make_ready_future(StatusOr<int>(2 * request));
+          },
+          42, "error message")
+          .get();
+  ASSERT_THAT(actual.status(), StatusIs(StatusCode::kOk));
+  EXPECT_EQ(84, *actual);
+}
+
+TEST(AsyncRetryLoopTest, TransientFailureNonIdempotent) {
+  AutomaticallyCreatedBackgroundThreads background;
+  StatusOr<int> actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), TestBackoffPolicy(), false, background.cq(),
+          [](google::cloud::CompletionQueue&,
+             std::unique_ptr<grpc::ClientContext>, int) {
+            return make_ready_future(StatusOr<int>(
+                Status(StatusCode::kUnavailable, "test-message-try-again")));
+          },
+          42, "test-location")
+          .get();
+  EXPECT_THAT(actual.status(),
+              StatusIs(StatusCode::kUnavailable,
+                       AllOf(HasSubstr("test-message-try-again"),
+                             HasSubstr("Error in non-idempotent"),
+                             HasSubstr("test-location"))));
+}
+
+TEST(AsyncRetryLoopTest, PermanentFailureIdempotent) {
+  AutomaticallyCreatedBackgroundThreads background;
+  StatusOr<int> actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), TestBackoffPolicy(), true, background.cq(),
+          [](google::cloud::CompletionQueue&,
+             std::unique_ptr<grpc::ClientContext>, int) {
+            return make_ready_future(StatusOr<int>(
+                Status(StatusCode::kPermissionDenied, "test-message-uh-oh")));
+          },
+          42, "test-location")
+          .get();
+  EXPECT_THAT(actual.status(), StatusIs(StatusCode::kPermissionDenied,
+                                        AllOf(HasSubstr("test-message-uh-oh"),
+                                              HasSubstr("Permanent error in"),
+                                              HasSubstr("test-location"))));
+}
+
+TEST(AsyncRetryLoopTest, TooManyTransientFailuresIdempotent) {
+  AutomaticallyCreatedBackgroundThreads background;
+  StatusOr<int> actual =
+      AsyncRetryLoop(
+          TestRetryPolicy(), TestBackoffPolicy(), false, background.cq(),
+          [](google::cloud::CompletionQueue&,
+             std::unique_ptr<grpc::ClientContext>, int) {
+            return make_ready_future(StatusOr<int>(
+                Status(StatusCode::kUnavailable, "test-message-try-again")));
+          },
+          42, "test-location")
+          .get();
+  EXPECT_THAT(actual.status(),
+              StatusIs(StatusCode::kUnavailable,
+                       AllOf(HasSubstr("test-message-try-again"),
+                             HasSubstr("Error in non-idempotent"),
+                             HasSubstr("test-location"))));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/internal/retry_loop_helpers.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -27,19 +28,6 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
-
-/// A helper function to treat all results the same way in `RetryLoop()`.
-inline Status GetResultStatus(Status status) { return status; }
-
-/// @copydoc GetResultStatus(Status)
-template <typename T>
-Status GetResultStatus(StatusOr<T> result) {
-  return std::move(result).status();
-}
-
-/// Generate an error Status for `RetryLoop()`
-Status RetryLoopError(char const* loop_message, char const* location,
-                      Status const& last_status);
 
 /**
  * A generic retry loop for gRPC operations.

--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/retry_loop.h"
+#include "google/cloud/internal/retry_loop_helpers.h"
 #include <sstream>
 
 namespace google {

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_LOOP_HELPERS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_LOOP_HELPERS_H
+
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// Generic programming adapter for `RetryLoop()` and `AsyncRetryLoop()`.
+inline Status GetResultStatus(Status status) { return status; }
+
+/// @copydoc GetResultStatus(Status)
+template <typename T>
+Status GetResultStatus(StatusOr<T> result) {
+  return std::move(result).status();
+}
+
+/// Generate an error Status for `RetryLoop()` and `AsyncRetryLoop()`
+Status RetryLoopError(char const* loop_message, char const* location,
+                      Status const& last_status);
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RETRY_LOOP_HELPERS_H


### PR DESCRIPTION
In the Cloud Pub/Sub library (and I think in all future libraries) the
signature for an asynchronous RPC is:

```cc
future<StatusOr<ResponseProto> AsyncFooBar(
    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> ctx,
    RequestProto const& request);
```

This PR introduces a retry loop for functions with that signature,
previous retry loops required a different return type and arguments. The
older signature was really hard to mock and test.

Part of the work for #4971 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4972)
<!-- Reviewable:end -->
