### PR TITLE
cleanup(pubsub): enable ordering examples in production

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -1608,9 +1608,10 @@ void AutoRun(std::vector<std::string> const& argv) {
                      .set_maximum_batch_message_count(1)
                      .enable_message_ordering()));
   std::cout << "\nRunning PublishOrderingKey() sample" << std::endl;
+  PublishOrderingKey(publisher_with_ordering_key, {});
 
-  if (UsingEmulator()) PublishOrderingKey(publisher_with_ordering_key, {});
-  if (UsingEmulator()) ResumeOrderingKey(publisher_with_ordering_key, {});
+  std::cout << "\nRunning ResumeOrderingKey() sample" << std::endl;
+  ResumeOrderingKey(publisher_with_ordering_key, {});
 
   std::cout << "\nRunning Publish() sample [4]" << std::endl;
   Publish(publisher, {});


### PR DESCRIPTION
Now that ordering keys are GA we can enable the examples in production.

Fixes #5300

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5310)
<!-- Reviewable:end -->
