### PR TITLE
feat(pubsub): optionally retry Publisher::Publish

### DIFF
--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -113,11 +113,13 @@ class Publisher {
    * Publishes a message to this publisher's topic
    *
    * Note that the message maybe be batched based on the Publisher's
-   * configuration, the message may not be immediately sent.
+   * configuration. It could be delayed until the batch has enough messages,
+   * or enough data, or enough time has elapsed. See the `PublisherOptions`
+   * documentation for more details.
    *
    * @par Idempotency
-   * This is a non-idempotent operation, by default the request is *not* retried
-   * if there is a transient error. Applications wanting to enable retries can
+   * This is a non-idempotent operation. By default the request is *not* retried
+   * if there is a transient error. Applications wanting to retry requests can
    * do so by enabling the `retry_publish_failures()` parameter in the
    * `PublisherOptions`.
    *

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -115,6 +115,12 @@ class Publisher {
    * Note that the message maybe be batched based on the Publisher's
    * configuration, the message may not be immediately sent.
    *
+   * @par Idempotency
+   * This is a non-idempotent operation, by default the request is *not* retried
+   * if there is a transient error. Applications wanting to enable retries can
+   * do so by enabling the `retry_publish_failures()` parameter in the
+   * `PublisherOptions`.
+   *
    * @par Example
    * @snippet samples.cc publish
    *

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -112,7 +112,7 @@ class Publisher {
   /**
    * Publishes a message to this publisher's topic
    *
-   * Note that the message may be be batched based on the Publisher's
+   * Note that the message may be batched based on the Publisher's
    * configuration. It could be delayed until the batch has enough messages,
    * or enough data, or enough time has elapsed. See the `PublisherOptions`
    * documentation for more details.

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -112,7 +112,7 @@ class Publisher {
   /**
    * Publishes a message to this publisher's topic
    *
-   * Note that the message maybe be batched based on the Publisher's
+   * Note that the message may be be batched based on the Publisher's
    * configuration. It could be delayed until the batch has enough messages,
    * or enough data, or enough time has elapsed. See the `PublisherOptions`
    * documentation for more details.

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -15,10 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_PUBLISHER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_PUBLISHER_CONNECTION_H
 
+#include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/publisher_options.h"
+#include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/future.h"
@@ -61,10 +63,17 @@ class PublisherConnection {
  *     returned connection.
  * @param connection_options (optional) general configuration for this
  *    connection, this type is also used to configure `pubsub::Subscriber`.
+ * @param retry_policy (optional) configure the retry loop. This is only used
+ *    if `retry_publish_failures()` is enabled in @p options.
+ * @param backoff_policy (optional) configure the backoff period between
+ *    retries. This is only used if `retry_publish_failures()` is enabled in
+ *    @p options.
  */
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, PublisherOptions options,
-    ConnectionOptions connection_options = {});
+    ConnectionOptions connection_options = {},
+    std::unique_ptr<RetryPolicy const> retry_policy = {},
+    std::unique_ptr<BackoffPolicy const> backoff_policy = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
@@ -75,7 +84,9 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
     pubsub::Topic topic, pubsub::PublisherOptions options,
     pubsub::ConnectionOptions connection_options,
-    std::shared_ptr<PublisherStub> stub);
+    std::shared_ptr<PublisherStub> stub,
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -118,6 +118,16 @@ class PublisherOptions {
     return *this;
   }
 
+  bool retry_publish_failures() const { return retry_publish_failures_; }
+  PublisherOptions& enable_retry_publish_failures() {
+    retry_publish_failures_ = true;
+    return *this;
+  }
+  PublisherOptions& disable_retry_publish_failures() {
+    retry_publish_failures_ = false;
+    return *this;
+  }
+
  private:
   static auto constexpr kDefaultMaximumHoldTime = std::chrono::milliseconds(10);
   static std::size_t constexpr kDefaultMaximumMessageCount = 100;
@@ -126,7 +136,8 @@ class PublisherOptions {
   std::chrono::microseconds maximum_hold_time_ = kDefaultMaximumHoldTime;
   std::size_t maximum_message_count_ = kDefaultMaximumMessageCount;
   std::size_t maximum_batch_bytes_ = kDefaultMaximumMessageSize;
-  bool message_ordering_{false};
+  bool message_ordering_ = false;
+  bool retry_publish_failures_ = false;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
Cloud Pub/Sub libraries are expected to retry `Publish()` requests.
Because these are not idempotent I chose to disable retries by default,
but they can be turned no relatively easily.

Fixes #4971

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4976)
<!-- Reviewable:end -->
