### PR TITLE
doc(spanner): use custom retry example

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -656,6 +656,9 @@ std::shared_ptr<Connection> MakeConnection(
  *     failures.
  * @param backoff_policy override the default `BackoffPolicy`, controls how
  *     long the `Connection` object waits before retrying a failed request.
+ *
+ * @par Example
+ * @snippet samples.cc custom-retry-policy
  */
 std::shared_ptr<Connection> MakeConnection(
     Database const& db, ConnectionOptions const& connection_options,


### PR DESCRIPTION
The example showing how to use a custom retry policy was implemented,
but not referenced from the Doxygen documentation.

Fixes #5162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5164)
<!-- Reviewable:end -->
