### PR TITLE
test: replace EXPECT_EQ(kOk) with EXPECT_STATUS_OK

### DIFF
--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/http_response.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -42,10 +43,9 @@ TEST(HttpResponseTest, AsStatus) {
             AsStatus(HttpResponse{-42, "weird", {}}).code());
   EXPECT_EQ(StatusCode::kUnknown,
             AsStatus(HttpResponse{99, "still weird", {}}).code());
-  EXPECT_EQ(StatusCode::kOk,
-            AsStatus(HttpResponse{100, "Continue", {}}).code());
-  EXPECT_EQ(StatusCode::kOk, AsStatus(HttpResponse{200, "success", {}}).code());
-  EXPECT_EQ(StatusCode::kOk, AsStatus(HttpResponse{299, "success", {}}).code());
+  EXPECT_STATUS_OK(AsStatus(HttpResponse{100, "Continue", {}}));
+  EXPECT_STATUS_OK(AsStatus(HttpResponse{200, "success", {}}));
+  EXPECT_STATUS_OK(AsStatus(HttpResponse{299, "success", {}}));
   EXPECT_EQ(
       StatusCode::kUnknown,
       AsStatus(HttpResponse{300, "libcurl should handle this", {}}).code());

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -344,7 +344,6 @@ TEST_F(AuthorizedUserCredentialsTest, ParseAuthorizedUserRefreshResponse) {
   auto status = ParseAuthorizedUserRefreshResponse(HttpResponse{200, r1, {}},
                                                    FakeClock::now());
   EXPECT_STATUS_OK(status);
-  EXPECT_EQ(status.status().code(), StatusCode::kOk);
   auto token = *status;
   EXPECT_EQ(
       std::chrono::time_point_cast<std::chrono::seconds>(token.expiration_time)

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -160,7 +160,6 @@ TEST_F(ComputeEngineCredentialsTest, ParseComputeEngineRefreshResponse) {
   auto status = ParseComputeEngineRefreshResponse(
       HttpResponse{200, token_info_resp, {}}, FakeClock::now());
   EXPECT_STATUS_OK(status);
-  EXPECT_EQ(status.status().code(), StatusCode::kOk);
   auto token = *status;
   EXPECT_EQ(
       std::chrono::time_point_cast<std::chrono::seconds>(token.expiration_time)
@@ -203,7 +202,6 @@ TEST_F(ComputeEngineCredentialsTest, ParseMetadataServerResponse) {
   auto status =
       ParseMetadataServerResponse(HttpResponse{200, svc_acct_info_resp, {}});
   EXPECT_STATUS_OK(status);
-  EXPECT_EQ(status.status().code(), StatusCode::kOk);
   auto metadata = *status;
   EXPECT_EQ(metadata.email, email);
   EXPECT_TRUE(metadata.scopes.count("scope1"));

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -847,7 +847,6 @@ TEST_F(ServiceAccountCredentialsTest, ParseServiceAccountRefreshResponse) {
   auto status = ParseServiceAccountRefreshResponse(HttpResponse{200, r1, {}},
                                                    FakeClock::now());
   EXPECT_STATUS_OK(status);
-  EXPECT_EQ(status.status().code(), StatusCode::kOk);
   auto token = *status;
   EXPECT_EQ(
       std::chrono::time_point_cast<std::chrono::seconds>(token.expiration_time)


### PR DESCRIPTION
EXPECT_STATUS_OK prints the full status on failure instead of just the code.
In some places we were redundantly doing both and I removed the EXPECT_EQ.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5209)
<!-- Reviewable:end -->
