### PR TITLE
fix: specify content length in gRPC GCS

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1411,6 +1411,10 @@ google::storage::v1::StartResumableWriteRequest GrpcClient::ToProto(
   SetProjection(object_spec, request);
   SetCommonParameters(result, request);
   SetCommonObjectParameters(result, request);
+  if (request.HasOption<UploadContentLength>()) {
+    // TODO(5032): make sure it actually works when implemented in service
+    resource.set_size(request.GetOption<UploadContentLength>().value());
+  }
 
   resource.set_bucket(request.bucket_name());
   resource.set_name(request.object_name());

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -230,6 +230,25 @@ TEST(GrpcClientObjectRequest, ResumableUploadRequestSimple) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcClientObjectRequest, ResumableUploadRequestContentLength) {
+  google::storage::v1::StartResumableWriteRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+      insert_object_spec: {
+          resource: {
+            name: "test-object"
+            bucket: "test-bucket"
+            size: 3
+          }
+      })""",
+                                                            &expected));
+
+  ResumableUploadRequest req("test-bucket", "test-object");
+  req.set_multiple_options(UploadContentLength(3));
+
+  auto actual = GrpcClient::ToProto(req);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 TEST(GrpcClientObjectRequest, ResumableUploadRequestAllFields) {
   google::storage::v1::StartResumableWriteRequest expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(


### PR DESCRIPTION
This doesn't really work - the service ingores this field.

This is related to #5032  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5033)
<!-- Reviewable:end -->
