### PR TITLE
cleanup: fix bucket name prefix in integration tests

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
@@ -44,11 +44,11 @@ TEST(StorageBenchmarksUtilsTest, MakeRandomBucket) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
-  auto d1 = MakeRandomBucketName(generator, "prefix-");
-  auto d2 = MakeRandomBucketName(generator, "prefix-");
+  auto d1 = MakeRandomBucketName(generator, "prefix");
+  auto d2 = MakeRandomBucketName(generator, "prefix");
   EXPECT_NE(d1, d2);
 
-  EXPECT_EQ(0, d1.rfind("prefix-", 0));
+  EXPECT_EQ(0, d1.rfind("prefix", 0));
   EXPECT_GE(63U, d1.size());
   EXPECT_EQ(std::string::npos,
             d1.find_first_not_of("-_abcdefghijklmnopqrstuvwxyz0123456789"))

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
       google::cloud::internal::MakeDefaultPRNG();
 
   auto bucket_name =
-      gcs_bm::MakeRandomBucketName(generator, "gcs-file-transfer-");
+      gcs_bm::MakeRandomBucketName(generator, "gcs-file-transfer");
   auto meta =
       client
           .CreateBucket(bucket_name,

--- a/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
+++ b/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
@@ -80,7 +80,7 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
   EXPECT_CALL(*mock, ListObjects)
       .Times(2)
       .WillRepeatedly([](internal::ListObjectsRequest const& r) {
-        EXPECT_THAT(r.bucket_name(), StartsWith("matching_2020-09-21_"));
+        EXPECT_THAT(r.bucket_name(), StartsWith("matching-2020-09-21_"));
         EXPECT_TRUE(r.HasOption<Versions>());
         return internal::ListObjectsResponse{};
       });
@@ -101,11 +101,11 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
         internal::ListBucketsResponse response;
         response.items.push_back(CreateBucket("not-matching", affected_tp));
         response.items.push_back(
-            CreateBucket("matching_2020-09-21_0", affected_tp));
+            CreateBucket("matching-2020-09-21_0", affected_tp));
         response.items.push_back(
-            CreateBucket("matching_2020-09-21_1", affected_tp));
+            CreateBucket("matching-2020-09-21_1", affected_tp));
         response.items.push_back(
-            CreateBucket("matching_2020-09-21_2", unaffected_tp));
+            CreateBucket("matching-2020-09-21_2", unaffected_tp));
         return response;
       });
 

--- a/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
+++ b/google/cloud/storage/examples/cleanup_stale_buckets_test.cc
@@ -80,7 +80,7 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
   EXPECT_CALL(*mock, ListObjects)
       .Times(2)
       .WillRepeatedly([](internal::ListObjectsRequest const& r) {
-        EXPECT_THAT(r.bucket_name(), StartsWith("matching-2020-09-21_"));
+        EXPECT_THAT(r.bucket_name(), StartsWith("matching_2020-09-21_"));
         EXPECT_TRUE(r.HasOption<Versions>());
         return internal::ListObjectsResponse{};
       });
@@ -101,17 +101,16 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
         internal::ListBucketsResponse response;
         response.items.push_back(CreateBucket("not-matching", affected_tp));
         response.items.push_back(
-            CreateBucket("matching-2020-09-21_0", affected_tp));
+            CreateBucket("matching_2020-09-21_0", affected_tp));
         response.items.push_back(
-            CreateBucket("matching-2020-09-21_1", affected_tp));
+            CreateBucket("matching_2020-09-21_1", affected_tp));
         response.items.push_back(
-            CreateBucket("matching-2020-09-21_2", unaffected_tp));
+            CreateBucket("matching_2020-09-21_2", unaffected_tp));
         return response;
       });
 
   Client client(mock, Client::NoDecorations{});
-  auto const actual =
-      RemoveStaleBuckets(client, "matching-", create_time_limit);
+  auto const actual = RemoveStaleBuckets(client, "matching", create_time_limit);
   EXPECT_THAT(actual, StatusIs(StatusCode::kOk));
 }
 

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -240,8 +240,7 @@ void RunAll(std::vector<std::string> const& argv) {
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const entity = "user-" + service_account;
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_bucket_cors_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_cors_samples.cc
@@ -94,8 +94,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -107,8 +107,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -382,8 +382,7 @@ void RunAll(std::vector<std::string> const& argv) {
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the examples (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_requester_pays_samples.cc
@@ -179,8 +179,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const object_name =
       examples::MakeRandomObjectName(generator, "object-") + ".txt";
   auto client = gcs::Client::CreateDefaultClient().value();

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -531,8 +531,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   // This is the only example that cleans up stale buckets. The examples run in
@@ -541,7 +540,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const create_time_limit =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   std::cout << "\nRemoving stale buckets for examples" << std::endl;
-  examples::RemoveStaleBuckets(client, "cloud-cpp-test-examples-",
+  examples::RemoveStaleBuckets(client, "cloud-cpp-test-examples",
                                create_time_limit);
 
   std::cout << "\nRunning ListBucketsForProject() example" << std::endl;

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -197,8 +197,7 @@ void RunAll(std::vector<std::string> const& argv) {
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const entity = "user-" + service_account;
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -119,8 +119,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -37,8 +37,7 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
   static std::size_t const kMaxBucketNameLength = 63;
   auto const date =
       absl::FormatCivilTime(absl::ToCivilDay(absl::Now(), absl::UTCTimeZone()));
-  auto const full =
-      std::string("cloud-cpp-testing-examples") + '_' + date + '_';
+  auto const full = std::string("cloud-cpp-testing-examples-") + date + '_';
   std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
   // bucket names might also contain `-` and `_` characters, but we do not
   // *need* to use them.
@@ -98,7 +97,7 @@ Status RemoveBucketAndContents(google::cloud::storage::Client client,
 Status RemoveStaleBuckets(
     google::cloud::storage::Client client, std::string const& prefix,
     std::chrono::system_clock::time_point created_time_limit) {
-  std::regex re("^" + prefix + R"re(_\d{4}-\d{2}-\d{2}_.*$)re");
+  std::regex re("^" + prefix + R"re(-\d{4}-\d{2}-\d{2}_.*$)re");
   for (auto& bucket : client.ListBuckets()) {
     if (!bucket) return std::move(bucket).status();
     if (!std::regex_match(bucket->name(), re)) continue;

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -31,13 +31,14 @@ bool UsingTestbench() {
               .empty();
 }
 
-std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
-                                 std::string const& prefix) {
+// TODO(#4905) - I am planning to refactor this to `storage::testing::`
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
   // The total length of a bucket name must be <= 63 characters,
   static std::size_t const kMaxBucketNameLength = 63;
   auto const date =
       absl::FormatCivilTime(absl::ToCivilDay(absl::Now(), absl::UTCTimeZone()));
-  auto const full = prefix + date + "_";
+  auto const full =
+      std::string("cloud-cpp-testing-examples") + '_' + date + '_';
   std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
   // bucket names might also contain `-` and `_` characters, but we do not
   // *need* to use them.
@@ -97,7 +98,7 @@ Status RemoveBucketAndContents(google::cloud::storage::Client client,
 Status RemoveStaleBuckets(
     google::cloud::storage::Client client, std::string const& prefix,
     std::chrono::system_clock::time_point created_time_limit) {
-  std::regex re("^" + prefix + R"re(\d{4}-\d{2}-\d{2}_.*$)re");
+  std::regex re("^" + prefix + R"re(_\d{4}-\d{2}-\d{2}_.*$)re");
   for (auto& bucket : client.ListBuckets()) {
     if (!bucket) return std::move(bucket).status();
     if (!std::regex_match(bucket->name(), re)) continue;

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -32,8 +32,7 @@ using ::google::cloud::testing_util::Usage;
 
 bool UsingTestbench();
 
-std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
-                                 std::string const& prefix);
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix);
 

--- a/google/cloud/storage/examples/storage_examples_common_test.cc
+++ b/google/cloud/storage/examples/storage_examples_common_test.cc
@@ -26,10 +26,10 @@ using ::testing::StartsWith;
 
 TEST(StorageExamplesCommon, RandomBucket) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const actual_1 = MakeRandomBucketName(generator, "test-prefix-");
-  EXPECT_THAT(actual_1, StartsWith("test-prefix-"));
-  auto const actual_2 = MakeRandomBucketName(generator, "test-prefix-");
-  EXPECT_THAT(actual_2, StartsWith("test-prefix-"));
+  auto const actual_1 = MakeRandomBucketName(generator);
+  EXPECT_THAT(actual_1, StartsWith("cloud-cpp-testing-examples"));
+  auto const actual_2 = MakeRandomBucketName(generator);
+  EXPECT_THAT(actual_2, StartsWith("cloud-cpp-testing-examples"));
   EXPECT_NE(actual_1, actual_2);
 }
 

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -125,8 +125,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;

--- a/google/cloud/storage/examples/storage_notification_samples.cc
+++ b/google/cloud/storage/examples/storage_notification_samples.cc
@@ -124,8 +124,7 @@ void RunAll(std::vector<std::string> const& argv) {
                               "GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME")
                               .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -253,8 +253,7 @@ void RunAll(std::vector<std::string> const& argv) {
           "GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const entity = "user-" + service_account;
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -105,8 +105,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -563,8 +563,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/examples/storage_object_versioning_samples.cc
+++ b/google/cloud/storage/examples/storage_object_versioning_samples.cc
@@ -165,8 +165,7 @@ void RunAll(std::vector<std::string> const& argv) {
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY")
           .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -123,8 +123,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto const object_name =
       examples::MakeRandomObjectName(generator, "upload-object-");
   auto client = gcs::Client::CreateDefaultClient().value();

--- a/google/cloud/storage/examples/storage_quickstart.cc
+++ b/google/cloud/storage/examples/storage_quickstart.cc
@@ -63,8 +63,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
 
   std::cout << "\nRunning StorageQuickStart() example" << std::endl;
   StorageQuickstartCommand({bucket_name});

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -171,8 +171,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
 
   std::cout << "\nCreating bucket to run the examples" << std::endl;

--- a/google/cloud/storage/examples/storage_website_samples.cc
+++ b/google/cloud/storage/examples/storage_website_samples.cc
@@ -135,8 +135,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto const bucket_name =
-      examples::MakeRandomBucketName(generator, "cloud-cpp-test-examples-");
+  auto const bucket_name = examples::MakeRandomBucketName(generator);
   auto client = gcs::Client::CreateDefaultClient().value();
   std::cout << "\nCreating bucket to run the example (" << bucket_name << ")"
             << std::endl;

--- a/google/cloud/storage/testing/random_names.cc
+++ b/google/cloud/storage/testing/random_names.cc
@@ -28,7 +28,7 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
   static std::size_t const kMaxBucketNameLength = 63;
   auto const date =
       absl::FormatCivilTime(absl::ToCivilDay(absl::Now(), absl::UTCTimeZone()));
-  auto const full = prefix + '_' + date + '_';
+  auto const full = prefix + '-' + date + '_';
   std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
   return full + google::cloud::internal::Sample(
                     gen, static_cast<int>(max_random_characters),

--- a/google/cloud/storage/testing/random_names.cc
+++ b/google/cloud/storage/testing/random_names.cc
@@ -28,7 +28,7 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen,
   static std::size_t const kMaxBucketNameLength = 63;
   auto const date =
       absl::FormatCivilTime(absl::ToCivilDay(absl::Now(), absl::UTCTimeZone()));
-  auto const full = prefix + date + "_";
+  auto const full = prefix + '_' + date + '_';
   std::size_t const max_random_characters = kMaxBucketNameLength - full.size();
   return full + google::cloud::internal::Sample(
                     gen, static_cast<int>(max_random_characters),

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -121,19 +121,13 @@ std::unique_ptr<RetryPolicy> StorageIntegrationTest::TestRetryPolicy() {
       .clone();
 }
 
-std::string StorageIntegrationTest::MakeRandomBucketName(std::string prefix) {
+std::string StorageIntegrationTest::MakeRandomBucketName() {
   // The total length of this bucket name must be <= 63 characters,
-  char constexpr kPrefix[] = "gcs-cpp-test-bucket-";  // NOLINT
+  char constexpr kPrefix[] = "cloud-cpp-testing-";  // NOLINT
   auto constexpr kMaxBucketNameLength = 63;
   static_assert(kMaxBucketNameLength > sizeof(kPrefix),
                 "The bucket prefix is too long");
-  if (prefix.empty()) prefix = kPrefix;
-  prefix = prefix.substr(0, kMaxBucketNameLength);
-  std::size_t const max_random_characters =
-      kMaxBucketNameLength - prefix.size();
-  return prefix + google::cloud::internal::Sample(
-                      generator_, static_cast<int>(max_random_characters),
-                      "abcdefghijklmnopqrstuvwxyz0123456789");
+  return testing::MakeRandomBucketName(generator_, kPrefix);
 }
 
 std::string StorageIntegrationTest::MakeRandomObjectName() {

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -122,12 +122,7 @@ std::unique_ptr<RetryPolicy> StorageIntegrationTest::TestRetryPolicy() {
 }
 
 std::string StorageIntegrationTest::MakeRandomBucketName() {
-  // The total length of this bucket name must be <= 63 characters,
-  char constexpr kPrefix[] = "cloud-cpp-testing-";  // NOLINT
-  auto constexpr kMaxBucketNameLength = 63;
-  static_assert(kMaxBucketNameLength > sizeof(kPrefix),
-                "The bucket prefix is too long");
-  return testing::MakeRandomBucketName(generator_, kPrefix);
+  return testing::MakeRandomBucketName(generator_, "cloud-cpp-testing-");
 }
 
 std::string StorageIntegrationTest::MakeRandomObjectName() {

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -122,7 +122,7 @@ std::unique_ptr<RetryPolicy> StorageIntegrationTest::TestRetryPolicy() {
 }
 
 std::string StorageIntegrationTest::MakeRandomBucketName() {
-  return testing::MakeRandomBucketName(generator_, "cloud-cpp-testing-");
+  return testing::MakeRandomBucketName(generator_, "cloud-cpp-testing");
 }
 
 std::string StorageIntegrationTest::MakeRandomObjectName() {

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -67,7 +67,7 @@ class StorageIntegrationTest : public ::testing::Test {
   static std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
   static std::unique_ptr<RetryPolicy> TestRetryPolicy();
 
-  std::string MakeRandomBucketName(std::string prefix = {});
+  std::string MakeRandomBucketName();
   std::string MakeRandomObjectName();
   std::string MakeRandomFilename();
 

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -62,7 +62,7 @@ TEST_F(GrpcIntegrationTest, BucketCRUD) {
   auto client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
+  auto bucket_name = MakeRandomBucketName();
   auto bucket_metadata = client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
@@ -97,7 +97,7 @@ TEST_F(GrpcIntegrationTest, ObjectCRUD) {
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
+  auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
   auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
@@ -127,7 +127,7 @@ TEST_F(GrpcIntegrationTest, WriteResume) {
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
+  auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
   auto bucket_metadata = client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
@@ -178,7 +178,7 @@ TEST_F(GrpcIntegrationTest, GetObjectMediaNotFound) {
   auto client = Client::CreateDefaultClient();
   ASSERT_STATUS_OK(client);
 
-  auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
+  auto bucket_name = MakeRandomBucketName();
   auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
   ASSERT_STATUS_OK(bucket_metadata);
@@ -216,7 +216,7 @@ TEST_F(GrpcIntegrationTest, InsertLarge) {
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
+  auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
   auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());
@@ -250,7 +250,7 @@ TEST_F(GrpcIntegrationTest, StreamLargeChunks) {
   auto client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
-  auto bucket_name = MakeRandomBucketName("cloud-cpp-testing-");
+  auto bucket_name = MakeRandomBucketName();
   auto object_name = MakeRandomObjectName();
   auto bucket_metadata = bucket_client->CreateBucketForProject(
       bucket_name, project_id(), BucketMetadata());

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -103,8 +103,7 @@ std::vector<ObjectNameList> DivideIntoEqualSizedGroups(
 }  // anonymous namespace
 
 TEST_F(ThreadIntegrationTest, Unshared) {
-  std::string bucket_name =
-      MakeRandomBucketName(/*prefix=*/"cloud-cpp-testing-");
+  std::string bucket_name = MakeRandomBucketName();
   auto bucket_client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(bucket_client);
 
@@ -187,8 +186,7 @@ TEST_F(ThreadIntegrationTest, ReuseConnections) {
                     .set_enable_raw_client_tracing(true)
                     .set_enable_http_tracing(true));
 
-  std::string bucket_name =
-      MakeRandomBucketName(/*prefix=*/"cloud-cpp-testing-");
+  std::string bucket_name = MakeRandomBucketName();
 
   auto id = LogSink::Instance().AddBackend(log_backend);
   StatusOr<BucketMetadata> meta = client.CreateBucketForProject(


### PR DESCRIPTION
The integration tests could, but rarely did, use a different prefix for
the random bucket names used in the test. That makes it hard to clean
these up later. In this change we fix the prefix and do some refactoring
to always use `storage::testing::MakeRandomBucketName()`.

Part of the work for #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5151)
<!-- Reviewable:end -->
