### PR TITLE
test(storage): add more utils for gcs emulator

### DIFF
--- a/google/cloud/storage/emulator/database.py
+++ b/google/cloud/storage/emulator/database.py
@@ -12,24 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common utils"""
 
-import re
-import types
+class Database:
+    def __init__(self, buckets):
+        self.buckets = buckets
 
-# === STR === #
-
-
-re_snake_case = re.compile(r"(?<!^)(?=[A-Z])")
-
-
-def to_snake_case(string):
-    return re_snake_case.sub("_", string).lower()
-
-
-# === FAKE REQUEST === #
-
-
-class FakeRequest(types.SimpleNamespace):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    @classmethod
+    def init(cls):
+        return cls({})

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -12,24 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common utils"""
+import argparse
+import logging
 
-import re
-import types
+import database
+import rest_server
 
-# === STR === #
-
-
-re_snake_case = re.compile(r"(?<!^)(?=[A-Z])")
-
-
-def to_snake_case(string):
-    return re_snake_case.sub("_", string).lower()
-
-
-# === FAKE REQUEST === #
-
-
-class FakeRequest(types.SimpleNamespace):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+if __name__ == "__main__":
+    logging.basicConfig()
+    parser = argparse.ArgumentParser(
+        description="A testbench for the Google Cloud C++ Client Library"
+    )
+    parser.add_argument(
+        "--port_grpc", default="8000", help="The listening port for GRPC"
+    )
+    parser.add_argument(
+        "--port_rest", default="9000", help="The listening port for REST"
+    )
+    arguments = parser.parse_args()
+    db = database.Database.init()
+    rest_server.run(arguments.port_rest, db)

--- a/google/cloud/storage/emulator/requirements.txt
+++ b/google/cloud/storage/emulator/requirements.txt
@@ -1,5 +1,6 @@
 git+git://github.com/googleapis/python-storage@gapic-generation
 grpcio==1.32.0
 flask==1.1.2
-grpc-google-iam-v1==0.12.3
 pysimdjson==3.0.0
+pytest==6.0.2
+httpbin==0.7.0

--- a/google/cloud/storage/emulator/rest_server.py
+++ b/google/cloud/storage/emulator/rest_server.py
@@ -12,24 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common utils"""
+import flask
+import httpbin
+from werkzeug import serving
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
-import re
-import types
+db = None
 
-# === STR === #
-
-
-re_snake_case = re.compile(r"(?<!^)(?=[A-Z])")
-
-
-def to_snake_case(string):
-    return re_snake_case.sub("_", string).lower()
+# === DEFAULT ENTRY FOR REST SERVER === #
+root = flask.Flask(__name__)
+root.debug = True
 
 
-# === FAKE REQUEST === #
+@root.route("/")
+def index():
+    return "OK"
 
 
-class FakeRequest(types.SimpleNamespace):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+# === SERVER === #
+
+
+server = DispatcherMiddleware(root, {"/httpbin": httpbin.app})
+
+
+def run(port, database):
+    global db
+    db = database
+    serving.run_simple(
+        "localhost", int(port), server, use_reloader=False, threaded=True
+    )

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -1,0 +1,212 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test for utils"""
+
+import pytest
+import utils
+from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+
+
+class TestACL:
+    def test_extract_predefined_default_object_acl(self):
+        request = storage_pb2.InsertBucketRequest()
+        predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
+            request, ""
+        )
+        assert predefined_default_object_acl == 0
+
+        request.predefined_default_object_acl = 1
+        predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
+            request, ""
+        )
+        assert predefined_default_object_acl == 1
+
+        request = utils.common.FakeRequest(args={})
+        predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
+            request, None
+        )
+        assert predefined_default_object_acl == ""
+
+        request.args["predefinedDefaultObjectAcl"] = "authenticatedRead"
+        predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
+            request, None
+        )
+        assert predefined_default_object_acl == "authenticatedRead"
+
+    def test_extract_predefined_acl(self):
+        request = storage_pb2.InsertBucketRequest()
+        predefined_acl = utils.acl.extract_predefined_acl(request, False, "")
+        assert predefined_acl == 0
+
+        request.predefined_acl = 1
+        predefined_acl = utils.acl.extract_predefined_acl(request, False, "")
+        assert predefined_acl == 1
+
+        request = storage_pb2.CopyObjectRequest(destination_predefined_acl=2)
+        predefined_acl = utils.acl.extract_predefined_acl(request, True, "")
+        assert predefined_acl == 2
+
+        request = utils.common.FakeRequest(args={})
+        predefined_acl = utils.acl.extract_predefined_acl(request, False, None)
+        assert predefined_acl == ""
+
+        request.args["predefinedAcl"] = "authenticatedRead"
+        predefined_acl = utils.acl.extract_predefined_acl(request, False, None)
+        assert predefined_acl == "authenticatedRead"
+
+        request.args["destinationPredefinedAcl"] = "bucketOwnerFullControl"
+        predefined_acl = utils.acl.extract_predefined_acl(request, True, None)
+        assert predefined_acl == "bucketOwnerFullControl"
+
+    def test_compute_predefined_bucket_acl(self):
+        acls = utils.acl.compute_predefined_bucket_acl(
+            "bucket", "authenticatedRead", None
+        )
+        entities = [acl.entity for acl in acls]
+        assert entities == [
+            utils.acl.get_project_entity("owners", None),
+            "allAuthenticatedUsers",
+        ]
+
+    def test_compute_predefined_default_object_acl(self):
+        acls = utils.acl.compute_predefined_default_object_acl(
+            "bucket", "authenticatedRead", None
+        )
+        entities = [acl.entity for acl in acls]
+        assert entities == [
+            utils.acl.get_object_entity("OWNER", None),
+            "allAuthenticatedUsers",
+        ]
+
+        object_names = [acl.object for acl in acls]
+        assert object_names == 2 * [""]
+
+    def test_compute_predefined_object_acl(self):
+        acls = utils.acl.compute_predefined_object_acl(
+            "bucket", "object", 123456789, "authenticatedRead", None
+        )
+        entities = [acl.entity for acl in acls]
+        assert entities == [
+            utils.acl.get_object_entity("OWNER", None),
+            "allAuthenticatedUsers",
+        ]
+
+        object_names = [acl.object for acl in acls]
+        assert object_names == 2 * ["object"]
+
+        generations = [acl.generation for acl in acls]
+        assert generations == 2 * [123456789]
+
+
+class TestCommonUtils:
+    def test_snake_case(self):
+        assert utils.common.to_snake_case("authenticatedRead") == "authenticated_read"
+        assert (
+            utils.common.to_snake_case("allAuthenticatedUsers")
+            == "all_authenticated_users"
+        )
+
+
+class TestGeneration:
+    def test_extract_precondition(self):
+        request = storage_pb2.CopyObjectRequest(
+            if_generation_not_match={"value": 1},
+            if_metageneration_match={"value": 2},
+            if_metageneration_not_match={"value": 3},
+            if_source_generation_match={"value": 4},
+            if_source_generation_not_match={"value": 5},
+            if_source_metageneration_match={"value": 6},
+            if_source_metageneration_not_match={"value": 7},
+        )
+        match, not_match = utils.generation.extract_precondition(
+            request, False, False, ""
+        )
+        assert match is None
+        assert not_match == 1
+        match, not_match = utils.generation.extract_precondition(
+            request, True, False, ""
+        )
+        assert match == 2
+        assert not_match == 3
+        match, not_match = utils.generation.extract_precondition(
+            request, False, True, ""
+        )
+        assert match == 4
+        assert not_match == 5
+        match, not_match = utils.generation.extract_precondition(
+            request, True, True, ""
+        )
+        assert match == 6
+        assert not_match == 7
+
+        request = utils.common.FakeRequest(
+            args={
+                "ifGenerationNotMatch": 1,
+                "ifMetagenerationMatch": 2,
+                "ifMetagenerationNotMatch": 3,
+                "ifSourceGenerationMatch": 4,
+                "ifSourceGenerationNotMatch": 5,
+                "ifSourceMetagenerationMatch": 6,
+                "ifSourceMetagenerationNotMatch": 7,
+            }
+        )
+        match, not_match = utils.generation.extract_precondition(
+            request, False, False, None
+        )
+        assert match is None
+        assert not_match == 1
+        match, not_match = utils.generation.extract_precondition(
+            request, True, False, None
+        )
+        assert match == 2
+        assert not_match == 3
+        match, not_match = utils.generation.extract_precondition(
+            request, False, True, None
+        )
+        assert match == 4
+        assert not_match == 5
+        match, not_match = utils.generation.extract_precondition(
+            request, True, True, None
+        )
+        assert match == 6
+        assert not_match == 7
+
+    def test_extract_generation(self):
+        request = storage_pb2.GetObjectRequest()
+        generation = utils.generation.extract_generation(request, False, "")
+        assert generation == 0
+
+        request.generation = 1
+        generation = utils.generation.extract_generation(request, False, "")
+        assert generation == 1
+
+        request = storage_pb2.CopyObjectRequest(source_generation=2)
+        generation = utils.generation.extract_generation(request, True, "")
+        assert generation == 2
+
+        request = utils.common.FakeRequest(args={})
+        generation = utils.generation.extract_generation(request, False, None)
+        assert generation == 0
+
+        request.args["generation"] = 1
+        request.args["sourceGeneration"] = 2
+        generation = utils.generation.extract_generation(request, False, None)
+        assert generation == 1
+        generation = utils.generation.extract_generation(request, True, None)
+        assert generation == 2
+
+
+def run():
+    pytest.main(["-v"])

--- a/google/cloud/storage/emulator/tests_entry.py
+++ b/google/cloud/storage/emulator/tests_entry.py
@@ -12,24 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common utils"""
+"""Tests entry"""
 
-import re
-import types
+from tests import test_utils
 
-# === STR === #
-
-
-re_snake_case = re.compile(r"(?<!^)(?=[A-Z])")
-
-
-def to_snake_case(string):
-    return re_snake_case.sub("_", string).lower()
-
-
-# === FAKE REQUEST === #
-
-
-class FakeRequest(types.SimpleNamespace):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+if __name__ == "__main__":
+    test_utils.run()

--- a/google/cloud/storage/emulator/utils/__init__.py
+++ b/google/cloud/storage/emulator/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google Inc.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from utils import common, error, generation
+from utils import acl, common, error, generation

--- a/google/cloud/storage/emulator/utils/acl.py
+++ b/google/cloud/storage/emulator/utils/acl.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ def get_canonical_entity(entity):
 
 def get_project_entity(team, context):
     if team not in ["editors", "owners", "viewers"]:
-        utils.error.invaild("Team %s for project" % team)
+        utils.error.invaild("Team %s for project" % team, context)
     return "project-%s-%s" % (team, PROJECT_NUMBER)
 
 
@@ -134,7 +134,9 @@ def create_object_acl_from_default_object_acl(
     acl = resources_pb2.ObjectAccessControl()
     acl.CopyFrom(default_object_acl)
     acl.id = hashlib.md5(
-        (acl.bucket + object_name + generation + acl.entity + acl.role).encode("utf-8")
+        (acl.bucket + object_name + str(generation) + acl.entity + acl.role).encode(
+            "utf-8"
+        )
     ).hexdigest()
     acl.etag = acl.id
     acl.object = object_name

--- a/google/cloud/storage/emulator/utils/error.py
+++ b/google/cloud/storage/emulator/utils/error.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/storage/emulator/utils/generation.py
+++ b/google/cloud/storage/emulator/utils/generation.py
@@ -1,0 +1,96 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utils related to generation and pre-condition"""
+
+import grpc
+import utils
+
+# === EXTRACT INFORMATION === #
+
+
+def extract_precondition(request, is_meta, is_source, context):
+    match_field, not_match_field = "", ""
+    if is_meta:
+        match_field = (
+            "ifMetagenerationMatch" if not is_source else "ifSourceMetagenerationMatch"
+        )
+        not_match_field = (
+            "ifMetagenerationNotMatch"
+            if not is_source
+            else "ifSourceMetagenerationNotMatch"
+        )
+    else:
+        match_field = (
+            "ifGenerationMatch" if not is_source else "ifSourceGenerationMatch"
+        )
+        not_match_field = (
+            "ifGenerationNotMatch" if not is_source else "ifSourceGenerationNotMatch"
+        )
+    match, not_match = None, None
+    if context is not None:
+        match_field = utils.common.to_snake_case(match_field)
+        not_match_field = utils.common.to_snake_case(not_match_field)
+        match = (
+            getattr(request, match_field, None).value
+            if request.HasField(match_field)
+            else None
+        )
+        not_match = (
+            getattr(request, not_match_field, None).value
+            if request.HasField(not_match_field)
+            else None
+        )
+    else:
+        match = (
+            int(request.args.get(match_field)) if match_field in request.args else None
+        )
+        not_match = (
+            int(request.args.get(not_match_field))
+            if not_match_field in request.args
+            else None
+        )
+    return match, not_match
+
+
+def extract_generation(request, is_source, context):
+    if context is not None:
+        extract_field = "generation" if not is_source else "source_generation"
+        return getattr(request, extract_field, 0)
+    else:
+        extract_field = "generation" if not is_source else "sourceGeneration"
+        return int(request.args.get(extract_field, 0))
+
+
+# === CHECK === #
+
+
+def check_precondition(generation, match, not_match, is_meta, context):
+    msg = "generation" if not is_meta else "metageneration"
+    if generation is not None and not_match is not None and not_match == generation:
+        utils.error.generic(
+            "Precondition Failed (%s = %d vs %s_not_match = %d)"
+            % (msg, generation, msg, not_match),
+            412,
+            grpc.StatusCode.FAILED_PRECONDITION,
+            context,
+        )
+    if generation is not None and match is not None and match != generation:
+        utils.error.generic(
+            "Precondition Failed (%s = %d vs %s_match = %d)"
+            % (msg, generation, msg, match),
+            412,
+            grpc.StatusCode.FAILED_PRECONDITION,
+            context,
+        )


### PR DESCRIPTION
This PR adds:
- Init for `Database`
- Entry point for `emulator` and `REST`
- `generation` to deal with precondition and generation in request.
- Unit tests
- `FakeRequest` to mimic the structure of a `Flask` request. It will be added more feature in later PRs.

Related to #4751

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5124)
<!-- Reviewable:end -->
