### PR TITLE
test: use protobufs, not json in conformance tests

### DIFF
--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -73,6 +73,8 @@ $build_flags = @(
     "--per_file_copt=^//google/cloud@-experimental:external",
     "--per_file_copt=^//google/cloud@-external:W0",
     "--per_file_copt=^//google/cloud@-external:anglebrackets"
+# Disable warnings on generated proto files.
+    "--per_file_copt=.*\.pb\.cc@/wd4244"
 )
 
 $BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -227,6 +227,7 @@ std::vector<PolicyDocumentCondition> PolicyDocumentV4Request::GetAllConditions()
   for (auto const& field : extension_fields_) {
     conditions.push_back(PolicyDocumentCondition({field.first, field.second}));
   }
+  std::sort(conditions.begin(), conditions.end());
   auto const& document = policy_document();
   std::copy(document.conditions.begin(), document.conditions.end(),
             std::back_inserter(conditions));

--- a/google/cloud/storage/tests/BUILD
+++ b/google/cloud/storage/tests/BUILD
@@ -21,6 +21,19 @@ load(
     "storage_client_integration_tests",
 )
 
+proto_library(
+    name = "storage_conformance_tests_proto",
+    srcs = [
+        "conformance_tests.proto",
+    ],
+    deps = ["@com_google_protobuf//:timestamp_proto"],
+)
+
+cc_proto_library(
+    name = "storage_conformance_tests_cc_proto",
+    deps = [":storage_conformance_tests_proto"],
+)
+
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
@@ -36,6 +49,7 @@ load(
         "integration-test",
     ],
     deps = [
+        ":storage_conformance_tests_cc_proto",
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client",
         "//google/cloud/storage:storage_client_testing",

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -15,7 +15,7 @@
 # ~~~
 
 set(storage_client_integration_tests
-    # cmake-format: sort
+    # cmake - format : sort
     bucket_integration_test.cc
     curl_download_request_integration_test.cc
     curl_request_integration_test.cc
@@ -42,7 +42,6 @@ set(storage_client_integration_tests
     object_rewrite_integration_test.cc
     object_write_streambuf_integration_test.cc
     service_account_integration_test.cc
-    signed_url_conformance_test.cc
     signed_url_integration_test.cc
     slow_reader_chunk_integration_test.cc
     slow_reader_stream_integration_test.cc
@@ -50,14 +49,37 @@ set(storage_client_integration_tests
     storage_include_test.cc
     thread_integration_test.cc)
 
+# Signed URL conformance tests are parsed using protos. In order to simplify the
+# build files, only build these conformance tests if gRPC in GCS is compiled.
+if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
+    list(APPEND storage_client_integration_tests signed_url_conformance_test.cc)
+    # We need to disable clang tidy for the generated CC files.
+    google_cloud_cpp_proto_library(
+        google_cloud_cpp_storage_tests_conformance_protos
+        conformance_tests.proto PROTO_PATH_DIRECTORIES
+        ${CMAKE_CURRENT_SOURCE_DIR} LOCAL_INCLUDE)
+    if (CMAKE_VERSION VERSION_GREATER 3.6)
+        # This works because we're not using clang-tidy with older cmake
+        # versions.
+        set_target_properties(google_cloud_cpp_storage_tests_conformance_protos
+                              PROPERTIES CXX_CLANG_TIDY "")
+    endif ()
+    if (MSVC)
+        # We're compiling generated code, so there's no use in MSVC failing on
+        # warnings.
+        target_compile_options(google_cloud_cpp_storage_tests_conformance_protos
+                               PUBLIC "/wd4244")
+    endif ()
+endif ()
+
 foreach (fname ${storage_client_integration_tests})
     google_cloud_cpp_add_executable(target "storage" "${fname}")
     target_link_libraries(
         ${target}
         PRIVATE storage_client
                 storage_client_testing
-                google_cloud_cpp_testing
                 google_cloud_cpp_common
+                google_cloud_cpp_testing
                 GTest::gmock_main
                 GTest::gmock
                 GTest::gtest
@@ -65,6 +87,12 @@ foreach (fname ${storage_client_integration_tests})
                 Threads::Threads
                 absl::strings
                 nlohmann_json)
+    if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
+        target_link_libraries(
+            ${target} PRIVATE storage_client
+                              google_cloud_cpp_storage_tests_conformance_protos)
+    endif ()
+
     add_test(NAME ${target} COMMAND ${target})
     set_tests_properties(
         ${target} PROPERTIES LABELS

--- a/google/cloud/storage/tests/conformance_tests.proto
+++ b/google/cloud/storage/tests/conformance_tests.proto
@@ -1,0 +1,159 @@
+// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.conformance.storage.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option csharp_namespace = "Google.Cloud.Storage.V1.Tests.Conformance";
+option java_package = "com.google.cloud.conformance.storage.v1";
+option java_multiple_files = true;
+
+message TestFile {
+  repeated SigningV4Test signing_v4_tests = 1;
+  repeated PostPolicyV4Test post_policy_v4_tests = 2;
+}
+
+enum UrlStyle {
+  PATH_STYLE = 0;
+  VIRTUAL_HOSTED_STYLE = 1;
+  BUCKET_BOUND_HOSTNAME = 2;
+}
+
+message SigningV4Test {
+  string fileName = 1;
+  string description = 2;
+  string bucket = 3;
+  string object = 4;
+  string method = 5;
+  int64 expiration = 6;
+  google.protobuf.Timestamp timestamp = 7;
+  string expectedUrl = 8;
+  map<string, string> headers = 9;
+  map<string, string> query_parameters = 10;
+  string scheme = 11;
+  UrlStyle urlStyle = 12;
+  string bucketBoundHostname = 13;
+  string expectedCanonicalRequest = 14;
+  string expectedStringToSign = 15;
+}
+
+message ConditionalMatches {
+  repeated string expression = 1;
+}
+
+message PolicyConditions {
+  repeated int32 contentLengthRange = 1;
+  repeated string startsWith = 2;
+}
+
+// Specification documentation is located at:
+// https://cloud.google.com/storage/docs/authentication/signatures
+
+message PolicyInput {
+  // http or https
+  string scheme = 1;
+  UrlStyle urlStyle = 2;
+  string bucketBoundHostname = 3;
+  string bucket = 4;
+  string object = 5;
+  int32 expiration = 6;
+  google.protobuf.Timestamp timestamp = 7;
+  /*
+    fields with strict equivalence which are added into
+    PolicyOutput.expectedDecodedPolicy to generate the
+    signature.
+
+    Expectations
+
+    E.1: Order them in lexigraphical order so it's the
+    signature can be verified across different language
+    implementations.
+
+  */
+  map<string, string> fields = 8;
+  PolicyConditions conditions = 9;
+}
+
+message PolicyOutput {
+  string url = 1;
+  map<string, string> fields = 2;
+  /*
+    Expectations
+
+    E.1: PolicyInput.fields must be prepended to form expectedDecodedPolicy
+    for consistent result across languages. Ordering doesn't matter to the
+    service but the decision is made to make it easier to conform implementations
+    in implementation.
+
+    Example:
+
+    # Step 1
+
+    PolicyInput.fields has:
+    {
+      "content-disposition":"attachment; filename=\"~._-%=/é0Aa\"",
+      "content-encoding":"gzip",
+      "content-type":"text/plain",
+      "success_action_redirect":"http://www.google.com/"
+    }
+
+    # Step 2
+
+    The expectedDecodedPolicy before prepending the PolicyInput.fields
+    would look like this:
+
+    {
+      "conditions":[
+        ...prepend here in the same order provided in PolicyInput.fields...
+        {"bucket":"bucket-name"},
+        {"key":"test-object"},
+        {"x-goog-date":"20200123T043530Z"},
+        {"x-goog-credential":"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request"},
+        {"x-goog-algorithm":"GOOG4-RSA-SHA256"}
+      ],
+      "expiration":"2020-01-23T04:35:40Z"
+    }
+
+    # Step 3
+
+    Then expectedDecodedPolicy should prepends PolicyInput.fields in
+    the same order to PolicyOutput.expectedDecodedPolicy `conditions` key.
+
+    {
+      "conditions":[
+        {"content-disposition":"attachment; filename=\"~._-%=/é0Aa\""},
+        {"content-encoding":"gzip"},
+        {"content-type":"text/plain"},
+        {"success_action_redirect":"http://www.google.com/"},
+        {"bucket":"bucket-name"},
+        {"key":"test-object"},
+        {"x-goog-date":"20200123T043530Z"},
+        {"x-goog-credential":"test-iam-credentials@dummy-project-id.iam.gserviceaccount.com/20200123/auto/storage/goog4_request"},
+        {"x-goog-algorithm":"GOOG4-RSA-SHA256"}
+      ],
+      "expiration":"2020-01-23T04:35:40Z"
+    }
+  */
+
+  string expectedDecodedPolicy = 3;
+}
+
+message PostPolicyV4Test {
+  string description = 1;
+  PolicyInput policyInput = 2;
+  PolicyOutput policyOutput = 3;
+}

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -17,13 +17,15 @@
 #include "google/cloud/storage/internal/signed_url_requests.h"
 #include "google/cloud/storage/list_objects_reader.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/storage/tests/conformance_tests.pb.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/time_utils.h"
 #include "google/cloud/terminate_handler.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "absl/memory/memory.h"
+#include <google/protobuf/util/json_util.h>
 #include <gmock/gmock.h>
-#include <nlohmann/json.hpp>
 #include <fstream>
 #include <type_traits>
 
@@ -46,39 +48,14 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace {
+using google::cloud::conformance::storage::v1::PostPolicyV4Test;
+using google::cloud::conformance::storage::v1::SigningV4Test;
+using google::cloud::conformance::storage::v1::UrlStyle;
 using ::testing::HasSubstr;
 
 // Initialized in main() below.
-std::map<std::string, nlohmann::json>* signing_tests;
-std::map<std::string, nlohmann::json>* post_policy_tests;
-
-std::vector<std::pair<std::string, std::string>> ExtractListOfPairs(
-    nlohmann::json j_obj, std::string const& field) {
-  std::vector<std::pair<std::string, std::string>> res;
-
-  // Check for the keys of the relevant field
-  for (auto& x : j_obj[field].items()) {
-    // The keys are returned in alphabetical order by `nlohmann::json`, but
-    // the order does not matter when creating signed urls.
-    res.emplace_back(x.key(), x.value());
-  }
-  return res;
-}
-
-std::vector<std::pair<std::string, std::string>> ExtractHeaders(
-    nlohmann::json j_obj) {
-  return ExtractListOfPairs(std::move(j_obj), "headers");
-}
-
-std::vector<std::pair<std::string, std::string>> ExtractQueryParams(
-    nlohmann::json j_obj) {
-  return ExtractListOfPairs(std::move(j_obj), "queryParameters");
-}
-
-std::vector<std::pair<std::string, std::string>> ExtractFields(
-    nlohmann::json j_obj) {
-  return ExtractListOfPairs(std::move(j_obj), "fields");
-}
+std::map<std::string, SigningV4Test>* signing_tests;
+std::map<std::string, PostPolicyV4Test>* post_policy_tests;
 
 class V4SignedUrlConformanceTest
     : public google::cloud::storage::testing::StorageIntegrationTest,
@@ -107,67 +84,65 @@ TEST_P(V4SignedUrlConformanceTest, V4SignJson) {
   std::string actual_canonical_request;
   std::string actual_string_to_sign;
 
-  auto j_obj = (*signing_tests)[GetParam()];
-  std::string const method_name = j_obj["method"];
-  std::string const bucket_name = j_obj["bucket"];
-  std::string const object_name = j_obj["object"];
-  std::string const scheme = j_obj["scheme"];
-  std::string url_style;
-  if (j_obj.count("urlStyle") > 0) {
-    url_style = j_obj["urlStyle"].get<std::string>();
-  }
-  std::string const date = j_obj["timestamp"];
-  auto const valid_for =
-      std::chrono::seconds(internal::ParseIntField(j_obj, "expiration"));
-  std::string const expected = j_obj["expectedUrl"];
-  std::string const expected_canonical_request =
-      j_obj["expectedCanonicalRequest"];
-  std::string const expected_string_to_sign = j_obj["expectedStringToSign"];
+  auto const& test_params = (*signing_tests)[GetParam()];
+  auto const& method_name = test_params.method();
+  auto const& bucket_name = test_params.bucket();
+  auto const& object_name = test_params.object();
+  auto const& scheme = test_params.scheme();
+  auto const& url_style = test_params.urlstyle();
+  auto const date =
+      ::google::cloud::internal::ToChronoTimePoint(test_params.timestamp());
+  auto const valid_for = std::chrono::seconds(test_params.expiration());
+  auto const& expected = test_params.expectedurl();
+  auto const& expected_canonical_request =
+      test_params.expectedcanonicalrequest();
+  auto const& expected_string_to_sign = test_params.expectedstringtosign();
 
   // Extract the headers for each object
-  auto headers = ExtractHeaders(j_obj);
-  auto params = ExtractQueryParams(j_obj);
+  auto headers = test_params.headers();
+  auto params = test_params.query_parameters();
 
   google::cloud::storage::internal::V4SignUrlRequest request(
       method_name, bucket_name, object_name);
-  request.set_multiple_options(
-      SignedUrlTimestamp(google::cloud::internal::ParseRfc3339(date)),
-      SignedUrlDuration(valid_for));
+  request.set_multiple_options(SignedUrlTimestamp(date),
+                               SignedUrlDuration(valid_for));
 
   std::vector<AddExtensionHeaderOption> header_extensions(5);
   ASSERT_LE(headers.size(), header_extensions.size());
-  for (std::size_t i = 0; i < headers.size(); ++i) {
-    auto& header = headers.at(i);
+  std::size_t idx = 0;
+  for (auto const& name_val : headers) {
     request.set_multiple_options(
-        AddExtensionHeader(header.first, header.second));
-    header_extensions[i] = AddExtensionHeader(header.first, header.second);
+        AddExtensionHeader(name_val.first, name_val.second));
+    header_extensions[idx++] =
+        AddExtensionHeader(name_val.first, name_val.second);
   }
 
   std::vector<AddQueryParameterOption> query_params(5);
   ASSERT_LE(params.size(), query_params.size());
-  for (std::size_t i = 0; i < params.size(); ++i) {
-    auto& param = params.at(i);
+  idx = 0;
+  for (auto const& name_val : params) {
     request.set_multiple_options(
-        AddQueryParameterOption(param.first, param.second));
-    query_params[i] = AddQueryParameterOption(param.first, param.second);
+        AddQueryParameterOption(name_val.first, name_val.second));
+    query_params[idx++] =
+        AddQueryParameterOption(name_val.first, name_val.second);
   }
 
   VirtualHostname virtual_hotname;
-  if (url_style == "VIRTUAL_HOSTED_STYLE") {
+  if (url_style == UrlStyle::VIRTUAL_HOSTED_STYLE) {
     virtual_hotname = VirtualHostname(true);
     request.set_multiple_options(VirtualHostname(true));
   }
 
   BucketBoundHostname domain_named_bucket;
-  if (url_style == "BUCKET_BOUND_HOSTNAME") {
-    domain_named_bucket = BucketBoundHostname(j_obj["bucketBoundHostname"]);
+  if (url_style == UrlStyle::BUCKET_BOUND_HOSTNAME) {
+    domain_named_bucket =
+        BucketBoundHostname(test_params.bucketboundhostname());
     request.set_multiple_options(
-        BucketBoundHostname(j_obj["bucketBoundHostname"]));
+        BucketBoundHostname(test_params.bucketboundhostname()));
   }
 
   auto actual = client.CreateV4SignedUrl(
-      method_name, bucket_name, object_name,
-      SignedUrlTimestamp(google::cloud::internal::ParseRfc3339(date)),
+      method_name, bucket_name, object_name, SignedUrlTimestamp(date),
       SignedUrlDuration(valid_for), header_extensions[0], header_extensions[1],
       header_extensions[2], header_extensions[3], header_extensions[4],
       query_params[0], query_params[1], query_params[2], query_params[3],
@@ -194,7 +169,7 @@ INSTANTIATE_TEST_SUITE_P(
       std::vector<std::string> res;
       std::transform(signing_tests->begin(), signing_tests->end(),
                      std::back_inserter(res),
-                     [](std::pair<std::string, nlohmann::json> const& p) {
+                     [](std::pair<std::string, SigningV4Test> const& p) {
                        return p.first;
                      });
       return res;
@@ -208,81 +183,62 @@ TEST_P(V4PostPolicyConformanceTest, V4PostPolicy) {
   std::string account_email = creds->get()->AccountEmail();
   Client client(*creds);
 
-  auto const j_obj = (*post_policy_tests)[GetParam()];
-  auto const input = j_obj["policyInput"];
-  auto const output = j_obj["policyOutput"];
-  std::string const bucket_name = input["bucket"];
-  std::string const object_name = input["object"];
-  auto const valid_for = std::chrono::seconds(input["expiration"].get<int>());
-  auto timestamp = google::cloud::internal::ParseRfc3339(input["timestamp"]);
-  std::string const scheme = input["scheme"];
+  auto const& test_params = (*post_policy_tests)[GetParam()];
+  auto const& input = test_params.policyinput();
+  auto const& output = test_params.policyoutput();
+  auto const& bucket_name = input.bucket();
+  auto const& object_name = input.object();
+  auto const valid_for = std::chrono::seconds(input.expiration());
+  auto const timestamp =
+      ::google::cloud::internal::ToChronoTimePoint(input.timestamp());
+  auto const& scheme = input.scheme();
   BucketBoundHostname domain_named_bucket;
-  std::string url_style;
-  if (input.count("urlStyle") > 0) {
-    url_style = input["urlStyle"].get<std::string>();
-  }
-  if (url_style == "BUCKET_BOUND_HOSTNAME") {
-    domain_named_bucket = BucketBoundHostname(input["bucketBoundHostname"]);
+  auto const& url_style = input.urlstyle();
+  if (url_style == UrlStyle::BUCKET_BOUND_HOSTNAME) {
+    domain_named_bucket = BucketBoundHostname(input.bucketboundhostname());
   }
   VirtualHostname virtual_hotname;
-  if (url_style == "VIRTUAL_HOSTED_STYLE") {
+  if (url_style == UrlStyle::VIRTUAL_HOSTED_STYLE) {
     virtual_hotname = VirtualHostname(true);
   }
 
   std::vector<PolicyDocumentCondition> conditions;
-  if (input.count("conditions") > 0) {
-    auto conditions_json = input["conditions"];
-    if (!conditions_json.is_discarded()) {
-      for (auto const& condition : conditions_json.items()) {
-        std::vector<std::string> tokens;
-        if (condition.value().size() == 2) {
-          if (condition.key() == "startsWith") {
-            conditions.emplace_back(PolicyDocumentCondition::StartsWith(
-                condition.value()[0].get<std::string>().substr(1),
-                condition.value()[1]));
-          } else if (condition.key() == "contentLengthRange") {
-            conditions.emplace_back(PolicyDocumentCondition::ContentLengthRange(
-                condition.value()[0], condition.value()[1]));
-          } else {
-            ASSERT_TRUE(false) << "Unknown operator: " << condition.key();
-          }
-        } else if (condition.value().size() == 1) {
-          conditions.emplace_back(PolicyDocumentCondition::ExactMatchObject(
-              condition.key(), condition.value()[0]));
+  auto const& condition = input.conditions();
 
-        } else {
-          ASSERT_TRUE(false)
-              << "Expected 2 or 3 tokens, got " << condition.value().size() + 1;
-        }
-      }
-    }
+  ASSERT_TRUE(condition.startswith().empty() ||
+              condition.startswith().size() == 2U)
+      << condition.startswith().size();
+  if (condition.startswith().size() == 2U) {
+    conditions.emplace_back(PolicyDocumentCondition::StartsWith(
+        condition.startswith()[0].substr(1), condition.startswith()[1]));
+  }
+  ASSERT_TRUE(condition.contentlengthrange().empty() ||
+              condition.contentlengthrange().size() == 2U)
+      << condition.contentlengthrange().size();
+  if (condition.contentlengthrange().size() == 2U) {
+    conditions.emplace_back(PolicyDocumentCondition::ContentLengthRange(
+        condition.contentlengthrange()[0], condition.contentlengthrange()[1]));
   }
 
-  std::string const expected_url = output["url"];
-  auto fields = output["fields"];
-  std::string const expected_key = fields["key"];
-  std::string const expected_algorithm = fields["x-goog-algorithm"];
-  std::string const expected_credential = fields["x-goog-credential"];
-  std::string const expected_date = fields["x-goog-date"];
-  std::string const expected_signature = fields["x-goog-signature"];
-  std::string const expected_policy = fields["policy"];
+  auto const& expected_url = output.url();
+  auto const& fields = output.fields();
+  auto const& expected_algorithm = fields.at("x-goog-algorithm");
+  auto const& expected_credential = fields.at("x-goog-credential");
+  auto const& expected_date = fields.at("x-goog-date");
+  auto const& expected_signature = fields.at("x-goog-signature");
+  auto const& expected_policy = fields.at("policy");
 
-  std::map<std::string, std::string> expected_form_fields;
-  for (auto const& field : fields.items()) {
-    expected_form_fields[field.key()] = field.value().get<std::string>();
-  }
   // We need to escape it because `nlohmann::json` interprets the escaped
   // characters.
   std::string const expected_decoded_policy =
-      *internal::PostPolicyV4Escape(output["expectedDecodedPolicy"]);
-
-  auto headers = ExtractFields(input);
+      *internal::PostPolicyV4Escape(output.expecteddecodedpolicy());
 
   std::vector<AddExtensionFieldOption> extension_fields(5);
-  ASSERT_LE(headers.size(), extension_fields.size());
-  for (std::size_t i = 0; i < headers.size(); ++i) {
-    auto& header = headers.at(i);
-    extension_fields[i] = AddExtensionField(header.first, header.second);
+  ASSERT_LE(input.fields().size(), extension_fields.size());
+  std::size_t idx = 0;
+  for (auto const& name_val : input.fields()) {
+    extension_fields[idx++] =
+        AddExtensionField(name_val.first, name_val.second);
   }
   PolicyDocumentV4 doc{bucket_name, object_name, valid_for, timestamp,
                        std::move(conditions)};
@@ -301,7 +257,8 @@ TEST_P(V4PostPolicyConformanceTest, V4PostPolicy) {
                                doc_res->expiration - valid_for));
   EXPECT_EQ(expected_algorithm, doc_res->signing_algorithm);
   EXPECT_EQ(expected_signature, doc_res->signature);
-  EXPECT_EQ(expected_form_fields, doc_res->required_form_fields);
+  EXPECT_EQ((std::map<std::string, std::string>(fields.begin(), fields.end())),
+            doc_res->required_form_fields);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -310,7 +267,7 @@ INSTANTIATE_TEST_SUITE_P(
       std::vector<std::string> res;
       std::transform(post_policy_tests->begin(), post_policy_tests->end(),
                      std::back_inserter(res),
-                     [](std::pair<std::string, nlohmann::json> const& p) {
+                     [](std::pair<std::string, PostPolicyV4Test> const& p) {
                        return p.first;
                      });
       return res;
@@ -321,6 +278,9 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace storage
 }  // namespace cloud
 }  // namespace google
+
+using google::cloud::conformance::storage::v1::PostPolicyV4Test;
+using google::cloud::conformance::storage::v1::SigningV4Test;
 
 int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   auto conformance_tests_file =
@@ -333,66 +293,32 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
         << " environment variable must be set and not empty.\n";
     return 1;
   }
+
   std::ifstream ifstr(conformance_tests_file);
   if (!ifstr.is_open()) {
     std::cerr << "Failed to open data file: \"" << conformance_tests_file
               << "\"\n";
     return 1;
   }
+  std::string json_rep(std::istreambuf_iterator<char>{ifstr}, {});
+  google::cloud::conformance::storage::v1::TestFile tests;
+  auto status = google::protobuf::util::JsonStringToMessage(json_rep, &tests);
+  if (!status.ok()) {
+    std::cerr << "Failed to parse conformance tests: " << status.error_code()
+              << ": " << status.error_message() << "\n";
+    return 1;
+  }
 
   auto signing_tests_destroyer =
-      absl::make_unique<std::map<std::string, nlohmann::json>>();
+      absl::make_unique<std::map<std::string, SigningV4Test>>();
   google::cloud::storage::signing_tests = signing_tests_destroyer.get();
 
   // The implementation is not yet completed and these tests still fail, so skip
   // them so far.
   std::set<std::string> nonconformant_url_tests{"ListObjects"};
 
-  auto json = nlohmann::json::parse(ifstr);
-  if (json.is_discarded()) {
-    std::cerr << "Failed to parse provided data file\n";
-    return 1;
-  }
-
-  if (!json.is_object()) {
-    std::cerr << "The provided file should contain one JSON object.\n";
-    return 1;
-  }
-  if (json.count("signingV4Tests") < 1) {
-    std::cerr << "The provided file should contain a 'signingV4Tests' entry.\n"
-              << json;
-    return 1;
-  }
-
-  auto signing_tests_json = json["signingV4Tests"];
-  if (!signing_tests_json.is_array()) {
-    std::cerr << "Expected an obects' value to be arrays, found: "
-              << signing_tests_json << ".\n";
-    return 1;
-  }
-  if (!signing_tests_json.is_array()) {
-    std::cerr << "Expected an obects' value to be arrays, found: "
-              << signing_tests_json << ".\n";
-    return 1;
-  }
-
-  for (auto const& j_obj : signing_tests_json) {
-    if (!j_obj.is_object()) {
-      std::cerr << "Expected an array of objects, got this element in array: "
-                << j_obj << "\n";
-      return 1;
-    }
-    if (j_obj.count("description") != 1) {
-      std::cerr << "Expected all tests to have a description\n";
-      return 1;
-    }
-    auto j_descr = j_obj["description"];
-    if (!j_descr.is_string()) {
-      std::cerr << "Expected description to be a string, got: " << j_descr
-                << "\n";
-      return 1;
-    }
-    std::string name_with_spaces = j_descr;
+  for (auto const& signing_test : tests.signing_v4_tests()) {
+    std::string name_with_spaces = signing_test.description();
     std::string name;
     // gtest doesn't allow for anything other than [a-zA-Z]
     std::copy_if(name_with_spaces.begin(), name_with_spaces.end(),
@@ -403,39 +329,19 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       continue;
     }
     bool inserted =
-        google::cloud::storage::signing_tests->emplace(name, j_obj).second;
+        google::cloud::storage::signing_tests->emplace(name, signing_test)
+            .second;
     if (!inserted) {
       std::cerr << "Duplicate test description: " << name << "\n";
     }
   }
 
   auto post_policy_tests_destroyer =
-      absl::make_unique<std::map<std::string, nlohmann::json>>();
+      absl::make_unique<std::map<std::string, PostPolicyV4Test>>();
   google::cloud::storage::post_policy_tests = post_policy_tests_destroyer.get();
 
-  auto post_policy_tests_json = json["postPolicyV4Tests"];
-  if (!post_policy_tests_json.is_array()) {
-    std::cerr << "Expected an obects' value to be arrays, found: "
-              << post_policy_tests_json << ".\n";
-    return 1;
-  }
-  for (auto const& j_obj : post_policy_tests_json.items()) {
-    if (!j_obj.value().is_object()) {
-      std::cerr << "Expected an array of objects, got this element in array: "
-                << j_obj.value() << "\n";
-      return 1;
-    }
-    if (j_obj.value().count("description") != 1) {
-      std::cerr << "Expected all tests to have a description\n";
-      return 1;
-    }
-    auto j_descr = j_obj.value()["description"];
-    if (!j_descr.is_string()) {
-      std::cerr << "Expected description to be a string, got: " << j_descr
-                << "\n";
-      return 1;
-    }
-    std::string name_with_spaces = j_descr;
+  for (auto const& policy_test : tests.post_policy_v4_tests()) {
+    std::string name_with_spaces = policy_test.description();
     std::string name;
     // gtest doesn't allow for anything other than [a-zA-Z]
     std::copy_if(name_with_spaces.begin(), name_with_spaces.end(),
@@ -449,7 +355,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
     }
 #endif  // !GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     bool inserted =
-        google::cloud::storage::post_policy_tests->emplace(name, j_obj.value())
+        google::cloud::storage::post_policy_tests->emplace(name, policy_test)
             .second;
     if (!inserted) {
       std::cerr << "Duplicate test description: " << name << "\n";

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -43,11 +43,11 @@ storage_client_integration_tests = [
     "object_rewrite_integration_test.cc",
     "object_write_streambuf_integration_test.cc",
     "service_account_integration_test.cc",
-    "signed_url_conformance_test.cc",
     "signed_url_integration_test.cc",
     "slow_reader_chunk_integration_test.cc",
     "slow_reader_stream_integration_test.cc",
     "small_reads_integration_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
+    "signed_url_conformance_test.cc",
 ]


### PR DESCRIPTION
The file was imported from:
https://github.com/googleapis/conformance-tests/blob/d505e92d98f4f319ba774606ac95f693da2145c8/storage/v1/proto/google/cloud/conformance/storage/v1/tests.proto

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5294)
<!-- Reviewable:end -->
