### PR TITLE
ci: merge coverage data before uploading

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -22,7 +22,7 @@ ARG NCPU=4
 RUN dnf makecache && \
     dnf install -y abi-compliance-checker abi-dumper \
         clang clang-tools-extra cmake diffutils doxygen findutils gcc-c++ git \
-        grpc-devel grpc-plugins libcxx-devel libcxxabi-devel libcurl-devel \
+        grpc-devel grpc-plugins lcov libcxx-devel libcxxabi-devel libcurl-devel \
         make ninja-build openssl-devel pkgconfig protobuf-compiler python3 python3-pip \
         ShellCheck tar unzip w3m wget which zlib-devel
 

--- a/ci/kokoro/docker/upload-coverage.sh
+++ b/ci/kokoro/docker/upload-coverage.sh
@@ -99,11 +99,20 @@ docker_flags+=(
   "--env" "CI_JOB_ID=${KOKORO_BUILD_NUMBER:-}"
 )
 
+echo -n "Merging coverage data"
+readonly MERGED_COVERAGE="merged-coverage.lcov"
+lcov_flags=()
+while read -r file; do
+  echo -n "."
+  lcov_flags+=("--add-tracefile" "${file}")
+done < <(find "${BUILD_HOME}" -name "coverage.dat")
+lcov --quiet "${lcov_flags[@]}" --output-file "${BUILD_HOME}/${MERGED_COVERAGE}"
+echo
+
 echo -n "Uploading code coverage to codecov.io..."
 codecov_flags=(
-  "-s" "/h"
-  "-f" "'!*/baseline_coverage.dat'"
   "-X" "gcov"
+  "-f" "/h/${MERGED_COVERAGE}"
   "-q" "/v/${BUILD_OUTPUT}/coverage-report.txt"
 )
 # This controls the output format from bash's `time` command.

--- a/ci/kokoro/docker/upload-coverage.sh
+++ b/ci/kokoro/docker/upload-coverage.sh
@@ -102,6 +102,8 @@ docker_flags+=(
 # This controls the output format from bash's `time` command.
 readonly TIMEFORMAT="DONE in %R seconds\n"
 
+# We first merge all the coverage.dat files into a single file. This reduces
+# the overall file size from about 900MB to about 16MB.
 echo -n "Merging coverage data"
 readonly MERGED_COVERAGE="merged-coverage.lcov"
 time {
@@ -110,8 +112,8 @@ time {
     echo -n "."
     lcov_flags+=("--add-tracefile" "${file}")
   done < <(find "${BUILD_HOME}" -name "coverage.dat")
-  lcov --quiet "${lcov_flags[@]}" --output-file "${BUILD_HOME}/${MERGED_COVERAGE}"
   echo
+  lcov --quiet "${lcov_flags[@]}" --output-file "${BUILD_HOME}/${MERGED_COVERAGE}"
 }
 
 echo -n "Uploading code coverage to codecov.io..."


### PR DESCRIPTION
This reduces the uploaded report size from ~900MB to ~16MB, which may make our coverage reports less flaky.

Part of https://github.com/googleapis/google-cloud-cpp/issues/5082

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5086)
<!-- Reviewable:end -->
