### PR TITLE
test(storage): store the full Status in ThroughputResult

### DIFF
--- a/google/cloud/storage/benchmarks/storage_benchmarks.bzl
+++ b/google/cloud/storage/benchmarks/storage_benchmarks.bzl
@@ -29,5 +29,4 @@ storage_benchmarks_srcs = [
     "throughput_experiment.cc",
     "throughput_options.cc",
     "throughput_result.cc",
-    "throughput_result_test.cc",
 ]

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -312,7 +312,7 @@ TestResults RunThread(ThroughputOptions const& options,
     auto status = upload_result.status;
     results.emplace_back(std::move(upload_result));
 
-    if (status != google::cloud::StatusCode::kOk) {
+    if (!status.ok()) {
       if (options.thread_count == 1) {
         std::cout << "# status=" << status << ", api=" << gcs_bm::ToString(api)
                   << "\n";

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -78,7 +78,7 @@ class UploadObject : public ThroughputExperiment {
                               api_,
                               timer.elapsed_time(),
                               timer.cpu_time(),
-                              object_metadata.status().code()};
+                              object_metadata.status()};
     }
     SimpleTimer timer;
     timer.Start();
@@ -106,7 +106,7 @@ class UploadObject : public ThroughputExperiment {
                             api_,
                             timer.elapsed_time(),
                             timer.cpu_time(),
-                            writer.metadata().status().code()};
+                            writer.metadata().status()};
   }
 
  private:
@@ -156,7 +156,7 @@ class DownloadObject : public ThroughputExperiment {
                             api_,
                             timer.elapsed_time(),
                             timer.cpu_time(),
-                            reader.status().code()};
+                            reader.status()};
   }
 
  private:
@@ -222,8 +222,9 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
 
     curl_easy_setopt(hnd, CURLOPT_STDERR, stderr);
     CURLcode ret = curl_easy_perform(hnd);
-    auto status_code = ret == CURLE_OK ? google::cloud::StatusCode::kOk
-                                       : google::cloud::StatusCode::kUnknown;
+    Status status = ret == CURLE_OK
+                        ? Status{}
+                        : Status{StatusCode::kUnknown, "curl failed"};
 
     curl_easy_cleanup(hnd);
     curl_slist_free_all(slist1);
@@ -237,7 +238,7 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
                             api_,
                             timer.elapsed_time(),
                             timer.cpu_time(),
-                            status_code};
+                            status};
   }
 
  private:
@@ -292,7 +293,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
                             ApiName::kApiRawGrpc,
                             timer.elapsed_time(),
                             timer.cpu_time(),
-                            status.code()};
+                            status};
   }
 
  private:

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -62,8 +62,8 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
                                       /*enable_crc32c=*/false,
                                       /*enable_md5=*/false};
     auto result = e->Run(bucket_name_, object_name, config);
-    EXPECT_EQ(result.status, StatusCode::kOk);
-    if (result.status == StatusCode::kOk) {
+    EXPECT_STATUS_OK(result.status);
+    if (result.status.ok()) {
       auto status = client->DeleteObject(bucket_name_, object_name);
       EXPECT_STATUS_OK(status);
     }

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -13,16 +13,36 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/throughput_result.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
+#include <sstream>
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace storage_benchmarks {
 
+namespace {
+template <typename T>
+std::string QuoteCsv(T const& element) {
+  std::ostringstream os;
+  os << element;
+  std::string result = os.str();
+  if (result.find_first_of(",\r\n") == std::string::npos) {
+    return result;
+  }
+
+  // Enclose the string in double quotes, and escape other double quotes.
+  return absl::StrCat(R"(")", absl::StrReplaceAll(result, {{R"(")", R"("")"}}),
+                      R"(")");
+}
+}  // namespace
+
 void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
   os << ToString(r.op) << ',' << r.object_size << ',' << r.app_buffer_size
      << ',' << r.lib_buffer_size << ',' << r.crc_enabled << ',' << r.md5_enabled
      << ',' << ToString(r.api) << ',' << r.elapsed_time.count() << ','
-     << r.cpu_time.count() << ',' << r.status << '\n';
+     << r.cpu_time.count() << ',' << QuoteCsv(r.status) << '\n';
 }
 
 void PrintThroughputResultHeader(std::ostream& os) {

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -28,7 +28,7 @@ std::string QuoteCsv(T const& element) {
   std::ostringstream os;
   os << element;
   std::string result = os.str();
-  if (result.find_first_of(",\r\n") == std::string::npos) {
+  if (result.find_first_of("\",\r\n") == std::string::npos) {
     return result;
   }
 

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -80,7 +80,7 @@ struct ThroughputResult {
   std::chrono::microseconds cpu_time;
   /// The result of the operation. The analysis may need to discard failed
   /// uploads or downloads.
-  google::cloud::StatusCode status;
+  google::cloud::Status status;
 };
 
 /// Print @p r as a CSV line.

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -29,13 +29,14 @@ TEST(ThroughtputResult, HeaderMatches) {
   auto const header = std::move(header_stream).str();
 
   std::ostringstream line_stream;
-  PrintAsCsv(line_stream,
-             ThroughputResult{
-                 kOpInsert, /*object_size=*/3 * kMiB,
-                 /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
-                 /*crc_enabled=*/true, /*md5_enabled=*/false, ApiName::kApiGrpc,
-                 std::chrono::microseconds(234000),
-                 std::chrono::microseconds(345000), StatusCode::kOutOfRange});
+  PrintAsCsv(
+      line_stream,
+      ThroughputResult{
+          kOpInsert, /*object_size=*/3 * kMiB,
+          /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
+          /*crc_enabled=*/true, /*md5_enabled=*/false, ApiName::kApiGrpc,
+          std::chrono::microseconds(234000), std::chrono::microseconds(345000),
+          Status{StatusCode::kOutOfRange, "OOR-status-message"}});
   EXPECT_TRUE(line_stream);
   auto const line = std::move(line_stream).str();
 
@@ -60,6 +61,7 @@ TEST(ThroughtputResult, HeaderMatches) {
   EXPECT_THAT(line, HasSubstr(",234000,"));
   EXPECT_THAT(line, HasSubstr(",345000,"));
   EXPECT_THAT(line, HasSubstr(StatusCodeToString(StatusCode::kOutOfRange)));
+  EXPECT_THAT(line, HasSubstr("OOR-status-message"));
 }
 
 }  // namespace

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -100,7 +100,6 @@ TEST(ThroughputResult, HeaderMatches) {
 }
 
 TEST(ThroughputResult, QuoteCsv) {
-  std::ostringstream os;
   ThroughputResult result{};
 
   result.status = Status{StatusCode::kInternal, R"(message "with quotes")"};

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -64,6 +64,22 @@ TEST(ThroughtputResult, HeaderMatches) {
   EXPECT_THAT(line, HasSubstr("OOR-status-message"));
 }
 
+TEST(ThroughtputResult, QuoteCsv) {
+  std::ostringstream line_stream;
+  PrintAsCsv(
+      line_stream,
+      ThroughputResult{
+          kOpInsert, 0, 0, 0, false, false, ApiName::kApiGrpc,
+          std::chrono::microseconds(0), std::chrono::microseconds(0),
+          Status{StatusCode::kInternal, R"(message, "with quotes", commas,)"
+                                        "\nand newlines"}});
+
+  EXPECT_TRUE(line_stream);
+  auto const line = std::move(line_stream).str();
+  EXPECT_THAT(line, HasSubstr(R"("message, ""with quotes"", commas,)"
+                              "\nand newlines"));
+}
+
 }  // namespace
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -41,7 +41,7 @@ MATCHER_P(
   }
   std::string status = arg.substr(pos);
   if (!status.empty() && status.back() == '\n') status.pop_back();
-  if (status.size() < 2 || status.front() != '"' ||  status.back() != '"') {
+  if (status.size() < 2 || status.front() != '"' || status.back() != '"') {
     *result_listener << "Missing opening or closing quote: " << status;
     return false;
   }
@@ -60,7 +60,6 @@ StatusOr<std::string> ToString(ThroughputResult const& result) {
   };
   return os.str();
 }
-
 
 TEST(ThroughputResult, HeaderMatches) {
   std::ostringstream header_stream;

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/throughput_result.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -22,62 +26,110 @@ namespace {
 
 using ::testing::HasSubstr;
 
-TEST(ThroughtputResult, HeaderMatches) {
+MATCHER_P(
+    HasQuotedStatus, substr,
+    "status field from PrintAsCsv is properly quoted and contains substr") {
+  // The status field is the 10th value.
+  std::size_t pos = 0;
+  for (int i = 0; i < 9; ++i) {
+    pos = arg.find(",", pos);
+    if (pos == std::string::npos) {
+      *result_listener << "Couldn't find status field: " << arg;
+      return false;
+    }
+    ++pos;
+  }
+  std::string status = arg.substr(pos);
+  if (!status.empty() && status.back() == '\n') status.pop_back();
+  if (status.size() < 2 || status.front() != '"' ||  status.back() != '"') {
+    *result_listener << "Missing opening or closing quote: " << status;
+    return false;
+  }
+  if (status.find(substr) == std::string::npos) {
+    *result_listener << "Didn't find " << substr << " in " << status;
+    return false;
+  }
+  return true;
+}
+
+StatusOr<std::string> ToString(ThroughputResult const& result) {
+  std::ostringstream os;
+  PrintAsCsv(os, result);
+  if (!os) {
+    return Status{StatusCode::kInternal, "PrintAsCsv failed"};
+  };
+  return os.str();
+}
+
+
+TEST(ThroughputResult, HeaderMatches) {
   std::ostringstream header_stream;
   PrintThroughputResultHeader(header_stream);
   EXPECT_TRUE(header_stream);
   auto const header = std::move(header_stream).str();
 
-  std::ostringstream line_stream;
-  PrintAsCsv(
-      line_stream,
-      ThroughputResult{
-          kOpInsert, /*object_size=*/3 * kMiB,
-          /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
-          /*crc_enabled=*/true, /*md5_enabled=*/false, ApiName::kApiGrpc,
-          std::chrono::microseconds(234000), std::chrono::microseconds(345000),
-          Status{StatusCode::kOutOfRange, "OOR-status-message"}});
-  EXPECT_TRUE(line_stream);
-  auto const line = std::move(line_stream).str();
-
+  auto const line = ToString(ThroughputResult{
+      kOpInsert, /*object_size=*/3 * kMiB,
+      /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
+      /*crc_enabled=*/true, /*md5_enabled=*/false, ApiName::kApiGrpc,
+      std::chrono::microseconds(234000), std::chrono::microseconds(345000),
+      Status{StatusCode::kOutOfRange, "OOR-status-message"}});
+  ASSERT_STATUS_OK(line);
   ASSERT_FALSE(header.empty());
-  ASSERT_FALSE(line.empty());
+  ASSERT_FALSE(line->empty());
 
   auto const header_fields = std::count(header.begin(), header.end(), ',');
-  auto const line_fields = std::count(line.begin(), line.end(), ',');
+  auto const line_fields = std::count(line->begin(), line->end(), ',');
   EXPECT_EQ(header_fields, line_fields);
-  EXPECT_EQ(line.back(), '\n');
+  EXPECT_EQ(line->back(), '\n');
   EXPECT_EQ(header.back(), '\n');
 
   // We don't want to create a change detector test, but we can verify the basic
   // fields are formatted correctly.
-  EXPECT_THAT(line, HasSubstr(ToString(kOpInsert)));
-  EXPECT_THAT(line, HasSubstr("," + std::to_string(3 * kMiB) + ","));
-  EXPECT_THAT(line, HasSubstr("," + std::to_string(2 * kMiB) + ","));
-  EXPECT_THAT(line, HasSubstr("," + std::to_string(4 * kMiB) + ","));
-  EXPECT_THAT(line, HasSubstr(",1,"));  // crc_enabled==true
-  EXPECT_THAT(line, HasSubstr(",0,"));  // md5_enabled==false
-  EXPECT_THAT(line, HasSubstr(ToString(ApiName::kApiGrpc)));
-  EXPECT_THAT(line, HasSubstr(",234000,"));
-  EXPECT_THAT(line, HasSubstr(",345000,"));
-  EXPECT_THAT(line, HasSubstr(StatusCodeToString(StatusCode::kOutOfRange)));
-  EXPECT_THAT(line, HasSubstr("OOR-status-message"));
+  EXPECT_THAT(*line, HasSubstr(ToString(kOpInsert)));
+  EXPECT_THAT(*line, HasSubstr("," + std::to_string(3 * kMiB) + ","));
+  EXPECT_THAT(*line, HasSubstr("," + std::to_string(2 * kMiB) + ","));
+  EXPECT_THAT(*line, HasSubstr("," + std::to_string(4 * kMiB) + ","));
+  EXPECT_THAT(*line, HasSubstr(",1,"));  // crc_enabled==true
+  EXPECT_THAT(*line, HasSubstr(",0,"));  // md5_enabled==false
+  EXPECT_THAT(*line, HasSubstr(ToString(ApiName::kApiGrpc)));
+  EXPECT_THAT(*line, HasSubstr(",234000,"));
+  EXPECT_THAT(*line, HasSubstr(",345000,"));
+  EXPECT_THAT(*line, HasSubstr(StatusCodeToString(StatusCode::kOutOfRange)));
+  EXPECT_THAT(*line, HasSubstr("OOR-status-message"));
 }
 
-TEST(ThroughtputResult, QuoteCsv) {
-  std::ostringstream line_stream;
-  PrintAsCsv(
-      line_stream,
-      ThroughputResult{
-          kOpInsert, 0, 0, 0, false, false, ApiName::kApiGrpc,
-          std::chrono::microseconds(0), std::chrono::microseconds(0),
-          Status{StatusCode::kInternal, R"(message, "with quotes", commas,)"
-                                        "\nand newlines"}});
+TEST(ThroughputResult, QuoteCsv) {
+  std::ostringstream os;
+  ThroughputResult result{};
 
-  EXPECT_TRUE(line_stream);
-  auto const line = std::move(line_stream).str();
-  EXPECT_THAT(line, HasSubstr(R"("message, ""with quotes"", commas,)"
-                              "\nand newlines"));
+  result.status = Status{StatusCode::kInternal, R"(message "with quotes")"};
+  auto line = ToString(result);
+  ASSERT_STATUS_OK(line);
+  EXPECT_THAT(*line, HasQuotedStatus(R"(message ""with quotes"")"));
+
+  result.status = Status{StatusCode::kInternal, R"(message, with comma)"};
+  line = ToString(result);
+  ASSERT_STATUS_OK(line);
+  EXPECT_THAT(*line, HasQuotedStatus(R"("message, with comma)"));
+
+  result.status = Status{StatusCode::kInternal, "message\nwith newline"};
+  line = ToString(result);
+  ASSERT_STATUS_OK(line);
+  EXPECT_THAT(*line, HasQuotedStatus("message\nwith newline"));
+
+  result.status = Status{StatusCode::kInternal, "message\r\nwith CRLF"};
+  line = ToString(result);
+  ASSERT_STATUS_OK(line);
+  EXPECT_THAT(*line, HasQuotedStatus("message\r\nwith CRLF"));
+
+  result.status =
+      Status{StatusCode::kInternal, R"("message, "with quotes", commas,)"
+                                    "\r\nand CRLF"};
+  line = ToString(result);
+  ASSERT_STATUS_OK(line);
+  EXPECT_THAT(*line, HasQuotedStatus(R"(message, ""with quotes"", commas,)"
+                                     "\r\nand CRLF"));
 }
 
 }  // namespace


### PR DESCRIPTION
This may give us more information if googleapis#5202 recurs.

coryan: one thing that changed is the PrintAsCsv() format, is that going
to mess up any of your analysis? Should I change it?

INSERT,3145728,2097152,4194304,1,0,GRPC,234000,345000,OOR-status-message [OUT_OF_RANGE]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5203)
<!-- Reviewable:end -->
