### PR TITLE
ci: check for diffs post-build

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -430,6 +430,14 @@ if [[ "${GENERATE_DOCS}" == "yes" ]]; then
   cmake --build "${BINARY_DIR}" --target doxygen-docs -- -j "${NCPU}"
 fi
 
+# Report any differences created by the build, some steps may modify the code
+# *after* the style-checking tools run (e.g. the `*.bzl` file generators do).
+if [[ "${CHECK_STYLE:-}" == "yes" ]]; then
+  echo "================================================================"
+  io::log_yellow "checking for post-build changes is the code"
+  git diff --ignore-submodules=all --color --exit-code .
+fi
+
 if command -v ccache; then
   echo "================================================================"
   io::log_yellow "ccache stats"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -432,7 +432,7 @@ fi
 
 # Report any differences created by the build, some steps may modify the code
 # *after* the style-checking tools run (e.g. the `*.bzl` file generators do).
-if [[ "${CHECK_STYLE:-}" == "yes" ]]; then
+if [[ "${CHECK_STYLE:-}" == "yes" && "${RUNNING_CI}" == "yes" ]]; then
   echo "================================================================"
   io::log_yellow "checking for post-build changes in the code"
   git diff --ignore-submodules=all --color --exit-code .

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -434,7 +434,7 @@ fi
 # *after* the style-checking tools run (e.g. the `*.bzl` file generators do).
 if [[ "${CHECK_STYLE:-}" == "yes" ]]; then
   echo "================================================================"
-  io::log_yellow "checking for post-build changes is the code"
+  io::log_yellow "checking for post-build changes in the code"
   git diff --ignore-submodules=all --color --exit-code .
 fi
 


### PR DESCRIPTION
This can help us detect any changes introduced by the build scripts,
such as modifications to the `*.bzl` files that happen after we invoke
`ci/check-style.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5219)
<!-- Reviewable:end -->
