### PR TITLE
feat(common): wrapper for bi-dir async streaming RPCs

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -348,6 +348,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         grpc_utils/grpc_error_delegate.h
         grpc_utils/version.h
         internal/async_read_stream_impl.h
+        internal/async_read_write_stream_impl.h
         internal/async_retry_loop.h
         internal/async_retry_unary_rpc.h
         internal/async_rpc_details.h
@@ -396,6 +397,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             completion_queue_test.cc
             connection_options_test.cc
             grpc_error_delegate_test.cc
+            internal/async_read_write_stream_impl_test.cc
             internal/async_retry_loop_test.cc
             internal/async_retry_unary_rpc_test.cc
             internal/background_threads_impl_test.cc

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -27,6 +27,12 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
+class CompletionQueue;
+
+namespace internal {
+std::shared_ptr<CompletionQueueImpl> GetCompletionQueueImpl(
+    CompletionQueue& cq);
+}  // namespace internal
 
 /**
  * Call the functor associated with asynchronous operations when they complete.
@@ -226,8 +232,19 @@ class CompletionQueue {
   }
 
  private:
+  friend std::shared_ptr<internal::CompletionQueueImpl>
+  internal::GetCompletionQueueImpl(CompletionQueue& cq);
   std::shared_ptr<internal::CompletionQueueImpl> impl_;
 };
+
+namespace internal {
+
+inline std::shared_ptr<CompletionQueueImpl> GetCompletionQueueImpl(
+    CompletionQueue& cq) {
+  return cq.impl_;
+}
+
+}  // namespace internal
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -27,6 +27,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "grpc_utils/grpc_error_delegate.h",
     "grpc_utils/version.h",
     "internal/async_read_stream_impl.h",
+    "internal/async_read_write_stream_impl.h",
     "internal/async_retry_loop.h",
     "internal/async_retry_unary_rpc.h",
     "internal/async_rpc_details.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "completion_queue_test.cc",
     "connection_options_test.cc",
     "grpc_error_delegate_test.cc",
+    "internal/async_read_write_stream_impl_test.cc",
     "internal/async_retry_loop_test.cc",
     "internal/async_retry_unary_rpc_test.cc",
     "internal/background_threads_impl_test.cc",

--- a/google/cloud/internal/async_read_write_stream_impl.h
+++ b/google/cloud/internal/async_read_write_stream_impl.h
@@ -1,0 +1,171 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_READ_WRITE_STREAM_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_READ_WRITE_STREAM_IMPL_H
+
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/version.h"
+#include "absl/functional/function_ref.h"
+#include "absl/types/optional.h"
+#include <grpcpp/support/async_stream.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/**
+ * Wrapper for Asynchronous Streaming Read/Write RPCs.
+ *
+ * A wrapper for gRPC's asynchronous streaming read-write APIs, which can be
+ * combined with `google::cloud::CompletionQueue` and `google::cloud::future<>`
+ * to provide easier-to-use abstractions.
+ */
+template <typename Request, typename Response>
+class AsyncStreamingReadWriteRpc {
+ public:
+  AsyncStreamingReadWriteRpc(
+      std::shared_ptr<CompletionQueueImpl> cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      std::unique_ptr<grpc::ClientAsyncReaderWriterInterface<Request, Response>>
+          stream)
+      : cq_(std::move(cq)),
+        context_(std::move(context)),
+        stream_(std::move(stream)) {}
+
+  void Cancel() { context_->TryCancel(); }
+
+  future<bool> Start() {
+    struct OnStart : public AsyncGrpcOperation {
+      promise<bool> p;
+      bool Notify(bool ok) override {
+        p.set_value(ok);
+        return true;
+      }
+      void Cancel() override {}
+    };
+    auto op = std::make_shared<OnStart>();
+    cq_->StartOperation(op, [&](void* tag) { stream_->StartCall(tag); });
+    return op->p.get_future();
+  }
+
+  future<absl::optional<Response>> Read() {
+    struct OnRead : public AsyncGrpcOperation {
+      promise<absl::optional<Response>> p;
+      Response response;
+      bool Notify(bool ok) override {
+        if (!ok) {
+          p.set_value({});
+          return true;
+        }
+        p.set_value(std::move(response));
+        return true;
+      }
+      void Cancel() override {}
+    };
+    auto op = std::make_shared<OnRead>();
+    cq_->StartOperation(op,
+                        [&](void* tag) { stream_->Read(&op->response, tag); });
+    return op->p.get_future();
+  }
+
+  future<bool> Write(Request const& request, grpc::WriteOptions options) {
+    struct OnWrite : public AsyncGrpcOperation {
+      promise<bool> p;
+      bool Notify(bool ok) override {
+        p.set_value(ok);
+        return true;
+      }
+      void Cancel() override {}
+    };
+    auto op = std::make_shared<OnWrite>();
+    cq_->StartOperation(op, [&](void* tag) {
+      stream_->Write(request, std::move(options), tag);
+    });
+    return op->p.get_future();
+  }
+
+  future<bool> WritesDone() {
+    struct OnWritesDone : public AsyncGrpcOperation {
+      promise<bool> p;
+      bool Notify(bool ok) override {
+        p.set_value(ok);
+        return true;
+      }
+      void Cancel() override {}
+    };
+    auto op = std::make_shared<OnWritesDone>();
+    cq_->StartOperation(op, [&](void* tag) { stream_->WritesDone(tag); });
+    return op->p.get_future();
+  }
+
+  future<Status> Finish() {
+    struct OnFinish : public AsyncGrpcOperation {
+      promise<Status> p;
+      grpc::Status status;
+      bool Notify(bool /*ok*/) override {
+        p.set_value(MakeStatusFromRpcError(std::move(status)));
+        return true;
+      }
+      void Cancel() override {}
+    };
+    auto op = std::make_shared<OnFinish>();
+    cq_->StartOperation(op,
+                        [&](void* tag) { stream_->Finish(&op->status, tag); });
+    return op->p.get_future();
+  }
+
+ private:
+  std::shared_ptr<CompletionQueueImpl> cq_;
+  std::unique_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<grpc::ClientAsyncReaderWriterInterface<Request, Response>>
+      stream_;
+};
+
+template <typename Request, typename Response>
+using PrepareAsyncReadWriteRpc = absl::FunctionRef<
+    std::unique_ptr<grpc::ClientAsyncReaderWriterInterface<Request, Response>>(
+        grpc::ClientContext*, grpc::CompletionQueue*)>;
+
+/**
+ * Make an asynchronous streaming read/write RPC using `CompletionQueue`.
+ *
+ * @note in the past we would have made this a member function of the
+ *     `CompletionQueue` class. We want to avoid this as (a) we are not certain
+ *     this is the long term API we want to expose, (b) once in the public
+ *     `CompletionQueue` class it is hard to remove member functions.  Placing
+ *     the API in the `internal::` namespace give us more flexibility for the
+ *     future, at the cost of (hopefully controlled) breaks in encapsulation.
+ */
+template <typename Request, typename Response>
+std::unique_ptr<AsyncStreamingReadWriteRpc<Request, Response>>
+MakeStreamingReadWriteRpc(
+    CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
+    PrepareAsyncReadWriteRpc<Request, Response> async_call) {
+  auto cq_impl = GetCompletionQueueImpl(cq);
+  auto stream = async_call(context.get(), &cq_impl->cq());
+  return absl::make_unique<AsyncStreamingReadWriteRpc<Request, Response>>(
+      std::move(cq_impl), std::move(context), std::move(stream));
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_READ_WRITE_STREAM_IMPL_H

--- a/google/cloud/internal/async_read_write_stream_impl_test.cc
+++ b/google/cloud/internal/async_read_write_stream_impl_test.cc
@@ -1,0 +1,185 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/async_read_write_stream_impl.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+#include <deque>
+#include <memory>
+#include <string>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::_;
+using ::testing::ReturnRef;
+
+struct FakeRequest {
+  std::string key;
+};
+
+struct FakeResponse {
+  std::string key;
+  std::string value;
+};
+
+// Used as part of the EXPECT_CALL() below:
+bool operator==(FakeRequest const& lhs, FakeRequest const& rhs) {
+  return lhs.key == rhs.key;
+}
+
+using MockReturnType = std::unique_ptr<
+    grpc::ClientAsyncReaderWriterInterface<FakeRequest, FakeResponse>>;
+
+class MockReaderWriter
+    : public grpc::ClientAsyncReaderWriterInterface<FakeRequest, FakeResponse> {
+ public:
+  MOCK_METHOD(void, WritesDone, (void*), (override));
+  MOCK_METHOD(void, Read, (FakeResponse*, void*), (override));
+  MOCK_METHOD(void, Write, (FakeRequest const&, void*), (override));
+  MOCK_METHOD(void, Write, (FakeRequest const&, grpc::WriteOptions, void*),
+              (override));
+  MOCK_METHOD(void, Finish, (grpc::Status*, void*), (override));
+  MOCK_METHOD(void, StartCall, (void*), (override));
+  MOCK_METHOD(void, ReadInitialMetadata, (void*), (override));
+};
+
+class MockStub {
+ public:
+  MOCK_METHOD(MockReturnType, FakeRpc,
+              (grpc::ClientContext*, grpc::CompletionQueue*), ());
+};
+
+class MockCompletionQueueImpl : public CompletionQueueImpl {
+ public:
+  MOCK_METHOD0(Run, void());
+  MOCK_METHOD0(Shutdown, void());
+  MOCK_METHOD0(CancelAll, void());
+  MOCK_METHOD1(MakeDeadlineTimer,
+               future<StatusOr<std::chrono::system_clock::time_point>>(
+                   std::chrono::system_clock::time_point));
+  MOCK_METHOD1(MakeRelativeTimer,
+               future<StatusOr<std::chrono::system_clock::time_point>>(
+                   std::chrono::nanoseconds));
+  MOCK_METHOD1(RunAsync, void(std::unique_ptr<RunAsyncBase>));
+
+  MOCK_METHOD2(StartOperation, void(std::shared_ptr<AsyncGrpcOperation>,
+                                    absl::FunctionRef<void(void*)>));
+
+  MOCK_METHOD0(cq, grpc::CompletionQueue&());
+};
+
+TEST(AsyncReadWriteStreamingRpcTest, Basic) {
+  MockStub mock;
+  EXPECT_CALL(mock, FakeRpc)
+      .WillOnce([](grpc::ClientContext*, grpc::CompletionQueue*) {
+        auto stream = absl::make_unique<MockReaderWriter>();
+        EXPECT_CALL(*stream, StartCall).Times(1);
+        EXPECT_CALL(*stream, Write(FakeRequest{"key0"}, _, _)).Times(1);
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([](FakeResponse* response, void*) {
+              response->key = "key0";
+              response->value = "value0_0";
+            })
+            .WillOnce([](FakeResponse* response, void*) {
+              response->key = "key0";
+              response->value = "value0_1";
+            })
+            .WillOnce([](FakeResponse*, void*) {});
+        EXPECT_CALL(*stream, WritesDone).Times(1);
+        EXPECT_CALL(*stream, Finish).WillOnce([](grpc::Status* status, void*) {
+          *status = grpc::Status::OK;
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  grpc::CompletionQueue grpc_cq;
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
+
+  std::deque<std::shared_ptr<AsyncGrpcOperation>> operations;
+  auto notify_next_op = [&](bool ok = true) {
+    auto op = std::move(operations.front());
+    operations.pop_front();
+    op->Notify(ok);
+  };
+
+  EXPECT_CALL(*mock_cq, StartOperation)
+      .WillRepeatedly([&operations](std::shared_ptr<AsyncGrpcOperation> op,
+                                    absl::FunctionRef<void(void*)> call) {
+        operations.push_back(std::move(op));
+        call(op.get());
+      });
+
+  google::cloud::CompletionQueue cq(mock_cq);
+  auto stream = MakeStreamingReadWriteRpc<FakeRequest, FakeResponse>(
+      cq, absl::make_unique<grpc::ClientContext>(),
+      [&mock](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+        return mock.FakeRpc(context, cq);
+      });
+
+  auto start = stream->Start();
+  ASSERT_EQ(1, operations.size());
+  notify_next_op();
+  EXPECT_TRUE(start.get());
+
+  auto write = stream->Write(FakeRequest{"key0"},
+                             grpc::WriteOptions().set_last_message());
+  ASSERT_EQ(1, operations.size());
+  notify_next_op();
+
+  auto read0 = stream->Read();
+  ASSERT_EQ(1, operations.size());
+  notify_next_op();
+  auto response0 = read0.get();
+  ASSERT_TRUE(response0.has_value());
+  EXPECT_EQ("key0", response0->key);
+  EXPECT_EQ("value0_0", response0->value);
+
+  auto read1 = stream->Read();
+  ASSERT_EQ(1, operations.size());
+  notify_next_op();
+  auto response1 = read1.get();
+  ASSERT_TRUE(response1.has_value());
+  EXPECT_EQ("key0", response1->key);
+  EXPECT_EQ("value0_1", response1->value);
+
+  auto writes_done = stream->WritesDone();
+  ASSERT_EQ(1, operations.size());
+  notify_next_op();
+
+  auto read2 = stream->Read();
+  ASSERT_EQ(1, operations.size());
+  notify_next_op(false);
+  auto response2 = read2.get();
+  EXPECT_FALSE(response2.has_value());
+
+  auto finish = stream->Finish();
+  ASSERT_EQ(1, operations.size());
+  notify_next_op();
+  EXPECT_THAT(finish.get(), StatusIs(StatusCode::kOk));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Implement a wrapper for bi-direction, asynchronous, streaming RPCs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5181)
<!-- Reviewable:end -->
