### PR TITLE
ci: pin vcpkg to specific SHA as workaround

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -45,7 +45,9 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 if [[ -d "${vcpkg_dir}" ]]; then
   git -C "${vcpkg_dir}" pull --quiet
 else
-  git clone --quiet --depth 10 https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+  git clone --quiet \
+      https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+  git -C "${vcpkg_dir}" checkout 8776756e08dddfc47b209eebfec5c927f14c7c74
 fi
 
 if [[ -d "${HOME}/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -46,7 +46,7 @@ if [[ -d "${vcpkg_dir}" ]]; then
   git -C "${vcpkg_dir}" pull --quiet
 else
   git clone --quiet \
-      https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+    https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
   git -C "${vcpkg_dir}" checkout 8776756e08dddfc47b209eebfec5c927f14c7c74
 fi
 


### PR DESCRIPTION
Currently `HEAD` for `vcpkg` is broken for us, and the latest release
does not support Cloud Pub/Sub. I am pinning to the last version that is
*not* broken as a workaround.

See microsoft/vcpkg#13790 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5167)
<!-- Reviewable:end -->
