### PR TITLE
test: enable all clang-tidy presubmit warnings for source files

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -141,14 +141,14 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   SOURCE_FILTER_REGEX='google/cloud/.*\.cc$'
 
   # Get the list of modified files.
-  readonly modified=$(git diff --diff-filter=d --name-only "${TARGET_BRANCH}")
+  readonly MODIFIED=$(git diff --diff-filter=d --name-only "${TARGET_BRANCH}")
 
   # Run clang_tidy against files that regex match the first argument (less some
   # exclusions). Any remaining arguments are passed to clang-tidy.
   run_clang_tidy() {
     local -r file_regex="$1"
     shift
-    grep -E "${file_regex}" <<<"${modified}" |
+    grep -E "${file_regex}" <<<"${MODIFIED}" |
       grep -v google/cloud/bigtable/examples/opencensus |
       grep -v generator/integration_tests/golden |
       xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy \

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -146,7 +146,7 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   # Run clang_tidy against files that regex match the first argument (less some
   # exclusions). Any remaining arguments are passed to clang-tidy.
   run_clang_tidy() {
-    readonly file_regex="$1"
+    local -r file_regex="$1"
     shift
     grep -E "${file_regex}" <<<"${modified}" |
       grep -v google/cloud/bigtable/examples/opencensus |

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -139,17 +139,32 @@ if [[ "${CLANG_TIDY:-}" == "yes" && (\
   HEADER_FILTER_REGEX=$(clang-tidy -dump-config |
     sed -n "s/HeaderFilterRegex: *'\([^']*\)'/\1/p")
   SOURCE_FILTER_REGEX='google/cloud/.*\.cc$'
+
+  # Get the list of modified files.
+  readonly modified=$(git diff --diff-filter=d --name-only "${TARGET_BRANCH}")
+
+  # Run clang_tidy against files that regex match the first argument (less some
+  # exclusions). Any remaining arguments are passed to clang-tidy.
+  run_clang_tidy() {
+    readonly file_regex="$1"
+    shift
+    grep -E "${file_regex}" <<<"${modified}" |
+      grep -v google/cloud/bigtable/examples/opencensus |
+      grep -v generator/integration_tests/golden |
+      xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy \
+        -p="${BINARY_DIR}" "$@"
+  }
+
   # We disable the following checks:
   #     misc-unused-using-decls
   #     readability-redundant-declaration
   # because they produce false positives when run on headers.
   # For more details, see issue #4230.
-  git diff --diff-filter=d --name-only "${TARGET_BRANCH}" |
-    grep -E "(${HEADER_FILTER_REGEX})|(${SOURCE_FILTER_REGEX})" |
-    grep -v google/cloud/bigtable/examples/opencensus |
-    grep -v generator/integration_tests/golden |
-    xargs --verbose -d '\n' -r -n 1 -P "${NCPU}" clang-tidy -p="${BINARY_DIR}" \
-      -checks="-misc-unused-using-decls,-readability-redundant-declaration"
+  run_clang_tidy "${HEADER_FILTER_REGEX}" \
+    '-checks="-misc-unused-using-decls,-readability-redundant-declaration"'
+
+  # We don't need to exclude any checks for source files.
+  run_clang_tidy "${SOURCE_FILTER_REGEX}"
 fi
 
 echo "================================================================"


### PR DESCRIPTION
As discussed in #4230, running clang-tidy on a subset of files produces
some false positives in header files. However, the fix to that also
disabled some warnings for source files. This PR re-enables our full
set of warnings for source files, allowing presubmit to catch more issues
(see #5240 as an example of a break caused by this.)

To test, I forced the relevant section of the build script to run in a local build and added an unnecessary `using` declaration to a `.h` and `.cc ` file.  Note that both are scanned but the warning only appears for the `.cc` file (which would have been missed prior to this PR)

```
2020-10-14T01:27:21Z: Run clang-tidy on changed files in a presubmit build 
clang-tidy -p=cmake-out/ci-fedora-install-31-clang-tidy -checks="-misc-unused-using-decls,-readability-redundant-declaration" google/cloud/log.h 
10458 warnings generated.
/v/google/cloud/log.h:101:12: error: using decl 'make_pair' is unused [misc-unused-using-decls,-warnings-as-errors]
using std::make_pair;
           ^
/v/google/cloud/log.h:101:12: note: remove the using
using std::make_pair;
~~~~~~~~~~~^~~~~~~~~~
Suppressed 10477 warnings (10457 in non-user code, 20 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
2020-10-14T01:27:25Z: Docker run failed with exit status 123. 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5248)
<!-- Reviewable:end -->
