### PR TITLE
ci: enable ccache on all CI builds

### DIFF
--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -23,11 +23,9 @@ cache_download_enabled() {
     return 1
   fi
 
-  if [[ "${RUNNING_CI:-}" != "yes" || (\
-    "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GERRIT_ON_BORG" && \
-    "${KOKORO_JOB_TYPE:-}" != "PRESUBMIT_GITHUB") ]]; then
+  if [[ "${RUNNING_CI:-}" != "yes" ]]; then
     echo "================================================================"
-    io::log "Cache not downloaded as this is not a PR build."
+    io::log "Cache not downloaded as this is not a CI build."
     return 1
   fi
   return 0


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-cpp/issues/4783, by using ccache during the full builds with cmake. https://github.com/googleapis/google-cloud-cpp/pull/4869 was already submitted, which enabled a bazel cache for all CI builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5063)
<!-- Reviewable:end -->
