### PR TITLE
cleanup(spanner): Use CompletionQueue for long running operations

### DIFF
--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -344,12 +344,17 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::unique_ptr<PollingPolicy> polling_policy);
 
 namespace internal {
-/// Create a connection with only the retry decorator.
+
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::shared_ptr<internal::DatabaseAdminStub> stub,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    ConnectionOptions const& options);
+
+std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    std::shared_ptr<internal::DatabaseAdminStub> stub,
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
+
 }  // namespace internal
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -234,19 +234,14 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::unique_ptr<PollingPolicy> polling_policy);
 
 namespace internal {
-/**
- * Create an InstanceAdminConnection using an existing base Stub.
- *
- * Returns a new InstanceAdminConnection with all the normal decorators applied
- * to @p base_stub.
- */
+
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
     ConnectionOptions const& options);
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
 

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -49,7 +49,8 @@ std::shared_ptr<InstanceAdminConnection> MakeLimitedRetryConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   return internal::MakeInstanceAdminConnection(
-      std::move(mock), retry.clone(), backoff.clone(), polling.clone());
+      std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
+      polling.clone());
 }
 
 TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {


### PR DESCRIPTION
Use `google::cloud::CompletionQueue` via (`BackgroundThreads`)
to execute long-running operations in `DatabaseAdminConnection`
and `InstanceAdminConnection`, rather than directly forking a
`std::thread`.

Fixes #4038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5112)
<!-- Reviewable:end -->
