### PR TITLE
cleanup(storage): remove testbench hack for XML

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -46,7 +46,7 @@ std::string JsonUploadEndpoint(ClientOptions const& options) {
 
 std::string XmlDownloadEndpoint(ClientOptions const& options) {
   auto testbench = GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
-  if (testbench) return *testbench + "/xmlapi";
+  if (testbench) return *testbench;
   auto const& endpoint = options.endpoint_;
   if (endpoint != kDefaultEndpoint) return endpoint;
   return "https://storage-download.googleapis.com";
@@ -54,7 +54,7 @@ std::string XmlDownloadEndpoint(ClientOptions const& options) {
 
 std::string XmlUploadEndpoint(ClientOptions const& options) {
   auto testbench = GetEnv("CLOUD_STORAGE_TESTBENCH_ENDPOINT");
-  if (testbench) return *testbench + "/xmlapi";
+  if (testbench) return *testbench;
   auto const& endpoint = options.endpoint_;
   if (endpoint != kDefaultEndpoint) return endpoint;
   return "https://storage-upload.googleapis.com";

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -167,10 +167,8 @@ TEST_F(ClientOptionsTest, EndpointsTestBench) {
             internal::JsonEndpoint(options));
   EXPECT_EQ("http://localhost:1234/upload/storage/v1",
             internal::JsonUploadEndpoint(options));
-  EXPECT_EQ("http://localhost:1234/xmlapi",
-            internal::XmlDownloadEndpoint(options));
-  EXPECT_EQ("http://localhost:1234/xmlapi",
-            internal::XmlUploadEndpoint(options));
+  EXPECT_EQ("http://localhost:1234", internal::XmlDownloadEndpoint(options));
+  EXPECT_EQ("http://localhost:1234", internal::XmlUploadEndpoint(options));
   EXPECT_EQ("http://localhost:1234/iamapi", internal::IamEndpoint(options));
 }
 

--- a/google/cloud/storage/testbench/testbench.py
+++ b/google/cloud/storage/testbench/testbench.py
@@ -879,33 +879,6 @@ def delete_resumable_upload(bucket_name):
     return testbench_utils.filtered_response(flask.request, {})
 
 
-# Define the WSGI application to handle (a few) requests in the XML API.
-XMLAPI_HANDLER_PATH = "/xmlapi"
-xmlapi = flask.Flask(__name__)
-xmlapi.debug = True
-
-
-@xmlapi.errorhandler(error_response.ErrorResponse)
-def xmlapi_error(error):
-    return error.as_response()
-
-
-@xmlapi.route("/<bucket_name>/<path:object_name>")
-def xmlapi_get_object(bucket_name, object_name):
-    """Implement the 'Objects: insert' API.  Insert a new GCS Object."""
-    return xml_get_object(bucket_name, object_name)
-
-
-@xmlapi.route("/<bucket_name>/<path:object_name>", methods=["PUT"])
-def xmlapi_put_object(bucket_name, object_name):
-    """Inserts a new GCS Object.
-
-    Implement the PUT request in the XML API.
-    """
-    gcs_url = flask.request.host_url.replace("/xmlapi/", "/")
-    return xml_put_object(gcs_url, bucket_name, object_name)
-
-
 def xml_put_object(gcs_url, bucket_name, object_name):
     """Implement PUT for the XML API."""
     insert_magic_bucket(gcs_url)
@@ -957,7 +930,6 @@ application = DispatcherMiddleware(
         GCS_HANDLER_PATH: gcs,
         UPLOAD_HANDLER_PATH: upload,
         DOWNLOAD_HANDLER_PATH: download,
-        XMLAPI_HANDLER_PATH: xmlapi,
         PROJECTS_HANDLER_PATH: projects_app,
         IAM_HANDLER_PATH: iam_app,
     },


### PR DESCRIPTION
Cleanup the library and the testbench to use the same paths for the XML
API on the testbench as we use in production. Wrote a test to verify the
testbench can be used via `ClientOptions::set_endpoint()`.

Part of the work for #5072

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5097)
<!-- Reviewable:end -->
