### PR TITLE
feat(pubsub): sequence batches with ordering keys

### DIFF
--- a/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
+++ b/google/cloud/pubsub/integration_tests/subscriber_integration_test.cc
@@ -70,7 +70,7 @@ class SubscriberIntegrationTest : public ::testing::Test {
             .set_ack_deadline(std::chrono::seconds(30))
             .enable_message_ordering(true));
     ASSERT_THAT(
-        subscription_metadata,
+        ordered_subscription_metadata,
         AnyOf(StatusIs(StatusCode::kOk), StatusIs(StatusCode::kAlreadyExists)));
   }
 

--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -28,11 +28,13 @@ struct Batch {
   // well name it as one.
   google::cloud::CompletionQueue executor;
   std::vector<promise<StatusOr<std::string>>> waiters;
+  std::weak_ptr<BatchingPublisherConnection> weak;
 
   void operator()(future<StatusOr<google::pubsub::v1::PublishResponse>> f) {
     auto response = f.get();
     if (!response) {
       SatisfyAllWaiters(response.status());
+      if (auto batcher = weak.lock()) batcher->DiscardCorked(response.status());
       return;
     }
     if (static_cast<std::size_t>(response->message_ids_size()) !=
@@ -50,6 +52,7 @@ struct Batch {
     for (auto& w : waiters) {
       executor.RunAsync(SetValue{std::move(w), response->message_ids(idx++)});
     }
+    if (auto batcher = weak.lock()) batcher->UnCork();
   }
 
   void SatisfyAllWaiters(Status const& status) {
@@ -66,16 +69,56 @@ struct Batch {
 
 future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
     PublishParams p) {
-  promise<StatusOr<std::string>> promise;
-  auto f = promise.get_future();
+  promise<StatusOr<std::string>> pr;
+  auto f = pr.get_future();
   std::unique_lock<std::mutex> lk(mu_);
-  pending_.push_back(Item{std::move(promise), std::move(p.message)});
+  if (!corked_status_.ok()) {
+    struct MoveCapture {
+      promise<StatusOr<std::string>> p;
+      Status status;
+      void operator()() { p.set_value(std::move(status)); }
+    };
+    cq_.RunAsync(MoveCapture{std::move(pr), corked_status_});
+    return f;
+  }
+  pending_.push_back(Item{std::move(pr), std::move(p.message)});
   MaybeFlush(std::move(lk));
   return f;
 }
 
 void BatchingPublisherConnection::Flush(FlushParams) {
   FlushImpl(std::unique_lock<std::mutex>(mu_));
+}
+
+void BatchingPublisherConnection::ResumePublish(ResumePublishParams p) {
+  if (ordering_key_ != p.ordering_key) return;
+  UnCork();
+}
+
+void BatchingPublisherConnection::UnCork() {
+  std::unique_lock<std::mutex> lk(mu_);
+  corked_ = false;
+  corked_status_ = {};
+  MaybeFlush(std::move(lk));
+}
+
+void BatchingPublisherConnection::DiscardCorked(Status const& status) {
+  auto pending = [&] {
+    std::unique_lock<std::mutex> lk(mu_);
+    corked_ = true;
+    corked_status_ = status;
+    std::vector<Item> tmp;
+    tmp.swap(pending_);
+    return tmp;
+  }();
+  for (auto& p : pending) {
+    struct MoveCapture {
+      promise<StatusOr<std::string>> p;
+      Status status;
+      void operator()() { p.set_value(std::move(status)); }
+    };
+    cq_.RunAsync(MoveCapture{std::move(p.response), status});
+  }
 }
 
 void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
@@ -93,25 +136,23 @@ void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
     return;
   }
   // If the batch is empty obviously we do not need a timer, and if it has more
-  // than one element then we already have setup a timer previously.
-  if (pending_.size() == 1U) {
-    batch_expiration_ =
-        std::chrono::system_clock::now() + options_.maximum_hold_time();
-    lk.unlock();
-    // We need a weak_ptr<> because this class owns the completion queue,
-    // creating a lambda with a shared_ptr<> owning this class would create a
-    // cycle.  Unfortunately some older compiler/libraries lack
-    // `weak_from_this()`.
-    auto weak = std::weak_ptr<BatchingPublisherConnection>(shared_from_this());
-    // Note that at this point the lock is released, so whether the timer
-    // schedules later on schedules in this thread has no effect.
-    cq_.MakeDeadlineTimer(batch_expiration_)
-        .then([weak](future<StatusOr<std::chrono::system_clock::time_point>>) {
-          auto self = weak.lock();
-          if (!self) return;
-          self->OnTimer();
-        });
-  }
+  // than one element then we have setup a timer previously and there is no need
+  // to set it again.
+  if (pending_.size() != 1U) return;
+  auto const expiration = batch_expiration_ =
+      std::chrono::system_clock::now() + options_.maximum_hold_time();
+  lk.unlock();
+  // We need a weak_ptr<> because this class owns the completion queue,
+  // creating a lambda with a shared_ptr<> owning this class would create a
+  // cycle.  Unfortunately some older compiler/libraries lack
+  // `weak_from_this()`.
+  auto weak = std::weak_ptr<BatchingPublisherConnection>(shared_from_this());
+  // Note that at this point the lock is released, so whether the timer
+  // schedules later on schedules in this thread has no effect.
+  cq_.MakeDeadlineTimer(expiration)
+      .then([weak](future<StatusOr<std::chrono::system_clock::time_point>>) {
+        if (auto self = weak.lock()) self->OnTimer();
+      });
 }
 
 void BatchingPublisherConnection::OnTimer() {
@@ -126,13 +167,14 @@ void BatchingPublisherConnection::OnTimer() {
 }
 
 void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
-  if (pending_.empty()) return;
+  if (pending_.empty() || corked_) return;
 
   auto context = absl::make_unique<grpc::ClientContext>();
 
   Batch batch;
   batch.executor = cq_;
   batch.waiters.reserve(pending_.size());
+  batch.weak = shared_from_this();
   google::pubsub::v1::PublishRequest request;
   request.set_topic(topic_full_name_);
   request.mutable_messages()->Reserve(static_cast<int>(pending_.size()));
@@ -142,6 +184,7 @@ void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
     *request.add_messages() = pubsub_internal::ToProto(std::move(i.message));
   }
   pending_.clear();
+  corked_ = !ordering_key_.empty();
   lk.unlock();
 
   auto& stub = stub_;

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -15,11 +15,14 @@
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
+#include "google/cloud/future.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
 
 namespace google {
 namespace cloud {
@@ -28,7 +31,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
@@ -36,7 +38,7 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&,
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
@@ -54,13 +56,14 @@ TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
         return make_ready_future(make_status_or(response));
       });
 
-  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
           .set_maximum_hold_time(std::chrono::milliseconds(50)),
-      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
+      ordering_key, mock, background.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
 
   // We expect the responses to be satisfied in the context of the completion
@@ -94,7 +97,7 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&,
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
@@ -108,12 +111,11 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
         return make_ready_future(make_status_or(response));
       });
 
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the zero-maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
       topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
+      ordering_key, mock, background.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto r0 =
       publisher
@@ -132,20 +134,15 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageCount) {
             EXPECT_EQ("test-message-id-1", *r);
           });
 
-  std::thread t([&cq] { cq.Run(); });
-
   r0.get();
   r1.get();
-
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&,
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
@@ -163,15 +160,14 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
   auto constexpr kMessageSizeOverhead = 20;
   auto constexpr kMaxMessageBytes =
       sizeof("test-data-N") + kMessageSizeOverhead + 2;
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the zero-maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_batch_message_count(4)
           .set_maximum_batch_bytes(kMaxMessageBytes),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
+      ordering_key, mock, background.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto r0 =
       publisher
@@ -190,20 +186,15 @@ TEST(BatchingPublisherConnectionTest, BatchByMessageSize) {
             EXPECT_EQ("test-message-id-1", *r);
           });
 
-  std::thread t([&cq] { cq.Run(); });
-
   r0.get();
   r1.get();
-
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&,
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
@@ -217,15 +208,14 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
         return make_ready_future(make_status_or(response));
       });
 
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
           .set_maximum_batch_message_count(4),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
+      ordering_key, mock, background.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto r0 =
       publisher
@@ -244,20 +234,15 @@ TEST(BatchingPublisherConnectionTest, BatchByMaximumHoldTime) {
             EXPECT_EQ("test-message-id-1", *r);
           });
 
-  std::thread t([&cq] { cq.Run(); });
-
   r0.get();
   r1.get();
-
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, BatchByFlush) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([&](google::cloud::CompletionQueue&,
                     std::unique_ptr<grpc::ClientContext>,
                     google::pubsub::v1::PublishRequest const& request) {
@@ -281,15 +266,14 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
         return make_ready_future(make_status_or(response));
       });
 
-  // Use our own completion queue, initially inactive, to avoid race conditions
-  // due to the maximum-hold-time timer expiring.
-  google::cloud::CompletionQueue cq;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
       topic,
       pubsub::PublisherOptions{}
           .set_maximum_hold_time(std::chrono::milliseconds(5))
           .set_maximum_batch_message_count(4),
-      mock, cq, pubsub_testing::TestRetryPolicy(),
+      ordering_key, mock, background.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
 
   std::vector<future<void>> results;
@@ -321,10 +305,7 @@ TEST(BatchingPublisherConnectionTest, BatchByFlush) {
             }));
   }
 
-  std::thread t([&cq] { cq.Run(); });
   for (auto& r : results) r.get();
-  cq.Shutdown();
-  t.join();
 }
 
 TEST(BatchingPublisherConnectionTest, HandleError) {
@@ -332,7 +313,7 @@ TEST(BatchingPublisherConnectionTest, HandleError) {
   pubsub::Topic const topic("test-project", "test-topic");
 
   auto const error_status = Status(StatusCode::kPermissionDenied, "uh-oh");
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillRepeatedly([&](google::cloud::CompletionQueue&,
                           std::unique_ptr<grpc::ClientContext>,
                           google::pubsub::v1::PublishRequest const&) {
@@ -341,9 +322,10 @@ TEST(BatchingPublisherConnectionTest, HandleError) {
       });
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
+  auto const ordering_key = std::string{};
   auto publisher = BatchingPublisherConnection::Create(
       topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
-      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
+      ordering_key, mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
@@ -367,7 +349,7 @@ TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   pubsub::Topic const topic("test-project", "test-topic");
 
-  EXPECT_CALL(*mock, AsyncPublish(_, _, _))
+  EXPECT_CALL(*mock, AsyncPublish)
       .WillRepeatedly([&](google::cloud::CompletionQueue&,
                           std::unique_ptr<grpc::ClientContext>,
                           google::pubsub::v1::PublishRequest const&) {
@@ -375,11 +357,11 @@ TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
         return make_ready_future(make_status_or(response));
       });
 
-  google::cloud::internal::AutomaticallyCreatedBackgroundThreads bg;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
   auto publisher = BatchingPublisherConnection::Create(
       topic, pubsub::PublisherOptions{}.set_maximum_batch_message_count(2),
-      mock, bg.cq(), pubsub_testing::TestRetryPolicy(),
-      pubsub_testing::TestBackoffPolicy());
+      "test-ordering-key", mock, background.cq(),
+      pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy());
   auto check_status = [&](future<StatusOr<std::string>> f) {
     auto r = f.get();
     EXPECT_EQ(StatusCode::kUnknown, r.status().code());
@@ -396,6 +378,215 @@ TEST(BatchingPublisherConnectionTest, HandleInvalidResponse) {
 
   r0.get();
   r1.get();
+}
+
+TEST(BatchingPublisherConnectionTest, OrderingBatchCorked) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  std::mutex mu;
+  std::condition_variable cv;
+  std::deque<promise<void>> pending;
+  auto add_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    pending.emplace_back();
+    cv.notify_one();
+    return pending.back().get_future();
+  };
+  auto wait_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return !pending.empty(); });
+    auto p = std::move(pending.front());
+    pending.pop_front();
+    return p;
+  };
+  auto make_response = [&](int expected_count) {
+    return
+        [&, expected_count](google::cloud::CompletionQueue&,
+                            std::unique_ptr<grpc::ClientContext>,
+                            google::pubsub::v1::PublishRequest const& request) {
+          EXPECT_EQ(expected_count, request.messages_size());
+          google::pubsub::v1::PublishResponse response;
+          for (auto const& m : request.messages()) {
+            response.add_message_ids("id-" + m.data());
+          }
+          return add_pending().then(
+              [response](future<void>) { return make_status_or(response); });
+        };
+  };
+  auto constexpr kBatchSize = 2;
+  auto constexpr kMessageCount = 3 * kBatchSize;
+  EXPECT_CALL(*mock, AsyncPublish)
+      .WillOnce(make_response(kBatchSize))
+      .WillOnce(make_response(kMessageCount - kBatchSize));
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::PublisherOptions{}.set_maximum_batch_message_count(kBatchSize),
+      "test-key", mock, background.cq(), pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
+  std::vector<future<StatusOr<std::string>>> responses;
+  for (int i = 0; i != kMessageCount; ++i) {
+    responses.push_back(
+        publisher->Publish({pubsub::MessageBuilder{}
+                                .SetData("d-" + std::to_string(i))
+                                .SetOrderingKey("test-key")
+                                .Build()}));
+  }
+
+  // None of the responses should be ready because the mock has not sent a
+  // response
+  for (auto& r : responses) {
+    using ms = std::chrono::milliseconds;
+    EXPECT_EQ(std::future_status::timeout, r.wait_for(ms(0)));
+  }
+  // Trigger the first response.
+  wait_pending().set_value();
+  for (int i = 0; i != kBatchSize; ++i) {
+    ASSERT_STATUS_OK(responses[i].get());
+  }
+
+  // Trigger the second response.
+  wait_pending().set_value();
+  for (int i = kBatchSize; i != kMessageCount; ++i) {
+    ASSERT_STATUS_OK(responses[i].get());
+  }
+}
+
+TEST(BatchingPublisherConnectionTest, OrderingBatchRejectAfterError) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+  auto const expected_status = Status{StatusCode::kPermissionDenied, "uh-oh"};
+
+  EXPECT_CALL(*mock, AsyncPublish).Times(0);
+
+  auto constexpr kBatchSize = 2;
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::PublisherOptions{}.set_maximum_batch_message_count(kBatchSize),
+      "test-key", mock, background.cq(), pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
+
+  // Simulate a previous error
+  publisher->DiscardCorked(expected_status);
+  for (int i = 0; i != 3 * kBatchSize; ++i) {
+    auto response = publisher
+                        ->Publish({pubsub::MessageBuilder{}
+                                       .SetData("d-" + std::to_string(i))
+                                       .SetOrderingKey("test-key")
+                                       .Build()})
+                        .get();
+    EXPECT_EQ(response.status(), expected_status);
+  }
+}
+
+TEST(BatchingPublisherConnectionTest, OrderingBatchDiscardOnError) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  std::mutex mu;
+  std::condition_variable cv;
+  std::deque<promise<void>> pending;
+  auto add_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    pending.emplace_back();
+    cv.notify_one();
+    return pending.back().get_future();
+  };
+  auto wait_pending = [&] {
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return !pending.empty(); });
+    auto p = std::move(pending.front());
+    pending.pop_front();
+    return p;
+  };
+  auto const expected_status = Status{StatusCode::kPermissionDenied, "uh-oh"};
+  auto make_error_response = [&](int expected_count) {
+    return [&, expected_count](
+               google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::pubsub::v1::PublishRequest const& request) {
+      EXPECT_EQ(expected_count, request.messages_size());
+      return add_pending().then([&](future<void>) {
+        return StatusOr<google::pubsub::v1::PublishResponse>(expected_status);
+      });
+    };
+  };
+  auto make_response = [&](int expected_count) {
+    return
+        [&, expected_count](google::cloud::CompletionQueue&,
+                            std::unique_ptr<grpc::ClientContext>,
+                            google::pubsub::v1::PublishRequest const& request) {
+          EXPECT_EQ(expected_count, request.messages_size());
+          google::pubsub::v1::PublishResponse response;
+          for (auto const& m : request.messages()) {
+            response.add_message_ids("id-" + m.data());
+          }
+          return add_pending().then(
+              [response](future<void>) { return make_status_or(response); });
+        };
+  };
+
+  auto constexpr kBatchSize = 2;
+  auto constexpr kDiscarded = 2 * kBatchSize;
+  auto constexpr kResumed = 3 * kBatchSize;
+  EXPECT_CALL(*mock, AsyncPublish)
+      .WillOnce(make_error_response(kBatchSize))
+      .WillOnce(make_response(kBatchSize))
+      .WillOnce(make_response(kResumed - kBatchSize));
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      pubsub::PublisherOptions{}
+          .set_maximum_batch_message_count(kBatchSize)
+          .set_maximum_hold_time(std::chrono::seconds(5)),
+      "test-key", mock, background.cq(), pubsub_testing::TestRetryPolicy(),
+      pubsub_testing::TestBackoffPolicy());
+  std::vector<future<StatusOr<std::string>>> responses;
+  for (int i = 0; i != kBatchSize + kDiscarded; ++i) {
+    responses.push_back(
+        publisher->Publish({pubsub::MessageBuilder{}
+                                .SetData("d-" + std::to_string(i))
+                                .SetOrderingKey("test-key")
+                                .Build()}));
+  }
+  publisher->Flush({});
+
+  // None of the responses should be ready because the mock has not sent a
+  // response
+  for (auto& r : responses) {
+    using ms = std::chrono::milliseconds;
+    EXPECT_EQ(std::future_status::timeout, r.wait_for(ms(0)));
+  }
+  // Trigger the first response.
+  wait_pending().set_value();
+  for (auto& r : responses) {
+    EXPECT_THAT(
+        r.get().status(),
+        StatusIs(expected_status.code(), HasSubstr(expected_status.message())));
+  }
+
+  // Allow the publisher to publish again.
+  publisher->ResumePublish({"test-key"});
+  responses.clear();
+  for (int i = 0; i != kResumed; ++i) {
+    responses.push_back(
+        publisher->Publish({pubsub::MessageBuilder{}
+                                .SetData("d-" + std::to_string(i))
+                                .SetOrderingKey("test-key")
+                                .Build()}));
+  }
+  publisher->Flush({});
+
+  // Trigger the following responses.
+  wait_pending().set_value();  // First batch
+  wait_pending().set_value();  // Corked batch
+  for (auto& r : responses) {
+    ASSERT_STATUS_OK(r.get());
+  }
 }
 
 }  // namespace

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
@@ -41,10 +41,14 @@ class OrderingKeyPublisherConnection : public pubsub::PublisherConnection {
 
   future<StatusOr<std::string>> Publish(PublishParams p) override;
   void Flush(FlushParams) override;
+  void ResumePublish(ResumePublishParams p) override;
 
  private:
   explicit OrderingKeyPublisherConnection(ConnectionFactory factory)
       : factory_(std::move(factory)) {}
+
+  std::shared_ptr<PublisherConnection> GetChild(
+      std::string const& ordering_key);
 
   ConnectionFactory factory_;
   std::mutex mu_;

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.cc
@@ -34,6 +34,10 @@ void RejectsWithOrderingKey::Flush(FlushParams p) {
   return connection_->Flush(p);
 }
 
+void RejectsWithOrderingKey::ResumePublish(ResumePublishParams p) {
+  connection_->ResumePublish(std::move(p));
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.h
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.h
@@ -35,6 +35,7 @@ class RejectsWithOrderingKey : public pubsub::PublisherConnection {
 
   future<StatusOr<std::string>> Publish(PublishParams p) override;
   void Flush(FlushParams) override;
+  void ResumePublish(ResumePublishParams p) override;
 
  private:
   explicit RejectsWithOrderingKey(

--- a/google/cloud/pubsub/mocks/mock_publisher_connection.h
+++ b/google/cloud/pubsub/mocks/mock_publisher_connection.h
@@ -36,6 +36,8 @@ class MockPublisherConnection : public pubsub::PublisherConnection {
               (pubsub::PublisherConnection::PublishParams), (override));
   MOCK_METHOD(void, Flush, (pubsub::PublisherConnection::FlushParams),
               (override));
+  MOCK_METHOD(void, ResumePublish,
+              (pubsub::PublisherConnection::ResumePublishParams), (override));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -54,7 +54,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * messages that share a common ordering key (see
  * `MessageBuilder::SetOrderingKey()`). Messages will be batched by ordering
  * key, and new batches will wait until the status of the previous batch is
- * known. Or an error, all pending and queued messages are discarded, and the
+ * known. On an error, all pending and queued messages are discarded, and the
  * publisher rejects any new messages for the ordering key that experienced
  * problems. The application must call `Publisher::ResumePublishing()` to
  * to restore publishing.

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -37,7 +37,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  *   service.
  *
  * @par Example
- *
  * @code
  * namespace pubsub = ::google::cloud::pubsub;
  *
@@ -50,8 +49,17 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * });
  * @endcode
  *
- * @par Performance
+ * @par Message Ordering
+ * A `Publisher` configured to preserve message ordering will sequence the
+ * messages that share a common ordering key (see
+ * `MessageBuilder::SetOrderingKey()`). Messages will be batched by ordering
+ * key, and new batches will wait until the status of the previous batch is
+ * known. Or an error, all pending and queued messages are discarded, and the
+ * publisher rejects any new messages for the ordering key that experienced
+ * problems. The application must call `Publisher::ResumePublishing()` to
+ * to restore publishing.
  *
+ * @par Performance
  * `Publisher` objects are relatively cheap to create, copy, and move. However,
  * each `Publisher` object must be created with a
  * `std::shared_ptr<PublisherConnection>`, which itself is relatively expensive
@@ -60,14 +68,12 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * interface for more details.
  *
  * @par Thread Safety
- *
  * Instances of this class created via copy-construction or copy-assignment
  * share the underlying pool of connections. Access to these copies via multiple
  * threads is guaranteed to work. Two threads operating on the same instance of
  * this class is not guaranteed to work.
  *
  * @par Background Threads
- *
  * This class uses the background threads configured via `ConnectionOptions`.
  * Applications can create their own pool of background threads by (a) creating
  * their own #google::cloud::v1::CompletionQueue, (b) setting this completion
@@ -78,7 +84,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * @snippet samples.cc custom-thread-pool-publisher
  *
  * @par Asynchronous Functions
- *
  * Some of the member functions in this class return a `future<T>` (or
  * `future<StatusOr<T>>`) object.  Readers are probably familiar with
  * [`std::future<T>`][std-future-link]. Our version adds a `.then()` function to
@@ -88,7 +93,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * documentation.
  *
  * @par Error Handling
- *
  * This class uses `StatusOr<T>` to report errors. When an operation fails to
  * perform its work the returned `StatusOr<T>` contains the error details. If
  * the `ok()` member function in the `StatusOr<T>` returns `true` then it
@@ -157,6 +161,21 @@ class Publisher {
    *     each `Publish()` call to find out what the results are.
    */
   void Flush() { connection_->Flush({}); }
+
+  /**
+   * Resume publishing after an error.
+   *
+   * If the publisher options have message ordering enabled (see
+   * `PublisherOptions::message_ordering()`) all messages for a key that
+   * experience failure will be rejected until the application calls this
+   * function.
+   *
+   * @par Example
+   * @snippet samples.cc resume-publish
+   */
+  void ResumePublish(std::string ordering_key) {
+    connection_->ResumePublish({std::move(ordering_key)});
+  }
 
  private:
   std::shared_ptr<PublisherConnection> connection_;

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -66,6 +66,11 @@ class PublisherConnection {
 
   /// Wrap the arguments for `Flush()`
   struct FlushParams {};
+
+  /// Wrap the arguments for `ResumePublish()`
+  struct ResumePublishParams {
+    std::string ordering_key;
+  };
   //@}
 
   /// Defines the interface for `Publisher::Publish()`
@@ -73,6 +78,9 @@ class PublisherConnection {
 
   /// Defines the interface for `Publisher::Flush()`
   virtual void Flush(FlushParams) = 0;
+
+  /// Defines the interface for `Publisher::ResumePublish()`
+  virtual void ResumePublish(ResumePublishParams p) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/publisher_options.h
+++ b/google/cloud/pubsub/publisher_options.h
@@ -110,11 +110,24 @@ class PublisherOptions {
     return *this;
   }
 
+  /// Return `true` if message ordering is enabled.
   bool message_ordering() const { return message_ordering_; }
+
+  /**
+   * Enable message ordering.
+   *
+   * @see the documentation for the `Publisher` class for details.
+   */
   PublisherOptions& enable_message_ordering() {
     message_ordering_ = true;
     return *this;
   }
+
+  /**
+   * Disable message ordering.
+   *
+   * @see the documentation for the `Publisher` class for details.
+   */
   PublisherOptions& disable_message_ordering() {
     message_ordering_ = false;
     return *this;

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -780,6 +780,49 @@ void PublishOrderingKey(google::cloud::pubsub::Publisher publisher,
   (std::move(publisher));
 }
 
+void ResumeOrderingKey(google::cloud::pubsub::Publisher publisher,
+                       std::vector<std::string> const&) {
+  //! [START pubsub_resume_publish_with_ordering_keys] [resume-publish]
+  namespace pubsub = google::cloud::pubsub;
+  using google::cloud::future;
+  using google::cloud::StatusOr;
+  [](pubsub::Publisher publisher) {
+    struct SampleData {
+      std::string ordering_key;
+      std::string data;
+    } data[] = {
+        {"key1", "message1"}, {"key2", "message2"}, {"key1", "message3"},
+        {"key1", "message4"}, {"key1", "message5"},
+    };
+    std::vector<future<void>> done;
+    for (auto const& datum : data) {
+      auto& da = datum;  // workaround MSVC capture rules
+      auto handler = [da, publisher](future<StatusOr<std::string>> f) mutable {
+        auto const msg = da.ordering_key + "#" + da.data;
+        auto id = f.get();
+        if (!id) {
+          std::cout << "An error has occurred publishing " << msg << "\n";
+          publisher.ResumePublish(da.ordering_key);
+          return;
+        }
+        std::cout << "Message " << msg << " published as id=" << *id << "\n";
+      };
+      done.push_back(
+          publisher
+              .Publish(pubsub::MessageBuilder{}
+                           .SetData("Hello World! [" + datum.data + "]")
+                           .SetOrderingKey(datum.ordering_key)
+                           .Build())
+              .then(handler));
+    }
+    publisher.Flush();
+    // Block until all the messages are published (optional)
+    for (auto& f : done) f.get();
+  }
+  //! [END pubsub_resume_publish_with_ordering_keys] [resume-publish]
+  (std::move(publisher));
+}
+
 void Subscribe(google::cloud::pubsub::Subscriber subscriber,
                std::vector<std::string> const&) {
   //! [START pubsub_quickstart_subscriber]
@@ -1567,6 +1610,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning PublishOrderingKey() sample" << std::endl;
 
   if (UsingEmulator()) PublishOrderingKey(publisher_with_ordering_key, {});
+  if (UsingEmulator()) ResumeOrderingKey(publisher_with_ordering_key, {});
 
   std::cout << "\nRunning Publish() sample [4]" << std::endl;
   Publish(publisher, {});
@@ -1705,6 +1749,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
       CreatePublisherCommand("publish-custom-attributes", {},
                              PublishCustomAttributes),
       CreatePublisherCommand("publish-ordering-key", {}, PublishOrderingKey),
+      CreatePublisherCommand("resume-ordering-key", {}, ResumeOrderingKey),
       CreateSubscriberCommand("subscribe", {}, Subscribe),
       CreateSubscriberCommand("subscribe-error-listener", {},
                               SubscribeErrorListener),


### PR DESCRIPTION
While a batch of messages with the same ordering key is pending (i.e.
sent but the response is not received) any additional messages should be
batched. Add an example showing how to use the `ResumePublish()` API.

Fixes #4803 and #4640

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5304)
<!-- Reviewable:end -->
