### PR TITLE
fix: use streaming RPC for Partitioned DML

### DIFF
--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -79,6 +79,17 @@ std::int64_t DmlResult::RowsModified() const {
   return GetRowsModified(source_);
 }
 
+StatusOr<std::int64_t> StreamingDmlResult::RowsModified() const {
+  while (auto row = source_->NextRow()) {
+    if (!row.ok()) {
+      return std::move(row).status();
+    }
+    // We don't expect to get any data; if we do just drop it.
+    if (row->size() == 0) break;
+  }
+  return GetRowsModified(source_);
+}
+
 std::int64_t ProfileDmlResult::RowsModified() const {
   return GetRowsModified(source_);
 }

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -131,6 +131,29 @@ class DmlResult {
   std::unique_ptr<internal::ResultSourceInterface> source_;
 };
 
+class StreamingDmlResult {
+ public:
+  StreamingDmlResult() = default;
+  explicit StreamingDmlResult(
+      std::unique_ptr<internal::ResultSourceInterface> source)
+      : source_(std::move(source)) {}
+
+  // This class is movable but not copyable.
+  StreamingDmlResult(StreamingDmlResult&&) = default;
+  StreamingDmlResult& operator=(StreamingDmlResult&&) = default;
+
+  /**
+   * Returns the number of rows modified by the DML statement.
+   *
+   * @note Partitioned DML only provides a lower bound of the rows modified, all
+   *     other DML statements provide an exact count.
+   */
+  StatusOr<std::int64_t> RowsModified() const;
+
+ private:
+  std::unique_ptr<internal::ResultSourceInterface> source_;
+};
+
 /**
  * Represents the stream of `Rows` and profile stats returned from
  * `spanner::Client::ProfileQuery()`.


### PR DESCRIPTION
WORK IN PROGRESS - DO NOT SUBMIT
I need to update the tests but wanted to get comments on this.

It may be a good idea just to have *all* DML use streaming, to be able
to handle long running operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5137)
<!-- Reviewable:end -->
