### PR TITLE
fix(storage): Make private_key_id optional for JSON credentials

### DIFF
--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -42,8 +42,7 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
   std::string const private_key_key = "private_key";
   std::string const token_uri_key = "token_uri";
   std::string const client_email_key = "client_email";
-  for (auto const& key :
-       {private_key_id_key, private_key_key, client_email_key}) {
+  for (auto const& key : {private_key_key, client_email_key}) {
     if (credentials.count(key) == 0) {
       return Status(StatusCode::kInvalidArgument,
                     "Invalid ServiceAccountCredentials, the " +
@@ -189,8 +188,10 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
 std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,
     std::chrono::system_clock::time_point now) {
-  nlohmann::json assertion_header = {
-      {"alg", "RS256"}, {"kid", info.private_key_id}, {"typ", "JWT"}};
+  nlohmann::json assertion_header = {{"alg", "RS256"}, {"typ", "JWT"}};
+  if (info.private_key_id) {
+    assertion_header["kid"] = *(info.private_key_id);
+  }
 
   // Scopes must be specified in a comma-delimited string.
   std::string scope_str;

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -189,8 +189,8 @@ std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,
     std::chrono::system_clock::time_point now) {
   nlohmann::json assertion_header = {{"alg", "RS256"}, {"typ", "JWT"}};
-  if (info.private_key_id) {
-    assertion_header["kid"] = *(info.private_key_id);
+  if (!info.private_key_id.empty()) {
+    assertion_header["kid"] = info.private_key_id;
   }
 
   // Scopes must be specified in a comma-delimited string.

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -38,7 +38,7 @@ namespace oauth2 {
 /// Object to hold information used to instantiate an ServiceAccountCredentials.
 struct ServiceAccountCredentialsInfo {
   std::string client_email;
-  std::string private_key_id;
+  absl::optional<std::string> private_key_id;
   std::string private_key;
   std::string token_uri;
   // If no set is supplied, a default set of scopes will be used.
@@ -184,7 +184,9 @@ class ServiceAccountCredentials : public Credentials {
   }
 
   std::string AccountEmail() const override { return info_.client_email; }
-  std::string KeyId() const override { return info_.private_key_id; }
+  std::string KeyId() const override {
+    return info_.private_key_id.value_or("");
+  }
 
  private:
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh() {

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -38,7 +38,7 @@ namespace oauth2 {
 /// Object to hold information used to instantiate an ServiceAccountCredentials.
 struct ServiceAccountCredentialsInfo {
   std::string client_email;
-  absl::optional<std::string> private_key_id;
+  std::string private_key_id;
   std::string private_key;
   std::string token_uri;
   // If no set is supplied, a default set of scopes will be used.
@@ -184,9 +184,7 @@ class ServiceAccountCredentials : public Credentials {
   }
 
   std::string AccountEmail() const override { return info_.client_email; }
-  std::string KeyId() const override {
-    return info_.private_key_id.value_or("");
-  }
+  std::string KeyId() const override { return info_.private_key_id; }
 
  private:
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh() {


### PR DESCRIPTION
Fixes: #5227

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5230)
<!-- Reviewable:end -->
