### PR TITLE
refactor(storage): cleanup stale buckets code moves

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -334,6 +334,8 @@ if (BUILD_TESTING)
         testing/object_integration_test.h
         testing/random_names.cc
         testing/random_names.h
+        testing/remove_stale_buckets.cc
+        testing/remove_stale_buckets.h
         testing/retry_tests.h
         testing/storage_integration_test.cc
         testing/storage_integration_test.h
@@ -445,6 +447,7 @@ if (BUILD_TESTING)
         storage_class_test.cc
         storage_iam_policy_test.cc
         storage_version_test.cc
+        testing/remove_stale_buckets_test.cc
         well_known_headers_test.cc
         well_known_parameters_test.cc)
 

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -54,8 +54,7 @@ if (BUILD_TESTING)
 
     set(storage_examples_unit_tests
         # cmake-format: sort
-        cleanup_stale_buckets_test.cc storage_client_mock_samples.cc
-        storage_examples_common_test.cc)
+        storage_client_mock_samples.cc storage_examples_common_test.cc)
 
     include(CreateBazelConfig)
     export_list_to_bazel("storage_examples.bzl" "storage_examples")

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_EXAMPLES_STORAGE_EXAMPLES_COMMON_H
 
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/example_driver.h"
 
@@ -24,6 +25,8 @@ namespace cloud {
 namespace storage {
 namespace examples {
 
+using ::google::cloud::storage::testing::RemoveBucketAndContents;
+using ::google::cloud::storage::testing::RemoveStaleBuckets;
 using ::google::cloud::testing_util::CheckEnvironmentVariablesAreSet;
 using ::google::cloud::testing_util::Commands;
 using ::google::cloud::testing_util::CommandType;
@@ -44,29 +47,6 @@ using ClientCommand = std::function<void(google::cloud::storage::Client,
 Commands::value_type CreateCommandEntry(
     std::string const& name, std::vector<std::string> const& arg_names,
     ClientCommand const& command);
-
-/// Remove a bucket, including any objects in it
-Status RemoveBucketAndContents(google::cloud::storage::Client client,
-                               std::string const& bucket_name);
-
-/**
- * Remove stale buckets created for examples.
- *
- * The examples and integration tests create buckets in the production
- * environment. While these programs are supposed to clean after themselves,
- * they might crash or otherwise fail to delete any buckets they create. These
- * buckets can accumulate and cause future tests to fail (see #4905). To prevent
- * these problems we delete any bucket that match the pattern of these randomly
- * created buckets, as long as the bucket was created more than 48 hours ago.
- *
- * @param client used to make calls to GCS.
- * @param prefix only delete buckets that start with this string followed by a
- *   date (in `YYYY-mm-dd` format), and then an underscore character (`_`).
- * @param created_time_limit only delete buckets created before this timestamp.
- */
-Status RemoveStaleBuckets(
-    google::cloud::storage::Client client, std::string const& prefix,
-    std::chrono::system_clock::time_point created_time_limit);
 
 }  // namespace examples
 }  // namespace storage

--- a/google/cloud/storage/examples/storage_examples_unit_tests.bzl
+++ b/google/cloud/storage/examples/storage_examples_unit_tests.bzl
@@ -17,7 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_examples_unit_tests = [
-    "cleanup_stale_buckets_test.cc",
     "storage_client_mock_samples.cc",
     "storage_examples_common_test.cc",
 ]

--- a/google/cloud/storage/storage_client_testing.bzl
+++ b/google/cloud/storage/storage_client_testing.bzl
@@ -23,6 +23,7 @@ storage_client_testing_hdrs = [
     "testing/mock_http_request.h",
     "testing/object_integration_test.h",
     "testing/random_names.h",
+    "testing/remove_stale_buckets.h",
     "testing/retry_tests.h",
     "testing/storage_integration_test.h",
     "testing/temp_file.h",
@@ -33,6 +34,7 @@ storage_client_testing_srcs = [
     "testing/mock_http_request.cc",
     "testing/object_integration_test.cc",
     "testing/random_names.cc",
+    "testing/remove_stale_buckets.cc",
     "testing/storage_integration_test.cc",
     "testing/temp_file.cc",
 ]

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -101,6 +101,7 @@ storage_client_unit_tests = [
     "storage_class_test.cc",
     "storage_iam_policy_test.cc",
     "storage_version_test.cc",
+    "testing/remove_stale_buckets_test.cc",
     "well_known_headers_test.cc",
     "well_known_parameters_test.cc",
 ]

--- a/google/cloud/storage/testing/remove_stale_buckets.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets.cc
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/testing/remove_stale_buckets.h"
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+Status RemoveBucketAndContents(google::cloud::storage::Client client,
+                               std::string const& bucket_name) {
+  // List all the objects and versions, and then delete each.
+  for (auto o : client.ListObjects(bucket_name, Versions(true))) {
+    if (!o) return std::move(o).status();
+    auto status = client.DeleteObject(bucket_name, o->name(),
+                                      Generation(o->generation()));
+    if (!status.ok()) return status;
+  }
+  return client.DeleteBucket(bucket_name);
+}
+
+Status RemoveStaleBuckets(
+    google::cloud::storage::Client client, std::string const& prefix,
+    std::chrono::system_clock::time_point created_time_limit) {
+  std::regex re("^" + prefix + R"re(-\d{4}-\d{2}-\d{2}_.*$)re");
+  for (auto& bucket : client.ListBuckets()) {
+    if (!bucket) return std::move(bucket).status();
+    if (!std::regex_match(bucket->name(), re)) continue;
+    if (bucket->time_created() > created_time_limit) continue;
+    (void)RemoveBucketAndContents(client, bucket->name());
+  }
+  return {};
+}
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/testing/remove_stale_buckets.h
+++ b/google/cloud/storage/testing/remove_stale_buckets.h
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_REMOVE_STALE_BUCKETS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_REMOVE_STALE_BUCKETS_H
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/status.h"
+#include <chrono>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+/// Remove a bucket, including any objects in it
+Status RemoveBucketAndContents(google::cloud::storage::Client client,
+                               std::string const& bucket_name);
+
+/**
+ * Remove stale buckets created for examples.
+ *
+ * The examples and integration tests create buckets in the production
+ * environment. While these programs are supposed to clean after themselves,
+ * they might crash or otherwise fail to delete any buckets they create. These
+ * buckets can accumulate and cause future tests to fail (see #4905). To prevent
+ * these problems we delete any bucket that match the pattern of these randomly
+ * created buckets, as long as the bucket was created more than 48 hours ago.
+ *
+ * @param client used to make calls to GCS.
+ * @param prefix only delete buckets that start with this string followed by a
+ *   date (in `YYYY-mm-dd` format), and then an underscore character (`_`).
+ * @param created_time_limit only delete buckets created before this timestamp.
+ */
+Status RemoveStaleBuckets(
+    google::cloud::storage::Client client, std::string const& prefix,
+    std::chrono::system_clock::time_point created_time_limit);
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_REMOVE_STALE_BUCKETS_H

--- a/google/cloud/storage/testing/remove_stale_buckets_test.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/storage/examples/storage_examples_common.h"
+#include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -20,7 +20,7 @@
 namespace google {
 namespace cloud {
 namespace storage {
-namespace examples {
+namespace testing {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
@@ -115,7 +115,7 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
 }
 
 }  // namespace
-}  // namespace examples
+}  // namespace testing
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Move the functions to remove stale buckets to a common library so I can
use it to remove the stale buckets created by any integration tests and
benchmarks.

Part of the work for #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5156)
<!-- Reviewable:end -->
