### PR TITLE
doc(storage): prefer UBLA over Bucket Policy Only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,13 @@ ci/kokoro/install/ccache-contents/
 
 google/cloud/storage/testbench/__pycache__/
 google/cloud/storage/testbench/*.pyc
+
+
+google/cloud/bigtable/internal/async_longrunning_op_test.cc.old
+google/cloud/bigtable/internal/async_poll_op.h.old
+google/cloud/bigtable/internal/async_poll_op_test.cc.bkp
+google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc.old
+google/cloud/bigtable/internal/tags
+google/cloud/bigtable/tags
+google/cloud/tags
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -27,13 +27,3 @@ ci/kokoro/install/ccache-contents/
 
 google/cloud/storage/testbench/__pycache__/
 google/cloud/storage/testbench/*.pyc
-
-
-google/cloud/bigtable/internal/async_longrunning_op_test.cc.old
-google/cloud/bigtable/internal/async_poll_op.h.old
-google/cloud/bigtable/internal/async_poll_op_test.cc.bkp
-google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc.old
-google/cloud/bigtable/internal/tags
-google/cloud/bigtable/tags
-google/cloud/tags
-tags

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -142,11 +142,11 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs);
  *
  * @see Before enabling Uniform Bucket Level Access please
  *     review the [feature documentation][bpo-link], as well as
- *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+ *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
  *
- * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+ * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
  * [bpo-should-link]:
- * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+ * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use 
  */
 struct UniformBucketLevelAccess {
   bool enabled;
@@ -200,13 +200,13 @@ std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs);
  * @warning this is a Beta feature of Google Cloud Storage, it is not subject
  *     to the deprecation policy and subject to change without notice.
  *
- * @see Before enabling Bucket Policy Only please review the
+ * @see Before enabling Uniform Bucket Level Access please review the
  *     [feature documentation][bpo-link], as well as
- *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+ *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
  *
- * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+ * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
  * [bpo-should-link]:
- * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+ * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
  */
 struct BucketIamConfiguration {
   absl::optional<BucketPolicyOnly> bucket_policy_only;
@@ -650,13 +650,13 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    * @warning this is a Beta feature of Google Cloud Storage, it is not
    *     subject to the deprecation policy and subject to change without notice.
    *
-   * @see Before enabling Bucket Policy Only please review the
+   * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][bpo-link], as well as
-   *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+   *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
    *
-   * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+   * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
    * [bpo-should-link]:
-   * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+   * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
    */
   bool has_iam_configuration() const { return iam_configuration_.has_value(); }
   BucketIamConfiguration const& iam_configuration() const {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -333,13 +333,13 @@ class Client {
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket
    *
-   * @see Before enabling Bucket Policy Only please review the
+   * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][bpo-link], as well as
-   *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+   *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
    *
-   * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+   * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
    * [bpo-should-link]:
-   * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+   * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use 
    */
   template <typename... Options>
   StatusOr<BucketMetadata> CreateBucket(std::string bucket_name,
@@ -368,13 +368,13 @@ class Client {
    * @par Example
    * @snippet storage_bucket_samples.cc create bucket for project
    *
-   * @see Before enabling Bucket Policy Only please review the
+   * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][bpo-link], as well as
-   *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+   *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
    *
-   * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+   * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
    * [bpo-should-link]:
-   * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+   * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
    */
   template <typename... Options>
   StatusOr<BucketMetadata> CreateBucketForProject(std::string bucket_name,
@@ -456,13 +456,13 @@ class Client {
    * @par Example
    * @snippet storage_bucket_samples.cc update bucket
    *
-   * @see Before enabling Bucket Policy Only please review the
+   * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][bpo-link], as well as
-   *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+   *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
    *
-   * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+   * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access 
    * [bpo-should-link]:
-   * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+   * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
    */
   template <typename... Options>
   StatusOr<BucketMetadata> UpdateBucket(std::string bucket_name,
@@ -502,13 +502,13 @@ class Client {
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class
    *
-   * @see Before enabling Bucket Policy Only please review the
+   * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][bpo-link], as well as
-   *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+   *     ["Should you use Uniform bucket-level access?"][bpo-should-link].
    *
-   * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+   * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
    * [bpo-should-link]:
-   * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+   * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
    */
   template <typename... Options>
   StatusOr<BucketMetadata> PatchBucket(std::string bucket_name,
@@ -544,13 +544,13 @@ class Client {
    * @par Example
    * @snippet storage_bucket_samples.cc patch bucket storage class with builder
    *
-   * @see Before enabling Bucket Policy Only please review the
+   * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][bpo-link], as well as
-   *     ["Should you use Bucket Policy Only?"][bpo-should-link].
+   *     ["Should you use Uniform bucket-level access ?"][bpo-should-link].
    *
-   * [bpo-link]: https://cloud.google.com/storage/docs/bucket-policy-only
+   * [bpo-link]: https://cloud.google.com/storage/docs/uniform-bucket-level-access
    * [bpo-should-link]:
-   * https://cloud.google.com/storage/docs/bucket-policy-only#should-you-use
+   * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
    */
   template <typename... Options>
   StatusOr<BucketMetadata> PatchBucket(


### PR DESCRIPTION
replaced text "Bucket Policy Only" by "Uniform bucket-level access" in related files. Also replaced links directly pointing to UBLA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5186)
<!-- Reviewable:end -->
