### PR TITLE
refactor(pubsub): split SubscriptionSession [4]

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
     pubsub_client # cmake-format: sort
     ack_handler.cc
     ack_handler.h
+    application_callback.h
     backoff_policy.h
     connection_options.cc
     connection_options.h
@@ -58,6 +59,8 @@ add_library(
     internal/subscriber_stub.cc
     internal/subscriber_stub.h
     internal/subscription_batch_source.h
+    internal/subscription_concurrency_control.cc
+    internal/subscription_concurrency_control.h
     internal/subscription_flow_control.cc
     internal/subscription_flow_control.h
     internal/subscription_lease_management.cc
@@ -167,6 +170,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         testing/mock_publisher_stub.h
         testing/mock_subscriber_stub.h
         testing/mock_subscription_batch_source.h
+        testing/mock_subscription_message_source.h
         testing/random_names.cc
         testing/random_names.h
         testing/test_retry_policies.cc

--- a/google/cloud/pubsub/application_callback.h
+++ b/google/cloud/pubsub/application_callback.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_APPLICATION_CALLBACK_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_APPLICATION_CALLBACK_H
+
+#include "google/cloud/pubsub/version.h"
+#include <functional>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+class Message;
+class AckHandler;
+
+/**
+ * Defines the interface for application-level callbacks.
+ *
+ * Applications provide a callable compatible with this type to receive
+ * messages.  They acknowledge (or reject) messages using `AckHandler`. This is
+ * a move-only type to support asynchronously acknowledgements.
+ */
+using ApplicationCallback = std::function<void(Message, AckHandler)>;
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_APPLICATION_CALLBACK_H

--- a/google/cloud/pubsub/internal/session_shutdown_manager.h
+++ b/google/cloud/pubsub/internal/session_shutdown_manager.h
@@ -54,6 +54,12 @@ class SessionShutdownManager {
   ~SessionShutdownManager();
 
   /// Set the promise to signal when the shutdown has completed.
+  future<Status> Start(promise<Status> p) {
+    done_ = std::move(p);
+    return done_.get_future();
+  }
+
+  // TODO(#4790) - remove old overload.
   future<Status> Start() { return done_.get_future(); }
 
   /**

--- a/google/cloud/pubsub/internal/subscription_concurrency_control.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control.cc
@@ -1,0 +1,129 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/internal/subscription_concurrency_control.h"
+#include "google/cloud/pubsub/ack_handler.h"
+#include "google/cloud/log.h"
+#include "absl/memory/memory.h"
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+class AckHandlerImpl : public pubsub::AckHandler::Impl {
+ public:
+  explicit AckHandlerImpl(
+      std::shared_ptr<SubscriptionConcurrencyControl> const& source,
+      std::string ack_id, std::int32_t delivery_attempt,
+      std::size_t message_size)
+      : source_(source),
+        ack_id_(std::move(ack_id)),
+        delivery_attempt_(delivery_attempt),
+        message_size_(message_size) {}
+  ~AckHandlerImpl() override = default;
+
+  void ack() override {
+    if (auto s = source_.lock()) s->AckMessage(ack_id_, message_size_);
+  }
+  void nack() override {
+    if (auto s = source_.lock()) s->NackMessage(ack_id_, message_size_);
+  }
+  std::string ack_id() const override { return ack_id_; }
+  std::int32_t delivery_attempt() const override { return delivery_attempt_; }
+
+ private:
+  std::weak_ptr<SubscriptionConcurrencyControl> source_;
+  std::string ack_id_;
+  std::int32_t delivery_attempt_;
+  std::size_t message_size_;
+};
+
+}  // namespace
+
+void SubscriptionConcurrencyControl::Start(pubsub::ApplicationCallback cb) {
+  std::unique_lock<std::mutex> lk(mu_);
+  if (callback_) return;
+  callback_ = std::move(cb);
+  std::weak_ptr<SubscriptionConcurrencyControl> weak = shared_from_this();
+  source_->Start([weak](google::pubsub::v1::ReceivedMessage r) {
+    if (auto self = weak.lock()) self->OnMessage(std::move(r));
+  });
+  if (total_messages() >= message_count_hwm_) return;
+  auto const read_count = message_count_hwm_ - total_messages();
+  messages_requested_ = read_count;
+  if (total_messages() >= message_count_hwm_) overflow_ = true;
+  lk.unlock();
+  source_->Read(read_count);
+}
+
+void SubscriptionConcurrencyControl::Shutdown() {
+  shutdown_manager_->MarkAsShutdown(__func__, {});
+  source_->Shutdown();
+}
+
+void SubscriptionConcurrencyControl::AckMessage(std::string const& ack_id,
+                                                std::size_t size) {
+  source_->AckMessage(ack_id, size);
+  MessageHandled();
+}
+
+void SubscriptionConcurrencyControl::NackMessage(std::string const& ack_id,
+                                                 std::size_t size) {
+  source_->NackMessage(ack_id, size);
+  MessageHandled();
+}
+
+void SubscriptionConcurrencyControl::MessageHandled() {
+  if (shutdown_manager_->FinishedOperation("callback")) return;
+  std::unique_lock<std::mutex> lk(mu_);
+  --message_count_;
+  if (total_messages() <= message_count_lwm_) {
+    auto const read_count = message_count_hwm_ - total_messages();
+    messages_requested_ += read_count;
+    lk.unlock();
+    source_->Read(read_count);
+  }
+}
+
+void SubscriptionConcurrencyControl::OnMessage(
+    google::pubsub::v1::ReceivedMessage m) {
+  std::unique_lock<std::mutex> lk(mu_);
+  if (messages_requested_ > 0) --messages_requested_;
+  ++message_count_;
+  if (total_messages() >= message_count_hwm_) overflow_ = true;
+  lk.unlock();
+
+  struct MoveCapture {
+    pubsub::ApplicationCallback callback;
+    pubsub::Message m;
+    std::unique_ptr<AckHandlerImpl> h;
+    void operator()() {
+      GCP_LOG(DEBUG) << "calling callback(" << h->ack_id() << ")";
+      callback(std::move(m), pubsub::AckHandler(std::move(h)));
+    }
+  };
+  auto handler = absl::make_unique<AckHandlerImpl>(
+      shared_from_this(), std::move(*m.mutable_ack_id()), m.delivery_attempt(),
+      MessageProtoSize(m.message()));
+  auto message = FromProto(std::move(*m.mutable_message()));
+  shutdown_manager_->StartAsyncOperation(
+      __func__, "callback", cq_,
+      MoveCapture{callback_, std::move(message), std::move(handler)});
+}
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/internal/subscription_concurrency_control.h
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control.h
@@ -1,0 +1,87 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIPTION_CONCURRENCY_CONTROL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIPTION_CONCURRENCY_CONTROL_H
+
+#include "google/cloud/pubsub/application_callback.h"
+#include "google/cloud/pubsub/internal/session_shutdown_manager.h"
+#include "google/cloud/pubsub/internal/subscription_message_source.h"
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/version.h"
+#include <chrono>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+class SubscriptionConcurrencyControl
+    : public std::enable_shared_from_this<SubscriptionConcurrencyControl> {
+ public:
+  static std::shared_ptr<SubscriptionConcurrencyControl> Create(
+      google::cloud::CompletionQueue cq,
+      std::shared_ptr<SessionShutdownManager> shutdown_manager,
+      std::shared_ptr<SubscriptionMessageSource> source,
+      std::size_t message_count_lwm, std::size_t message_count_hwm) {
+    return std::shared_ptr<SubscriptionConcurrencyControl>(
+        new SubscriptionConcurrencyControl(
+            std::move(cq), std::move(shutdown_manager), std::move(source),
+            message_count_lwm, message_count_hwm));
+  }
+
+  void Start(pubsub::ApplicationCallback);
+  void Shutdown();
+  void AckMessage(std::string const& ack_id, std::size_t size);
+  void NackMessage(std::string const& ack_id, std::size_t size);
+
+ private:
+  SubscriptionConcurrencyControl(
+      google::cloud::CompletionQueue cq,
+      std::shared_ptr<SessionShutdownManager> shutdown_manager,
+      std::shared_ptr<SubscriptionMessageSource> source,
+      std::size_t message_count_lwm, std::size_t message_count_hwm)
+      : cq_(std::move(cq)),
+        shutdown_manager_(std::move(shutdown_manager)),
+        source_(std::move(source)),
+        message_count_lwm_((std::min)(message_count_lwm, message_count_hwm)),
+        message_count_hwm_(message_count_hwm) {}
+
+  void MessageHandled();
+  void OnMessage(google::pubsub::v1::ReceivedMessage m);
+
+  std::size_t total_messages() const {
+    return message_count_ + messages_requested_;
+  }
+
+  google::cloud::CompletionQueue cq_;
+  std::shared_ptr<SessionShutdownManager> const shutdown_manager_;
+  std::shared_ptr<SubscriptionMessageSource> const source_;
+  std::size_t const message_count_lwm_;
+  std::size_t const message_count_hwm_;
+
+  std::mutex mu_;
+  pubsub::ApplicationCallback callback_;
+  bool overflow_ = false;
+  std::size_t message_count_ = 0;
+  std::size_t messages_requested_ = 0;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIPTION_CONCURRENCY_CONTROL_H

--- a/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
@@ -49,9 +49,10 @@ class SubscriptionConcurrencyControlTest : public ::testing::Test {
       messages_.push_back(std::move(m));
     }
   }
-  void PushMessages(MessageCallback const& cb, std::int32_t n) {
+
+  void PushMessages(MessageCallback const& cb, std::size_t n) {
     std::unique_lock<std::mutex> lk(messages_mu_);
-    for (std::int32_t i = 0; i != n && !messages_.empty(); ++i) {
+    for (std::size_t i = 0; i != n && !messages_.empty(); ++i) {
       auto m = std::move(messages_.front());
       messages_.pop_front();
       lk.unlock();
@@ -71,7 +72,7 @@ TEST_F(SubscriptionConcurrencyControlTest, MessageLifecycle) {
       std::make_shared<pubsub_testing::MockSubscriptionMessageSource>();
   MessageCallback message_callback;
   auto push_messages = [&](std::size_t n) {
-    PushMessages(message_callback, static_cast<std::int32_t>(n));
+    PushMessages(message_callback, n);
   };
   PrepareMessages("ack-0-", 2);
   PrepareMessages("ack-1-", 3);
@@ -150,7 +151,7 @@ TEST_F(SubscriptionConcurrencyControlTest, ParallelCallbacks) {
   PrepareMessages("ack-0-", 8);
   PrepareMessages("ack-1-", 8);
   auto push_messages = [&](std::size_t n) {
-    PushMessages(message_callback, static_cast<std::int32_t>(n));
+    PushMessages(message_callback, n);
   };
   {
     ::testing::InSequence sequence;
@@ -231,7 +232,7 @@ TEST_F(SubscriptionConcurrencyControlTest, ParallelCallbacksRespectHwmLimit) {
   PrepareMessages("ack-0-", kCallbackCount);
   PrepareMessages("ack-1-", 8);
   auto push_messages = [&](std::size_t n) {
-    PushMessages(message_callback, static_cast<std::int32_t>(n));
+    PushMessages(message_callback, n);
   };
   {
     ::testing::InSequence sequence;
@@ -315,7 +316,7 @@ TEST_F(SubscriptionConcurrencyControlTest, CleanShutdown) {
   PrepareMessages("ack-0-", kTestDoneThreshold + 1);
   PrepareMessages("ack-1-", kTestDoneThreshold);
   auto push_messages = [&](std::size_t n) {
-    PushMessages(message_callback, static_cast<std::int32_t>(n));
+    PushMessages(message_callback, n);
   };
   {
     ::testing::InSequence sequence;
@@ -373,7 +374,7 @@ TEST_F(SubscriptionConcurrencyControlTest, MessageContents) {
       std::make_shared<pubsub_testing::MockSubscriptionMessageSource>();
   MessageCallback message_callback;
   auto push_messages = [&](std::size_t n) {
-    PushMessages(message_callback, static_cast<std::int32_t>(n));
+    PushMessages(message_callback, n);
   };
   PrepareMessages("ack-0-", 3);
   PrepareMessages("ack-1-", 2);

--- a/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/pubsub/internal/subscription_concurrency_control.h"
 #include "google/cloud/pubsub/internal/subscription_session.h"
-#include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
+#include "google/cloud/pubsub/testing/mock_subscription_message_source.h"
 #include "google/cloud/log.h"
-#include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/mock_completion_queue.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
-#include <thread>
-#include <vector>
 
 namespace google {
 namespace cloud {
@@ -31,190 +29,337 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::StartsWith;
 
-/// @test Verify session can schedule parallel callbacks.
-TEST(SubscriptionConcurrentControlTest, ScheduleParallelCallbacks) {
-  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
-  pubsub::Subscription const subscription("test-project", "test-subscription");
-
-  std::mutex mu;
-  int count = 0;
-  auto constexpr kTestHwm = 4;
-  auto constexpr kBatchSize = 2 * kTestHwm;
-
-  auto generate = [&](google::cloud::CompletionQueue&,
-                      std::unique_ptr<grpc::ClientContext>,
-                      google::pubsub::v1::PullRequest const& request) {
-    EXPECT_EQ(subscription.FullName(), request.subscription());
-    google::pubsub::v1::PullResponse response;
-    for (int i = 0; i != kBatchSize; ++i) {
-      auto& m = *response.add_received_messages();
-      std::lock_guard<std::mutex> lk(mu);
-      m.set_ack_id("test-ack-id-" + std::to_string(count));
-      m.mutable_message()->set_message_id("test-message-id-" +
-                                          std::to_string(count));
-      ++count;
+class SubscriptionConcurrencyControlTest : public ::testing::Test {
+ protected:
+  void PrepareMessages(std::string const& prefix, int n) {
+    std::unique_lock<std::mutex> lk(messages_mu_);
+    for (int i = 0; i != n; ++i) {
+      google::pubsub::v1::ReceivedMessage m;
+      m.set_ack_id(prefix + std::to_string(i));
+      messages_.push_back(std::move(m));
     }
-    return make_ready_future(make_status_or(response));
-  };
-
-  EXPECT_CALL(*mock, AsyncPull).Times(AtLeast(1)).WillRepeatedly(generate);
-  EXPECT_CALL(*mock, AsyncAcknowledge)
-      .Times(AtLeast(kBatchSize))
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
-                         google::pubsub::v1::AcknowledgeRequest const&) {
-        return make_ready_future(Status{});
-      });
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
-                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
-        return make_ready_future(Status{});
-      });
-
-  google::cloud::CompletionQueue cq;
-  std::vector<std::thread> tasks;
-  std::generate_n(std::back_inserter(tasks), 4,
-                  [&] { return std::thread([&cq] { cq.Run(); }); });
-
-  std::mutex handlers_mu;
-  std::condition_variable handlers_cv;
-  std::deque<pubsub::AckHandler> handlers;
-  auto handler = [&](pubsub::Message const&, pubsub::AckHandler h) {
-    std::lock_guard<std::mutex> lk(handlers_mu);
-    handlers.push_back(std::move(h));
-    auto const m = static_cast<std::size_t>(kTestHwm);
-    if (handlers.size() >= m) handlers_cv.notify_one();
-  };
-
-  auto session = SubscriptionSession::Create(
-      mock, cq,
-      {subscription.FullName(), handler,
-       pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, kTestHwm)});
-  auto response = session->Start();
-
-  auto ack_current = [&](std::unique_lock<std::mutex> lk) {
-    std::deque<pubsub::AckHandler> tmp;
-    tmp.swap(handlers);
-    lk.unlock();
-    for (auto& h : tmp) std::move(h).ack();
-  };
-  for (auto i = 0; i != kBatchSize / kTestHwm; ++i) {
-    std::unique_lock<std::mutex> lk(handlers_mu);
-    auto const m = static_cast<std::size_t>(kTestHwm);
-    handlers_cv.wait(lk, [&] { return handlers.size() >= m; });
-    ack_current(std::move(lk));
+  }
+  void PushMessages(MessageCallback const& cb, std::int32_t n) {
+    std::unique_lock<std::mutex> lk(messages_mu_);
+    for (std::int32_t i = 0; i != n && !messages_.empty(); ++i) {
+      auto m = std::move(messages_.front());
+      messages_.pop_front();
+      lk.unlock();
+      cb(std::move(m));
+      lk.lock();
+    }
   }
 
-  response.cancel();
-  ack_current(std::unique_lock<std::mutex>(handlers_mu));
-  EXPECT_STATUS_OK(response.get());
+ private:
+  std::mutex messages_mu_;
+  std::deque<google::pubsub::v1::ReceivedMessage> messages_;
+};
 
-  cq.Shutdown();
-  for (auto& t : tasks) t.join();
+/// @test Verify SubscriptionConcurrencyControl works in the simple case.
+TEST_F(SubscriptionConcurrencyControlTest, MessageLifecycle) {
+  auto source =
+      std::make_shared<pubsub_testing::MockSubscriptionMessageSource>();
+  MessageCallback message_callback;
+  auto push_messages = [&](std::size_t n) {
+    PushMessages(message_callback, static_cast<std::int32_t>(n));
+  };
+  PrepareMessages("ack-0-", 2);
+  PrepareMessages("ack-1-", 3);
+  EXPECT_CALL(*source, Shutdown).Times(1);
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*source, Start)
+        .WillOnce([&message_callback](MessageCallback cb) {
+          message_callback = std::move(cb);
+        });
+    EXPECT_CALL(*source, Read(1))
+        .Times(AtLeast(5))
+        .WillRepeatedly(push_messages);
+  }
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*source, AckMessage("ack-0-0", _));
+    EXPECT_CALL(*source, NackMessage("ack-0-1", _));
+    EXPECT_CALL(*source, AckMessage("ack-1-0", _));
+    EXPECT_CALL(*source, NackMessage("ack-1-1", _));
+    EXPECT_CALL(*source, NackMessage("ack-1-2", _));
+  }
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+
+  // Create the unit under test, configured to run 1 event at a time, this makes
+  // it easier to setup expectations.
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+
+  auto uut = SubscriptionConcurrencyControl::Create(
+      background.cq(), shutdown, source, /*message_count_lwm=*/0,
+      /*message_count_hwm=*/1);
+
+  std::mutex handler_mu;
+  std::condition_variable handler_cv;
+  std::deque<pubsub::AckHandler> ack_handlers;
+  auto handler = [&](pubsub::Message const&, pubsub::AckHandler h) {
+    std::lock_guard<std::mutex> lk(handler_mu);
+    ack_handlers.push_back(std::move(h));
+    handler_cv.notify_one();
+  };
+  auto pull_next = [&] {
+    std::unique_lock<std::mutex> lk(handler_mu);
+    handler_cv.wait(lk, [&] { return !ack_handlers.empty(); });
+    auto h = std::move(ack_handlers.front());
+    ack_handlers.pop_front();
+    return h;
+  };
+
+  auto done = shutdown->Start({});
+  uut->Start(handler);
+
+  auto h = pull_next();
+  std::move(h).ack();
+  h = pull_next();
+  std::move(h).nack();
+
+  h = pull_next();
+  std::move(h).ack();
+  h = pull_next();
+  std::move(h).nack();
+  h = pull_next();
+  std::move(h).nack();
+
+  shutdown->MarkAsShutdown(__func__, {});
+  uut->Shutdown();
+  EXPECT_THAT(done.get(), StatusIs(StatusCode::kOk));
 }
 
-/// @test Verify session does not schedule too many parallel callbacks.
-TEST(SubscriptionConcurrentControlTest, ScheduleParallelCallbacksLimits) {
-  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
-  pubsub::Subscription const subscription("test-project", "test-subscription");
-
-  auto constexpr kThreadCount = 4;
-  auto constexpr kTestHwm = 16;
-  auto constexpr kBatchSize = 32;
-  auto constexpr kTotalMessages = 4 * kBatchSize;
-
-  auto generate = [&](google::cloud::CompletionQueue&,
-                      std::unique_ptr<grpc::ClientContext>,
-                      google::pubsub::v1::PullRequest const&) {
-    static std::atomic<int> call{0};
-    auto const base = ++call;
-    google::pubsub::v1::PullResponse response;
-    for (int i = 0; i != kBatchSize; ++i) {
-      auto const suffix = std::to_string(base) + "-" + std::to_string(i);
-      auto& m = *response.add_received_messages();
-      m.set_ack_id("test-ack-id-" + suffix);
-      m.mutable_message()->set_message_id("test-message-id-" + suffix);
-    }
-    return make_ready_future(make_status_or(response));
+/// @test Verify SubscriptionConcurrencyControl schedules multiple callbacks.
+TEST_F(SubscriptionConcurrencyControlTest, ParallelCallbacks) {
+  auto source =
+      std::make_shared<pubsub_testing::MockSubscriptionMessageSource>();
+  MessageCallback message_callback;
+  EXPECT_CALL(*source, Shutdown).Times(1);
+  PrepareMessages("ack-0-", 8);
+  PrepareMessages("ack-1-", 8);
+  auto push_messages = [&](std::size_t n) {
+    PushMessages(message_callback, static_cast<std::int32_t>(n));
   };
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*source, Start)
+        .WillOnce([&message_callback](MessageCallback cb) {
+          message_callback = std::move(cb);
+        });
+    EXPECT_CALL(*source, Read(4)).WillOnce(push_messages);
+    EXPECT_CALL(*source, Read(2)).WillOnce(push_messages);
+    EXPECT_CALL(*source, Read(2)).WillOnce(push_messages);
+    EXPECT_CALL(*source, Read).WillRepeatedly(push_messages);
+  }
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*source, AckMessage(StartsWith("ack-0-"), _)).Times(8);
+    EXPECT_CALL(*source, AckMessage(StartsWith("ack-1-"), _)).Times(1);
+    EXPECT_CALL(*source, NackMessage(StartsWith("ack-1-"), _)).Times(1);
+    EXPECT_CALL(*source, AckMessage(StartsWith("ack-1-"), _)).Times(1);
+    EXPECT_CALL(*source, NackMessage(StartsWith("ack-1-"), _)).Times(5);
+  }
 
-  EXPECT_CALL(*mock, AsyncPull).Times(AtLeast(1)).WillRepeatedly(generate);
-  EXPECT_CALL(*mock, AsyncAcknowledge)
-      .Times(AtLeast(kBatchSize))
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
-                         google::pubsub::v1::AcknowledgeRequest const&) {
-        return make_ready_future(Status{});
-      });
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillRepeatedly([](google::cloud::CompletionQueue&,
-                         std::unique_ptr<grpc::ClientContext>,
-                         google::pubsub::v1::ModifyAckDeadlineRequest const&) {
-        return make_ready_future(Status{});
-      });
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(4);
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+  // Create the unit under test, configured to run at most 4 events at a time.
+  auto uut = SubscriptionConcurrencyControl::Create(
+      background.cq(), shutdown, source, /*message_count_lwm=*/2,
+      /*message_count_hwm=*/4);
 
-  google::cloud::CompletionQueue cq;
-  std::vector<std::thread> tasks;
-  std::generate_n(std::back_inserter(tasks), kThreadCount,
-                  [&] { return std::thread([&cq] { cq.Run(); }); });
-
-  auto const callback_running_time = std::chrono::microseconds(100);
-  using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
-  std::mutex handlers_mu;
-  std::condition_variable handlers_cv;
-  int current_callback_count = 0;
-  int maximum_callback_count = 0;
-  int total_callbacks = 0;
-
-  auto handler_done = [&](pubsub::AckHandler h) {
-    std::unique_lock<std::mutex> lk(handlers_mu);
-    --current_callback_count;
-    std::move(h).ack();
-    if (++total_callbacks < kTotalMessages) return;
-    lk.unlock();
-    handlers_cv.notify_one();
-  };
-
+  std::mutex handler_mu;
+  std::condition_variable handler_cv;
+  std::deque<pubsub::AckHandler> ack_handlers;
   auto handler = [&](pubsub::Message const&, pubsub::AckHandler h) {
-    std::unique_lock<std::mutex> lk(handlers_mu);
-    ++current_callback_count;
-    maximum_callback_count =
-        (std::max)(current_callback_count, maximum_callback_count);
-    lk.unlock();
-    struct MoveCapture {
-      pubsub::AckHandler h;
-      std::function<void(pubsub::AckHandler)> done;
-      void operator()(TimerFuture) { done(std::move(h)); }
-    };
-    cq.MakeRelativeTimer(callback_running_time)
-        .then(MoveCapture{std::move(h), handler_done});
+    std::lock_guard<std::mutex> lk(handler_mu);
+    ack_handlers.push_back(std::move(h));
+    handler_cv.notify_one();
+  };
+  auto wait_n = [&](std::size_t n) {
+    std::unique_lock<std::mutex> lk(handler_mu);
+    handler_cv.wait(lk, [&] { return ack_handlers.size() >= n; });
+  };
+  auto pull_next = [&] {
+    std::unique_lock<std::mutex> lk(handler_mu);
+    handler_cv.wait(lk, [&] { return !ack_handlers.empty(); });
+    auto h = std::move(ack_handlers.front());
+    ack_handlers.pop_front();
+    return h;
   };
 
+  auto done = shutdown->Start({});
+  uut->Start(handler);
+
+  wait_n(4);
+  for (int i = 0; i != 2; ++i) pull_next().ack();
+  wait_n(4);
+  for (int i = 0; i != 2; ++i) pull_next().ack();
+  wait_n(4);
+  for (int i = 0; i != 4; ++i) pull_next().ack();
+
+  pull_next().ack();
+  pull_next().nack();
+  pull_next().ack();
+  for (int i = 0; i != 5; ++i) pull_next().nack();
+
+  shutdown->MarkAsShutdown(__func__, Status{});
+  uut->Shutdown();
+  EXPECT_THAT(done.get(), StatusIs(StatusCode::kOk));
+}
+
+/// @test Verify SubscriptionConcurrencyControl respects the HWM limit.
+TEST_F(SubscriptionConcurrencyControlTest, ParallelCallbacksRespectHwmLimit) {
+  auto constexpr kConcurrencyHwm = 8;
+  auto constexpr kConcurrencyLwm = 0;
+  auto constexpr kCallbackCount = 200;
+
+  auto source =
+      std::make_shared<pubsub_testing::MockSubscriptionMessageSource>();
+  MessageCallback message_callback;
+  PrepareMessages("ack-0-", kCallbackCount);
+  PrepareMessages("ack-1-", 8);
+  auto push_messages = [&](std::size_t n) {
+    PushMessages(message_callback, static_cast<std::int32_t>(n));
+  };
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*source, Start)
+        .WillOnce([&message_callback](MessageCallback cb) {
+          message_callback = std::move(cb);
+        });
+    EXPECT_CALL(*source, Read).WillRepeatedly(push_messages);
+  }
+
+  EXPECT_CALL(*source, Shutdown).Times(1);
+  EXPECT_CALL(*source, AckMessage).Times(AtLeast(kCallbackCount));
+  EXPECT_CALL(*source, NackMessage).Times(AtLeast(0));
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(
+      2 * kConcurrencyHwm);
+
+  // Create the unit under test, configured to run 1 event at a time, this makes
+  // it easier to setup expectations.
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+
+  auto uut = SubscriptionConcurrencyControl::Create(
+      background.cq(), shutdown, source, kConcurrencyLwm, kConcurrencyHwm);
+
+  std::mutex handler_mu;
+  std::condition_variable handler_cv;
+
+  std::size_t current_callbacks = 0;
+  std::size_t total_callbacks = 0;
+  std::size_t observed_hwm = 0;
+  auto delayed_handler = [&](pubsub::AckHandler h) {
+    {
+      std::lock_guard<std::mutex> lk(handler_mu);
+      --current_callbacks;
+      if (++total_callbacks > kCallbackCount) return;
+    }
+    handler_cv.notify_one();
+    std::move(h).ack();
+  };
+  auto handler = [&](pubsub::Message const&, pubsub::AckHandler h) {
+    {
+      std::lock_guard<std::mutex> lk(handler_mu);
+      ++current_callbacks;
+      observed_hwm = (std::max)(observed_hwm, current_callbacks);
+    }
+    struct DelayedHandler {
+      pubsub::AckHandler h;
+      std::function<void(pubsub::AckHandler)> handler;
+      void operator()(future<StatusOr<std::chrono::system_clock::time_point>>) {
+        handler(std::move(h));
+      }
+    };
+    background.cq()
+        .MakeRelativeTimer(std::chrono::microseconds(100))
+        .then(DelayedHandler{std::move(h), delayed_handler});
+  };
+
+  auto done = shutdown->Start({});
+  uut->Start(handler);
+
+  {
+    std::unique_lock<std::mutex> lk(handler_mu);
+    handler_cv.wait(lk, [&] { return total_callbacks >= kCallbackCount; });
+    EXPECT_GE(kConcurrencyHwm, observed_hwm);
+  }
+
+  shutdown->MarkAsShutdown(__func__, Status{});
+  uut->Shutdown();
+
+  EXPECT_THAT(done.get(), StatusIs(StatusCode::kOk));
+}
+
+/// @test Verify SubscriptionConcurrencyControl shutdown cleanly.
+TEST_F(SubscriptionConcurrencyControlTest, CleanShutdown) {
+  auto constexpr kNackThreshold = 10;
+  auto constexpr kTestDoneThreshold = 2 * kNackThreshold;
+
+  auto source =
+      std::make_shared<pubsub_testing::MockSubscriptionMessageSource>();
+  MessageCallback message_callback;
+  PrepareMessages("ack-0-", kTestDoneThreshold + 1);
+  PrepareMessages("ack-1-", kTestDoneThreshold);
+  auto push_messages = [&](std::size_t n) {
+    PushMessages(message_callback, static_cast<std::int32_t>(n));
+  };
+  {
+    ::testing::InSequence sequence;
+    EXPECT_CALL(*source, Start)
+        .WillOnce([&message_callback](MessageCallback cb) {
+          message_callback = std::move(cb);
+        });
+    EXPECT_CALL(*source, Read).WillRepeatedly(push_messages);
+  }
+
+  EXPECT_CALL(*source, Shutdown).Times(1);
+  EXPECT_CALL(*source, AckMessage).Times(AtLeast(1));
+  EXPECT_CALL(*source, NackMessage).Times(AtLeast(1));
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(4);
+
+  std::mutex handler_mu;
+  std::condition_variable handler_cv;
+  int message_counter = 0;
+  auto handler = [&](pubsub::Message const&, pubsub::AckHandler h) {
+    std::unique_lock<std::mutex> lk(handler_mu);
+    if (++message_counter >= kTestDoneThreshold) {
+      handler_cv.notify_one();
+      return;
+    }
+    if (message_counter >= kNackThreshold) return;
+    std::move(h).ack();
+  };
+
+  // Transfer ownership to a future, like we would do for a fully configured
   auto session = [&] {
-    return SubscriptionSession::Create(
-               mock, cq,
-               {subscription.FullName(), handler,
-                pubsub::SubscriptionOptions{}.set_concurrency_watermarks(
-                    kTestHwm / 2, kTestHwm)})
-        ->Start();
+    auto shutdown = std::make_shared<SessionShutdownManager>();
+
+    auto uut = SubscriptionConcurrencyControl::Create(
+        background.cq(), shutdown, source,
+        /*message_count_lwm=*/0, /*message_count_hwm=*/4);
+    promise<Status> p([uut] { uut->Shutdown(); });
+
+    auto f = shutdown->Start(std::move(p));
+    uut->Start(std::move(handler));
+    return f;
   }();
 
   {
-    std::unique_lock<std::mutex> lk(handlers_mu);
-    handlers_cv.wait(lk, [&] { return total_callbacks >= kTotalMessages; });
+    std::unique_lock<std::mutex> lk(handler_mu);
+    handler_cv.wait(lk, [&] { return message_counter >= kTestDoneThreshold; });
   }
   session.cancel();
-  auto status = session.get();
-  EXPECT_STATUS_OK(status);
-
-  EXPECT_LT(0, maximum_callback_count);
-  EXPECT_GE(kTestHwm, maximum_callback_count);
-
-  cq.Shutdown();
-  for (auto& t : tasks) t.join();
+  EXPECT_THAT(session.get(), StatusIs(StatusCode::kOk));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -18,6 +18,7 @@
 
 pubsub_client_hdrs = [
     "ack_handler.h",
+    "application_callback.h",
     "backoff_policy.h",
     "connection_options.h",
     "internal/batching_publisher_connection.h",
@@ -33,6 +34,7 @@ pubsub_client_hdrs = [
     "internal/subscriber_metadata.h",
     "internal/subscriber_stub.h",
     "internal/subscription_batch_source.h",
+    "internal/subscription_concurrency_control.h",
     "internal/subscription_flow_control.h",
     "internal/subscription_lease_management.h",
     "internal/subscription_message_queue.h",
@@ -77,6 +79,7 @@ pubsub_client_srcs = [
     "internal/subscriber_logging.cc",
     "internal/subscriber_metadata.cc",
     "internal/subscriber_stub.cc",
+    "internal/subscription_concurrency_control.cc",
     "internal/subscription_flow_control.cc",
     "internal/subscription_lease_management.cc",
     "internal/subscription_message_queue.cc",

--- a/google/cloud/pubsub/pubsub_client_testing.bzl
+++ b/google/cloud/pubsub/pubsub_client_testing.bzl
@@ -20,6 +20,7 @@ pubsub_client_testing_hdrs = [
     "testing/mock_publisher_stub.h",
     "testing/mock_subscriber_stub.h",
     "testing/mock_subscription_batch_source.h",
+    "testing/mock_subscription_message_source.h",
     "testing/random_names.h",
     "testing/test_retry_policies.h",
 ]

--- a/google/cloud/pubsub/testing/mock_subscription_message_source.h
+++ b/google/cloud/pubsub/testing/mock_subscription_message_source.h
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TESTING_MOCK_SUBSCRIPTION_MESSAGE_SOURCE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TESTING_MOCK_SUBSCRIPTION_MESSAGE_SOURCE_H
+
+#include "google/cloud/pubsub/internal/subscription_message_source.h"
+#include "google/cloud/pubsub/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub_testing {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+
+class MockSubscriptionMessageSource
+    : public pubsub_internal::SubscriptionMessageSource {
+ public:
+  MOCK_METHOD1(Start, void(pubsub_internal::MessageCallback));
+  MOCK_METHOD0(Shutdown, void());
+  MOCK_METHOD1(Read, void(std::size_t max_callbacks));
+  MOCK_METHOD2(AckMessage,
+               future<Status>(std::string const& ack_id, std::size_t size));
+  MOCK_METHOD2(NackMessage,
+               future<Status>(std::string const& ack_id, std::size_t size));
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TESTING_MOCK_SUBSCRIPTION_MESSAGE_SOURCE_H


### PR DESCRIPTION
Copy the functionality to perform concurrency control to a separate
class. For now, this class is only used in tests. A future PR will
replace `pubsub_internal::SubscriptionSession` with a class that uses
this new component.

Part of the work for #4970

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/4998)
<!-- Reviewable:end -->
