### PR TITLE
test: use `StatusIs` matcher in spanner tests

### DIFF
--- a/google/cloud/spanner/benchmarks/benchmarks_config_test.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/benchmarks/benchmarks_config.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -22,6 +23,7 @@ namespace cloud {
 namespace spanner_benchmarks {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
+using ::google::cloud::testing_util::StatusIs;
 
 TEST(BenchmarkConfigTest, ParseAll) {
   auto config = ParseArgs(
@@ -61,59 +63,59 @@ TEST(BenchmarkConfigTest, ParseThreads) {
 
 TEST(BenchmarkConfigTest, InvalidFlag) {
   auto config = ParseArgs({"placeholder", "--not-a-flag=1"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, EmptyExperiment) {
   auto config = ParseArgs({"placeholder", "--experiment="});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, EmptyProject) {
   auto config = ParseArgs({"placeholder", "--project="});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, InvalidMinimumThreads) {
   auto config = ParseArgs(
       {"placeholder", "--project=test-project", "--minimum-threads=-7"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, InvalidMaximumThreads) {
   auto config = ParseArgs({"placeholder", "--project=test-project",
                            "--minimum-threads=100", "--maximum-threads=5"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, InvalidMinimumClients) {
   auto config = ParseArgs(
       {"placeholder", "--project=test-project", "--minimum-clients=-7"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, InvalidMaximumClients) {
   auto config = ParseArgs({"placeholder", "--project=test-project",
                            "--minimum-clients=100", "--maximum-clients=5"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, InvalidQuerySize) {
   auto config =
       ParseArgs({"placeholder", "--project=test-project", "--query-size=0"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, InvalidTableSize) {
   auto config = ParseArgs({"placeholder", "--project=test-project",
                            "--query-size=100", "--table-size=10"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, OnlyStubsAndOnlyClients) {
   auto config = ParseArgs({"placeholder", "--project=test-project",
                            "--use-only-stubs", "--use-only-clients"});
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
+  EXPECT_THAT(config, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST(BenchmarkConfigTest, OnlyStubs) {

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/types/optional.h"
 #include <gmock/gmock.h>
 
@@ -28,6 +29,7 @@ namespace {
 
 using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
@@ -152,7 +154,7 @@ TEST(DatabaseAdminClientTest, ListDatabases) {
   auto range = client.ListDatabases(expected_instance);
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify DatabaseAdminClient uses GetIamPolicy() correctly.
@@ -209,7 +211,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccGetFailure) {
   auto actual = client.SetIamPolicy(db, [](google::iam::v1::Policy const&) {
     return absl::optional<google::iam::v1::Policy>{};
   });
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(DatabaseAdminClientTest, SetIamPolicyOccNoUpdates) {
@@ -312,8 +314,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
   auto actual = client.SetIamPolicy(
       db, [](google::iam::v1::Policy p) { return p; }, RerunPolicyForTesting(),
       BackoffPolicyForTesting());
-  EXPECT_EQ(StatusCode::kAborted, actual.status().code());
-  EXPECT_THAT(actual.status().message(), HasSubstr("test-msg"));
+  EXPECT_THAT(actual, StatusIs(StatusCode::kAborted, HasSubstr("test-msg")));
 }
 
 /// @test Verify DatabaseAdminClient uses TestIamPermissions() correctly.
@@ -508,7 +509,7 @@ TEST(DatabaseAdminClientTest, ListBackups) {
   auto range = client.ListBackups(expected_instance, expected_filter);
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify DatabaseAdminClient uses GetBackup() correctly.
@@ -599,7 +600,7 @@ TEST(DatabaseAdminClientTest, ListBackupOperations) {
   auto range = client.ListBackupOperations(expected_instance, expected_filter);
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(DatabaseAdminClientTest, ListDatabaseOperations) {
@@ -629,7 +630,7 @@ TEST(DatabaseAdminClientTest, ListDatabaseOperations) {
       client.ListDatabaseOperations(expected_instance, expected_filter);
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 }  // namespace

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/testing/mock_database_admin_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -27,6 +28,7 @@ namespace {
 
 using ::google::cloud::spanner_testing::MockDatabaseAdminStub;
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;
@@ -97,7 +99,7 @@ TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
   auto fut = conn->CreateDatabase({dbase, {}});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
+  EXPECT_THAT(db, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that the successful case works.
@@ -135,7 +137,7 @@ TEST(DatabaseAdminClientTest, GetDatabasePermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetDatabase(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -149,7 +151,7 @@ TEST(DatabaseAdminClientTest, GetDatabaseTooManyTransients) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetDatabase(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that the successful case works.
@@ -186,7 +188,7 @@ TEST(DatabaseAdminClientTest, GetDatabaseDdlPermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetDatabaseDdl(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -200,7 +202,7 @@ TEST(DatabaseAdminClientTest, GetDatabaseDdlTooManyTransients) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetDatabaseDdl(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that successful case works.
@@ -259,7 +261,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabaseErrorInPoll) {
       {dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"}});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
+  EXPECT_THAT(db, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that errors in the polling loop are reported.
@@ -288,7 +290,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseErrorInPoll) {
   auto conn = CreateTestingConnection(std::move(mock));
   Database dbase("test-project", "test-instance", "test-db");
   auto db = conn->CreateDatabase({dbase, {}}).get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
+  EXPECT_THAT(db, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that errors in the polling loop are reported.
@@ -321,7 +323,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabaseGetOperationError) {
       conn->UpdateDatabase(
               {dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"}})
           .get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
+  EXPECT_THAT(db, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that we can list databases in multiple pages.
@@ -388,7 +390,7 @@ TEST(DatabaseAdminClientTest, ListDatabasesPermanentFailure) {
   auto range = conn->ListDatabases({in});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(DatabaseAdminClientTest, ListDatabasesTooManyFailures) {
@@ -403,7 +405,7 @@ TEST(DatabaseAdminClientTest, ListDatabasesTooManyFailures) {
   auto range = conn->ListDatabases({in});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kUnavailable, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that successful case works.
@@ -458,7 +460,7 @@ TEST(DatabaseAdminClientTest, HandleRestoreDatabaseError) {
   auto fut = conn->RestoreDatabase({dbase, backup.FullName()});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
+  EXPECT_THAT(db, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that the successful case works.
@@ -502,7 +504,7 @@ TEST(DatabaseAdminClientTest, GetIamPolicyPermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetIamPolicy(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -516,7 +518,7 @@ TEST(DatabaseAdminClientTest, GetIamPolicyTooManyTransients) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetIamPolicy(
       {Database("test-project", "test-instance", "test-database")});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that the successful case works.
@@ -571,7 +573,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyPermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->SetIamPolicy(
       {Database("test-project", "test-instance", "test-database"), {}});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that request without the Etag field should fail with the first
@@ -586,7 +588,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyNonIdempotent) {
   google::iam::v1::Policy policy;
   auto response = conn->SetIamPolicy(
       {Database("test-project", "test-instance", "test-database"), policy});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that request with the Etag field is retried for transient
@@ -603,7 +605,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyIdempotent) {
   policy.set_etag("test-etag-value");
   auto response = conn->SetIamPolicy(
       {Database("test-project", "test-instance", "test-database"), policy});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that the successful case works.
@@ -645,7 +647,7 @@ TEST(DatabaseAdminClientTest, TestIamPermissionsPermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->TestIamPermissions(
       {Database("test-project", "test-instance", "test-database"), {}});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -659,7 +661,7 @@ TEST(DatabaseAdminClientTest, TestIamPermissionsTooManyTransients) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->TestIamPermissions(
       {Database("test-project", "test-instance", "test-database"), {}});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that successful case works.
@@ -769,7 +771,7 @@ TEST(DatabaseAdminClientTest, HandleCreateBackupError) {
   auto fut = conn->CreateBackup({dbase, "test-backup", {}});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto backup = fut.get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, backup.status().code());
+  EXPECT_THAT(backup, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that the successful case works.
@@ -809,7 +811,7 @@ TEST(DatabaseAdminClientTest, GetBackupPermanentError) {
   auto response = conn->GetBackup(
       {Backup(Instance("test-project", "test-instance"), "test-backup")
            .FullName()});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -824,7 +826,7 @@ TEST(DatabaseAdminClientTest, GetBackupTooManyTransients) {
   auto response = conn->GetBackup(
       {Backup(Instance("test-project", "test-instance"), "test-backup")
            .FullName()});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that the successful case works.
@@ -856,7 +858,7 @@ TEST(DatabaseAdminClientTest, DeleteBackupPermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto status = conn->DeleteBackup(
       {"projects/test-project/instances/test-instance/backups/test-backup"});
-  EXPECT_EQ(StatusCode::kPermissionDenied, status.code());
+  EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -870,7 +872,7 @@ TEST(DatabaseAdminClientTest, DeleteBackupTooManyTransients) {
   auto conn = CreateTestingConnection(std::move(mock));
   auto status = conn->DeleteBackup(
       {"projects/test-project/instances/test-instance/backups/test-backup"});
-  EXPECT_EQ(StatusCode::kUnavailable, status.code());
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that we can list backups in multiple pages.
@@ -935,7 +937,7 @@ TEST(DatabaseAdminClientTest, ListBackupsPermanentFailure) {
   auto range = conn->ListBackups({in, ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(DatabaseAdminClientTest, ListBackupsTooManyFailures) {
@@ -950,7 +952,7 @@ TEST(DatabaseAdminClientTest, ListBackupsTooManyFailures) {
   auto range = conn->ListBackups({in, ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kUnavailable, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that the successful case works.
@@ -991,7 +993,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupPermanentError) {
   auto conn = CreateTestingConnection(std::move(mock));
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   auto response = conn->UpdateBackup({request});
-  EXPECT_EQ(StatusCode::kPermissionDenied, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kPermissionDenied));
 }
 
 /// @test Verify that too many transients errors are reported correctly.
@@ -1005,7 +1007,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupTooManyTransients) {
   auto conn = CreateTestingConnection(std::move(mock));
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   auto response = conn->UpdateBackup({request});
-  EXPECT_EQ(StatusCode::kUnavailable, response.status().code());
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that we can list backup operations in multiple pages.
@@ -1072,7 +1074,7 @@ TEST(DatabaseAdminClientTest, ListBackupOperationsPermanentFailure) {
   auto range = conn->ListBackupOperations({in, ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(DatabaseAdminClientTest, ListBackupOperationsTooManyFailures) {
@@ -1087,7 +1089,7 @@ TEST(DatabaseAdminClientTest, ListBackupOperationsTooManyFailures) {
   auto range = conn->ListBackupOperations({in, ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kUnavailable, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kUnavailable));
 }
 
 /// @test Verify that we can list database operations in multiple pages.
@@ -1154,7 +1156,7 @@ TEST(DatabaseAdminClientTest, ListDatabaseOperationsPermanentFailure) {
   auto range = conn->ListDatabaseOperations({in, ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(DatabaseAdminClientTest, ListDatabaseOperationsTooManyFailures) {
@@ -1169,7 +1171,7 @@ TEST(DatabaseAdminClientTest, ListDatabaseOperationsTooManyFailures) {
   auto range = conn->ListDatabaseOperations({in, ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kUnavailable, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kUnavailable));
 }
 
 }  // namespace

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/mocks/mock_instance_admin_connection.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/types/optional.h"
 #include <gmock/gmock.h>
 
@@ -24,6 +25,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
+using ::google::cloud::testing_util::StatusIs;
 using spanner_mocks::MockInstanceAdminConnection;
 using ::testing::_;
 using ::testing::AtLeast;
@@ -67,7 +69,7 @@ TEST(InstanceAdminClientTest, GetInstance) {
 
   InstanceAdminClient client(mock);
   auto actual = client.GetInstance(Instance("test-project", "test-instance"));
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, GetInstanceConfig) {
@@ -82,7 +84,7 @@ TEST(InstanceAdminClientTest, GetInstanceConfig) {
   InstanceAdminClient client(mock);
   auto actual = client.GetInstanceConfig(
       "projects/test-project/instanceConfigs/test-config");
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, ListInstanceConfigs) {
@@ -106,7 +108,7 @@ TEST(InstanceAdminClientTest, ListInstanceConfigs) {
   auto range = client.ListInstanceConfigs("test-project");
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, ListInstances) {
@@ -133,7 +135,7 @@ TEST(InstanceAdminClientTest, ListInstances) {
       client.ListInstances("test-project", "labels.test-key:test-value");
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, GetIamPolicy) {
@@ -147,7 +149,7 @@ TEST(InstanceAdminClientTest, GetIamPolicy) {
 
   InstanceAdminClient client(mock);
   auto actual = client.GetIamPolicy(Instance("test-project", "test-instance"));
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, SetIamPolicy) {
@@ -162,7 +164,7 @@ TEST(InstanceAdminClientTest, SetIamPolicy) {
   InstanceAdminClient client(mock);
   auto actual = client.SetIamPolicy(Instance("test-project", "test-instance"),
                                     google::iam::v1::Policy{});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, SetIamPolicyOccGetFailure) {
@@ -180,7 +182,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccGetFailure) {
                           [](google::iam::v1::Policy const&) {
                             return absl::optional<google::iam::v1::Policy>{};
                           });
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, SetIamPolicyOccNoUpdates) {
@@ -288,8 +290,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
       Instance("test-project", "test-instance"),
       [](google::iam::v1::Policy p) { return p; }, RerunPolicyForTesting(),
       BackoffPolicyForTesting());
-  EXPECT_EQ(StatusCode::kAborted, actual.status().code());
-  EXPECT_THAT(actual.status().message(), HasSubstr("test-msg"));
+  EXPECT_THAT(actual, StatusIs(StatusCode::kAborted, HasSubstr("test-msg")));
 }
 
 TEST(InstanceAdminClientTest, TestIamPermissions) {
@@ -307,7 +308,7 @@ TEST(InstanceAdminClientTest, TestIamPermissions) {
   auto actual =
       client.TestIamPermissions(Instance("test-project", "test-instance"),
                                 {"test.permission1", "test.permission2"});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 }  // namespace

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/testing/mock_instance_admin_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -27,6 +28,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;
@@ -92,7 +94,7 @@ TEST(InstanceAdminConnectionTest, GetInstancePermanentFailure) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual = conn->GetInstance({"test-name"});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, GetInstanceTooManyTransients) {
@@ -102,7 +104,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceTooManyTransients) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual = conn->GetInstance({"test-name"});
-  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
@@ -175,7 +177,7 @@ TEST(InstanceAdminClientTest, CreateInstanceError) {
            .Build()});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
+  EXPECT_THAT(instance, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, UpdateInstanceSuccess) {
@@ -230,7 +232,7 @@ TEST(InstanceAdminClientTest, UpdateInstancePermanentFailure) {
   auto fut = conn->UpdateInstance({gcsa::UpdateInstanceRequest()});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
-  EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
+  EXPECT_THAT(instance, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminClientTest, UpdateInstanceTooManyTransients) {
@@ -247,7 +249,7 @@ TEST(InstanceAdminClientTest, UpdateInstanceTooManyTransients) {
   auto fut = conn->UpdateInstance({gcsa::UpdateInstanceRequest()});
   ASSERT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
-  EXPECT_EQ(StatusCode::kUnavailable, instance.status().code());
+  EXPECT_THAT(instance, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, DeleteInstanceSuccess) {
@@ -279,7 +281,7 @@ TEST(InstanceAdminConnectionTest, DeleteInstancePermanentFailure) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto status = conn->DeleteInstance({"test-name"});
-  EXPECT_EQ(StatusCode::kPermissionDenied, status.code());
+  EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, DeleteInstanceTooManyTransients) {
@@ -289,7 +291,7 @@ TEST(InstanceAdminConnectionTest, DeleteInstanceTooManyTransients) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto status = conn->DeleteInstance({"test-name"});
-  EXPECT_EQ(StatusCode::kUnavailable, status.code());
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, GetInstanceConfigSuccess) {
@@ -330,7 +332,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigPermanentFailure) {
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual =
       conn->GetInstanceConfig({"projects/test/instanceConfig/test-name"});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, GetInstanceConfigTooManyTransients) {
@@ -341,7 +343,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigTooManyTransients) {
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual =
       conn->GetInstanceConfig({"projects/test/instanceConfig/test-name"});
-  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
@@ -396,7 +398,7 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsPermanentFailure) {
   auto range = conn->ListInstanceConfigs({"test-project"});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsTooManyTransients) {
@@ -409,7 +411,7 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsTooManyTransients) {
   auto range = conn->ListInstanceConfigs({"test-project"});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kUnavailable, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, ListInstancesSuccess) {
@@ -467,7 +469,7 @@ TEST(InstanceAdminConnectionTest, ListInstancesPermanentFailure) {
   auto range = conn->ListInstances({"test-project", ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kPermissionDenied, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, ListInstancesTooManyTransients) {
@@ -479,7 +481,7 @@ TEST(InstanceAdminConnectionTest, ListInstancesTooManyTransients) {
   auto range = conn->ListInstances({"test-project", ""});
   auto begin = range.begin();
   ASSERT_NE(begin, range.end());
-  EXPECT_EQ(StatusCode::kUnavailable, begin->status().code());
+  EXPECT_THAT(*begin, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, GetIamPolicySuccess) {
@@ -519,7 +521,7 @@ TEST(InstanceAdminConnectionTest, GetIamPolicyPermanentFailure) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual = conn->GetIamPolicy({"test-instance-name"});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, GetIamPolicyTooManyTransients) {
@@ -529,7 +531,7 @@ TEST(InstanceAdminConnectionTest, GetIamPolicyTooManyTransients) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual = conn->GetIamPolicy({"test-instance-name"});
-  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, SetIamPolicySuccess) {
@@ -578,7 +580,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicyPermanentFailure) {
 
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual = conn->SetIamPolicy({"test-instance-name", {}});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, SetIamPolicyNonIdempotent) {
@@ -591,7 +593,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicyNonIdempotent) {
   auto conn = MakeLimitedRetryConnection(mock);
   google::iam::v1::Policy policy;
   auto actual = conn->SetIamPolicy({"test-instance-name", policy});
-  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, SetIamPolicyIdempotent) {
@@ -604,7 +606,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicyIdempotent) {
   google::iam::v1::Policy policy;
   policy.set_etag("test-etag-value");
   auto actual = conn->SetIamPolicy({"test-instance-name", policy});
-  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
 TEST(InstanceAdminConnectionTest, TestIamPermissionsSuccess) {
@@ -644,7 +646,7 @@ TEST(InstanceAdminConnectionTest, TestIamPermissionsPermanentFailure) {
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual =
       conn->TestIamPermissions({"test-instance-name", {"test.permission"}});
-  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kPermissionDenied));
 }
 
 TEST(InstanceAdminConnectionTest, TestIamPermissionsTooManyTransients) {
@@ -656,7 +658,7 @@ TEST(InstanceAdminConnectionTest, TestIamPermissionsTooManyTransients) {
   auto conn = MakeLimitedRetryConnection(mock);
   auto actual =
       conn->TestIamPermissions({"test-instance-name", {"test.permission"}});
-  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+  EXPECT_THAT(actual, StatusIs(StatusCode::kUnavailable));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/merge_chunk_test.cc
+++ b/google/cloud/spanner/internal/merge_chunk_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/struct.pb.h>
 #include <gmock/gmock.h>
 #include <string>
@@ -28,6 +29,9 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::HasSubstr;
+using ::testing::Not;
 
 //
 // MakeProtoValue() is an overloaded helper function for creating
@@ -161,8 +165,8 @@ TEST(MergeChunk, ErrorMismatchedTypes) {
   auto value = MakeProtoValue(std::vector<std::string>{"hello"});
   auto status = MergeChunk(value, MakeProtoValue("world"));
 
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.message(), testing::HasSubstr("mismatched types"));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
+                               testing::HasSubstr("mismatched types")));
 }
 
 //
@@ -177,8 +181,8 @@ TEST(MergeChunk, CannotMergeBools) {
   bool2.set_bool_value(true);
 
   auto status = MergeChunk(bool1, std::move(bool2));
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.message(), testing::HasSubstr("invalid type"));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
+                               testing::HasSubstr("invalid type")));
 }
 
 TEST(MergeChunk, CannotMergeNumbers) {
@@ -189,8 +193,8 @@ TEST(MergeChunk, CannotMergeNumbers) {
   number2.set_number_value(2.0);
 
   auto status = MergeChunk(number1, std::move(number2));
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.message(), testing::HasSubstr("invalid type"));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
+                               testing::HasSubstr("invalid type")));
 }
 
 TEST(MergeChunk, CannotMergeNull) {
@@ -201,8 +205,8 @@ TEST(MergeChunk, CannotMergeNull) {
   null2.set_null_value(google::protobuf::NullValue::NULL_VALUE);
 
   auto status = MergeChunk(null1, std::move(null2));
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.message(), testing::HasSubstr("invalid type"));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
+                               testing::HasSubstr("invalid type")));
 }
 
 TEST(MergeChunk, CannotMergeStruct) {
@@ -213,8 +217,8 @@ TEST(MergeChunk, CannotMergeStruct) {
   struct2.mutable_struct_value();
 
   auto status = MergeChunk(struct1, std::move(struct2));
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(status.message(), testing::HasSubstr("invalid type"));
+  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
+                               testing::HasSubstr("invalid type")));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -36,6 +37,7 @@ namespace spanner_proto = ::google::spanner::v1;
 using ::google::cloud::internal::Idempotency;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::AtLeast;
@@ -223,8 +225,8 @@ TEST(PartialResultSetResume, PermanentError) {
   v = reader->Read();
   ASSERT_FALSE(v.has_value());
   auto status = reader->Finish();
-  EXPECT_EQ(StatusCode::kPermissionDenied, status.code());
-  EXPECT_THAT(status.message(), HasSubstr("uh-oh-1"));
+  EXPECT_THAT(status,
+              StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh-1")));
 }
 
 TEST(PartialResultSetResume, TransientNonIdempotent) {
@@ -267,8 +269,8 @@ TEST(PartialResultSetResume, TransientNonIdempotent) {
   v = reader->Read();
   ASSERT_FALSE(v.has_value());
   auto status = reader->Finish();
-  EXPECT_EQ(StatusCode::kUnavailable, status.code());
-  EXPECT_THAT(status.message(), HasSubstr("try-again-0"));
+  EXPECT_THAT(status,
+              StatusIs(StatusCode::kUnavailable, HasSubstr("try-again-0")));
 }
 
 TEST(PartialResultSetResume, TooManyTransients) {
@@ -291,8 +293,8 @@ TEST(PartialResultSetResume, TooManyTransients) {
   auto v = reader->Read();
   ASSERT_FALSE(v.has_value());
   auto status = reader->Finish();
-  EXPECT_EQ(StatusCode::kUnavailable, status.code());
-  EXPECT_THAT(status.message(), HasSubstr("try-again-N"));
+  EXPECT_THAT(status,
+              StatusIs(StatusCode::kUnavailable, HasSubstr("try-again-N")));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -36,6 +37,7 @@ namespace spanner_proto = ::google::spanner::v1;
 
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -54,8 +56,7 @@ TEST(PartialResultSetSourceTest, InitialReadFailure) {
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
 
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
-  EXPECT_FALSE(reader.status().ok());
-  EXPECT_EQ(reader.status().code(), StatusCode::kInvalidArgument);
+  EXPECT_THAT(reader, StatusIs(StatusCode::kInvalidArgument));
 }
 
 /**
@@ -89,7 +90,7 @@ TEST(PartialResultSetSourceTest, ReadSuccessThenFailure) {
   EXPECT_THAT((*reader)->NextRow(),
               IsValidAndEquals(MakeTestRow({{"AnInt", Value(80)}})));
   auto row = (*reader)->NextRow();
-  EXPECT_EQ(row.status().code(), StatusCode::kCancelled);
+  EXPECT_THAT(row, StatusIs(StatusCode::kCancelled));
 }
 
 /// @test Verify the behavior when the first response does not contain metadata.
@@ -103,9 +104,8 @@ TEST(PartialResultSetSourceTest, MissingMetadata) {
 
   auto context = absl::make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
-  EXPECT_FALSE(reader.status().ok());
-  EXPECT_EQ(reader.status().code(), StatusCode::kInternal);
-  EXPECT_EQ(reader.status().message(), "response contained no metadata");
+  EXPECT_THAT(reader, StatusIs(StatusCode::kInternal,
+                               "response contained no metadata"));
 }
 
 /**
@@ -148,9 +148,8 @@ TEST(PartialResultSetSourceTest, MissingRowTypeWithData) {
   auto reader = PartialResultSetSource::Create(std::move(grpc_reader));
   ASSERT_STATUS_OK(reader);
   StatusOr<Row> row = (*reader)->NextRow();
-  EXPECT_EQ(row.status().code(), StatusCode::kInternal);
-  EXPECT_THAT(row.status().message(),
-              HasSubstr("missing row type information"));
+  EXPECT_THAT(row, StatusIs(StatusCode::kInternal,
+                            HasSubstr("missing row type information")));
 }
 
 /**
@@ -495,10 +494,9 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoValue) {
 
   // Trying to read the next row should fail.
   auto row = (*reader)->NextRow();
-  EXPECT_EQ(row.status().code(), StatusCode::kInternal);
-  EXPECT_EQ(
-      row.status().message(),
-      "PartialResultSet had chunked_value set true but contained no values");
+  EXPECT_THAT(row, StatusIs(StatusCode::kInternal,
+                            "PartialResultSet had chunked_value set true but "
+                            "contained no values"));
 }
 
 /**
@@ -540,10 +538,9 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoFollowingValue) {
 
   // Trying to read the next row should fail.
   auto row = (*reader)->NextRow();
-  EXPECT_EQ(row.status().code(), StatusCode::kInternal);
-  EXPECT_EQ(row.status().message(),
-            "PartialResultSet contained no values to merge with prior "
-            "chunked_value");
+  EXPECT_THAT(row, StatusIs(StatusCode::kInternal,
+                            "PartialResultSet contained no values to merge "
+                            "with prior chunked_value"));
 }
 
 /**
@@ -584,9 +581,8 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetAtEndOfStream) {
 
   // Trying to read the next row should fail.
   auto row = (*reader)->NextRow();
-  EXPECT_EQ(row.status().code(), StatusCode::kInternal);
-  EXPECT_EQ(row.status().message(),
-            "incomplete chunked_value at end of stream");
+  EXPECT_THAT(row, StatusIs(StatusCode::kInternal,
+                            "incomplete chunked_value at end of stream"));
 }
 
 /**
@@ -633,8 +629,7 @@ TEST(PartialResultSetSourceTest, ChunkedValueMergeFailure) {
 
   // Trying to read the next row should fail.
   auto row = (*reader)->NextRow();
-  EXPECT_EQ(row.status().code(), StatusCode::kInvalidArgument);
-  EXPECT_EQ(row.status().message(), "invalid type");
+  EXPECT_THAT(row, StatusIs(StatusCode::kInvalidArgument, "invalid type"));
 }
 
 /**
@@ -717,8 +712,8 @@ TEST(PartialResultSetSourceTest, ErrorOnIncompleteRow) {
 
   auto row = (*reader)->NextRow();
   EXPECT_FALSE(row.ok());
-  EXPECT_EQ(row.status().code(), StatusCode::kInternal);
-  EXPECT_THAT(row.status().message(), HasSubstr("incomplete row"));
+  EXPECT_THAT(row,
+              StatusIs(StatusCode::kInternal, HasSubstr("incomplete row")));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/mock_async_response_reader.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -41,6 +42,7 @@ namespace {
 using ::google::cloud::spanner_testing::FakeSteadyClock;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::MockAsyncResponseReader;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::ByMove;
@@ -153,8 +155,8 @@ TEST(SessionPool, CreateError) {
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads threads;
   auto pool = MakeSessionPool(db, {mock}, {}, threads.cq());
   auto session = pool->Allocate();
-  EXPECT_EQ(session.status().code(), StatusCode::kInternal);
-  EXPECT_THAT(session.status().message(), HasSubstr("some failure"));
+  EXPECT_THAT(session,
+              StatusIs(StatusCode::kInternal, HasSubstr("some failure")));
 }
 
 TEST(SessionPool, ReuseSession) {
@@ -272,8 +274,8 @@ TEST(SessionPool, MaxSessionsFailOnExhaustion) {
   }
   EXPECT_THAT(session_names, UnorderedElementsAre("s1", "s2", "s3"));
   auto session = pool->Allocate();
-  EXPECT_EQ(session.status().code(), StatusCode::kResourceExhausted);
-  EXPECT_EQ(session.status().message(), "session pool exhausted");
+  EXPECT_THAT(session, StatusIs(StatusCode::kResourceExhausted,
+                                "session pool exhausted"));
 }
 
 TEST(SessionPool, MaxSessionsBlockUntilRelease) {
@@ -379,8 +381,8 @@ TEST(SessionPool, MultipleChannelsPreAllocation) {
               UnorderedElementsAre("c1s1", "c1s2", "c1s3", "c2s1", "c2s2",
                                    "c2s3", "c3s1", "c3s2", "c3s3"));
   auto session = pool->Allocate();
-  EXPECT_EQ(session.status().code(), StatusCode::kResourceExhausted);
-  EXPECT_EQ(session.status().message(), "session pool exhausted");
+  EXPECT_THAT(session, StatusIs(StatusCode::kResourceExhausted,
+                                "session pool exhausted"));
 }
 
 TEST(SessionPool, GetStubForStublessSession) {

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,6 +25,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
 using ::testing::Contains;
 using ::testing::HasSubstr;
@@ -52,9 +54,9 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
                        std::chrono::milliseconds(5));
   auto session =
       stub->CreateSession(context, google::spanner::v1::CreateSessionRequest());
-  EXPECT_THAT(session.status().code(),
-              AnyOf(StatusCode::kUnavailable, StatusCode::kInvalidArgument,
-                    StatusCode::kDeadlineExceeded));
+  EXPECT_THAT(session, StatusIs(AnyOf(StatusCode::kUnavailable,
+                                      StatusCode::kInvalidArgument,
+                                      StatusCode::kDeadlineExceeded)));
 
   EXPECT_THAT(backend->ClearLogLines(),
               Contains(HasSubstr(session.status().message())));

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -34,6 +35,7 @@ namespace spanner_proto = ::google::spanner::v1;
 
 using ::google::cloud::spanner_mocks::MockResultSetSource;
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::Eq;
 using ::testing::Return;
@@ -105,9 +107,7 @@ TEST(RowStream, IterateError) {
         break;
 
       case 1:
-        EXPECT_FALSE(row.ok());
-        EXPECT_EQ(row.status().code(), StatusCode::kUnknown);
-        EXPECT_EQ(row.status().message(), "oops");
+        EXPECT_THAT(row, StatusIs(StatusCode::kUnknown, "oops"));
         break;
 
       default:

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -25,6 +26,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
 using ::testing::AnyOf;
 using ::testing::Eq;
@@ -68,9 +70,8 @@ TEST(SqlStatementTest, GetParameterNotExist) {
                                     {"first", Value("Elwood")}};
   SqlStatement stmt("select * from foo", params);
   auto results = stmt.GetParameter("middle");
-  ASSERT_FALSE(results.ok());
-  EXPECT_EQ(StatusCode::kNotFound, results.status().code());
-  EXPECT_EQ("No such parameter: middle", results.status().message());
+  EXPECT_THAT(results,
+              StatusIs(StatusCode::kNotFound, "No such parameter: middle"));
 }
 
 TEST(SqlStatementTest, OStreamOperatorNoParams) {

--- a/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -26,6 +27,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::UnorderedElementsAreArray;
 namespace gcsa = ::google::spanner::admin::database::v1;
@@ -80,7 +82,7 @@ TEST(CleanupStaleDatabases, ListError) {
   spanner::DatabaseAdminClient client(mock);
   auto status = CleanupStaleDatabases(client, "test-project", "test-instance",
                                       std::chrono::system_clock::now());
-  EXPECT_EQ(status, Status(StatusCode::kPermissionDenied, "uh-oh"));
+  EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
 }
 
 TEST(CleanupStaleDatabases, RemovesMatching) {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -34,6 +35,8 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::HasSubstr;
 using ::testing::Not;
 
 std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
@@ -357,8 +360,8 @@ TEST(Value, BytesDecodingError) {
   // We know the type is Bytes, but we cannot get a value out of it because the
   // base64 decoding will fail.
   StatusOr<Bytes> bytes = bad.get<Bytes>();
-  EXPECT_FALSE(bytes.ok());
-  EXPECT_THAT(bytes.status().message(), testing::HasSubstr("Invalid base64"));
+  EXPECT_THAT(bytes,
+              StatusIs(Not(StatusCode::kOk), HasSubstr("Invalid base64")));
 }
 
 TEST(Value, BytesRelationalOperators) {


### PR DESCRIPTION
This was mostly pretty mechanical, a couple files that might deserve a bit more attention:

* `bytes_test.cc`: uses `ContainsRegex` instead of two `HasSubstr` calls. That imposes an order on the two substrings that did not previously exist but it LGTM and passes.
* `numeric_test.cc`: replaced the `HasStatus` matcher with the equivalent `StatusIs` invocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5211)
<!-- Reviewable:end -->
