### PR TITLE
doc(pubsub): update Doxygen version numbers

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -16,8 +16,8 @@
 
 set(DOXYGEN_PROJECT_NAME "Google Cloud Pub/Sub C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Pub/Sub")
-# TODO(#4878) - restore the version number in the documents
-set(DOXYGEN_PROJECT_NUMBER "0.0.0 (dev)") # "${GOOGLE_CLOUD_CPP_VERSION}")
+# TODO(#4878) - remove the Beta label
+set(DOXYGEN_PROJECT_NUMBER "${GOOGLE_CLOUD_CPP_VERSION} (Beta)")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/samples
                          ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "pubsub_internal" "pubsub_testing")


### PR DESCRIPTION
We need to publish the docs to https://googleapis.dev with the current
version or they do not show up in the "latest" link. Still mark the
current code as "Beta" so users know what to expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5041)
<!-- Reviewable:end -->
