### PR TITLE
feat(spanner): start using NUMERIC types in database schema

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -160,6 +160,14 @@ int main(int argc, char* argv[]) {
   std::vector<std::string> additional_statements = [&available, generator] {
     std::vector<std::string> statements;
     for (auto const& kv : available) {
+      // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+      if (google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST")
+              .has_value()) {
+        auto pos = kv.first.rfind("-numeric");
+        if (pos != std::string::npos) {
+          continue;
+        }
+      }
       auto experiment = kv.second(generator);
       auto s = experiment->AdditionalDdlStatement();
       if (s.empty()) continue;
@@ -351,6 +359,21 @@ struct TimestampTraits {
                 0, std::numeric_limits<std::chrono::nanoseconds::rep>::max())(
                 generator));
     return spanner::MakeTimestamp(tp).value();
+  }
+};
+
+struct NumericTraits {
+  using native_type = spanner::Numeric;
+  static std::string SpannerDataType() { return "NUMERIC"; }
+  static std::string TableSuffix() { return "numeric"; }
+  static native_type MakeRandomValue(
+      google::cloud::internal::DefaultPRNG& generator) {
+    return spanner::MakeNumeric(
+               std::uniform_int_distribution<std::int64_t>(
+                   std::numeric_limits<std::int64_t>::min(),
+                   std::numeric_limits<std::int64_t>::max())(generator),
+               -9)  // scale by 10^-9
+        .value();
   }
 };
 
@@ -1546,6 +1569,15 @@ class RunAllExperiment : public Experiment {
     for (auto& kv : AvailableExperiments()) {
       // Do not recurse, skip this experiment.
       if (kv.first == "run-all") continue;
+      // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+      if (google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST")
+              .has_value()) {
+        auto pos = kv.first.rfind("-numeric");
+        if (pos != std::string::npos) {
+          continue;
+        }
+      }
+
       Config config = cfg;
       config.experiment = kv.first;
       config.samples = 1;
@@ -1626,6 +1658,7 @@ std::map<std::string, ExperimentFactory> AvailableExperiments() {
       {"read-int64", MakeReadFactory<Int64Traits>()},
       {"read-string", MakeReadFactory<StringTraits>()},
       {"read-timestamp", MakeReadFactory<TimestampTraits>()},
+      {"read-numeric", MakeReadFactory<NumericTraits>()},
       {"select-bool", MakeSelectFactory<BoolTraits>()},
       {"select-bytes", MakeSelectFactory<BytesTraits>()},
       {"select-date", MakeSelectFactory<DateTraits>()},
@@ -1633,6 +1666,7 @@ std::map<std::string, ExperimentFactory> AvailableExperiments() {
       {"select-int64", MakeSelectFactory<Int64Traits>()},
       {"select-string", MakeSelectFactory<StringTraits>()},
       {"select-timestamp", MakeSelectFactory<TimestampTraits>()},
+      {"select-numeric", MakeSelectFactory<NumericTraits>()},
       {"update-bool", MakeUpdateFactory<BoolTraits>()},
       {"update-bytes", MakeUpdateFactory<BytesTraits>()},
       {"update-date", MakeUpdateFactory<DateTraits>()},
@@ -1640,6 +1674,7 @@ std::map<std::string, ExperimentFactory> AvailableExperiments() {
       {"update-int64", MakeUpdateFactory<Int64Traits>()},
       {"update-string", MakeUpdateFactory<StringTraits>()},
       {"update-timestamp", MakeUpdateFactory<TimestampTraits>()},
+      {"update-numeric", MakeUpdateFactory<NumericTraits>()},
       {"mutation-bool", MakeMutationFactory<BoolTraits>()},
       {"mutation-bytes", MakeMutationFactory<BytesTraits>()},
       {"mutation-date", MakeMutationFactory<DateTraits>()},
@@ -1647,6 +1682,7 @@ std::map<std::string, ExperimentFactory> AvailableExperiments() {
       {"mutation-int64", MakeMutationFactory<Int64Traits>()},
       {"mutation-string", MakeMutationFactory<StringTraits>()},
       {"mutation-timestamp", MakeMutationFactory<TimestampTraits>()},
+      {"mutation-numeric", MakeMutationFactory<NumericTraits>()},
   };
 }
 

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -214,6 +214,30 @@ TEST_F(DataTypeIntegrationTest, WriteReadDate) {
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }
 
+TEST_F(DataTypeIntegrationTest, WriteReadNumeric) {
+  // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+  if (google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST").has_value()) {
+    GTEST_SKIP();
+  }
+  auto min = MakeNumeric("-99999999999999999999999999999.999999999");
+  ASSERT_STATUS_OK(min);
+  auto max = MakeNumeric("99999999999999999999999999999.999999999");
+  ASSERT_STATUS_OK(max);
+
+  std::vector<Numeric> const data = {
+      *min,                                //
+      MakeNumeric(-999999999e-3).value(),  //
+      MakeNumeric(-1).value(),             //
+      MakeNumeric(0).value(),              //
+      MakeNumeric(1).value(),              //
+      MakeNumeric(999999999e-3).value(),   //
+      *max,                                //
+  };
+  auto result = WriteReadData(*client_, data, "NumericValue");
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+}
+
 TEST_F(DataTypeIntegrationTest, WriteReadArrayBool) {
   std::vector<std::vector<bool>> const data = {
       std::vector<bool>{},
@@ -297,6 +321,25 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayDate) {
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayDateValue");
+  ASSERT_STATUS_OK(result);
+  EXPECT_THAT(*result, UnorderedElementsAreArray(data));
+}
+
+TEST_F(DataTypeIntegrationTest, WriteReadArrayNumeric) {
+  // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+  if (google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST").has_value()) {
+    GTEST_SKIP();
+  }
+  std::vector<std::vector<Numeric>> const data = {
+      std::vector<Numeric>{},
+      std::vector<Numeric>{Numeric()},
+      std::vector<Numeric>{
+          MakeNumeric(-1e+9).value(),
+          MakeNumeric(1e-9).value(),
+          MakeNumeric(1e+9).value(),
+      },
+  };
+  auto result = WriteReadData(*client_, data, "ArrayNumericValue");
   ASSERT_STATUS_OK(result);
   EXPECT_THAT(*result, UnorderedElementsAreArray(data));
 }

--- a/google/cloud/spanner/numeric.h
+++ b/google/cloud/spanner/numeric.h
@@ -55,8 +55,6 @@ StatusOr<Numeric> MakeNumeric(std::string s);
  * `Numeric` values can be copied/assigned/moved, compared for equality, and
  * streamed.
  *
- * @warning NUMERIC columns are not yet available for use in database schemas.
- *
  * @par Example
  *
  * @code

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -33,6 +33,7 @@
 #include "absl/types/optional.h"
 #include <google/protobuf/util/time_util.h>
 #include <chrono>
+#include <iomanip>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -472,6 +473,7 @@ void CreateTableWithDatatypes(
                 LastContactDate DATE,
                 OutdoorVenue    BOOL,
                 PopularityScore FLOAT64,
+                Revenue         NUMERIC,
                 LastUpdateTime  TIMESTAMP NOT NULL OPTIONS
                     (allow_commit_timestamp=true)
             ) PRIMARY KEY (VenueId))"""});
@@ -1343,6 +1345,20 @@ void DeleteAll(google::cloud::spanner::Client client) {
 }
 //! [keyset-all]
 
+// TODO(#5024): Remove DeleteAllEmulator() when the emulator supports NUMERIC.
+void DeleteAllEmulator(google::cloud::spanner::Client client) {
+  namespace spanner = ::google::cloud::spanner;
+
+  // Delete all the performances, venues, albums and singers.
+  auto commit = client.Commit(spanner::Mutations{
+      spanner::MakeDeleteMutation("Performances", spanner::KeySet::All()),
+      spanner::MakeDeleteMutation("Albums", spanner::KeySet::All()),
+      spanner::MakeDeleteMutation("Singers", spanner::KeySet::All()),
+  });
+  if (!commit) throw std::runtime_error(commit.status().message());
+  std::cout << "delete-all was successful\n";
+}
+
 //! [insert-mutation-builder]
 void InsertMutationBuilder(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
@@ -1577,6 +1593,49 @@ void QueryDataWithTimestamp(google::cloud::spanner::Client client) {
   }
 }
 // [END spanner_query_data_with_timestamp_column]
+
+// [START spanner_query_data_with_numeric]
+void QueryDataWithNumeric(google::cloud::spanner::Client client) {
+  namespace spanner = ::google::cloud::spanner;
+
+  auto revenue = spanner::MakeNumeric(300000).value();
+  spanner::SqlStatement select(
+      "SELECT VenueId, VenueName, Revenue"
+      "  FROM Venues"
+      " WHERE Revenue >= @revenue",
+      {{"revenue", spanner::Value(std::move(revenue))}});
+  using RowType = std::tuple<std::int64_t, absl::optional<std::string>,
+                             absl::optional<spanner::Numeric>>;
+
+  auto rows = client.ExecuteQuery(select);
+  for (auto const& row : spanner::StreamOf<RowType>(rows)) {
+    if (!row) throw std::runtime_error(row.status().message());
+    std::cout << "VenueId: " << std::get<0>(*row);
+    std::cout << " VenueName: ";
+    auto venue_name = std::get<1>(*row);
+    if (!venue_name) {
+      std::cout << "NULL";
+    } else {
+      std::cout << *venue_name;
+    }
+    std::cout << " Revenue: ";
+    auto revenue = std::get<2>(*row);
+    if (!revenue) {
+      std::cout << "NULL";
+    } else {
+      auto const& numeric = *revenue;
+      // [START spanner_cast_numeric_type]
+      std::string const& str = numeric.ToString();
+      double dbl = spanner::ToDouble(numeric);
+      int scaled_int = *spanner::ToInteger<int>(numeric, 2);  // scale by 10^2
+      // [END spanner_cast_numeric_type]
+      std::cout << str << " (d.16=" << std::setprecision(16) << dbl
+                << ", i*10^2=" << scaled_int << ")";
+    }
+    std::cout << "\n";
+  }
+}
+// [END spanner_query_data_with_numeric]
 
 //! [START spanner_read_only_transaction]
 void ReadOnlyTransaction(google::cloud::spanner::Client client) {
@@ -2871,6 +2930,7 @@ int RunOneCommand(std::vector<std::string> argv) {
       make_command_entry("insert-data-with-timestamp", InsertDataWithTimestamp),
       make_command_entry("update-data-with-timestamp", UpdateDataWithTimestamp),
       make_command_entry("query-data-with-timestamp", QueryDataWithTimestamp),
+      make_command_entry("query-data-with-numeric", QueryDataWithNumeric),
       make_command_entry("read-only-transaction", ReadOnlyTransaction),
       make_command_entry("read-stale-data", ReadStaleData),
       make_command_entry("use-partition-query", UsePartitionQuery),
@@ -3131,10 +3191,13 @@ void RunAll(bool emulator) {
   std::cout << "\nRunning spanner_create_database sample" << std::endl;
   CreateDatabase(database_admin_client, project_id, instance_id, database_id);
 
-  std::cout << "\nRunning spanner_create_table_with_datatypes sample"
-            << std::endl;
-  CreateTableWithDatatypes(database_admin_client, project_id, instance_id,
-                           database_id);
+  // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+  if (!emulator) {
+    std::cout << "\nRunning spanner_create_table_with_datatypes sample"
+              << std::endl;
+    CreateTableWithDatatypes(database_admin_client, project_id, instance_id,
+                             database_id);
+  }
 
   std::cout << "\nRunning spanner_create_table_with_timestamp_column sample"
             << std::endl;
@@ -3196,39 +3259,43 @@ void RunAll(bool emulator) {
   std::cout << "\nRunning spanner_update_data sample" << std::endl;
   UpdateData(client);
 
-  std::cout << "\nRunning spanner_insert_datatypes_data sample" << std::endl;
-  InsertDatatypesData(client);
+  // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+  if (!emulator) {
+    std::cout << "\nRunning spanner_insert_datatypes_data sample" << std::endl;
+    InsertDatatypesData(client);
 
-  std::cout << "\nRunning spanner_query_with_array_parameter sample"
-            << std::endl;
-  QueryWithArrayParameter(client);
+    std::cout << "\nRunning spanner_query_with_array_parameter sample"
+              << std::endl;
+    QueryWithArrayParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_bool_parameter sample"
-            << std::endl;
-  QueryWithBoolParameter(client);
+    std::cout << "\nRunning spanner_query_with_bool_parameter sample"
+              << std::endl;
+    QueryWithBoolParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_bytes_parameter sample"
-            << std::endl;
-  QueryWithBytesParameter(client);
+    std::cout << "\nRunning spanner_query_with_bytes_parameter sample"
+              << std::endl;
+    QueryWithBytesParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_date_parameter sample"
-            << std::endl;
-  QueryWithDateParameter(client);
+    std::cout << "\nRunning spanner_query_with_date_parameter sample"
+              << std::endl;
+    QueryWithDateParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_float_parameter sample"
-            << std::endl;
-  QueryWithFloatParameter(client);
+    std::cout << "\nRunning spanner_query_with_float_parameter sample"
+              << std::endl;
+    QueryWithFloatParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_int_parameter sample" << std::endl;
-  QueryWithIntParameter(client);
+    std::cout << "\nRunning spanner_query_with_int_parameter sample"
+              << std::endl;
+    QueryWithIntParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_string_parameter sample"
-            << std::endl;
-  QueryWithStringParameter(client);
+    std::cout << "\nRunning spanner_query_with_string_parameter sample"
+              << std::endl;
+    QueryWithStringParameter(client);
 
-  std::cout << "\nRunning spanner_query_with_timestamp_parameter sample"
-            << std::endl;
-  QueryWithTimestampParameter(client);
+    std::cout << "\nRunning spanner_query_with_timestamp_parameter sample"
+              << std::endl;
+    QueryWithTimestampParameter(client);
+  }
 
   std::cout << "\nRunning spanner_insert_data_with_timestamp_column sample"
             << std::endl;
@@ -3241,6 +3308,13 @@ void RunAll(bool emulator) {
   std::cout << "\nRunning spanner_query_data_with_timestamp_column sample"
             << std::endl;
   QueryDataWithTimestamp(client);
+
+  // TODO(#5024): Remove this check when the emulator supports NUMERIC.
+  if (!emulator) {
+    std::cout << "\nRunning spanner_query_data_with_numeric sample"
+              << std::endl;
+    QueryDataWithNumeric(client);
+  }
 
   std::cout << "\nRunning spanner_read_only_transaction sample" << std::endl;
   ReadOnlyTransaction(client);
@@ -3386,7 +3460,11 @@ void RunAll(bool emulator) {
   DeleteData(client);
 
   std::cout << "\nDeleting all data to run the mutation examples" << std::endl;
-  DeleteAll(client);
+  if (!emulator) {
+    DeleteAll(client);
+  } else {
+    DeleteAllEmulator(client);
+  }
 
   std::cout << "\nRunning the insert-mutation-builder example" << std::endl;
   InsertMutationBuilder(client);
@@ -3421,7 +3499,11 @@ void RunAll(bool emulator) {
   MakeDeleteMutation(client);
 
   std::cout << "\nRunning spanner_drop_database sample" << std::endl;
-  DeleteAll(client);
+  if (!emulator) {
+    DeleteAll(client);
+  } else {
+    DeleteAllEmulator(client);
+  }
   DropDatabase(database_admin_client, project_id, instance_id, database_id);
 }
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -485,6 +485,36 @@ void CreateTableWithDatatypes(
 }
 // [END spanner_create_table_with_datatypes]
 
+void CreateTableWithDatatypesEmulator(
+    google::cloud::spanner::DatabaseAdminClient client,
+    std::string const& project_id, std::string const& instance_id,
+    std::string const& database_id) {
+  using ::google::cloud::future;
+  using ::google::cloud::StatusOr;
+  google::cloud::spanner::Database database(project_id, instance_id,
+                                            database_id);
+  future<
+      StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
+      f = client.UpdateDatabase(database, {R"""(
+            CREATE TABLE Venues (
+                VenueId         INT64 NOT NULL,
+                VenueName       STRING(100),
+                VenueInfo       BYTES(MAX),
+                Capacity        INT64,
+                AvailableDates  ARRAY<DATE>,
+                LastContactDate DATE,
+                OutdoorVenue    BOOL,
+                PopularityScore FLOAT64,
+                LastUpdateTime  TIMESTAMP NOT NULL OPTIONS
+                    (allow_commit_timestamp=true)
+            ) PRIMARY KEY (VenueId))"""});
+  StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>
+      metadata = f.get();
+  if (!metadata) throw std::runtime_error(metadata.status().message());
+  std::cout << "`Venues` table created, new DDL:\n"
+            << metadata->DebugString() << "\n";
+}
+
 // [START spanner_create_table_with_timestamp_column]
 void CreateTableWithTimestamp(
     google::cloud::spanner::DatabaseAdminClient client,
@@ -3191,12 +3221,15 @@ void RunAll(bool emulator) {
   std::cout << "\nRunning spanner_create_database sample" << std::endl;
   CreateDatabase(database_admin_client, project_id, instance_id, database_id);
 
+  std::cout << "\nRunning spanner_create_table_with_datatypes sample"
+            << std::endl;
   // TODO(#5024): Remove this check when the emulator supports NUMERIC.
   if (!emulator) {
-    std::cout << "\nRunning spanner_create_table_with_datatypes sample"
-              << std::endl;
     CreateTableWithDatatypes(database_admin_client, project_id, instance_id,
                              database_id);
+  } else {
+    CreateTableWithDatatypesEmulator(database_admin_client, project_id,
+                                     instance_id, database_id);
   }
 
   std::cout << "\nRunning spanner_create_table_with_timestamp_column sample"
@@ -3259,43 +3292,39 @@ void RunAll(bool emulator) {
   std::cout << "\nRunning spanner_update_data sample" << std::endl;
   UpdateData(client);
 
-  // TODO(#5024): Remove this check when the emulator supports NUMERIC.
-  if (!emulator) {
-    std::cout << "\nRunning spanner_insert_datatypes_data sample" << std::endl;
-    InsertDatatypesData(client);
+  std::cout << "\nRunning spanner_insert_datatypes_data sample" << std::endl;
+  InsertDatatypesData(client);
 
-    std::cout << "\nRunning spanner_query_with_array_parameter sample"
-              << std::endl;
-    QueryWithArrayParameter(client);
+  std::cout << "\nRunning spanner_query_with_array_parameter sample"
+            << std::endl;
+  QueryWithArrayParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_bool_parameter sample"
-              << std::endl;
-    QueryWithBoolParameter(client);
+  std::cout << "\nRunning spanner_query_with_bool_parameter sample"
+            << std::endl;
+  QueryWithBoolParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_bytes_parameter sample"
-              << std::endl;
-    QueryWithBytesParameter(client);
+  std::cout << "\nRunning spanner_query_with_bytes_parameter sample"
+            << std::endl;
+  QueryWithBytesParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_date_parameter sample"
-              << std::endl;
-    QueryWithDateParameter(client);
+  std::cout << "\nRunning spanner_query_with_date_parameter sample"
+            << std::endl;
+  QueryWithDateParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_float_parameter sample"
-              << std::endl;
-    QueryWithFloatParameter(client);
+  std::cout << "\nRunning spanner_query_with_float_parameter sample"
+            << std::endl;
+  QueryWithFloatParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_int_parameter sample"
-              << std::endl;
-    QueryWithIntParameter(client);
+  std::cout << "\nRunning spanner_query_with_int_parameter sample" << std::endl;
+  QueryWithIntParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_string_parameter sample"
-              << std::endl;
-    QueryWithStringParameter(client);
+  std::cout << "\nRunning spanner_query_with_string_parameter sample"
+            << std::endl;
+  QueryWithStringParameter(client);
 
-    std::cout << "\nRunning spanner_query_with_timestamp_parameter sample"
-              << std::endl;
-    QueryWithTimestampParameter(client);
-  }
+  std::cout << "\nRunning spanner_query_with_timestamp_parameter sample"
+            << std::endl;
+  QueryWithTimestampParameter(client);
 
   std::cout << "\nRunning spanner_insert_data_with_timestamp_column sample"
             << std::endl;

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -64,7 +64,7 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  * FLOAT64      | `double`
  * STRING       | `std::string`
  * BYTES        | `google::cloud::spanner::Bytes`
- * NUMERIC      | `google::cloud::spanner::Numeric`  // [2]
+ * NUMERIC      | `google::cloud::spanner::Numeric`
  * TIMESTAMP    | `google::cloud::spanner::Timestamp`
  * DATE         | `absl::CivilDay`
  * ARRAY        | `std::vector<T>`  // [1]
@@ -72,8 +72,6 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  *
  * [1] The type `T` may be any of the other supported types, except for
  *     ARRAY/`std::vector`.
- *
- * [2] NUMERIC columns are not yet available for use in database schemas.
  *
  * Value is a regular C++ value type with support for copy, move, equality,
  * etc. A default-constructed Value represents an empty value with no type.


### PR DESCRIPTION
Includes some amount of short-circuiting when running tests
against the Cloud Spanner Emulator, which does not yet support
`NUMERIC`.  This will be removed later.  See #5024.

Fixes #4527.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5025)
<!-- Reviewable:end -->
