### PR TITLE
feat(storage): disable XML via environment variable

### DIFF
--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -68,10 +68,10 @@ which should give you a taste of the Cloud Storage C++ client library API.
   the application developer may want to test using an emulator that does not
   support XML, while the library defaults to XML for some media operations.
 
-- `GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG...` used with
+- `GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=...` used with
   `google::cloud::storage_experimental::DefaultGrpcClient()` to configure
   configure the gRPC protocol. Setting this to `media` enables gRPC for just
-  media operations (reading and writing data), setting this to `metadata`
+  media operations (reading and writing data), while setting this to `metadata`
   enables gRPC for all operations. Note that gRPC support is an early access
   program, contact Google Cloud support for details.
 

--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -61,6 +61,20 @@ which should give you a taste of the Cloud Storage C++ client library API.
 - `CLOUD_STORAGE_TESTBENCH_ENDPOINT=...` override the default endpoint used by
   the library, intended for testing only.
 
+### Experimental
+
+- `GOOGLE_CLOUD_CPP_STORAGE_REST_CONFIG=...` configuration for the REST
+  protocol, currently only the `disable-xml` value has any effect. Sometimes
+  the application developer may want to test using an emulator that does not
+  support XML, while the library defaults to XML for some media operations.
+
+- `GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG...` used with
+  `google::cloud::storage_experimental::DefaultGrpcClient()` to configure
+  configure the gRPC protocol. Setting this to `media` enables gRPC for just
+  media operations (reading and writing data), setting this to `metadata`
+  enables gRPC for all operations. Note that gRPC support is an early access
+  program, contact Google Cloud support for details.
+
 ### Using GOOGLE_CLOUD_PROJECT to set the default project
 
 Some of the GCS APIs need a [project][project-definition-link] as a parameter.

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -221,6 +221,7 @@ class CurlClient : public RawClient,
   std::string const xml_download_endpoint_;
   std::string const xml_download_host_;
   std::string const iam_endpoint_;
+  bool const xml_enabled_;
 
   std::mutex mu_;
   google::cloud::internal::DefaultPRNG generator_;  // GUARDED_BY(mu_);


### PR DESCRIPTION
When using emulators that do not support XML, application developers may
need to switch off the automatic XML switching in the client library. We
use an environment variable over a `ClientOptions` setting because (a)
this is an implementation detail that we want to change if needed, a
setting would require API changes, and (b) this appears to be needed
only for development / testing, presumably the application developers
don't want to change their code to test against an emulator vs.
production.

Fixes #5072

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5100)
<!-- Reviewable:end -->
