### PR TITLE
cleanup(pubsub)!: make Subscriber more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@
 
 ### Pub/Sub
 
-**BREAKING CHANGES**:
+**BREAKING CHANGES:**
 
 While the Pub/Sub library is not GA, and breaking changes are to be expected, we
 are close enough to a GA release that we think highlighting them is important.
+
+* Change the `pubsub::Subscriber` API. A `Subscriber` is now bound to a specific
+  Cloud Pub/Sub subscription, with a fixed set of `SuscriptionOptions`, just
+  like a `pubsub::Publisher` is bound to a specific topic and a set of
+  `PublisherOptions`. In addition to making publishers and subscribers more
+  symmetrical, this makes the library more consistent with the Cloud Pub/Sub
+  library for other languages. Finally, note that we are planning to rename
+  `SubscriptionOptions` to `SubscriberOptions` in a future PR too.
 
 * Remove option to disable retries in `Publisher::Publish`. This is redundant as
   the application can set a "no retries" retry policy. This is more consistent

--- a/google/cloud/pubsub/integration_tests/message_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/message_integration_test.cc
@@ -69,7 +69,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
       AnyOf(StatusIs(StatusCode::kOk), StatusIs(StatusCode::kAlreadyExists)));
 
   auto publisher = Publisher(MakePublisherConnection(topic, {}));
-  auto subscriber = Subscriber(MakeSubscriberConnection());
+  auto subscriber = Subscriber(MakeSubscriberConnection(subscription));
 
   std::mutex mu;
   std::map<std::string, int> ids;
@@ -106,7 +106,7 @@ TEST(MessageIntegrationTest, PublishPullAck) {
     std::move(h).ack();
   };
 
-  auto result = subscriber.Subscribe(subscription, handler);
+  auto result = subscriber.Subscribe(handler);
   // Wait until there are no more ids pending, then cancel the subscription and
   // get its status.
   ids_empty.get_future().get();

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -29,6 +29,7 @@ class SubscriptionSessionImpl
     : public std::enable_shared_from_this<SubscriptionSessionImpl> {
  public:
   static future<Status> Create(
+      pubsub::SubscriptionOptions const& options,
       google::cloud::CompletionQueue executor,
       std::shared_ptr<SessionShutdownManager> shutdown_manager,
       std::shared_ptr<SubscriptionBatchSource> source,
@@ -36,12 +37,12 @@ class SubscriptionSessionImpl
     auto queue =
         SubscriptionMessageQueue::Create(shutdown_manager, std::move(source));
     auto concurrency_control = SubscriptionConcurrencyControl::Create(
-        executor, shutdown_manager, std::move(queue),
-        p.options.concurrency_lwm(), p.options.concurrency_hwm());
+        executor, shutdown_manager, std::move(queue), options.concurrency_lwm(),
+        options.concurrency_hwm());
 
     auto self = std::make_shared<SubscriptionSessionImpl>(
         std::move(executor), std::move(shutdown_manager),
-        std::move(concurrency_control), p.options.shutdown_polling_period());
+        std::move(concurrency_control), options.shutdown_polling_period());
 
     auto weak = std::weak_ptr<SubscriptionSessionImpl>(self);
     auto result = self->shutdown_manager_->Start(promise<Status>([weak] {
@@ -157,6 +158,8 @@ class SubscriptionSessionImpl
 }  // namespace
 
 future<Status> CreateSubscriptionSession(
+    pubsub::Subscription const& subscription,
+    pubsub::SubscriptionOptions const& options,
     std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
     google::cloud::CompletionQueue const& executor, std::string client_id,
     pubsub::SubscriberConnection::SubscribeParams p,
@@ -164,19 +167,21 @@ future<Status> CreateSubscriptionSession(
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
   auto shutdown_manager = std::make_shared<SessionShutdownManager>();
   auto batch = std::make_shared<StreamingSubscriptionBatchSource>(
-      executor, shutdown_manager, stub, std::move(p.full_subscription_name),
-      std::move(client_id), p.options, std::move(retry_policy),
+      executor, shutdown_manager, stub, subscription.FullName(),
+      std::move(client_id), options, std::move(retry_policy),
       std::move(backoff_policy));
   auto lease_management = SubscriptionLeaseManagement::Create(
       executor, shutdown_manager, std::move(batch),
-      p.options.max_deadline_time());
+      options.max_deadline_time());
 
   return SubscriptionSessionImpl::Create(
-      std::move(executor), std::move(shutdown_manager),
+      options, std::move(executor), std::move(shutdown_manager),
       std::move(lease_management), std::move(p));
 }
 
 future<Status> CreateTestingSubscriptionSession(
+    pubsub::Subscription const& subscription,
+    pubsub::SubscriptionOptions const& options,
     std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
     google::cloud::CompletionQueue const& executor,
     pubsub::SubscriberConnection::SubscribeParams p,
@@ -194,8 +199,8 @@ future<Status> CreateTestingSubscriptionSession(
   }
   auto shutdown_manager = std::make_shared<SessionShutdownManager>();
   auto batch = std::make_shared<StreamingSubscriptionBatchSource>(
-      executor, shutdown_manager, stub, std::move(p.full_subscription_name),
-      "test-client-id", p.options, std::move(retry_policy),
+      executor, shutdown_manager, stub, subscription.FullName(),
+      "test-client-id", options, std::move(retry_policy),
       std::move(backoff_policy));
 
   auto cq = executor;  // need a copy to make it mutable
@@ -207,10 +212,10 @@ future<Status> CreateTestingSubscriptionSession(
   };
   auto lease_management = SubscriptionLeaseManagement::CreateForTesting(
       executor, shutdown_manager, timer, std::move(batch),
-      p.options.max_deadline_time());
+      options.max_deadline_time());
 
   return SubscriptionSessionImpl::Create(
-      std::move(executor), std::move(shutdown_manager),
+      options, std::move(executor), std::move(shutdown_manager),
       std::move(lease_management), std::move(p));
 }
 

--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -34,6 +34,8 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 future<Status> CreateSubscriptionSession(
+    pubsub::Subscription const& subscription,
+    pubsub::SubscriptionOptions const& options,
     std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
     google::cloud::CompletionQueue const& executor, std::string client_id,
     pubsub::SubscriberConnection::SubscribeParams p,
@@ -41,6 +43,8 @@ future<Status> CreateSubscriptionSession(
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
 
 future<Status> CreateTestingSubscriptionSession(
+    pubsub::Subscription const& subscription,
+    pubsub::SubscriptionOptions const& options,
     std::shared_ptr<pubsub_internal::SubscriberStub> const& stub,
     google::cloud::CompletionQueue const& executor,
     pubsub::SubscriberConnection::SubscribeParams p,

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -137,9 +137,9 @@ TEST(SubscriptionSessionTest, ScheduleCallbacks) {
   };
 
   auto response = CreateTestingSubscriptionSession(
-      mock, cq,
-      {subscription.FullName(), handler,
-       pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, 1)});
+      subscription,
+      pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, 1), mock, cq,
+      {handler});
   {
     std::unique_lock<std::mutex> lk(ack_id_mu);
     ack_id_cv.wait(lk, [&] { return expected_ack_id >= kAckCount; });
@@ -178,9 +178,9 @@ TEST(SubscriptionSessionTest, SequencedCallbacks) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
   auto response = CreateTestingSubscriptionSession(
-      mock, cq,
-      {subscription.FullName(), handler,
-       pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, 1)});
+      subscription,
+      pubsub::SubscriptionOptions{}.set_concurrency_watermarks(0, 1), mock, cq,
+      {handler});
   enough_messages.get_future()
       .then([&](future<void>) { response.cancel(); })
       .get();
@@ -212,12 +212,12 @@ TEST(SubscriptionSessionTest, ShutdownNackCallbacks) {
 
   google::cloud::CompletionQueue cq;
   auto response = CreateTestingSubscriptionSession(
-      mock, cq,
-      {subscription.FullName(), handler,
-       pubsub::SubscriptionOptions{}
-           .set_max_outstanding_messages(1)
-           .set_max_outstanding_bytes(1)
-           .set_max_deadline_time(std::chrono::seconds(60))});
+      subscription,
+      pubsub::SubscriptionOptions{}
+          .set_max_outstanding_messages(1)
+          .set_max_outstanding_bytes(1)
+          .set_max_deadline_time(std::chrono::seconds(60)),
+      mock, cq, {handler});
   // Setup the system to cancel after the second message.
   auto done = enough_messages.get_future().then(
       [&](future<void>) { response.cancel(); });
@@ -256,9 +256,9 @@ TEST(SubscriptionSessionTest, ShutdownWaitsFutures) {
     };
 
     auto session = CreateSubscriptionSession(
-        mock, background.cq(), "fake-client-id",
-        {subscription.FullName(), handler, pubsub::SubscriptionOptions{}},
-        pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+        subscription, pubsub::SubscriptionOptions{}, mock, background.cq(),
+        "fake-client-id", {handler}, pubsub_testing::TestRetryPolicy(),
+        pubsub_testing::TestBackoffPolicy());
     got_one.get_future()
         .then([&session](future<void>) { session.cancel(); })
         .get();
@@ -316,8 +316,7 @@ TEST(SubscriptionSessionTest, ShutdownWaitsConditionVars) {
     };
 
     auto session = CreateSubscriptionSession(
-        mock, background.cq(), "fake-client-id",
-        {subscription.FullName(), handler, {}},
+        subscription, {}, mock, background.cq(), "fake-client-id", {handler},
         pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
     {
       std::unique_lock<std::mutex> lk(mu);
@@ -378,10 +377,10 @@ TEST(SubscriptionSessionTest, ShutdownWaitsEarlyAcks) {
     };
 
     auto session = CreateSubscriptionSession(
-        mock, background.cq(), "fake-client-id",
-        {subscription.FullName(), handler,
-         pubsub::SubscriptionOptions{}.set_concurrency_watermarks(
-             kMessageCount / 2, 2 * kMessageCount)},
+        subscription,
+        pubsub::SubscriptionOptions{}.set_concurrency_watermarks(
+            kMessageCount / 2, 2 * kMessageCount),
+        mock, background.cq(), "fake-client-id", {handler},
         pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
     {
       std::unique_lock<std::mutex> lk(mu);
@@ -439,12 +438,12 @@ TEST(SubscriptionSessionTest, FireAndForget) {
       };
 
       (void)CreateSubscriptionSession(
-          mock, background.cq(), "fake-client-id",
-          {subscription.FullName(), handler,
-           pubsub::SubscriptionOptions{}
-               .set_max_outstanding_messages(kMessageCount / 2)
-               .set_concurrency_watermarks(0, kMessageCount / 2)
-               .set_shutdown_polling_period(std::chrono::milliseconds(20))},
+          subscription,
+          pubsub::SubscriptionOptions{}
+              .set_max_outstanding_messages(kMessageCount / 2)
+              .set_concurrency_watermarks(0, kMessageCount / 2)
+              .set_shutdown_polling_period(std::chrono::milliseconds(20)),
+          mock, background.cq(), "fake-client-id", {handler},
           pubsub_testing::TestRetryPolicy(),
           pubsub_testing::TestBackoffPolicy())
           .then([&](future<Status> f) {

--- a/google/cloud/pubsub/samples/mock_subscriber.cc
+++ b/google/cloud/pubsub/samples/mock_subscriber.cc
@@ -86,8 +86,7 @@ TEST(MockSubscribeExample, Subscribe) {
     payloads.push_back(m.data());
     std::move(h).ack();
   };
-  auto session = subscriber.Subscribe(
-      pubsub::Subscription("mock-project", "mock-subscription"), handler);
+  auto session = subscriber.Subscribe(handler);
   //! [client-call]
 
   //! [expected-results]

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -59,9 +59,9 @@ google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
       }
       throw google::cloud::testing_util::Usage{std::move(os).str()};
     }
-    pubsub::Subscription subscription(argv.at(0), argv.at(1));
     google::cloud::pubsub::Subscriber client(
-        google::cloud::pubsub::MakeSubscriberConnection(subscription));
+        google::cloud::pubsub::MakeSubscriberConnection(
+            pubsub::Subscription(argv.at(0), argv.at(1))));
     argv.erase(argv.begin(), argv.begin() + 2);
     command(std::move(client), std::move(argv));
   };

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -63,7 +63,7 @@ google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
     google::cloud::pubsub::Subscriber client(
         google::cloud::pubsub::MakeSubscriberConnection(subscription));
     argv.erase(argv.begin(), argv.begin() + 2);
-    command(std::move(client), std::move(subscription), std::move(argv));
+    command(std::move(client), std::move(argv));
   };
   return google::cloud::testing_util::Commands::value_type{name,
                                                            std::move(adapter)};

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -59,9 +59,9 @@ google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
       }
       throw google::cloud::testing_util::Usage{std::move(os).str()};
     }
-    google::cloud::pubsub::Subscriber client(
-        google::cloud::pubsub::MakeSubscriberConnection());
     pubsub::Subscription subscription(argv.at(0), argv.at(1));
+    google::cloud::pubsub::Subscriber client(
+        google::cloud::pubsub::MakeSubscriberConnection(subscription));
     argv.erase(argv.begin(), argv.begin() + 2);
     command(std::move(client), std::move(subscription), std::move(argv));
   };

--- a/google/cloud/pubsub/samples/pubsub_samples_common.h
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.h
@@ -33,9 +33,8 @@ google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
     std::string const& name, std::vector<std::string> const& arg_names,
     PublisherCommand const& command);
 
-using SubscriberCommand = std::function<void(
-    pubsub::Subscriber, pubsub::Subscription const& subscription,
-    std::vector<std::string> const&)>;
+using SubscriberCommand =
+    std::function<void(pubsub::Subscriber, std::vector<std::string> const&)>;
 
 google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
     std::string const& name, std::vector<std::string> const& arg_names,

--- a/google/cloud/pubsub/samples/pubsub_samples_common_test.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common_test.cc
@@ -65,7 +65,6 @@ TEST(PubSubSamplesCommon, SubscriberCommand) {
       "PUBSUB_EMULATOR_HOST", "localhost:8085");
   int call_count = 0;
   auto command = [&call_count](pubsub::Subscriber const&,
-                               pubsub::Subscription const&,
                                std::vector<std::string> const& argv) {
     ++call_count;
     ASSERT_EQ(2, argv.size());

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -341,7 +341,6 @@ void UpdateDeadLetterSubscription(
 
 void ReceiveDeadLetterDeliveryAttempt(
     google::cloud::pubsub::Subscriber subscriber,
-    google::cloud::pubsub::Subscription const&,
     std::vector<std::string> const&) {
   //! [dead-letter-delivery-attempt]
   // [START pubsub_dead_letter_delivery_attempt]
@@ -755,7 +754,6 @@ void PublishOrderingKey(google::cloud::pubsub::Publisher publisher,
 }
 
 void Subscribe(google::cloud::pubsub::Subscriber subscriber,
-               google::cloud::pubsub::Subscription const&,
                std::vector<std::string> const&) {
   //! [START pubsub_quickstart_subscriber]
   //! [START pubsub_subscriber_async_pull] [subscribe]
@@ -794,7 +792,6 @@ void Subscribe(google::cloud::pubsub::Subscriber subscriber,
 }
 
 void SubscribeErrorListener(google::cloud::pubsub::Subscriber subscriber,
-                            google::cloud::pubsub::Subscription const&,
                             std::vector<std::string> const&) {
   // [START pubsub_subscriber_error_listener]
   namespace pubsub = google::cloud::pubsub;
@@ -837,7 +834,6 @@ void SubscribeErrorListener(google::cloud::pubsub::Subscriber subscriber,
 }
 
 void SubscribeCustomAttributes(google::cloud::pubsub::Subscriber subscriber,
-                               google::cloud::pubsub::Subscription const&,
                                std::vector<std::string> const&) {
   //! [START pubsub_subscriber_async_pull_custom_attributes]
   namespace pubsub = google::cloud::pubsub;
@@ -1474,21 +1470,20 @@ void AutoRun(std::vector<std::string> const& argv) {
   PublishCustomAttributes(publisher, {});
 
   std::cout << "\nRunning Subscribe() sample" << std::endl;
-  Subscribe(subscriber, subscription, {});
+  Subscribe(subscriber, {});
 
   std::cout << "\nRunning Publish() sample [2]" << std::endl;
   Publish(publisher, {});
 
   std::cout << "\nRunning SubscribeErrorListener() sample" << std::endl;
-  SubscribeErrorListener(subscriber, subscription, {});
+  SubscribeErrorListener(subscriber, {});
 
   std::cout << "\nRunning Publish() sample [3]" << std::endl;
   Publish(publisher, {});
 
   std::cout << "\nRunning ReceiveDeadLetterDeliveryAttempt() sample"
             << std::endl;
-  ReceiveDeadLetterDeliveryAttempt(dead_letter_subscriber,
-                                   dead_letter_subscription, {});
+  ReceiveDeadLetterDeliveryAttempt(dead_letter_subscriber, {});
 
   std::cout << "\nRunning RemoveDeadLetterPolicy() sample" << std::endl;
   RemoveDeadLetterPolicy(subscription_admin_client,
@@ -1517,7 +1512,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   PublishCustomAttributes(publisher, {});
 
   std::cout << "\nRunning SubscribeCustomAttributes() sample" << std::endl;
-  SubscribeCustomAttributes(subscriber, subscription, {});
+  SubscribeCustomAttributes(subscriber, {});
 
   auto publisher_with_ordering_key = google::cloud::pubsub::Publisher(
       google::cloud::pubsub::MakePublisherConnection(

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -341,18 +341,18 @@ void UpdateDeadLetterSubscription(
 
 void ReceiveDeadLetterDeliveryAttempt(
     google::cloud::pubsub::Subscriber subscriber,
-    google::cloud::pubsub::Subscription const& subscription,
+    google::cloud::pubsub::Subscription const&,
     std::vector<std::string> const&) {
   //! [dead-letter-delivery-attempt]
   // [START pubsub_dead_letter_delivery_attempt]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
-  [](pubsub::Subscriber subscriber, pubsub::Subscription const& subscription) {
+  [](pubsub::Subscriber subscriber) {
     std::mutex mu;
     std::condition_variable cv;
     int message_count = 0;
     auto session = subscriber.Subscribe(
-        subscription, [&](pubsub::Message const& m, pubsub::AckHandler h) {
+        [&](pubsub::Message const& m, pubsub::AckHandler h) {
           std::cout << "Received message " << m << "\n";
           std::cout << "Delivery attempt: " << h.delivery_attempt() << "\n";
           std::unique_lock<std::mutex> lk(mu);
@@ -373,7 +373,7 @@ void ReceiveDeadLetterDeliveryAttempt(
     // Report any final status, blocking.
     std::cout << "Message count: " << message_count << ", status: " << status
               << "\n";
-  }(std::move(subscriber), std::move(subscription));
+  }(std::move(subscriber));
   // [END pubsub_dead_letter_delivery_attempt]
   //! [dead-letter-delivery-attempt]
 }
@@ -755,19 +755,19 @@ void PublishOrderingKey(google::cloud::pubsub::Publisher publisher,
 }
 
 void Subscribe(google::cloud::pubsub::Subscriber subscriber,
-               google::cloud::pubsub::Subscription const& subscription,
+               google::cloud::pubsub::Subscription const&,
                std::vector<std::string> const&) {
   //! [START pubsub_quickstart_subscriber]
   //! [START pubsub_subscriber_async_pull] [subscribe]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
   using google::cloud::StatusOr;
-  [](pubsub::Subscriber subscriber, pubsub::Subscription const& subscription) {
+  [](pubsub::Subscriber subscriber) {
     std::mutex mu;
     std::condition_variable cv;
     int message_count = 0;
     auto session = subscriber.Subscribe(
-        subscription, [&](pubsub::Message const& m, pubsub::AckHandler h) {
+        [&](pubsub::Message const& m, pubsub::AckHandler h) {
           std::cout << "Received message " << m << "\n";
           std::unique_lock<std::mutex> lk(mu);
           ++message_count;
@@ -790,34 +790,32 @@ void Subscribe(google::cloud::pubsub::Subscriber subscriber,
   }
   //! [END pubsub_subscriber_async_pull] [subscribe]
   //! [END pubsub_quickstart_subscriber]
-  (std::move(subscriber), std::move(subscription));
+  (std::move(subscriber));
 }
 
-void SubscribeErrorListener(
-    google::cloud::pubsub::Subscriber subscriber,
-    google::cloud::pubsub::Subscription const& subscription,
-    std::vector<std::string> const&) {
+void SubscribeErrorListener(google::cloud::pubsub::Subscriber subscriber,
+                            google::cloud::pubsub::Subscription const&,
+                            std::vector<std::string> const&) {
   // [START pubsub_subscriber_error_listener]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
   using google::cloud::StatusOr;
-  [](pubsub::Subscriber subscriber, pubsub::Subscription const& subscription) {
+  [](pubsub::Subscriber subscriber) {
     std::mutex mu;
     std::condition_variable cv;
     bool done = false;
     int message_count = 0;
     auto session =
         subscriber
-            .Subscribe(subscription,
-                       [&](pubsub::Message const& m, pubsub::AckHandler h) {
-                         std::cout << "Received message " << m << "\n";
-                         std::unique_lock<std::mutex> lk(mu);
-                         ++message_count;
-                         done = true;
-                         lk.unlock();
-                         cv.notify_one();
-                         std::move(h).ack();
-                       })
+            .Subscribe([&](pubsub::Message const& m, pubsub::AckHandler h) {
+              std::cout << "Received message " << m << "\n";
+              std::unique_lock<std::mutex> lk(mu);
+              ++message_count;
+              done = true;
+              lk.unlock();
+              cv.notify_one();
+              std::move(h).ack();
+            })
             // Setup an error handler for the subscription session
             .then([&](future<google::cloud::Status> f) {
               std::cout << "Subscription session result: " << f.get() << "\n";
@@ -835,23 +833,22 @@ void SubscribeErrorListener(
     std::cout << "Message count:" << message_count << "\n";
   }
   // [END pubsub_subscriber_error_listener]
-  (std::move(subscriber), std::move(subscription));
+  (std::move(subscriber));
 }
 
-void SubscribeCustomAttributes(
-    google::cloud::pubsub::Subscriber subscriber,
-    google::cloud::pubsub::Subscription const& subscription,
-    std::vector<std::string> const&) {
+void SubscribeCustomAttributes(google::cloud::pubsub::Subscriber subscriber,
+                               google::cloud::pubsub::Subscription const&,
+                               std::vector<std::string> const&) {
   //! [START pubsub_subscriber_async_pull_custom_attributes]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
   using google::cloud::StatusOr;
-  [](pubsub::Subscriber subscriber, pubsub::Subscription const& subscription) {
+  [](pubsub::Subscriber subscriber) {
     std::mutex mu;
     std::condition_variable cv;
     int message_count = 0;
     auto session = subscriber.Subscribe(
-        subscription, [&](pubsub::Message const& m, pubsub::AckHandler h) {
+        [&](pubsub::Message const& m, pubsub::AckHandler h) {
           std::cout << "Received message with attributes:\n";
           for (auto const& kv : m.attributes()) {
             std::cout << "  " << kv.first << ": " << kv.second << "\n";
@@ -873,7 +870,7 @@ void SubscribeCustomAttributes(
               << "\n";
   }
   //! [END pubsub_subscriber_async_pull_custom_attributes]
-  (std::move(subscriber), std::move(subscription));
+  (std::move(subscriber));
 }
 
 void CustomThreadPoolPublisher(std::vector<std::string> const& argv) {
@@ -1107,9 +1104,9 @@ void CustomThreadPoolSubscriber(std::vector<std::string> const& argv) {
     });
 
     auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+        pubsub::Subscription(std::move(project_id), std::move(subscription_id)),
+        pubsub::SubscriptionOptions{},
         pubsub::ConnectionOptions{}.DisableBackgroundThreads(cq)));
-    auto subscription =
-        pubsub::Subscription(std::move(project_id), std::move(subscription_id));
 
     // Because this is an example we want to exit eventually, use a mutex and
     // condition variable to notify the current thread and stop the example.
@@ -1127,7 +1124,7 @@ void CustomThreadPoolSubscriber(std::vector<std::string> const& argv) {
 
     // Receive messages in the previously allocated thread pool.
     auto result = subscriber.Subscribe(
-        subscription, [&](pubsub::Message const& m, pubsub::AckHandler h) {
+        [&](pubsub::Message const& m, pubsub::AckHandler h) {
           std::cout << "Received message " << m << "\n";
           increase_count();
           std::move(h).ack();
@@ -1162,9 +1159,10 @@ void SubscriberConcurrencyControl(std::vector<std::string> const& argv) {
     // Create a subscriber with 16 threads handling I/O work, by default the
     // library creates `std::thread::hardware_concurrency()` threads.
     auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+        pubsub::Subscription(std::move(project_id), std::move(subscription_id)),
+        pubsub::SubscriptionOptions{}.set_concurrency_watermarks(
+            /*lwm=*/4, /*hwm=*/8),
         pubsub::ConnectionOptions{}.set_background_thread_pool_size(16)));
-    auto subscription =
-        pubsub::Subscription(std::move(project_id), std::move(subscription_id));
 
     std::mutex mu;
     std::condition_variable cv;
@@ -1187,10 +1185,7 @@ void SubscriberConcurrencyControl(std::vector<std::string> const& argv) {
     // Create a subscription where up to 8 messages are handled concurrently. By
     // default the library uses `0` and `std::thread::hardwarde_concurrency()`
     // for the concurrency watermarks.
-    auto session = subscriber.Subscribe(
-        subscription, std::move(handler),
-        pubsub::SubscriptionOptions{}.set_concurrency_watermarks(
-            /*lwm=*/4, /*hwm=*/8));
+    auto session = subscriber.Subscribe(std::move(handler));
     {
       std::unique_lock<std::mutex> lk(mu);
       cv.wait(lk, [&] { return count >= kExpectedMessageCount; });
@@ -1203,15 +1198,30 @@ void SubscriberConcurrencyControl(std::vector<std::string> const& argv) {
   (argv.at(0), argv.at(1));
 }
 
-void SubscriberFlowControlSettings(
-    google::cloud::pubsub::Subscriber subscriber,
-    google::cloud::pubsub::Subscription const& subscription,
-    std::vector<std::string> const&) {
+void SubscriberFlowControlSettings(std::vector<std::string> const& argv) {
+  namespace examples = ::google::cloud::testing_util;
+  if (argv.size() != 2) {
+    throw examples::Usage{
+        "subscriber-retry-settings <project-id> <subscription-id>"};
+  }
+
   //! [START pubsub_subscriber_flow_settings] [subscriber-flow-control]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
   using google::cloud::StatusOr;
-  [](pubsub::Subscriber subscriber, pubsub::Subscription const& subscription) {
+  [](std::string project_id, std::string subscription_id) {
+    // Change the flow control watermarks, by default the client library uses
+    // 0 and 1,000 for the message count watermarks, and 0 and 10MiB for the
+    // size watermarks. Recall that the library stops requesting messages if
+    // any of the high watermarks are reached, and the library resumes
+    // requesting messages when *both* low watermarks are reached.
+    auto constexpr kMiB = 1024 * 1024L;
+    auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
+        pubsub::Subscription(std::move(project_id), std::move(subscription_id)),
+        pubsub::SubscriptionOptions{}
+            .set_max_outstanding_messages(1000)
+            .set_max_outstanding_bytes(8 * kMiB)));
+
     std::mutex mu;
     std::condition_variable cv;
     int count = 0;
@@ -1225,18 +1235,7 @@ void SubscriberFlowControlSettings(
       }
       cv.notify_one();
     };
-
-    // Change the flow control watermarks, by default the client library uses
-    // 0 and 1,000 for the message count watermarks, and 0 and 10MiB for the
-    // size watermarks. Recall that the library stops requesting messages if
-    // any of the high watermarks are reached, and the library resumes
-    // requesting messages when *both* low watermarks are reached.
-    auto constexpr kMiB = 1024 * 1024L;
-    auto session =
-        subscriber.Subscribe(subscription, std::move(handler),
-                             pubsub::SubscriptionOptions{}
-                                 .set_max_outstanding_messages(1000)
-                                 .set_max_outstanding_bytes(8 * kMiB));
+    auto session = subscriber.Subscribe(std::move(handler));
     {
       std::unique_lock<std::mutex> lk(mu);
       cv.wait(lk, [&] { return count >= kExpectedMessageCount; });
@@ -1246,7 +1245,7 @@ void SubscriberFlowControlSettings(
     std::cout << "Message count: " << count << ", status: " << status << "\n";
   }
   //! [END pubsub_subscriber_flow_settings] [subscriber-flow-control]
-  (std::move(subscriber), std::move(subscription));
+  (argv.at(0), argv.at(1));
 }
 
 void SubscriberRetrySettings(std::vector<std::string> const& argv) {
@@ -1265,7 +1264,8 @@ void SubscriberRetrySettings(std::vector<std::string> const& argv) {
     // backoff of 100ms, a maximum backoff of 60 seconds, and the backoff will
     // grow by 30% after each attempt. This changes those defaults.
     auto subscriber = pubsub::Subscriber(pubsub::MakeSubscriberConnection(
-        pubsub::ConnectionOptions{},
+        pubsub::Subscription(std::move(project_id), std::move(subscription_id)),
+        pubsub::SubscriptionOptions{}, pubsub::ConnectionOptions{},
         pubsub::LimitedTimeRetryPolicy(
             /*maximum_duration=*/std::chrono::minutes(1))
             .clone(),
@@ -1274,8 +1274,6 @@ void SubscriberRetrySettings(std::vector<std::string> const& argv) {
             /*maximum_delay=*/std::chrono::seconds(10),
             /*scaling=*/2.0)
             .clone()));
-    auto subscription =
-        pubsub::Subscription(std::move(project_id), std::move(subscription_id));
 
     std::mutex mu;
     std::condition_variable cv;
@@ -1291,8 +1289,7 @@ void SubscriberRetrySettings(std::vector<std::string> const& argv) {
       cv.notify_one();
     };
 
-    auto session = subscriber.Subscribe(subscription, std::move(handler),
-                                        pubsub::SubscriptionOptions{});
+    auto session = subscriber.Subscribe(std::move(handler));
     {
       std::unique_lock<std::mutex> lk(mu);
       cv.wait(lk, [&] { return count >= kExpectedMessageCount; });
@@ -1462,11 +1459,13 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto subscription =
       google::cloud::pubsub::Subscription(project_id, subscription_id);
   auto subscriber = google::cloud::pubsub::Subscriber(
-      google::cloud::pubsub::MakeSubscriberConnection());
-  auto dead_letter_subscriber = google::cloud::pubsub::Subscriber(
-      google::cloud::pubsub::MakeSubscriberConnection());
+      google::cloud::pubsub::MakeSubscriberConnection(subscription));
+
   auto dead_letter_subscription = google::cloud::pubsub::Subscription(
       project_id, dead_letter_subscription_id);
+  auto dead_letter_subscriber = google::cloud::pubsub::Subscriber(
+      google::cloud::pubsub::MakeSubscriberConnection(
+          dead_letter_subscription));
 
   std::cout << "\nRunning Publish() sample [1]" << std::endl;
   Publish(publisher, {});
@@ -1538,7 +1537,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 
   std::cout << "\nRunning SubscriberFlowControlSettings() sample" << std::endl;
   PublishHelper(publisher, "SubscriberFlowControlSettings", 4);
-  SubscriberFlowControlSettings(subscriber, subscription, {});
+  SubscriberFlowControlSettings({project_id, subscription_id});
 
   std::cout << "\nRunning SubscriberRetrySettings() sample" << std::endl;
   PublishHelper(publisher, "SubscriberRetrySettings", 1);
@@ -1676,8 +1675,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       {"custom-batch-publisher", CustomBatchPublisher},
       {"custom-thread-pool-subscriber", CustomThreadPoolSubscriber},
       {"subscriber-concurrency-control", SubscriberConcurrencyControl},
-      CreateSubscriberCommand("subscriber-flow-control-settings", {},
-                              SubscriberFlowControlSettings),
+      {"subscriber-flow-control-settings", SubscriberFlowControlSettings},
       {"subscriber-retry-settings", SubscriberRetrySettings},
       {"auto", AutoRun},
   });

--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -99,14 +99,12 @@ class Subscriber {
   /**
    * Create a new session to receive messages from @p subscription.
    *
-   * @note Callable must be CopyConstructible, as @p cb will be stored in a
+   * @note Callable must be `CopyConstructible`, as @p cb will be stored in a
    *   [`std::function<>`][std-function-link].
    *
-   * @param subscription the Cloud Pub/Sub subscription to receive messages from
-   * @param cb an object usable to construct a
-   *     `std::function<void(pubsub::Message, pubsub::AckHandler)>`
-   * @param options configure the subscription's flow control, maximum message
-   *     lease time and other parameters, see `SubscriptionOptions` for details
+   * @param cb the callable invoked when messages are received. This must be
+   *     usable to construct a
+   *     `std::function<void(pubsub::Message, pubsub::AckHandler)>`.
    * @return a future that is satisfied when the session will no longer receive
    *     messages. For example because there was an unrecoverable error trying
    *     to receive data. Calling `.cancel()` in this object will (eventually)
@@ -116,11 +114,9 @@ class Subscriber {
    * https://en.cppreference.com/w/cpp/utility/functional/function
    */
   template <typename Callable>
-  future<Status> Subscribe(Subscription const& subscription, Callable&& cb,
-                           SubscriptionOptions options = {}) {
+  future<Status> Subscribe(Callable&& cb) {
     std::function<void(Message, AckHandler)> f(std::forward<Callable>(cb));
-    return connection_->Subscribe(
-        {subscription.FullName(), std::move(f), std::move(options)});
+    return connection_->Subscribe({std::move(f)});
   }
 
  private:

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -30,13 +30,15 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 SubscriberConnection::~SubscriberConnection() = default;
 
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
-    ConnectionOptions options,
+    Subscription subscription, SubscriptionOptions options,
+    ConnectionOptions connection_options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
-  auto stub =
-      pubsub_internal::CreateDefaultSubscriberStub(options, /*channel_id=*/0);
+  auto stub = pubsub_internal::CreateDefaultSubscriberStub(connection_options,
+                                                           /*channel_id=*/0);
   return pubsub_internal::MakeSubscriberConnection(
-      std::move(stub), std::move(options), std::move(retry_policy),
+      std::move(subscription), std::move(options),
+      std::move(connection_options), std::move(stub), std::move(retry_policy),
       std::move(backoff_policy));
 }
 
@@ -49,12 +51,15 @@ namespace {
 class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
  public:
   explicit SubscriberConnectionImpl(
+      pubsub::Subscription subscription, pubsub::SubscriptionOptions options,
+      pubsub::ConnectionOptions const& connection_options,
       std::shared_ptr<pubsub_internal::SubscriberStub> stub,
-      pubsub::ConnectionOptions const& options,
       std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
       std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy)
-      : stub_(std::move(stub)),
-        background_(options.background_threads_factory()()),
+      : subscription_(std::move(subscription)),
+        options_(std::move(options)),
+        stub_(std::move(stub)),
+        background_(connection_options.background_threads_factory()()),
         retry_policy_(std::move(retry_policy)),
         backoff_policy_(std::move(backoff_policy)),
         generator_(google::cloud::internal::MakeDefaultPRNG()) {}
@@ -69,11 +74,13 @@ class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
       return google::cloud::internal::Sample(generator_, kLength, kChars);
     }();
     return CreateSubscriptionSession(
-        stub_, background_->cq(), std::move(client_id), std::move(p),
-        retry_policy_->clone(), backoff_policy_->clone());
+        subscription_, options_, stub_, background_->cq(), std::move(client_id),
+        std::move(p), retry_policy_->clone(), backoff_policy_->clone());
   }
 
  private:
+  pubsub::Subscription const subscription_;
+  pubsub::SubscriptionOptions const options_;
   std::shared_ptr<pubsub_internal::SubscriberStub> stub_;
   std::shared_ptr<BackgroundThreads> background_;
   std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
@@ -84,28 +91,32 @@ class SubscriberConnectionImpl : public pubsub::SubscriberConnection {
 }  // namespace
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    std::shared_ptr<SubscriberStub> stub, pubsub::ConnectionOptions options,
+    pubsub::Subscription subscription, pubsub::SubscriptionOptions options,
+    pubsub::ConnectionOptions connection_options,
+    std::shared_ptr<SubscriberStub> stub,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
   if (!retry_policy) retry_policy = DefaultRetryPolicy();
   if (!backoff_policy) backoff_policy = DefaultBackoffPolicy();
   stub = std::make_shared<SubscriberMetadata>(std::move(stub));
-  if (options.tracing_enabled("rpc")) {
+  if (connection_options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), options.tracing_options());
+        std::move(stub), connection_options.tracing_options());
   }
   auto default_thread_pool_size = []() -> std::size_t {
     auto constexpr kDefaultThreadPoolSize = 4;
     auto const n = std::thread::hardware_concurrency();
     return n == 0 ? kDefaultThreadPoolSize : n;
   };
-  if (options.background_thread_pool_size() == 0) {
-    options.set_background_thread_pool_size(default_thread_pool_size());
+  if (connection_options.background_thread_pool_size() == 0) {
+    connection_options.set_background_thread_pool_size(
+        default_thread_pool_size());
   }
-  return std::make_shared<SubscriberConnectionImpl>(std::move(stub), options,
-                                                    std::move(retry_policy),
-                                                    std::move(backoff_policy));
+  return std::make_shared<SubscriberConnectionImpl>(
+      std::move(subscription), std::move(options),
+      std::move(connection_options), std::move(stub), std::move(retry_policy),
+      std::move(backoff_policy));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -63,9 +63,7 @@ class SubscriberConnection {
 
   /// Wrap the arguments for `Subscribe()`
   struct SubscribeParams {
-    std::string full_subscription_name;
     ApplicationCallback callback;
-    SubscriptionOptions options;
   };
   //@}
 
@@ -86,15 +84,20 @@ class SubscriberConnection {
  * @par Changing Retry Parameters Example
  * @snippet samples.cc subscriber-retry-settings
  *
- * @param options (optional) configure the `SubscriberConnection` created by
- *     this function.
+ * @param subscription the Cloud Pub/Sub subscription used by the returned
+ *     connection.
+ * @param options configure the flow control and other parameters in the
+ *     returned connection.
+ * @param connection_options (optional) general configuration for this
+ *    connection, this type is also used to configure `pubsub::Publisher`.
  * @param retry_policy control for how long (or how many times) are retryable
  *     RPCs attempted.
  * @param backoff_policy controls the backoff behavior between retry attempts,
  *     typically some form of exponential backoff with jitter.
  */
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
-    ConnectionOptions options = {},
+    Subscription subscription, SubscriptionOptions options = {},
+    ConnectionOptions connection_options = {},
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy = {});
 
@@ -105,7 +108,9 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
-    std::shared_ptr<SubscriberStub> stub, pubsub::ConnectionOptions options,
+    pubsub::Subscription subscription, pubsub::SubscriptionOptions options,
+    pubsub::ConnectionOptions connection_options,
+    std::shared_ptr<SubscriberStub> stub,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy);
 

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -48,10 +48,11 @@ TEST(SubscriberConnectionTest, Basic) {
 
   CompletionQueue cq;
   auto subscriber = pubsub_internal::MakeSubscriberConnection(
-      mock,
+      subscription, pubsub::SubscriptionOptions{},
       ConnectionOptions{grpc::InsecureChannelCredentials()}
           .DisableBackgroundThreads(cq),
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      mock, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   std::atomic_flag received_one{false};
   promise<void> waiter;
   auto handler = [&](Message const& m, AckHandler h) {
@@ -62,7 +63,7 @@ TEST(SubscriberConnectionTest, Basic) {
     waiter.set_value();
   };
   std::thread t([&cq] { cq.Run(); });
-  auto response = subscriber->Subscribe({subscription.FullName(), handler, {}});
+  auto response = subscriber->Subscribe({handler});
   waiter.get_future().wait();
   response.cancel();
   ASSERT_STATUS_OK(response.get());
@@ -104,10 +105,11 @@ TEST(SubscriberConnectionTest, PullFailure) {
       });
 
   auto subscriber = pubsub_internal::MakeSubscriberConnection(
-      mock, ConnectionOptions{grpc::InsecureChannelCredentials()},
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      subscription, {}, ConnectionOptions{grpc::InsecureChannelCredentials()},
+      mock, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   auto handler = [&](Message const&, AckHandler const&) {};
-  auto response = subscriber->Subscribe({subscription.FullName(), handler, {}});
+  auto response = subscriber->Subscribe({handler});
   EXPECT_THAT(response.get(),
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
 }
@@ -127,11 +129,12 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
 
   CompletionQueue cq;
   auto subscriber = pubsub_internal::MakeSubscriberConnection(
-      mock,
+      subscription, {},
       ConnectionOptions{grpc::InsecureChannelCredentials()}
           .DisableBackgroundThreads(cq)
           .enable_tracing("rpc"),
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      mock, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   std::atomic_flag received_one{false};
   promise<void> waiter;
   auto handler = [&](Message const&, AckHandler h) {
@@ -140,7 +143,7 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
     waiter.set_value();
   };
   std::thread t([&cq] { cq.Run(); });
-  auto response = subscriber->Subscribe({subscription.FullName(), handler, {}});
+  auto response = subscriber->Subscribe({handler});
   waiter.get_future().wait();
   response.cancel();
   ASSERT_STATUS_OK(response.get());
@@ -177,8 +180,9 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsMetadata) {
           });
 
   auto subscriber = pubsub_internal::MakeSubscriberConnection(
-      mock, ConnectionOptions{grpc::InsecureChannelCredentials()},
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
+      subscription, {}, ConnectionOptions{grpc::InsecureChannelCredentials()},
+      mock, pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
   std::atomic_flag received_one{false};
   promise<void> waiter;
   auto handler = [&](Message const&, AckHandler h) {
@@ -186,7 +190,7 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsMetadata) {
     if (received_one.test_and_set()) return;
     waiter.set_value();
   };
-  auto response = subscriber->Subscribe({subscription.FullName(), handler, {}});
+  auto response = subscriber->Subscribe({handler});
   waiter.get_future().wait();
   response.cancel();
   ASSERT_STATUS_OK(response.get());


### PR DESCRIPTION
**BREAKING CHANGE**

* Change the `pubsub::Subscriber` API. A `Subscriber` is now bound to a specific
  Cloud Pub/Sub subscription, with a fixed set of `SuscriptionOptions`, just
  like a `pubsub::Publisher` is bound to a specific topic and a set of
  `PublisherOptions`. In addition to making publishers and subscribers more
  symmetrical, this makes the library more consistent with the Cloud Pub/Sub
  library for other languages. Finally, note that we are planning to rename
  `SubscriptionOptions` to `SubscriberOptions` in a future PR too.

Part of the work for #5204 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5247)
<!-- Reviewable:end -->
