### PR TITLE
fix: avoid error_code, which doesn't exist internally

### DIFF
--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -304,8 +304,8 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
   google::cloud::conformance::storage::v1::TestFile tests;
   auto status = google::protobuf::util::JsonStringToMessage(json_rep, &tests);
   if (!status.ok()) {
-    std::cerr << "Failed to parse conformance tests: " << status.error_code()
-              << ": " << status.error_message() << "\n";
+    std::cerr << "Failed to parse conformance tests: " << status.ToString()
+              << "\n";
     return 1;
   }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5316)
<!-- Reviewable:end -->
