### PR TITLE
ci: update vcpkg revision

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -45,9 +45,9 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 if [[ -d "${vcpkg_dir}" ]]; then
   git -C "${vcpkg_dir}" pull --quiet
 else
-  git clone --quiet \
+  git clone --quiet --shallow-since 2020-10-01 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout 8776756e08dddfc47b209eebfec5c927f14c7c74
+  git -C "${vcpkg_dir}" checkout b999dfdfec58560df7978bd9e8bdb7476d29ef5f
 fi
 
 if [[ -d "${HOME}/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -28,7 +28,9 @@ vcpkg_dir="cmake-out/vcpkg-quickstart"
 if [[ -d "${vcpkg_dir}" ]]; then
   git -C "${vcpkg_dir}" pull --quiet
 else
-  git clone --quiet --depth 10 https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+  git clone --quiet --shallow-since 2020-10-01 \
+    https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+  git -C "${vcpkg_dir}" checkout b999dfdfec58560df7978bd9e8bdb7476d29ef5f
 fi
 
 if [[ -d "cmake-out/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -36,7 +36,6 @@ $IsPR = (Test-Path env:KOKORO_JOB_TYPE) -and `
     ($env:KOKORO_JOB_TYPE -eq "PRESUBMIT_GITHUB")
 $HasBuildCache = (Test-Path env:BUILD_CACHE)
 
-$project_root = (Get-Item -Path ".\" -Verbose).FullName
 $vcpkg_dir = "cmake-out\vcpkg"
 $packages = @("zlib", "openssl",
               "protobuf", "c-ares", "benchmark",
@@ -59,7 +58,9 @@ if ($RunningCI -and (Test-Path "${vcpkg_dir}")) {
 }
 if (-not (Test-Path ${vcpkg_dir})) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cloning vcpkg repository."
-    git clone --quiet --depth 10 --branch 2020.07 https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+    git clone --quiet --shallow-since 2020-10-01 `
+        https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
+    git -C "${vcpkg_dir}" checkout b999dfdfec58560df7978bd9e8bdb7476d29ef5f
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red `
             "vcpkg git setup failed with exit code $LastExitCode"


### PR DESCRIPTION
Update to a more recent version (circa 2020-10-01), and use the
same version for Windows and Linux builds. The macOS script
is not used, but might as well update it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5307)
<!-- Reviewable:end -->
