### PR TITLE
feat(pubsub)!: share connections for publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ are close enough to a GA release that we think highlighting them is important.
 
 * Allow sharing connections between multiple `pubsub::Publisher` objects.
   Creating a `pubsub::PublisherConnection` no longer requires a `pubsub::Topic`
-  or the `pubsub::PublisherOptions`, these are now parameters for the
+  or the `pubsub::PublisherOptions`. These are now parameters for the
   `pubsub::Publisher` constructor.
 
 * Rename `pubsub::SubscriptionOptions` to `pubsub::SubscriberOptions` as these

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 While the Pub/Sub library is not GA, and breaking changes are to be expected, we
 are close enough to a GA release that we think highlighting them is important.
 
+* Allow sharing connections between multiple `pubsub::Publisher` objects.
+  Creating a `pubsub::PublisherConnection` no longer requires a `pubsub::Topic`
+  or the `pubsub::PublisherOptions`, these are now parameters for the
+  `pubsub::Publisher` constructor.
+
 * Rename `pubsub::SubscriptionOptions` to `pubsub::SubscriberOptions` as these
   are bound to a specific subscriber object.
 

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -100,6 +100,11 @@ errors=""
 for library in $(quickstart::libraries); do
   echo
   echo "================================================================"
+  if [[ "${library}" == "pubsub" ]]; then
+    # TODO(#5296) - remove this code to skip vcpkg-based builds
+    io::log_yellow "Skipping ${library}, see #5296"
+    continue
+  fi
   io::log_yellow "Building ${library}'s quickstart"
   if ! build_quickstart "${library}"; then
     io::log_red "Building ${library}'s quickstart failed"

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -108,6 +108,11 @@ errors=""
 for library in $(quickstart::libraries); do
   echo
   echo "================================================================"
+  if [[ "${library}" == "pubsub" ]]; then
+    # TODO(#5296) - remove this code to skip vcpkg-based builds
+    io::log_yellow "Skipping ${library}, see #5296"
+    continue
+  fi
   io::log_yellow "Building ${library}'s quickstart"
   if ! build_quickstart "${library}"; then
     io::log_red "Building ${library}'s quickstart failed"

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -115,6 +115,11 @@ errors=""
 for library in $(quickstart::libraries); do
   echo
   echo "================================================================"
+  if [[ "${library}" == "pubsub" ]]; then
+    # TODO(#5296) - remove this code to skip vcpkg-based builds
+    io::log_yellow "Skipping ${library}, see #5296"
+    continue
+  fi
   io::log_yellow "Building ${library}'s quickstart"
   if ! build_quickstart "${library}"; then
     io::log_red "Building ${library}'s quickstart failed"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -95,6 +95,11 @@ errors=""
 for library in $(quickstart::libraries); do
   echo
   echo "================================================================"
+  if [[ "${library}" == "pubsub" ]]; then
+    # TODO(#5296) - remove this code to skip vcpkg-based builds
+    io::log_yellow "Skipping ${library}, see #5296"
+    continue
+  fi
   io::log_yellow "Building ${library}'s quickstart"
   if ! build_quickstart "${library}"; then
     io::log_red "Building ${library}'s quickstart failed"

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -99,6 +99,7 @@ $quickstart_args=@{
     "spanner"=@("${env:GOOGLE_CLOUD_PROJECT}", "${env:GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}", "quickstart-db")
 }
 
+# TODO(#5296) - add pubsub to the list
 ForEach($library in ("bigtable", "storage", "spanner")) {
     Set-Location "${project_root}/google/cloud/${library}/quickstart"
     ForEach($_ in (1, 2, 3)) {

--- a/ci/kokoro/windows/build-quickstart-cmake.ps1
+++ b/ci/kokoro/windows/build-quickstart-cmake.ps1
@@ -59,6 +59,7 @@ $quickstart_args=@{
     "spanner"=@("${env:GOOGLE_CLOUD_PROJECT}", "${env:GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}", "quickstart-db")
 }
 
+# TODO(#5296) - add pubsub to the list
 ForEach($library in ("bigtable", "storage", "spanner")) {
     Set-Location "${project_root}"
 

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(
     internal/default_retry_policies.h
     internal/emulator_overrides.cc
     internal/emulator_overrides.h
+    internal/message_batcher.h
     internal/ordering_key_publisher_connection.cc
     internal/ordering_key_publisher_connection.h
     internal/publisher_logging.cc
@@ -167,6 +168,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
         pubsub_client_testing # cmake-format: sort
         testing/fake_streaming_pull.cc
         testing/fake_streaming_pull.h
+        testing/mock_message_batcher.h
         testing/mock_publisher_stub.h
         testing/mock_subscriber_stub.h
         testing/mock_subscription_batch_source.h

--- a/google/cloud/pubsub/README.md
+++ b/google/cloud/pubsub/README.md
@@ -53,8 +53,7 @@ int main(int argc, char* argv[]) try {
 
   // Create a namespace alias to make the code easier to read.
   namespace pubsub = google::cloud::pubsub;
-  auto publisher = pubsub::Publisher(
-      pubsub::MakePublisherConnection(pubsub::Topic(project_id, topic_id), {}));
+  auto publisher = pubsub::Publisher(pubsub::Topic(project_id, topic_id));
   auto id =
       publisher
           .Publish(pubsub::MessageBuilder{}.SetData("Hello World!").Build())

--- a/google/cloud/pubsub/benchmarks/endurance.cc
+++ b/google/cloud/pubsub/benchmarks/endurance.cc
@@ -425,10 +425,10 @@ void PublisherTask(Config const& config, ExperimentFlowControl& flow_control,
                    int task) {
   auto make_publisher = [config, task] {
     auto const topic = pubsub::Topic(config.project_id, config.topic_id);
-    return pubsub::Publisher(pubsub::MakePublisherConnection(
-        topic, {},
-        pubsub::ConnectionOptions{}.set_channel_pool_domain(
-            "publisher:" + std::to_string(task))));
+    return pubsub::Publisher(
+        topic, pubsub::MakePublisherConnection(
+                   pubsub::ConnectionOptions{}.set_channel_pool_domain(
+                       "publisher:" + std::to_string(task))));
   };
   auto publisher = make_publisher();
 

--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -65,16 +65,16 @@ struct Batch {
 };
 
 future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
-    PublishParams p) {
+    pubsub::Message m) {
   promise<StatusOr<std::string>> promise;
   auto f = promise.get_future();
   std::unique_lock<std::mutex> lk(mu_);
-  pending_.push_back(Item{std::move(promise), std::move(p.message)});
+  pending_.push_back(Item{std::move(promise), std::move(m)});
   MaybeFlush(std::move(lk));
   return f;
 }
 
-void BatchingPublisherConnection::Flush(FlushParams) {
+void BatchingPublisherConnection::Flush() {
   FlushImpl(std::unique_lock<std::mutex>(mu_));
 }
 
@@ -144,17 +144,7 @@ void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
   pending_.clear();
   lk.unlock();
 
-  auto& stub = stub_;
-  google::cloud::internal::AsyncRetryLoop(
-      retry_policy_->clone(), backoff_policy_->clone(),
-      google::cloud::internal::Idempotency::kIdempotent, cq_,
-      [stub](google::cloud::CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext> context,
-             google::pubsub::v1::PublishRequest const& request) {
-        return stub->AsyncPublish(cq, std::move(context), request);
-      },
-      std::move(request), __func__)
-      .then(std::move(batch));
+  connection_->Publish({std::move(request)}).then(std::move(batch));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
-#include "google/cloud/pubsub/testing/mock_publisher_stub.h"
+#include "google/cloud/pubsub/mocks/mock_publisher_connection.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
 namespace google {
@@ -28,40 +27,43 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+using ::testing::Return;
+
+std::vector<std::string> DataElements(
+    pubsub::PublisherConnection::PublishParams const& p) {
+  std::vector<std::string> data;
+  std::transform(p.request.messages().begin(), p.request.messages().end(),
+                 std::back_inserter(data),
+                 [](google::pubsub::v1::PubsubMessage const& m) {
+                   return std::string(m.data());
+                 });
+  return data;
+}
 
 TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
-        std::vector<std::string> data;
-        std::transform(request.messages().begin(), request.messages().end(),
-                       std::back_inserter(data),
-                       [](google::pubsub::v1::PubsubMessage const& m) {
-                         return std::string(m.data());
-                       });
-        EXPECT_THAT(data, ElementsAre("test-data-0", "test-data-1"));
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
+        EXPECT_THAT(DataElements(p), ElementsAre("test-data-0", "test-data-1"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         response.add_message_ids("test-message-id-1");
         return make_ready_future(make_status_or(response));
       });
 
-  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
           .set_maximum_hold_time(std::chrono::milliseconds(50)),
-      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
 
   // We expect the responses to be satisfied in the context of the completion
   // queue threads. This is an important property, the processing of any
@@ -86,22 +88,20 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
             EXPECT_EQ("test-message-id-1", *r);
             EXPECT_NE(main_thread, std::this_thread::get_id());
           }));
-  publisher->Flush({});
+  publisher->Flush();
   for (auto& p : published) p.get();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(2, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
-        EXPECT_EQ("test-data-1", request.messages(1).data());
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
+        EXPECT_THAT(DataElements(p), ElementsAre("test-data-0", "test-data-1"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         response.add_message_ids("test-message-id-1");
@@ -113,8 +113,7 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
   google::cloud::CompletionQueue cq;
   auto publisher = BatchingPublisherConnection::Create(
       topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
   auto r0 =
       publisher
           ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
@@ -142,17 +141,15 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(2, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
-        EXPECT_EQ("test-data-1", request.messages(1).data());
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
+        EXPECT_THAT(DataElements(p), ElementsAre("test-data-0", "test-data-1"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         response.add_message_ids("test-message-id-1");
@@ -171,8 +168,7 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
           .set_maximum_batch_bytes(kMaxMessageBytes),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
   auto r0 =
       publisher
           ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
@@ -200,17 +196,15 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(2, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
-        EXPECT_EQ("test-data-1", request.messages(1).data());
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
+        EXPECT_THAT(DataElements(p), ElementsAre("test-data-0", "test-data-1"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         response.add_message_ids("test-message-id-1");
@@ -225,8 +219,7 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
           .set_maximum_batch_message_count(4),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
   auto r0 =
       publisher
           ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
@@ -254,28 +247,24 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByFlush) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(2, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
-        EXPECT_EQ("test-data-1", request.messages(1).data());
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
+        EXPECT_THAT(DataElements(p), ElementsAre("test-data-0", "test-data-1"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         response.add_message_ids("test-message-id-1");
         return make_ready_future(make_status_or(response));
       })
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
-                          google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
+      .WillRepeatedly([&](pubsub::PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
         google::pubsub::v1::PublishResponse response;
-        for (auto const& m : request.messages()) {
+        for (auto const& m : p.request.messages()) {
           response.add_message_ids("ack-for-" + std::string(m.data()));
         }
         return make_ready_future(make_status_or(response));
@@ -289,8 +278,7 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
           .set_maximum_batch_message_count(4),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
 
   std::vector<future<void>> results;
   for (auto i : {0, 1}) {
@@ -308,7 +296,7 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
 
   // Trigger the first `.WillOnce()` expectation.  CQ is not running yet, so the
   // flush cannot be explained by a timer, and the message count is too low.
-  publisher->Flush({});
+  publisher->Flush();
 
   for (auto i : {2, 3, 4}) {
     auto data = std::string{"test-data-"} + std::to_string(i);
@@ -328,23 +316,21 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
 }
 
 TEST(BatchingPublisherConnectionTest, HandleError) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
   auto const error_status = Status(StatusCode::kPermissionDenied, "uh-oh");
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
-                          google::pubsub::v1::PublishRequest const&) {
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const&) {
         return make_ready_future(
             StatusOr<google::pubsub::v1::PublishResponse>(error_status));
       });
 
-  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
   auto publisher = BatchingPublisherConnection::Create(
       topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
-      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
     EXPECT_THAT(r.status(),
@@ -364,26 +350,24 @@ TEST(BatchingPublisherConnectionTest, HandleError) {
 }
 
 TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
-      .WillRepeatedly([&](google::cloud::CompletionQueue&,
-                          std::unique_ptr<grpc::ClientContext>,
-                          google::pubsub::v1::PublishRequest const&) {
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](pubsub::PublisherConnection::PublishParams const&) {
         google::pubsub::v1::PublishResponse response;
         return make_ready_future(make_status_or(response));
       });
 
-  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
   auto publisher = BatchingPublisherConnection::Create(
       topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
-      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      mock);
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
-    EXPECT_EQ(StatusCode::kUnknown, r.status().code());
-    EXPECT_THAT(r.status().message(), HasSubstr("mismatched message id count"));
+    EXPECT_THAT(r.status(), StatusIs(StatusCode::kUnknown,
+                                     HasSubstr("mismatched message id count")));
   };
   auto r0 =
       publisher

--- a/google/cloud/pubsub/internal/message_batcher.h
+++ b/google/cloud/pubsub/internal/message_batcher.h
@@ -12,28 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_MESSAGE_BATCHER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_MESSAGE_BATCHER_H
+
+#include "google/cloud/pubsub/message.h"
+#include "google/cloud/pubsub/version.h"
+#include "google/cloud/future.h"
+#include "google/cloud/status_or.h"
 
 namespace google {
 namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-future<StatusOr<std::string>> RejectsWithOrderingKey::Publish(
-    pubsub::Message m) {
-  if (!m.ordering_key().empty()) {
-    return google::cloud::make_ready_future(StatusOr<std::string>(
-        Status(StatusCode::kInvalidArgument,
-               "Attempted to publish a message with an ordering"
-               " key with a publisher that does not have message"
-               " ordering enabled.")));
-  }
-  return child_->Publish(std::move(m));
-}
+/**
+ * Defines the interface to batch published messages.
+ */
+class MessageBatcher {
+ public:
+  virtual ~MessageBatcher() = default;
 
-void RejectsWithOrderingKey::Flush() { return child_->Flush(); }
+  /// Receive a new message to batch
+  virtual future<StatusOr<std::string>> Publish(pubsub::Message m) = 0;
+
+  /// Flush any pending messages
+  virtual void Flush() = 0;
+};
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_MESSAGE_BATCHER_H

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_ORDERING_KEY_PUBLISHER_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_ORDERING_KEY_PUBLISHER_CONNECTION_H
 
-#include "google/cloud/pubsub/publisher_connection.h"
+#include "google/cloud/pubsub/internal/message_batcher.h"
 #include "google/cloud/pubsub/version.h"
 #include <functional>
 #include <map>
@@ -26,10 +26,10 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-class OrderingKeyPublisherConnection : public pubsub::PublisherConnection {
+class OrderingKeyPublisherConnection : public MessageBatcher {
  public:
   using ConnectionFactory =
-      std::function<std::shared_ptr<PublisherConnection>(std::string const&)>;
+      std::function<std::shared_ptr<MessageBatcher>(std::string const&)>;
 
   static std::shared_ptr<OrderingKeyPublisherConnection> Create(
       ConnectionFactory factory) {
@@ -39,8 +39,8 @@ class OrderingKeyPublisherConnection : public pubsub::PublisherConnection {
 
   ~OrderingKeyPublisherConnection() override = default;
 
-  future<StatusOr<std::string>> Publish(PublishParams p) override;
-  void Flush(FlushParams) override;
+  future<StatusOr<std::string>> Publish(pubsub::Message m) override;
+  void Flush() override;
 
  private:
   explicit OrderingKeyPublisherConnection(ConnectionFactory factory)
@@ -48,7 +48,7 @@ class OrderingKeyPublisherConnection : public pubsub::PublisherConnection {
 
   ConnectionFactory factory_;
   std::mutex mu_;
-  std::map<std::string, std::shared_ptr<PublisherConnection>> children_;
+  std::map<std::string, std::shared_ptr<MessageBatcher>> children_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection_test.cc
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/ordering_key_publisher_connection.h"
-#include "google/cloud/pubsub/mocks/mock_publisher_connection.h"
+#include "google/cloud/pubsub/testing/mock_message_batcher.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -24,8 +23,6 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
-
-using ::testing::_;
 
 TEST(OrderingKeyPublisherConnectionTest, Publish) {
   struct TestStep {
@@ -38,21 +35,17 @@ TEST(OrderingKeyPublisherConnectionTest, Publish) {
 
   std::vector<pubsub::Message> received;
   auto factory = [&](std::string const& ordering_key) {
-    auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
-    EXPECT_CALL(*mock, Publish(_))
-        .WillRepeatedly(
-            [ordering_key](
-                pubsub::PublisherConnection::PublishParams const& p) {
-              EXPECT_EQ(ordering_key, p.message.ordering_key());
-              auto ack_id = p.message.ordering_key() + "#" +
-                            std::string(p.message.data());
-              return make_ready_future(make_status_or(ack_id));
-            });
-    EXPECT_CALL(*mock, Flush(_)).Times(2);
+    auto mock = std::make_shared<pubsub_testing::MockMessageBatcher>();
+    EXPECT_CALL(*mock, Publish)
+        .WillRepeatedly([ordering_key](pubsub::Message const& m) {
+          EXPECT_EQ(ordering_key, m.ordering_key());
+          auto ack_id = m.ordering_key() + "#" + std::string(m.data());
+          return make_ready_future(make_status_or(ack_id));
+        });
+    EXPECT_CALL(*mock, Flush).Times(2);
     return mock;
   };
 
-  google::cloud::CompletionQueue cq;
   auto publisher = OrderingKeyPublisherConnection::Create(factory);
 
   std::vector<future<void>> results;
@@ -71,8 +64,8 @@ TEST(OrderingKeyPublisherConnectionTest, Publish) {
   }
   for (auto& r : results) r.get();
 
-  publisher->Flush({});
-  publisher->Flush({});
+  publisher->Flush();
+  publisher->Flush();
 }
 
 }  // namespace

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.h
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_REJECTS_WITH_ORDERING_KEY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_REJECTS_WITH_ORDERING_KEY_H
 
-#include "google/cloud/pubsub/publisher_connection.h"
+#include "google/cloud/pubsub/internal/message_batcher.h"
 #include "google/cloud/pubsub/version.h"
 
 namespace google {
@@ -23,25 +23,24 @@ namespace cloud {
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-class RejectsWithOrderingKey : public pubsub::PublisherConnection {
+class RejectsWithOrderingKey : public MessageBatcher {
  public:
   static std::shared_ptr<RejectsWithOrderingKey> Create(
-      std::shared_ptr<pubsub::PublisherConnection> connection) {
+      std::shared_ptr<MessageBatcher> child) {
     return std::shared_ptr<RejectsWithOrderingKey>(
-        new RejectsWithOrderingKey(std::move(connection)));
+        new RejectsWithOrderingKey(std::move(child)));
   }
 
   ~RejectsWithOrderingKey() override = default;
 
-  future<StatusOr<std::string>> Publish(PublishParams p) override;
-  void Flush(FlushParams) override;
+  future<StatusOr<std::string>> Publish(pubsub::Message m) override;
+  void Flush() override;
 
  private:
-  explicit RejectsWithOrderingKey(
-      std::shared_ptr<PublisherConnection> connection)
-      : connection_(std::move(connection)) {}
+  explicit RejectsWithOrderingKey(std::shared_ptr<MessageBatcher> child)
+      : child_(std::move(child)) {}
 
-  std::shared_ptr<PublisherConnection> connection_;
+  std::shared_ptr<MessageBatcher> child_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key_test.cc
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
-#include "google/cloud/pubsub/mocks/mock_publisher_connection.h"
+#include "google/cloud/pubsub/testing/mock_message_batcher.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
@@ -25,25 +25,35 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::testing::HasSubstr;
+using ::google::cloud::testing_util::StatusIs;
 
-TEST(RejectsWithOrderingKeyTest, PublishWithOrderingKeyFailure) {
-  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
-  pubsub::Topic const topic("test-project", "test-topic");
+TEST(RejectsWithOrderingKeyTest, MessageRejected) {
+  auto mock = std::make_shared<pubsub_testing::MockMessageBatcher>();
+  EXPECT_CALL(*mock, Publish).Times(0);
+
+  auto publisher = RejectsWithOrderingKey::Create(mock);
+  auto response = publisher
+                      ->Publish({pubsub::MessageBuilder{}
+                                     .SetData("test-data-0")
+                                     .SetOrderingKey("test-ordering-key-0")
+                                     .Build()})
+                      .get();
+  EXPECT_THAT(response.status(), StatusIs(StatusCode::kInvalidArgument));
+}
+
+TEST(RejectsWithOrderingKeyTest, MessageAccepted) {
+  auto mock = std::make_shared<pubsub_testing::MockMessageBatcher>();
+  EXPECT_CALL(*mock, Publish).WillOnce([](pubsub::Message const&) {
+    return make_ready_future(StatusOr<std::string>("test-id"));
+  });
 
   auto publisher = RejectsWithOrderingKey::Create(mock);
   auto response =
       publisher
-          ->Publish({pubsub::MessageBuilder{}
-                         .SetData("test-data-0")
-                         .SetOrderingKey("test-ordering-key-0")
-                         .Build()})
-          .then([&](future<StatusOr<std::string>> f) {
-            auto response = f.get();
-            EXPECT_EQ(StatusCode::kInvalidArgument, response.status().code());
-            EXPECT_THAT(response.status().message(),
-                        HasSubstr("does not have message ordering enabled"));
-          });
+          ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
+          .get();
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ("test-id", *response);
 }
 
 }  // namespace

--- a/google/cloud/pubsub/mocks/mock_publisher_connection.h
+++ b/google/cloud/pubsub/mocks/mock_publisher_connection.h
@@ -32,10 +32,9 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  */
 class MockPublisherConnection : public pubsub::PublisherConnection {
  public:
-  MOCK_METHOD(future<StatusOr<std::string>>, Publish,
-              (pubsub::PublisherConnection::PublishParams), (override));
-  MOCK_METHOD(void, Flush, (pubsub::PublisherConnection::FlushParams),
-              (override));
+  MOCK_METHOD1(Publish, future<StatusOr<::google::pubsub::v1::PublishResponse>>(
+                            pubsub::PublisherConnection::PublishParams));
+  MOCK_METHOD0(cq, google::cloud::CompletionQueue());
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/publisher.cc
+++ b/google/cloud/pubsub/publisher.cc
@@ -13,17 +13,37 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher.h"
+#include "google/cloud/pubsub/internal/batching_publisher_connection.h"
+#include "google/cloud/pubsub/internal/ordering_key_publisher_connection.h"
+#include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 
 namespace google {
 namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+std::shared_ptr<pubsub_internal::MessageBatcher> MakeMessageBatcher(
+    pubsub::Topic topic, pubsub::PublisherOptions options,
+    std::shared_ptr<pubsub::PublisherConnection> connection) {
+  if (options.message_ordering()) {
+    auto factory = [topic, options, connection](std::string const&) {
+      return pubsub_internal::BatchingPublisherConnection::Create(
+          topic, options, connection);
+    };
+    return pubsub_internal::OrderingKeyPublisherConnection::Create(
+        std::move(factory));
+  }
+  return pubsub_internal::RejectsWithOrderingKey::Create(
+      pubsub_internal::BatchingPublisherConnection::Create(
+          std::move(topic), std::move(options), std::move(connection)));
+}
 
-// TODO(#4581) - use the options to setup batching
-// TODO(#4584) - use the ordering key configuration
-Publisher::Publisher(std::shared_ptr<PublisherConnection> connection,
-                     PublisherOptions)
-    : connection_(std::move(connection)) {}
+}  // namespace
+
+Publisher::Publisher(Topic topic, PublisherOptions options,
+                     std::shared_ptr<PublisherConnection> connection)
+    : batcher_(MakeMessageBatcher(std::move(topic), std::move(options),
+                                  std::move(connection))) {}
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_PUBLISHER_H
 
 #include "google/cloud/pubsub/connection_options.h"
+#include "google/cloud/pubsub/internal/message_batcher.h"
 #include "google/cloud/pubsub/publisher_connection.h"
 #include "google/cloud/pubsub/publisher_options.h"
 #include "google/cloud/pubsub/version.h"
@@ -102,8 +103,13 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  */
 class Publisher {
  public:
-  explicit Publisher(std::shared_ptr<PublisherConnection> connection,
-                     PublisherOptions options = {});
+  explicit Publisher(Topic topic, PublisherOptions options = {},
+                     std::shared_ptr<PublisherConnection> connection =
+                         MakePublisherConnection());
+
+  explicit Publisher(Topic topic,
+                     std::shared_ptr<PublisherConnection> connection)
+      : Publisher(std::move(topic), {}, std::move(connection)) {}
 
   //@{
   Publisher(Publisher const&) = default;
@@ -139,7 +145,7 @@ class Publisher {
    *     a unrecoverable error.
    */
   future<StatusOr<std::string>> Publish(Message m) {
-    return connection_->Publish({std::move(m)});
+    return batcher_->Publish({std::move(m)});
   }
 
   /**
@@ -156,10 +162,10 @@ class Publisher {
    *     application can use the `future<StatusOr<std::string>>` returned in
    *     each `Publish()` call to find out what the results are.
    */
-  void Flush() { connection_->Flush({}); }
+  void Flush() { batcher_->Flush(); }
 
  private:
-  std::shared_ptr<PublisherConnection> connection_;
+  std::shared_ptr<pubsub_internal::MessageBatcher> batcher_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -13,14 +13,12 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/publisher_connection.h"
-#include "google/cloud/pubsub/internal/batching_publisher_connection.h"
 #include "google/cloud/pubsub/internal/default_retry_policies.h"
-#include "google/cloud/pubsub/internal/ordering_key_publisher_connection.h"
 #include "google/cloud/pubsub/internal/publisher_logging.h"
 #include "google/cloud/pubsub/internal/publisher_metadata.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
-#include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 #include "google/cloud/future_void.h"
+#include "google/cloud/internal/async_retry_loop.h"
 #include "google/cloud/log.h"
 #include <memory>
 
@@ -28,37 +26,18 @@ namespace google {
 namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
-namespace {
-class ContainingPublisherConnection : public PublisherConnection {
- public:
-  ContainingPublisherConnection(std::shared_ptr<BackgroundThreads> background,
-                                std::shared_ptr<PublisherConnection> child)
-      : background_(std::move(background)), child_(std::move(child)) {}
-
-  ~ContainingPublisherConnection() override = default;
-
-  future<StatusOr<std::string>> Publish(PublishParams p) override {
-    return child_->Publish(std::move(p));
-  }
-  void Flush(FlushParams p) override { child_->Flush(std::move(p)); }
-
- private:
-  std::shared_ptr<BackgroundThreads> background_;
-  std::shared_ptr<PublisherConnection> child_;
-};
-}  // namespace
 
 PublisherConnection::~PublisherConnection() = default;
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
-    Topic topic, PublisherOptions options, ConnectionOptions connection_options,
+    ConnectionOptions connection_options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
     std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
   auto stub = pubsub_internal::CreateDefaultPublisherStub(connection_options,
                                                           /*channel_id=*/0);
   return pubsub_internal::MakePublisherConnection(
-      std::move(topic), std::move(options), std::move(connection_options),
-      std::move(stub), std::move(retry_policy), std::move(backoff_policy));
+      std::move(connection_options), std::move(stub), std::move(retry_policy),
+      std::move(backoff_policy));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
@@ -66,9 +45,67 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 
 namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
+namespace {
+class ContainingPublisherConnection : public pubsub::PublisherConnection {
+ public:
+  ContainingPublisherConnection(std::shared_ptr<BackgroundThreads> background,
+                                std::shared_ptr<PublisherConnection> child)
+      : background_(std::move(background)), child_(std::move(child)) {}
+
+  ~ContainingPublisherConnection() override = default;
+
+  future<StatusOr<google::pubsub::v1::PublishResponse>> Publish(
+      PublishParams p) override {
+    return child_->Publish(std::move(p));
+  }
+
+  google::cloud::CompletionQueue cq() override { return child_->cq(); }
+
+ private:
+  std::shared_ptr<BackgroundThreads> background_;
+  std::shared_ptr<PublisherConnection> child_;
+};
+
+class PublisherConnectionImpl : public pubsub::PublisherConnection {
+ public:
+  PublisherConnectionImpl(
+      std::shared_ptr<pubsub_internal::PublisherStub> stub,
+      google::cloud::CompletionQueue cq,
+      std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+      std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy)
+      : stub_(std::move(stub)),
+        cq_(std::move(cq)),
+        retry_policy_(std::move(retry_policy)),
+        backoff_policy_(std::move(backoff_policy)) {}
+
+  ~PublisherConnectionImpl() override = default;
+
+  future<StatusOr<google::pubsub::v1::PublishResponse>> Publish(
+      PublishParams p) override {
+    auto& stub = stub_;
+    return google::cloud::internal::AsyncRetryLoop(
+        retry_policy_->clone(), backoff_policy_->clone(),
+        google::cloud::internal::Idempotency::kIdempotent, cq_,
+        [stub](google::cloud::CompletionQueue& cq,
+               std::unique_ptr<grpc::ClientContext> context,
+               google::pubsub::v1::PublishRequest const& request) {
+          return stub->AsyncPublish(cq, std::move(context), request);
+        },
+        std::move(p.request), __func__);
+  }
+
+  google::cloud::CompletionQueue cq() override { return cq_; }
+
+ private:
+  std::shared_ptr<pubsub_internal::PublisherStub> stub_;
+  google::cloud::CompletionQueue cq_;
+  std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
+  std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy_;
+};
+
+}  // namespace
 
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, pubsub::PublisherOptions options,
     pubsub::ConnectionOptions connection_options,
     std::shared_ptr<PublisherStub> stub,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
@@ -91,30 +128,12 @@ std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
     connection_options.set_background_thread_pool_size(
         default_thread_pool_size());
   }
-
   auto background = connection_options.background_threads_factory()();
-  auto make_connection = [&]() -> std::shared_ptr<pubsub::PublisherConnection> {
-    auto cq = background->cq();
-    if (options.message_ordering()) {
-      // We need to copy these values because we will call `clone()` on them
-      // multiple times.
-      std::shared_ptr<pubsub::RetryPolicy const> retry =
-          std::move(retry_policy);
-      std::shared_ptr<pubsub::BackoffPolicy const> backoff =
-          std::move(backoff_policy);
-      auto factory = [topic, options, stub, cq, retry,
-                      backoff](std::string const&) {
-        return BatchingPublisherConnection::Create(
-            topic, options, stub, cq, retry->clone(), backoff->clone());
-      };
-      return OrderingKeyPublisherConnection::Create(std::move(factory));
-    }
-    return RejectsWithOrderingKey::Create(BatchingPublisherConnection::Create(
-        std::move(topic), std::move(options), std::move(stub), std::move(cq),
-        std::move(retry_policy), std::move(backoff_policy)));
-  };
-  return std::make_shared<pubsub::ContainingPublisherConnection>(
-      std::move(background), make_connection());
+  auto connection = std::make_shared<PublisherConnectionImpl>(
+      std::move(stub), background->cq(), std::move(retry_policy),
+      std::move(backoff_policy));
+  return std::make_shared<ContainingPublisherConnection>(std::move(background),
+                                                         std::move(connection));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -63,7 +63,6 @@ class PublisherConnection {
   struct PublishParams {
     google::pubsub::v1::PublishRequest request;
   };
-
   //@}
 
   /// Defines the interface for `Publisher::Publish()`

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -61,18 +61,17 @@ class PublisherConnection {
 
   /// Wrap the arguments for `Publish()`
   struct PublishParams {
-    Message message;
+    google::pubsub::v1::PublishRequest request;
   };
 
-  /// Wrap the arguments for `Flush()`
-  struct FlushParams {};
   //@}
 
   /// Defines the interface for `Publisher::Publish()`
-  virtual future<StatusOr<std::string>> Publish(PublishParams p) = 0;
+  virtual future<StatusOr<google::pubsub::v1::PublishResponse>> Publish(
+      PublishParams p) = 0;
 
-  /// Defines the interface for `Publisher::Flush()`
-  virtual void Flush(FlushParams) = 0;
+  /// Returns the completion queue used by this publisher
+  virtual google::cloud::CompletionQueue cq() = 0;
 };
 
 /**
@@ -85,10 +84,6 @@ class PublisherConnection {
  *
  * @see `PublisherConnection`
  *
- * @param topic the Cloud Pub/Sub topic used by the returned
- *     `PublisherConnection`.
- * @param options configure the batching policy and other parameters in the
- *     returned connection.
  * @param connection_options (optional) general configuration for this
  *    connection, this type is also used to configure `pubsub::Subscriber`.
  * @param retry_policy (optional) configure the retry loop. This is only used
@@ -98,7 +93,6 @@ class PublisherConnection {
  *    @p options.
  */
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
-    Topic topic, PublisherOptions options,
     ConnectionOptions connection_options = {},
     std::unique_ptr<RetryPolicy const> retry_policy = {},
     std::unique_ptr<BackoffPolicy const> backoff_policy = {});
@@ -110,7 +104,6 @@ namespace pubsub_internal {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 std::shared_ptr<pubsub::PublisherConnection> MakePublisherConnection(
-    pubsub::Topic topic, pubsub::PublisherOptions options,
     pubsub::ConnectionOptions connection_options,
     std::shared_ptr<PublisherStub> stub,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -31,7 +31,19 @@ namespace {
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AtLeast;
 using ::testing::Contains;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+
+std::vector<std::string> DataElements(
+    google::pubsub::v1::PublishRequest const& request) {
+  std::vector<std::string> data;
+  std::transform(request.messages().begin(), request.messages().end(),
+                 std::back_inserter(data),
+                 [](google::pubsub::v1::PubsubMessage const& m) {
+                   return std::string(m.data());
+                 });
+  return data;
+}
 
 TEST(PublisherConnectionTest, Basic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
@@ -42,21 +54,21 @@ TEST(PublisherConnectionTest, Basic) {
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(1, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
+        EXPECT_THAT(DataElements(request), ElementsAre("test-data-0"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         return make_ready_future(make_status_or(response));
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, {}, mock, pubsub_testing::TestRetryPolicy(),
+      {}, mock, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
-  auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
-          .get();
+  google::pubsub::v1::PublishRequest request;
+  request.set_topic(topic.FullName());
+  request.add_messages()->set_data("test-data-0");
+  auto response = publisher->Publish({std::move(request)}).get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ("test-message-id-0", *response);
+  EXPECT_THAT(response->message_ids(), ElementsAre("test-message-id-0"));
 }
 
 TEST(PublisherConnectionTest, Metadata) {
@@ -79,11 +91,12 @@ TEST(PublisherConnectionTest, Metadata) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, ConnectionOptions{}.enable_tracing("rpc"), mock,
+      ConnectionOptions{}.enable_tracing("rpc"), mock,
       pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
-  auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
-          .get();
+  google::pubsub::v1::PublishRequest request;
+  request.set_topic(topic.FullName());
+  request.add_messages()->set_data("test-data-0");
+  auto response = publisher->Publish({std::move(request)}).get();
   ASSERT_STATUS_OK(response);
 }
 
@@ -107,85 +120,15 @@ TEST(PublisherConnectionTest, Logging) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, ConnectionOptions{}.enable_tracing("rpc"), mock,
+      ConnectionOptions{}.enable_tracing("rpc"), mock,
       pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
-  auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
-          .get();
+  google::pubsub::v1::PublishRequest request;
+  request.add_messages()->set_data("test-data-0");
+  auto response = publisher->Publish({std::move(request)}).get();
   ASSERT_STATUS_OK(response);
 
   EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("AsyncPublish")));
   google::cloud::LogSink::Instance().RemoveBackend(id);
-}
-
-TEST(PublisherConnectionTest, OrderingKey) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
-  Topic const topic("test-project", "test-topic");
-
-  EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const& request) {
-        EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(1, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
-        google::pubsub::v1::PublishResponse response;
-        response.add_message_ids("test-message-id-0");
-        return make_ready_future(make_status_or(response));
-      });
-
-  auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}.enable_message_ordering(), {}, mock,
-      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
-  auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
-          .get();
-  ASSERT_STATUS_OK(response);
-  EXPECT_EQ("test-message-id-0", *response);
-}
-
-TEST(PublisherConnectionTest, OrderingKeyWithoutMessageOrdering) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
-  Topic const topic("test-project", "test-topic");
-
-  auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}, {}, mock, pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
-  auto response = publisher
-                      ->Publish({MessageBuilder{}
-                                     .SetOrderingKey("test-ordering-key-0")
-                                     .SetData("test-data-0")
-                                     .Build()})
-                      .get();
-  EXPECT_EQ(StatusCode::kInvalidArgument, response.status().code());
-  EXPECT_THAT(response.status().message(),
-              HasSubstr("does not have message ordering enabled"));
-}
-
-TEST(PublisherConnectionTest, HandleInvalidResponse) {
-  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
-  Topic const topic("test-project", "test-topic");
-
-  EXPECT_CALL(*mock, AsyncPublish)
-      .WillOnce([&](google::cloud::CompletionQueue&,
-                    std::unique_ptr<grpc::ClientContext>,
-                    google::pubsub::v1::PublishRequest const&) {
-        google::pubsub::v1::PublishResponse response;
-        return make_ready_future(make_status_or(response));
-      });
-
-  auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, {}, mock, pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
-  auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
-          .get();
-  // It is very unlikely we will see this in production, it would indicate a bug
-  // in the Cloud Pub/Sub service where we successfully published N events, but
-  // we received M != N message ids back.
-  EXPECT_EQ(StatusCode::kUnknown, response.status().code());
-  EXPECT_THAT(response.status().message(),
-              HasSubstr("mismatched message id count"));
 }
 
 TEST(PublisherConnectionTest, HandleTooManyFailures) {
@@ -202,11 +145,10 @@ TEST(PublisherConnectionTest, HandleTooManyFailures) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}, {}, mock, pubsub_testing::TestRetryPolicy(),
+      {}, mock, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
-          .get();
+      publisher->Publish({google::pubsub::v1::PublishRequest{}}).get();
   EXPECT_THAT(response.status(),
               StatusIs(StatusCode::kUnavailable, HasSubstr("try-again")));
 }
@@ -224,11 +166,10 @@ TEST(PublisherConnectionTest, HandlePermanentError) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, {}, {}, mock, pubsub_testing::TestRetryPolicy(),
+      {}, mock, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
-          .get();
+      publisher->Publish({google::pubsub::v1::PublishRequest{}}).get();
   EXPECT_THAT(response.status(),
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
 }
@@ -246,12 +187,11 @@ TEST(PublisherConnectionTest, HandleTransientDisabledRetry) {
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}, {}, mock,
+      {}, mock,
       pubsub::LimitedErrorCountRetryPolicy(/*maximum_failures=*/0).clone(),
       pubsub_testing::TestBackoffPolicy());
   auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-message-0").Build()})
-          .get();
+      publisher->Publish({google::pubsub::v1::PublishRequest{}}).get();
   EXPECT_THAT(response.status(),
               StatusIs(StatusCode::kUnavailable, HasSubstr("try-again")));
 }
@@ -271,21 +211,21 @@ TEST(PublisherConnectionTest, HandleTransientEnabledRetry) {
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
         EXPECT_EQ(topic.FullName(), request.topic());
-        EXPECT_EQ(1, request.messages_size());
-        EXPECT_EQ("test-data-0", request.messages(0).data());
+        EXPECT_THAT(DataElements(request), ElementsAre("test-data-0"));
         google::pubsub::v1::PublishResponse response;
         response.add_message_ids("test-message-id-0");
         return make_ready_future(make_status_or(response));
       });
 
   auto publisher = pubsub_internal::MakePublisherConnection(
-      topic, PublisherOptions{}, {}, mock, pubsub_testing::TestRetryPolicy(),
+      {}, mock, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
-  auto response =
-      publisher->Publish({MessageBuilder{}.SetData("test-data-0").Build()})
-          .get();
+  google::pubsub::v1::PublishRequest request;
+  request.set_topic(topic.FullName());
+  request.add_messages()->set_data("test-data-0");
+  auto response = publisher->Publish({std::move(request)}).get();
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ("test-message-id-0", *response);
+  EXPECT_THAT(response->message_ids(), ElementsAre("test-message-id-0"));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/publisher_test.cc
+++ b/google/cloud/pubsub/publisher_test.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/pubsub/publisher.h"
 #include "google/cloud/pubsub/mocks/mock_publisher_connection.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -23,24 +25,104 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::testing::_;
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::Return;
 
 TEST(PublisherTest, PublishSimple) {
-  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
-  EXPECT_CALL(*mock, Publish(_))
-      .WillOnce([&](PublisherConnection::PublishParams const& p) {
-        EXPECT_EQ("test-data-0", p.message.data());
-        return make_ready_future(StatusOr<std::string>("test-id-0"));
-      });
-  EXPECT_CALL(*mock, Flush(_)).Times(1);
+  auto const topic = pubsub::Topic("test-project", "test-topic");
+  auto const message = pubsub::MessageBuilder{}.SetData("test-data-0").Build();
 
-  Publisher publisher(mock);
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(p.request.topic(), topic.FullName());
+        EXPECT_THAT(
+            p.request.messages(),
+            ElementsAre(IsProtoEqual(pubsub_internal::ToProto(message))));
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-id-0");
+        return make_ready_future(make_status_or(response));
+      });
+
+  Publisher publisher(topic, mock);
   publisher.Flush();
-  auto id =
-      publisher.Publish(pubsub::MessageBuilder{}.SetData("test-data-0").Build())
-          .get();
+  auto id = publisher.Publish(message).get();
   ASSERT_STATUS_OK(id);
   EXPECT_EQ("test-id-0", *id);
+}
+
+TEST(PublisherTest, OrderingKey) {
+  auto const topic = Topic("test-project", "test-topic");
+  auto const message = MessageBuilder{}.SetData("test-data-0").Build();
+
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](PublisherConnection::PublishParams const& p) {
+        EXPECT_EQ(topic.FullName(), p.request.topic());
+        EXPECT_THAT(
+            p.request.messages(),
+            ElementsAre(IsProtoEqual(pubsub_internal::ToProto(message))));
+        google::pubsub::v1::PublishResponse response;
+        response.add_message_ids("test-message-id-0");
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto publisher =
+      Publisher(topic, PublisherOptions{}.enable_message_ordering(), mock);
+  auto response = publisher.Publish(message).get();
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ("test-message-id-0", *response);
+}
+
+TEST(PublisherTest, OrderingKeyWithoutMessageOrdering) {
+  auto const topic = Topic("test-project", "test-topic");
+
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish).Times(0);
+
+  auto publisher = Publisher(topic, PublisherOptions{}, mock);
+  auto response = publisher
+                      .Publish({MessageBuilder{}
+                                    .SetOrderingKey("test-ordering-key-0")
+                                    .SetData("test-data-0")
+                                    .Build()})
+                      .get();
+  EXPECT_THAT(response.status(),
+              StatusIs(StatusCode::kInvalidArgument,
+                       HasSubstr("does not have message ordering enabled")));
+}
+
+TEST(PublisherTest, HandleInvalidResponse) {
+  Topic const topic("test-project", "test-topic");
+
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce([&](PublisherConnection::PublishParams const&) {
+        google::pubsub::v1::PublishResponse response;
+        return make_ready_future(make_status_or(response));
+      });
+
+  auto publisher = Publisher(topic, PublisherOptions{}, mock);
+  auto response =
+      publisher.Publish({MessageBuilder{}.SetData("test-data-0").Build()})
+          .get();
+  // It is very unlikely we will see this in production, it would indicate a bug
+  // in the Cloud Pub/Sub service where we successfully published N events, but
+  // we received M != N message ids back.
+  EXPECT_THAT(
+      response.status(),
+      StatusIs(StatusCode::kUnknown, HasSubstr("mismatched message id count")));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/pubsub_client.bzl
+++ b/google/cloud/pubsub/pubsub_client.bzl
@@ -24,6 +24,7 @@ pubsub_client_hdrs = [
     "internal/batching_publisher_connection.h",
     "internal/default_retry_policies.h",
     "internal/emulator_overrides.h",
+    "internal/message_batcher.h",
     "internal/ordering_key_publisher_connection.h",
     "internal/publisher_logging.h",
     "internal/publisher_metadata.h",

--- a/google/cloud/pubsub/pubsub_client_testing.bzl
+++ b/google/cloud/pubsub/pubsub_client_testing.bzl
@@ -18,6 +18,7 @@
 
 pubsub_client_testing_hdrs = [
     "testing/fake_streaming_pull.h",
+    "testing/mock_message_batcher.h",
     "testing/mock_publisher_stub.h",
     "testing/mock_subscriber_stub.h",
     "testing/mock_subscription_batch_source.h",

--- a/google/cloud/pubsub/quickstart/quickstart.cc
+++ b/google/cloud/pubsub/quickstart/quickstart.cc
@@ -28,8 +28,7 @@ int main(int argc, char* argv[]) try {
 
   // Create a namespace alias to make the code easier to read.
   namespace pubsub = google::cloud::pubsub;
-  auto publisher = pubsub::Publisher(
-      pubsub::MakePublisherConnection(pubsub::Topic(project_id, topic_id), {}));
+  auto publisher = pubsub::Publisher(pubsub::Topic(project_id, topic_id));
   auto id =
       publisher
           .Publish(pubsub::MessageBuilder{}.SetData("Hello World!").Build())

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -37,8 +37,7 @@ google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
     }
     Topic const topic(argv.at(0), argv.at(1));
     argv.erase(argv.begin(), argv.begin() + 2);
-    google::cloud::pubsub::Publisher client(
-        google::cloud::pubsub::MakePublisherConnection(topic, {}));
+    google::cloud::pubsub::Publisher client(topic);
     command(std::move(client), std::move(argv));
   };
   return google::cloud::testing_util::Commands::value_type{name,

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -918,9 +918,10 @@ void CustomThreadPoolPublisher(std::vector<std::string> const& argv) {
     });
 
     auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
-    auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
-        std::move(topic), pubsub::PublisherOptions{},
-        pubsub::ConnectionOptions{}.DisableBackgroundThreads(cq)));
+    auto publisher = pubsub::Publisher(
+        std::move(topic),
+        pubsub::MakePublisherConnection(
+            pubsub::ConnectionOptions{}.DisableBackgroundThreads(cq)));
 
     std::vector<future<void>> ids;
     for (char const* data : {"1", "2", "3", "go!"}) {
@@ -958,10 +959,10 @@ void PublisherConcurrencyControl(std::vector<std::string> const& argv) {
     auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
     // Override the default number of background (I/O) threads. By default the
     // library uses `std::thread::hardware_concurrency()` threads.
-    auto options =
-        pubsub::ConnectionOptions{}.set_background_thread_pool_size(8);
-    auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
-        std::move(topic), pubsub::PublisherOptions{}, std::move(options)));
+    auto publisher = pubsub::Publisher(
+        std::move(topic),
+        pubsub::MakePublisherConnection(
+            pubsub::ConnectionOptions{}.set_background_thread_pool_size(8)));
 
     std::vector<future<void>> ids;
     for (char const* data : {"1", "2", "3", "go!"}) {
@@ -995,16 +996,18 @@ void PublisherRetrySettings(std::vector<std::string> const& argv) {
     // By default a publisher will retry for 60 seconds, with an initial backoff
     // of 100ms, a maximum backoff of 60 seconds, and the backoff will grow by
     // 30% after each attempt. This changes those defaults.
-    auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
-        std::move(topic), pubsub::PublisherOptions{}, {},
-        pubsub::LimitedTimeRetryPolicy(
-            /*maximum_duration=*/std::chrono::minutes(10))
-            .clone(),
-        pubsub::ExponentialBackoffPolicy(
-            /*initial_delay=*/std::chrono::milliseconds(200),
-            /*maximum_delay=*/std::chrono::seconds(45),
-            /*scaling=*/2.0)
-            .clone()));
+    auto publisher = pubsub::Publisher(
+        std::move(topic),
+        pubsub::MakePublisherConnection(
+            {},
+            pubsub::LimitedTimeRetryPolicy(
+                /*maximum_duration=*/std::chrono::minutes(10))
+                .clone(),
+            pubsub::ExponentialBackoffPolicy(
+                /*initial_delay=*/std::chrono::milliseconds(200),
+                /*maximum_delay=*/std::chrono::seconds(45),
+                /*scaling=*/2.0)
+                .clone()));
 
     std::vector<future<bool>> done;
     for (char const* data : {"1", "2", "3", "go!"}) {
@@ -1036,14 +1039,17 @@ void PublisherDisableRetries(std::vector<std::string> const& argv) {
   using google::cloud::StatusOr;
   [](std::string project_id, std::string topic_id) {
     auto topic = pubsub::Topic(std::move(project_id), std::move(topic_id));
-    auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
-        std::move(topic), pubsub::PublisherOptions{}, {},
-        pubsub::LimitedErrorCountRetryPolicy(/*maximum_failures=*/0).clone(),
-        pubsub::ExponentialBackoffPolicy(
-            /*initial_delay=*/std::chrono::milliseconds(200),
-            /*maximum_delay=*/std::chrono::seconds(45),
-            /*scaling=*/2.0)
-            .clone()));
+    auto publisher = pubsub::Publisher(
+        std::move(topic),
+        pubsub::MakePublisherConnection(
+            {},
+            pubsub::LimitedErrorCountRetryPolicy(/*maximum_failures=*/0)
+                .clone(),
+            pubsub::ExponentialBackoffPolicy(
+                /*initial_delay=*/std::chrono::milliseconds(200),
+                /*maximum_delay=*/std::chrono::seconds(45),
+                /*scaling=*/2.0)
+                .clone()));
 
     std::vector<future<bool>> done;
     for (char const* data : {"1", "2", "3", "go!"}) {
@@ -1079,13 +1085,12 @@ void CustomBatchPublisher(std::vector<std::string> const& argv) {
     // By default the publisher will flush a batch after 10ms, after it contains
     // more than 100 message, or after it contains more than 1MiB of data,
     // whichever comes first. This changes those defaults.
-    auto publisher = pubsub::Publisher(pubsub::MakePublisherConnection(
+    auto publisher = pubsub::Publisher(
         std::move(topic),
         pubsub::PublisherOptions{}
             .set_maximum_hold_time(std::chrono::milliseconds(20))
             .set_maximum_batch_bytes(4 * 1024 * 1024L)
-            .set_maximum_batch_message_count(200),
-        pubsub::ConnectionOptions{}));
+            .set_maximum_batch_message_count(200));
 
     std::vector<future<void>> ids;
     for (char const* data : {"1", "2", "3", "go!"}) {
@@ -1487,9 +1492,9 @@ void AutoRun(std::vector<std::string> const& argv) {
 
   auto topic = google::cloud::pubsub::Topic(project_id, topic_id);
   auto publisher = google::cloud::pubsub::Publisher(
-      google::cloud::pubsub::MakePublisherConnection(
-          topic, google::cloud::pubsub::PublisherOptions{}
-                     .set_maximum_batch_message_count(1)));
+      topic,
+      google::cloud::pubsub::PublisherOptions{}.set_maximum_batch_message_count(
+          1));
   auto subscription =
       google::cloud::pubsub::Subscription(project_id, subscription_id);
   auto subscriber_connection =
@@ -1562,10 +1567,9 @@ void AutoRun(std::vector<std::string> const& argv) {
   SubscribeCustomAttributes(subscriber, {});
 
   auto publisher_with_ordering_key = google::cloud::pubsub::Publisher(
-      google::cloud::pubsub::MakePublisherConnection(
-          topic, google::cloud::pubsub::PublisherOptions{}
-                     .set_maximum_batch_message_count(1)
-                     .enable_message_ordering()));
+      topic, google::cloud::pubsub::PublisherOptions{}
+                 .set_maximum_batch_message_count(1)
+                 .enable_message_ordering());
   std::cout << "\nRunning PublishOrderingKey() sample" << std::endl;
 
   if (UsingEmulator()) PublishOrderingKey(publisher_with_ordering_key, {});

--- a/google/cloud/pubsub/testing/mock_message_batcher.h
+++ b/google/cloud/pubsub/testing/mock_message_batcher.h
@@ -12,28 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TESTING_MOCK_MESSAGE_BATCHER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TESTING_MOCK_MESSAGE_BATCHER_H
+
+#include "google/cloud/pubsub/internal/message_batcher.h"
+#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
-namespace pubsub_internal {
+namespace pubsub_testing {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-future<StatusOr<std::string>> RejectsWithOrderingKey::Publish(
-    pubsub::Message m) {
-  if (!m.ordering_key().empty()) {
-    return google::cloud::make_ready_future(StatusOr<std::string>(
-        Status(StatusCode::kInvalidArgument,
-               "Attempted to publish a message with an ordering"
-               " key with a publisher that does not have message"
-               " ordering enabled.")));
-  }
-  return child_->Publish(std::move(m));
-}
-
-void RejectsWithOrderingKey::Flush() { return child_->Flush(); }
+/**
+ * A class to mock pubsub_internal::MessageBatcher
+ */
+class MockMessageBatcher : public pubsub_internal::MessageBatcher {
+ public:
+  MOCK_METHOD1(Publish, future<StatusOr<std::string>>(pubsub::Message));
+  MOCK_METHOD0(Flush, void());
+};
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
-}  // namespace pubsub_internal
+}  // namespace pubsub_testing
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_TESTING_MOCK_MESSAGE_BATCHER_H


### PR DESCRIPTION
**BREAKING CHANGE:**

* Allow sharing connections between multiple `pubsub::Publisher` objects.
  Creating a `pubsub::PublisherConnection` no longer requires a `pubsub::Topic`
  or the `pubsub::PublisherOptions`, these are now parameters for the
  `pubsub::Publisher` constructor.

Fixes #5266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5295)
<!-- Reviewable:end -->
