### PR TITLE
fix(pubsub): streaming pull race conditions

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -78,6 +78,7 @@ class StreamingSubscriptionBatchSource
       std::int32_t max_count) override;
 
   using AsyncPullStream = SubscriberStub::AsyncPullStream;
+  using StreamShptr = std::shared_ptr<AsyncPullStream>;
 
   enum class StreamState {
     kNull,
@@ -96,7 +97,6 @@ class StreamingSubscriptionBatchSource
 
   void StartStream();
 
-  using StreamShptr = std::shared_ptr<AsyncPullStream>;
   void OnStreamStart(StatusOr<StreamShptr> stream);
   void ReadLoop();
 

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -531,7 +531,7 @@ TEST(StreamingSubscriptionBatchSourceTest, ShutdownWithPendingRead) {
   AutomaticallyCreatedBackgroundThreads background;
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
 
-  auto const expected_status = Status{StatusCode::kOk, "fine"};
+  auto const expected_status = Status{};
   FakeStream fake_stream(true, true, expected_status);
 
   EXPECT_CALL(*mock, AsyncStreamingPull)


### PR DESCRIPTION
Found some race conditions when using this against production.
Apparently the timing is different enough from the emulator that these
do not show up in the emulator even when running thousands of times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5210)
<!-- Reviewable:end -->
