### PR TITLE
feat(pubsub): add streaming pull function to stub

### DIFF
--- a/google/cloud/pubsub/integration_tests/CMakeLists.txt
+++ b/google/cloud/pubsub/integration_tests/CMakeLists.txt
@@ -23,8 +23,11 @@ function (google_cloud_cpp_pubsub_define_integration_tests)
 
     set(pubsub_client_integration_tests
         # cmake-format: sortable
-        message_integration_test.cc subscription_admin_integration_test.cc
-        subscription_lifecycle_test.cc topic_admin_integration_test.cc)
+        message_integration_test.cc
+        subscriber_integration_test.cc
+        subscription_admin_integration_test.cc
+        subscription_lifecycle_test.cc
+        topic_admin_integration_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
+++ b/google/cloud/pubsub/integration_tests/pubsub_client_integration_tests.bzl
@@ -18,6 +18,7 @@
 
 pubsub_client_integration_tests = [
     "message_integration_test.cc",
+    "subscriber_integration_test.cc",
     "subscription_admin_integration_test.cc",
     "subscription_lifecycle_test.cc",
     "topic_admin_integration_test.cc",

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -126,9 +126,8 @@ TEST_F(SubscriberIntegrationTest, RawStub) {
       acks.add_ack_ids(m.ack_id());
       expected_ids.erase(m.message().message_id());
     }
-    stream->Write(acks, grpc::WriteOptions{}).then([&](future<bool> f) {
-      if (f.get()) ++ack_count;
-    });
+    auto write_ok = stream->Write(acks, grpc::WriteOptions{}).get();
+    if (write_ok) ++ack_count;
     if (expected_ids.empty()) break;
   }
   EXPECT_TRUE(expected_ids.empty());

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -1,0 +1,149 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/subscriber.h"
+#include "google/cloud/pubsub/subscription.h"
+#include "google/cloud/pubsub/subscription_admin_client.h"
+#include "google/cloud/pubsub/testing/random_names.h"
+#include "google/cloud/pubsub/testing/test_retry_policies.h"
+#include "google/cloud/pubsub/topic_admin_client.h"
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace pubsub {
+inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::AnyOf;
+
+class SubscriberIntegrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    auto project_id =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+    ASSERT_FALSE(project_id.empty());
+    generator_ = google::cloud::internal::DefaultPRNG(std::random_device{}());
+    topic_ = Topic(project_id, pubsub_testing::RandomTopicId(generator_));
+    subscription_ = Subscription(
+        project_id, pubsub_testing::RandomSubscriptionId(generator_));
+
+    auto topic_admin = TopicAdminClient(MakeTopicAdminConnection());
+    auto subscription_admin =
+        SubscriptionAdminClient(MakeSubscriptionAdminConnection());
+
+    auto topic_metadata = topic_admin.CreateTopic(TopicMutationBuilder(topic_));
+    ASSERT_THAT(topic_metadata, AnyOf(StatusIs(StatusCode::kOk),
+                                      StatusIs(StatusCode::kAlreadyExists)));
+    auto subscription_metadata = subscription_admin.CreateSubscription(
+        topic_, subscription_,
+        SubscriptionMutationBuilder{}.set_ack_deadline(
+            std::chrono::seconds(10)));
+    ASSERT_THAT(
+        subscription_metadata,
+        AnyOf(StatusIs(StatusCode::kOk), StatusIs(StatusCode::kAlreadyExists)));
+  }
+
+  void TearDown() override {
+    auto topic_admin = TopicAdminClient(MakeTopicAdminConnection());
+    auto subscription_admin =
+        SubscriptionAdminClient(MakeSubscriptionAdminConnection());
+
+    auto delete_subscription =
+        subscription_admin.DeleteSubscription(subscription_);
+    EXPECT_THAT(delete_subscription, AnyOf(StatusIs(StatusCode::kOk),
+                                           StatusIs(StatusCode::kNotFound)));
+    auto delete_topic = topic_admin.DeleteTopic(topic_);
+    EXPECT_THAT(delete_topic, AnyOf(StatusIs(StatusCode::kOk),
+                                    StatusIs(StatusCode::kNotFound)));
+  }
+
+  google::cloud::internal::DefaultPRNG generator_;
+  Topic topic_ = Topic("unused", "unused");
+  Subscription subscription_ = Subscription("unused", "unused");
+};
+
+TEST_F(SubscriberIntegrationTest, RawStub) {
+  auto publisher = Publisher(MakePublisherConnection(topic_, {}));
+
+  internal::AutomaticallyCreatedBackgroundThreads background(4);
+  auto stub = pubsub_internal::CreateDefaultSubscriberStub({}, 0);
+  google::pubsub::v1::StreamingPullRequest request;
+  request.set_client_id("test-client-0001");
+  request.set_subscription(subscription_.FullName());
+  request.set_max_outstanding_messages(1000);
+  request.set_stream_ack_deadline_seconds(600);
+
+  auto stream = [&stub, &request](CompletionQueue cq) {
+    return stub->AsyncStreamingPull(
+        cq, absl::make_unique<grpc::ClientContext>(), request);
+  }(background.cq());
+
+  ASSERT_TRUE(stream->Start().get());
+  ASSERT_TRUE(
+      stream->Write(request, grpc::WriteOptions{}.set_write_through()).get());
+
+  auto constexpr kPublishCount = 1000;
+  std::set<std::string> expected_ids = [&] {
+    std::set<std::string> ids;
+    std::vector<future<StatusOr<std::string>>> message_ids;
+    for (int i = 0; i != kPublishCount; ++i) {
+      message_ids.push_back(publisher.Publish(
+          MessageBuilder{}.SetData("message-" + std::to_string(i)).Build()));
+    }
+    for (auto& id : message_ids) {
+      auto r = id.get();
+      EXPECT_STATUS_OK(r);
+      ids.insert(*std::move(r));
+    }
+    return ids;
+  }();
+
+  int read_count = 0;
+  std::atomic<int> ack_count{0};
+  for (auto r = stream->Read().get(); r.has_value(); r = stream->Read().get()) {
+    ++read_count;
+    google::pubsub::v1::StreamingPullRequest acks;
+    for (auto const& m : r->received_messages()) {
+      acks.add_ack_ids(m.ack_id());
+      expected_ids.erase(m.message().message_id());
+    }
+    stream->Write(acks, grpc::WriteOptions{}).then([&](future<bool> f) {
+      if (f.get()) ++ack_count;
+    });
+    if (expected_ids.empty()) break;
+  }
+  EXPECT_TRUE(expected_ids.empty());
+
+  stream->Cancel();
+  // After cancel one needs to discard any read results.
+  for (auto r = stream->Read().get(); r.has_value(); r = stream->Read().get()) {
+  }
+
+  EXPECT_THAT(stream->Finish().get(), AnyOf(StatusIs(StatusCode::kOk),
+                                            StatusIs(StatusCode::kCancelled)));
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
+}  // namespace pubsub
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -130,7 +130,8 @@ TEST_F(SubscriberIntegrationTest, RawStub) {
   EXPECT_TRUE(expected_ids.empty());
 
   stream->Cancel();
-  // Before closing the stream we need to wait Read().get() == false.
+  // Before closing the stream we need to wait for:
+  //     Read().get().has_value() == false
   for (auto r = stream->Read().get(); r.has_value(); r = stream->Read().get()) {
   }
 

--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -20,6 +20,7 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
+using ::google::cloud::internal::DebugString;
 using ::google::cloud::internal::LogWrapper;
 
 StatusOr<google::pubsub::v1::Subscription>
@@ -89,6 +90,20 @@ Status SubscriberLogging::ModifyPushConfig(
         return child_->ModifyPushConfig(context, request);
       },
       context, request, __func__, tracing_options_);
+}
+
+std::unique_ptr<SubscriberStub::AsyncPullStream>
+SubscriberLogging::AsyncStreamingPull(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::StreamingPullRequest const& request) {
+  auto request_id = google::cloud::internal::RequestIdForLogging();
+  auto prefix = std::string(__func__) + "(" + request_id + ")";
+  GCP_LOG(DEBUG) << prefix
+                 << " << request=" << DebugString(request, tracing_options_);
+  return absl::make_unique<LoggingAsyncPullStream>(
+      child_->AsyncStreamingPull(cq, std::move(context), request),
+      tracing_options_, request_id);
 }
 
 future<StatusOr<google::pubsub::v1::PullResponse>> SubscriberLogging::AsyncPull(
@@ -195,6 +210,88 @@ StatusOr<google::pubsub::v1::SeekResponse> SubscriberLogging::Seek(
         return child_->Seek(context, request);
       },
       context, request, __func__, tracing_options_);
+}
+
+LoggingAsyncPullStream::LoggingAsyncPullStream(
+    std::unique_ptr<SubscriberStub::AsyncPullStream> child,
+    TracingOptions tracing_options, std::string request_id)
+    : child_(std::move(child)),
+      tracing_options_(std::move(tracing_options)),
+      request_id_(std::move(request_id)) {}
+
+void LoggingAsyncPullStream::Cancel() {
+  auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  GCP_LOG(DEBUG) << prefix << " <<";
+  child_->Cancel();
+  GCP_LOG(DEBUG) << prefix << " >>";
+}
+
+future<bool> LoggingAsyncPullStream::Start() {
+  auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  GCP_LOG(DEBUG) << prefix << " <<";
+  return child_->Start().then([prefix](future<bool> f) {
+    auto r = f.get();
+    GCP_LOG(DEBUG) << prefix << " >> response=" << r;
+    return r;
+  });
+}
+
+future<absl::optional<google::pubsub::v1::StreamingPullResponse>>
+LoggingAsyncPullStream::Read() {
+  auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  GCP_LOG(DEBUG) << prefix << " <<";
+  auto& options = tracing_options_;
+  return child_->Read().then(
+      [prefix, options](
+          future<absl::optional<google::pubsub::v1::StreamingPullResponse>> f) {
+        auto response = f.get();
+        if (!response) {
+          GCP_LOG(DEBUG) << prefix << " >> response={}";
+        } else {
+          GCP_LOG(DEBUG) << prefix
+                         << " >> response=" << DebugString(*response, options);
+        }
+        return response;
+      });
+}
+
+future<bool> LoggingAsyncPullStream::Write(
+    google::pubsub::v1::StreamingPullRequest const& request,
+    grpc::WriteOptions options) {
+  auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  GCP_LOG(DEBUG) << prefix
+                 << " << request=" << DebugString(request, tracing_options_)
+                 << ", options={is_write_through=" << options.is_write_through()
+                 << ", is_last_message=" << options.is_last_message()
+                 << ", is_corked=" << options.is_corked()
+                 << ", buffer_hint=" << options.get_buffer_hint()
+                 << ", no_compression=" << options.get_no_compression() << "}";
+  return child_->Write(request, std::move(options))
+      .then([prefix](future<bool> f) {
+        auto r = f.get();
+        GCP_LOG(DEBUG) << prefix << " >> response=" << r;
+        return r;
+      });
+}
+
+future<bool> LoggingAsyncPullStream::WritesDone() {
+  auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  GCP_LOG(DEBUG) << prefix << " <<";
+  return child_->WritesDone().then([prefix](future<bool> f) {
+    auto r = f.get();
+    GCP_LOG(DEBUG) << prefix << " >> response=" << r;
+    return r;
+  });
+}
+
+future<Status> LoggingAsyncPullStream::Finish() {
+  auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  GCP_LOG(DEBUG) << prefix << " <<";
+  return child_->Finish().then([prefix](future<Status> f) {
+    auto r = f.get();
+    GCP_LOG(DEBUG) << prefix << " >> status=" << r;
+    return r;
+  });
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -136,6 +136,74 @@ TEST_F(SubscriberLoggingTest, ModifyPushConfig) {
                              HasSubstr("test-subscription-name"))));
 }
 
+TEST_F(SubscriberLoggingTest, AsyncStreamingPull) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  EXPECT_CALL(*mock, AsyncStreamingPull)
+      .WillOnce([](google::cloud::CompletionQueue&,
+                   std::unique_ptr<grpc::ClientContext>,
+                   google::pubsub::v1::StreamingPullRequest const&) {
+        auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+        EXPECT_CALL(*stream, Cancel).Times(1);
+        EXPECT_CALL(*stream, Start).WillOnce([&] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([&] {
+              return make_ready_future(absl::make_optional(
+                  google::pubsub::v1::StreamingPullResponse{}));
+            })
+            .WillOnce([&] {
+              return make_ready_future(
+                  absl::optional<google::pubsub::v1::StreamingPullResponse>{});
+            });
+        EXPECT_CALL(*stream, Write)
+            .WillOnce([&](google::pubsub::v1::StreamingPullRequest const&,
+                          grpc::WriteOptions const&) {
+              return make_ready_future(true);
+            });
+        EXPECT_CALL(*stream, WritesDone).WillOnce([&] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([&] {
+          return make_ready_future(Status{});
+        });
+        return stream;
+      });
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  google::cloud::CompletionQueue cq;
+
+  google::pubsub::v1::StreamingPullRequest request;
+  request.set_subscription("test-subscription-name");
+  auto stream = stub.AsyncStreamingPull(
+      cq, absl::make_unique<grpc::ClientContext>(), request);
+  EXPECT_THAT(backend_->ClearLogLines(),
+              Contains(HasSubstr("AsyncStreamingPull")));
+
+  EXPECT_TRUE(stream->Start().get());
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("Start")));
+
+  EXPECT_TRUE(
+      stream->Write(request, grpc::WriteOptions{}.set_write_through()).get());
+  EXPECT_THAT(
+      backend_->ClearLogLines(),
+      Contains(AllOf(HasSubstr("Write"), HasSubstr("test-subscription-name"))));
+
+  EXPECT_TRUE(stream->Read().get().has_value());
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("Read")));
+
+  EXPECT_FALSE(stream->Read().get().has_value());
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("Read")));
+
+  EXPECT_TRUE(stream->WritesDone().get());
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("WritesDone")));
+
+  EXPECT_STATUS_OK(stream->Finish().get());
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("Finish")));
+
+  stream->Cancel();
+  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("Cancel")));
+}
+
 TEST_F(SubscriberLoggingTest, AsyncPull) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncPull)

--- a/google/cloud/pubsub/internal/subscriber_metadata.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata.cc
@@ -70,6 +70,15 @@ Status SubscriberMetadata::ModifyPushConfig(
   return child_->ModifyPushConfig(context, request);
 }
 
+std::unique_ptr<SubscriberStub::AsyncPullStream>
+SubscriberMetadata::AsyncStreamingPull(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::StreamingPullRequest const& request) {
+  SetMetadata(*context, "subscription=" + request.subscription());
+  return child_->AsyncStreamingPull(cq, std::move(context), request);
+}
+
 future<StatusOr<google::pubsub::v1::PullResponse>>
 SubscriberMetadata::AsyncPull(google::cloud::CompletionQueue& cq,
                               std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/pubsub/internal/subscriber_metadata.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata.h
@@ -53,6 +53,11 @@ class SubscriberMetadata : public SubscriberStub {
       grpc::ClientContext& context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) override;
 
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::StreamingPullRequest const& request) override;
+
   future<StatusOr<google::pubsub::v1::PullResponse>> AsyncPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -83,6 +83,19 @@ class DefaultSubscriberStub : public SubscriberStub {
     return {};
   }
 
+  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::StreamingPullRequest const&) override {
+    return google::cloud::internal::MakeStreamingReadWriteRpc<
+        google::pubsub::v1::StreamingPullRequest,
+        google::pubsub::v1::StreamingPullResponse>(
+        cq, std::move(context),
+        [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+          return grpc_stub_->PrepareAsyncStreamingPull(context, cq);
+        });
+  }
+
   future<StatusOr<google::pubsub::v1::PullResponse>> AsyncPull(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/version.h"
+#include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.grpc.pb.h>
 
@@ -69,6 +70,15 @@ class SubscriberStub {
   virtual Status ModifyPushConfig(
       grpc::ClientContext& client_context,
       google::pubsub::v1::ModifyPushConfigRequest const& request) = 0;
+
+  using AsyncPullStream = google::cloud::internal::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>;
+
+  /// Start a bi-directional stream to read messages and send ack/nacks.
+  virtual std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
+      google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::pubsub::v1::StreamingPullRequest const& request) = 0;
 
   /// Pull a batch of messages.
   virtual future<StatusOr<google::pubsub::v1::PullResponse>> AsyncPull(

--- a/google/cloud/pubsub/testing/mock_subscriber_stub.h
+++ b/google/cloud/pubsub/testing/mock_subscriber_stub.h
@@ -61,6 +61,13 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
                google::pubsub::v1::ModifyPushConfigRequest const& request),
               (override));
 
+  MOCK_METHOD(std::unique_ptr<pubsub_internal::SubscriberStub::AsyncPullStream>,
+              AsyncStreamingPull,
+              (google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::pubsub::v1::StreamingPullRequest const&),
+              (override));
+
   MOCK_METHOD(future<StatusOr<google::pubsub::v1::PullResponse>>, AsyncPull,
               (google::cloud::CompletionQueue&,
                std::unique_ptr<grpc::ClientContext>,
@@ -108,6 +115,21 @@ class MockSubscriberStub : public pubsub_internal::SubscriberStub {
   MOCK_METHOD(StatusOr<google::pubsub::v1::SeekResponse>, Seek,
               (grpc::ClientContext&, google::pubsub::v1::SeekRequest const&),
               (override));
+};
+
+class MockAsyncPullStream
+    : public pubsub_internal::SubscriberStub::AsyncPullStream {
+ public:
+  MOCK_METHOD0(Cancel, void());
+  MOCK_METHOD0(Start, future<bool>());
+  MOCK_METHOD0(
+      Read,
+      future<absl::optional<google::pubsub::v1::StreamingPullResponse>>());
+  MOCK_METHOD2(Write,
+               future<bool>(google::pubsub::v1::StreamingPullRequest const&,
+                            grpc::WriteOptions));
+  MOCK_METHOD0(WritesDone, future<bool>());
+  MOCK_METHOD0(Finish, future<Status>());
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
This adds `AsyncStreamingPull()`, a new member function to start a
streaming pull request. This is a bi-directional streaming RPC. It can
(and soon will) be used to receive messages, update leases, nack
messages, and ack messages. It also implements flow control from the
server side, simplifying some of the library code.

Part of the work for #5026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5188)
<!-- Reviewable:end -->
