### PR TITLE
cleanup(pubsub)!: remove redundant publisher option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 While the Pub/Sub library is not GA, and breaking changes are to be expected, we
 are close enough to a GA release that we think highlighting them is important.
 
+* Remove option to disable retries in `Publisher::Publish`. This is redundant as
+  the application can set a "no retries" retry policy. This is more consistent
+  with other Cloud Pub/Sub libraries. We include an example showing how to
+  configure a "no retries" retry policy.
+
 * Fix inconsistent naming for `PublisherOptions` attributes controlling the
   maximum number of messages per batch and the maximum number of bytes per
   batch.

--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -144,13 +144,10 @@ void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
   pending_.clear();
   lk.unlock();
 
-  auto const idempotency =
-      options_.retry_publish_failures()
-          ? google::cloud::internal::Idempotency::kIdempotent
-          : google::cloud::internal::Idempotency::kNonIdempotent;
   auto& stub = stub_;
   google::cloud::internal::AsyncRetryLoop(
-      retry_policy_->clone(), backoff_policy_->clone(), idempotency, cq_,
+      retry_policy_->clone(), backoff_policy_->clone(),
+      google::cloud::internal::Idempotency::kIdempotent, cq_,
       [stub](google::cloud::CompletionQueue& cq,
              std::unique_ptr<grpc::ClientContext> context,
              google::pubsub::v1::PublishRequest const& request) {

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -115,19 +115,22 @@ class Publisher {
   /**
    * Publishes a message to this publisher's topic
    *
-   * Note that the message may be batched based on the Publisher's
+   * Note that the message may be batched, depending on the Publisher's
    * configuration. It could be delayed until the batch has enough messages,
    * or enough data, or enough time has elapsed. See the `PublisherOptions`
    * documentation for more details.
    *
    * @par Idempotency
-   * This is a non-idempotent operation. By default the request is *not* retried
-   * if there is a transient error. Applications wanting to retry requests can
-   * do so by enabling the `retry_publish_failures()` parameter in the
-   * `PublisherOptions`.
+   * This is a non-idempotent operation. As Cloud Pub/Sub has "at least once"
+   * delivery semantics applications are expected to handle duplicate messages
+   * without problems. However, if the application does not want to retry these
+   * requests they can set the retry policy as shown in the example below.
    *
    * @par Example
    * @snippet samples.cc publish
+   *
+   * @par Disabling Retries Example
+   * @snippet samples.cc publisher-disable-retries
    *
    * @par Changing Retry Parameters Example
    * @snippet samples.cc publisher-retry-settings

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -202,8 +202,8 @@ TEST(PublisherConnectionTest, HandleTooManyFailures) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}.enable_retry_publish_failures(), {}, mock,
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      topic, PublisherOptions{}, {}, mock, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
           .get();
@@ -246,8 +246,9 @@ TEST(PublisherConnectionTest, HandleTransientDisabledRetry) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}.disable_retry_publish_failures(), {}, mock,
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      topic, PublisherOptions{}, {}, mock,
+      pubsub::LimitedErrorCountRetryPolicy(/*maximum_failures=*/0).clone(),
+      pubsub_testing::TestBackoffPolicy());
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
           .get();
@@ -278,8 +279,8 @@ TEST(PublisherConnectionTest, HandleTransientEnabledRetry) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}.enable_retry_publish_failures(), {}, mock,
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      topic, PublisherOptions{}, {}, mock, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   auto response =
       publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
           .get();

--- a/google/cloud/pubsub/publisher_option_test.cc
+++ b/google/cloud/pubsub/publisher_option_test.cc
@@ -37,6 +37,10 @@ TEST(PublisherOptions, Setters) {
       std::chrono::seconds(12));
   EXPECT_EQ(expected, b.maximum_hold_time());
   EXPECT_TRUE(b.message_ordering());
+
+  auto const b1 =
+      PublisherOptions{}.enable_message_ordering().disable_message_ordering();
+  EXPECT_FALSE(b1.message_ordering());
 }
 
 }  // namespace

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -120,16 +120,6 @@ class PublisherOptions {
     return *this;
   }
 
-  bool retry_publish_failures() const { return retry_publish_failures_; }
-  PublisherOptions& enable_retry_publish_failures() {
-    retry_publish_failures_ = true;
-    return *this;
-  }
-  PublisherOptions& disable_retry_publish_failures() {
-    retry_publish_failures_ = false;
-    return *this;
-  }
-
  private:
   static auto constexpr kDefaultMaximumHoldTime = std::chrono::milliseconds(10);
   static std::size_t constexpr kDefaultMaximumMessageCount = 100;
@@ -139,7 +129,6 @@ class PublisherOptions {
   std::size_t maximum_batch_message_count_ = kDefaultMaximumMessageCount;
   std::size_t maximum_batch_bytes_ = kDefaultMaximumMessageSize;
   bool message_ordering_ = false;
-  bool retry_publish_failures_ = false;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
**BREAKING CHANGE**:

* Remove option to disable retries in `Publisher::Publish`. This is redundant as
  the application can set a "no retries" retry policy. This is more consistent
  with other Cloud Pub/Sub libraries. We include an example showing how to
  configure a "no retries" retry policy.

Fixes #5206 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5244)
<!-- Reviewable:end -->
