### PR TITLE
feat(common): create promises without shared state

### DIFF
--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -135,11 +135,17 @@ template <typename T>
 class promise final : private internal::promise_base<T> {
  public:
   /// Creates a promise with an unsatisfied shared state.
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  promise(
+  promise() : internal::promise_base<T>([] {}) {}
+
+  /// Creates a promise with an unsatisfied shared state.
+  explicit promise(
       // NOLINTNEXTLINE(performance-unnecessary-value-param) TODO(#4112)
-      std::function<void()> cancellation_callback = [] {})
+      std::function<void()> cancellation_callback)
       : internal::promise_base<T>(std::move(cancellation_callback)) {}
+
+  /// Creates a promise *without* a shared state.
+  explicit promise(null_promise_t x)
+      : internal::promise_base<T>(std::move(x)) {}
 
   /// Constructs a new promise and transfer any shared state from @p rhs.
   promise(promise&&) noexcept = default;

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -717,6 +717,13 @@ TEST(FutureTestInt, CancellationAfterSatisfaction) {
   ASSERT_EQ(1, f0.get());
 }
 
+/// @test Verify we can create promises without a shared state.
+TEST(FutureTestInt, CreateInvalid) {
+  promise<int> p0(null_promise_t{});
+
+  ExpectFutureError([&] { p0.set_value(42); }, std::future_errc::no_state);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -131,9 +131,14 @@ template <>
 class promise<void> final : private internal::promise_base<void> {
  public:
   /// Creates a promise with an unsatisfied shared state.
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  promise(std::function<void()> cancellation_callback = [] {})
+  promise() : promise_base([] {}) {}
+
+  /// Creates a promise with an unsatisfied shared state.
+  explicit promise(std::function<void()> cancellation_callback)
       : promise_base(std::move(cancellation_callback)) {}
+
+  /// Creates a promise *without* a shared state.
+  explicit promise(null_promise_t x) : promise_base(std::move(x)) {}
 
   /// Constructs a new promise and transfer any shared state from @p rhs.
   promise(promise&&) noexcept = default;

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -732,6 +732,13 @@ TEST(FutureTestVoid, cancellation_after_satisfaction) {
   ASSERT_FALSE(cancelled);
 }
 
+/// @test Verify we can create promises without a shared state.
+TEST(FutureTestVoid, CreateInvalid) {
+  promise<void> p0(null_promise_t{});
+
+  ExpectFutureError([&] { p0.set_value(); }, std::future_errc::no_state);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -26,7 +26,12 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
+/// A helper class to initialize promises to a null state.
+struct null_promise_t {  // NOLINT(readability-identifier-naming)
+};
+
 namespace internal {
+
 /**
  * Refactor common functions to `future<T>`, `future<R&>` and `future<void>`.
  * @tparam T
@@ -150,6 +155,10 @@ class future_base {  // NOLINT(readability-identifier-naming)
 template <typename T>
 class promise_base {  // NOLINT(readability-identifier-naming)
  public:
+  /// Initialize the common components to a null state.
+  explicit promise_base(null_promise_t) {}
+
+  /// Initialize the common components of a promise
   explicit promise_base(std::function<void()> cancellation_callback)
       : shared_state_(
             std::make_shared<shared_state_type>(cancellation_callback)) {}


### PR DESCRIPTION
Sometimes we need to create a `promise<T>` without any shared state,
typically because we won't be able to create the cancellation callback
until later in the code. One can create a promise and replace its shared
state, but that seems wasteful, like creating a `unique_ptr<>` with an
object only to reset it a few lines later. This PR introduces
`google::cloud::null_promise_t`, analogous to `nullopt_t` to initialize
such promises.

Motivated by #5026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5046)
<!-- Reviewable:end -->
