### PR TITLE
ci: make cspell output a bit quieter

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -112,8 +112,7 @@ time {
 printf "%-30s" "Running cspell:"
 time {
   if ! git ls-files -z | grep -zE '\.(h)$' |
-    xargs -P "${NCPU}" -n 50 -0 cspell -c ci/cspell.json; then
-    io::log_red "Detected spelling problems"
+    xargs -P "${NCPU}" -n 50 -0 cspell --no-summary -c ci/cspell.json; then
     problems="${problems} cspell"
   fi
 }


### PR DESCRIPTION
This removes its summary output, which was messing up the alignment of
the console output. Misspelled words will still be output to the
console, which will mess up the output, but that's the non-expected
case, so it's fine with me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5131)
<!-- Reviewable:end -->
