### PR TITLE
ci: use per-build prefix for Bazel caches

### DIFF
--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -16,6 +16,7 @@
 readonly CACHE_KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
 
 cache_download_enabled() {
+  # TODO(#5113) - we should do this for all Bazel builds, and only on full CIs
   if [[ "${BUILD_NAME:-}" = "msan" ]]; then
     io::log "Skipping build cache for msan builds"
     return 1

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -16,7 +16,7 @@
 readonly CACHE_KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
 
 cache_download_enabled() {
-  if [[ "${BUILD_NAME:-}" = "msan"  ]]; then
+  if [[ "${BUILD_NAME:-}" = "msan" ]]; then
     io::log "Skipping build cache for msan builds"
     return 1
   fi

--- a/ci/kokoro/cache-functions.sh
+++ b/ci/kokoro/cache-functions.sh
@@ -16,6 +16,11 @@
 readonly CACHE_KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
 
 cache_download_enabled() {
+  if [[ "${BUILD_NAME:-}" = "msan"  ]]; then
+    io::log "Skipping build cache for msan builds"
+    return 1
+  fi
+
   if [[ ! -f "${CACHE_KEYFILE}" ]]; then
     echo "================================================================"
     io::log "Service account for cache access is not configured."

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -66,11 +66,7 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 # not hit this cache.
 if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}"
-  if [[ "${BUILD_NAME:-}" = "msan" ]]; then
-    bazel_args+=("--remote_cache=https://storage.googleapis.com/cloud-cpp-bazel-cache-${BUILD_NAME}")
-  else
-    bazel_args+=("--remote_cache=${BAZEL_CACHE}")
-  fi
+  bazel_args+=("--remote_cache=https://storage.googleapis.com/cloud-cpp-bazel-cache/docker/${BUILD_NAME}")
   bazel_args+=("--google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}")
   # See https://docs.bazel.build/versions/master/remote-caching.html#known-issues
   # and https://github.com/bazelbuild/bazel/issues/3360

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -66,7 +66,7 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 # not hit this cache.
 if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}"
-  bazel_args+=("--remote_cache=https://storage.googleapis.com/cloud-cpp-bazel-cache/docker/${BUILD_NAME}")
+  bazel_args+=("--remote_cache=${BAZEL_CACHE}/docker/${BUILD_NAME}")
   bazel_args+=("--google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}")
   # See https://docs.bazel.build/versions/master/remote-caching.html#known-issues
   # and https://github.com/bazelbuild/bazel/issues/3360

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -64,7 +64,7 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 # If we have the right credentials, tell bazel to cache build results in a GCS
 # bucket. Note: this will not cache external deps, so the "fetch" below will
 # not hit this cache.
-if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" && "${BUILD_NAME:-}" != "msan" ]]; then
+if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}"
   bazel_args+=("--remote_cache=${BAZEL_CACHE}")
   bazel_args+=("--google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}")

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -64,7 +64,7 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 # If we have the right credentials, tell bazel to cache build results in a GCS
 # bucket. Note: this will not cache external deps, so the "fetch" below will
 # not hit this cache.
-if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" && "${BUILD_NAME:-}" != "msan" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}"
   bazel_args+=("--remote_cache=${BAZEL_CACHE}")
   bazel_args+=("--google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}")

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -66,7 +66,11 @@ readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 # not hit this cache.
 if [[ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
   io::log "Using bazel remote cache: ${BAZEL_CACHE}"
-  bazel_args+=("--remote_cache=${BAZEL_CACHE}")
+  if [[ "${BUILD_NAME:-}" = "msan" ]]; then
+    bazel_args+=("--remote_cache=https://storage.googleapis.com/cloud-cpp-bazel-cache-${BUILD_NAME}")
+  else
+    bazel_args+=("--remote_cache=${BAZEL_CACHE}")
+  fi
   bazel_args+=("--google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}")
   # See https://docs.bazel.build/versions/master/remote-caching.html#known-issues
   # and https://github.com/bazelbuild/bazel/issues/3360


### PR DESCRIPTION
Using a fresh cache for the msan build fixes the problem.  I am splitting each build to its own
cache directory, so we can clear the cache for one build at a time in the future.

Part of the work for #5106

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5108)
<!-- Reviewable:end -->
