### PR TITLE
test(pubsub): fix race condition in example

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -872,8 +872,8 @@ void CustomThreadPoolSubscriber(std::vector<std::string> const& argv) {
         .get();
     // Report any final status, blocking until the subscription loop completes,
     // either with a failure or because it was canceled.
-    std::cout << "Message count=" << count << ", status=" << result.get()
-              << "\n";
+    auto status = result.get();
+    std::cout << "Message count=" << count << ", status=" << status << "\n";
 
     // Shutdown the completion queue and join the threads
     cq.Shutdown();


### PR DESCRIPTION
While this is (mostly) harmless, TSAN does not like us
accessing `count` while other threads are changing it.
The fix is to call `result.get()` before reading it, as this
waits for any threads / callbacks that might change
`count`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4986)
<!-- Reviewable:end -->
