### PR TITLE
fix: Do not require the google.api.http RPC option

### DIFF
--- a/google/cloud/testing_util/validate_metadata.cc
+++ b/google/cloud/testing_util/validate_metadata.cc
@@ -168,8 +168,7 @@ StatusOr<std::map<std::string, std::string> > ExtractParamsFromMethod(
   }
   auto options = method_desc->options();
   if (!options.HasExtension(google::api::http)) {
-    return Status(StatusCode::kInvalidArgument,
-                  "Method " + method + " doesn't have a http option.");
+    return std::map<std::string, std::string>{};
   }
   auto const& http = options.GetExtension(google::api::http);
   std::string pattern;


### PR DESCRIPTION
If a method does not have the google.api.http option, return
an empty map from `ExtractParamsFromMethod()` instead of an
invalid-argument error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4973)
<!-- Reviewable:end -->
