### PR TITLE
test(spanner): refactor connection_impl_test

### DIFF
--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -60,6 +60,7 @@ using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::AtLeast;
 using ::testing::ByMove;
 using ::testing::DoAll;
@@ -72,31 +73,32 @@ using ::testing::Sequence;
 using ::testing::SetArgPointee;
 using ::testing::StartsWith;
 using ::testing::UnorderedPointwise;
+using ::testing::Unused;
 
 namespace spanner_proto = ::google::spanner::v1;
 
-// Matches a spanner_proto::ReadRequest with the specified `session` and
-// `transaction_id`.
-MATCHER_P2(ReadRequestHasSessionAndTransactionId, session, transaction_id,
-           "ReadRequest has expected session and transaction") {
-  return arg.session() == session && arg.transaction().id() == transaction_id;
+// Matchers for mock calls.
+MATCHER_P(HasSession, session, "request has expected session name") {
+  return arg.session() == session;
 }
-
-// Matches a spanner_proto::ReadRequest with the specified `session` and
-// 'begin` set in the TransactionSelector.
-MATCHER_P(ReadRequestHasSessionAndBeginTransaction, session,
-          "ReadRequest has expected session and transaction") {
-  return arg.session() == session && arg.transaction().has_begin();
+MATCHER_P(HasTransactionId, transaction_id,
+          "request has expected transaction id") {
+  return arg.transaction().id() == transaction_id;
 }
-
-// Matches a spanner_proto::BatchCreateSessionsRequest with the specified
-// `database`.
-MATCHER_P(BatchCreateSessionsRequestHasDatabase, database,
-          "BatchCreateSessionsRequest has expected database") {
+// As above, but for Commit and Rollback requests, which don't have a
+// `TransactionSelector` but just store the "naked" ID directly in the proto.
+MATCHER_P(HasNakedTransactionId, transaction_id,
+          "commit or rollback request has expected transaction id") {
+  return arg.transaction_id() == transaction_id;
+}
+MATCHER(HasBeginTransaction, "request has begin TransactionSelector set") {
+  return arg.transaction().has_begin();
+}
+MATCHER_P(HasDatabase, database, "Request has expected database") {
   return arg.database() == database.FullName();
 }
 
-// Matches a spanner::Transaction that is bound to a "bad" session"
+// Matches a `spanner::Transaction` that is bound to a "bad" session.
 MATCHER(HasBadSession, "bound to a session that's marked bad") {
   return internal::Visit(
       arg,
@@ -143,13 +145,21 @@ spanner_proto::Transaction MakeTestTransaction(std::string id = "1234567890") {
   return txn;
 }
 
-// Create a response with the given `sessions`
+// Create a `BatchCreateSessionsResponse` with the given `sessions`.
 spanner_proto::BatchCreateSessionsResponse MakeSessionsResponse(
     std::vector<std::string> sessions) {
   spanner_proto::BatchCreateSessionsResponse response;
   for (auto& session : sessions) {
     response.add_session()->set_name(std::move(session));
   }
+  return response;
+}
+
+// Create a `CommitResponse with the given `commit_timestamp`.
+spanner_proto::CommitResponse MakeCommitResponse(Timestamp commit_timestamp) {
+  spanner_proto::CommitResponse response;
+  *response.mutable_commit_timestamp() =
+      internal::TimestampToProto(commit_timestamp);
   return response;
 }
 
@@ -180,19 +190,51 @@ class MockGrpcReader
   MOCK_METHOD0(WaitForInitialMetadata, void());
 };
 
+// Creates a MockGrpcReader that yields the specified `PartialResultSet`
+// `responses` (which can be given in proto or text format) in sequence.
+std::unique_ptr<MockGrpcReader> MakeReader(
+    std::vector<spanner_proto::PartialResultSet> responses) {
+  auto reader = absl::make_unique<MockGrpcReader>();
+  Sequence s;
+  for (auto& response : responses) {
+    EXPECT_CALL(*reader, Read(_))
+        .InSequence(s)
+        .WillOnce(DoAll(SetArgPointee<0>(std::move(response)), Return(true)));
+  }
+  EXPECT_CALL(*reader, Read(_)).InSequence(s).WillOnce(Return(false));
+  EXPECT_CALL(*reader, Finish()).InSequence(s).WillOnce(Return(grpc::Status()));
+  return reader;
+}
+
+std::unique_ptr<MockGrpcReader> MakeReader(
+    std::vector<std::string> const& responses) {
+  std::vector<spanner_proto::PartialResultSet> response_protos;
+  response_protos.resize(responses.size());
+  for (std::size_t i = 0; i < responses.size(); ++i) {
+    if (!TextFormat::ParseFromString(responses[i], &response_protos[i])) {
+      ADD_FAILURE() << "Failed to parse proto " << responses[i];
+    }
+  }
+  return MakeReader(std::move(response_protos));
+}
+
+// Creates a MockGrpcReader that fails and yields the specified `status`.
+std::unique_ptr<MockGrpcReader> MakeFailingReader(grpc::Status status) {
+  auto reader = absl::make_unique<MockGrpcReader>();
+  EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*reader, Finish()).WillOnce(Return(std::move(status)));
+  return reader;
+}
+
 TEST(ConnectionImplTest, ReadGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   auto rows =
       conn->Read({MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -200,8 +242,8 @@ TEST(ConnectionImplTest, ReadGetSessionFailure) {
                   KeySet::All(),
                   {"column1"}});
   for (auto& row : rows) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(), HasSubstr("uh-oh in GetSession"));
+    EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
+                              HasSubstr("uh-oh in GetSession")));
   }
 }
 
@@ -212,21 +254,12 @@ TEST(ConnectionImplTest, ReadStreamingReadFailure) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   grpc::Status finish_status(grpc::StatusCode::PERMISSION_DENIED,
                              "uh-oh in GrpcReader::Finish");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
   EXPECT_CALL(*mock, StreamingRead(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeFailingReader(finish_status))));
 
   auto rows =
       conn->Read({MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -234,9 +267,8 @@ TEST(ConnectionImplTest, ReadStreamingReadFailure) {
                   KeySet::All(),
                   {"column1"}});
   for (auto& row : rows) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(),
-                HasSubstr("uh-oh in GrpcReader::Finish"));
+    EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
+                              HasSubstr("uh-oh in GrpcReader::Finish")));
   }
 }
 
@@ -246,21 +278,10 @@ TEST(ConnectionImplTest, ReadSuccess) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
 
-  auto reader1 = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*reader1, Read(_)).WillOnce(Return(false));
-  EXPECT_CALL(*reader1, Finish())
-      .WillOnce(
-          Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
-
-  auto reader2 = absl::make_unique<MockGrpcReader>();
+  grpc::Status retry_status(grpc::StatusCode::UNAVAILABLE, "try-again");
   auto constexpr kText = R"pb(
     metadata: {
       row_type: {
@@ -279,15 +300,9 @@ TEST(ConnectionImplTest, ReadSuccess) {
     values: { string_value: "42" }
     values: { string_value: "Ann" }
   )pb";
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-  EXPECT_CALL(*reader2, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*reader2, Finish()).WillOnce(Return(grpc::Status()));
   EXPECT_CALL(*mock, StreamingRead(_, _))
-      .WillOnce(Return(ByMove(std::move(reader1))))
-      .WillOnce(Return(ByMove(std::move(reader2))));
+      .WillOnce(Return(ByMove(MakeFailingReader(retry_status))))
+      .WillOnce(Return(ByMove(MakeReader({kText}))));
 
   auto rows =
       conn->Read({MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -313,21 +328,11 @@ TEST(ConnectionImplTest, ReadPermanentFailure) {
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto reader1 = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*reader1, Read(_)).WillOnce(Return(false));
-  EXPECT_CALL(*reader1, Finish())
-      .WillOnce(
-          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, StreamingRead(_, _))
-      .WillOnce(Return(ByMove(std::move(reader1))));
+      .WillOnce(Return(ByMove(
+          MakeFailingReader({grpc::StatusCode::PERMISSION_DENIED, "uh-oh"}))));
 
   auto rows =
       conn->Read({MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -335,8 +340,8 @@ TEST(ConnectionImplTest, ReadPermanentFailure) {
                   KeySet::All(),
                   {"UserId", "UserName"}});
   for (auto& row : rows) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(), HasSubstr("uh-oh"));
+    EXPECT_THAT(row,
+                StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
   }
 }
 
@@ -345,25 +350,14 @@ TEST(ConnectionImplTest, ReadTooManyTransientFailures) {
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, StreamingRead(_, _))
       .Times(AtLeast(2))
-      .WillRepeatedly(
-          [](grpc::ClientContext&, spanner_proto::ReadRequest const&) {
-            auto reader = absl::make_unique<MockGrpcReader>();
-            EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
-            EXPECT_CALL(*reader, Finish())
-                .WillOnce(Return(
-                    grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
-            return reader;
-          });
+      // This won't compile without `Unused` despite what the gMock docs say.
+      .WillRepeatedly([](Unused, Unused) {
+        return MakeFailingReader({grpc::StatusCode::UNAVAILABLE, "try-again"});
+      });
 
   auto rows =
       conn->Read({MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -371,36 +365,22 @@ TEST(ConnectionImplTest, ReadTooManyTransientFailures) {
                   KeySet::All(),
                   {"UserId", "UserName"}});
   for (auto& row : rows) {
-    EXPECT_EQ(StatusCode::kUnavailable, row.status().code());
-    EXPECT_THAT(row.status().message(), HasSubstr("try-again"));
+    EXPECT_THAT(row,
+                StatusIs(StatusCode::kUnavailable, HasSubstr("try-again")));
   }
 }
 
 /// @test Verify implicit "begin transaction" in Read() works.
 TEST(ConnectionImplTest, ReadImplicitBeginTransaction) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   auto constexpr kText = R"pb(metadata: { transaction: { id: "ABCDEF00" } })pb";
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
   EXPECT_CALL(*mock, StreamingRead(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeReader({kText}))));
 
   Transaction txn = MakeReadOnlyTransaction(Transaction::ReadOnlyOptions());
   auto rows = conn->Read({txn, "table", KeySet::All(), {"UserId", "UserName"}});
@@ -416,35 +396,24 @@ TEST(ConnectionImplTest, ReadImplicitBeginTransactionPermanentFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
 
-  auto make_reader = [] {
-    grpc::Status grpc_status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh");
-    auto reader = absl::make_unique<MockGrpcReader>();
-    EXPECT_CALL(*reader, Read(_)).WillOnce(Return(false));
-    EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc_status));
-    return reader;
-  };
-  auto reader1 = make_reader();
-  auto reader2 = make_reader();
+  grpc::Status grpc_status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh");
+  auto reader1 = MakeFailingReader(grpc_status);
+  auto reader2 = MakeFailingReader(grpc_status);
   // n.b. these calls are explicitly sequenced because using the scoped
   // `InSequence` object causes gMock to get confused by the reader calls.
   Sequence s;
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .InSequence(s)
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-  EXPECT_CALL(*mock, StreamingRead(_, ReadRequestHasSessionAndBeginTransaction(
-                                          "test-session-name")))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, StreamingRead(_, AllOf(HasSession("test-session-name"),
+                                            HasBeginTransaction())))
       .InSequence(s)
       .WillOnce(Return(ByMove(std::move(reader1))));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .InSequence(s)
       .WillOnce(Return(MakeTestTransaction("FEDCBA98")));
-  EXPECT_CALL(*mock, StreamingRead(_, ReadRequestHasSessionAndTransactionId(
-                                          "test-session-name", "FEDCBA98")))
+  EXPECT_CALL(*mock, StreamingRead(_, AllOf(HasSession("test-session-name"),
+                                            HasTransactionId("FEDCBA98"))))
       .InSequence(s)
       .WillOnce(Return(ByMove(std::move(reader2))));
 
@@ -461,20 +430,16 @@ TEST(ConnectionImplTest, ExecuteQueryGetSessionFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
   for (auto& row : rows) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(), HasSubstr("uh-oh in GetSession"));
+    EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
+                              HasSubstr("uh-oh in GetSession")));
   }
 }
 
@@ -484,29 +449,19 @@ TEST(ConnectionImplTest, ExecuteQueryStreamingReadFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
-  grpc::Status finish_status(grpc::StatusCode::PERMISSION_DENIED,
-                             "uh-oh in GrpcReader::Finish");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(
+          Return(ByMove(MakeFailingReader({grpc::StatusCode::PERMISSION_DENIED,
+                                           "uh-oh in GrpcReader::Finish"}))));
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
   for (auto& row : rows) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(),
-                HasSubstr("uh-oh in GrpcReader::Finish"));
+    EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
+                              HasSubstr("uh-oh in GrpcReader::Finish")));
   }
 }
 
@@ -516,15 +471,8 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   auto constexpr kText = R"pb(
     metadata: {
       row_type: {
@@ -543,14 +491,8 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
     values: { string_value: "42" }
     values: { string_value: "Ann" }
   )pb";
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
   EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeReader({kText}))));
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -572,28 +514,14 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
 /// @test Verify implicit "begin transaction" in ExecuteQuery() works.
 TEST(ConnectionImplTest, ExecuteQueryImplicitBeginTransaction) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   auto constexpr kText = R"pb(metadata: { transaction: { id: "00FEDCBA" } })pb";
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
   EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeReader({kText}))));
 
   Transaction txn = MakeReadOnlyTransaction(Transaction::ReadOnlyOptions());
   auto rows = conn->ExecuteQuery({txn, SqlStatement("select * from table")});
@@ -614,8 +542,6 @@ TEST(ConnectionImplTest, QueryOptions) {
     if (version) qo.set_optimizer_version(*version);
     auto m = Property(kQueryOptionsProp, IsProtoEqual(qo));
     auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-        .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
     auto txn = MakeReadOnlyTransaction(Transaction::ReadOnlyOptions());
     auto query_options = QueryOptions().set_optimizer_version(version);
@@ -623,6 +549,9 @@ TEST(ConnectionImplTest, QueryOptions) {
     auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
     auto conn = MakeConnection(
         db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
+
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+        .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
     // We wrap MockGrpcReader in NiceMock, because we don't really care how
     // it's called in this test (aside from needing to return a transaction in
@@ -658,19 +587,15 @@ TEST(ConnectionImplTest, ExecuteDmlGetSessionFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
 
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in GetSession")));
 }
 
 TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
@@ -679,7 +604,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   auto constexpr kText = R"pb(
@@ -707,7 +632,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeletePermanentFailure) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
     Status status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml");
     EXPECT_CALL(*mock, ExecuteSql(_, _)).WillOnce(Return(status));
@@ -718,9 +643,8 @@ TEST(ConnectionImplTest, ExecuteDmlDeletePermanentFailure) {
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in ExecuteDml")));
 }
 
 TEST(ConnectionImplTest, ExecuteDmlDeleteTooManyTransientFailures) {
@@ -730,7 +654,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteTooManyTransientFailures) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
     Status status(StatusCode::kUnavailable, "try-again in ExecuteDml");
     EXPECT_CALL(*mock, ExecuteSql(_, _))
@@ -745,9 +669,8 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteTooManyTransientFailures) {
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
+                               HasSubstr("try-again in ExecuteDml")));
 }
 
 // Tests that a Transaction that fails to begin does not successfully commit.
@@ -762,7 +685,7 @@ TEST(ConnectionImplTest, ExecuteDmlTransactionAtomicity) {
   Status begin_status(StatusCode::kInvalidArgument, "BeginTransaction status");
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
     // The first `ExecuteDml` call tries to implicitly begin the transaction
@@ -791,7 +714,7 @@ TEST(ConnectionImplTest, ExecuteDmlTransactionMissing) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   // Return an otherwise valid response that does not contain a transaction.
@@ -812,15 +735,8 @@ TEST(ConnectionImplTest, ProfileQuerySuccess) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"session-name"})));
   auto constexpr kText = R"pb(
     metadata: {
       row_type: {
@@ -848,14 +764,8 @@ TEST(ConnectionImplTest, ProfileQuerySuccess) {
       }
     }
   )pb";
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
-      .WillOnce(Return(false));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
   EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeReader({kText}))));
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
@@ -895,20 +805,16 @@ TEST(ConnectionImplTest, ProfileQueryGetSessionFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
   for (auto& row : result) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(), HasSubstr("uh-oh in GetSession"));
+    EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
+                              HasSubstr("uh-oh in GetSession")));
   }
 }
 
@@ -918,29 +824,19 @@ TEST(ConnectionImplTest, ProfileQueryStreamingReadFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   grpc::Status finish_status(grpc::StatusCode::PERMISSION_DENIED,
                              "uh-oh in GrpcReader::Finish");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
   EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeFailingReader(finish_status))));
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
   for (auto& row : result) {
-    EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
-    EXPECT_THAT(row.status().message(),
-                HasSubstr("uh-oh in GrpcReader::Finish"));
+    EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
+                              HasSubstr("uh-oh in GrpcReader::Finish")));
   }
 }
 
@@ -949,19 +845,14 @@ TEST(ConnectionImplTest, ProfileDmlGetSessionFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in GetSession")));
 }
 
 TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
@@ -970,7 +861,7 @@ TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   auto constexpr kText = R"pb(
@@ -1023,7 +914,7 @@ TEST(ConnectionImplTest, ProfileDmlDeletePermanentFailure) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
     Status status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml");
     EXPECT_CALL(*mock, ExecuteSql(_, _)).WillOnce(Return(status));
@@ -1034,9 +925,8 @@ TEST(ConnectionImplTest, ProfileDmlDeletePermanentFailure) {
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in ExecuteDml")));
 }
 
 TEST(ConnectionImplTest, ProfileDmlDeleteTooManyTransientFailures) {
@@ -1046,7 +936,7 @@ TEST(ConnectionImplTest, ProfileDmlDeleteTooManyTransientFailures) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
     Status status(StatusCode::kUnavailable, "try-again in ExecuteDml");
     EXPECT_CALL(*mock, ExecuteSql(_, _))
@@ -1061,9 +951,8 @@ TEST(ConnectionImplTest, ProfileDmlDeleteTooManyTransientFailures) {
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
+                               HasSubstr("try-again in ExecuteDml")));
 }
 
 TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
@@ -1072,15 +961,9 @@ TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
   auto constexpr kText = R"pb(
     metadata: {}
     stats: { query_plan { plan_nodes: { index: 42 } } }
@@ -1110,19 +993,14 @@ TEST(ConnectionImplTest, AnalyzeSqlGetSessionFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->AnalyzeSql({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in GetSession")));
 }
 
 TEST(ConnectionImplTest, AnalyzeSqlDeletePermanentFailure) {
@@ -1133,7 +1011,7 @@ TEST(ConnectionImplTest, AnalyzeSqlDeletePermanentFailure) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
     Status status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml");
     EXPECT_CALL(*mock, ExecuteSql(_, _)).WillOnce(Return(status));
@@ -1144,9 +1022,8 @@ TEST(ConnectionImplTest, AnalyzeSqlDeletePermanentFailure) {
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->AnalyzeSql({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in ExecuteDml")));
 }
 
 TEST(ConnectionImplTest, AnalyzeSqlDeleteTooManyTransientFailures) {
@@ -1156,7 +1033,7 @@ TEST(ConnectionImplTest, AnalyzeSqlDeleteTooManyTransientFailures) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
     Status status(StatusCode::kUnavailable, "try-again in ExecuteDml");
     EXPECT_CALL(*mock, ExecuteSql(_, _))
@@ -1171,16 +1048,15 @@ TEST(ConnectionImplTest, AnalyzeSqlDeleteTooManyTransientFailures) {
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->AnalyzeSql({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
+                               HasSubstr("try-again in ExecuteDml")));
 }
 
 TEST(ConnectionImplTest, ExecuteBatchDmlSuccess) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   auto constexpr kText = R"pb(
@@ -1221,7 +1097,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlPartialFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   auto constexpr kText = R"pb(
@@ -1247,8 +1123,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlPartialFailure) {
   auto txn = MakeReadWriteTransaction();
   auto result = conn->ExecuteBatchDml({txn, request});
   EXPECT_STATUS_OK(result);
-  EXPECT_EQ(result->status.code(), StatusCode::kUnknown);
-  EXPECT_EQ(result->status.message(), "oops");
+  EXPECT_THAT(result->status, StatusIs(StatusCode::kUnknown, "oops"));
   EXPECT_NE(result->stats.size(), request.size());
   EXPECT_EQ(result->stats.size(), 2);
   EXPECT_EQ(result->stats[0].row_count, 42);
@@ -1262,7 +1137,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlPermanentFailure) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
     Status status(StatusCode::kPermissionDenied, "uh-oh in ExecuteBatchDml");
@@ -1281,8 +1156,8 @@ TEST(ConnectionImplTest, ExecuteBatchDmlPermanentFailure) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto result = conn->ExecuteBatchDml({txn, request});
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteBatchDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in ExecuteBatchDml")));
 }
 
 TEST(ConnectionImplTest, ExecuteBatchDmlTooManyTransientFailures) {
@@ -1291,7 +1166,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlTooManyTransientFailures) {
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
         .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
     Status status(StatusCode::kUnavailable, "try-again in ExecuteBatchDml");
@@ -1314,9 +1189,8 @@ TEST(ConnectionImplTest, ExecuteBatchDmlTooManyTransientFailures) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto result = conn->ExecuteBatchDml({txn, request});
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(),
-              HasSubstr("try-again in ExecuteBatchDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
+                               HasSubstr("try-again in ExecuteBatchDml")));
 }
 
 TEST(ConnectionImplTest, ExecuteBatchDmlNoResultSets) {
@@ -1333,14 +1207,13 @@ TEST(ConnectionImplTest, ExecuteBatchDmlNoResultSets) {
         R"pb(status: { code: 6 message: "failed to insert ..." })pb";
     spanner_proto::ExecuteBatchDmlResponse response;
     ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-    EXPECT_CALL(
-        *mock, ExecuteBatchDml(
-                   _, ReadRequestHasSessionAndBeginTransaction("session-name")))
+    EXPECT_CALL(*mock, ExecuteBatchDml(_, AllOf(HasSession("session-name"),
+                                                HasBeginTransaction())))
         .WillOnce(Return(response));
     EXPECT_CALL(*mock, BeginTransaction(_, _))
         .WillOnce(Return(MakeTestTransaction("BD000001")));
-    EXPECT_CALL(*mock, ExecuteBatchDml(_, ReadRequestHasSessionAndTransactionId(
-                                              "session-name", "BD000001")))
+    EXPECT_CALL(*mock, ExecuteBatchDml(_, AllOf(HasSession("session-name"),
+                                                HasTransactionId("BD000001"))))
         .WillOnce(Return(response));
   }
 
@@ -1360,17 +1233,12 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteSuccess) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
-  auto constexpr kTextTxn = R"pb(
-    id: "1234567890"
-  )pb";
-  spanner_proto::Transaction txn;
-  ASSERT_TRUE(TextFormat::ParseFromString(kTextTxn, &txn));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce(Return(txn));
+      .WillOnce(Return(MakeTestTransaction()));
 
   auto constexpr kTextResponse = R"pb(
     stats: { row_count_lower_bound: 42 }
@@ -1393,19 +1261,14 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlGetSessionFailure) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   auto result =
       conn->ExecutePartitionedDml({SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in GetSession")));
 }
 
 TEST(ConnectionImplTest, ExecutePartitionedDmlDeletePermanentFailure) {
@@ -1414,17 +1277,12 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeletePermanentFailure) {
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
-  auto constexpr kTextTxn = R"pb(
-    id: "1234567890"
-  )pb";
-  spanner_proto::Transaction txn;
-  ASSERT_TRUE(TextFormat::ParseFromString(kTextTxn, &txn));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce(Return(txn));
+      .WillOnce(Return(MakeTestTransaction()));
 
   // A `kInternal` status can be treated as transient based on the message.
   // This tests that other `kInternal` errors are treated as permanent.
@@ -1433,9 +1291,8 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeletePermanentFailure) {
 
   auto result =
       conn->ExecutePartitionedDml({SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kInternal, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("permanent failure"));
+  EXPECT_THAT(result,
+              StatusIs(StatusCode::kInternal, HasSubstr("permanent failure")));
 }
 
 TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteTooManyTransientFailures) {
@@ -1443,17 +1300,12 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteTooManyTransientFailures) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
-  auto constexpr kTextTxn = R"pb(
-    id: "1234567890"
-  )pb";
-  spanner_proto::Transaction txn;
-  ASSERT_TRUE(TextFormat::ParseFromString(kTextTxn, &txn));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce(Return(txn));
+      .WillOnce(Return(MakeTestTransaction()));
 
   EXPECT_CALL(*mock, ExecuteSql(_, _))
       .Times(AtLeast(2))
@@ -1462,10 +1314,9 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteTooManyTransientFailures) {
 
   auto result =
       conn->ExecutePartitionedDml({SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(),
-              HasSubstr("try-again in ExecutePartitionedDml"));
+  EXPECT_THAT(result,
+              StatusIs(StatusCode::kUnavailable,
+                       HasSubstr("try-again in ExecutePartitionedDml")));
 }
 
 TEST(ConnectionImplTest, ExecutePartitionedDmlRetryableInternalErrors) {
@@ -1476,12 +1327,8 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlRetryableInternalErrors) {
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
-  auto constexpr kTextTxn = R"pb(
-    id: "2345678901"
-  )pb";
-  spanner_proto::Transaction txn;
-  ASSERT_TRUE(TextFormat::ParseFromString(kTextTxn, &txn));
-  EXPECT_CALL(*mock, BeginTransaction(_, _)).WillOnce(Return(txn));
+  EXPECT_CALL(*mock, BeginTransaction(_, _))
+      .WillOnce(Return(MakeTestTransaction("2345678901")));
 
   auto constexpr kTextResponse = R"pb(
     stats: { row_count_lower_bound: 99999 }
@@ -1514,7 +1361,7 @@ TEST(ConnectionImplTest,
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   EXPECT_CALL(*mock, BeginTransaction(_, _))
@@ -1523,10 +1370,8 @@ TEST(ConnectionImplTest,
 
   auto result =
       conn->ExecutePartitionedDml({SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(),
-              HasSubstr("uh-oh in ExecutePartitionedDml"));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in ExecutePartitionedDml")));
 }
 
 TEST(ConnectionImplTest,
@@ -1535,7 +1380,7 @@ TEST(ConnectionImplTest,
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
 
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
 
   EXPECT_CALL(*mock, BeginTransaction(_, _))
@@ -1545,10 +1390,9 @@ TEST(ConnectionImplTest,
 
   auto result =
       conn->ExecutePartitionedDml({SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(),
-              HasSubstr("try-again in ExecutePartitionedDml"));
+  EXPECT_THAT(result,
+              StatusIs(StatusCode::kUnavailable,
+                       HasSubstr("try-again in ExecutePartitionedDml")));
 }
 
 TEST(ConnectionImplTest, CommitGetSessionPermanentFailure) {
@@ -1556,17 +1400,13 @@ TEST(ConnectionImplTest, CommitGetSessionPermanentFailure) {
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   auto commit = conn->Commit({MakeReadWriteTransaction()});
-  EXPECT_EQ(StatusCode::kPermissionDenied, commit.status().code());
-  EXPECT_THAT(commit.status().message(), HasSubstr("uh-oh in GetSession"));
+  EXPECT_THAT(commit, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in GetSession")));
 }
 
 TEST(ConnectionImplTest, CommitGetSessionTooManyTransientFailures) {
@@ -1574,18 +1414,14 @@ TEST(ConnectionImplTest, CommitGetSessionTooManyTransientFailures) {
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .Times(AtLeast(2))
       .WillRepeatedly(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kUnavailable, "try-again in GetSession");
-          });
+          Return(Status(StatusCode::kUnavailable, "try-again in GetSession")));
 
   auto commit = conn->Commit({MakeReadWriteTransaction()});
-  EXPECT_EQ(StatusCode::kUnavailable, commit.status().code());
-  EXPECT_THAT(commit.status().message(), HasSubstr("try-again in GetSession"));
+  EXPECT_THAT(commit, StatusIs(StatusCode::kUnavailable,
+                               HasSubstr("try-again in GetSession")));
 }
 
 TEST(ConnectionImplTest, CommitGetSessionRetry) {
@@ -1594,30 +1430,18 @@ TEST(ConnectionImplTest, CommitGetSessionRetry) {
   spanner_proto::Transaction txn = MakeTestTransaction();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kUnavailable, "try-again in GetSession");
-          })
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+          Return(Status(StatusCode::kUnavailable, "try-again in GetSession")))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, BeginTransaction(_, _)).WillOnce(Return(txn));
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([&txn](grpc::ClientContext&,
-                       spanner_proto::CommitRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ(txn.id(), request.transaction_id());
-        return Status(StatusCode::kPermissionDenied, "uh-oh in Commit");
-      });
+  EXPECT_CALL(*mock, Commit(_, AllOf(HasSession("test-session-name"),
+                                     HasNakedTransactionId(txn.id()))))
+      .WillOnce(
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in Commit")));
   auto commit = conn->Commit({MakeReadWriteTransaction()});
-  EXPECT_EQ(StatusCode::kPermissionDenied, commit.status().code());
-  EXPECT_THAT(commit.status().message(), HasSubstr("uh-oh in Commit"));
+  EXPECT_THAT(commit, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in Commit")));
 }
 
 TEST(ConnectionImplTest, CommitBeginTransactionRetry) {
@@ -1626,29 +1450,16 @@ TEST(ConnectionImplTest, CommitBeginTransactionRetry) {
   spanner_proto::Transaction txn = MakeTestTransaction();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(txn));
   auto const commit_timestamp =
       MakeTimestamp(std::chrono::system_clock::from_time_t(123)).value();
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([&txn, commit_timestamp](
-                    grpc::ClientContext&,
-                    spanner_proto::CommitRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ(txn.id(), request.transaction_id());
-        spanner_proto::CommitResponse response;
-        *response.mutable_commit_timestamp() =
-            internal::TimestampToProto(commit_timestamp);
-        return response;
-      });
+  EXPECT_CALL(*mock, Commit(_, AllOf(HasSession("test-session-name"),
+                                     HasNakedTransactionId(txn.id()))))
+      .WillOnce(Return(MakeCommitResponse(commit_timestamp)));
 
   auto commit = conn->Commit({MakeReadWriteTransaction()});
   EXPECT_STATUS_OK(commit);
@@ -1659,13 +1470,8 @@ TEST(ConnectionImplTest, CommitBeginTransactionSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
   auto txn = MakeReadWriteTransaction();
@@ -1680,8 +1486,8 @@ TEST(ConnectionImplTest, CommitBeginTransactionPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(Return(MakeSessionsResponse({"session-name"})));
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
       .WillOnce(Return(
           Status(StatusCode::kInvalidArgument, "BeginTransaction failed")));
@@ -1703,24 +1509,16 @@ TEST(ConnectionImplTest, CommitCommitPermanentFailure) {
   spanner_proto::Transaction txn = MakeTestTransaction();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, BeginTransaction(_, _)).WillOnce(Return(txn));
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([&txn](grpc::ClientContext&,
-                       spanner_proto::CommitRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ(txn.id(), request.transaction_id());
-        return Status(StatusCode::kPermissionDenied, "uh-oh in Commit");
-      });
+  EXPECT_CALL(*mock, Commit(_, AllOf(HasSession("test-session-name"),
+                                     HasNakedTransactionId(txn.id()))))
+      .WillOnce(
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in Commit")));
   auto commit = conn->Commit({MakeReadWriteTransaction()});
-  EXPECT_EQ(StatusCode::kPermissionDenied, commit.status().code());
-  EXPECT_THAT(commit.status().message(), HasSubstr("uh-oh in Commit"));
+  EXPECT_THAT(commit, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in Commit")));
 }
 
 TEST(ConnectionImplTest, CommitCommitTooManyTransientFailures) {
@@ -1729,24 +1527,16 @@ TEST(ConnectionImplTest, CommitCommitTooManyTransientFailures) {
   spanner_proto::Transaction txn = MakeTestTransaction();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   EXPECT_CALL(*mock, BeginTransaction(_, _)).WillOnce(Return(txn));
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([&txn](grpc::ClientContext&,
-                       spanner_proto::CommitRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ(txn.id(), request.transaction_id());
-        return Status(StatusCode::kPermissionDenied, "uh-oh in Commit");
-      });
+  EXPECT_CALL(*mock, Commit(_, AllOf(HasSession("test-session-name"),
+                                     HasNakedTransactionId(txn.id()))))
+      .WillOnce(
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in Commit")));
   auto commit = conn->Commit({MakeReadWriteTransaction()});
-  EXPECT_EQ(StatusCode::kPermissionDenied, commit.status().code());
-  EXPECT_THAT(commit.status().message(), HasSubstr("uh-oh in Commit"));
+  EXPECT_THAT(commit, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr("uh-oh in Commit")));
 }
 
 TEST(ConnectionImplTest, CommitCommitInvalidatedTransaction) {
@@ -1767,8 +1557,8 @@ TEST(ConnectionImplTest, CommitCommitInvalidatedTransaction) {
   auto commit = conn->Commit({txn});
   EXPECT_FALSE(commit.ok());
   auto status = commit.status();
-  EXPECT_EQ(StatusCode::kAlreadyExists, commit.status().code());
-  EXPECT_THAT(commit.status().message(), HasSubstr("constraint error"));
+  EXPECT_THAT(commit, StatusIs(StatusCode::kAlreadyExists,
+                               HasSubstr("constraint error")));
 }
 
 TEST(ConnectionImplTest, CommitCommitIdempotentTransientSuccess) {
@@ -1777,32 +1567,14 @@ TEST(ConnectionImplTest, CommitCommitIdempotentTransientSuccess) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   auto const commit_timestamp =
       MakeTimestamp(std::chrono::system_clock::from_time_t(123)).value();
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::CommitRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ("test-txn-id", request.transaction_id());
-        return Status(StatusCode::kUnavailable, "try-again");
-      })
-      .WillOnce(
-          [commit_timestamp](grpc::ClientContext&,
-                             spanner_proto::CommitRequest const& request) {
-            EXPECT_EQ("test-session-name", request.session());
-            EXPECT_EQ("test-txn-id", request.transaction_id());
-            spanner_proto::CommitResponse response;
-            *response.mutable_commit_timestamp() =
-                internal::TimestampToProto(commit_timestamp);
-            return response;
-          });
+  EXPECT_CALL(*mock, Commit(_, AllOf(HasSession("test-session-name"),
+                                     HasNakedTransactionId("test-txn-id"))))
+      .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
+      .WillOnce(Return(MakeCommitResponse(commit_timestamp)));
 
   // Set the id because that makes the commit idempotent.
   auto txn = MakeReadWriteTransaction();
@@ -1819,23 +1591,12 @@ TEST(ConnectionImplTest, CommitSuccessWithTransactionId) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::CommitRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ("test-txn-id", request.transaction_id());
-        spanner_proto::CommitResponse response;
-        *response.mutable_commit_timestamp() = internal::TimestampToProto(
-            MakeTimestamp(std::chrono::system_clock::from_time_t(123)).value());
-        return response;
-      });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, Commit(_, AllOf(HasSession("test-session-name"),
+                                     HasNakedTransactionId("test-txn-id"))))
+      .WillOnce(Return(MakeCommitResponse(
+          MakeTimestamp(std::chrono::system_clock::from_time_t(123)).value())));
 
   // Set the id because that makes the commit idempotent.
   auto txn = MakeReadWriteTransaction();
@@ -1849,13 +1610,9 @@ TEST(ConnectionImplTest, RollbackGetSessionFailure) {
   auto db = Database("project", "instance", "database");
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
-          });
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
   auto conn = MakeConnection(
@@ -1863,31 +1620,23 @@ TEST(ConnectionImplTest, RollbackGetSessionFailure) {
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
   auto rollback = conn->Rollback({txn});
-  EXPECT_EQ(StatusCode::kPermissionDenied, rollback.code());
-  EXPECT_THAT(rollback.message(), HasSubstr("uh-oh in GetSession"));
+  EXPECT_THAT(rollback, StatusIs(StatusCode::kPermissionDenied,
+                                 HasSubstr("uh-oh in GetSession")));
 }
 
 TEST(ConnectionImplTest, RollbackBeginTransaction) {
   auto db = Database("project", "instance", "database");
   std::string const session_name = "test-session-name";
+  std::string const transaction_id = "RollbackBeginTransaction";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({session_name})));
   EXPECT_CALL(*mock, BeginTransaction(_, _))
-      .WillOnce(Return(MakeTestTransaction("RollbackBeginTransaction")));
-  EXPECT_CALL(*mock, Rollback(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::RollbackRequest const& request) {
-        EXPECT_EQ("test-session-name", request.session());
-        EXPECT_EQ("RollbackBeginTransaction", request.transaction_id());
-        return Status();
-      });
+      .WillOnce(Return(MakeTestTransaction(transaction_id)));
+  EXPECT_CALL(*mock, Rollback(_, AllOf(HasSession(session_name),
+                                       HasNakedTransactionId(transaction_id))))
+      .WillOnce(Return(Status()));
 
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
@@ -1909,8 +1658,8 @@ TEST(ConnectionImplTest, RollbackSingleUseTransaction) {
   auto txn = internal::MakeSingleUseTransaction(
       Transaction::SingleUseOptions{Transaction::ReadOnlyOptions{}});
   auto rollback = conn->Rollback({txn});
-  EXPECT_EQ(StatusCode::kInvalidArgument, rollback.code());
-  EXPECT_THAT(rollback.message(), HasSubstr("Cannot rollback"));
+  EXPECT_THAT(rollback, StatusIs(StatusCode::kInvalidArgument,
+                                 HasSubstr("Cannot rollback")));
 }
 
 TEST(ConnectionImplTest, RollbackPermanentFailure) {
@@ -1919,28 +1668,19 @@ TEST(ConnectionImplTest, RollbackPermanentFailure) {
   std::string const transaction_id = "test-txn-id";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([&db, &session_name](
-                    grpc::ClientContext&,
-                    spanner_proto::BatchCreateSessionsRequest const& request) {
-        EXPECT_EQ(db.FullName(), request.database());
-        return MakeSessionsResponse({session_name});
-      });
-  EXPECT_CALL(*mock, Rollback(_, _))
-      .WillOnce([&session_name, &transaction_id](
-                    grpc::ClientContext&,
-                    spanner_proto::RollbackRequest const& request) {
-        EXPECT_EQ(session_name, request.session());
-        EXPECT_EQ(transaction_id, request.transaction_id());
-        return Status(StatusCode::kPermissionDenied, "uh-oh in Rollback");
-      });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({session_name})));
+  EXPECT_CALL(*mock, Rollback(_, AllOf(HasSession(session_name),
+                                       HasNakedTransactionId(transaction_id))))
+      .WillOnce(
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in Rollback")));
 
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, transaction_id);
   auto rollback = conn->Rollback({txn});
-  EXPECT_EQ(StatusCode::kPermissionDenied, rollback.code());
-  EXPECT_THAT(rollback.message(), HasSubstr("uh-oh in Rollback"));
+  EXPECT_THAT(rollback, StatusIs(StatusCode::kPermissionDenied,
+                                 HasSubstr("uh-oh in Rollback")));
 }
 
 TEST(ConnectionImplTest, RollbackTooManyTransientFailures) {
@@ -1949,29 +1689,20 @@ TEST(ConnectionImplTest, RollbackTooManyTransientFailures) {
   std::string const transaction_id = "test-txn-id";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([&db, &session_name](
-                    grpc::ClientContext&,
-                    spanner_proto::BatchCreateSessionsRequest const& request) {
-        EXPECT_EQ(db.FullName(), request.database());
-        return MakeSessionsResponse({session_name});
-      });
-  EXPECT_CALL(*mock, Rollback(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({session_name})));
+  EXPECT_CALL(*mock, Rollback(_, AllOf(HasSession(session_name),
+                                       HasNakedTransactionId(transaction_id))))
       .Times(AtLeast(2))
-      .WillRepeatedly([&session_name, &transaction_id](
-                          grpc::ClientContext&,
-                          spanner_proto::RollbackRequest const& request) {
-        EXPECT_EQ(session_name, request.session());
-        EXPECT_EQ(transaction_id, request.transaction_id());
-        return Status(StatusCode::kUnavailable, "try-again in Rollback");
-      });
+      .WillRepeatedly(
+          Return(Status(StatusCode::kUnavailable, "try-again in Rollback")));
 
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, transaction_id);
   auto rollback = conn->Rollback({txn});
-  EXPECT_EQ(StatusCode::kUnavailable, rollback.code());
-  EXPECT_THAT(rollback.message(), HasSubstr("try-again in Rollback"));
+  EXPECT_THAT(rollback, StatusIs(StatusCode::kUnavailable,
+                                 HasSubstr("try-again in Rollback")));
 }
 
 TEST(ConnectionImplTest, RollbackSuccess) {
@@ -1980,22 +1711,12 @@ TEST(ConnectionImplTest, RollbackSuccess) {
   std::string const transaction_id = "test-txn-id";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([&db, &session_name](
-                    grpc::ClientContext&,
-                    spanner_proto::BatchCreateSessionsRequest const& request) {
-        EXPECT_EQ(db.FullName(), request.database());
-        return MakeSessionsResponse({session_name});
-      });
-  EXPECT_CALL(*mock, Rollback(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({session_name})));
+  EXPECT_CALL(*mock, Rollback(_, AllOf(HasSession(session_name),
+                                       HasNakedTransactionId(transaction_id))))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce([&session_name, &transaction_id](
-                    grpc::ClientContext&,
-                    spanner_proto::RollbackRequest const& request) {
-        EXPECT_EQ(session_name, request.session());
-        EXPECT_EQ(transaction_id, request.transaction_id());
-        return Status();
-      });
+      .WillOnce(Return(Status()));
 
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
@@ -2020,24 +1741,17 @@ TEST(ConnectionImplTest, RollbackInvalidatedTransaction) {
                         Status(StatusCode::kAlreadyExists, "constraint error"));
 
   auto rollback_status = conn->Rollback({txn});
-  EXPECT_EQ(StatusCode::kAlreadyExists, rollback_status.code());
-  EXPECT_THAT(rollback_status.message(), HasSubstr("constraint error"));
+  EXPECT_THAT(rollback_status, StatusIs(StatusCode::kAlreadyExists,
+                                        HasSubstr("constraint error")));
 }
 
 TEST(ConnectionImplTest, PartitionReadSuccess) {
-  auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn =
-      MakeConnection(db, {mock_spanner_stub},
-                     ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
+  auto conn = MakeConnection(
+      db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   auto constexpr kTextPartitionResponse = R"pb(
     partitions: { partition_token: "BADDECAF" }
     partitions: { partition_token: "DEADBEEF" }
@@ -2062,8 +1776,7 @@ TEST(ConnectionImplTest, PartitionReadSuccess) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTextPartitionRequest, &partition_request));
 
-  EXPECT_CALL(*mock_spanner_stub,
-              PartitionRead(_, IsProtoEqual(partition_request)))
+  EXPECT_CALL(*mock, PartitionRead(_, IsProtoEqual(partition_request)))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(partition_response));
 
@@ -2086,27 +1799,19 @@ TEST(ConnectionImplTest, PartitionReadSuccess) {
 }
 
 TEST(ConnectionImplTest, PartitionReadPermanentFailure) {
-  auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeLimitedRetryConnection(db, mock_spanner_stub);
+  auto conn = MakeLimitedRetryConnection(db, mock);
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
-        .WillOnce(
-            [&db](grpc::ClientContext&,
-                  spanner_proto::BatchCreateSessionsRequest const& request) {
-              EXPECT_EQ(db.FullName(), request.database());
-              return MakeSessionsResponse({"test-session-name"});
-            });
-
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+        .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
     Status status(StatusCode::kPermissionDenied, "uh-oh");
-    EXPECT_CALL(*mock_spanner_stub, PartitionRead(_, _))
-        .WillOnce(Return(status));
-    EXPECT_CALL(*mock_spanner_stub, BeginTransaction(_, _))
+    EXPECT_CALL(*mock, PartitionRead(_, _)).WillOnce(Return(status));
+    EXPECT_CALL(*mock, BeginTransaction(_, _))
         .WillOnce(Return(MakeTestTransaction()));
-    EXPECT_CALL(*mock_spanner_stub, PartitionRead(_, _))
-        .WillOnce(Return(status));
+    EXPECT_CALL(*mock, PartitionRead(_, _)).WillOnce(Return(status));
   }
 
   StatusOr<std::vector<ReadPartition>> result = conn->PartitionRead(
@@ -2114,32 +1819,26 @@ TEST(ConnectionImplTest, PartitionReadPermanentFailure) {
         "table",
         KeySet::All(),
         {"UserId", "UserName"}}});
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("uh-oh"));
+  EXPECT_THAT(result,
+              StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
 }
 
 TEST(ConnectionImplTest, PartitionReadTooManyTransientFailures) {
-  auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeLimitedRetryConnection(db, mock_spanner_stub);
+  auto conn = MakeLimitedRetryConnection(db, mock);
 
   {
     InSequence seq;
-    EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
-        .WillOnce(
-            [&db](grpc::ClientContext&,
-                  spanner_proto::BatchCreateSessionsRequest const& request) {
-              EXPECT_EQ(db.FullName(), request.database());
-              return MakeSessionsResponse({"test-session-name"});
-            });
-
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+        .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
     Status status(StatusCode::kUnavailable, "try-again");
-    EXPECT_CALL(*mock_spanner_stub, PartitionRead(_, _))
+    EXPECT_CALL(*mock, PartitionRead(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(Return(status));
-    EXPECT_CALL(*mock_spanner_stub, BeginTransaction(_, _))
+    EXPECT_CALL(*mock, BeginTransaction(_, _))
         .WillOnce(Return(MakeTestTransaction()));
-    EXPECT_CALL(*mock_spanner_stub, PartitionRead(_, _))
+    EXPECT_CALL(*mock, PartitionRead(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(Return(status));
   }
@@ -2149,24 +1848,17 @@ TEST(ConnectionImplTest, PartitionReadTooManyTransientFailures) {
         "table",
         KeySet::All(),
         {"UserId", "UserName"}}});
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr("try-again"));
+  EXPECT_THAT(result,
+              StatusIs(StatusCode::kUnavailable, HasSubstr("try-again")));
 }
 
 TEST(ConnectionImplTest, PartitionQuerySuccess) {
-  auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn =
-      MakeConnection(db, {mock_spanner_stub},
-                     ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
-
+  auto conn = MakeConnection(
+      db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
   auto constexpr kTextPartitionResponse = R"pb(
     partitions: { partition_token: "BADDECAF" }
     partitions: { partition_token: "DEADBEEF" }
@@ -2188,8 +1880,7 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
   google::spanner::v1::PartitionQueryRequest partition_request;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTextPartitionRequest, &partition_request));
-  EXPECT_CALL(*mock_spanner_stub,
-              PartitionQuery(_, IsProtoEqual(partition_request)))
+  EXPECT_CALL(*mock, PartitionQuery(_, IsProtoEqual(partition_request)))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(partition_response));
 
@@ -2209,59 +1900,45 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
 }
 
 TEST(ConnectionImplTest, PartitionQueryPermanentFailure) {
-  auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeLimitedRetryConnection(db, mock_spanner_stub);
+  auto conn = MakeLimitedRetryConnection(db, mock);
 
   Status failed_status = Status(StatusCode::kPermissionDenied, "End of line.");
   {
     InSequence seq;
-    EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
-        .WillOnce(
-            [&db](grpc::ClientContext&,
-                  spanner_proto::BatchCreateSessionsRequest const& request) {
-              EXPECT_EQ(db.FullName(), request.database());
-              return MakeSessionsResponse({"test-session-name"});
-            });
-
-    EXPECT_CALL(*mock_spanner_stub, PartitionQuery(_, _))
-        .WillOnce(Return(failed_status));
-    EXPECT_CALL(*mock_spanner_stub, BeginTransaction(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+        .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+    EXPECT_CALL(*mock, PartitionQuery(_, _)).WillOnce(Return(failed_status));
+    EXPECT_CALL(*mock, BeginTransaction(_, _))
         .WillOnce(Return(MakeTestTransaction()));
-    EXPECT_CALL(*mock_spanner_stub, PartitionQuery(_, _))
-        .WillOnce(Return(failed_status));
+    EXPECT_CALL(*mock, PartitionQuery(_, _)).WillOnce(Return(failed_status));
   }
 
   StatusOr<std::vector<QueryPartition>> result = conn->PartitionQuery(
       {MakeReadOnlyTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr(failed_status.message()));
+  EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
+                               HasSubstr(failed_status.message())));
 }
 
 TEST(ConnectionImplTest, PartitionQueryTooManyTransientFailures) {
-  auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeLimitedRetryConnection(db, mock_spanner_stub);
+  auto conn = MakeLimitedRetryConnection(db, mock);
 
   Status failed_status =
       Status(StatusCode::kUnavailable, "try-again in PartitionQuery");
   {
     InSequence seq;
-    EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
-        .WillOnce(
-            [&db](grpc::ClientContext&,
-                  spanner_proto::BatchCreateSessionsRequest const& request) {
-              EXPECT_EQ(db.FullName(), request.database());
-              return MakeSessionsResponse({"test-session-name"});
-            });
-
-    EXPECT_CALL(*mock_spanner_stub, PartitionQuery(_, _))
+    EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+        .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+    EXPECT_CALL(*mock, PartitionQuery(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(Return(failed_status));
-    EXPECT_CALL(*mock_spanner_stub, BeginTransaction(_, _))
+    EXPECT_CALL(*mock, BeginTransaction(_, _))
         .WillOnce(Return(MakeTestTransaction()));
-    EXPECT_CALL(*mock_spanner_stub, PartitionQuery(_, _))
+    EXPECT_CALL(*mock, PartitionQuery(_, _))
         .Times(AtLeast(2))
         .WillRepeatedly(Return(failed_status));
   }
@@ -2269,8 +1946,8 @@ TEST(ConnectionImplTest, PartitionQueryTooManyTransientFailures) {
   StatusOr<std::vector<QueryPartition>> result = conn->PartitionQuery(
       {MakeReadOnlyTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
-  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(), HasSubstr(failed_status.message()));
+  EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
+                               HasSubstr(failed_status.message())));
 }
 
 TEST(ConnectionImplTest, MultipleThreads) {
@@ -2280,12 +1957,11 @@ TEST(ConnectionImplTest, MultipleThreads) {
   std::atomic<int> session_counter(0);
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillRepeatedly(
-          [&db, &session_prefix, &session_counter](
+          [&session_prefix, &session_counter](
               grpc::ClientContext&,
               spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::BatchCreateSessionsResponse response;
             for (int i = 0; i < request.session_count(); ++i) {
               response.add_session()->set_name(
@@ -2345,13 +2021,11 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock,
-              BatchCreateSessions(_, BatchCreateSessionsRequestHasDatabase(db)))
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-1"})))
       .WillOnce(Return(MakeSessionsResponse({"session-2"})));
 
   constexpr int kNumResponses = 4;
-  std::array<spanner_proto::PartialResultSet, kNumResponses> responses;
   std::array<std::unique_ptr<MockGrpcReader>, kNumResponses> readers;
   for (int i = 0; i < kNumResponses; ++i) {
     auto constexpr kText = R"pb(
@@ -2364,45 +2038,39 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
         }
       }
     )pb";
-    ASSERT_TRUE(TextFormat::ParseFromString(kText, &responses[i]));
+    spanner_proto::PartialResultSet response;
+    ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
     // The first two responses are reads from two different "begin"
     // transactions.
     switch (i) {
       case 0:
-        *responses[i].mutable_metadata()->mutable_transaction() =
+        *response.mutable_metadata()->mutable_transaction() =
             MakeTestTransaction("ABCDEF01");
         break;
       case 1:
-        *responses[i].mutable_metadata()->mutable_transaction() =
+        *response.mutable_metadata()->mutable_transaction() =
             MakeTestTransaction("ABCDEF02");
         break;
     }
-    responses[i].add_values()->set_string_value(std::to_string(i));
-
-    readers[i] = absl::make_unique<MockGrpcReader>();
-    EXPECT_CALL(*readers[i], Read(_))
-        .WillOnce(DoAll(SetArgPointee<0>(responses[i]), Return(true)))
-        .WillOnce(Return(false));
-    EXPECT_CALL(*readers[i], Finish()).WillOnce(Return(grpc::Status()));
+    response.add_values()->set_string_value(std::to_string(i));
+    readers[i] = MakeReader({std::move(response)});
   }
 
   // Ensure the StreamingRead calls have the expected session and transaction
   // IDs or "begin" set as appropriate.
   {
     InSequence s;
-    EXPECT_CALL(
-        *mock,
-        StreamingRead(_, ReadRequestHasSessionAndBeginTransaction("session-1")))
+    EXPECT_CALL(*mock, StreamingRead(_, AllOf(HasSession("session-1"),
+                                              HasBeginTransaction())))
         .WillOnce(Return(ByMove(std::move(readers[0]))));
-    EXPECT_CALL(
-        *mock,
-        StreamingRead(_, ReadRequestHasSessionAndBeginTransaction("session-2")))
+    EXPECT_CALL(*mock, StreamingRead(_, AllOf(HasSession("session-2"),
+                                              HasBeginTransaction())))
         .WillOnce(Return(ByMove(std::move(readers[1]))));
-    EXPECT_CALL(*mock, StreamingRead(_, ReadRequestHasSessionAndTransactionId(
-                                            "session-1", "ABCDEF01")))
+    EXPECT_CALL(*mock, StreamingRead(_, AllOf(HasSession("session-1"),
+                                              HasTransactionId("ABCDEF01"))))
         .WillOnce(Return(ByMove(std::move(readers[2]))));
-    EXPECT_CALL(*mock, StreamingRead(_, ReadRequestHasSessionAndTransactionId(
-                                            "session-2", "ABCDEF02")))
+    EXPECT_CALL(*mock, StreamingRead(_, AllOf(HasSession("session-2"),
+                                              HasTransactionId("ABCDEF02"))))
         .WillOnce(Return(ByMove(std::move(readers[3]))));
   }
 
@@ -2449,26 +2117,18 @@ TEST(ConnectionImplTest, TransactionOutlivesConnection) {
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(
       db, {mock}, ConnectionOptions{grpc::InsecureChannelCredentials()});
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          });
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
 
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
   auto constexpr kText = R"pb(metadata: { transaction: { id: "ABCDEF00" } })pb";
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
   EXPECT_CALL(*mock, StreamingRead(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
+      .WillOnce(Return(ByMove(MakeReader({kText}))));
 
   Transaction txn = MakeReadOnlyTransaction(Transaction::ReadOnlyOptions());
   auto rows = conn->Read({txn, "table", KeySet::All(), {"UserId", "UserName"}});
+  for (auto& row : rows) {
+    EXPECT_STATUS_OK(row);
+  }
   EXPECT_THAT(txn, HasSessionAndTransactionId("test-session-name", "ABCDEF00"));
 
   // `conn` is the only reference to the `ConnectionImpl`, so dropping it will
@@ -2479,19 +2139,13 @@ TEST(ConnectionImplTest, TransactionOutlivesConnection) {
 
 TEST(ConnectionImplTest, ReadSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
-  grpc::Status finish_status(grpc::StatusCode::NOT_FOUND, "Session not found");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
-  EXPECT_CALL(*mock, StreamingRead(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  grpc::Status finish_status(grpc::StatusCode::NOT_FOUND, "Session not found");
+  EXPECT_CALL(*mock, StreamingRead(_, _))
+      .WillOnce(Return(ByMove(MakeFailingReader(finish_status))));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2505,18 +2159,12 @@ TEST(ConnectionImplTest, ReadSessionNotFound) {
 
 TEST(ConnectionImplTest, PartitionReadSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, PartitionRead(_, _))
-      .WillOnce(
-          [](grpc::ClientContext&, spanner_proto::PartitionReadRequest const&) {
-            return Status(StatusCode::kNotFound, "Session not found");
-          });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, PartitionRead(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2530,19 +2178,13 @@ TEST(ConnectionImplTest, PartitionReadSessionNotFound) {
 
 TEST(ConnectionImplTest, ExecuteQuerySessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
-  grpc::Status finish_status(grpc::StatusCode::NOT_FOUND, "Session not found");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
-  EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  grpc::Status finish_status(grpc::StatusCode::NOT_FOUND, "Session not found");
+  EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
+      .WillOnce(Return(ByMove(MakeFailingReader(finish_status))));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2555,19 +2197,13 @@ TEST(ConnectionImplTest, ExecuteQuerySessionNotFound) {
 
 TEST(ConnectionImplTest, ProfileQuerySessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  auto grpc_reader = absl::make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
-  grpc::Status finish_status(grpc::StatusCode::NOT_FOUND, "Session not found");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
-  EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  grpc::Status finish_status(grpc::StatusCode::NOT_FOUND, "Session not found");
+  EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
+      .WillOnce(Return(ByMove(MakeFailingReader(finish_status))));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2580,18 +2216,12 @@ TEST(ConnectionImplTest, ProfileQuerySessionNotFound) {
 
 TEST(ConnectionImplTest, ExecuteDmlSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, ExecuteSql(_, _))
-      .WillOnce(
-          [](grpc::ClientContext&, spanner_proto::ExecuteSqlRequest const&) {
-            return Status(StatusCode::kNotFound, "Session not found");
-          });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, ExecuteSql(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2604,18 +2234,12 @@ TEST(ConnectionImplTest, ExecuteDmlSessionNotFound) {
 
 TEST(ConnectionImplTest, ProfileDmlSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, ExecuteSql(_, _))
-      .WillOnce(
-          [](grpc::ClientContext&, spanner_proto::ExecuteSqlRequest const&) {
-            return Status(StatusCode::kNotFound, "Session not found");
-          });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, ExecuteSql(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2628,18 +2252,12 @@ TEST(ConnectionImplTest, ProfileDmlSessionNotFound) {
 
 TEST(ConnectionImplTest, AnalyzeSqlSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, ExecuteSql(_, _))
-      .WillOnce(
-          [](grpc::ClientContext&, spanner_proto::ExecuteSqlRequest const&) {
-            return Status(StatusCode::kNotFound, "Session not found");
-          });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, ExecuteSql(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2652,18 +2270,12 @@ TEST(ConnectionImplTest, AnalyzeSqlSessionNotFound) {
 
 TEST(ConnectionImplTest, PartitionQuerySessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, PartitionQuery(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::PartitionQueryRequest const&) {
-        return Status(StatusCode::kNotFound, "Session not found");
-      });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, PartitionQuery(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2676,18 +2288,12 @@ TEST(ConnectionImplTest, PartitionQuerySessionNotFound) {
 
 TEST(ConnectionImplTest, ExecuteBatchDmlSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, ExecuteBatchDml(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::ExecuteBatchDmlRequest const&) {
-        return Status(StatusCode::kNotFound, "Session not found");
-      });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, ExecuteBatchDml(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2707,17 +2313,12 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlSessionNotFound) {
 
 TEST(ConnectionImplTest, CommitSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, Commit(_, _))
-      .WillOnce([](grpc::ClientContext&, spanner_proto::CommitRequest const&) {
-        return Status(StatusCode::kNotFound, "Session not found");
-      });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, Commit(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
@@ -2730,18 +2331,12 @@ TEST(ConnectionImplTest, CommitSessionNotFound) {
 
 TEST(ConnectionImplTest, RollbackSessionNotFound) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce([](grpc::ClientContext&,
-                   spanner_proto::BatchCreateSessionsRequest const&) {
-        return MakeSessionsResponse({"test-session-name"});
-      });
-  EXPECT_CALL(*mock, Rollback(_, _))
-      .WillOnce(
-          [](grpc::ClientContext&, spanner_proto::RollbackRequest const&) {
-            return Status(StatusCode::kNotFound, "Session not found");
-          });
-
   auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, HasDatabase(db)))
+      .WillOnce(Return(MakeSessionsResponse({"test-session-name"})));
+  EXPECT_CALL(*mock, Rollback(_, _))
+      .WillOnce(Return(Status(StatusCode::kNotFound, "Session not found")));
+
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -122,9 +122,7 @@ MATCHER(HasBadSession, "bound to a session that's marked bad") {
 
 // Ideally this would be a matcher, but matcher args are `const` and `RowStream`
 // only has non-const methods.
-bool ContainsNoRows(RowStream& rows) {
-  return rows.begin() == rows.end();
-}
+bool ContainsNoRows(RowStream& rows) { return rows.begin() == rows.end(); }
 
 // Helper to set the Transaction's ID. Requires selector.ok().
 void SetTransactionId(Transaction& txn, std::string tid) {


### PR DESCRIPTION
Reduce the amount of per-test boilerplate, largely by replacing lambdas
and places where protos were directly constructed with matchers and helpers.

* Add helper functions to create a `MockGrpcReader` that returns a
  sequence of responses or an error status.
* Add and consistently use matchers for various request fields.
* Consistently use `StatusIs`.
* Use other helpers: `MakeCommitResponse`, `MakeTestTransaction`, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5150)
<!-- Reviewable:end -->
