### PR TITLE
feat(pubsub): retry loops for subscriptions

### DIFF
--- a/google/cloud/pubsub/internal/default_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/default_subscription_batch_source.h
@@ -15,8 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULT_SUBSCRIPTION_BATCH_SOURCE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULT_SUBSCRIPTION_BATCH_SOURCE_H
 
+#include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/internal/subscription_batch_source.h"
+#include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status.h"
@@ -33,12 +35,16 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 class DefaultSubscriptionBatchSource : public SubscriptionBatchSource {
  public:
-  explicit DefaultSubscriptionBatchSource(google::cloud::CompletionQueue cq,
-                                          std::shared_ptr<SubscriberStub> stub,
-                                          std::string subscription_full_name)
+  explicit DefaultSubscriptionBatchSource(
+      google::cloud::CompletionQueue cq, std::shared_ptr<SubscriberStub> stub,
+      std::string subscription_full_name,
+      std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+      std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy)
       : cq_(std::move(cq)),
         stub_(std::move(stub)),
-        subscription_full_name_(std::move(subscription_full_name)) {}
+        subscription_full_name_(std::move(subscription_full_name)),
+        retry_policy_(std::move(retry_policy)),
+        backoff_policy_(std::move(backoff_policy)) {}
 
   ~DefaultSubscriptionBatchSource() override = default;
 
@@ -58,6 +64,8 @@ class DefaultSubscriptionBatchSource : public SubscriptionBatchSource {
   google::cloud::CompletionQueue cq_;
   std::shared_ptr<SubscriberStub> stub_;
   std::string subscription_full_name_;
+  std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
+  std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -15,11 +15,13 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIPTION_SESSION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_SUBSCRIPTION_SESSION_H
 
+#include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/internal/session_shutdown_manager.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/internal/subscription_concurrency_control.h"
 #include "google/cloud/pubsub/internal/subscription_flow_control.h"
 #include "google/cloud/pubsub/internal/subscription_lease_management.h"
+#include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/subscriber_connection.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/completion_queue.h"
@@ -36,12 +38,16 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 future<Status> CreateSubscriptionSession(
     std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
     google::cloud::CompletionQueue const& executor,
-    pubsub::SubscriberConnection::SubscribeParams p);
+    pubsub::SubscriberConnection::SubscribeParams p,
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
 
 future<Status> CreateTestingSubscriptionSession(
     std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
     google::cloud::CompletionQueue const& executor,
-    pubsub::SubscriberConnection::SubscribeParams p);
+    pubsub::SubscriberConnection::SubscribeParams p,
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/internal/subscription_session.h"
 #include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
+#include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/mock_completion_queue.h"
@@ -551,7 +552,8 @@ TEST(SubscriptionSessionTest, ShutdownWaitsFutures) {
 
     auto session = CreateSubscriptionSession(
         mock, background.cq(),
-        {subscription.FullName(), handler, pubsub::SubscriptionOptions{}});
+        {subscription.FullName(), handler, pubsub::SubscriptionOptions{}},
+        pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
     got_one.get_future()
         .then([&session](future<void>) { session.cancel(); })
         .get();
@@ -646,7 +648,8 @@ TEST(SubscriptionSessionTest, ShutdownWaitsConditionVars) {
     };
 
     auto session = CreateSubscriptionSession(
-        mock, background.cq(), {subscription.FullName(), handler, {}});
+        mock, background.cq(), {subscription.FullName(), handler, {}},
+        pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
     {
       std::unique_lock<std::mutex> lk(mu);
       cv.wait(lk, [&] { return ack_count >= kMaximumAcks; });

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -17,9 +17,11 @@
 
 #include "google/cloud/pubsub/ack_handler.h"
 #include "google/cloud/pubsub/application_callback.h"
+#include "google/cloud/pubsub/backoff_policy.h"
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/subscription.h"
 #include "google/cloud/pubsub/subscription_options.h"
 #include "google/cloud/pubsub/version.h"
@@ -83,9 +85,15 @@ class SubscriberConnection {
  *
  * @param options (optional) configure the `SubscriberConnection` created by
  *     this function.
+ * @param retry_policy control for how long (or how many times) are retryable
+ *     RPCs attempted.
+ * @param backoff_policy controls the backoff behavior between retry attempts,
+ *     typically some form of exponential backoff with jitter.
  */
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
-    ConnectionOptions options = {});
+    ConnectionOptions options = {},
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
@@ -94,7 +102,9 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    std::shared_ptr<SubscriberStub> stub, pubsub::ConnectionOptions options);
+    std::shared_ptr<SubscriberStub> stub, pubsub::ConnectionOptions options,
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal


### PR DESCRIPTION
With this change a subscription session (the result of calling
`Subscriber::Subscribe()`) has a retry loop.

Fixes #4699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5022)
<!-- Reviewable:end -->
