### PR TITLE
cleanup(storage): always list all tests

### DIFF
--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(storage_client_integration_tests
     object_rewrite_integration_test.cc
     object_write_streambuf_integration_test.cc
     service_account_integration_test.cc
+    signed_url_conformance_test.cc
     signed_url_integration_test.cc
     slow_reader_chunk_integration_test.cc
     slow_reader_stream_integration_test.cc
@@ -52,7 +53,6 @@ set(storage_client_integration_tests
 # Signed URL conformance tests are parsed using protos. In order to simplify the
 # build files, only build these conformance tests if gRPC in GCS is compiled.
 if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
-    list(APPEND storage_client_integration_tests signed_url_conformance_test.cc)
     # We need to disable clang tidy for the generated CC files.
     google_cloud_cpp_proto_library(
         google_cloud_cpp_storage_tests_conformance_protos

--- a/google/cloud/storage/tests/signed_url_conformance_test.cc
+++ b/google/cloud/storage/tests/signed_url_conformance_test.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/internal/openssl_util.h"
 #include "google/cloud/storage/internal/signed_url_requests.h"
 #include "google/cloud/storage/list_objects_reader.h"
-#include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/storage/tests/conformance_tests.pb.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
@@ -366,3 +367,4 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
 
   return RUN_ALL_TESTS();
 }
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -43,11 +43,11 @@ storage_client_integration_tests = [
     "object_rewrite_integration_test.cc",
     "object_write_streambuf_integration_test.cc",
     "service_account_integration_test.cc",
+    "signed_url_conformance_test.cc",
     "signed_url_integration_test.cc",
     "slow_reader_chunk_integration_test.cc",
     "slow_reader_stream_integration_test.cc",
     "small_reads_integration_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
-    "signed_url_conformance_test.cc",
 ]


### PR DESCRIPTION
We should always list all the tests in the CMake files, or they are not
included in the generated .bzl files. This is slightly annoying for
tests that only make sense when the GCS+gRPC plugin is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5322)
<!-- Reviewable:end -->
