### PR TITLE
feat(pubsub): sequence batches with ordering keys

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -28,11 +28,13 @@ struct Batch {
   // well name it as one.
   google::cloud::CompletionQueue executor;
   std::vector<promise<StatusOr<std::string>>> waiters;
+  std::weak_ptr<BatchingPublisherConnection> weak;
 
   void operator()(future<StatusOr<google::pubsub::v1::PublishResponse>> f) {
     auto response = f.get();
     if (!response) {
       SatisfyAllWaiters(response.status());
+      if (auto batcher = weak.lock()) batcher->DiscardCorked(response.status());
       return;
     }
     if (static_cast<std::size_t>(response->message_ids_size()) !=
@@ -50,6 +52,7 @@ struct Batch {
     for (auto& w : waiters) {
       executor.RunAsync(SetValue{std::move(w), response->message_ids(idx++)});
     }
+    if (auto batcher = weak.lock()) batcher->UnCork();
   }
 
   void SatisfyAllWaiters(Status const& status) {
@@ -66,16 +69,56 @@ struct Batch {
 
 future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
     pubsub::Message m) {
-  promise<StatusOr<std::string>> promise;
-  auto f = promise.get_future();
+  promise<StatusOr<std::string>> p;
+  auto f = p.get_future();
   std::unique_lock<std::mutex> lk(mu_);
-  pending_.push_back(Item{std::move(promise), std::move(m)});
+  if (!corked_status_.ok()) {
+    struct MoveCapture {
+      promise<StatusOr<std::string>> p;
+      Status status;
+      void operator()() { p.set_value(std::move(status)); }
+    };
+    cq_.RunAsync(MoveCapture{std::move(p), corked_status_});
+    return f;
+  }
+  pending_.push_back(Item{std::move(p), std::move(m)});
   MaybeFlush(std::move(lk));
   return f;
 }
 
 void BatchingPublisherConnection::Flush() {
   FlushImpl(std::unique_lock<std::mutex>(mu_));
+}
+
+void BatchingPublisherConnection::ResumePublish(std::string const& key) {
+  if (ordering_key_ != key) return;
+  UnCork();
+}
+
+void BatchingPublisherConnection::UnCork() {
+  std::unique_lock<std::mutex> lk(mu_);
+  corked_ = false;
+  corked_status_ = {};
+  MaybeFlush(std::move(lk));
+}
+
+void BatchingPublisherConnection::DiscardCorked(Status const& status) {
+  auto pending = [&] {
+    std::unique_lock<std::mutex> lk(mu_);
+    corked_ = true;
+    corked_status_ = status;
+    std::vector<Item> tmp;
+    tmp.swap(pending_);
+    return tmp;
+  }();
+  for (auto& p : pending) {
+    struct MoveCapture {
+      promise<StatusOr<std::string>> p;
+      Status status;
+      void operator()() { p.set_value(std::move(status)); }
+    };
+    cq_.RunAsync(MoveCapture{std::move(p.response), status});
+  }
 }
 
 void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
@@ -126,13 +169,14 @@ void BatchingPublisherConnection::OnTimer() {
 }
 
 void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
-  if (pending_.empty()) return;
+  if (pending_.empty() || corked_) return;
 
   auto context = absl::make_unique<grpc::ClientContext>();
 
   Batch batch;
   batch.executor = cq_;
   batch.waiters.reserve(pending_.size());
+  batch.weak = shared_from_this();
   google::pubsub::v1::PublishRequest request;
   request.set_topic(topic_full_name_);
   request.mutable_messages()->Reserve(static_cast<int>(pending_.size()));
@@ -142,6 +186,7 @@ void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
     *request.add_messages() = pubsub_internal::ToProto(std::move(i.message));
   }
   pending_.clear();
+  corked_ = !ordering_key_.empty();
   lk.unlock();
 
   connection_->Publish({std::move(request)}).then(std::move(batch));

--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -41,7 +41,7 @@ class BatchingPublisherConnection
 
   future<StatusOr<std::string>> Publish(pubsub::Message m) override;
   void Flush() override;
-  void ResumePublish(std::string const&);
+  void ResumePublish(std::string const&) override;
 
   void UnCork();
   void DiscardCorked(Status const& status);

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -15,10 +15,13 @@
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
 #include "google/cloud/pubsub/mocks/mock_publisher_connection.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
+#include "google/cloud/future.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
 
 namespace google {
 namespace cloud {
@@ -63,7 +66,7 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
           .set_maximum_hold_time(std::chrono::milliseconds(50)),
-      mock);
+      {}, mock);
 
   // We expect the responses to be satisfied in the context of the completion
   // queue threads. This is an important property, the processing of any
@@ -108,11 +111,8 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
         return make_ready_future(make_status_or(response));
       });
 
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the zero-maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
   auto publisher = BatchingPublisherConnection::Create(
-      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
+      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2), {},
       mock);
   auto r0 =
       publisher
@@ -131,13 +131,8 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
             EXPECT_EQ("test-message-id-1", *r);
           });
 
-  std::thread t([&cq] { cq.Run(); });
-
   r0.get();
   r1.get();
-
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
@@ -160,15 +155,12 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
   auto constexpr kMessageSizeOverhead = 20;
   auto constexpr kMaxMessageBytes =
       sizeof("test-data-N") + kMessageSizeOverhead + 2;
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the zero-maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
           .set_maximum_batch_bytes(kMaxMessageBytes),
-      mock);
+      {}, mock);
   auto r0 =
       publisher
           ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
@@ -186,13 +178,8 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
             EXPECT_EQ("test-message-id-1", *r);
           });
 
-  std::thread t([&cq] { cq.Run(); });
-
   r0.get();
   r1.get();
-
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
@@ -211,15 +198,12 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
         return make_ready_future(make_status_or(response));
       });
 
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
           .set_maximum_batch_message_count(4),
-      mock);
+      {}, mock);
   auto r0 =
       publisher
           ->Publish({pubsub::MessageBuilder{}.SetData("test-data-0").Build()})
@@ -237,13 +221,8 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
             EXPECT_EQ("test-message-id-1", *r);
           });
 
-  std::thread t([&cq] { cq.Run(); });
-
   r0.get();
   r1.get();
-
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByFlush) {
@@ -270,15 +249,12 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
         return make_ready_future(make_status_or(response));
       });
 
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
           .set_maximum_batch_message_count(4),
-      mock);
+      {}, mock);
 
   std::vector<future<void>> results;
   for (auto i : {0, 1}) {
@@ -309,10 +285,7 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
             }));
   }
 
-  std::thread t([&cq] { cq.Run(); });
   for (auto& r : results) r.get();
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, HandleError) {
@@ -329,7 +302,7 @@ TEST(BatchingPublisherConnectionTest, HandleError) {
       });
 
   auto publisher = BatchingPublisherConnection::Create(
-      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
+      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2), {},
       mock);
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
@@ -362,7 +335,7 @@ TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
       });
 
   auto publisher = BatchingPublisherConnection::Create(
-      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
+      topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2), {},
       mock);
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
@@ -380,6 +353,207 @@ TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
 
   r0.get();
   r1.get();
+}
+
+TEST(BatchingPublisherConnectionTest, OrderingBatchCorked) {
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  std::mutex mu;
+  std::condition_variable cv;
+  std::deque<promise<void>> pending;
+  auto add_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    pending.emplace_back();
+    cv.notify_one();
+    return pending.back().get_future();
+  };
+  auto wait_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return !pending.empty(); });
+    auto p = std::move(pending.front());
+    pending.pop_front();
+    return p;
+  };
+  auto make_response = [&](int expected_count) {
+    return [&, expected_count](
+               pubsub::PublisherConnection::PublishParams const& p) {
+      EXPECT_EQ(expected_count, p.request.messages_size());
+      google::pubsub::v1::PublishResponse response;
+      for (auto const& m : p.request.messages()) {
+        response.add_message_ids("id-" + m.data());
+      }
+      return add_pending().then(
+          [response](future<void>) { return make_status_or(response); });
+    };
+  };
+  auto constexpr kBatchSize = 2;
+  auto constexpr kMessageCount = 3 * kBatchSize;
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce(make_response(kBatchSize))
+      .WillOnce(make_response(kMessageCount - kBatchSize));
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::PublisherOptions{}.set_maximum_batch_message_count(kBatchSize),
+      "test-key", mock);
+  std::vector<future<StatusOr<std::string>>> responses;
+  for (int i = 0; i != kMessageCount; ++i) {
+    responses.push_back(
+        publisher->Publish({pubsub::MessageBuilder{}
+                                .SetData("d-" + std::to_string(i))
+                                .SetOrderingKey("test-key")
+                                .Build()}));
+  }
+
+  // None of the responses should be ready because the mock has not sent a
+  // response
+  for (auto& r : responses) {
+    using ms = std::chrono::milliseconds;
+    EXPECT_EQ(std::future_status::timeout, r.wait_for(ms(0)));
+  }
+  // Trigger the first response.
+  wait_pending().set_value();
+  for (int i = 0; i != kBatchSize; ++i) {
+    ASSERT_STATUS_OK(responses[i].get());
+  }
+
+  // Trigger the second response.
+  wait_pending().set_value();
+  for (int i = kBatchSize; i != kMessageCount; ++i) {
+    ASSERT_STATUS_OK(responses[i].get());
+  }
+}
+
+TEST(BatchingPublisherConnectionTest, OrderingBatchRejectAfterError) {
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  pubsub::Topic const topic("test-project", "test-topic");
+  auto const expected_status = Status{StatusCode::kPermissionDenied, "uh-oh"};
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  EXPECT_CALL(*mock, Publish).Times(0);
+
+  auto constexpr kBatchSize = 2;
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::PublisherOptions{}.set_maximum_batch_message_count(kBatchSize),
+      "test-key", mock);
+
+  // Simulate a previous error
+  publisher->DiscardCorked(expected_status);
+  for (int i = 0; i != 3 * kBatchSize; ++i) {
+    auto response = publisher
+                        ->Publish({pubsub::MessageBuilder{}
+                                       .SetData("d-" + std::to_string(i))
+                                       .SetOrderingKey("test-key")
+                                       .Build()})
+                        .get();
+    EXPECT_EQ(response.status(), expected_status);
+  }
+}
+
+TEST(BatchingPublisherConnectionTest, OrderingBatchDiscardOnError) {
+  auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  EXPECT_CALL(*mock, cq).WillRepeatedly(Return(background.cq()));
+  std::mutex mu;
+  std::condition_variable cv;
+  std::deque<promise<void>> pending;
+  auto add_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    pending.emplace_back();
+    cv.notify_one();
+    return pending.back().get_future();
+  };
+  auto wait_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return !pending.empty(); });
+    auto p = std::move(pending.front());
+    pending.pop_front();
+    return p;
+  };
+  auto const expected_status = Status{StatusCode::kPermissionDenied, "uh-oh"};
+  auto make_error_response = [&](int expected_count) {
+    return [&, expected_count](
+               pubsub::PublisherConnection::PublishParams const& p) {
+      EXPECT_EQ(expected_count, p.request.messages_size());
+      google::pubsub::v1::PublishResponse response;
+      for (auto const& m : p.request.messages()) {
+        response.add_message_ids("id-" + m.data());
+      }
+      return add_pending().then([&](future<void>) {
+        return StatusOr<google::pubsub::v1::PublishResponse>(expected_status);
+      });
+    };
+  };
+  auto make_response = [&](int expected_count) {
+    return [&, expected_count](
+               pubsub::PublisherConnection::PublishParams const& p) {
+      EXPECT_EQ(expected_count, p.request.messages_size());
+      google::pubsub::v1::PublishResponse response;
+      for (auto const& m : p.request.messages()) {
+        response.add_message_ids("id-" + m.data());
+      }
+      return add_pending().then(
+          [response](future<void>) { return make_status_or(response); });
+    };
+  };
+
+  auto constexpr kBatchSize = 2;
+  auto constexpr kDiscarded = 2 * kBatchSize;
+  auto constexpr kResumed = 3 * kBatchSize;
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce(make_error_response(kBatchSize))
+      .WillOnce(make_response(kBatchSize))
+      .WillOnce(make_response(kResumed - kBatchSize));
+
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::PublisherOptions{}.set_maximum_batch_message_count(kBatchSize),
+      "test-key", mock);
+  std::vector<future<StatusOr<std::string>>> responses;
+  for (int i = 0; i != kBatchSize + kDiscarded; ++i) {
+    responses.push_back(
+        publisher->Publish({pubsub::MessageBuilder{}
+                                .SetData("d-" + std::to_string(i))
+                                .SetOrderingKey("test-key")
+                                .Build()}));
+  }
+
+  // None of the responses should be ready because the mock has not sent a
+  // response
+  for (auto& r : responses) {
+    using ms = std::chrono::milliseconds;
+    EXPECT_EQ(std::future_status::timeout, r.wait_for(ms(0)));
+  }
+  // Trigger the first response.
+  wait_pending().set_value();
+  for (auto& r : responses) {
+    ASSERT_EQ(r.get().status(), expected_status);
+  }
+
+  // Allow the publisher to publish again.
+  publisher->ResumePublish("test-key");
+  responses.clear();
+  for (int i = 0; i != kResumed; ++i) {
+    responses.push_back(
+        publisher->Publish({pubsub::MessageBuilder{}
+                                .SetData("d-" + std::to_string(i))
+                                .SetOrderingKey("test-key")
+                                .Build()}));
+  }
+
+  // Trigger the following responses.
+  wait_pending().set_value();  // First batch
+  wait_pending().set_value();  // Corked batch
+  for (auto& r : responses) {
+    ASSERT_STATUS_OK(r.get());
+  }
 }
 
 }  // namespace

--- a/google/cloud/pubsub/internal/message_batcher.h
+++ b/google/cloud/pubsub/internal/message_batcher.h
@@ -37,6 +37,9 @@ class MessageBatcher {
 
   /// Flush any pending messages
   virtual void Flush() = 0;
+
+  /// Resume publishing after an error if ordering keys are enabled
+  virtual void ResumePublish(std::string const& ordering_key) = 0;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
@@ -41,10 +41,13 @@ class OrderingKeyPublisherConnection : public MessageBatcher {
 
   future<StatusOr<std::string>> Publish(pubsub::Message m) override;
   void Flush() override;
+  void ResumePublish(std::string const& ordering_key) override;
 
  private:
   explicit OrderingKeyPublisherConnection(ConnectionFactory factory)
       : factory_(std::move(factory)) {}
+
+  std::shared_ptr<MessageBatcher> GetChild(std::string const& ordering_key);
 
   ConnectionFactory factory_;
   std::mutex mu_;

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection_test.cc
@@ -42,6 +42,7 @@ TEST(OrderingKeyPublisherConnectionTest, Publish) {
           auto ack_id = m.ordering_key() + "#" + std::string(m.data());
           return make_ready_future(make_status_or(ack_id));
         });
+    EXPECT_CALL(*mock, ResumePublish).Times(ordering_key == "k0" ? 1 : 0);
     EXPECT_CALL(*mock, Flush).Times(2);
     return mock;
   };
@@ -64,6 +65,7 @@ TEST(OrderingKeyPublisherConnectionTest, Publish) {
   }
   for (auto& r : results) r.get();
 
+  publisher->ResumePublish("k0");
   publisher->Flush();
   publisher->Flush();
 }

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
@@ -33,8 +33,7 @@ future<StatusOr<std::string>> RejectsWithOrderingKey::Publish(
 
 void RejectsWithOrderingKey::Flush() { return child_->Flush(); }
 
-void RejectsWithOrderingKey::ResumePublish(std::string const&) {
-}
+void RejectsWithOrderingKey::ResumePublish(std::string const&) {}
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
@@ -33,6 +33,9 @@ future<StatusOr<std::string>> RejectsWithOrderingKey::Publish(
 
 void RejectsWithOrderingKey::Flush() { return child_->Flush(); }
 
+void RejectsWithOrderingKey::ResumePublish(std::string const&) {
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.h
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.h
@@ -35,6 +35,7 @@ class RejectsWithOrderingKey : public MessageBatcher {
 
   future<StatusOr<std::string>> Publish(pubsub::Message m) override;
   void Flush() override;
+  void ResumePublish(std::string const&) override;
 
  private:
   explicit RejectsWithOrderingKey(std::shared_ptr<MessageBatcher> child)

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key_test.cc
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key_test.cc
@@ -30,6 +30,7 @@ using ::google::cloud::testing_util::StatusIs;
 TEST(RejectsWithOrderingKeyTest, MessageRejected) {
   auto mock = std::make_shared<pubsub_testing::MockMessageBatcher>();
   EXPECT_CALL(*mock, Publish).Times(0);
+  EXPECT_CALL(*mock, ResumePublish).Times(0);
 
   auto publisher = RejectsWithOrderingKey::Create(mock);
   auto response = publisher
@@ -39,6 +40,7 @@ TEST(RejectsWithOrderingKeyTest, MessageRejected) {
                                      .Build()})
                       .get();
   EXPECT_THAT(response.status(), StatusIs(StatusCode::kInvalidArgument));
+  publisher->ResumePublish("test-ordering-key-0");
 }
 
 TEST(RejectsWithOrderingKeyTest, MessageAccepted) {

--- a/google/cloud/pubsub/publisher.cc
+++ b/google/cloud/pubsub/publisher.cc
@@ -26,16 +26,16 @@ std::shared_ptr<pubsub_internal::MessageBatcher> MakeMessageBatcher(
     pubsub::Topic topic, pubsub::PublisherOptions options,
     std::shared_ptr<pubsub::PublisherConnection> connection) {
   if (options.message_ordering()) {
-    auto factory = [topic, options, connection](std::string const&) {
+    auto factory = [topic, options, connection](std::string const& key) {
       return pubsub_internal::BatchingPublisherConnection::Create(
-          topic, options, connection);
+          topic, options, key, connection);
     };
     return pubsub_internal::OrderingKeyPublisherConnection::Create(
         std::move(factory));
   }
   return pubsub_internal::RejectsWithOrderingKey::Create(
       pubsub_internal::BatchingPublisherConnection::Create(
-          std::move(topic), std::move(options), std::move(connection)));
+          std::move(topic), std::move(options), {}, std::move(connection)));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -51,6 +51,16 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * });
  * @endcode
  *
+ * @par Message Ordering
+ * A `Publisher` configured to preserve message ordering will sequence the
+ * messages that share a common ordering key (see
+ * `MessageBuilder::SetOrderingKey()`). Messages will be batched by ordering
+ * key, and new batches will wait until the status of the previous batch is
+ * known. Or an error, all pending and queued messages are discarded, and the
+ * publisher rejects any new messages for the ordering key that experienced
+ * problems. The application must call `Publisher::ResumePublishing()` to
+ * to restore publishing.
+ *
  * @par Performance
  *
  * `Publisher` objects are relatively cheap to create, copy, and move. However,
@@ -163,6 +173,18 @@ class Publisher {
    *     each `Publish()` call to find out what the results are.
    */
   void Flush() { batcher_->Flush(); }
+
+  /**
+   * Resume publishing after an error.
+   *
+   * If the publisher options have message ordering enabled (see
+   * `PublisherOptions::message_ordering()`) all messages for a key that
+   * experience failure will be rejected until the application calls this
+   * function.
+   */
+  void ResumePublish(std::string const& ordering_key) {
+    batcher_->ResumePublish(ordering_key);
+  }
 
  private:
   std::shared_ptr<pubsub_internal::MessageBatcher> batcher_;

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -38,7 +38,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  *   service.
  *
  * @par Example
- *
  * @code
  * namespace pubsub = ::google::cloud::pubsub;
  *
@@ -62,7 +61,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * to restore publishing.
  *
  * @par Performance
- *
  * `Publisher` objects are relatively cheap to create, copy, and move. However,
  * each `Publisher` object must be created with a
  * `std::shared_ptr<PublisherConnection>`, which itself is relatively expensive
@@ -71,14 +69,12 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * interface for more details.
  *
  * @par Thread Safety
- *
  * Instances of this class created via copy-construction or copy-assignment
  * share the underlying pool of connections. Access to these copies via multiple
  * threads is guaranteed to work. Two threads operating on the same instance of
  * this class is not guaranteed to work.
  *
  * @par Background Threads
- *
  * This class uses the background threads configured via `ConnectionOptions`.
  * Applications can create their own pool of background threads by (a) creating
  * their own #google::cloud::v1::CompletionQueue, (b) setting this completion
@@ -89,7 +85,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * @snippet samples.cc custom-thread-pool-publisher
  *
  * @par Asynchronous Functions
- *
  * Some of the member functions in this class return a `future<T>` (or
  * `future<StatusOr<T>>`) object.  Readers are probably familiar with
  * [`std::future<T>`][std-future-link]. Our version adds a `.then()` function to
@@ -99,7 +94,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * documentation.
  *
  * @par Error Handling
- *
  * This class uses `StatusOr<T>` to report errors. When an operation fails to
  * perform its work the returned `StatusOr<T>` contains the error details. If
  * the `ok()` member function in the `StatusOr<T>` returns `true` then it
@@ -181,6 +175,9 @@ class Publisher {
    * `PublisherOptions::message_ordering()`) all messages for a key that
    * experience failure will be rejected until the application calls this
    * function.
+   *
+   * @par Example
+   * @snippet samples.cc resume-publish
    */
   void ResumePublish(std::string const& ordering_key) {
     batcher_->ResumePublish(ordering_key);

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -110,11 +110,24 @@ class PublisherOptions {
     return *this;
   }
 
+  /// Return `true` if message ordering is enabled.
   bool message_ordering() const { return message_ordering_; }
+
+  /**
+   * Enable message ordering.
+   *
+   * @see the documentation for the @ref `Publisher` class for details.
+   */
   PublisherOptions& enable_message_ordering() {
     message_ordering_ = true;
     return *this;
   }
+
+  /**
+   * Disable message ordering.
+   *
+   * @see the documentation for the @ref `Publisher` class for details.
+   */
   PublisherOptions& disable_message_ordering() {
     message_ordering_ = false;
     return *this;

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -116,7 +116,7 @@ class PublisherOptions {
   /**
    * Enable message ordering.
    *
-   * @see the documentation for the @ref `Publisher` class for details.
+   * @see the documentation for the `Publisher` class for details.
    */
   PublisherOptions& enable_message_ordering() {
     message_ordering_ = true;
@@ -126,7 +126,7 @@ class PublisherOptions {
   /**
    * Disable message ordering.
    *
-   * @see the documentation for the @ref `Publisher` class for details.
+   * @see the documentation for the `Publisher` class for details.
    */
   PublisherOptions& disable_message_ordering() {
     message_ordering_ = false;

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -796,13 +796,13 @@ void ResumeOrderingKey(google::cloud::pubsub::Publisher publisher,
     };
     std::vector<future<void>> done;
     for (auto const& datum : data) {
-      auto handler = [datum,
-                      publisher](future<StatusOr<std::string>> f) mutable {
-        auto const msg = datum.ordering_key + "#" + datum.data;
+      auto& da = datum;  // workaround MSVC capture rules
+      auto handler = [da, publisher](future<StatusOr<std::string>> f) mutable {
+        auto const msg = da.ordering_key + "#" + da.data;
         auto id = f.get();
         if (!id) {
           std::cout << "An error has occurred publishing " << msg << "\n";
-          publisher.ResumePublish(datum.ordering_key);
+          publisher.ResumePublish(da.ordering_key);
           return;
         }
         std::cout << "Message " << msg << " published as id=" << *id << "\n";

--- a/google/cloud/pubsub/testing/mock_message_batcher.h
+++ b/google/cloud/pubsub/testing/mock_message_batcher.h
@@ -30,6 +30,7 @@ class MockMessageBatcher : public pubsub_internal::MessageBatcher {
  public:
   MOCK_METHOD1(Publish, future<StatusOr<std::string>>(pubsub::Message));
   MOCK_METHOD0(Flush, void());
+  MOCK_METHOD1(ResumePublish, void(std::string const&));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
While a batch of messages with the same ordering key is pending (i.e.
sent but the response is not received) any additional messages should be
batched.

Fixes #4803 and fixes #4640 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5299)
<!-- Reviewable:end -->
