### PR TITLE
cleanup(storage): Remove references of BucketPolicyOnly

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -51,9 +51,9 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs) {
             << join(", ", rhs.response_header) << "]}";
 }
 
-std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs) {
+std::ostream& operator<<(std::ostream& os, UniformBucketLevelAccess const& rhs) {
   google::cloud::internal::IosFlagsSaver save_format(os);
-  return os << "BucketPolicyOnly={enabled=" << std::boolalpha << rhs.enabled
+  return os << "UniformBucketLevelAccess={enabled=" << std::boolalpha << rhs.enabled
             << ", locked_time="
             << google::cloud::internal::FormatRfc3339(rhs.locked_time) << "}";
 }
@@ -61,15 +61,9 @@ std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs) {
 std::ostream& operator<<(std::ostream& os, BucketIamConfiguration const& rhs) {
   os << "BucketIamConfiguration={";
   if (rhs.uniform_bucket_level_access.has_value()) {
-    os << "uniform_bucket_level_access=" << *rhs.uniform_bucket_level_access
-       << ", ";
-    os << "bucket_policy_only=" << *rhs.uniform_bucket_level_access;
+    os << "uniform_bucket_level_access=" << *rhs.uniform_bucket_level_access;
     return os << "}";
   };
-  if (rhs.bucket_policy_only.has_value()) {
-    os << "uniform_bucket_level_access=" << *rhs.bucket_policy_only << ", ";
-    os << "bucket_policy_only=" << *rhs.bucket_policy_only;
-  }
   return os << "}";
 }
 
@@ -341,32 +335,14 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetIamConfiguration(
 
   if (v.uniform_bucket_level_access.has_value()) {
     internal::PatchBuilder uniform_bucket_level_access;
-    internal::PatchBuilder bucket_policy_only;
     uniform_bucket_level_access.SetBoolField(
         "enabled", v.uniform_bucket_level_access->enabled);
-    bucket_policy_only.SetBoolField("enabled",
-                                    v.uniform_bucket_level_access->enabled);
     // The lockedTime field should not be set, this is not a mutable field, it
     // is set by the server when the policy is enabled.
     iam_configuration.AddSubPatch("uniformBucketLevelAccess",
-                                  uniform_bucket_level_access);
-    iam_configuration.AddSubPatch("bucketPolicyOnly",
                                   uniform_bucket_level_access);
     impl_.AddSubPatch("iamConfiguration", iam_configuration);
     return *this;
-  }
-
-  if (v.bucket_policy_only.has_value()) {
-    internal::PatchBuilder uniform_bucket_level_access;
-    internal::PatchBuilder bucket_policy_only;
-    uniform_bucket_level_access.SetBoolField("enabled",
-                                             v.bucket_policy_only->enabled);
-    bucket_policy_only.SetBoolField("enabled", v.bucket_policy_only->enabled);
-    // The lockedTime field should not be set, this is not a mutable field, it
-    // is set by the server when the policy is enabled.
-    iam_configuration.AddSubPatch("uniformBucketLevelAccess",
-                                  bucket_policy_only);
-    iam_configuration.AddSubPatch("bucketPolicyOnly", bucket_policy_only);
   }
   impl_.AddSubPatch("iamConfiguration", iam_configuration);
   return *this;

--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -51,10 +51,11 @@ std::ostream& operator<<(std::ostream& os, CorsEntry const& rhs) {
             << join(", ", rhs.response_header) << "]}";
 }
 
-std::ostream& operator<<(std::ostream& os, UniformBucketLevelAccess const& rhs) {
+std::ostream& operator<<(std::ostream& os,
+                         UniformBucketLevelAccess const& rhs) {
   google::cloud::internal::IosFlagsSaver save_format(os);
-  return os << "UniformBucketLevelAccess={enabled=" << std::boolalpha << rhs.enabled
-            << ", locked_time="
+  return os << "UniformBucketLevelAccess={enabled=" << std::boolalpha
+            << rhs.enabled << ", locked_time="
             << google::cloud::internal::FormatRfc3339(rhs.locked_time) << "}";
 }
 

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -153,6 +153,7 @@ struct UniformBucketLevelAccess {
   bool enabled;
   std::chrono::system_clock::time_point locked_time;
 };
+using BucketPolicyOnly = UniformBucketLevelAccess;
 
 //@{
 /// @name Comparison operators For UniformBucketLevelAccess
@@ -194,8 +195,8 @@ std::ostream& operator<<(std::ostream& os, UniformBucketLevelAccess const& rhs);
 /**
  * The IAM configuration for a Bucket.
  *
- * Currently this only holds the UniformBucketLevelAccess. In the future, we may define
- * additional IAM which would be included in this object.
+ * Currently this only holds the UniformBucketLevelAccess. In the future, we may
+ * define additional IAM which would be included in this object.
  *
  * @warning this is a Beta feature of Google Cloud Storage, it is not subject
  *     to the deprecation policy and subject to change without notice.

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -153,10 +153,9 @@ struct UniformBucketLevelAccess {
   bool enabled;
   std::chrono::system_clock::time_point locked_time;
 };
-using BucketPolicyOnly = UniformBucketLevelAccess;
 
 //@{
-/// @name Comparison operators For BucketOnlyPolicy.
+/// @name Comparison operators For UniformBucketLevelAccess
 inline bool operator==(UniformBucketLevelAccess const& lhs,
                        UniformBucketLevelAccess const& rhs) {
   return std::tie(lhs.enabled, lhs.locked_time) ==
@@ -190,12 +189,12 @@ inline bool operator>=(UniformBucketLevelAccess const& lhs,
 }
 //@}
 
-std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs);
+std::ostream& operator<<(std::ostream& os, UniformBucketLevelAccess const& rhs);
 
 /**
  * The IAM configuration for a Bucket.
  *
- * Currently this only holds the BucketOnlyPolicy. In the future, we may define
+ * Currently this only holds the UniformBucketLevelAccess. In the future, we may define
  * additional IAM which would be included in this object.
  *
  * @warning this is a Beta feature of Google Cloud Storage, it is not subject
@@ -211,7 +210,6 @@ std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs);
  * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
  */
 struct BucketIamConfiguration {
-  absl::optional<BucketPolicyOnly> bucket_policy_only;
   absl::optional<UniformBucketLevelAccess> uniform_bucket_level_access;
 };
 

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -267,88 +267,6 @@ void GetBucketClassAndLocation(google::cloud::storage::Client client,
   (std::move(client), argv.at(0));
 }
 
-void EnableBucketPolicyOnly(google::cloud::storage::Client client,
-                            std::vector<std::string> const& argv) {
-  //! [enable bucket policy only]
-  // [START storage_enable_bucket_policy_only]
-  namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
-  [](gcs::Client client, std::string const& bucket_name) {
-    gcs::BucketIamConfiguration configuration;
-    configuration.bucket_policy_only = gcs::BucketPolicyOnly{true, {}};
-    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
-                         std::move(configuration)));
-
-    if (!updated_metadata) {
-      throw std::runtime_error(updated_metadata.status().message());
-    }
-
-    std::cout << "Successfully enabled Bucket Policy Only on bucket "
-              << updated_metadata->name() << "\n";
-  }
-  // [END storage_enable_bucket_policy_only]
-  //! [enable bucket policy only]
-  (std::move(client), argv.at(0));
-}
-
-void DisableBucketPolicyOnly(google::cloud::storage::Client client,
-                             std::vector<std::string> const& argv) {
-  //! [disable bucket policy only]
-  // [START storage_disable_bucket_policy_only]
-  namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
-  [](gcs::Client client, std::string const& bucket_name) {
-    gcs::BucketIamConfiguration configuration;
-    configuration.bucket_policy_only = gcs::BucketPolicyOnly{false, {}};
-    StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
-                         std::move(configuration)));
-
-    if (!updated_metadata) {
-      throw std::runtime_error(updated_metadata.status().message());
-    }
-
-    std::cout << "Successfully disabled Bucket Policy Only on bucket "
-              << updated_metadata->name() << "\n";
-  }
-  // [END storage_disable_bucket_policy_only]
-  //! [disable bucket policy only]
-  (std::move(client), argv.at(0));
-}
-
-void GetBucketPolicyOnly(google::cloud::storage::Client client,
-                         std::vector<std::string> const& argv) {
-  //! [get bucket policy only]
-  // [START storage_get_bucket_policy_only]
-  namespace gcs = google::cloud::storage;
-  using google::cloud::StatusOr;
-  [](gcs::Client client, std::string const& bucket_name) {
-    StatusOr<gcs::BucketMetadata> bucket_metadata =
-        client.GetBucketMetadata(bucket_name);
-
-    if (!bucket_metadata) {
-      throw std::runtime_error(bucket_metadata.status().message());
-    }
-
-    if (bucket_metadata->has_iam_configuration() &&
-        bucket_metadata->iam_configuration().bucket_policy_only.has_value()) {
-      gcs::BucketPolicyOnly bucket_policy_only =
-          *bucket_metadata->iam_configuration().bucket_policy_only;
-
-      std::cout << "Bucket Policy Only is enabled for "
-                << bucket_metadata->name() << "\n";
-      std::cout << "Bucket will be locked on " << bucket_policy_only << "\n";
-    } else {
-      std::cout << "Bucket Policy Only is not enabled for "
-                << bucket_metadata->name() << "\n";
-    }
-  }
-  // [END storage_get_bucket_policy_only]
-  //! [get bucket policy only]
-  (std::move(client), argv.at(0));
-}
-
 void EnableUniformBucketLevelAccess(google::cloud::storage::Client client,
                                     std::vector<std::string> const& argv) {
   //! [enable uniform bucket level access]
@@ -565,15 +483,6 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning GetBucketClassAndLocation() example" << std::endl;
   GetBucketClassAndLocation(client, {bucket_name});
 
-  std::cout << "\nRunning EnableBucketPolicyOnly() example" << std::endl;
-  EnableBucketPolicyOnly(client, {bucket_name});
-
-  std::cout << "\nRunning DisableBucketPolicyOnly() example" << std::endl;
-  DisableBucketPolicyOnly(client, {bucket_name});
-
-  std::cout << "\nRunning GetBucketPolicyOnly() example" << std::endl;
-  GetBucketPolicyOnly(client, {bucket_name});
-
   std::cout << "\nRunning EnableUniformBucketLevelAccess() example"
             << std::endl;
   EnableUniformBucketLevelAccess(client, {bucket_name});
@@ -651,9 +560,6 @@ int main(int argc, char* argv[]) {
                  PatchBucketStorageClassWithBuilder),
       make_entry("get-bucket-class-and-location", {},
                  GetBucketClassAndLocation),
-      make_entry("enable-bucket-policy-only", {}, EnableBucketPolicyOnly),
-      make_entry("disable-bucket-policy-only", {}, DisableBucketPolicyOnly),
-      make_entry("get-bucket-policy-only", {}, GetBucketPolicyOnly),
       make_entry("enable-uniform-bucket-level-access", {},
                  EnableUniformBucketLevelAccess),
       make_entry("disable-uniform-bucket-level-access", {},

--- a/google/cloud/storage/internal/bucket_requests_test.cc
+++ b/google/cloud/storage/internal/bucket_requests_test.cc
@@ -414,25 +414,6 @@ TEST(PatchBucketRequestTest, DiffResetEncryption) {
   EXPECT_EQ(expected, patch);
 }
 
-TEST(PatchBucketRequestTest, DiffSetIamConfigurationBPO) {
-  BucketMetadata original = CreateBucketMetadataForTest();
-  original.reset_encryption();
-  BucketMetadata updated = original;
-  BucketIamConfiguration configuration;
-  configuration.bucket_policy_only = BucketPolicyOnly{true, {}};
-  updated.set_iam_configuration(std::move(configuration));
-  PatchBucketRequest request("test-bucket", original, updated);
-
-  auto patch = nlohmann::json::parse(request.payload());
-  auto expected = nlohmann::json::parse(R"""({
-      "iamConfiguration": {
-          "bucketPolicyOnly": {"enabled": true},
-          "uniformBucketLevelAccess":{"enabled": true}
-       }
-  })""");
-  EXPECT_EQ(expected, patch);
-}
-
 TEST(PatchBucketRequestTest, DiffSetIamConfigurationUBLA) {
   BucketMetadata original = CreateBucketMetadataForTest();
   original.reset_encryption();
@@ -446,24 +427,9 @@ TEST(PatchBucketRequestTest, DiffSetIamConfigurationUBLA) {
   auto patch = nlohmann::json::parse(request.payload());
   auto expected = nlohmann::json::parse(R"""({
       "iamConfiguration": {
-          "bucketPolicyOnly": {"enabled": true},
           "uniformBucketLevelAccess":{"enabled": true}
        }
   })""");
-  EXPECT_EQ(expected, patch);
-}
-
-TEST(PatchBucketRequestTest, DiffResetIamConfigurationBPO) {
-  BucketMetadata original = CreateBucketMetadataForTest();
-  BucketIamConfiguration configuration;
-  configuration.bucket_policy_only = BucketPolicyOnly{true, {}};
-  original.set_iam_configuration(std::move(configuration));
-  BucketMetadata updated = original;
-  updated.reset_iam_configuration();
-  PatchBucketRequest request("test-bucket", original, updated);
-
-  auto patch = nlohmann::json::parse(request.payload());
-  auto expected = nlohmann::json::parse(R"""({"iamConfiguration": null})""");
   EXPECT_EQ(expected, patch);
 }
 

--- a/google/cloud/storage/testbench/gcs_bucket.py
+++ b/google/cloud/storage/testbench/gcs_bucket.py
@@ -128,7 +128,9 @@ class GcsBucket(object):
         """
         field_was_enabled = False
         if self.metadata.get("iamConfiguration"):
-            field_value = self.metadata.get("iamConfiguration").get("uniformBucketLevelAccess")
+            field_value = self.metadata.get("iamConfiguration").get(
+                "uniformBucketLevelAccess"
+            )
             if field_value:
                 field_was_enabled = field_value.get("enabled")
         config = patch.get("iamConfiguration")

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -399,38 +399,6 @@ TEST_F(BucketIntegrationTest, FullPatch) {
 }
 
 // @test Verify that we can set the iam_configuration() in a Bucket.
-TEST_F(BucketIntegrationTest, BucketPolicyOnlyPatch) {
-  std::string bucket_name = MakeRandomBucketName();
-  StatusOr<Client> client = MakeBucketIntegrationTestClient();
-  ASSERT_STATUS_OK(client);
-
-  // Create a Bucket, use the default settings for all fields. Fetch the full
-  // attributes of the bucket.
-  StatusOr<BucketMetadata> const insert_meta = client->CreateBucketForProject(
-      bucket_name, project_id_, BucketMetadata(), PredefinedAcl("private"),
-      PredefinedDefaultObjectAcl("projectPrivate"), Projection("full"));
-  ASSERT_STATUS_OK(insert_meta);
-  EXPECT_EQ(bucket_name, insert_meta->name());
-
-  // Patch the iam_configuration().
-  BucketMetadata desired_state = *insert_meta;
-  BucketIamConfiguration iam_configuration;
-  iam_configuration.bucket_policy_only = BucketPolicyOnly{true, {}};
-  desired_state.set_iam_configuration(std::move(iam_configuration));
-
-  StatusOr<BucketMetadata> patched =
-      client->PatchBucket(bucket_name, *insert_meta, desired_state);
-  ASSERT_STATUS_OK(patched);
-
-  ASSERT_TRUE(patched->has_iam_configuration()) << "patched=" << *patched;
-  ASSERT_TRUE(patched->iam_configuration().bucket_policy_only)
-      << "patched=" << *patched;
-
-  auto status = client->DeleteBucket(bucket_name);
-  ASSERT_STATUS_OK(status);
-}
-
-// @test Verify that we can set the iam_configuration() in a Bucket.
 TEST_F(BucketIntegrationTest, UniformBucketLevelAccessPatch) {
   std::string bucket_name = MakeRandomBucketName();
   StatusOr<Client> client = MakeIntegrationTestClient();


### PR DESCRIPTION
Fixes: #3194

**BREAKING CHANGE**

* `UniformBucketLevelAccess` was known as `BucketPolicyOnly` during the beta.
  For compatibility the C++ Cloud Storage library supported both, however
  `BucketPolicyOnly` is now completely removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5254)
<!-- Reviewable:end -->
