### PR TITLE
test: make test utility class thread-safe

### DIFF
--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -727,7 +727,7 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
   google::cloud::LogSink::Instance().RemoveBackend(id);
 
   EXPECT_THAT(
-      backend->log_lines,
+      backend->ClearLogLines(),
       Not(Contains(HasSubstr(
           "RowReader has an error, and the error status was not retrieved"))));
 }

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -157,13 +157,13 @@ TEST(LogWrapper, FutureStatusOrValue) {
 
   LogWrapper(mock, MakeMutation(), "in-test", {});
 
-  EXPECT_THAT(backend->log_lines,
+  auto const log_lines = backend->ClearLogLines();
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
-  EXPECT_THAT(backend->log_lines, Contains(AllOf(HasSubstr("in-test("),
-                                                 HasSubstr(" >> response="))));
-  EXPECT_THAT(
-      backend->log_lines,
-      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> response="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> future_status="))));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
@@ -180,15 +180,15 @@ TEST(LogWrapper, FutureStatusOrError) {
 
   LogWrapper(mock, MakeMutation(), "in-test", {});
 
-  EXPECT_THAT(backend->log_lines,
+  auto const log_lines = backend->ClearLogLines();
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> status="))));
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr("uh-oh"))));
-  EXPECT_THAT(
-      backend->log_lines,
-      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> future_status="))));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
@@ -209,13 +209,13 @@ TEST(LogWrapper, FutureStatusOrValueWithContextAndCQ) {
   std::unique_ptr<grpc::ClientContext> context;
   LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
 
-  EXPECT_THAT(backend->log_lines,
+  auto const log_lines = backend->ClearLogLines();
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
-  EXPECT_THAT(backend->log_lines, Contains(AllOf(HasSubstr("in-test("),
-                                                 HasSubstr(" >> response="))));
-  EXPECT_THAT(
-      backend->log_lines,
-      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> response="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> future_status="))));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
@@ -237,15 +237,15 @@ TEST(LogWrapper, FutureStatusOrErrorWithContextAndCQ) {
   std::unique_ptr<grpc::ClientContext> context;
   LogWrapper(mock, cq, std::move(context), MakeMutation(), "in-test", {});
 
-  EXPECT_THAT(backend->log_lines,
+  auto const log_lines = backend->ClearLogLines();
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> status="))));
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr("uh-oh"))));
-  EXPECT_THAT(
-      backend->log_lines,
-      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> future_status="))));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
@@ -271,14 +271,14 @@ TEST(LogWrapper, FutureStatusWithContextAndCQ) {
   os << status;
   auto status_as_string = std::move(os).str();
 
-  EXPECT_THAT(backend->log_lines,
+  auto const log_lines = backend->ClearLogLines();
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("),
                              HasSubstr(" >> response=" + status_as_string))));
-  EXPECT_THAT(
-      backend->log_lines,
-      Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> future_status="))));
+  EXPECT_THAT(log_lines, Contains(AllOf(HasSubstr("in-test("),
+                                        HasSubstr(" >> future_status="))));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -63,7 +63,7 @@ TEST_F(PublisherLoggingTest, CreateTopic) {
   topic.set_name("test-topic-name");
   auto status = stub.CreateTopic(context, topic);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("CreateTopic")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateTopic")));
 }
 
 TEST_F(PublisherLoggingTest, GetTopic) {
@@ -76,7 +76,7 @@ TEST_F(PublisherLoggingTest, GetTopic) {
   request.set_topic("test-topic-name");
   auto status = stub.GetTopic(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("GetTopic")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetTopic")));
 }
 
 TEST_F(PublisherLoggingTest, UpdateTopic) {
@@ -89,7 +89,7 @@ TEST_F(PublisherLoggingTest, UpdateTopic) {
   request.mutable_topic()->set_name("test-topic-name");
   auto status = stub.UpdateTopic(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("UpdateTopic")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("UpdateTopic")));
 }
 
 TEST_F(PublisherLoggingTest, ListTopics) {
@@ -104,7 +104,7 @@ TEST_F(PublisherLoggingTest, ListTopics) {
   auto status = stub.ListTopics(context, request);
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->log_lines,
+      backend_->ClearLogLines(),
       Contains(AllOf(HasSubstr("ListTopics"), HasSubstr("test-project-name"))));
 }
 
@@ -118,7 +118,7 @@ TEST_F(PublisherLoggingTest, DeleteTopic) {
   auto status = stub.DeleteTopic(context, request);
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->log_lines,
+      backend_->ClearLogLines(),
       Contains(AllOf(HasSubstr("DeleteTopic"), HasSubstr("test-topic-name"))));
 }
 
@@ -133,7 +133,7 @@ TEST_F(PublisherLoggingTest, DetachSubscription) {
   request.set_subscription("test-subscription-name");
   auto status = stub.DetachSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("DetachSubscription"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -149,7 +149,7 @@ TEST_F(PublisherLoggingTest, ListTopicSubscriptions) {
   request.set_topic("test-topic-name");
   auto status = stub.ListTopicSubscriptions(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("ListTopicSubscriptions"),
                              HasSubstr("test-topic-name"))));
 }
@@ -165,7 +165,7 @@ TEST_F(PublisherLoggingTest, ListTopicSnapshots) {
   request.set_topic("test-topic-name");
   auto status = stub.ListTopicSnapshots(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("ListTopicSnapshots"),
                              HasSubstr("test-topic-name"))));
 }
@@ -188,7 +188,7 @@ TEST_F(PublisherLoggingTest, AsyncPublish) {
           .get();
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->log_lines,
+      backend_->ClearLogLines(),
       Contains(AllOf(HasSubstr("AsyncPublish"), HasSubstr("test-topic-name"))));
 }
 

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -62,7 +62,8 @@ TEST_F(SubscriberLoggingTest, CreateSubscription) {
   google::pubsub::v1::Subscription subscription;
   auto status = stub.CreateSubscription(context, subscription);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("CreateSubscription")));
+  EXPECT_THAT(backend_->ClearLogLines(),
+              Contains(HasSubstr("CreateSubscription")));
 }
 
 TEST_F(SubscriberLoggingTest, GetSubscription) {
@@ -74,7 +75,8 @@ TEST_F(SubscriberLoggingTest, GetSubscription) {
   google::pubsub::v1::GetSubscriptionRequest request;
   auto status = stub.GetSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("GetSubscription")));
+  EXPECT_THAT(backend_->ClearLogLines(),
+              Contains(HasSubstr("GetSubscription")));
 }
 
 TEST_F(SubscriberLoggingTest, UpdateSubscription) {
@@ -86,7 +88,8 @@ TEST_F(SubscriberLoggingTest, UpdateSubscription) {
   google::pubsub::v1::UpdateSubscriptionRequest request;
   auto status = stub.UpdateSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("UpdateSubscription")));
+  EXPECT_THAT(backend_->ClearLogLines(),
+              Contains(HasSubstr("UpdateSubscription")));
 }
 
 TEST_F(SubscriberLoggingTest, ListSubscriptions) {
@@ -100,7 +103,7 @@ TEST_F(SubscriberLoggingTest, ListSubscriptions) {
   request.set_project("test-project-name");
   auto status = stub.ListSubscriptions(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("ListSubscriptions"),
                              HasSubstr("test-project-name"))));
 }
@@ -114,7 +117,7 @@ TEST_F(SubscriberLoggingTest, DeleteSubscription) {
   request.set_subscription("test-subscription-name");
   auto status = stub.DeleteSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("DeleteSubscription"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -128,7 +131,7 @@ TEST_F(SubscriberLoggingTest, ModifyPushConfig) {
   request.set_subscription("test-subscription-name");
   auto status = stub.ModifyPushConfig(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("ModifyPushConfig"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -150,7 +153,7 @@ TEST_F(SubscriberLoggingTest, AsyncPull) {
       stub.AsyncPull(cq, absl::make_unique<grpc::ClientContext>(), request)
           .get();
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("AsyncPull"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -171,7 +174,7 @@ TEST_F(SubscriberLoggingTest, AsyncAcknowledge) {
                         cq, absl::make_unique<grpc::ClientContext>(), request)
                     .get();
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("AsyncAcknowledge"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -192,7 +195,7 @@ TEST_F(SubscriberLoggingTest, AsyncModifyAckDeadline) {
                         cq, absl::make_unique<grpc::ClientContext>(), request)
                     .get();
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("AsyncModifyAckDeadline"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -206,7 +209,7 @@ TEST_F(SubscriberLoggingTest, CreateSnapshot) {
   google::pubsub::v1::CreateSnapshotRequest request;
   auto status = stub.CreateSnapshot(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("CreateSnapshot")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateSnapshot")));
 }
 
 TEST_F(SubscriberLoggingTest, GetSnapshot) {
@@ -218,7 +221,7 @@ TEST_F(SubscriberLoggingTest, GetSnapshot) {
   google::pubsub::v1::GetSnapshotRequest request;
   auto status = stub.GetSnapshot(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("GetSnapshot")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetSnapshot")));
 }
 
 TEST_F(SubscriberLoggingTest, ListSnapshots) {
@@ -232,7 +235,7 @@ TEST_F(SubscriberLoggingTest, ListSnapshots) {
   request.set_project("test-project-name");
   auto status = stub.ListSnapshots(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines,
+  EXPECT_THAT(backend_->ClearLogLines(),
               Contains(AllOf(HasSubstr("ListSnapshots"),
                              HasSubstr("test-project-name"))));
 }
@@ -246,7 +249,7 @@ TEST_F(SubscriberLoggingTest, UpdateSnapshot) {
   google::pubsub::v1::UpdateSnapshotRequest request;
   auto status = stub.UpdateSnapshot(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("UpdateSnapshot")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("UpdateSnapshot")));
 }
 
 TEST_F(SubscriberLoggingTest, DeleteSnapshot) {
@@ -257,7 +260,7 @@ TEST_F(SubscriberLoggingTest, DeleteSnapshot) {
   google::pubsub::v1::DeleteSnapshotRequest request;
   auto status = stub.DeleteSnapshot(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->log_lines, Contains(HasSubstr("DeleteSnapshot")));
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DeleteSnapshot")));
 }
 
 TEST_F(SubscriberLoggingTest, Seek) {
@@ -271,7 +274,7 @@ TEST_F(SubscriberLoggingTest, Seek) {
   auto status = stub.Seek(context, request);
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->log_lines,
+      backend_->ClearLogLines(),
       Contains(AllOf(HasSubstr("Seek"), HasSubstr("test-subscription-name"))));
 }
 

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -114,7 +114,7 @@ TEST(PublisherConnectionTest, Logging) {
           .get();
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("AsyncPublish")));
+  EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("AsyncPublish")));
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -175,8 +175,9 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
   cq.Shutdown();
   t.join();
 
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("AsyncPull")));
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("AsyncAcknowledge")));
+  auto const log_lines = backend->ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncPull")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncAcknowledge")));
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -196,7 +196,8 @@ TEST(SubscriptionAdminConnectionTest, DeleteWithLogging) {
   auto response = subscription_admin->DeleteSubscription({subscription});
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("DeleteSubscription")));
+  EXPECT_THAT(backend->ClearLogLines(),
+              Contains(HasSubstr("DeleteSubscription")));
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 
@@ -224,7 +225,8 @@ TEST(SubscriptionAdminConnectionTest, ModifyPushConfig) {
   auto response = subscription_admin->ModifyPushConfig({request});
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("ModifyPushConfig")));
+  EXPECT_THAT(backend->ClearLogLines(),
+              Contains(HasSubstr("ModifyPushConfig")));
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -178,7 +178,7 @@ TEST(TopicAdminConnectionTest, DeleteWithLogging) {
   auto response = topic_admin->DeleteTopic({topic});
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("DeleteTopic")));
+  EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("DeleteTopic")));
   google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -51,9 +51,7 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  void HasLogLineWith(std::string const& contents) {
-    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
-  }
+  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
 
   std::shared_ptr<spanner_testing::MockDatabaseAdminStub> mock_;
 
@@ -71,8 +69,9 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   auto status = stub.CreateDatabase(context, gcsa::CreateDatabaseRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("CreateDatabase");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("CreateDatabase")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetDatabase) {
@@ -84,8 +83,9 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabase) {
   auto response = stub.GetDatabase(context, gcsa::GetDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("GetDatabase");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabase")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
@@ -97,8 +97,9 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
   auto response = stub.GetDatabaseDdl(context, gcsa::GetDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("GetDatabaseDdl");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabaseDdl")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
@@ -110,8 +111,9 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   auto status = stub.UpdateDatabase(context, gcsa::UpdateDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("UpdateDatabase");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateDatabase")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, DropDatabase) {
@@ -123,8 +125,9 @@ TEST_F(DatabaseAdminLoggingTest, DropDatabase) {
   auto status = stub.DropDatabase(context, gcsa::DropDatabaseRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  HasLogLineWith("DropDatabase");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("DropDatabase")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
@@ -136,8 +139,9 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
   auto response = stub.ListDatabases(context, gcsa::ListDatabasesRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("ListDatabases");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListDatabases")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
@@ -149,8 +153,9 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   auto status = stub.RestoreDatabase(context, gcsa::RestoreDatabaseRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("RestoreDatabase");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("RestoreDatabase")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetIamPolicy) {
@@ -163,8 +168,9 @@ TEST_F(DatabaseAdminLoggingTest, GetIamPolicy) {
       stub.GetIamPolicy(context, google::iam::v1::GetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("GetIamPolicy");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetIamPolicy")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, SetIamPolicy) {
@@ -177,8 +183,9 @@ TEST_F(DatabaseAdminLoggingTest, SetIamPolicy) {
       stub.SetIamPolicy(context, google::iam::v1::SetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("SetIamPolicy");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("SetIamPolicy")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
@@ -192,8 +199,9 @@ TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
       context, google::iam::v1::TestIamPermissionsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("TestIamPermissions");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("TestIamPermissions")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
@@ -205,8 +213,9 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   auto status = stub.CreateBackup(context, gcsa::CreateBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("CreateBackup");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("CreateBackup")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetBackup) {
@@ -218,8 +227,9 @@ TEST_F(DatabaseAdminLoggingTest, GetBackup) {
   auto status = stub.GetBackup(context, gcsa::GetBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("GetBackup");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetBackup")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, DeleteBackup) {
@@ -231,8 +241,9 @@ TEST_F(DatabaseAdminLoggingTest, DeleteBackup) {
   auto status = stub.DeleteBackup(context, gcsa::DeleteBackupRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  HasLogLineWith("DeleteBackup");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteBackup")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListBackups) {
@@ -244,8 +255,9 @@ TEST_F(DatabaseAdminLoggingTest, ListBackups) {
   auto response = stub.ListBackups(context, gcsa::ListBackupsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("ListBackups");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListBackups")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, UpdateBackup) {
@@ -257,8 +269,9 @@ TEST_F(DatabaseAdminLoggingTest, UpdateBackup) {
   auto status = stub.UpdateBackup(context, gcsa::UpdateBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("UpdateBackup");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateBackup")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListBackupOperations) {
@@ -272,8 +285,9 @@ TEST_F(DatabaseAdminLoggingTest, ListBackupOperations) {
       stub.ListBackupOperations(context, gcsa::ListBackupOperationsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("ListBackupOperations");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListBackupOperations")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
@@ -287,8 +301,9 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
       context, gcsa::ListDatabaseOperationsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("ListDatabaseOperations");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListDatabaseOperations")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetOperation) {
@@ -301,8 +316,9 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
       stub.GetOperation(context, google::longrunning::GetOperationRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("GetOperation");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetOperation")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
@@ -315,8 +331,9 @@ TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
       context, google::longrunning::CancelOperationRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  HasLogLineWith("CancelOperation");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("CancelOperation")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -51,9 +51,7 @@ class InstanceAdminLoggingTest : public ::testing::Test {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  void HasLogLineWith(std::string const& contents) {
-    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
-  }
+  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
 
   std::shared_ptr<spanner_testing::MockInstanceAdminStub> mock_;
 
@@ -71,8 +69,9 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
   auto response = stub.GetInstance(context, gcsa::GetInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("GetInstance");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetInstance")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, CreateInstance) {
@@ -84,8 +83,9 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   auto response = stub.CreateInstance(context, gcsa::CreateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("CreateInstance");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("CreateInstance")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
@@ -97,8 +97,9 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   auto response = stub.UpdateInstance(context, gcsa::UpdateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("UpdateInstance");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateInstance")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
@@ -110,8 +111,9 @@ TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
   auto status = stub.DeleteInstance(context, gcsa::DeleteInstanceRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  HasLogLineWith("DeleteInstance");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteInstance")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
@@ -125,8 +127,9 @@ TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
       stub.GetInstanceConfig(context, gcsa::GetInstanceConfigRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("GetInstanceConfig");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetInstanceConfig")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, ListInstanceConfigs) {
@@ -140,8 +143,9 @@ TEST_F(InstanceAdminLoggingTest, ListInstanceConfigs) {
       stub.ListInstanceConfigs(context, gcsa::ListInstanceConfigsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("ListInstanceConfigs");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstanceConfigs")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, ListInstances) {
@@ -153,8 +157,9 @@ TEST_F(InstanceAdminLoggingTest, ListInstances) {
   auto response = stub.ListInstances(context, gcsa::ListInstancesRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("ListInstances");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstances")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, GetIamPolicy) {
@@ -167,8 +172,9 @@ TEST_F(InstanceAdminLoggingTest, GetIamPolicy) {
       stub.GetIamPolicy(context, google::iam::v1::GetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("GetIamPolicy");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetIamPolicy")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, SetIamPolicy) {
@@ -181,8 +187,9 @@ TEST_F(InstanceAdminLoggingTest, SetIamPolicy) {
       stub.SetIamPolicy(context, google::iam::v1::SetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("SetIamPolicy");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("SetIamPolicy")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(InstanceAdminLoggingTest, TestIamPermissions) {
@@ -196,8 +203,9 @@ TEST_F(InstanceAdminLoggingTest, TestIamPermissions) {
       context, google::iam::v1::TestIamPermissionsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  HasLogLineWith("TestIamPermissions");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("TestIamPermissions")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -80,8 +80,6 @@ TEST_F(LoggingResultSetReaderTest, Read) {
   EXPECT_THAT(log_lines, Contains(HasSubstr("Read")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("test-token")));
 
-  // Clear previous captured lines to ensure the following checks for new
-  // messages.
   result = reader.Read();
   ASSERT_FALSE(result.has_value());
   log_lines = ClearLogLines();

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -51,9 +51,7 @@ class LoggingSpannerStubTest : public ::testing::Test {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  void HasLogLineWith(std::string const& contents) {
-    EXPECT_THAT(backend_->log_lines, Contains(HasSubstr(contents)));
-  }
+  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
 
   std::shared_ptr<spanner_testing::MockSpannerStub> mock_;
 
@@ -80,8 +78,9 @@ TEST_F(LoggingSpannerStubTest, CreateSessionSuccess) {
       stub.CreateSession(context, spanner_proto::CreateSessionRequest());
   EXPECT_STATUS_OK(status);
 
-  HasLogLineWith("CreateSession");
-  HasLogLineWith("test-session-name");
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("CreateSession")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr("test-session-name")));
 }
 
 TEST_F(LoggingSpannerStubTest, CreateSession) {
@@ -93,8 +92,9 @@ TEST_F(LoggingSpannerStubTest, CreateSession) {
       stub.CreateSession(context, spanner_proto::CreateSessionRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("CreateSession");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("CreateSession")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, BatchCreateSessions) {
@@ -107,8 +107,9 @@ TEST_F(LoggingSpannerStubTest, BatchCreateSessions) {
       context, spanner_proto::BatchCreateSessionsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  HasLogLineWith("BatchCreateSessions");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("BatchCreateSessions")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, GetSession) {
@@ -118,8 +119,10 @@ TEST_F(LoggingSpannerStubTest, GetSession) {
   grpc::ClientContext context;
   auto status = stub.GetSession(context, spanner_proto::GetSessionRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("GetSession");
-  HasLogLineWith(TransientError().message());
+
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("GetSession")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, ListSessions) {
@@ -130,8 +133,10 @@ TEST_F(LoggingSpannerStubTest, ListSessions) {
   auto status =
       stub.ListSessions(context, spanner_proto::ListSessionsRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("ListSessions");
-  HasLogLineWith(TransientError().message());
+
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ListSessions")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, DeleteSession) {
@@ -142,8 +147,9 @@ TEST_F(LoggingSpannerStubTest, DeleteSession) {
   auto status =
       stub.DeleteSession(context, spanner_proto::DeleteSessionRequest());
   EXPECT_EQ(TransientError(), status);
-  HasLogLineWith("DeleteSession");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteSession")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, ExecuteSql) {
@@ -153,8 +159,9 @@ TEST_F(LoggingSpannerStubTest, ExecuteSql) {
   grpc::ClientContext context;
   auto status = stub.ExecuteSql(context, spanner_proto::ExecuteSqlRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("ExecuteSql");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ExecuteSql")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, ExecuteStreamingSql) {
@@ -169,8 +176,9 @@ TEST_F(LoggingSpannerStubTest, ExecuteStreamingSql) {
   grpc::ClientContext context;
   auto status =
       stub.ExecuteStreamingSql(context, spanner_proto::ExecuteSqlRequest());
-  HasLogLineWith("ExecuteStreamingSql");
-  HasLogLineWith(" null stream");
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ExecuteStreamingSql")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(" null stream")));
 }
 
 TEST_F(LoggingSpannerStubTest, ExecuteBatchDml) {
@@ -181,8 +189,9 @@ TEST_F(LoggingSpannerStubTest, ExecuteBatchDml) {
   auto status =
       stub.ExecuteBatchDml(context, spanner_proto::ExecuteBatchDmlRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("ExecuteBatchDml");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("ExecuteBatchDml")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, StreamingRead) {
@@ -195,8 +204,9 @@ TEST_F(LoggingSpannerStubTest, StreamingRead) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status = stub.StreamingRead(context, spanner_proto::ReadRequest());
-  HasLogLineWith("StreamingRead");
-  HasLogLineWith(" null stream");
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("StreamingRead")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr("null stream")));
 }
 
 TEST_F(LoggingSpannerStubTest, BeginTransaction) {
@@ -208,8 +218,9 @@ TEST_F(LoggingSpannerStubTest, BeginTransaction) {
   auto status =
       stub.BeginTransaction(context, spanner_proto::BeginTransactionRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("BeginTransaction");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("BeginTransaction")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, Commit) {
@@ -219,8 +230,9 @@ TEST_F(LoggingSpannerStubTest, Commit) {
   grpc::ClientContext context;
   auto status = stub.Commit(context, spanner_proto::CommitRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("Commit");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("Commit")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, Rollback) {
@@ -230,8 +242,9 @@ TEST_F(LoggingSpannerStubTest, Rollback) {
   grpc::ClientContext context;
   auto status = stub.Rollback(context, spanner_proto::RollbackRequest());
   EXPECT_EQ(TransientError(), status);
-  HasLogLineWith("Rollback");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("Rollback")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, PartitionQuery) {
@@ -242,8 +255,9 @@ TEST_F(LoggingSpannerStubTest, PartitionQuery) {
   auto status =
       stub.PartitionQuery(context, spanner_proto::PartitionQueryRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("PartitionQuery");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("PartitionQuery")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 TEST_F(LoggingSpannerStubTest, PartitionRead) {
@@ -254,8 +268,9 @@ TEST_F(LoggingSpannerStubTest, PartitionRead) {
   auto status =
       stub.PartitionRead(context, spanner_proto::PartitionReadRequest());
   EXPECT_EQ(TransientError(), status.status());
-  HasLogLineWith("PartitionRead");
-  HasLogLineWith(TransientError().message());
+  auto const log_lines = ClearLogLines();
+  EXPECT_THAT(log_lines, Contains(HasSubstr("PartitionRead")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -56,7 +56,7 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
               AnyOf(StatusCode::kUnavailable, StatusCode::kInvalidArgument,
                     StatusCode::kDeadlineExceeded));
 
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(backend->ClearLogLines(),
               Contains(HasSubstr(session.status().message())));
 
   google::cloud::LogSink::Instance().RemoveBackend(id);

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -69,7 +69,7 @@ TEST_F(LoggingResumableUploadSessionTest, UploadChunk) {
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_EQ("uh oh", result.status().message());
 
-  EXPECT_THAT(log_backend_->log_lines,
+  EXPECT_THAT(log_backend_->ClearLogLines(),
               ContainsOnce(HasSubstr("[UNAVAILABLE]")));
 }
 
@@ -91,11 +91,10 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_EQ("uh oh", result.status().message());
 
-  EXPECT_THAT(
-      log_backend_->log_lines,
-      ContainsOnce(HasSubstr("upload_size=" + std::to_string(513 * 1024))));
-  EXPECT_THAT(log_backend_->log_lines,
-              ContainsOnce(HasSubstr("[UNAVAILABLE]")));
+  auto const log_lines = log_backend_->ClearLogLines();
+  EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("upload_size=" +
+                                                std::to_string(513 * 1024))));
+  EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("[UNAVAILABLE]")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
@@ -112,7 +111,7 @@ TEST_F(LoggingResumableUploadSessionTest, ResetSession) {
   EXPECT_EQ(StatusCode::kFailedPrecondition, result.status().code());
   EXPECT_EQ("uh oh", result.status().message());
 
-  EXPECT_THAT(log_backend_->log_lines,
+  EXPECT_THAT(log_backend_->ClearLogLines(),
               ContainsOnce(HasSubstr("[FAILED_PRECONDITION]")));
 }
 
@@ -128,7 +127,7 @@ TEST_F(LoggingResumableUploadSessionTest, NextExpectedByte) {
   auto result = session.next_expected_byte();
   EXPECT_EQ(512 * 1024, result);
 
-  EXPECT_THAT(log_backend_->log_lines,
+  EXPECT_THAT(log_backend_->ClearLogLines(),
               ContainsOnce(HasSubstr(std::to_string(512 * 1024))));
 }
 
@@ -144,8 +143,9 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseOk) {
   auto result = session.last_response();
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result.value(), last_response.value());
-  EXPECT_THAT(log_backend_->log_lines, ContainsOnce(HasSubstr("upload url")));
-  EXPECT_THAT(log_backend_->log_lines, ContainsOnce(HasSubstr("payload={}")));
+  auto const log_lines = log_backend_->ClearLogLines();
+  EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("upload url")));
+  EXPECT_THAT(log_lines, ContainsOnce(HasSubstr("payload={}")));
 }
 
 TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
@@ -161,7 +161,7 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
   EXPECT_EQ(StatusCode::kFailedPrecondition, result.status().code());
   EXPECT_EQ("something bad", result.status().message());
 
-  EXPECT_THAT(log_backend_->log_lines,
+  EXPECT_THAT(log_backend_->ClearLogLines(),
               ContainsOnce(HasSubstr("[FAILED_PRECONDITION]")));
 }
 

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -168,7 +168,8 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines, Contains(StartsWith("x-goog-hash: crc32c=")));
+  EXPECT_THAT(backend->ClearLogLines(),
+              Contains(StartsWith("x-goog-hash: crc32c=")));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
   EXPECT_STATUS_OK(status);
@@ -196,7 +197,7 @@ TEST_F(ObjectChecksumIntegrationTest, DefaultCrc32cInsertJSON) {
   // Unfortunately I (@coryan) cannot think of a way to examine the upload
   // contents.
   EXPECT_THAT(
-      backend->log_lines,
+      backend->ClearLogLines(),
       Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -358,7 +358,8 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
   ASSERT_STATUS_OK(meta);
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines, Contains(HasSubstr("not a regular file")));
+  EXPECT_THAT(backend->ClearLogLines(),
+              Contains(HasSubstr("not a regular file")));
 
   t.join();
   auto status = client->DeleteObject(bucket_name_, object_name);

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -63,7 +63,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(backend->ClearLogLines(),
               Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
@@ -92,7 +92,7 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
   // Unfortunately I (@coryan) cannot think of a way to examine the upload
   // contents.
   EXPECT_THAT(
-      backend->log_lines,
+      backend->ClearLogLines(),
       Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {
@@ -124,7 +124,7 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(backend->ClearLogLines(),
               Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
@@ -154,7 +154,7 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
   // Unfortunately I (@coryan) cannot think of a way to examine the upload
   // contents.
   EXPECT_THAT(
-      backend->log_lines,
+      backend->ClearLogLines(),
       Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_testbench_upload")) {

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -558,7 +558,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(backend->ClearLogLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("quotaUser=test-quota-user"))));
@@ -593,7 +593,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(backend->ClearLogLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("userIp=127.0.0.1"))));
@@ -640,7 +640,7 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
 
   LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->log_lines,
+  EXPECT_THAT(backend->ClearLogLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("userIp="))));

--- a/google/cloud/testing_util/capture_log_lines_backend.cc
+++ b/google/cloud/testing_util/capture_log_lines_backend.cc
@@ -20,9 +20,11 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
 std::vector<std::string> CaptureLogLinesBackend::ClearLogLines() {
-  std::lock_guard<std::mutex> lk(mu_);
-  auto result = std::move(log_lines_);
-  log_lines_.clear();
+  std::vector<std::string> result;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    result.swap(log_lines_);
+  }
   return result;
 }
 

--- a/google/cloud/testing_util/capture_log_lines_backend.cc
+++ b/google/cloud/testing_util/capture_log_lines_backend.cc
@@ -19,12 +19,20 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
+std::vector<std::string> CaptureLogLinesBackend::ClearLogLines() {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto result = std::move(log_lines_);
+  log_lines_.clear();
+  return result;
+}
+
 void CaptureLogLinesBackend::Process(LogRecord const& lr) {
   // Break the records in lines, it is easier to analyze them as such.
   std::istringstream is(lr.message);
   std::string line;
+  std::lock_guard<std::mutex> lk(mu_);
   while (std::getline(is, line)) {
-    log_lines.emplace_back(line);
+    log_lines_.emplace_back(line);
   }
 }
 

--- a/google/cloud/testing_util/capture_log_lines_backend.h
+++ b/google/cloud/testing_util/capture_log_lines_backend.h
@@ -30,10 +30,14 @@ namespace testing_util {
  */
 class CaptureLogLinesBackend : public LogBackend {
  public:
-  std::vector<std::string> log_lines;
+  std::vector<std::string> ClearLogLines();
 
   void Process(LogRecord const& lr) override;
   void ProcessWithOwnership(LogRecord lr) override;
+
+ private:
+  std::mutex mu_;
+  std::vector<std::string> log_lines_;
 };
 
 }  // namespace testing_util


### PR DESCRIPTION
For Cloud Pub/Sub I need `CaptureLogLinesBackend` to be thread-safe.
Cloud Pub/Sub launches (and uses) multiple threads behind the scenes,
and TSAN detected some racy code in the tests. Most of our tests are
single-threaded, and could get away with a thread-unsafe backend, I
guess the happy days are over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4987)
<!-- Reviewable:end -->
