### PR TITLE
cleanup: remove testing_util::internal namespace

### DIFF
--- a/google/cloud/testing_util/contains_once.h
+++ b/google/cloud/testing_util/contains_once.h
@@ -24,9 +24,7 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-namespace testing_util {
-
-namespace internal {
+namespace testing_util_internal {
 
 template <typename Container>
 class ContainsOnceMatcherImpl : public ::testing::MatcherInterface<Container> {
@@ -84,7 +82,9 @@ class ContainsOnceMatcher {
   InnerMatcher const inner_matcher_;
 };
 
-}  // namespace internal
+}  // namespace testing_util_internal
+
+namespace testing_util {
 
 /**
  * Matches an STL-style container or a native array that contains exactly
@@ -101,9 +101,11 @@ class ContainsOnceMatcher {
  * @endcode
  */
 template <typename InnerMatcher>
-internal::ContainsOnceMatcher<typename std::decay<InnerMatcher>::type>
+testing_util_internal::ContainsOnceMatcher<
+    typename std::decay<InnerMatcher>::type>
 ContainsOnce(InnerMatcher&& inner_matcher) {
-  return internal::ContainsOnceMatcher<typename std::decay<InnerMatcher>::type>(
+  return testing_util_internal::ContainsOnceMatcher<
+      typename std::decay<InnerMatcher>::type>(
       std::forward<InnerMatcher>(inner_matcher));
 }
 

--- a/google/cloud/testing_util/status_matchers.h
+++ b/google/cloud/testing_util/status_matchers.h
@@ -23,21 +23,21 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-namespace testing_util {
-
-namespace internal {
+namespace testing_util_internal {
 // Allows the matchers to work with `Status` or `StatusOr<T>`
-inline const ::google::cloud::Status& GetStatus(
-    const ::google::cloud::Status& status) {
+inline ::google::cloud::Status const& GetStatus(
+    ::google::cloud::Status const& status) {
   return status;
 }
 
 template <typename T>
-inline const ::google::cloud::Status& GetStatus(
-    const ::google::cloud::StatusOr<T>& status) {
+inline ::google::cloud::Status const& GetStatus(
+    ::google::cloud::StatusOr<T> const& status) {
   return status.status();
 }
-}  // namespace internal
+}  // namespace testing_util_internal
+
+namespace testing_util {
 
 /**
  * Match the `code` and `message` of a `google::cloud::Status`.
@@ -53,7 +53,7 @@ inline const ::google::cloud::Status& GetStatus(
 // NOLINTNEXTLINE(readability-redundant-string-init)
 MATCHER_P2(StatusIs, code_matcher, message_matcher, "") {
   ::testing::StringMatchResultListener code_listener;
-  auto const& status = ::google::cloud::testing_util::internal::GetStatus(arg);
+  auto const& status = ::google::cloud::testing_util_internal::GetStatus(arg);
   bool result = true;
   if (!::testing::MatcherCast<::google::cloud::StatusCode const&>(code_matcher)
            .MatchAndExplain(status.code(), &code_listener)) {
@@ -84,7 +84,7 @@ MATCHER_P2(StatusIs, code_matcher, message_matcher, "") {
 /// Match the `code` of a `google::cloud::Status`, disregarding the message
 // NOLINTNEXTLINE(readability-redundant-string-init)
 MATCHER_P(StatusIs, code_matcher, "") {
-  auto const& status = ::google::cloud::testing_util::internal::GetStatus(arg);
+  auto const& status = ::google::cloud::testing_util_internal::GetStatus(arg);
   return ::testing::MatcherCast<::google::cloud::Status const&>(
              StatusIs(code_matcher, ::testing::_))
       .MatchAndExplain(status, result_listener);
@@ -93,7 +93,7 @@ MATCHER_P(StatusIs, code_matcher, "") {
 /// Shorthand for `StatusIs(StatusCode::kOk)`
 // NOLINTNEXTLINE(readability-redundant-string-init)
 MATCHER(IsOk, "") {
-  auto const& status = ::google::cloud::testing_util::internal::GetStatus(arg);
+  auto const& status = ::google::cloud::testing_util_internal::GetStatus(arg);
   return ::testing::MatcherCast<::google::cloud::Status const&>(
              StatusIs(::google::cloud::StatusCode::kOk, ::testing::_))
       .MatchAndExplain(status, result_listener);


### PR DESCRIPTION
Use `testing_util_internal` instead. Why? Because we already have
`google::cloud::internal` and any usage of `internal::` becomes
ambiguous inside the `testing_util` namespace depending on what you
include.

Arguably we should avoid `internal::` altogether, this seemed (to me)
the minimal way to fix the ambiguity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5040)
<!-- Reviewable:end -->
