### PR TITLE
fix: retry unexpected curl errors

### DIFF
--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -334,8 +334,8 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
       // As described above, there are about 100 error codes, some are
       // explicitly marked as obsolete, some are not available in all libcurl
       // versions. Use this `default:` case to treat all such errors as
-      // `kUnknown`.
-      code = StatusCode::kUnknown;
+      // `kUnavailable` and they will be retried.
+      code = StatusCode::kUnavailable;
       break;
   }
   return Status(code, std::move(os).str());

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -189,7 +189,6 @@ Status CurlHandle::AsStatus(CURLcode e, char const* where) {
     case CURLE_FTP_WEIRD_PASS_REPLY:
     case CURLE_FTP_WEIRD_227_FORMAT:
     case CURLE_FTP_CANT_GET_HOST:
-    // missing in some older libcurl versions:   CURLE_HTTP2
     case CURLE_FTP_COULDNT_SET_TYPE:
       code = StatusCode::kUnknown;
       break;

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -47,6 +47,7 @@ TEST(CurlHandleTest, AsStatus) {
       {CURLE_FTP_PORT_FAILED, StatusCode::kUnknown},
       {CURLE_GOT_NOTHING, StatusCode::kUnavailable},
       {CURLE_AGAIN, StatusCode::kUnknown},
+      {CURLE_HTTP2, StatusCode::kUnavailable},
   };
 
   for (auto const& codes : expected_codes) {


### PR DESCRIPTION
We were sometimes seeing `CURLE_HTTP2` "Error in the HTTP2 framing
layer" errors when downloading large (20G) files using HTTP2. Details
captured in b/171350177.

Retying these errors works around the problem. Changed the default
behavior to retry all curl errors that aren't explicitly handled
separately in the switch statement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5312)
<!-- Reviewable:end -->
