### PR TITLE
test: use helper to cleanup sample buckets

### DIFF
--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -54,7 +54,8 @@ if (BUILD_TESTING)
 
     set(storage_examples_unit_tests
         # cmake-format: sort
-        storage_client_mock_samples.cc storage_examples_common_test.cc)
+        cleanup_stale_buckets_test.cc storage_client_mock_samples.cc
+        storage_examples_common_test.cc)
 
     include(CreateBazelConfig)
     export_list_to_bazel("storage_examples.bzl" "storage_examples")

--- a/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
+++ b/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
@@ -1,0 +1,66 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/testing_util/status_matchers.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace examples {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::Return;
+
+ObjectMetadata CreateObject(std::string const& name, int generation) {
+  nlohmann::json metadata{
+      {"bucket", "fake-bucket"},
+      {"name", name},
+      {"generation", generation},
+      {"kind", "storage#object"},
+  };
+  return internal::ObjectMetadataParser::FromJson(metadata).value();
+};
+
+TEST(CleanupStaleBucketsTest, RemoveBucketContents) {
+  auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, DeleteBucket)
+      .Times(1)
+      .WillRepeatedly(Return(internal::EmptyResponse{}));
+  EXPECT_CALL(*mock, DeleteObject)
+      .Times(4)
+      .WillRepeatedly(Return(internal::EmptyResponse{}));
+  EXPECT_CALL(*mock, ListObjects)
+      .WillOnce([](internal::ListObjectsRequest const& r) {
+        EXPECT_EQ(r.bucket_name(), "fake-bucket");
+        EXPECT_TRUE(r.HasOption<Versions>());
+        internal::ListObjectsResponse response;
+        response.items.push_back(CreateObject("foo", 1));
+        response.items.push_back(CreateObject("foo", 2));
+        response.items.push_back(CreateObject("bar", 1));
+        response.items.push_back(CreateObject("baz", 1));
+        return response;
+      });
+  Client client(mock, Client::NoDecorations{});
+  auto const actual = RemoveBucketAndContents(client, "fake-bucket");
+  EXPECT_THAT(actual, StatusIs(StatusCode::kOk));
+}
+
+}  // namespace
+}  // namespace examples
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -285,7 +285,7 @@ void RunAll(std::vector<std::string> const& argv) {
   RemoveBucketOwner(client, {bucket_name, entity});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -115,7 +115,7 @@ void RunAll(std::vector<std::string> const& argv) {
   RemoveCorsConfiguration(client, {bucket_name});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -136,7 +136,7 @@ void RunAll(std::vector<std::string> const& argv) {
   RemoveBucketDefaultKmsKey(client, {bucket_name});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -462,7 +462,7 @@ void RunAll(std::vector<std::string> const& argv) {
   SetBucketPublicIam(client, {bucket_name});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -220,7 +220,7 @@ void RunAll(std::vector<std::string> const& argv) {
   GetBilling(client, {bucket_name, project_id});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -236,7 +236,7 @@ void RunAll(std::vector<std::string> const& argv) {
   DeleteDefaultObjectAcl(client, {bucket_name, entity});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -142,7 +142,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCleaning up" << std::endl;
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -81,6 +81,18 @@ Commands::value_type CreateCommandEntry(
   return {name, std::move(adapter)};
 }
 
+Status RemoveBucketAndContents(google::cloud::storage::Client client,
+                               std::string const& bucket_name) {
+  // List all the objects and versions, and then delete each.
+  for (auto o : client.ListObjects(bucket_name, Versions(true))) {
+    if (!o) return std::move(o).status();
+    auto status = client.DeleteObject(bucket_name, o->name(),
+                                      Generation(o->generation()));
+    if (!status.ok()) return status;
+  }
+  return client.DeleteBucket(bucket_name);
+}
+
 }  // namespace examples
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -46,6 +46,10 @@ Commands::value_type CreateCommandEntry(
     std::string const& name, std::vector<std::string> const& arg_names,
     ClientCommand const& command);
 
+/// Remove a bucket, including any objects in it
+Status RemoveBucketAndContents(google::cloud::storage::Client client,
+                               std::string const& bucket_name);
+
 }  // namespace examples
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/examples/storage_examples_unit_tests.bzl
+++ b/google/cloud/storage/examples/storage_examples_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_examples_unit_tests = [
+    "cleanup_stale_buckets_test.cc",
     "storage_client_mock_samples.cc",
     "storage_examples_common_test.cc",
 ]

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -153,7 +153,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCleaning up" << std::endl;
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -179,7 +179,7 @@ void RunAll(std::vector<std::string> const& argv) {
   DeleteNotification(client, {bucket_name, n2.id()});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -309,7 +309,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   (void)client.DeleteObject(bucket_name, object_name);
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -159,7 +159,7 @@ void RunAll(std::vector<std::string> const& argv) {
   (void)client.DeleteObject(bucket_name, csek_object_name);
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -685,7 +685,7 @@ void RunAll(std::vector<std::string> const& argv) {
   DeleteObject(client, {bucket_name, object_name_retry});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_object_versioning_samples.cc
+++ b/google/cloud/storage/examples/storage_object_versioning_samples.cc
@@ -220,7 +220,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   (void)client.DeleteObject(bucket_name, dst_object_name);
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -151,7 +151,7 @@ void RunAll(std::vector<std::string> const& argv) {
   CreatePolicyDocumentFormV4(client, {bucket_name, object_name});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -70,7 +70,7 @@ void RunAll(std::vector<std::string> const& argv) {
   StorageQuickstartCommand({bucket_name});
 
   auto client = gcs::Client::CreateDefaultClient().value();
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -200,7 +200,7 @@ void RunAll(std::vector<std::string> const& argv) {
 
   std::cout << "\nCleaning up" << std::endl;
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // anonymous namespace

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -160,7 +160,7 @@ void RunAll(std::vector<std::string> const& argv) {
   RemoveStaticWebsiteConfiguration(client, {bucket_name});
 
   if (!examples::UsingTestbench()) std::this_thread::sleep_until(pause);
-  (void)client.DeleteBucket(bucket_name);
+  (void)examples::RemoveBucketAndContents(client, bucket_name);
 }
 
 }  // namespace


### PR DESCRIPTION
Previously the examples would remove any temporary buckets using just
`client.DeleteBucket()`, but if the sample code accidentally left an
object or two in the temporary bucket the `DeleteBucket()` call fails
and we leak the bucket (and its objects).

Part of the work for #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5136)
<!-- Reviewable:end -->
