### PR TITLE
fix(storage): work with unknown SSL version in curl

### DIFF
--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -192,7 +192,8 @@ class CurlInitializer {
 
 std::string CurlSslLibraryId() {
   auto vinfo = curl_version_info(CURLVERSION_NOW);
-  return vinfo->ssl_version;
+  auto const is_null = vinfo == nullptr || vinfo->ssl_version == nullptr;
+  return is_null ? "" : vinfo->ssl_version;
 }
 
 bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {

--- a/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
@@ -33,12 +33,12 @@ TEST(CurlWrappers, SigpipeHandlerDisabledTest) {
 #if __has_feature(memory_sanitizer)
   // The memory sanitizer seems to intercept SIGPIPE, simply disable the test
   // in this case.
-  return;
+  GTEST_SKIP();
 #endif  // __has_feature(memory_sanitizer)
 #endif  // __has_fature
 
 #if !defined(SIGPIPE)
-  return;  // nothing to do
+  GTEST_SKIP();  // nothing to do
 #elif CURL_AT_LEAST_VERSION(7, 30, 0)
   // libcurl <= 7.29.0 installs its own signal handler for SIGPIPE during
   // curl_global_init(). Unfortunately 7.29.0 is the default on CentOS-7, and

--- a/google/cloud/storage/internal/curl_wrappers_enable_sigpipe_handler_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_enable_sigpipe_handler_test.cc
@@ -30,7 +30,7 @@ extern "C" void test_handler(int) {}
 /// works as expected.
 TEST(CurlWrappers, SigpipeHandlerEnabledTest) {
 #if !defined(SIGPIPE)
-  return;  // nothing to do
+  GTEST_SKIP();  // nothing to do
 #else
   auto initial_handler = std::signal(SIGPIPE, &test_handler);
   CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())

--- a/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
@@ -29,10 +29,8 @@ extern "C" void test_cb(int /*mode*/, int /*type*/, char const* /*file*/,
 
 /// @test Verify that installing the libraries
 TEST(CurlWrappers, LockingDisabledTest) {
-  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) {
-    // The test cannot execute in this case.
-    return;
-  }
+  // The test cannot execute in this case.
+  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) GTEST_SKIP();
   // Install a trivial callback, this should disable the installation of the
   // normal callbacks in the the curl wrappers.
   CRYPTO_set_locking_callback(test_cb);

--- a/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
@@ -24,10 +24,8 @@ namespace internal {
 namespace {
 /// @test Verify that installing the libraries
 TEST(CurlWrappers, LockingDisabledTest) {
-  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) {
-    // The test cannot execute in this case.
-    return;
-  }
+  // The test cannot execute in this case.
+  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) GTEST_SKIP();
   CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
                          .set_enable_ssl_locking_callbacks(false));
   EXPECT_FALSE(SslLockingCallbacksInstalled());

--- a/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
@@ -24,10 +24,8 @@ namespace internal {
 namespace {
 /// @test Verify that installing the libraries
 TEST(CurlWrappers, LockingEnabledTest) {
-  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) {
-    // The test cannot execute in this case.
-    return;
-  }
+  // The test cannot execute in this case.
+  if (!SslLibraryNeedsLocking(CurlSslLibraryId())) GTEST_SKIP();
   CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
                          .set_enable_ssl_locking_callbacks(true));
   EXPECT_TRUE(SslLockingCallbacksInstalled());


### PR DESCRIPTION
Sometimes libcurl will report the SSL version as `NULL`, typically
because there are multiple SSL engines, or because there is no SSL
version (say when compiled only with Schannel). This change avoids
crashes in that case by returning an empty string for the SSL version
name.

This name is used to determine if SSL requires locking. I think an empty
string works correctly in that case. Only a limited number of *known*
SSL versions do require the locks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5037)
<!-- Reviewable:end -->
