### PR TITLE
test: fix bucket leak from running example

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -606,6 +606,10 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning ListObjectsAndPrefixes() example" << std::endl;
   ListObjectsAndPrefixes(client, {bucket_name, bucket_prefix});
 
+  // Cleanup the objects so the bucket can be deleted
+  client.DeleteObject(bucket_name, bucket_prefix + "/foo/bar");
+  client.DeleteObject(bucket_name, bucket_prefix + "/qux/bar");
+
   std::cout << "\nRunning GetObjectMetadata() example" << std::endl;
   GetObjectMetadata(client, {bucket_name, object_name});
 


### PR DESCRIPTION
One of the examples was creating a bucket and not cleaning up after
itself.

Part of the fixes for #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5128)
<!-- Reviewable:end -->
