### PR TITLE
test(storage): add init bucket and filter_reponse

### DIFF
--- a/google/cloud/storage/emulator/gcs/__init__.py
+++ b/google/cloud/storage/emulator/gcs/__init__.py
@@ -12,10 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests entry"""
-
-from tests import test_utils, test_gcs
-
-if __name__ == "__main__":
-    test_utils.run()
-    test_gcs.run()
+from gcs import bucket

--- a/google/cloud/storage/emulator/gcs/bucket.py
+++ b/google/cloud/storage/emulator/gcs/bucket.py
@@ -64,12 +64,6 @@ class Bucket:
             )
             valid &= not bucket_name.startswith("goog")
             valid &= re.search("g[0o][0o]g[1l][e3]", bucket_name) is None
-            valid &= (
-                re.match(
-                    "^[0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}$", bucket_name
-                )
-                is None
-            )
         if not valid:
             utils.error.invalid("Bucket name %s" % bucket_name, context)
 
@@ -178,7 +172,6 @@ class Bucket:
 
     @classmethod
     def init_iam_policy(cls, metadata, context):
-        # TODO(vnvo2409): Check for iamConfiguration.uniformBucketLevelAccess.enabled
         role_mapping = {
             "READER": "roles/storage.legacyBucketReader",
             "WRITER": "roles/storage.legacyBucketWriter",

--- a/google/cloud/storage/emulator/gcs/bucket.py
+++ b/google/cloud/storage/emulator/gcs/bucket.py
@@ -1,0 +1,206 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implement a class to simulate GCS buckets."""
+
+import datetime
+import hashlib
+import re
+
+import scalpl
+import simdjson
+
+import utils
+from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
+from google.iam.v1 import policy_pb2
+from google.protobuf import field_mask_pb2, json_format
+
+
+class Bucket:
+    modifiable_fields = [
+        "acl",
+        "default_object_acl",
+        "lifecycle",
+        "cors",
+        "storage_class",
+        "default_event_based_hold",
+        "labels",
+        "website",
+        "versioning",
+        "logging",
+        "encryption",
+        "billing",
+        "retention_policy",
+        "location_type",
+        "iam_configuration",
+    ]
+
+    def __init__(self, metadata, notifications, iam_policy):
+        self.metadata = metadata
+        self.notifications = notifications
+        self.iam_policy = iam_policy
+
+    @classmethod
+    def __validate_bucket_name(cls, bucket_name, context):
+        valid = True
+        if "." in bucket_name:
+            valid &= len(bucket_name) <= 222
+            valid &= all([len(part) <= 63 for part in bucket_name.split(".")])
+        else:
+            valid &= len(bucket_name) <= 63
+            valid &= (
+                re.match("^[a-z0-9][a-z0-9._\\-]+[a-z0-9]$", bucket_name) is not None
+            )
+            valid &= not bucket_name.startswith("goog")
+            valid &= re.search("g[0o][0o]g[1l][e3]", bucket_name) is None
+            valid &= (
+                re.match(
+                    "^[0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}[.][0-9]{1,3}$", bucket_name
+                )
+                is None
+            )
+        if not valid:
+            utils.error.invalid("Bucket name %s" % bucket_name, context)
+
+    @classmethod
+    def __preprocess_rest(cls, data):
+        proxy = scalpl.Cut(data)
+        keys = utils.common.nested_key(data)
+        proxy.pop("iamConfiguration.bucketPolicyOnly", None)
+        for key in keys:
+            if key.endswith("createdBefore"):
+                proxy[key] = proxy[key] + "T00:00:00Z"
+        return proxy.data
+
+    @classmethod
+    def __postprocess_rest(cls, data):
+        proxy = scalpl.Cut(data)
+        keys = utils.common.nested_key(data)
+        for key in keys:
+            if key.endswith("createdBefore"):
+                proxy[key] = proxy[key].replace("T00:00:00Z", "")
+        proxy["kind"] = "storage#bucket"
+        return proxy.data
+
+    @classmethod
+    def __insert_predefined_acl(cls, metadata, predefined_acl, context):
+        if predefined_acl == "" and predefined_acl == 0:
+            return
+        if metadata.iam_configuration.uniform_bucket_level_access.enabled:
+            utils.error.invalid(
+                "Predefined ACL with uniform bucket level access enabled", context
+            )
+        acls = utils.acl.compute_predefined_bucket_acl(
+            metadata.name, predefined_acl, context
+        )
+        del metadata.acl[:]
+        metadata.acl.extend(acls)
+
+    @classmethod
+    def __insert_predefined_default_object_acl(
+        cls, metadata, predefined_default_object_acl, context
+    ):
+        if predefined_default_object_acl == "" and predefined_default_object_acl == 0:
+            return
+        if metadata.iam_configuration.uniform_bucket_level_access.enabled:
+            utils.error.invalid(
+                "Predefined Default Object ACL with uniform bucket level access enabled",
+                context,
+            )
+        acls = utils.acl.compute_predefined_default_object_acl(
+            metadata.name, predefined_default_object_acl, context
+        )
+        del metadata.default_object_acl[:]
+        metadata.default_object_acl.extend(acls)
+
+    # === INITIALIZATION === #
+
+    @classmethod
+    def init(cls, request, context):
+        time_created = datetime.datetime.now()
+        metadata = None
+        if context is not None:
+            metadata = request.bucket
+        else:
+            metadata = json_format.ParseDict(
+                cls.__preprocess_rest(simdjson.loads(request.data)),
+                resources_pb2.Bucket(),
+            )
+        cls.__validate_bucket_name(metadata.name, context)
+        default_projection = 1
+        if len(metadata.acl) != 0 or len(metadata.default_object_acl) != 0:
+            default_projection = 2
+        if len(metadata.acl) == 0:
+            predefined_acl = utils.acl.extract_predefined_acl(request, False, context)
+            if predefined_acl == 0:
+                predefined_acl = 3
+            elif predefined_acl == "":
+                predefined_acl = "projectPrivate"
+            cls.__insert_predefined_acl(metadata, predefined_acl, context)
+        if len(metadata.default_object_acl) == 0:
+            predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
+                request, context
+            )
+            if predefined_default_object_acl == 0:
+                predefined_default_object_acl = 5
+            elif predefined_default_object_acl == "":
+                predefined_default_object_acl = "projectPrivate"
+            cls.__insert_predefined_default_object_acl(
+                metadata, predefined_default_object_acl, context
+            )
+        metadata.id = metadata.name
+        metadata.project_number = int(utils.acl.PROJECT_NUMBER)
+        metadata.metageneration = 0
+        metadata.etag = hashlib.md5(metadata.name.encode("utf-8")).hexdigest()
+        metadata.time_created.FromDatetime(time_created)
+        metadata.updated.FromDatetime(time_created)
+        metadata.owner.entity = utils.acl.get_project_entity("owners", context)
+        metadata.owner.entity_id = hashlib.md5(
+            metadata.owner.entity.encode("utf-8")
+        ).hexdigest()
+        return (
+            cls(metadata, [], None),
+            utils.common.extract_projection(request, default_projection, context),
+        )
+
+    # === IAM === #
+
+    @classmethod
+    def init_iam_policy(cls, metadata, context):
+        # TODO(vnvo2409): Check for iamConfiguration.uniformBucketLevelAccess.enabled
+        role_mapping = {
+            "READER": "roles/storage.legacyBucketReader",
+            "WRITER": "roles/storage.legacyBucketWriter",
+            "OWNER": "roles/storage.legacyBucketOwner",
+        }
+        bindings = []
+        for entry in metadata.acl:
+            legacy_role = entry.role
+            if legacy_role is None or entry.entity is None:
+                utils.error.invalid("ACL entry", context)
+            role = role_mapping.get(legacy_role)
+            if role is None:
+                utils.error.invalid("Legacy role %s" % legacy_role, context)
+            bindings.append(policy_pb2.Binding(role=role, members=[entry.entity]))
+        return policy_pb2.Policy(
+            version=1,
+            bindings=bindings,
+            etag=datetime.datetime.now().isoformat().encode("utf-8"),
+        )
+
+    # === RESPONSE === #
+
+    def rest(self):
+        response = json_format.MessageToDict(self.metadata)
+        return Bucket.__postprocess_rest(response)

--- a/google/cloud/storage/emulator/requirements.txt
+++ b/google/cloud/storage/emulator/requirements.txt
@@ -4,3 +4,4 @@ flask==1.1.2
 pysimdjson==3.0.0
 pytest==6.0.2
 httpbin==0.7.0
+scalpl==0.4.0

--- a/google/cloud/storage/emulator/tests/test_gcs.py
+++ b/google/cloud/storage/emulator/tests/test_gcs.py
@@ -1,0 +1,118 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test for utils"""
+
+import pytest
+import utils
+import gcs
+import simdjson
+from google.protobuf import json_format
+from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+
+
+class TestBucket:
+    def test_init_grpc(self):
+        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
+        bucket, projection = gcs.bucket.Bucket.init(request, "")
+        assert bucket.metadata.name == "bucket"
+        assert projection == 1
+        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
+            "bucket", 3, ""
+        )
+        assert list(
+            bucket.metadata.default_object_acl
+        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+
+        # WITH ACL
+        request = storage_pb2.InsertBucketRequest(
+            bucket={
+                "name": "bucket",
+                "acl": utils.acl.compute_predefined_bucket_acl("bucket", 1, ""),
+            }
+        )
+        bucket, projection = gcs.bucket.Bucket.init(request, "")
+        assert bucket.metadata.name == "bucket"
+        assert projection == 2
+        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
+            "bucket", 1, ""
+        )
+        assert list(
+            bucket.metadata.default_object_acl
+        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+
+        # WITH PREDEFINED ACL
+        request = storage_pb2.InsertBucketRequest(
+            bucket={"name": "bucket"}, predefined_acl=5
+        )
+        bucket, projection = gcs.bucket.Bucket.init(request, "")
+        assert bucket.metadata.name == "bucket"
+        assert projection == 1
+        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
+            "bucket", 5, ""
+        )
+        assert list(
+            bucket.metadata.default_object_acl
+        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+
+        # WITH ACL AND PREDEFINED ACL
+        request = storage_pb2.InsertBucketRequest(
+            bucket={
+                "name": "bucket",
+                "acl": utils.acl.compute_predefined_bucket_acl("bucket", 1, ""),
+            },
+            predefined_acl=2,
+        )
+        bucket, projection = gcs.bucket.Bucket.init(request, "")
+        assert bucket.metadata.name == "bucket"
+        assert projection == 2
+        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
+            "bucket", 1, ""
+        )
+        assert list(
+            bucket.metadata.default_object_acl
+        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+
+    def test_init_rest(self):
+        request = utils.common.FakeRequest(
+            args={}, data=simdjson.dumps({"name": "bucket"})
+        )
+        bucket, projection = gcs.bucket.Bucket.init(request, None)
+        assert bucket.metadata.name == "bucket"
+        assert projection == "noAcl"
+
+        request = utils.common.FakeRequest(
+            args={},
+            data=simdjson.dumps(
+                {
+                    "name": "bucket",
+                    "acl": [
+                        json_format.MessageToDict(acl)
+                        for acl in utils.acl.compute_predefined_bucket_acl(
+                            "bucket", "authenticatedRead", None
+                        )
+                    ],
+                }
+            ),
+        )
+        bucket, projection = gcs.bucket.Bucket.init(request, None)
+        assert bucket.metadata.name == "bucket"
+        assert projection == "full"
+        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
+            "bucket", "authenticatedRead", None
+        )
+
+
+def run():
+    pytest.main(["-v"])

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -15,7 +15,11 @@
 """Common utils"""
 
 import re
+import scalpl
 import types
+
+re_remove_index = re.compile(r":[0-9]+|^[0-9]+")
+re_split_fields = re.compile(r"[a-zA-Z0-9]*\(.*\)|[^,]+")
 
 # === STR === #
 
@@ -27,9 +31,102 @@ def to_snake_case(string):
     return re_snake_case.sub("_", string).lower()
 
 
+def remove_index(string):
+    return re_remove_index.sub("", string)
+
+
 # === FAKE REQUEST === #
 
 
 class FakeRequest(types.SimpleNamespace):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+
+# === REST === #
+
+
+def nested_key(data):
+    # This function take a dict and return a list of keys that works with `Scalpl` library.
+    if isinstance(data, list):
+        keys = []
+        for i in range(len(data)):
+            result = nested_key(data[i])
+            if isinstance(result, list):
+                if isinstance(data[i], dict):
+                    keys.extend(["[%d].%s" % (i, item) for item in result])
+                elif isinstance(data[i], list):
+                    keys.extend(["[%d]%s" % (i, item) for item in result])
+            elif result == "":
+                keys.append("[%d]" % i)
+        return keys
+    elif isinstance(data, dict):
+        keys = []
+        for key, value in data.items():
+            result = nested_key(value)
+            if isinstance(result, list):
+                if isinstance(value, dict):
+                    keys.extend(["%s.%s" % (key, item) for item in result])
+                elif isinstance(value, list):
+                    keys.extend(["%s%s" % (key, item) for item in result])
+            elif result == "":
+                keys.append("%s" % key)
+        return keys
+    else:
+        return ""
+
+
+def parse_fields(fields):
+    # "kind,items(id,name)" -> ["kind", "items.id", "items.name"]
+    result = []
+    for field in re_split_fields.findall(fields):
+        if "(" not in field and ")" not in field:
+            result.append(field)
+        else:
+            prefix = field[0 : field.find("(")]
+            subfields = field[len(prefix) + 1 : -1]
+            items = parse_fields(subfields)
+            for item in items:
+                result.append(prefix + "." + item)
+    return result
+
+
+def filter_response_rest(response, projection, fields):
+    if fields is not None:
+        fields.replace(" ", "")
+        fields.replace("/", ".")
+        fields = parse_fields(fields)
+    deleted_keys = set()
+    for key in nested_key(response):
+        simplfied_key = remove_index(key)
+        if projection == "noAcl":
+            if simplfied_key == "owner" or simplfied_key == "items.owner":
+                deleted_keys.add(key)
+            if simplfied_key == "acl" or simplfied_key == "items.acl":
+                deleted_keys.add(key)
+            if (
+                simplfied_key == "defaultObjectAcl"
+                or simplfied_key == "items.defaultObjectAcl"
+            ):
+                deleted_keys.add(key)
+        if fields is not None:
+            if simplfied_key not in fields:
+                deleted_keys.add(key)
+    proxy = scalpl.Cut(response)
+    for key in deleted_keys:
+        del proxy[key]
+    return proxy.data
+
+
+# === RESPONSE === #
+
+
+def extract_projection(request, default, context):
+    if context is not None:
+        return request.projection if request.projection != 0 else default
+    else:
+        projection_map = ["noAcl", "full"]
+        projection = request.args.get("projection")
+        return (
+            projection if projection in projection_map else projection_map[default - 1]
+        )


### PR DESCRIPTION
This PR adds:
- Initialization for `Bucket`.
- Some helper functions to support REST `fields` completely. ( Now we can do something like `fields=kind, items(acl(role, entity), name)`)

Related to #4751 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5166)
<!-- Reviewable:end -->
