### PR TITLE
feat(pubsub): support fire & forget subscriptions

### DIFF
--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -24,7 +24,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
     set(pubsub_client_integration_tests
         # cmake-format: sortable
         message_integration_test.cc subscription_admin_integration_test.cc
-        subscription_lifecycle.cc topic_admin_integration_test.cc)
+        subscription_lifecycle_test.cc topic_admin_integration_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -24,7 +24,7 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
     set(pubsub_client_integration_tests
         # cmake-format: sortable
         message_integration_test.cc subscription_admin_integration_test.cc
-        topic_admin_integration_test.cc)
+        subscription_lifecycle.cc topic_admin_integration_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
+++ b/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
@@ -19,6 +19,6 @@
 pubsub_client_integration_tests = [
     "message_integration_test.cc",
     "subscription_admin_integration_test.cc",
-    "subscription_lifecycle.cc",
+    "subscription_lifecycle_test.cc",
     "topic_admin_integration_test.cc",
 ]

--- a/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
+++ b/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
@@ -19,5 +19,6 @@
 pubsub_client_integration_tests = [
     "message_integration_test.cc",
     "subscription_admin_integration_test.cc",
+    "subscription_lifecycle.cc",
     "topic_admin_integration_test.cc",
 ]

--- a/google/cloud/pubsub/integration_tests/subscription_lifecycle.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_lifecycle.cc
@@ -1,0 +1,137 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/pubsub/subscription_admin_client.h"
+#include "google/cloud/pubsub/testing/random_names.h"
+#include "google/cloud/pubsub/topic_admin_client.h"
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <map>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::AnyOf;
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+
+TEST(MessageIntegrationTest, FireAndForget) {
+  auto project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  ASSERT_FALSE(project_id.empty());
+
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  Topic topic(project_id, pubsub_testing::RandomTopicId(generator));
+  Subscription subscription(project_id,
+                            pubsub_testing::RandomSubscriptionId(generator));
+
+  auto topic_admin = TopicAdminClient(MakeTopicAdminConnection());
+  auto subscription_admin =
+      SubscriptionAdminClient(MakeSubscriptionAdminConnection());
+
+  auto topic_metadata = topic_admin.CreateTopic(TopicMutationBuilder(topic));
+  ASSERT_THAT(topic_metadata, AnyOf(StatusIs(StatusCode::kOk),
+                                    StatusIs(StatusCode::kAlreadyExists)));
+
+  struct Cleanup {
+    std::function<void()> action;
+    explicit Cleanup(std::function<void()> a) : action(std::move(a)) {}
+    ~Cleanup() { action(); }
+  };
+  Cleanup cleanup_topic(
+      [topic_admin, &topic]() mutable { topic_admin.DeleteTopic(topic); });
+
+  auto subscription_metadata = subscription_admin.CreateSubscription(
+      topic, subscription,
+      SubscriptionMutationBuilder{}.set_ack_deadline(std::chrono::minutes(2)));
+  ASSERT_THAT(
+      subscription_metadata,
+      AnyOf(StatusIs(StatusCode::kOk), StatusIs(StatusCode::kAlreadyExists)));
+
+  std::mutex mu;
+  std::condition_variable cv;
+  std::set<std::string> received;
+  Status subscription_result;
+  std::set<std::string> published;
+  std::vector<Status> publish_errors;
+  auto constexpr kMinimumMessages = 10;
+
+  auto publisher = Publisher(MakePublisherConnection(topic, {}));
+  auto subscriber = Subscriber(MakeSubscriberConnection());
+  internal::AutomaticallyCreatedBackgroundThreads background(4);
+  {
+    (void)subscriber
+        .Subscribe(subscription,
+                   [&](Message const& m, AckHandler h) {
+                     std::move(h).ack();
+                     std::unique_lock<std::mutex> lk(mu);
+                     std::cout << "received " << m.message_id() << std::endl;
+                     received.insert(m.message_id());
+                     lk.unlock();
+                     cv.notify_one();
+                   })
+        .then([&](future<Status> f) {
+          std::unique_lock<std::mutex> lk(mu);
+          subscription_result = f.get();
+          cv.notify_one();
+        });
+
+    std::vector<future<void>> pending;
+    for (int i = 0; i != kMinimumMessages; ++i) {
+      pending.push_back(
+          publisher
+              .Publish(MessageBuilder{}
+                           .SetAttributes({{"index", std::to_string(i)}})
+                           .Build())
+              .then([&](future<StatusOr<std::string>> f) {
+                std::unique_lock<std::mutex> lk(mu);
+                auto s = f.get();
+                if (!s) {
+                  publish_errors.push_back(std::move(s).status());
+                  return;
+                }
+                published.insert(*std::move(s));
+              }));
+    }
+    publisher.Flush();
+    for (auto& p : pending) p.get();
+  }
+  {
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return received.size() >= published.size(); });
+  }
+  EXPECT_THAT(publish_errors, ElementsAre());
+  EXPECT_THAT(received, ElementsAreArray(published));
+
+  auto delete_response = subscription_admin.DeleteSubscription(subscription);
+  EXPECT_THAT(delete_response, AnyOf(StatusIs(StatusCode::kOk),
+                                     StatusIs(StatusCode::kNotFound)));
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/integration_tests/subscription_lifecycle_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscription_lifecycle_test.cc
@@ -24,7 +24,11 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
-#include <map>
+#include <condition_variable>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
@@ -353,7 +353,10 @@ TEST_F(SubscriptionConcurrencyControlTest, CleanShutdown) {
     auto uut = SubscriptionConcurrencyControl::Create(
         background.cq(), shutdown, source,
         /*message_count_lwm=*/0, /*message_count_hwm=*/4);
-    promise<Status> p([uut] { uut->Shutdown(); });
+    promise<Status> p([shutdown, uut] {
+      shutdown->MarkAsShutdown("test-function-", {});
+      uut->Shutdown();
+    });
 
     auto f = shutdown->Start(std::move(p));
     uut->Start(std::move(handler));

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -106,8 +106,8 @@ class SubscriptionSessionImpl
     lk.unlock();
     auto t = cq_.MakeRelativeTimer(shutdown_polling_period_)
                  .then([self](TimerArg f) { self->OnTimer(!f.get().ok()); });
-    if (shutdown_state_ == kShutdownByCompletionQueue) return;
     lk.lock();
+    if (shutdown_state_ == kShutdownByCompletionQueue) return;
     timer_ = std::move(t);
   }
 

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -705,7 +705,6 @@ TEST(SubscriptionSessionTest, FireAndForget) {
     std::unique_lock<std::mutex> lk(mu);
     EXPECT_STATUS_OK(status);
   }
-  SUCCEED();
 }
 
 }  // namespace

--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -188,6 +188,24 @@ class SubscriptionOptions {
   std::size_t concurrency_lwm() const { return concurrency_lwm_; }
   std::size_t concurrency_hwm() const { return concurrency_hwm_; }
 
+  /**
+   * Control how often the session polls for automatic shutdowns.
+   *
+   * Applications can shutdown a session by calling `.cancel()` on the returned
+   * `future<Status>`.  In addition, applications can fire & forget a session,
+   * which is only shutdown once the completion queue servicing the session
+   * shuts down. In this latter case the session polls periodically to detect
+   * if the CQ has shutdown. This controls how often this polling happens.
+   */
+  SubscriptionOptions& set_shutdown_polling_period(
+      std::chrono::milliseconds v) {
+    shutdown_polling_period_ = v;
+    return *this;
+  }
+  std::chrono::milliseconds shutdown_polling_period() const {
+    return shutdown_polling_period_;
+  }
+
  private:
   static std::size_t DefaultConcurrencyHwm() {
     auto constexpr kDefaultHwm = 4;
@@ -202,6 +220,7 @@ class SubscriptionOptions {
   std::size_t message_size_hwm_ = 100 * 1024 * 1024L;
   std::size_t concurrency_lwm_ = 0;
   std::size_t concurrency_hwm_ = DefaultConcurrencyHwm();
+  std::chrono::milliseconds shutdown_polling_period_ = std::chrono::seconds(5);
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
Some applications may want to create a subscription, setup a handler for
messages and errors, and then just leave the subscription "running" in
the background, associated with its completion queue. Until this PR the
subscription was terminated when the associated `future<Status>`
finished.

Fixes #4970 and fixes #4983

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5027)
<!-- Reviewable:end -->
