### PR TITLE
fix(pubsub): crashes for fire & forget sessions

### DIFF
--- a/google/cloud/pubsub/internal/session_shutdown_manager.h
+++ b/google/cloud/pubsub/internal/session_shutdown_manager.h
@@ -19,6 +19,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/status.h"
 #include <mutex>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -117,6 +118,7 @@ class SessionShutdownManager {
   int outstanding_operations_ = 0;
   Status result_;
   promise<Status> done_;
+  std::unordered_map<std::string, int> ops_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
We need to keep the gRPC objects (the client context, the streaming RPC)
alive while an asynchronous request is pending, otherwise we may delete
these objects while gRPC is still using them.

Fixes #5287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5291)
<!-- Reviewable:end -->
