### PR TITLE
ci: use GCS Bazel cache on Linux quickstart builds

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -52,11 +52,19 @@ if [[ -n "${BAZEL_CONFIG}" ]]; then
   bazel_args+=(--config "${BAZEL_CONFIG}")
 fi
 
+readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
+
 if [[ -r "/c/kokoro-run-key.json" ]]; then
   run_vars+=(
     "GOOGLE_APPLICATION_CREDENTIALS=/c/kokoro-run-key.json"
     "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
   )
+  io::log "Using bazel remote cache: ${BAZEL_CACHE}/docker/${BUILD_NAME}"
+  bazel_args+=("--remote_cache=${BAZEL_CACHE}/docker/${BUILD_NAME}")
+  bazel_args+=("--google_credentials=/c/kokoro-run-key.json")
+  # See https://docs.bazel.build/versions/master/remote-caching.html#known-issues
+  # and https://github.com/bazelbuild/bazel/issues/3360
+  bazel_args+=("--experimental_guard_against_concurrent_changes")
 fi
 
 build_quickstart() {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5146)
<!-- Reviewable:end -->
