### PR TITLE
test: automatically cleanup stale example buckets

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -184,9 +184,9 @@ std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {
 
   os << ", project_number=" << rhs.project_number()
      << ", self_link=" << rhs.self_link()
-     << ", storage_class=" << rhs.storage_class()
-     << ", time_created=" << rhs.time_created().time_since_epoch().count()
-     << ", updated=" << rhs.updated().time_since_epoch().count();
+     << ", storage_class=" << rhs.storage_class() << ", time_created="
+     << google::cloud::internal::FormatRfc3339(rhs.time_created())
+     << ", updated=" << google::cloud::internal::FormatRfc3339(rhs.updated());
 
   if (rhs.has_retention_policy()) {
     os << ", retention_policy.retention_period="

--- a/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
+++ b/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
@@ -91,9 +91,9 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
 
   auto const now =
       google::cloud::internal::ParseRfc3339("2020-09-23T12:34:56Z");
-  auto const deadline = now - std::chrono::hours(48);
-  auto const affected_tp = deadline - std::chrono::hours(1);
-  auto const unaffected_tp = deadline + std::chrono::hours(1);
+  auto const create_time_limit = now - std::chrono::hours(48);
+  auto const affected_tp = create_time_limit - std::chrono::hours(1);
+  auto const unaffected_tp = create_time_limit + std::chrono::hours(1);
 
   EXPECT_CALL(*mock, ListBuckets)
       .WillOnce([&](internal::ListBucketsRequest const& r) {
@@ -110,7 +110,8 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
       });
 
   Client client(mock, Client::NoDecorations{});
-  auto const actual = RemoveStaleBuckets(client, "matching-", deadline);
+  auto const actual =
+      RemoveStaleBuckets(client, "matching-", create_time_limit);
   EXPECT_THAT(actual, StatusIs(StatusCode::kOk));
 }
 

--- a/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
+++ b/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/storage/testing/mock_client.h"
+#include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/testing_util/status_matchers.h"
 
 namespace google {
@@ -24,6 +25,8 @@ namespace {
 
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::StartsWith;
 
 ObjectMetadata CreateObject(std::string const& name, int generation) {
   nlohmann::json metadata{
@@ -33,6 +36,16 @@ ObjectMetadata CreateObject(std::string const& name, int generation) {
       {"kind", "storage#object"},
   };
   return internal::ObjectMetadataParser::FromJson(metadata).value();
+};
+
+BucketMetadata CreateBucket(std::string const& name,
+                            std::chrono::system_clock::time_point tp) {
+  nlohmann::json metadata{
+      {"name", name},
+      {"timeCreated", google::cloud::internal::FormatRfc3339(tp)},
+      {"kind", "storage#bucket"},
+  };
+  return internal::BucketMetadataParser::FromJson(metadata).value();
 };
 
 TEST(CleanupStaleBucketsTest, RemoveBucketContents) {
@@ -56,6 +69,48 @@ TEST(CleanupStaleBucketsTest, RemoveBucketContents) {
       });
   Client client(mock, Client::NoDecorations{});
   auto const actual = RemoveBucketAndContents(client, "fake-bucket");
+  EXPECT_THAT(actual, StatusIs(StatusCode::kOk));
+}
+
+TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
+  auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, DeleteBucket)
+      .Times(2)
+      .WillRepeatedly(Return(internal::EmptyResponse{}));
+  EXPECT_CALL(*mock, ListObjects)
+      .Times(2)
+      .WillRepeatedly([](internal::ListObjectsRequest const& r) {
+        EXPECT_THAT(r.bucket_name(), StartsWith("matching-2020-09-21_"));
+        EXPECT_TRUE(r.HasOption<Versions>());
+        return internal::ListObjectsResponse{};
+      });
+  auto const options =
+      ClientOptions{oauth2::CreateAnonymousCredentials()}.set_project_id(
+          "fake-project");
+  EXPECT_CALL(*mock, client_options).WillRepeatedly(ReturnRef(options));
+
+  auto const now =
+      google::cloud::internal::ParseRfc3339("2020-09-23T12:34:56Z");
+  auto const deadline = now - std::chrono::hours(48);
+  auto const affected_tp = deadline - std::chrono::hours(1);
+  auto const unaffected_tp = deadline + std::chrono::hours(1);
+
+  EXPECT_CALL(*mock, ListBuckets)
+      .WillOnce([&](internal::ListBucketsRequest const& r) {
+        EXPECT_EQ("fake-project", r.project_id());
+        internal::ListBucketsResponse response;
+        response.items.push_back(CreateBucket("not-matching", affected_tp));
+        response.items.push_back(
+            CreateBucket("matching-2020-09-21_0", affected_tp));
+        response.items.push_back(
+            CreateBucket("matching-2020-09-21_1", affected_tp));
+        response.items.push_back(
+            CreateBucket("matching-2020-09-21_2", unaffected_tp));
+        return response;
+      });
+
+  Client client(mock, Client::NoDecorations{});
+  auto const actual = RemoveStaleBuckets(client, "matching-", deadline);
   EXPECT_THAT(actual, StatusIs(StatusCode::kOk));
 }
 

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -538,10 +538,11 @@ void RunAll(std::vector<std::string> const& argv) {
   // This is the only example that cleans up stale buckets. The examples run in
   // parallel (within a build and across the builds), having multiple examples
   // doing the same cleanup is probably more trouble than it is worth.
-  auto const deadline =
+  auto const create_time_limit =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   std::cout << "\nRemoving stale buckets for examples" << std::endl;
-  examples::RemoveStaleBuckets(client, "cloud-cpp-test-examples-", deadline);
+  examples::RemoveStaleBuckets(client, "cloud-cpp-test-examples-",
+                               create_time_limit);
 
   std::cout << "\nRunning ListBucketsForProject() example" << std::endl;
   ListBucketsForProject(client, {project_id});

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -535,6 +535,14 @@ void RunAll(std::vector<std::string> const& argv) {
       examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
   auto client = gcs::Client::CreateDefaultClient().value();
 
+  // This is the only example that cleans up stale buckets. The examples run in
+  // parallel (within a build and across the builds), having multiple examples
+  // doing the same cleanup is probably more trouble than it is worth.
+  auto const deadline =
+      std::chrono::system_clock::now() - std::chrono::hours(48);
+  std::cout << "\nRemoving stale buckets for examples" << std::endl;
+  examples::RemoveStaleBuckets(client, "cloud-cpp-test-examples-", deadline);
+
   std::cout << "\nRunning ListBucketsForProject() example" << std::endl;
   ListBucketsForProject(client, {project_id});
 

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -50,6 +50,25 @@ Commands::value_type CreateCommandEntry(
 Status RemoveBucketAndContents(google::cloud::storage::Client client,
                                std::string const& bucket_name);
 
+/**
+ * Remove stale buckets created for examples.
+ *
+ * The examples and integration tests create buckets in the production
+ * environment. While these programs are supposed to clean after themselves,
+ * they might crash or otherwise fail to delete any buckets they create. These
+ * buckets can accumulate and cause future tests to fail (see #4905). To prevent
+ * these problems we delete any bucket that match the pattern of these randomly
+ * created buckets, as long as the bucket was created more than 48 hours ago.
+ *
+ * @param client used to make calls to GCS.
+ * @param prefix only delete buckets that start with this string followed by a
+ *   date (in `YYYY-mm-dd` format), and then an underscore character (`_`).
+ * @param created_time_limit only delete buckets created before this timestamp.
+ */
+Status RemoveStaleBuckets(
+    google::cloud::storage::Client client, std::string const& prefix,
+    std::chrono::system_clock::time_point created_time_limit);
+
 }  // namespace examples
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -30,7 +30,11 @@ class GcsBucket(object):
     def __init__(self, gcs_url, name):
         self.name = name
         self.gcs_url = gcs_url
+        now = time.gmtime(time.time())
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
         self.metadata = {
+            "timeCreated": timestamp,
+            "updated": timestamp,
             "metageneration": "0",
             "name": self.name,
             "location": "US",
@@ -160,14 +164,15 @@ class GcsBucket(object):
         metadata = GcsBucket._remove_non_writable_keys(metadata)
         tmp.update(metadata)
         tmp["name"] = tmp.get("name", self.name)
+        now = time.gmtime(time.time())
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
         tmp.update(
             {
                 "id": self.name,
                 "kind": "storage#bucket",
                 "selfLink": self.gcs_url + self.name,
                 "projectNumber": "123456789",
-                "timeCreated": "2018-05-19T19:31:14Z",
-                "updated": "2018-05-19T19:31:24Z",
+                "updated": timestamp,
             }
         )
         self.metadata = tmp


### PR DESCRIPTION
The examples create buckets and sometimes fail to clean after
themselves, either because they are buggy, are terminated before they
can cleanup, or any other reason. With this change we remove any stale
buckets, i.e., buckets created over two days ago and that match the
prefix used by the examples.

I had to fix some timestamps hardcoded in the testbench, and improve
the debug logging to troubleshoot the problems.

Part of the work for #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5149)
<!-- Reviewable:end -->
