### PR TITLE
fix(common): crashes on background thread shutdown

### DIFF
--- a/google/cloud/internal/background_threads_impl.cc
+++ b/google/cloud/internal/background_threads_impl.cc
@@ -43,6 +43,7 @@ AutomaticallyCreatedBackgroundThreads::
 void AutomaticallyCreatedBackgroundThreads::Shutdown() {
   cq_.Shutdown();
   for (auto& t : pool_) t.join();
+  pool_.clear();
 }
 
 }  // namespace internal

--- a/google/cloud/internal/background_threads_impl_test.cc
+++ b/google/cloud/internal/background_threads_impl_test.cc
@@ -108,6 +108,21 @@ TEST(AutomaticallyCreatedBackgroundThreads, ManyThreads) {
   EXPECT_THAT(ids, Not(Contains(std::this_thread::get_id())));
 }
 
+/// @test Verify that automatically created completion queues work.
+TEST(AutomaticallyCreatedBackgroundThreads, ManualShutdown) {
+  auto constexpr kThreadCount = 4;
+  AutomaticallyCreatedBackgroundThreads actual(kThreadCount);
+  EXPECT_EQ(kThreadCount, actual.pool_size());
+
+  std::vector<promise<void>> promises(2 * kThreadCount);
+  for (auto& p : promises) {
+    actual.cq().RunAsync([&p] { p.set_value(); });
+  }
+  for (auto& p : promises) p.get_future().get();
+
+  actual.Shutdown();
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS


### PR DESCRIPTION
Once we join the threads in a
`internal::AutomaticallyCreatedBackgroundThreads` we should clear the
pool to avoid crashes in the destructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5324)
<!-- Reviewable:end -->
