### PR TITLE
cleanup(pubsub)!: inconsistent names in PublisherOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 While the Pub/Sub library is not GA, and breaking changes are to be expected, we
 are close enough to a GA release that we think highlighting them is important.
 
+* Fix inconsistent naming for `PublisherOptions` attributes controlling the
+  maximum number of messages per batch and the maximum number of bytes per
+  batch.
+
 * Rename `TopicMutationBuilder` to `TopicBuilder`, and
   `SubscriptionMutationBuilder` to `SubscriptionBuilder`. This makes the C++
   library more familiar for Cloud Pub/Sub developers coming from other

--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -79,7 +79,7 @@ void BatchingPublisherConnection::Flush(FlushParams) {
 }
 
 void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
-  if (pending_.size() >= options_.maximum_message_count()) {
+  if (pending_.size() >= options_.maximum_batch_message_count()) {
     FlushImpl(std::move(lk));
     return;
   }

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -58,7 +58,7 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
-          .set_maximum_message_count(4)
+          .set_maximum_batch_message_count(4)
           .set_maximum_hold_time(std::chrono::milliseconds(50)),
       mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
@@ -112,8 +112,9 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
   // due to the zero-maximum-hold-time timer expiring.
   google::cloud::CompletionQueue cq;
   auto publisher = BatchingPublisherConnection::Create(
-      topic, pubsub::PublisherOptions{}.set_maximum_message_count(2), mock, cq,
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
+      mock, cq, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   auto r0 =
       publisher
           ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
@@ -168,8 +169,8 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
-          .set_maximum_message_count(4)
-          .set_maximum_batch_bytes(kMaxMessageBytes),
+          .set_maximum_batch_message_count(4)
+          .set_maximum_batch_message_count(kMaxMessageBytes),
       mock, cq, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto r0 =
@@ -223,7 +224,7 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
-          .set_maximum_message_count(4),
+          .set_maximum_batch_message_count(4),
       mock, cq, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto r0 =
@@ -287,7 +288,7 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
-          .set_maximum_message_count(4),
+          .set_maximum_batch_message_count(4),
       mock, cq, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
 
@@ -341,8 +342,8 @@ TEST(BatchingPublisherConnectionTest, HandleError) {
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
   auto publisher = BatchingPublisherConnection::Create(
-      topic, pubsub::PublisherOptions{}.set_maximum_message_count(2), mock,
-      bg.cq(), pubsub_testing::TestRetryPolicy(),
+      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
+      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
@@ -376,8 +377,8 @@ TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
   auto publisher = BatchingPublisherConnection::Create(
-      topic, pubsub::PublisherOptions{}.set_maximum_message_count(2), mock,
-      bg.cq(), pubsub_testing::TestRetryPolicy(),
+      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
+      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -170,7 +170,7 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
-          .set_maximum_batch_message_count(kMaxMessageBytes),
+          .set_maximum_batch_bytes(kMaxMessageBytes),
       mock, cq, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto r0 =

--- a/google/cloud/pubsub/publisher_option_test.cc
+++ b/google/cloud/pubsub/publisher_option_test.cc
@@ -29,9 +29,9 @@ TEST(PublisherOptions, Setters) {
   auto const b = PublisherOptions{}
                      .set_maximum_hold_time(std::chrono::seconds(12))
                      .set_maximum_batch_bytes(123)
-                     .set_maximum_message_count(10)
+                     .set_maximum_batch_message_count(10)
                      .enable_message_ordering();
-  EXPECT_EQ(10, b.maximum_message_count());
+  EXPECT_EQ(10, b.maximum_batch_message_count());
   EXPECT_EQ(123, b.maximum_batch_bytes());
   auto const expected = std::chrono::duration_cast<std::chrono::microseconds>(
       std::chrono::seconds(12));

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -74,7 +74,9 @@ class PublisherOptions {
     return *this;
   }
 
-  std::size_t maximum_message_count() const { return maximum_message_count_; }
+  std::size_t maximum_batch_message_count() const {
+    return maximum_batch_message_count_;
+  }
 
   /**
    * Set the maximum number of messages in a batch.
@@ -86,8 +88,8 @@ class PublisherOptions {
    *
    * [pubsub-quota-link]: https://cloud.google.com/pubsub/quotas#resource_limits
    */
-  PublisherOptions& set_maximum_message_count(std::size_t v) {
-    maximum_message_count_ = v;
+  PublisherOptions& set_maximum_batch_message_count(std::size_t v) {
+    maximum_batch_message_count_ = v;
     return *this;
   }
 
@@ -134,7 +136,7 @@ class PublisherOptions {
   static std::size_t constexpr kDefaultMaximumMessageSize = 1024 * 1024L;
 
   std::chrono::microseconds maximum_hold_time_ = kDefaultMaximumHoldTime;
-  std::size_t maximum_message_count_ = kDefaultMaximumMessageCount;
+  std::size_t maximum_batch_message_count_ = kDefaultMaximumMessageCount;
   std::size_t maximum_batch_bytes_ = kDefaultMaximumMessageSize;
   bool message_ordering_ = false;
   bool retry_publish_failures_ = false;

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -1026,7 +1026,7 @@ void CustomBatchPublisher(std::vector<std::string> const& argv) {
         pubsub::PublisherOptions{}
             .set_maximum_hold_time(std::chrono::milliseconds(20))
             .set_maximum_batch_bytes(4 * 1024 * 1024L)
-            .set_maximum_message_count(200),
+            .set_maximum_batch_message_count(200),
         pubsub::ConnectionOptions{}));
 
     std::vector<future<void>> ids;
@@ -1419,9 +1419,8 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto topic = google::cloud::pubsub::Topic(project_id, topic_id);
   auto publisher = google::cloud::pubsub::Publisher(
       google::cloud::pubsub::MakePublisherConnection(
-          topic,
-          google::cloud::pubsub::PublisherOptions{}.set_maximum_message_count(
-              1)));
+          topic, google::cloud::pubsub::PublisherOptions{}
+                     .set_maximum_batch_message_count(1)));
   auto subscription =
       google::cloud::pubsub::Subscription(project_id, subscription_id);
   auto subscriber = google::cloud::pubsub::Subscriber(
@@ -1483,7 +1482,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto publisher_with_ordering_key = google::cloud::pubsub::Publisher(
       google::cloud::pubsub::MakePublisherConnection(
           topic, google::cloud::pubsub::PublisherOptions{}
-                     .set_maximum_message_count(1)
+                     .set_maximum_batch_message_count(1)
                      .enable_message_ordering()));
   std::cout << "\nRunning PublishOrderingKey() sample" << std::endl;
 


### PR DESCRIPTION
**BREAKING CHANGE**

* Fix inconsistent naming for `PublisherOptions` attributes controlling the
  maximum number of messages per batch and the maximum number of bytes per
  batch.

Fixes #5196

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5242)
<!-- Reviewable:end -->
