### PR TITLE
test(spanner): correct guard on UpdateDatabaseDdlMetadata expectation

### DIFF
--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -30,6 +30,7 @@ namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::EndsWith;
+using ::testing::HasSubstr;
 
 class DatabaseAdminClientTest : public ::testing::Test {
  protected:
@@ -170,8 +171,8 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
   EXPECT_THAT(metadata->database(), EndsWith(database_.database_id()));
   EXPECT_EQ(1, metadata->statements_size());
   EXPECT_EQ(1, metadata->commit_timestamps_size());
-  if (metadata->statements_size() > 1) {
-    EXPECT_EQ(create_table_statement, metadata->statements(0));
+  if (metadata->statements_size() >= 1) {
+    EXPECT_THAT(metadata->statements(0), HasSubstr("CREATE TABLE"));
   }
 
   EXPECT_TRUE(DatabaseExists()) << "Database " << database_;


### PR DESCRIPTION
A `repeated` field size of 1 allows us to inspect the 0th element.

Also use `HasSubstr` in the expectation as the returned DDL statement
can have whitespace differences against the `UpdateDatabase()` argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5301)
<!-- Reviewable:end -->
