### PR TITLE
fix: remove unneeded dep

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -61,7 +61,6 @@ load(
         ":google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/types:variant",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_common_unit_tests]
@@ -112,7 +111,6 @@ load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_absl//absl/memory",
-        "@com_google_absl//absl/types:variant",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
         "@com_google_googleapis//google/spanner/v1:spanner_cc_grpc",


### PR DESCRIPTION
This was an unnecessary dep that @coryan discovered in
https://github.com/googleapis/google-cloud-cpp/pull/5051 and removed in
the CMakeLists.txt file. This PR cleans up the unneeded dep in the bazel
build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5054)
<!-- Reviewable:end -->
