### PR TITLE
feat(common): support cancels for asynchronous unary RPCs

### DIFF
--- a/google/cloud/internal/async_rpc_details.h
+++ b/google/cloud/internal/async_rpc_details.h
@@ -86,7 +86,7 @@ class AsyncUnaryRpcFuture : public AsyncGrpcOperation {
 
  private:
   // These are the parameters for the RPC, most of them have obvious semantics.
-  // The promise will hold the grpc::ClientContext (in its cancel callback), it
+  // The promise will hold the grpc::ClientContext (in its cancel callback). It
   // uses a `unique_ptr` because (a) we need to receive it as a parameter,
   // otherwise the caller could not set timeouts, metadata, or any other
   // attributes, and (b) there is no move or assignment operator for


### PR DESCRIPTION
Part of the work for #5026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5047)
<!-- Reviewable:end -->
