### PR TITLE
test: clang-tidy fixes

### DIFF
--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -30,7 +30,6 @@ namespace {
 
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AnyOf;
-using ::testing::Eq;
 
 /**
  * @test Verify GrpcClient and HybridClient report failures correctly.


### PR DESCRIPTION
These passed the PR build because we get false positives (and therefore
ignore) `misc-unused-using-decls` in the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5240)
<!-- Reviewable:end -->
