### PR TITLE
cleanup(common): simplify promise::set_value()

### DIFF
--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -191,22 +191,12 @@ class promise final : private internal::promise_base<T> {
    * @throws std::future_error with std::no_state if the promise does not have
    *   a shared state.
    */
-  void set_value(T&& value) {
+  void set_value(T value) {
     if (!this->shared_state_) {
       internal::ThrowFutureError(std::future_errc::no_state, __func__);
     }
-    this->shared_state_->set_value(std::forward<T>(value));
+    this->shared_state_->set_value(std::move(value));
   }
-
-  /**
-   * Satisfies the shared state.
-   *
-   * @throws std::future_error with std::future_errc::promise_already_satisfied
-   *   if the shared state is already satisfied.
-   * @throws std::future_error with std::no_state if the promise does not have
-   *   a shared state.
-   */
-  void set_value(T const& value) { set_value(T(value)); }
 
   using internal::promise_base<T>::set_exception;
 };

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -54,6 +54,60 @@ TEST(FutureTestInt, DestroyInSignalingThread) {
   }
 }
 
+/// @test Verify promise<bool> works as expected
+TEST(FutureTestBool, SetValueBasic) {
+  promise<bool> p;
+  auto f = p.get_future();
+  p.set_value(true);
+  EXPECT_TRUE(f.get());
+}
+
+/// @test Verify promise<bool> works as expected
+TEST(FutureTestBool, SetValueConstRef) {
+  promise<bool> p;
+  auto f = p.get_future();
+  auto const v = true;
+  auto const& r = v;
+  p.set_value(r);
+  EXPECT_TRUE(f.get());
+}
+
+/// @test Verify promise<bool> works as expected
+TEST(FutureTestBool, SetValueRefRef) {
+  promise<bool> p;
+  auto f = p.get_future();
+  auto v = true;
+  p.set_value(std::move(v));
+  EXPECT_TRUE(f.get());
+}
+
+/// @test Verify promise<bool> works as expected
+TEST(FutureTestString, SetValueBasic) {
+  promise<std::string> p;
+  auto f = p.get_future();
+  p.set_value("42");
+  EXPECT_EQ("42", f.get());
+}
+
+/// @test Verify promise<bool> works as expected
+TEST(FutureTestString, SetValueConstRef) {
+  promise<std::string> p;
+  auto f = p.get_future();
+  auto const v = std::string("42");
+  auto const& r = v;
+  p.set_value(r);
+  EXPECT_EQ("42", f.get());
+}
+
+/// @test Verify promise<bool> works as expected
+TEST(FutureTestString, SetValueRefRef) {
+  promise<std::string> p;
+  auto f = p.get_future();
+  auto v = std::string("42");
+  p.set_value(std::move(v));
+  EXPECT_EQ("42", f.get());
+}
+
 /// @test Verify conformance with section 30.6.5 of the C++14 spec.
 // NOLINTNEXTLINE(google-readability-avoid-underscore-in-googletest-name)
 TEST(FutureTestInt, conform_30_6_5_3) {

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -385,7 +385,7 @@ class future_shared_state final : private future_shared_state_base {
    * @throws `std::future_error` if the shared state was already satisfied. The
    *     error code is `std::future_errc::promise_already_satisfied`.
    */
-  void set_value(T&& value) {
+  void set_value(T value) {
     std::unique_lock<std::mutex> lk(mu_);
     if (is_ready_unlocked()) {
       ThrowFutureError(std::future_errc::promise_already_satisfied, __func__);


### PR DESCRIPTION
We do not need the `&&` and `const&` overloads, this makes the code
simpler *and* it compiles with MSVC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5182)
<!-- Reviewable:end -->
