### PR TITLE
cleanup: Fix typos in Doxygen comments

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -150,7 +150,7 @@ struct FormatDuration {
  *
  * The benchmarks need to report time in human readable terms.  This operator
  * streams a FormatDuration in hours, minutes, seconds and sub-seconds.  Any
- * component that is zero gets ommitted, e.g. 1 hour exactly is printed as 1h.
+ * component that is zero gets omitted, e.g. 1 hour exactly is printed as 1h.
  *
  * If the time is less than 1 second then the format uses millisecond or
  * microsecond resolution, as appropriate.

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -324,7 +324,7 @@ class InstanceAdmin {
    * @param instance_update_config config with modified instance.
    *
    * @return a future satisfied when either (a) the instance is updated or (b)
-   *     an unretriable error occurs or (c) polling or retry policy has been
+   *     an non-retryable error occurs or (c) polling or retry policy has been
    *     exhausted.
    *
    * @par Idempotency
@@ -591,7 +591,7 @@ class InstanceAdmin {
    * @param cluster_config cluster with updated values.
    *
    * @return a future satisfied when either (a) the cluster is updated or (b)
-   *     an unretriable error occurs or (c) polling or retry policy has been
+   *     an non-retryable error occurs or (c) polling or retry policy has been
    *     exhausted.
    *
    * @par Idempotency
@@ -757,7 +757,7 @@ class InstanceAdmin {
    * @param instance_id the instance to look the profile in.
    * @param profile_id the id of the profile within that instance.
    * @return a future satisfied when either (a) the profile is fetched or (b)
-   *     an unretriable error occurs or (c) retry policy has been exhausted.
+   *     an non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -808,7 +808,7 @@ class InstanceAdmin {
    * @param config the configuration for the new application profile.
    *
    * @return a future satisfied when either (a) the profile is updated or (b)
-   *     an unretriable error occurs or (c) polling or retry policy has been
+   *     an non-retryable error occurs or (c) polling or retry policy has been
    *     exhausted.
    *
    * @par Idempotency
@@ -889,7 +889,8 @@ class InstanceAdmin {
    *     pending.
    *
    * @return a future satisfied when either (a) the app profile is deleted or
-   *     (b) an unretriable error occurs or (c) retry policy has been exhausted.
+   *     (b) an non-retryable error occurs or (c) retry policy has been
+   * exhausted.
    *
    * @par Idempotency
    * This operation is always treated as non-idempotent.
@@ -949,7 +950,7 @@ class InstanceAdmin {
    *     `cq.Run()`.
    * @param instance_id the instance to query.
    * @return a future satisfied when either (a) the policy is fetched or (b)
-   *     an unretriable error occurs or (c) retry policy has been exhausted.
+   *     an non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
@@ -977,7 +978,7 @@ class InstanceAdmin {
    *     `cq.Run()`.
    * @param instance_id the instance to query.
    * @return a future satisfied when either (a) the policy is fetched or (b)
-   *     an unretriable error occurs or (c) retry policy has been exhausted.
+   *     an non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -1056,7 +1057,7 @@ class InstanceAdmin {
    * @param iam_bindings IamBindings object containing role and members.
    * @param etag the expected ETag value for the current policy.
    * @return a future satisfied when either (a) the policy is created or (b)
-   *     an unretriable error occurs or (c) retry policy has been
+   *     an non-retryable error occurs or (c) retry policy has been
    *     exhausted.
    *
    * @deprecated this function is deprecated; it doesn't support conditional
@@ -1087,7 +1088,7 @@ class InstanceAdmin {
    * @param iam_policy google::iam::v1::Policy object containing role and
    * members.
    * @return a future satisfied when either (a) the policy is created or (b)
-   *     an unretriable error occurs or (c) retry policy has been
+   *     an non-retryable error occurs or (c) retry policy has been
    *     exhausted.
    *
    * @warning ETags are currently not used by Cloud Bigtable.

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -324,7 +324,7 @@ class InstanceAdmin {
    * @param instance_update_config config with modified instance.
    *
    * @return a future satisfied when either (a) the instance is updated or (b)
-   *     an non-retryable error occurs or (c) polling or retry policy has been
+   *     a non-retryable error occurs or (c) polling or retry policy has been
    *     exhausted.
    *
    * @par Idempotency
@@ -591,7 +591,7 @@ class InstanceAdmin {
    * @param cluster_config cluster with updated values.
    *
    * @return a future satisfied when either (a) the cluster is updated or (b)
-   *     an non-retryable error occurs or (c) polling or retry policy has been
+   *     a non-retryable error occurs or (c) polling or retry policy has been
    *     exhausted.
    *
    * @par Idempotency
@@ -757,7 +757,7 @@ class InstanceAdmin {
    * @param instance_id the instance to look the profile in.
    * @param profile_id the id of the profile within that instance.
    * @return a future satisfied when either (a) the profile is fetched or (b)
-   *     an non-retryable error occurs or (c) retry policy has been exhausted.
+   *     a non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -808,7 +808,7 @@ class InstanceAdmin {
    * @param config the configuration for the new application profile.
    *
    * @return a future satisfied when either (a) the profile is updated or (b)
-   *     an non-retryable error occurs or (c) polling or retry policy has been
+   *     a non-retryable error occurs or (c) polling or retry policy has been
    *     exhausted.
    *
    * @par Idempotency
@@ -889,8 +889,8 @@ class InstanceAdmin {
    *     pending.
    *
    * @return a future satisfied when either (a) the app profile is deleted or
-   *     (b) an non-retryable error occurs or (c) retry policy has been
-   * exhausted.
+   *     (b) a non-retryable error occurs or (c) retry policy has been
+   *     exhausted.
    *
    * @par Idempotency
    * This operation is always treated as non-idempotent.
@@ -950,7 +950,7 @@ class InstanceAdmin {
    *     `cq.Run()`.
    * @param instance_id the instance to query.
    * @return a future satisfied when either (a) the policy is fetched or (b)
-   *     an non-retryable error occurs or (c) retry policy has been exhausted.
+   *     a non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
@@ -978,7 +978,7 @@ class InstanceAdmin {
    *     `cq.Run()`.
    * @param instance_id the instance to query.
    * @return a future satisfied when either (a) the policy is fetched or (b)
-   *     an non-retryable error occurs or (c) retry policy has been exhausted.
+   *     a non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -1057,7 +1057,7 @@ class InstanceAdmin {
    * @param iam_bindings IamBindings object containing role and members.
    * @param etag the expected ETag value for the current policy.
    * @return a future satisfied when either (a) the policy is created or (b)
-   *     an non-retryable error occurs or (c) retry policy has been
+   *     a non-retryable error occurs or (c) retry policy has been
    *     exhausted.
    *
    * @deprecated this function is deprecated; it doesn't support conditional
@@ -1088,7 +1088,7 @@ class InstanceAdmin {
    * @param iam_policy google::iam::v1::Policy object containing role and
    * members.
    * @return a future satisfied when either (a) the policy is created or (b)
-   *     an non-retryable error occurs or (c) retry policy has been
+   *     a non-retryable error occurs or (c) retry policy has been
    *     exhausted.
    *
    * @warning ETags are currently not used by Cloud Bigtable.

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -60,7 +60,7 @@ class RowSet {
    * Modify this object to contain the ranges and keys inside @p range.
    *
    * This function removes any rowkeys outside @p range, it removes any row
-   * ranges that do not insersect with @p range, and keeps only the intersection
+   * ranges that do not intersect with @p range, and keeps only the intersection
    * for those ranges that do intersect @p range.
    */
   RowSet Intersect(bigtable::RowRange const& range) const;

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -747,7 +747,7 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
-   * @returns a future satisfied when the operation completes, failed
+   * @returns a future satisfied when the operation completes, fails
    *     permanently or keeps failing transiently, but the retry policy has been
    *     exhausted. The future will return a tuple. The first element is a
    *     boolean, with value `false` if the row does not exist.  If the first

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -230,7 +230,7 @@ class Table {
    * @par Example
    * @code
    * using namespace std::chrono_literals; // assuming C++14.
-   * auto client = bigtable::CreateDefaultClient(...); // details ommitted
+   * auto client = bigtable::CreateDefaultClient(...); // details omitted
    * bigtable::Table table(client, "my-table",
    *                       // Allow up to 20 minutes to retry operations
    *                       bigtable::LimitedTimeRetryPolicy(20min),
@@ -293,7 +293,7 @@ class Table {
    * @par Example
    * @code
    * using namespace std::chrono_literals; // assuming C++14.
-   * auto client = bigtable::CreateDefaultClient(...); // details ommitted
+   * auto client = bigtable::CreateDefaultClient(...); // details omitted
    * bigtable::Table table(client, "app_id", "my-table",
    *                       // Allow up to 20 minutes to retry operations
    *                       bigtable::LimitedTimeRetryPolicy(20min),
@@ -747,7 +747,7 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
-   * @returns a future satisfied when the operation completes, failes
+   * @returns a future satisfied when the operation completes, failed
    *     permanently or keeps failing transiently, but the retry policy has been
    *     exhausted. The future will return a tuple. The first element is a
    *     boolean, with value `false` if the row does not exist.  If the first

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -1222,7 +1222,7 @@ class TableAdmin {
    *     `cq.Run()`.
    * @param table_id the instance to query.
    * @return a future satisfied when either (a) the policy is fetched or (b)
-   *     an non-retryable error occurs or (c) retry policy has been exhausted.
+   *     a non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -1266,7 +1266,7 @@ class TableAdmin {
    * @param iam_policy google::iam::v1::Policy object containing role and
    * members.
    * @return a future satisfied when either (a) the policy is created or (b)
-   *     an non-retryable error occurs or (c) retry policy has been
+   *     a non-retryable error occurs or (c) retry policy has been
    *     exhausted.
    *
    * @warning ETags are currently not used by Cloud Bigtable.

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -741,7 +741,7 @@ class TableAdmin {
      *
      * @param cluster_id the name of the cluster relative to the instance
      *     managed by the `TableAdmin` object. If no cluster_id is specified,
-     *     teh all backups in all clusters are listed. The full cluster name is
+     *     the all backups in all clusters are listed. The full cluster name is
      *     `projects/<PROJECT_ID>/instances/<INSTANCE_ID>/clusters/<cluster_id>`
      *     where PROJECT_ID is obtained from the associated AdminClient and
      *     INSTANCE_ID is the instance_id() of the `TableAdmin` object.
@@ -1222,7 +1222,7 @@ class TableAdmin {
    *     `cq.Run()`.
    * @param table_id the instance to query.
    * @return a future satisfied when either (a) the policy is fetched or (b)
-   *     an unretriable error occurs or (c) retry policy has been exhausted.
+   *     an non-retryable error occurs or (c) retry policy has been exhausted.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -1266,7 +1266,7 @@ class TableAdmin {
    * @param iam_policy google::iam::v1::Policy object containing role and
    * members.
    * @return a future satisfied when either (a) the policy is created or (b)
-   *     an unretriable error occurs or (c) retry policy has been
+   *     an non-retryable error occurs or (c) retry policy has been
    *     exhausted.
    *
    * @warning ETags are currently not used by Cloud Bigtable.

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -30,7 +30,7 @@ namespace testing {
  *
  * This class is mainly for testing purpose, it enable use of a single embedded
  * server
- * for multiple test cases. This adminlient uses a pre-defined channel.
+ * for multiple test cases. This admin client uses a pre-defined channel.
  */
 class InProcessAdminClient : public bigtable::AdminClient {
  public:

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -32,7 +32,7 @@ namespace testing {
  * Refactor code common to several mock objects.
  *
  * Mocking a grpc::ClientReaderInterface<> was getting tedious. This refactors
- * most (but unfortunately cannnot refactor all) the code for such objects.
+ * most (but unfortunately cannot refactor all) the code for such objects.
  *
  * @tparam Response the response type.
  */

--- a/google/cloud/firestore/field_path.h
+++ b/google/cloud/firestore/field_path.h
@@ -120,7 +120,7 @@ class FieldPath {
   static std::vector<std::string> Split(std::string string);
 
   /**
-   * Replace all occurences of @p find in @p string with @p replace.
+   * Replace all occurrences of @p find in @p string with @p replace.
    *
    * @param string A string to search and replace
    * @param find A const String to find and replace with @p replace

--- a/google/cloud/internal/async_retry_unary_rpc.h
+++ b/google/cloud/internal/async_retry_unary_rpc.h
@@ -45,7 +45,6 @@ namespace internal {
  *     and the member function to invoke.
  * @tparam RequestType the type of the request object.
  * @tparam IdempotencyPolicy the type of the idempotency policy.
- * @tparam Sig discover the signature and return type of `AsyncCallType`.
  * @tparam ResponseType the discovered response type for `AsyncCallType`.
  * @tparam validate_parameters validate the other template parameters.
  */

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -39,7 +39,7 @@ namespace internal {
  *     failure.
  * @param idempotency if `Idempotency::kNonIdempotent`, the operation is not
  *     retried even on transient errors.
- * @param functor the operation to retry, typically a lambda that encasulates
+ * @param functor the operation to retry, typically a lambda that encapsulates
  *     both the Stub and the function to call.
  * @param context the gRPC context used for the request, previous Stubs in the
  *     stack can set timeouts and metadata through this context.

--- a/google/cloud/internal/tuple.h
+++ b/google/cloud/internal/tuple.h
@@ -44,7 +44,7 @@ struct ApplyRes<F, std::tuple<Args...>> {
 /**
  * Implementation of `apply`.
  *
- * Inspired by the exampe in section 20.5.1 of the standard.
+ * Inspired by the example in section 20.5.1 of the standard.
  *
  * @tparam F the functor to apply the tuple to
  * @tparam Tuple the tuple of arguments to apply to `F`

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -48,7 +48,7 @@ using index_sequence = integer_sequence<std::size_t, Ints...>;
  *
  * @tparam T the type of the index in `index_sequence`
  * @tparam N the counter bounding type recursion; `std::integral_constant` has
- *     to be used because spacializing a template with a value of type which is
+ *     to be used because specializing a template with a value of type which is
  *     dependent on a different template parameter is not allowed.
  * @tparam Enable ignored, formal parameter to allow for disabling some
  *     specializations

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -221,7 +221,7 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
  * @param retry_policy control for how long (or how many times) are retryable
  *     RPCs attempted
  * @param backoff_policy controls the backoff behavior between retry attempts,
- *     typically some form of expotential backoff with jitter
+ *     typically some form of exponential backoff with jitter
  * @param polling_policy controls for how often, and how quickly, are long
  *     running checked for completion
  *

--- a/google/cloud/spanner/internal/polling_loop.h
+++ b/google/cloud/spanner/internal/polling_loop.h
@@ -99,7 +99,7 @@ struct PollingLoopMetadataExtractor {
  *     failure.
  * @param is_idempotent if false, the operation is not retried even on transient
  *     errors.
- * @param functor the operation to retry, typically a lambda that encasulates
+ * @param functor the operation to retry, typically a lambda that encapsulates
  *     both the Stub and the function to call.
  * @param context the gRPC context used for the request, previous Stubs in the
  *     stack can set timeouts and metadata through this context.

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -149,7 +149,7 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  * Spanner STRUCT fields may optionally contain a string indicating the field's
  * name. Fields names may be empty, unique, or repeated. A named field may be
  * specified as a tuple element of type `std::pair<std::string, T>`, where the
- * pair's `.first` member indicate's the field's name, and the `.second` member
+ * pair's `.first` member indicates the field's name, and the `.second` member
  * is any valid Spanner type `T`.
  *
  * @code

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3367,7 +3367,7 @@ class ScopedDeleter {
  * The implementation may need to perform multiple Client::ComposeObject calls
  * to create intermediate, temporary objects which are then further composed.
  * Due to the lack of atomicity of this series of operations, stray temporary
- * objects might be left over if there are transient failuers. In order to allow
+ * objects might be left over if there are transient failures. In order to allow
  * the user to easily control for such situations, the user is expected to
  * provide a unique @p prefix parameter, which will become the prefix of all the
  * temporary objects created by this function. Once this function finishes, the

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -31,7 +31,7 @@ inline namespace STORAGE_CLIENT_NS {
  * certificate authority certificates in a hard-coded location.
  *
  * This is a separate class, as it is used to configure both the normal
- * connections to GCS and the connections used to obtain Oauth2 access
+ * connections to GCS and the connections used to obtain OAuth2 access
  * tokens.
  */
 class ChannelOptions {

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -30,7 +30,7 @@ inline namespace STORAGE_CLIENT_NS {
  * Sets the user IP on an operation for quota enforcement purposes.
  *
  * This parameter lets you enforce per-user quotas when calling the API from a
- * server-side application. This parameter is overriden by `UserQuota` if both
+ * server-side application. This parameter is overridden by `UserQuota` if both
  * are set.
  *
  * If you set this parameter to an empty string, the client library will

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -33,7 +33,7 @@ namespace internal {
  * Assuming the account used to access Google Cloud Platform has enough
  * privileges, this account might be different than the service account used to
  * sign the blob. And in cases where the service account keys are not known, for
- * example when using Google Compute Engine metadata server to acess GCP, the
+ * example when using Google Compute Engine metadata server to access GCP, the
  * blob can be signed without having to download the account keys.
  *
  * In Google Cloud Storage this is useful to create signed URLs and signed

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -82,7 +82,7 @@ class SignUrlRequestCommon {
    * Splits the "object_name" by '/' delimiter
    *
    * "object_name" may contain '/' to represent the object path and these
-   * '/' must not be escaped in "V4SignUrlRequest". This funtion helps in
+   * '/' must not be escaped in "V4SignUrlRequest". This function helps in
    * splitting string of "object_name" in parts.
    */
   std::vector<std::string> ObjectNameParts() const;

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -44,7 +44,7 @@ class Credentials {
    *
    * If unable to obtain a value for the Authorization header, which could
    * happen for `Credentials` that need to be periodically refreshed, the
-   * underyling `Status` will indicate failure details from the refresh HTTP
+   * underlying `Status` will indicate failure details from the refresh HTTP
    * request. Otherwise, the returned value will contain the Authorization
    * header to be used in HTTP requests.
    */

--- a/google/cloud/storage/policy_document.h
+++ b/google/cloud/storage/policy_document.h
@@ -122,7 +122,7 @@ std::ostream& operator<<(std::ostream& os, PolicyDocumentCondition const& rhs);
  *
  * Policy documents allow HTML forms to restrict uploads based on certain
  * conditions. If the policy document is expired or the conditions are not
- * satisified, POST'ing the form will not succeed.
+ * satisfied, POST'ing the form will not succeed.
  *
  * @see https://cloud.google.com/storage/docs/xml-api/post-object#policydocument
  * for general information on policy documents in Google Cloud Storage.
@@ -139,7 +139,7 @@ std::ostream& operator<<(std::ostream& os, PolicyDocument const& rhs);
  *
  * Policy documents allow HTML forms to restrict uploads based on certain
  * conditions. If the policy document is expired or the conditions are not
- * satisified, POST'ing the form will not succeed.
+ * satisfied, POST'ing the form will not succeed.
  *
  * @see https://cloud.google.com/storage/docs/xml-api/post-object#policydocument
  * for general information on policy documents in Google Cloud Storage.

--- a/google/cloud/storage/signed_url_options.h
+++ b/google/cloud/storage/signed_url_options.h
@@ -212,8 +212,9 @@ struct SigningAccountDelegates
 /**
  * Indicate that the bucket should be a part of hostname in the URL.
  *
- * If this option is set, the resultin
- * 'https://mybucket.storage.googleapis.com'
+ * If this option is set, the resulting URL is in the format:
+ * 'https://mybucket.storage.googleapis.com'. Otherwise, it is in the format:
+ * 'https://storage.googleapis.com/mybucket'
  */
 struct VirtualHostname : public internal::ComplexOption<VirtualHostname, bool> {
   using ComplexOption<VirtualHostname, bool>::ComplexOption;

--- a/google/cloud/storage/upload_options.h
+++ b/google/cloud/storage/upload_options.h
@@ -31,7 +31,7 @@ inline namespace STORAGE_CLIENT_NS {
  *
  * If the value passed to this option is the empty string, then the library will
  * create a new resumable session. Otherwise the value should be the id of a
- * previous upload sesion, the client library will restore that session in
+ * previous upload session, the client library will restore that session in
  * this case.
  */
 struct UseResumableUploadSession

--- a/google/cloud/testing_util/example_driver.h
+++ b/google/cloud/testing_util/example_driver.h
@@ -65,7 +65,7 @@ using Commands = std::map<std::string, CommandType>;
  * examples in a specific sequence for the CI builds.
  *
  * This class refactors this common code. In general, we write the examples as
- * (anmed) short functions, which may receive arguments (such as project ids)
+ * (named) short functions, which may receive arguments (such as project ids)
  * from the command line (as a `std::vector<std::string>`).
  *
  * The `auto` function name is special, it is invoked automatically if no


### PR DESCRIPTION
This changes nonretriable (which I don't think is a word) to non-retryable, but
happy to go either way on this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5090)
<!-- Reviewable:end -->
