### PR TITLE
cleanup(pubsub): use bigger counters in benchmark

### DIFF
--- a/google/cloud/pubsub/benchmarks/endurance.cc
+++ b/google/cloud/pubsub/benchmarks/endurance.cc
@@ -62,8 +62,8 @@ struct Config {
   int subscription_count = 4;
   int session_count = 8;
 
-  int minimum_samples = 30 * 1000;
-  int maximum_samples = (std::numeric_limits<int>::max)();
+  std::int64_t minimum_samples = 30 * 1000;
+  std::int64_t maximum_samples = (std::numeric_limits<std::int64_t>::max)();
   std::chrono::seconds minimum_runtime = std::chrono::seconds(5);
   std::chrono::seconds maximum_runtime = std::chrono::seconds(300);
 


### PR DESCRIPTION
We need more than 31 bits (or 32 bits) to count messages, smaller
counters overflow in a matter of hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5323)
<!-- Reviewable:end -->
