### PR TITLE
feat(pubsub): publisher_retry_settings example

### DIFF
--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -126,6 +126,9 @@ class Publisher {
    * @par Example
    * @snippet samples.cc publish
    *
+   * @par Changing Retry Parameters Example
+   * @snippet samples.cc publisher-retry-settings
+   *
    * @return a future that becomes satisfied when the message is published or on
    *     a unrecoverable error.
    */


### PR DESCRIPTION
Implement the `pubsub_publisher_retry_settings` example, showing how to
change the default retry configuration for a `pubsub::Publisher`.

Fixes #4646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4979)
<!-- Reviewable:end -->
