### PR TITLE
feat(common): make CompletionQueueImpl mockable [3]

### DIFF
--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -88,7 +88,8 @@ class CompletionQueue {
   template <typename Rep, typename Period>
   future<StatusOr<std::chrono::system_clock::time_point>> MakeRelativeTimer(
       std::chrono::duration<Rep, Period> duration) {
-    return MakeDeadlineTimer(std::chrono::system_clock::now() + duration);
+    return impl_->MakeRelativeTimer(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
   }
 
   /**

--- a/google/cloud/internal/completion_queue_impl.h
+++ b/google/cloud/internal/completion_queue_impl.h
@@ -59,6 +59,10 @@ class CompletionQueueImpl {
   virtual future<StatusOr<std::chrono::system_clock::time_point>>
   MakeDeadlineTimer(std::chrono::system_clock::time_point deadline) = 0;
 
+  /// Create a new timer.
+  virtual future<StatusOr<std::chrono::system_clock::time_point>>
+  MakeRelativeTimer(std::chrono::nanoseconds duration) = 0;
+
   /// Enqueue a new asynchronous function.
   virtual void RunAsync(std::unique_ptr<RunAsyncBase> function) = 0;
 

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -165,6 +165,12 @@ DefaultCompletionQueueImpl::MakeDeadlineTimer(
   return op->GetFuture();
 }
 
+future<StatusOr<std::chrono::system_clock::time_point>>
+DefaultCompletionQueueImpl::MakeRelativeTimer(
+    std::chrono::nanoseconds duration) {
+  return MakeDeadlineTimer(std::chrono::system_clock::now() + duration);
+}
+
 void DefaultCompletionQueueImpl::RunAsync(
     std::unique_ptr<internal::RunAsyncBase> function) {
   auto op = std::make_shared<AsyncFunction>(std::move(function));

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -168,7 +168,9 @@ DefaultCompletionQueueImpl::MakeDeadlineTimer(
 future<StatusOr<std::chrono::system_clock::time_point>>
 DefaultCompletionQueueImpl::MakeRelativeTimer(
     std::chrono::nanoseconds duration) {
-  return MakeDeadlineTimer(std::chrono::system_clock::now() + duration);
+  using std::chrono::system_clock;
+  auto const d = std::chrono::duration_cast<system_clock::duration>(duration);
+  return MakeDeadlineTimer(system_clock::now() + d);
 }
 
 void DefaultCompletionQueueImpl::RunAsync(

--- a/google/cloud/internal/default_completion_queue_impl.h
+++ b/google/cloud/internal/default_completion_queue_impl.h
@@ -45,6 +45,10 @@ class DefaultCompletionQueueImpl : public CompletionQueueImpl {
   future<StatusOr<std::chrono::system_clock::time_point>> MakeDeadlineTimer(
       std::chrono::system_clock::time_point deadline) override;
 
+  /// Create a new timer.
+  future<StatusOr<std::chrono::system_clock::time_point>> MakeRelativeTimer(
+      std::chrono::nanoseconds duration) override;
+
   /// Enqueue a new asynchronous function.
   void RunAsync(std::unique_ptr<RunAsyncBase> function) override;
 

--- a/google/cloud/testing_util/fake_completion_queue_impl.cc
+++ b/google/cloud/testing_util/fake_completion_queue_impl.cc
@@ -106,7 +106,9 @@ FakeCompletionQueueImpl::MakeDeadlineTimer(
 
 future<StatusOr<std::chrono::system_clock::time_point>>
 FakeCompletionQueueImpl::MakeRelativeTimer(std::chrono::nanoseconds duration) {
-  return MakeDeadlineTimer(std::chrono::system_clock::now() + duration);
+  using std::chrono::system_clock;
+  auto const d = std::chrono::duration_cast<system_clock::duration>(duration);
+  return MakeDeadlineTimer(system_clock::now() + d);
 }
 
 void FakeCompletionQueueImpl::RunAsync(

--- a/google/cloud/testing_util/fake_completion_queue_impl.cc
+++ b/google/cloud/testing_util/fake_completion_queue_impl.cc
@@ -104,6 +104,11 @@ FakeCompletionQueueImpl::MakeDeadlineTimer(
   return op->GetFuture();
 }
 
+future<StatusOr<std::chrono::system_clock::time_point>>
+FakeCompletionQueueImpl::MakeRelativeTimer(std::chrono::nanoseconds duration) {
+  return MakeDeadlineTimer(std::chrono::system_clock::now() + duration);
+}
+
 void FakeCompletionQueueImpl::RunAsync(
     std::unique_ptr<internal::RunAsyncBase> function) {
   auto op = std::make_shared<FakeAsyncFunction>(std::move(function));

--- a/google/cloud/testing_util/fake_completion_queue_impl.h
+++ b/google/cloud/testing_util/fake_completion_queue_impl.h
@@ -43,6 +43,8 @@ class FakeCompletionQueueImpl
 
   future<StatusOr<std::chrono::system_clock::time_point>> MakeDeadlineTimer(
       std::chrono::system_clock::time_point deadline) override;
+  future<StatusOr<std::chrono::system_clock::time_point>> MakeRelativeTimer(
+      std::chrono::nanoseconds duration) override;
   void RunAsync(std::unique_ptr<internal::RunAsyncBase> function) override;
 
   void StartOperation(std::shared_ptr<internal::AsyncGrpcOperation> op,


### PR DESCRIPTION
We want `MakeRelativeTimer()` to be mockable too, it is hard to verify
that backoff timers are "right" when using absolute times only.

This fixes #4718

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5043)
<!-- Reviewable:end -->
