### PR TITLE
fix: CompletionQueue shutdown disables RunAsync

### DIFF
--- a/google/cloud/completion_queue.cc
+++ b/google/cloud/completion_queue.cc
@@ -96,8 +96,8 @@ class AsyncFunction : public internal::AsyncGrpcOperation {
   }
 
  private:
-  bool Notify(bool) override {
-    fun_->exec();
+  bool Notify(bool ok) override {
+    if (ok) fun_->exec();  // do not run async operations on shutdown CQs
     fun_.reset();
     return true;
   }


### PR DESCRIPTION
After a completion queue is shutdown we should not run any functions
scheduled via `RunAsync()` that is both surprising and makes it hard to
schedule a clean shutdown for application developers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5008)
<!-- Reviewable:end -->
