### PR TITLE
cleanup: silence CMake warnings in absl package

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -16,7 +16,10 @@
 
 include(GoogleCloudCppCommon)
 include(FindProtobufWithTargets)
+# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
+set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
+unset(FPHSA_NAME_MISMATCHED)
 
 find_package(ProtobufWithTargets REQUIRED)
 


### PR DESCRIPTION
Abseil (at least the version we are using) incorrectly uses
`find_package()` instead of `find_dependency()` in its package file.
Newer versions of CMake produce scary looking warnings for this, we
silence them to avoid confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5005)
<!-- Reviewable:end -->
