### PR TITLE
test(storage): remove stale buckets

### DIFF
--- a/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_file_transfer_benchmark.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
@@ -80,6 +81,11 @@ int main(int argc, char* argv[]) {
   client_options->set_project_id(options->project_id);
 
   gcs::Client client(*std::move(client_options));
+
+  std::cout << "# Cleaning up stale benchmark buckets\n";
+  google::cloud::storage::testing::RemoveStaleBuckets(
+      client, gcs_bm::RandomBucketPrefix(),
+      std::chrono::system_clock::now() - std::chrono::hours(48));
 
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -121,8 +121,12 @@ std::unique_ptr<RetryPolicy> StorageIntegrationTest::TestRetryPolicy() {
       .clone();
 }
 
+std::string StorageIntegrationTest::RandomBucketNamePrefix() {
+  return "cloud-cpp-testing";
+}
+
 std::string StorageIntegrationTest::MakeRandomBucketName() {
-  return testing::MakeRandomBucketName(generator_, "cloud-cpp-testing");
+  return testing::MakeRandomBucketName(generator_, RandomBucketNamePrefix());
 }
 
 std::string StorageIntegrationTest::MakeRandomObjectName() {

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -67,6 +67,7 @@ class StorageIntegrationTest : public ::testing::Test {
   static std::unique_ptr<BackoffPolicy> TestBackoffPolicy();
   static std::unique_ptr<RetryPolicy> TestRetryPolicy();
 
+  static std::string RandomBucketNamePrefix();
   std::string MakeRandomBucketName();
   std::string MakeRandomObjectName();
   std::string MakeRandomFilename();

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/list_objects_reader.h"
+#include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -71,6 +72,12 @@ TEST_F(BucketIntegrationTest, BasicCRUD) {
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
+
+  // We use this test to remove any buckets created by the integration tests
+  // more than 48 hours ago.
+  testing::RemoveStaleBuckets(
+      *client, RandomBucketNamePrefix(),
+      std::chrono::system_clock::now() - std::chrono::hours(48));
 
   auto list_bucket_names = [&client, this] {
     std::vector<std::string> names;


### PR DESCRIPTION
Remove stale buckets created by the integration tests and/or the
benchmarks. In both cases I picked one of the integration tests
(`bucket_integration_test`) and one of the benchmarks
(`storage_file_transfer_benchmark`) to perform the cleanup. Doing this
in each test or benchmark is just duplication of work and asking for
"thundering herd"-type problems.

Fixes #4905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5160)
<!-- Reviewable:end -->
