### PR TITLE
cleanup(storage): normalize benchmark bucket prefix

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
@@ -44,11 +44,11 @@ TEST(StorageBenchmarksUtilsTest, MakeRandomBucket) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
-  auto d1 = MakeRandomBucketName(generator, "prefix");
-  auto d2 = MakeRandomBucketName(generator, "prefix");
+  auto d1 = MakeRandomBucketName(generator);
+  auto d2 = MakeRandomBucketName(generator);
   EXPECT_NE(d1, d2);
 
-  EXPECT_EQ(0, d1.rfind("prefix", 0));
+  EXPECT_EQ(0, d1.rfind(RandomBucketPrefix(), 0));
   EXPECT_GE(63U, d1.size());
   EXPECT_EQ(std::string::npos,
             d1.find_first_not_of("-_abcdefghijklmnopqrstuvwxyz0123456789"))

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -328,6 +328,12 @@ char const* ToString(ApiName api) {
   return "";
 }
 
+std::string RandomBucketPrefix() { return "cloud-cpp-testing-bm"; }
+
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
+  return storage::testing::MakeRandomBucketName(gen, RandomBucketPrefix());
+}
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -30,7 +30,7 @@
 namespace google {
 namespace cloud {
 namespace storage_benchmarks {
-using ::google::cloud::storage::testing::MakeRandomBucketName;
+
 using ::google::cloud::storage::testing::MakeRandomData;
 using ::google::cloud::storage::testing::MakeRandomFileName;
 using ::google::cloud::storage::testing::MakeRandomObjectName;
@@ -130,6 +130,10 @@ enum class ApiName {
   kApiRawGrpc,
 };
 char const* ToString(ApiName api);
+
+std::string RandomBucketPrefix();
+
+std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -84,8 +84,7 @@ int main(int argc, char* argv[]) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
-  auto bucket_name =
-      gcs_bm::MakeRandomBucketName(generator, "gcs-file-transfer");
+  auto bucket_name = gcs_bm::MakeRandomBucketName(generator);
   auto meta =
       client
           .CreateBucket(bucket_name,

--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -83,7 +83,6 @@ using google::cloud::StatusOr;
 struct Options {
   std::string project_id;
   std::string region;
-  std::string bucket_prefix = "parallel-upload-bm-";
   std::string object_prefix = "parallel-upload-bm-";
   std::string directory = "/tmp/";
   std::chrono::seconds duration =
@@ -194,8 +193,7 @@ int main(int argc, char* argv[]) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
-  auto bucket_name =
-      gcs_bm::MakeRandomBucketName(generator, options->bucket_prefix);
+  auto bucket_name = gcs_bm::MakeRandomBucketName(generator);
   auto meta =
       client
           .CreateBucket(bucket_name,
@@ -316,8 +314,6 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
        [&wants_description](std::string const&) { wants_description = true; }},
       {"--project-id", "use the given project id for the benchmark",
        [&options](std::string const& val) { options.project_id = val; }},
-      {"--bucket-prefix", "use the given prefix for created temporary bucket",
-       [&options](std::string const& val) { options.bucket_prefix = val; }},
       {"--object-prefix", "use the given prefix for created objects",
        [&options](std::string const& val) { options.object_prefix = val; }},
       {"--directory", "use the given directory for files to be uploaded",
@@ -479,7 +475,6 @@ google::cloud::StatusOr<Options> SelfTest() {
   return ParseArgsDefault({
       "self-test",
       "--project-id=" + GetEnv("GOOGLE_CLOUD_PROJECT").value(),
-      "--bucket-prefix=cloud-cpp-testing-",
       "--object-prefix=parallel-upload/",
       "--directory=.",
       "--region=" + GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID").value(),

--- a/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_shard_throughput_benchmark.cc
@@ -121,8 +121,7 @@ int main(int argc, char* argv[]) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
 
-  auto bucket_name =
-      gcs_bm::MakeRandomBucketName(generator, options->bucket_prefix);
+  auto bucket_name = gcs_bm::MakeRandomBucketName(generator);
   std::cout << "# Creating bucket " << bucket_name << " in region "
             << options->region << "\n";
   auto meta =
@@ -317,8 +316,6 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
        [&wants_description](std::string const&) { wants_description = true; }},
       {"--project-id", "use the given project id for the benchmark",
        [&options](std::string const& val) { options.project_id = val; }},
-      {"--bucket-prefix", "configure the bucket's prefix",
-       [&options](std::string const& val) { options.bucket_prefix = val; }},
       {"--region", "use the given region for the benchmark",
        [&options](std::string const& val) { options.region = val; }},
       {"--object-count", "set the number of objects created by the benchmark",
@@ -413,7 +410,6 @@ google::cloud::StatusOr<Options> SelfTest() {
   return ParseArgsDefault({
       "self-test",
       "--project-id=" + GetEnv("GOOGLE_CLOUD_PROJECT").value(),
-      "--bucket-prefix=cloud-cpp-testing-",
       "--region=" + GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID").value(),
       "--object-count=4",
       "--thread-count=2",

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -138,8 +138,7 @@ int main(int argc, char* argv[]) {
   gcs::Client client(*std::move(client_options));
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto bucket_name =
-      gcs_bm::MakeRandomBucketName(generator, options->bucket_prefix);
+  auto bucket_name = gcs_bm::MakeRandomBucketName(generator);
   std::string notes = google::cloud::storage::version_string() + ";" +
                       google::cloud::internal::compiler() + ";" +
                       google::cloud::internal::compiler_flags();
@@ -367,7 +366,6 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
           "--project-id=" + GetEnv("GOOGLE_CLOUD_PROJECT").value(),
           "--region=" +
               GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID").value(),
-          "--bucket-prefix=cloud-cpp-testing-ci-",
           "--thread-count=1",
           "--minimum-object-size=16KiB",
           "--maximum-object-size=32KiB",

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -47,8 +47,6 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options](std::string const& val) { options.project_id = val; }},
       {"--region", "use the given region for the benchmark",
        [&options](std::string const& val) { options.region = val; }},
-      {"--bucket-prefix", "use the given prefix to create a bucket name",
-       [&options](std::string const& val) { options.bucket_prefix = val; }},
       {"--thread-count", "set the number of threads in the benchmark",
        [&options](std::string const& val) {
          options.thread_count = std::stoi(val);

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -26,7 +26,6 @@ namespace storage_benchmarks {
 struct ThroughputOptions {
   std::string project_id;
   std::string region;
-  std::string bucket_prefix = "cloud-cpp-testing-bm";
   std::chrono::seconds duration =
       std::chrono::seconds(std::chrono::minutes(15));
   int thread_count = 1;

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -30,7 +30,6 @@ TEST(ThroughputOptions, Basic) {
       "self-test",
       "--project-id=test-project",
       "--region=test-region",
-      "--bucket-prefix=test-prefix",
       "--thread-count=42",
       "--minimum-object-size=16KiB",
       "--maximum-object-size=32KiB",
@@ -50,7 +49,6 @@ TEST(ThroughputOptions, Basic) {
   ASSERT_STATUS_OK(options);
   EXPECT_EQ("test-project", options->project_id);
   EXPECT_EQ("test-region", options->region);
-  EXPECT_EQ("test-prefix", options->bucket_prefix);
   EXPECT_EQ(42, options->thread_count);
   EXPECT_EQ(16 * kKiB, options->minimum_object_size);
   EXPECT_EQ(32 * kKiB, options->maximum_object_size);


### PR DESCRIPTION
Use a single prefix for all the benchmark buckets, that will make it
easier to clean them up later.

Part of the work for #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5158)
<!-- Reviewable:end -->
