### PR TITLE
test(storage): fix test expectation

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -34,7 +34,7 @@ std::string RandomTableId(std::string const& prefix,
                           google::cloud::internal::DefaultPRNG& generator) {
   return TablePrefix(prefix, std::chrono::system_clock::now()) +
          google::cloud::internal::Sample(generator, 8,
-                                         "abcdefhijklmnopqrstuvwxyz");
+                                         "abcdefghijklmnopqrstuvwxyz");
 }
 
 void CleanupOldTables(std::string const& prefix,
@@ -106,7 +106,7 @@ std::string RandomInstanceId(std::string const& prefix,
   auto const suffix_len = kMaxInstanceIdLength - timestamped_prefix.size();
   return timestamped_prefix + google::cloud::internal::Sample(
                                   generator, static_cast<int>(suffix_len),
-                                  "abcdefhijklmnopqrstuvwxyz0123456789");
+                                  "abcdefghijklmnopqrstuvwxyz0123456789");
 }
 
 std::string RandomClusterId(std::string const& prefix,
@@ -117,7 +117,7 @@ std::string RandomClusterId(std::string const& prefix,
   auto const suffix_len = kMaxClusterIdLength - prefix.size();
   return prefix + google::cloud::internal::Sample(
                       generator, static_cast<int>(suffix_len),
-                      "abcdefhijklmnopqrstuvwxyz0123456789");
+                      "abcdefghijklmnopqrstuvwxyz0123456789");
 }
 
 void CleanupOldInstances(std::string const& prefix,

--- a/google/cloud/spanner/testing/random_backup_name.cc
+++ b/google/cloud/spanner/testing/random_backup_name.cc
@@ -26,7 +26,7 @@ std::string RandomBackupName(google::cloud::internal::DefaultPRNG& generator) {
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
+             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789_-") +
          google::cloud::internal::Sample(
              generator, 1, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -38,7 +38,7 @@ std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator,
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
+             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789_-") +
          google::cloud::internal::Sample(
              generator, 1, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -35,7 +35,7 @@ std::string RandomInstanceName(
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689-") +
+             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789-") +
          google::cloud::internal::Sample(generator, 1,
                                          "abcdefghijlkmnopqrstuvwxyz");
 }

--- a/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
@@ -51,7 +51,8 @@ TEST(StorageBenchmarksUtilsTest, MakeRandomBucket) {
   EXPECT_EQ(0, d1.rfind("prefix-", 0));
   EXPECT_GE(63U, d1.size());
   EXPECT_EQ(std::string::npos,
-            d1.find_first_not_of("-_abcdefghijklmnopqrstuvwxyz012456789"));
+            d1.find_first_not_of("-_abcdefghijklmnopqrstuvwxyz0123456789"))
+      << "d1=" << d1;
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -42,7 +42,7 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
   // *need* to use them.
   return full + google::cloud::internal::Sample(
                     gen, static_cast<int>(max_random_characters),
-                    "abcdefghijklmnopqrstuvwxyz012456789");
+                    "abcdefghijklmnopqrstuvwxyz0123456789");
 }
 
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
@@ -56,7 +56,7 @@ std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
   // a subset for these purposes.
   return prefix + google::cloud::internal::Sample(
                       gen, static_cast<int>(max_random_characters),
-                      "abcdefghijklmnopqrstuvwxyz012456789");
+                      "abcdefghijklmnopqrstuvwxyz0123456789");
 }
 
 Commands::value_type CreateCommandEntry(

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -1383,7 +1383,7 @@ std::string CurlClient::PickBoundary(std::string const& text_to_avoid) {
   // over `text_to_avoid`.
   auto generate_candidate = [this](int n) {
     static std::string const kChars =
-        "abcdefghijklmnopqrstuvwxyz012456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     std::unique_lock<std::mutex> lk(mu_);
     return google::cloud::internal::Sample(generator_, n, kChars);
   };

--- a/google/cloud/storage/internal/generate_message_boundary_test.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_test.cc
@@ -31,7 +31,7 @@ TEST(GenerateMessageBoundaryTest, Simple) {
 
   auto string_generator = [&generator](int n) {
     static std::string const kChars =
-        "abcdefghijklmnopqrstuvwxyz012456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     return google::cloud::internal::Sample(generator, n, kChars);
   };
 
@@ -45,7 +45,7 @@ TEST(GenerateMessageBoundaryTest, Simple) {
 
 TEST(GenerateMessageBoundaryTest, RequiresGrowth) {
   static std::string const kChars =
-      "abcdefghijklmnopqrstuvwxyz012456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+      "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 

--- a/google/cloud/storage/testing/random_names.cc
+++ b/google/cloud/storage/testing/random_names.cc
@@ -32,7 +32,7 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
   std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
   return full + google::cloud::internal::Sample(
                     gen, static_cast<int>(max_random_characters),
-                    "abcdefghijklmnopqrstuvwxyz012456789");
+                    "abcdefghijklmnopqrstuvwxyz0123456789");
 }
 
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
@@ -69,7 +69,7 @@ std::string MakeRandomData(google::cloud::internal::DefaultPRNG& gen,
     return google::cloud::internal::Sample(gen, static_cast<int>(count - 1),
                                            "abcdefghijklmnopqrstuvwxyz"
                                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                           "012456789"
+                                           "0123456789"
                                            " - _ : /") +
            "\n";
   };

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -133,7 +133,7 @@ std::string StorageIntegrationTest::MakeRandomBucketName(std::string prefix) {
       kMaxBucketNameLength - prefix.size();
   return prefix + google::cloud::internal::Sample(
                       generator_, static_cast<int>(max_random_characters),
-                      "abcdefghijklmnopqrstuvwxyz012456789");
+                      "abcdefghijklmnopqrstuvwxyz0123456789");
 }
 
 std::string StorageIntegrationTest::MakeRandomObjectName() {

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -62,7 +62,7 @@ TEST_F(ObjectMediaIntegrationTest, StreamingReadClose) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
   // Create an object with the contents to download.
@@ -102,7 +102,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeJSON) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
 
@@ -143,7 +143,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadRangeXml) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
 
@@ -183,7 +183,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetJSON) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
 
@@ -224,7 +224,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadFromOffsetXml) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
 
@@ -264,7 +264,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadMixedChunks) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
 
@@ -327,7 +327,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunk) {
     auto line = google::cloud::internal::Sample(generator_, kLineSize - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
   static_assert(kObjectSize % kLineSize == 0,
@@ -431,7 +431,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadLastChunkReadLast) {
     auto line = google::cloud::internal::Sample(generator_, kLineSize - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
   static_assert(kObjectSize % kLineSize == 0,
@@ -481,7 +481,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
     auto line = google::cloud::internal::Sample(generator_, kLineSize - 1,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
   static_assert(kObjectSize % kLineSize == 0,

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -395,7 +395,7 @@ TEST_F(ObjectRewriteIntegrationTest, RewriteLarge) {
     auto line = google::cloud::internal::Sample(generator_, 127,
                                                 "abcdefghijklmnopqrstuvwxyz"
                                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                                "012456789");
+                                                "0123456789");
     large_text += line + "\n";
   }
 


### PR DESCRIPTION
This is a flake in the making, it fails when the random bucket name
generator uses `3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4985)
<!-- Reviewable:end -->
