### PR TITLE
cleanup: automate Abseil pkg-config dependencies

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -201,3 +201,125 @@ function (google_cloud_cpp_add_executable target prefix source)
         "${target_name}"
         PARENT_SCOPE)
 endfunction ()
+
+#
+# google_cloud_cpp_absl_pkg_config : finds the right -l options for Abseil
+# dependencies.
+#
+# Finds the necessary `-l` flags to link Abseil (direct) dependencies of a
+# target. First discover all the names of any necessary abseil libraries, in the
+# correct order for the link line (first the library, then anything it depends
+# on). Remove duplicates in reverse order.
+#
+function (google_cloud_cpp_absl_pkg_config var target)
+    google_cloud_cpp_absl_pkg_config_all_basenames(bases ${target} 0)
+    list(REVERSE bases)
+    list(REMOVE_DUPLICATES bases)
+    list(REVERSE bases)
+    set(result)
+    foreach (b ${bases})
+        list(APPEND result " -l${b}")
+    endforeach ()
+    set("${var}"
+        "${result}"
+        PARENT_SCOPE)
+endfunction ()
+
+#
+# google_cloud_cpp_absl_pkg_config_basename : finds the basename (if any) for an
+# imported library target
+#
+# Computes the basename (i.e. the portion of the name suitable for -l flags) of
+# an imported static or shared library target.  All Abseil libraries are
+# imported library targets, but some are interface libraries that do not need -l
+# flags.
+#
+# Discovering the name requires extracting the right location property from the
+# target, which varies depending on the build type.
+#
+# Cleaning up the imported location (which is an actual filename)
+#
+function (google_cloud_cpp_absl_pkg_config_basename var target)
+    set("${var}"
+        ""
+        PARENT_SCOPE)
+    if (NOT TARGET ${target})
+        return()
+    endif ()
+    get_target_property(type "${target}" TYPE)
+    set(valid_types "STATIC_LIBRARY" "SHARED_LIBRARY")
+    if ("${type}" IN_LIST valid_types)
+        set(location_properties)
+        list(APPEND location_properties IMPORTED_LOCATION_NOCONFIG)
+        list(APPEND location_properties IMPORTED_LOCATION)
+        foreach (
+            c
+            "${CMAKE_BUILD_TYPE}"
+            Debug
+            Release
+            RelWithDebInfo
+            MinSizeRel
+            Coverage
+            ${CMAKE_CONFIGURATION_TYPES})
+            string(TOUPPER "${c}" CONFIG)
+            list(APPEND location_properties IMPORTED_LOCATION_${CONFIG})
+        endforeach ()
+        list(REMOVE_DUPLICATES location_properties)
+        foreach (property ${location_properties})
+            get_target_property(location "${target}" ${property})
+            if (location)
+                get_filename_component(base "${location}" NAME)
+                foreach (
+                    decoration
+                    CMAKE_STATIC_LIBRARY_PREFIX
+                    CMAKE_STATIC_LIBRARY_SUFFIX
+                    CMAKE_SHARED_LIBRARY_PREFIX
+                    CMAKE_SHARED_LIBRARY_SUFFIX
+                    CMAKE_STATIC_LIBRARY_PREFIX_CXX
+                    CMAKE_STATIC_LIBRARY_SUFFIX_CXX
+                    CMAKE_SHARED_LIBRARY_PREFIX_CXX
+                    CMAKE_SHARED_LIBRARY_SUFFIX_CXX)
+                    if ("${${decoration}}" STREQUAL "")
+                        continue()
+                    endif ()
+                    string(REPLACE "${${decoration}}" "" base "${base}")
+                endforeach ()
+                set("${var}"
+                    "${base}"
+                    PARENT_SCOPE)
+                return()
+            endif ()
+        endforeach ()
+    endif ()
+endfunction ()
+
+# google_cloud_cpp_absl_pkg_config_all_basenames : the required -l flag values
+# for all (direct) Abseil dependencies.
+#
+# To link a direct Abseil dependency with pkg-config we must build a list of -l
+# flags for this dependency and all its (indirect) dependencies.
+function (google_cloud_cpp_absl_pkg_config_all_basenames var target level)
+    set("${var}"
+        ""
+        PARENT_SCOPE)
+    if (NOT TARGET ${target})
+        return()
+    endif ()
+    get_target_property(type "${target}" TYPE)
+    get_target_property(linked_libraries ${target} INTERFACE_LINK_LIBRARIES)
+    google_cloud_cpp_absl_pkg_config_basename(result "${target}")
+    foreach (lib ${linked_libraries})
+        string(SUBSTRING "${lib}" 0 6 prefix)
+        if (NOT ("${prefix}" STREQUAL "absl::"))
+            continue()
+        endif ()
+        math(EXPR next_level "${level} + 1")
+        google_cloud_cpp_absl_pkg_config_all_basenames(sub ${lib} ${next_level})
+        if (NOT "${sub}" STREQUAL "")
+            list(APPEND result ${sub})
+        endif ()
+    endforeach ()
+    set("${var}"
+        "${result}"
+        PARENT_SCOPE)
+endfunction ()

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -169,7 +169,7 @@ add_library(
     version.h)
 target_link_libraries(
     google_cloud_cpp_common PUBLIC absl::memory absl::optional absl::time
-                                   absl::variant Threads::Threads)
+                                   Threads::Threads)
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
     google_cloud_cpp_common
@@ -303,9 +303,9 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
 # libraries, so we need to explicitly include them here. Here we include the
 # runtime deps of the absl::optional target (http://github.com/abseil/abseil-cpp
 # /blob/4a851046a0102cd986a5714a1af8deef28a544c4/absl/types/CMakeLists.txt#L164)
-set(GOOGLE_CLOUD_CPP_PC_LIBS
-    "-lgoogle_cloud_cpp_common -labsl_time -labsl_time_zone -labsl_bad_optional_access"
-)
+google_cloud_cpp_absl_pkg_config(absl_pkg_config google_cloud_cpp_common)
+string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_common"
+              ${absl_pkg_config})
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
@@ -470,7 +470,10 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
     set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
         "Provides gRPC Utilities for the Google Cloud C++ Client Library.")
     set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common")
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_grpc_utils")
+    google_cloud_cpp_absl_pkg_config(absl_pkg_config
+                                     google_cloud_cpp_grpc_utils)
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_grpc_utils"
+                  ${absl_pkg_config})
 
     # Create and install the pkg-config files.
     configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -384,7 +384,8 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
 set(GOOGLE_CLOUD_CPP_PC_REQUIRES
     "google_cloud_cpp_grpc_utils google_cloud_cpp_common googleapis_cpp_bigtable_protos"
 )
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lbigtable_client")
+google_cloud_cpp_absl_pkg_config(absl_pkg_config bigtable_client)
+string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lbigtable_client" ${absl_pkg_config})
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -306,7 +306,8 @@ set(GOOGLE_CLOUD_PC_DESCRIPTION
 set(GOOGLE_CLOUD_PC_REQUIRES
     "google_cloud_cpp_grpc_utils google_cloud_cpp_common googleapis_cpp_pubsub_protos"
 )
-set(GOOGLE_CLOUD_PC_LIBS "-lpubsub_client")
+google_cloud_cpp_absl_pkg_config(absl_pkg_config pubsub_client)
+string(CONCAT GOOGLE_CLOUD_PC_LIBS "-lpubsub_client" ${absl_pkg_config})
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/pubsub/config.pc.in"

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -415,8 +415,8 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
 set(GOOGLE_CLOUD_CPP_PC_REQUIRES
     "google_cloud_cpp_grpc_utils google_cloud_cpp_common googleapis_cpp_spanner_protos"
 )
-set(GOOGLE_CLOUD_CPP_PC_LIBS
-    "-lspanner_client -labsl_int128 -labsl_time -labsl_time_zone")
+google_cloud_cpp_absl_pkg_config(absl_pkg_config spanner_client)
+string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lspanner_client" ${absl_pkg_config})
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/spanner/config.pc.in"

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -228,6 +228,7 @@ target_link_libraries(
            absl::strings
            absl::str_format
            absl::time
+           absl::variant
            google_cloud_cpp_common
            nlohmann_json::nlohmann_json
            Crc32c::crc32c
@@ -554,9 +555,9 @@ set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Storage C++ Client Library")
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Storage.")
 set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common libcurl openssl")
+google_cloud_cpp_absl_pkg_config(absl_pkg_config storage_client)
 string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lstorage_client" " -lcrc32c"
-              " -labsl_strings" " -labsl_strings_internal"
-              " -labsl_str_format_internal")
+              ${absl_pkg_config})
 
 # Create and install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -152,14 +152,19 @@ if (BUILD_TESTING)
         "Testing Utilities used by the Google Cloud C++ Client Libraries.")
 
     # Create and install the pkg-config files. First for testing_util:
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_testing")
+    google_cloud_cpp_absl_pkg_config(absl_pkg_config google_cloud_cpp_testing)
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_testing"
+                  ${absl_pkg_config})
     set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common")
     configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
                    "google_cloud_cpp_testing.pc" @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_testing.pc"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
     # Then for testing_grpc:
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_testing_grpc")
+    google_cloud_cpp_absl_pkg_config(absl_pkg_config
+                                     google_cloud_cpp_testing_grpc)
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_testing_grpc"
+                  ${absl_pkg_config})
     set(GOOGLE_CLOUD_CPP_PC_REQUIRES
         "google_cloud_cpp_testing google_cloud_cpp_common")
     configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"


### PR DESCRIPTION
Abseil does not install its own pkg-config `.pc` files, so in our own
`.pc` files we need to list the `-l` options explicitly. With this
change we navigate the dependency graph for the CMake targets to
discover all these flags, instead of hard-coding them in our list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5051)
<!-- Reviewable:end -->
