### PR TITLE
bug: Fix building instructions w.r.t. testing

### DIFF
--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -64,7 +64,7 @@ CMake support files, then compiling and installing the libraries
 requires two commands:
 
 ```bash
-cmake -H. -Bcmake-out
+cmake -DBUILD_TESTING=OFF -H. -Bcmake-out
 cmake --build cmake-out --target install
 ```
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -43,7 +43,7 @@ CMake support files, then compiling and installing the libraries
 requires two commands:
 
 ```bash
-cmake -H. -Bcmake-out
+cmake -DBUILD_TESTING=OFF -H. -Bcmake-out
 cmake --build cmake-out --target install
 ```
 

--- a/doc/setup-development-environment.md
+++ b/doc/setup-development-environment.md
@@ -20,8 +20,8 @@ First, install the basic development tools:
 ```console
 sudo apt update
 sudo apt install -y build-essential cmake git gcc g++ cmake \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev make \
-        pkg-config tar wget zlib1g-dev
+        libc-ares-dev libc-ares2 libbenchmark-dev libcurl4-openssl-dev libssl-dev \
+        make pkg-config tar wget zlib1g-dev
 ```
 
 Then install `clang-10` and some additional Clang tools that we use to enforce


### PR DESCRIPTION
Fixes: #5228

Thanks @hbchai to pointing out the necessity for `libbenchmark-dev`. It
appears that is required for the microbenchmarks, so it should be added
to the list of development dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5298)
<!-- Reviewable:end -->
