### PR TITLE
fix(spanner): use `ExecuteStreamingSql`for PDML operations

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -324,9 +324,7 @@ class StreamingPartitionedDmlResult {
     StatusOr<Row> row;
     do {
       row = source_->NextRow();
-      if (!row.ok()) {
-        return std::move(row).status();
-      }
+      if (!row) return std::move(row).status();
       // We don't expect to get any data; if we do just drop it.
       // Exit the loop when we get an empty row.
     } while (row->size() != 0);
@@ -889,7 +887,7 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
       spanner_proto::ExecuteSqlRequest::NORMAL);
   auto rows_modified = dml_result.RowsModifiedLowerBound();
   if (!rows_modified.ok()) {
-    auto status = rows_modified.status();
+    auto status = std::move(rows_modified).status();
     if (internal::IsSessionNotFound(status)) session->set_bad();
     return status;
   }

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -303,6 +303,41 @@ class DmlResultSetSource : public internal::ResultSourceInterface {
   spanner_proto::ResultSet result_set_;
 };
 
+// Used as an intermediary for streaming PartitionedDml operations.
+class StreamingPartitionedDmlResult {
+ public:
+  StreamingPartitionedDmlResult() = default;
+  explicit StreamingPartitionedDmlResult(
+      std::unique_ptr<internal::ResultSourceInterface> source)
+      : source_(std::move(source)) {}
+
+  // This class is movable but not copyable.
+  StreamingPartitionedDmlResult(StreamingPartitionedDmlResult&&) = default;
+  StreamingPartitionedDmlResult& operator=(StreamingPartitionedDmlResult&&) =
+      default;
+
+  /**
+   * Returns a lower bound on the number of rows modified by the DML statement
+   * on success.
+   */
+  StatusOr<std::int64_t> RowsModifiedLowerBound() const {
+    StatusOr<Row> row;
+    do {
+      row = source_->NextRow();
+      if (!row.ok()) {
+        return std::move(row).status();
+      }
+      // We don't expect to get any data; if we do just drop it.
+      // Exit the loop when we get an empty row.
+    } while (row->size() != 0);
+
+    return source_->Stats()->row_count_lower_bound();
+  }
+
+ private:
+  std::unique_ptr<internal::ResultSourceInterface> source_;
+};
+
 /**
  * Helper function that ensures `session` holds a valid `Session`, or returns
  * an error if `session` is empty and no `Session` can be allocated.
@@ -845,34 +880,21 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
   }
   s->set_id(begin->id());
 
-  spanner_proto::ExecuteSqlRequest request;
-  request.set_session(session->session_name());
-  *request.mutable_transaction() = *s;
-  auto sql_statement = internal::ToProto(std::move(params.statement));
-  request.set_sql(std::move(*sql_statement.mutable_sql()));
-  *request.mutable_params() = std::move(*sql_statement.mutable_params());
-  *request.mutable_param_types() =
-      std::move(*sql_statement.mutable_param_types());
-  request.set_seqno(seqno);
-  auto stub = session_pool_->GetStub(*session);
-  auto response = RetryLoop(
-      retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
-      Idempotency::kIdempotent,
-      [&stub](grpc::ClientContext& context,
-              spanner_proto::ExecuteSqlRequest const& request) {
-        return stub->ExecuteSql(context, request);
-      },
-      request, __func__);
-  if (!response) {
-    auto status = std::move(response).status();
+  SqlParams sql_params(
+      {internal::MakeTransactionFromIds(session->session_name(), begin->id()),
+       std::move(params.statement), /*query_options=*/{},
+       /*partition_token=*/{}});
+  auto dml_result = CommonQueryImpl<StreamingPartitionedDmlResult>(
+      session, s, seqno, std::move(sql_params),
+      spanner_proto::ExecuteSqlRequest::NORMAL);
+  auto rows_modified = dml_result.RowsModifiedLowerBound();
+  if (!rows_modified.ok()) {
+    auto status = rows_modified.status();
     if (internal::IsSessionNotFound(status)) session->set_bad();
     return status;
   }
   PartitionedDmlResult result{0};
-  if (response->has_stats()) {
-    result.row_count_lower_bound = response->stats().row_count_lower_bound();
-  }
-
+  result.row_count_lower_bound = *rows_modified;
   return result;
 }
 


### PR DESCRIPTION
The streaming call allows us to properly resume the operation via
`PartialResultSet::resume_token` (already handled lower in the stack).

part of #4714 (it almost fixes it, I just need to tweak some timeouts).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5197)
<!-- Reviewable:end -->
