### PR TITLE
ci: remove unneeded explicit build step

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -85,12 +85,6 @@ echo "bazel test" "${bazel_args[@]}"
 "${BAZEL_BIN}" test \
   "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 
-echo "================================================================"
-io::log "Compiling all the code, including integration tests"
-# Then build everything else (integration tests, examples, etc). So we can run
-# them next.
-"${BAZEL_BIN}" build "${bazel_args[@]}" ...
-
 should_run_integration_tests() {
   if [[ "${SOURCE_DIR:-}" == "super" ]]; then
     # super builds cannot run the integration tests


### PR DESCRIPTION
I don't think there's any need to do an explicit `bazel build`. Any code and tests will be compiled when they need to be run. Additionally, if a `bazel test` invocation uses slightly different flags than the `bazel build` invocation, the cache will not be hit and we'll unnecessarily compile stuff in the `bazel build` step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5066)
<!-- Reviewable:end -->
