### PR TITLE
cleanup(pubsub)!: simplify flow control config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 **BREAKING CHANGES**:
 
-* Simplify the message flow control configuration, now that the library uses
+* Simplify the message flow control configuration. Now that the library uses
   streaming pulls, the low water marks are not used. The application developer
-  simply sets limits for the number of messages (and/or bytes) outstanding,
-  this limits are propagated to the service, and the service will stop streaming
-  if too many messages (or bytes) are outstanding. While the Pub/Sub library is
-  not GA, and this type of change is to be expected, we are close enough to a GA
-  release that we think highlight them is important.
+  simply sets limits for the number of messages (and/or bytes) outstanding.
+  These limits are propagated to the service, and the service will stop
+  streaming if too many messages (or bytes) are outstanding. While the Pub/Sub
+  library is not GA, and this type of change is to be expected, we are close
+  enough to a GA release that we think highlighting them is important.
 
 ## v1.19.0 - 2020-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
 
+
 # Changelog
 
 ## v1.20.0 - TBD
+
+### Pub/Sub
+
+**BREAKING CHANGES**:
+
+* Simplify the message flow control configuration, now that the library uses
+  streaming pulls, the low water marks are not used. The application developer
+  simply sets limits for the number of messages (and/or bytes) outstanding,
+  this limits are propagated to the service, and the service will stop streaming
+  if too many messages (or bytes) are outstanding. While the Pub/Sub library is
+  not GA, and this type of change is to be expected, we are close enough to a GA
+  release that we think highlight them is important.
 
 ## v1.19.0 - 2020-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-
-
 # Changelog
 
 ## v1.20.0 - TBD

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -53,8 +53,8 @@ class StreamingSubscriptionBatchSource
         stub_(std::move(stub)),
         subscription_full_name_(std::move(subscription_full_name)),
         client_id_(std::move(client_id)),
-        max_outstanding_messages_(options.message_count_hwm()),
-        max_outstanding_bytes_(options.message_size_hwm()),
+        max_outstanding_messages_(options.max_outstanding_messages()),
+        max_outstanding_bytes_(options.max_outstanding_bytes()),
         max_deadline_time_(options.max_deadline_time()),
         retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)) {}

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -131,8 +131,8 @@ class FakeStream {
 
 pubsub::SubscriptionOptions TestSubscriptionOptions() {
   return pubsub::SubscriptionOptions()
-      .set_message_size_watermarks(0, 100)
-      .set_message_size_watermarks(0, 100 * 1024 * 1024L)
+      .set_max_outstanding_messages(100)
+      .set_max_outstanding_bytes(100 * 1024 * 1024L)
       .set_max_deadline_time(std::chrono::seconds(300));
 }
 

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -1194,11 +1194,11 @@ void SubscriberFlowControlSettings(
     // any of the high watermarks are reached, and the library resumes
     // requesting messages when *both* low watermarks are reached.
     auto constexpr kMiB = 1024 * 1024L;
-    auto session = subscriber.Subscribe(
-        subscription, std::move(handler),
-        pubsub::SubscriptionOptions{}
-            .set_message_count_watermarks(/*lwm=*/800, /*hwm=*/1000)
-            .set_message_size_watermarks(/*lwm=*/4 * kMiB, /*hwm=*/8 * kMiB));
+    auto session =
+        subscriber.Subscribe(subscription, std::move(handler),
+                             pubsub::SubscriptionOptions{}
+                                 .set_max_outstanding_messages(1000)
+                                 .set_max_outstanding_bytes(8 * kMiB));
     {
       std::unique_lock<std::mutex> lk(mu);
       cv.wait(lk, [&] { return count >= kExpectedMessageCount; });

--- a/google/cloud/pubsub/subscription_options.cc
+++ b/google/cloud/pubsub/subscription_options.cc
@@ -20,17 +20,15 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-SubscriptionOptions& SubscriptionOptions::set_message_count_watermarks(
-    std::size_t lwm, std::size_t hwm) {
-  message_count_hwm_ = (std::max<std::size_t>)(1, hwm);
-  message_count_lwm_ = (std::min)(message_count_hwm_, lwm);
+SubscriptionOptions& SubscriptionOptions::set_max_outstanding_messages(
+    std::int64_t message_count) {
+  max_outstanding_messages_ = (std::max<std::int64_t>)(0, message_count);
   return *this;
 }
 
-SubscriptionOptions& SubscriptionOptions::set_message_size_watermarks(
-    std::size_t lwm, std::size_t hwm) {
-  message_size_hwm_ = (std::max<std::size_t>)(1, hwm);
-  message_size_lwm_ = (std::min)(message_size_hwm_, lwm);
+SubscriptionOptions& SubscriptionOptions::set_max_outstanding_bytes(
+    std::int64_t bytes) {
+  max_outstanding_bytes_ = (std::max<std::int64_t>)(0, bytes);
   return *this;
 }
 

--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -103,55 +103,40 @@ class SubscriptionOptions {
   }
 
   /**
-   * Set the parameters for message-count-based flow control.
+   * Set the maximum number of outstanding messages per streaming pull.
    *
-   * The Cloud Pub/Sub C++ client library will pull more messages from a
-   * subscription as long as the number of pending messages (that is received,
-   * but not fully processed is less than the high watermark (@p hwm). Once the
-   * @p hwm value is reached the client will not pull more messages until the
-   * number of pending messages is at or below the low watermark (@p lwm).
+   * The Cloud Pub/Sub C++ client library uses streaming pull requests to
+   * receive messages from the service. The service will stop delivering
+   * messages if more than @p message_count messages have not been acked nor
+   * nacked.
    *
    * @par Example
    * @snippet samples.cc subscriber-flow-control
    *
-   * @note applications that want to have a single pull request at a time, can
-   *     set these parameters to `lwm==0` and `hwm==1`.
-   *
-   * @param hwm the high watermark, if this parameter is `0` the high watermark
-   *     is set to `1`, to avoid starvation
-   * @param lwm the low watermark, if this parameter greater than @p hwm then
-   *    the low watermark is set to the same value as the high watermark
+   * @param message_count the maximum number of messages outstanding, use 0 or
+   *     negative numbers to make the message count unlimited.
    */
-  SubscriptionOptions& set_message_count_watermarks(std::size_t lwm,
-                                                    std::size_t hwm);
-  std::size_t message_count_lwm() const { return message_count_lwm_; }
-  std::size_t message_count_hwm() const { return message_count_hwm_; }
+  SubscriptionOptions& set_max_outstanding_messages(std::int64_t message_count);
+  std::int64_t max_outstanding_messages() const {
+    return max_outstanding_messages_;
+  }
 
   /**
-   * Set the parameters for message-size-based flow control.
+   * Set the maximum number of outstanding bytes per streaming pull.
    *
-   * The Cloud Pub/Sub C++ client library will pull more messages from a
-   * subscription as long as the total size of the pending messages (that is
-   * received, but not fully processed is less than the high watermark (@p hwm).
-   * Once the @p hwm value is reached the client will not pull more messages
-   * until the total size of the pending messages is at or below the low
-   * watermark (@p lwm).
+   * The Cloud Pub/Sub C++ client library uses streaming pull requests to
+   * receive messages from the service. The service will stop delivering
+   * messages if more than @p bytes or more worth of messages messages have
+   * not been acked nor nacked.
    *
    * @par Example
    * @snippet samples.cc subscriber-flow-control
    *
-   * @note applications that want to have a single pull request at a time, can
-   *     set these parameters to `lwm==0` and `hwm==1`.
-   *
-   * @param hwm the high watermark, if this parameter is `0` the high watermark
-   *     is set to `1`, to avoid starvation
-   * @param lwm the low watermark, if this parameter greater than @p hwm then
-   *    the low watermark is set to the same value as the high watermark
+   * @param bytes the maximum number of bytes outstanding, use 0 or negative
+   *     numbers to make the number of bytes unlimited.
    */
-  SubscriptionOptions& set_message_size_watermarks(std::size_t lwm,
-                                                   std::size_t hwm);
-  std::size_t message_size_lwm() const { return message_size_lwm_; }
-  std::size_t message_size_hwm() const { return message_size_hwm_; }
+  SubscriptionOptions& set_max_outstanding_bytes(std::int64_t bytes);
+  std::int64_t max_outstanding_bytes() const { return max_outstanding_bytes_; }
 
   /**
    * Set the high watermark and low watermarks for callback concurrency.
@@ -214,10 +199,8 @@ class SubscriptionOptions {
   }
 
   std::chrono::seconds max_deadline_time_ = std::chrono::seconds(0);
-  std::size_t message_count_lwm_ = 0;
-  std::size_t message_count_hwm_ = 1000;
-  std::size_t message_size_lwm_ = 0;
-  std::size_t message_size_hwm_ = 100 * 1024 * 1024L;
+  std::int64_t max_outstanding_messages_ = 1000;
+  std::int64_t max_outstanding_bytes_ = 100 * 1024 * 1024L;
   std::size_t concurrency_lwm_ = 0;
   std::size_t concurrency_hwm_ = DefaultConcurrencyHwm();
   std::chrono::milliseconds shutdown_polling_period_ = std::chrono::seconds(5);

--- a/google/cloud/pubsub/subscription_options.h
+++ b/google/cloud/pubsub/subscription_options.h
@@ -107,7 +107,7 @@ class SubscriptionOptions {
    *
    * The Cloud Pub/Sub C++ client library uses streaming pull requests to
    * receive messages from the service. The service will stop delivering
-   * messages if more than @p message_count messages have not been acked nor
+   * messages if @p message_count or more messages have not been acked nor
    * nacked.
    *
    * @par Example
@@ -126,8 +126,8 @@ class SubscriptionOptions {
    *
    * The Cloud Pub/Sub C++ client library uses streaming pull requests to
    * receive messages from the service. The service will stop delivering
-   * messages if more than @p bytes or more worth of messages messages have
-   * not been acked nor nacked.
+   * messages if @p bytes or more worth of messages have not been acked nor
+   * nacked.
    *
    * @par Example
    * @snippet samples.cc subscriber-flow-control

--- a/google/cloud/pubsub/subscription_options_test.cc
+++ b/google/cloud/pubsub/subscription_options_test.cc
@@ -23,40 +23,26 @@ namespace {
 
 TEST(SubscriptionOptionsTest, Default) {
   SubscriptionOptions const options{};
-  EXPECT_LE(options.message_count_lwm(), options.message_count_hwm());
-  EXPECT_LT(0, options.message_count_hwm());
-  EXPECT_LE(options.message_size_lwm(), options.message_size_hwm());
-  EXPECT_LT(0, options.message_size_hwm());
+  EXPECT_LT(0, options.max_outstanding_messages());
+  EXPECT_LT(0, options.max_outstanding_bytes());
   EXPECT_LE(options.concurrency_lwm(), options.concurrency_hwm());
   EXPECT_LT(0, options.concurrency_hwm());
 }
 
 TEST(SubscriptionOptionsTest, SetMessageCount) {
-  auto options = SubscriptionOptions{}.set_message_count_watermarks(8, 16);
-  EXPECT_EQ(16, options.message_count_hwm());
-  EXPECT_EQ(8, options.message_count_lwm());
+  auto options = SubscriptionOptions{}.set_max_outstanding_messages(16);
+  EXPECT_EQ(16, options.max_outstanding_messages());
 
-  options.set_message_count_watermarks(0, 0);
-  EXPECT_EQ(1, options.message_count_hwm());
-  EXPECT_EQ(0, options.message_count_lwm());
-
-  options.set_message_count_watermarks(10, 5);
-  EXPECT_EQ(5, options.message_count_hwm());
-  EXPECT_EQ(5, options.message_count_lwm());
+  options.set_max_outstanding_messages(-7);
+  EXPECT_EQ(0, options.max_outstanding_messages());
 }
 
-TEST(SubscriptionOptionsTest, SetMessageSize) {
-  auto options = SubscriptionOptions{}.set_message_size_watermarks(8, 16);
-  EXPECT_EQ(16, options.message_size_hwm());
-  EXPECT_EQ(8, options.message_size_lwm());
+TEST(SubscriptionOptionsTest, SetBytes) {
+  auto options = SubscriptionOptions{}.set_max_outstanding_bytes(16 * 1024);
+  EXPECT_EQ(16 * 1024, options.max_outstanding_bytes());
 
-  options.set_message_size_watermarks(0, 0);
-  EXPECT_EQ(1, options.message_size_hwm());
-  EXPECT_EQ(0, options.message_size_lwm());
-
-  options.set_message_size_watermarks(10, 5);
-  EXPECT_EQ(5, options.message_size_hwm());
-  EXPECT_EQ(5, options.message_size_lwm());
+  options.set_max_outstanding_bytes(-7);
+  EXPECT_EQ(0, options.max_outstanding_bytes());
 }
 
 TEST(SubscriptionOptionsTest, SetConcurrency) {


### PR DESCRIPTION
**BREAKING CHANGE**:

* Simplify the message flow control configuration, now that the library uses
  streaming pulls, the low water marks are not used. The application developer
  simply sets limits for the number of messages (and/or bytes) outstanding,
  this limits are propagated to the service, and the service will stop streaming
  if too many messages (or bytes) are outstanding. While the Pub/Sub library is
  not GA, and this type of change is to be expected, we are close enough to a GA
  release that we think highlight them is important.

Fixes #5195

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5226)
<!-- Reviewable:end -->
