### PR TITLE
fix(storage): consistent endpoint computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
+
 # Changelog
 
 ## v1.19.0 - TBD
+
+### Storage
+
+* fix: consistent computation of XML vs. JSON endpoints
+
+The interaction of `ClientOptions::set_endpoint()` and the
+`CLOUD_STORAGE_TESTBENCH_ENDPOINT` environment variable was inconsistent
+across endpoints. For JSON endpoints `set_endpoint()` overrode the
+`CLOUD_STORAGE_TESTBENCH_ENDPOINT` value, while for XML endpoints it
+was the opposite.
+
+In other libraries the environment variable always wins, so we are changing the
+behavior here. This behavior was never documented, and it was buggy, therefore
+it is not a breaking change. Nonetheless, we think the bug (and the fix) is
+surprising enough to highlight in the CHANGELOG.
 
 ## v1.18.0 - 2020-09
 

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -26,6 +26,48 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+
+using ::google::cloud::internal::GetEnv;
+auto constexpr kDefaultEndpoint = "https://storage.googleapis.com";
+
+namespace internal {
+
+std::string JsonEndpoint(ClientOptions const& options) {
+  return GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
+             .value_or(options.endpoint_) +
+         "/storage/" + options.version();
+}
+
+std::string JsonUploadEndpoint(ClientOptions const& options) {
+  return GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT")
+             .value_or(options.endpoint_) +
+         "/upload/storage/" + options.version();
+}
+
+std::string XmlDownloadEndpoint(ClientOptions const& options) {
+  auto testbench = GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
+  if (testbench) return *testbench + "/xmlapi";
+  auto const& endpoint = options.endpoint_;
+  if (endpoint != kDefaultEndpoint) return endpoint;
+  return "https://storage-download.googleapis.com";
+}
+
+std::string XmlUploadEndpoint(ClientOptions const& options) {
+  auto testbench = GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
+  if (testbench) return *testbench + "/xmlapi";
+  auto const& endpoint = options.endpoint_;
+  if (endpoint != kDefaultEndpoint) return endpoint;
+  return "https://storage-upload.googleapis.com";
+}
+
+std::string IamEndpoint(ClientOptions const& options) {
+  auto testbench = GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
+  if (testbench) return *testbench + "/iamapi";
+  return options.iam_endpoint();
+}
+
+}  // namespace internal
+
 namespace {
 StatusOr<std::shared_ptr<oauth2::Credentials>> StorageDefaultCredentials() {
   auto emulator = cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
@@ -95,8 +137,7 @@ ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials,
       download_stall_timeout_(
           GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_STALL_TIMEOUT),
       channel_options_(std::move(channel_options)) {
-  auto emulator =
-      google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
+  auto emulator = GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
   if (emulator.has_value()) {
     endpoint_ = *emulator;
     iam_endpoint_ = *emulator + "/iamapi";

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -23,6 +23,15 @@ namespace google {
 namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
+class ClientOptions;
+namespace internal {
+std::string JsonEndpoint(ClientOptions const&);
+std::string JsonUploadEndpoint(ClientOptions const&);
+std::string XmlDownloadEndpoint(ClientOptions const&);
+std::string XmlUploadEndpoint(ClientOptions const&);
+std::string IamEndpoint(ClientOptions const&);
+}  // namespace internal
+
 /**
  * Describes the configuration for low-level connection features.
  *
@@ -218,6 +227,12 @@ class ClientOptions {
   //@}
 
  private:
+  friend std::string internal::JsonEndpoint(ClientOptions const&);
+  friend std::string internal::JsonUploadEndpoint(ClientOptions const&);
+  friend std::string internal::XmlDownloadEndpoint(ClientOptions const&);
+  friend std::string internal::XmlUploadEndpoint(ClientOptions const&);
+  friend std::string internal::IamEndpoint(ClientOptions const&);
+
   void SetupFromEnvironment();
 
   std::shared_ptr<oauth2::Credentials> credentials_;
@@ -239,6 +254,7 @@ class ClientOptions {
   std::chrono::seconds download_stall_timeout_;
   ChannelOptions channel_options_;
 };
+
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -123,23 +123,65 @@ TEST_F(ClientOptionsTest, EnableHttp) {
   EXPECT_TRUE(options.enable_http_tracing());
 }
 
-TEST_F(ClientOptionsTest, EndpointFromEnvironment) {
+TEST_F(ClientOptionsTest, EndpointsDefault) {
+  testing_util::ScopedEnvironment endpoint("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
+                                           {});
+  ClientOptions options(oauth2::CreateAnonymousCredentials());
+  EXPECT_EQ("https://storage.googleapis.com", options.endpoint());
+  EXPECT_EQ("https://storage.googleapis.com/storage/v1",
+            internal::JsonEndpoint(options));
+  EXPECT_EQ("https://storage.googleapis.com/upload/storage/v1",
+            internal::JsonUploadEndpoint(options));
+  EXPECT_EQ("https://storage-download.googleapis.com",
+            internal::XmlDownloadEndpoint(options));
+  EXPECT_EQ("https://storage-upload.googleapis.com",
+            internal::XmlUploadEndpoint(options));
+  EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
+            internal::IamEndpoint(options));
+}
+
+TEST_F(ClientOptionsTest, EndpointsOverride) {
+  testing_util::ScopedEnvironment endpoint("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
+                                           {});
+  ClientOptions options(oauth2::CreateAnonymousCredentials());
+  options.set_endpoint("http://127.0.0.1.nip.io:1234");
+  EXPECT_EQ("http://127.0.0.1.nip.io:1234", options.endpoint());
+  EXPECT_EQ("http://127.0.0.1.nip.io:1234/storage/v1",
+            internal::JsonEndpoint(options));
+  EXPECT_EQ("http://127.0.0.1.nip.io:1234/upload/storage/v1",
+            internal::JsonUploadEndpoint(options));
+  EXPECT_EQ("http://127.0.0.1.nip.io:1234",
+            internal::XmlDownloadEndpoint(options));
+  EXPECT_EQ("http://127.0.0.1.nip.io:1234",
+            internal::XmlUploadEndpoint(options));
+  EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
+            internal::IamEndpoint(options));
+}
+
+TEST_F(ClientOptionsTest, EndpointsTestBench) {
   testing_util::ScopedEnvironment endpoint("CLOUD_STORAGE_TESTBENCH_ENDPOINT",
                                            "http://localhost:1234");
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   EXPECT_EQ("http://localhost:1234", options.endpoint());
+  EXPECT_EQ("http://localhost:1234/storage/v1",
+            internal::JsonEndpoint(options));
+  EXPECT_EQ("http://localhost:1234/upload/storage/v1",
+            internal::JsonUploadEndpoint(options));
+  EXPECT_EQ("http://localhost:1234/xmlapi",
+            internal::XmlDownloadEndpoint(options));
+  EXPECT_EQ("http://localhost:1234/xmlapi",
+            internal::XmlUploadEndpoint(options));
+  EXPECT_EQ("http://localhost:1234/iamapi", internal::IamEndpoint(options));
 }
 
 TEST_F(ClientOptionsTest, SetVersion) {
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   options.set_version("vTest");
   EXPECT_EQ("vTest", options.version());
-}
-
-TEST_F(ClientOptionsTest, SetEndpoint) {
-  ClientOptions options(oauth2::CreateAnonymousCredentials());
-  options.set_endpoint("http://localhost:2345");
-  EXPECT_EQ("http://localhost:2345", options.endpoint());
+  EXPECT_EQ("https://storage.googleapis.com/storage/vTest",
+            internal::JsonEndpoint(options));
+  EXPECT_EQ("https://storage.googleapis.com/upload/storage/vTest",
+            internal::JsonUploadEndpoint(options));
 }
 
 TEST_F(ClientOptionsTest, SetIamEndpoint) {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -229,30 +229,19 @@ CurlClient::CreateResumableSessionGeneric(RequestType const& request) {
 CurlClient::CurlClient(ClientOptions options)
     : options_(std::move(options)),
       x_goog_api_client_header_("x-goog-api-client: " + x_goog_api_client()),
+      storage_endpoint_(JsonEndpoint(options_)),
+      storage_host_(ExtractUrlHostpart(storage_endpoint_)),
+      upload_endpoint_(JsonUploadEndpoint(options_)),
+      xml_upload_endpoint_(XmlUploadEndpoint(options_)),
+      xml_upload_host_(ExtractUrlHostpart(xml_upload_endpoint_)),
+      xml_download_endpoint_(XmlDownloadEndpoint(options_)),
+      xml_download_host_(ExtractUrlHostpart(xml_download_endpoint_)),
+      iam_endpoint_(IamEndpoint(options_)),
       generator_(google::cloud::internal::MakeDefaultPRNG()),
       storage_factory_(CreateHandleFactory(options_)),
       upload_factory_(CreateHandleFactory(options_)),
       xml_upload_factory_(CreateHandleFactory(options_)),
       xml_download_factory_(CreateHandleFactory(options_)) {
-  storage_endpoint_ = options_.endpoint() + "/storage/" + options_.version();
-  upload_endpoint_ =
-      options_.endpoint() + "/upload/storage/" + options_.version();
-  iam_endpoint_ = options_.iam_endpoint();
-
-  auto endpoint =
-      google::cloud::internal::GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
-  if (endpoint.has_value()) {
-    xml_upload_endpoint_ = options_.endpoint() + "/xmlapi";
-    xml_download_endpoint_ = options_.endpoint() + "/xmlapi";
-    iam_endpoint_ = options_.endpoint() + "/iamapi";
-  } else {
-    xml_upload_endpoint_ = "https://storage-upload.googleapis.com";
-    xml_download_endpoint_ = "https://storage-download.googleapis.com";
-  }
-  storage_host_ = ExtractUrlHostpart(storage_endpoint_);
-  xml_upload_host_ = ExtractUrlHostpart(xml_upload_endpoint_);
-  xml_download_host_ = ExtractUrlHostpart(xml_download_endpoint_);
-
   CurlInitializeOnce(options);
 }
 

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -213,14 +213,14 @@ class CurlClient : public RawClient,
 
   ClientOptions options_;
   std::string const x_goog_api_client_header_;
-  std::string storage_endpoint_;
-  std::string storage_host_;
-  std::string upload_endpoint_;
-  std::string xml_upload_endpoint_;
-  std::string xml_upload_host_;
-  std::string xml_download_endpoint_;
-  std::string xml_download_host_;
-  std::string iam_endpoint_;
+  std::string const storage_endpoint_;
+  std::string const storage_host_;
+  std::string const upload_endpoint_;
+  std::string const xml_upload_endpoint_;
+  std::string const xml_upload_host_;
+  std::string const xml_download_endpoint_;
+  std::string const xml_download_host_;
+  std::string const iam_endpoint_;
 
   std::mutex mu_;
   google::cloud::internal::DefaultPRNG generator_;  // GUARDED_BY(mu_);

--- a/google/cloud/storage/tests/object_media_integration_test.cc
+++ b/google/cloud/storage/tests/object_media_integration_test.cc
@@ -16,15 +16,11 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/internal/setenv.h"
-#include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>
-#include <regex>
 #include <thread>
 
 namespace google {
@@ -32,6 +28,8 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+
+using ::google::cloud::testing_util::ScopedEnvironment;
 
 class ObjectMediaIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
@@ -533,6 +531,7 @@ TEST_F(ObjectMediaIntegrationTest, ReadByChunk) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
+  ScopedEnvironment disable_testbench("CLOUD_STORAGE_TESTBENCH_ENDPOINT", {});
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
                     .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
@@ -553,8 +552,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadJSON) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadXML) {
-  google::cloud::testing_util::ScopedEnvironment endpoint(
-      "CLOUD_STORAGE_TESTBENCH_ENDPOINT", "http://localhost:1");
+  ScopedEnvironment testbench("CLOUD_STORAGE_TESTBENCH_ENDPOINT", {});
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
                     .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
@@ -571,6 +569,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureReadXML) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteJSON) {
+  ScopedEnvironment testbench("CLOUD_STORAGE_TESTBENCH_ENDPOINT", {});
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
                     .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
@@ -589,8 +588,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteJSON) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureWriteXML) {
-  google::cloud::testing_util::ScopedEnvironment endpoint(
-      "CLOUD_STORAGE_TESTBENCH_ENDPOINT", "http://localhost:1");
+  ScopedEnvironment testbench("CLOUD_STORAGE_TESTBENCH_ENDPOINT", {});
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
                     .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};
@@ -621,8 +619,7 @@ TEST_F(ObjectMediaIntegrationTest, ConnectionFailureDownloadFile) {
 }
 
 TEST_F(ObjectMediaIntegrationTest, ConnectionFailureUploadFile) {
-  google::cloud::testing_util::ScopedEnvironment endpoint(
-      "CLOUD_STORAGE_TESTBENCH_ENDPOINT", "http://localhost:1");
+  ScopedEnvironment testbench("CLOUD_STORAGE_TESTBENCH_ENDPOINT", {});
   Client client{ClientOptions(oauth2::CreateAnonymousCredentials())
                     .set_endpoint("http://localhost:1"),
                 LimitedErrorCountRetryPolicy(2)};


### PR DESCRIPTION
The interaction of `ClientOptions::set_endpoint()` and the
`CLOUD_STORAGE_TESTBENCH_ENDPOINT` environment variable was inconsistent
across endpoints. For JSON endpoints `set_endpoint()` overrode the
`CLOUD_STORAGE_TESTBENCH_ENDPOINT` value, while for XML endpoints it was
the opposite.

In other libraries the environment variable always wins, so we are
changing the behavior here. This behavior was never documented, and it
was buggy, this is not a breaking change per-se, but should be
highlighted in the CHANGELOG.

I refactored the code to compute the different endpoints to standalone
functions. That makes them easier to test.

I used friend functions in `internal::` over member functions in
`ClientOptions` because we will (some day) remove the XML endpoints and
I do not want to make `XmlFoo()` part of the public interface.

Fixes #5094 part of the work for #5072 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5095)
<!-- Reviewable:end -->
