### PR TITLE
fix(storage): disable XML with custom endpoints

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -26,6 +26,10 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+std::string DefaultEndpoint() { return "https://storage.googleapis.com"; }
+}  // namespace internal
+
 namespace {
 StatusOr<std::shared_ptr<oauth2::Credentials>> StorageDefaultCredentials() {
   auto emulator = cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
@@ -81,7 +85,7 @@ StatusOr<ClientOptions> ClientOptions::CreateDefaultClientOptions(
 ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials,
                              ChannelOptions channel_options)
     : credentials_(std::move(credentials)),
-      endpoint_("https://storage.googleapis.com"),
+      endpoint_(internal::DefaultEndpoint()),
       iam_endpoint_("https://iamcredentials.googleapis.com/v1"),
       version_("v1"),
       enable_http_tracing_(false),

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -239,6 +239,10 @@ class ClientOptions {
   std::chrono::seconds download_stall_timeout_;
   ChannelOptions channel_options_;
 };
+
+namespace internal {
+std::string DefaultEndpoint();
+}  // namespace internal
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -179,8 +179,11 @@ class CurlClient : public RawClient,
   StatusOr<EmptyResponse> DeleteNotification(
       DeleteNotificationRequest const&) override;
 
-  void LockShared(curl_lock_data data);
-  void UnlockShared(curl_lock_data data);
+  bool xml_enabled() const { return xml_enabled_; }
+  std::string storage_endpoint() const { return storage_endpoint_; }
+  std::string upload_endpoint() const { return upload_endpoint_; }
+  std::string xml_upload_endpoint() const { return xml_upload_endpoint_; }
+  std::string xml_download_endpoint() const { return xml_download_endpoint_; }
 
  protected:
   // The constructor is private because the class must always be created
@@ -215,6 +218,7 @@ class CurlClient : public RawClient,
   CreateResumableSessionGeneric(RequestType const& request);
 
   ClientOptions options_;
+  bool const xml_enabled_;
   std::string const x_goog_api_client_header_;
   std::string storage_endpoint_;
   std::string upload_endpoint_;

--- a/google/cloud/storage/tests/object_basic_crud_integration_test.cc
+++ b/google/cloud/storage/tests/object_basic_crud_integration_test.cc
@@ -14,19 +14,14 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/object_integration_test.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
-#include "google/cloud/log.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/contains_once.h"
-#include "google/cloud/testing_util/expect_exception.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
-#include <sys/types.h>
 #include <algorithm>
-#include <cstring>
-#include <iostream>
-#include <memory>
 #include <string>
 
 namespace google {
@@ -132,6 +127,102 @@ TEST_F(ObjectBasicCRUDIntegrationTest, BasicCRUD) {
   auto status = client->DeleteObject(bucket_name_, object_name);
   ASSERT_STATUS_OK(status);
   EXPECT_THAT(list_object_names(), Not(Contains(object_name)));
+}
+
+StatusOr<Client> CreateNonDefaultClient() {
+  auto testbench =
+      google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
+  google::cloud::testing_util::ScopedEnvironment env(
+      "CLOUD_STORAGE_TESTBENCH_ENDPOINT", {});
+  auto options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  if (!testbench) {
+    // Use a non-standard spelling of the standard endpoint. This should disable
+    // the XML APIs, but still work against production
+    options.set_endpoint("https://storage.googleapis.com:443");
+    auto creds = oauth2::GoogleDefaultCredentials();
+    if (!creds) return std::move(creds).status();
+    options.set_credentials(*std::move(creds));
+  } else {
+    // Use the testbench endpoint, but not through the environment variable
+    options.set_endpoint(*testbench);
+    options.set_credentials(oauth2::CreateAnonymousCredentials());
+  }
+  return Client(options);
+}
+
+/// @test Verify that the client works with non-default endpoints.
+TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointInsertJSON) {
+  auto client = CreateNonDefaultClient();
+  ASSERT_STATUS_OK(client);
+  auto object_name = MakeRandomObjectName();
+  auto const expected = LoremIpsum();
+  auto insert = client->InsertObject(bucket_name_, object_name, expected);
+  ASSERT_STATUS_OK(insert);
+  auto stream =
+      client->ReadObject(bucket_name_, object_name, IfGenerationNotMatch(0));
+  EXPECT_STATUS_OK(stream.status());
+  std::string const actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  auto status = client->DeleteObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
+/// @test Verify that the client works with non-default endpoints.
+TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointInsertXml) {
+  auto client = CreateNonDefaultClient();
+  ASSERT_STATUS_OK(client);
+  auto object_name = MakeRandomObjectName();
+  auto const expected = LoremIpsum();
+  auto insert =
+      client->InsertObject(bucket_name_, object_name, expected, Fields(""));
+  ASSERT_STATUS_OK(insert);
+  auto stream = client->ReadObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(stream.status());
+  std::string const actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  auto status = client->DeleteObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
+/// @test Verify that the client works with non-default endpoints.
+TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteJSON) {
+  auto client = CreateNonDefaultClient();
+  ASSERT_STATUS_OK(client);
+  auto object_name = MakeRandomObjectName();
+  auto const expected = LoremIpsum();
+  auto writer = client->WriteObject(bucket_name_, object_name);
+  writer << expected;
+  writer.Close();
+  ASSERT_STATUS_OK(writer.metadata());
+  auto stream =
+      client->ReadObject(bucket_name_, object_name, IfGenerationNotMatch(0));
+  EXPECT_STATUS_OK(stream.status());
+  std::string const actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  auto status = client->DeleteObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(status);
+}
+
+/// @test Verify that the client works with non-default endpoints.
+TEST_F(ObjectBasicCRUDIntegrationTest, NonDefaultEndpointWriteXml) {
+  auto client = CreateNonDefaultClient();
+  ASSERT_STATUS_OK(client);
+  auto object_name = MakeRandomObjectName();
+  auto const expected = LoremIpsum();
+  auto writer = client->WriteObject(bucket_name_, object_name, Fields(""));
+  writer << expected;
+  writer.Close();
+  ASSERT_STATUS_OK(writer.metadata());
+  auto stream = client->ReadObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(stream.status());
+  std::string const actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(expected, actual);
+
+  auto status = client->DeleteObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(status);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
The library automatically uses XML for some operations (for performance
reasons). This does not work well when using a custom endpoint, as the
endpoints for XML are not set.  We completely disable XML if the
application sets a custom endpoint, as in this case they (most likely)
want to use an emulator.

Fixes #5072

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5074)
<!-- Reviewable:end -->
