### PR TITLE
refactor: use absl::StrJoin in simple cases

### DIFF
--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -172,7 +172,8 @@ google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
         argv.size() != 3 + args.size()) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id> <table-id>";
-      os << " " << absl::StrJoin(args, " ");
+      if (!args.empty()) os << " ";
+      os << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
@@ -194,7 +195,8 @@ Commands::value_type MakeCommandEntry(std::string const& name,
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id>";
-      os << " " << absl::StrJoin(args, " ");
+      if (!args.empty()) os << " ";
+      os << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::TableAdmin table(
@@ -216,7 +218,8 @@ Commands::value_type MakeCommandEntry(
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id>";
-      os << " " << absl::StrJoin(args, " ");
+      if (!args.empty()) os << " ";
+      os << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::InstanceAdmin instance(

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -172,7 +172,7 @@ google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
         argv.size() != 3 + args.size()) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id> <table-id>";
-      os << absl::StrJoin(args, " ");
+      os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
@@ -194,7 +194,7 @@ Commands::value_type MakeCommandEntry(std::string const& name,
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id>";
-      os << absl::StrJoin(args, " ");
+      os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::TableAdmin table(
@@ -216,7 +216,7 @@ Commands::value_type MakeCommandEntry(
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id>";
-      os << absl::StrJoin(args, " ");
+      os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::InstanceAdmin instance(

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -172,8 +172,7 @@ google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
         argv.size() != 3 + args.size()) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id> <table-id>";
-      if (!args.empty()) os << " ";
-      os << absl::StrJoin(args, " ");
+      if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
@@ -195,8 +194,7 @@ Commands::value_type MakeCommandEntry(std::string const& name,
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id>";
-      if (!args.empty()) os << " ";
-      os << absl::StrJoin(args, " ");
+      if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::TableAdmin table(
@@ -218,8 +216,7 @@ Commands::value_type MakeCommandEntry(
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id>";
-      if (!args.empty()) os << " ";
-      os << absl::StrJoin(args, " ");
+      if (!args.empty()) os << " " << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::InstanceAdmin instance(

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/getenv.h"
+#include "absl/strings/str_join.h"
 #include <google/protobuf/util/time_util.h>
 #include <sstream>
 
@@ -171,10 +172,7 @@ google::cloud::bigtable::examples::Commands::value_type MakeCommandEntry(
         argv.size() != 3 + args.size()) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id> <table-id>";
-      char const* sep = " ";
-      for (auto const& a : args) {
-        os << sep << a;
-      }
+      os << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
@@ -196,10 +194,7 @@ Commands::value_type MakeCommandEntry(std::string const& name,
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id> <instance-id>";
-      char const* sep = " ";
-      for (auto const& a : args) {
-        os << sep << a;
-      }
+      os << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::TableAdmin table(
@@ -221,10 +216,7 @@ Commands::value_type MakeCommandEntry(
         argv.size() != args.size() + kFixedArguments) {
       std::ostringstream os;
       os << name << " <project-id>";
-      char const* sep = " ";
-      for (auto const& a : args) {
-        os << sep << a;
-      }
+      os << absl::StrJoin(args, " ");
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::InstanceAdmin instance(

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/crash_handler.h"
+#include "absl/strings/str_join.h"
 
 namespace {
 
@@ -600,11 +601,7 @@ void GetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "The IAM Policy for " << instance_id << " is\n";
     for (auto const& kv : policy->bindings) {
       std::cout << "role " << kv.first << " includes [";
-      char const* sep = "";
-      for (auto const& member : kv.second) {
-        std::cout << sep << member;
-        sep = ", ";
-      }
+      std::cout << absl::StrJoin(kv.second, ", ");
       std::cout << "]\n";
     }
   }
@@ -630,11 +627,7 @@ void SetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
     std::cout << "The IAM Policy for " << instance_id << " is\n";
     for (auto const& kv : policy->bindings) {
       std::cout << "role " << kv.first << " includes [";
-      char const* sep = "";
-      for (auto const& m : kv.second) {
-        std::cout << sep << m;
-        sep = ", ";
-      }
+      std::cout << absl::StrJoin(kv.second, ", ");
       std::cout << "]\n";
     }
   }
@@ -715,11 +708,7 @@ void TestIamPermissions(std::vector<std::string> const& argv) {
         instance_admin.TestIamPermissions(resource, permissions);
     if (!result) throw std::runtime_error(result.status().message());
     std::cout << "The current user has the following permissions [";
-    char const* sep = "";
-    for (auto const& p : *result) {
-      std::cout << sep << p;
-      sep = ", ";
-    }
+    std::cout << absl::StrJoin(*result, ", ");
     std::cout << "]\n";
   }
   //! [test iam permissions]

--- a/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
+++ b/google/cloud/bigtable/examples/instance_admin_async_snippets.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/crash_handler.h"
+#include "absl/strings/str_join.h"
 #include <sstream>
 
 namespace {
@@ -680,11 +681,7 @@ void AsyncTestIamPermissions(
     auto result = permissions_future.get();
     if (!result) throw std::runtime_error(result.status().message());
     std::cout << "DONE, the current user has the following permissions [";
-    char const* sep = "";
-    for (auto const& p : *result) {
-      std::cout << sep << p;
-      sep = ", ";
-    }
+    std::cout << absl::StrJoin(*result, ", ");
     std::cout << "]\n";
   }
   //! [async test iam permissions]

--- a/google/cloud/bigtable/examples/table_admin_iam_policy_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_iam_policy_snippets.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/crash_handler.h"
+#include "absl/strings/str_join.h"
 #include <sstream>
 
 namespace {
@@ -98,11 +99,7 @@ void TestIamPermissions(std::vector<std::string> const& argv) {
         admin.TestIamPermissions(resource, permissions);
     if (!result) throw std::runtime_error(result.status().message());
     std::cout << "The current user has the following permissions [";
-    char const* sep = "";
-    for (auto const& p : *result) {
-      std::cout << sep << p;
-      sep = ", ";
-    }
+    std::cout << absl::StrJoin(*result, ", ");
     std::cout << "]\n";
   }
   //! [test iam permissions]
@@ -206,11 +203,7 @@ void AsyncTestIamPermissions(google::cloud::bigtable::TableAdmin const& admin,
     auto result = permissions_future.get();
     if (!result) throw std::runtime_error(result.status().message());
     std::cout << "DONE, the current user has the following permissions [";
-    char const* sep = "";
-    for (auto const& p : *result) {
-      std::cout << sep << p;
-      sep = ", ";
-    }
+    std::cout << absl::StrJoin(*result, ", ");
     std::cout << "]\n";
   }
   //! [async test iam permissions]

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
 #include "absl/time/civil_time.h"
 #include <nlohmann/json.hpp>
 #include <sstream>
@@ -767,11 +768,7 @@ std::ostream& operator<<(std::ostream& os,
                          TestBucketIamPermissionsRequest const& r) {
   os << "TestBucketIamPermissionsRequest={bucket_name=" << r.bucket_name()
      << ", permissions=[";
-  char const* sep = "";
-  for (auto const& p : r.permissions()) {
-    os << sep << p;
-    sep = ", ";
-  }
+  os << absl::StrJoin(r.permissions(), ", ");
   os << "]";
   r.DumpOptions(os, ", ");
   return os << "}";
@@ -793,11 +790,7 @@ TestBucketIamPermissionsResponse::FromHttpResponse(std::string const& payload) {
 std::ostream& operator<<(std::ostream& os,
                          TestBucketIamPermissionsResponse const& r) {
   os << "TestBucketIamPermissionsResponse={permissions=[";
-  char const* sep = "";
-  for (auto const& p : r.permissions) {
-    os << sep << p;
-    sep = ", ";
-  }
+  os << absl::StrJoin(r.permissions, ", ");
   return os << "]}";
 }
 

--- a/google/cloud/storage/internal/http_response.cc
+++ b/google/cloud/storage/internal/http_response.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/http_response.h"
+#include "absl/strings/str_join.h"
 #include <iostream>
 
 namespace google {
@@ -127,11 +128,7 @@ Status AsStatus(HttpResponse const& http_response) {
 
 std::ostream& operator<<(std::ostream& os, HttpResponse const& rhs) {
   os << "status_code=" << rhs.status_code << ", headers={";
-  char const* sep = "";
-  for (auto const& kv : rhs.headers) {
-    os << sep << kv.first << ": " << kv.second;
-    sep = ", ";
-  }
+  os << absl::StrJoin(rhs.headers, ", ", absl::PairFormatter(": "));
   return os << "}, payload=<" << rhs.payload << ">";
 }
 

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/notification_metadata.h"
 #include "google/cloud/storage/internal/notification_requests.h"
+#include "absl/strings/str_join.h"
 
 namespace google {
 namespace cloud {
@@ -55,21 +56,15 @@ std::ostream& operator<<(std::ostream& os, NotificationMetadata const& rhs) {
   os << "NotificationMetadata={id=" << rhs.id();
 
   // custom_attributes()
-  char const* sep = "custom_attributes.";
-  for (auto const& kv : rhs.custom_attributes()) {
-    os << sep << kv.first << "=" << kv.second;
-    sep = ", custom_attributes.";
-  }
+  os << "custom_attributes.";
+  os << absl::StrJoin(rhs.custom_attributes(), ", custom_attributes.",
+                      absl::PairFormatter("="));
 
   os << ", etag=" << rhs.etag();
 
   // event_types()
   os << ", event_types=[";
-  sep = "";
-  for (auto const& v : rhs.event_types()) {
-    os << sep << v;
-    sep = ", ";
-  }
+  os << absl::StrJoin(rhs.event_types(), ", ");
   os << "]";
 
   return os << ", kind=" << rhs.kind()

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -56,7 +56,7 @@ std::ostream& operator<<(std::ostream& os, NotificationMetadata const& rhs) {
   os << "NotificationMetadata={id=" << rhs.id();
 
   // custom_attributes()
-  os << "custom_attributes.";
+  if (!rhs.custom_attributes().empty()) os << "custom_attributes.";
   os << absl::StrJoin(rhs.custom_attributes(), ", custom_attributes.",
                       absl::PairFormatter("="));
 

--- a/google/cloud/storage/notification_metadata.cc
+++ b/google/cloud/storage/notification_metadata.cc
@@ -56,9 +56,11 @@ std::ostream& operator<<(std::ostream& os, NotificationMetadata const& rhs) {
   os << "NotificationMetadata={id=" << rhs.id();
 
   // custom_attributes()
-  if (!rhs.custom_attributes().empty()) os << "custom_attributes.";
-  os << absl::StrJoin(rhs.custom_attributes(), ", custom_attributes.",
-                      absl::PairFormatter("="));
+  if (!rhs.custom_attributes().empty()) {
+    os << "custom_attributes."
+       << absl::StrJoin(rhs.custom_attributes(), ", custom_attributes.",
+                        absl::PairFormatter("="));
+  }
 
   os << ", etag=" << rhs.etag();
 

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/oauth2/service_account_credentials.h"
 #include "google/cloud/storage/internal/openssl_util.h"
+#include "absl/strings/str_join.h"
 #include <nlohmann/json.hpp>
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -196,11 +197,7 @@ std::pair<std::string, std::string> AssertionComponentsFromInfo(
   if (!info.scopes) {
     scope_str = GoogleOAuthScopeCloudPlatform();
   } else {
-    char const* sep = "";
-    for (const auto& scope : *(info.scopes)) {
-      scope_str += sep + scope;
-      sep = ",";
-    }
+    absl::StrAppend(&scope_str, absl::StrJoin(*(info.scopes), ","));
   }
 
   auto expiration = now + GoogleOAuthAccessTokenLifetime();


### PR DESCRIPTION
Part of the work for: #5121

This uses `absl::StrJoin` where it does not require too much refactoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5159)
<!-- Reviewable:end -->
