### PR TITLE
test: test gRPC data plane on GCS

### DIFF
--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -47,6 +47,10 @@ class ObjectInsertIntegrationTest
       // this test are (1) it is relatively short (less than 60 seconds), (2) it
       // actually performs multiple operations against production.
       std::string const key_file_envvar = GetParam();
+      if (UsingGrpc() && key_file_envvar.find("P12") != std::string::npos) {
+        // TODO(5116): gRPC doesn't support PKCS #12 keys.
+        GTEST_SKIP();
+      }
       auto value =
           google::cloud::internal::GetEnv(key_file_envvar.c_str()).value_or("");
       ASSERT_FALSE(value.empty()) << " expected ${" << key_file_envvar

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/expect_exception.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <sys/types.h>
 #include <algorithm>
@@ -388,7 +389,11 @@ TEST_F(ObjectIntegrationTest, StreamingResumableWriteSizeMismatch) {
 
   os.Close();
   auto meta = os.metadata();
-  EXPECT_FALSE(meta.ok()) << "value=" << meta.value();
+  if (!UsingGrpc()) {
+    EXPECT_FALSE(meta.ok()) << "value=" << meta.value();
+    EXPECT_THAT(meta.status(),
+                testing_util::StatusIs(StatusCode::kInvalidArgument));
+  }
 }
 
 TEST_F(ObjectIntegrationTest, StreamingWriteAutoClose) {
@@ -443,7 +448,7 @@ TEST_F(ObjectIntegrationTest, StreamingWriteEmpty) {
 
 TEST_F(ObjectIntegrationTest, XmlStreamingWrite) {
   // This test makes no sense when using the gRPC API.
-  if (UsingGrpc()) return;
+  if (UsingGrpc()) GTEST_SKIP();
 
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
@@ -800,7 +805,12 @@ TEST_F(ObjectIntegrationTest, DeleteAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
-  StatusOr<Client> client = MakeIntegrationTestClient();
+  if (UsingGrpc()) {
+    // TODO(5030): DeleteResumableUpload doesn't work with gRPC yet.
+    GTEST_SKIP();
+  }
+  StatusOr<Client> client = MakeIntegrationTestClient(
+      absl::make_unique<LimitedErrorCountRetryPolicy>(1));
   ASSERT_STATUS_OK(client);
 
   auto object_name = MakeRandomObjectName();

--- a/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_parallel_upload_integration_test.cc
@@ -38,6 +38,8 @@ using ObjectResumableParallelUploadIntegrationTest =
     ::google::cloud::storage::testing::ObjectIntegrationTest;
 
 TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumableParallelUpload) {
+  // TODO(b/146890058) - reenable the test for gRPC
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -79,6 +81,8 @@ TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumableParallelUpload) {
 }
 
 TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumeParallelUploadFile) {
+  // TODO(b/146890058) - reenable the test for gRPC
+  if (UsingGrpc()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -107,6 +111,7 @@ TEST_F(ObjectResumableParallelUploadIntegrationTest, ResumeParallelUploadFile) {
       *client, temp_file.name(), bucket_name_, dest_object_name, prefix, false,
       MinStreamSize(0), IfGenerationMatch(0),
       UseResumableUploadSession(resumable_session_id));
+  ASSERT_STATUS_OK(object_metadata);
 
   auto stream =
       client->ReadObject(bucket_name_, dest_object_name,


### PR DESCRIPTION
The emulator doesn't support this, so production environment is needed.

This fixes #4492 .

A number of tests had to be weakened/disabled due to #5030, #5116 and
b/146890058.

This needs #5029.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5031)
<!-- Reviewable:end -->
