### PR TITLE
feat(pubsub): preserve order for messages with ordering keys

### DIFF
--- a/google/cloud/pubsub/BUILD
+++ b/google/cloud/pubsub/BUILD
@@ -25,6 +25,8 @@ cc_library(
     deps = [
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
     ],
 )
@@ -70,6 +72,7 @@ load(":pubsub_client_unit_tests.bzl", "pubsub_client_unit_tests")
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in pubsub_client_unit_tests]

--- a/google/cloud/pubsub/BUILD
+++ b/google/cloud/pubsub/BUILD
@@ -26,7 +26,6 @@ cc_library(
         "//google/cloud:google_cloud_cpp_common",
         "//google/cloud:google_cloud_cpp_grpc_utils",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
     ],
 )

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -121,8 +121,7 @@ target_include_directories(
 target_link_libraries(
     pubsub_client
     PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-           googleapis-c++::pubsub_protos absl::flat_hash_map
-           absl::flat_hash_set)
+           googleapis-c++::pubsub_protos absl::flat_hash_map)
 google_cloud_cpp_add_common_options(pubsub_client)
 set_target_properties(
     pubsub_client PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -25,6 +25,11 @@ set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_PUBSUB_NS=v1")
 
 include(GoogleCloudCppCommon)
 
+# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
+set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
+find_package(absl CONFIG REQUIRED)
+unset(FPHSA_NAME_MISMATCHED)
+
 configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(
     pubsub_client # cmake-format: sort
@@ -114,8 +119,10 @@ target_include_directories(
            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
-    pubsub_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-                         googleapis-c++::pubsub_protos)
+    pubsub_client
+    PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
+           googleapis-c++::pubsub_protos absl::flat_hash_map
+           absl::flat_hash_set)
 google_cloud_cpp_add_common_options(pubsub_client)
 set_target_properties(
     pubsub_client PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"
@@ -236,6 +243,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
                     googleapis-c++::pubsub_client
                     google_cloud_cpp_testing
                     google_cloud_cpp_testing_grpc
+                    absl::str_format
                     GTest::gmock_main
                     GTest::gmock
                     GTest::gtest)

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -119,9 +119,8 @@ target_include_directories(
            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
-    pubsub_client
-    PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-           googleapis-c++::pubsub_protos absl::flat_hash_map)
+    pubsub_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
+                         googleapis-c++::pubsub_protos absl::flat_hash_map)
 google_cloud_cpp_add_common_options(pubsub_client)
 set_target_properties(
     pubsub_client PROPERTIES VERSION "${GOOGLE_CLOUD_CPP_VERSION}"

--- a/google/cloud/pubsub/internal/subscription_message_queue.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue.cc
@@ -40,18 +40,20 @@ void SubscriptionMessageQueue::Shutdown() {
 void SubscriptionMessageQueue::Read(std::size_t max_callbacks) {
   std::unique_lock<std::mutex> lk(mu_);
   if (!callback_) return;
-  read_count_ += max_callbacks;
+  available_slots_ += max_callbacks;
   DrainQueue(std::move(lk));
 }
 
 future<Status> SubscriptionMessageQueue::AckMessage(std::string const& ack_id,
                                                     std::size_t) {
+  HandlerDone(ack_id);
   source_->AckMessage(ack_id);
   return make_ready_future(Status{});
 }
 
 future<Status> SubscriptionMessageQueue::NackMessage(std::string const& ack_id,
                                                      std::size_t) {
+  HandlerDone(ack_id);
   source_->NackMessage(ack_id);
   return make_ready_future(Status{});
 }
@@ -72,9 +74,17 @@ void SubscriptionMessageQueue::OnRead(
     google::pubsub::v1::StreamingPullResponse r) {
   auto handle_response = [&] {
     shutdown_manager_->FinishedOperation("OnRead");
-    std::move(r.mutable_received_messages()->begin(),
-              r.mutable_received_messages()->end(),
-              std::back_inserter(messages_));
+    for (auto& m : *r.mutable_received_messages()) {
+      auto key = m.message().ordering_key();
+      auto const ordered = !key.empty();
+      auto& queue = queues_[key];
+      queue.messages.push_back(std::move(m));
+      // Queues require ordering are runnable only if there are no running
+      // messages
+      if (!ordered || queue.running == 0) {
+        runnable_queues_.insert(std::move(key));
+      }
+    }
     DrainQueue(std::move(lk));
   };
   auto bulk_nack = [&] {
@@ -93,33 +103,73 @@ void SubscriptionMessageQueue::OnRead(
 }
 
 void SubscriptionMessageQueue::Shutdown(std::unique_lock<std::mutex> lk) {
-  auto messages = [&] {
-    shutdown_ = true;
-    auto messages = std::move(messages_);
-    messages_.clear();
-    lk.unlock();
-    return messages;
-  }();
+  shutdown_ = true;
+  auto ack_ids = [&](std::unique_lock<std::mutex>) {
+    std::vector<std::string> ack_ids;
+    for (auto& kv : queues_) {
+      for (auto& m : kv.second.messages) {
+        ack_ids.push_back(std::move(*m.mutable_ack_id()));
+      }
+    }
+    queues_.clear();
+    return ack_ids;
+  }(std::move(lk));
 
-  if (messages.empty()) return;
-  std::vector<std::string> ack_ids(messages.size());
-  std::transform(messages.begin(), messages.end(), ack_ids.begin(),
-                 [&](google::pubsub::v1::ReceivedMessage& m) {
-                   return std::move(*m.mutable_ack_id());
-                 });
+  if (ack_ids.empty()) return;
   source_->BulkNack(std::move(ack_ids));
 }
 
 void SubscriptionMessageQueue::DrainQueue(std::unique_lock<std::mutex> lk) {
-  while (!messages_.empty() && read_count_ > 0 && !shutdown_) {
-    auto m = std::move(messages_.front());
-    messages_.pop_front();
-    --read_count_;
+  while (KeepDraining(lk)) {
+    auto m = PickFromRunnable(lk);
+    if (!m) continue;
     // Don't hold a lock during the callback, as the callee may call `Read()`
     // or something similar.
     lk.unlock();
-    callback_(std::move(m));
+    callback_(std::move(*m));
     lk.lock();
+  }
+}
+
+absl::optional<google::pubsub::v1::ReceivedMessage>
+SubscriptionMessageQueue::PickFromRunnable(
+    std::unique_lock<std::mutex> const&) {
+  // Pick one of the runnable queues at random, and select the next element
+  // from that queue.
+  auto idx = std::uniform_int_distribution<std::size_t>(
+      0, runnable_queues_.size() - 1)(generator_);
+  auto r = runnable_queues_.begin();
+  for (std::size_t i = 0; i != idx; ++i) ++r;  // std::advance() did not work
+  auto key = *r;
+  auto const ordered = !key.empty();
+  auto ql = queues_.find(key);
+  if (ql == queues_.end()) return {};
+  auto& q = ql->second;
+  if (q.messages.empty()) {
+    runnable_queues_.erase(r);
+    return {};
+  }
+  auto m = std::move(q.messages.front());
+  ordering_key_by_ack_id_[m.ack_id()] = std::move(key);
+  q.messages.pop_front();
+  ++q.running;
+  --available_slots_;
+  if (q.messages.empty() || ordered) {
+    // The queue is no longer runnable, remove it from consideration.
+    runnable_queues_.erase(r);
+  }
+  return m;
+}
+
+void SubscriptionMessageQueue::HandlerDone(std::string const& ack_id) {
+  std::lock_guard<std::mutex> lk(mu_);
+  auto loc = ordering_key_by_ack_id_.find(ack_id);
+  if (loc == ordering_key_by_ack_id_.end()) return;
+  auto key = std::move(loc->second);
+  ordering_key_by_ack_id_.erase(loc);
+  auto& q = queues_[key];
+  if (--q.running == 0 && !q.messages.empty()) {
+    runnable_queues_.insert(std::move(key));
   }
 }
 

--- a/google/cloud/pubsub/internal/subscription_message_queue.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue.cc
@@ -162,7 +162,7 @@ SubscriptionMessageQueue::PickFromRunnable(
 }
 
 void SubscriptionMessageQueue::HandlerDone(std::string const& ack_id) {
-  std::lock_guard<std::mutex> lk(mu_);
+  std::unique_lock<std::mutex> lk(mu_);
   auto loc = ordering_key_by_ack_id_.find(ack_id);
   if (loc == ordering_key_by_ack_id_.end()) return;
   auto key = std::move(loc->second);
@@ -171,6 +171,7 @@ void SubscriptionMessageQueue::HandlerDone(std::string const& ack_id) {
   if (--q.running == 0 && !q.messages.empty()) {
     runnable_queues_.insert(std::move(key));
   }
+  DrainQueue(std::move(lk));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscription_message_queue.h
+++ b/google/cloud/pubsub/internal/subscription_message_queue.h
@@ -38,7 +38,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  * `SubscriptionSession` and go/cloud-cxx:pub-sub-subscriptions-dd for more
  * details.
  *
- * The next stage setups a callback in `Start()` to receive messages from this
+ * The next stage sets up a callback in `Start()` to receive messages from this
  * stage. This stage keeps a queue of messages ready to run, the next stage
  * drains the queue by calling `Read(n)` which allow this stage to send up to
  * `n` messages. After `n` messages are sent more calls to `Read(n)` *are*

--- a/google/cloud/pubsub/internal/subscription_message_queue_test.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue_test.cc
@@ -487,25 +487,11 @@ TEST_P(SubscriptionMessageQueueOrderingTest, RespectOrderingKeysTorture) {
   uut->Shutdown();
 }
 
-INSTANTIATE_TEST_SUITE_P(SubscriptionMessageQueueOrderingSmallKeySpaceST,
-                         SubscriptionMessageQueueOrderingTest,
-                         ::testing::Values(TestParams{1, 4, 10/*0000*/}),
-                         ::testing::PrintToStringParamName());
-
-INSTANTIATE_TEST_SUITE_P(SubscriptionMessageQueueOrderingSmallKeySpaceMT,
-                         SubscriptionMessageQueueOrderingTest,
-                         ::testing::Values(TestParams{8, 4, 10/*0000*/}),
-                         ::testing::PrintToStringParamName());
-
-INSTANTIATE_TEST_SUITE_P(SubscriptionMessageQueueOrderingLargeKeySpaceST,
-                         SubscriptionMessageQueueOrderingTest,
-                         ::testing::Values(TestParams{1, 1000, 10/*0000*/}),
-                         ::testing::PrintToStringParamName());
-
-INSTANTIATE_TEST_SUITE_P(SubscriptionMessageQueueOrderingLargeKeySpaceMT,
-                         SubscriptionMessageQueueOrderingTest,
-                         ::testing::Values(TestParams{8, 1000, 10/*0000*/}),
-                         ::testing::PrintToStringParamName());
+INSTANTIATE_TEST_SUITE_P(
+    SubscriptionMessageQueueOrderingTest, SubscriptionMessageQueueOrderingTest,
+    ::testing::Values(TestParams{1, 4, 1000}, TestParams{1, 1000, 1000},
+                      TestParams{8, 4, 1000}, TestParams{8, 1000, 1000}),
+    ::testing::PrintToStringParamName());
 
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/subscription_message_queue_test.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue_test.cc
@@ -14,7 +14,10 @@
 
 #include "google/cloud/pubsub/internal/subscription_message_queue.h"
 #include "google/cloud/pubsub/testing/mock_subscription_batch_source.h"
+#include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_format.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -25,7 +28,11 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::testing::AtLeast;
+using ::testing::AtMost;
 using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::IsEmpty;
 
 std::vector<google::pubsub::v1::ReceivedMessage> GenerateMessages() {
   auto constexpr kTextM0 = R"pb(
@@ -34,7 +41,6 @@ std::vector<google::pubsub::v1::ReceivedMessage> GenerateMessages() {
       attributes: { key: "k0" value: "m0-l0" }
       attributes: { key: "k1" value: "m0-l1" }
       message_id: "id-m0"
-      ordering_key: "abcd"
     }
     ack_id: "ack-m0"
   )pb";
@@ -44,7 +50,6 @@ std::vector<google::pubsub::v1::ReceivedMessage> GenerateMessages() {
       attributes: { key: "k0" value: "m1-l0" }
       attributes: { key: "k1" value: "m1-l1" }
       message_id: "id-m1"
-      ordering_key: "abcd"
     }
     ack_id: "ack-m1"
   )pb";
@@ -54,7 +59,6 @@ std::vector<google::pubsub::v1::ReceivedMessage> GenerateMessages() {
       attributes: { key: "k0" value: "m2-l0" }
       attributes: { key: "k1" value: "m2-l1" }
       message_id: "id-m2"
-      ordering_key: "abcd"
     }
     ack_id: "ack-m2"
   )pb";
@@ -68,7 +72,7 @@ std::vector<google::pubsub::v1::ReceivedMessage> GenerateMessages() {
   return {m0, m1, m2};
 }
 
-google::pubsub::v1::StreamingPullResponse GenerateResponse(
+google::pubsub::v1::StreamingPullResponse AsPullResponse(
     std::vector<google::pubsub::v1::ReceivedMessage> messages) {
   google::pubsub::v1::StreamingPullResponse response;
   for (auto& m : messages) {
@@ -95,7 +99,7 @@ TEST(SubscriptionMessageQueueTest, Basic) {
 
   auto const messages = GenerateMessages();
   ASSERT_FALSE(messages.empty());
-  auto const response = GenerateResponse(messages);
+  auto const response = AsPullResponse(messages);
 
   std::vector<google::pubsub::v1::ReceivedMessage> received;
   auto handler = [&received](google::pubsub::v1::ReceivedMessage m) {
@@ -140,7 +144,7 @@ TEST(SubscriptionMessageQueueTest, NackOnSessionShutdown) {
   ::testing::MockFunction<void(google::pubsub::v1::ReceivedMessage const&)>
       mock_handler;
 
-  auto const response = GenerateResponse(GenerateMessages());
+  auto const response = AsPullResponse(GenerateMessages());
   EXPECT_FALSE(response.received_messages().empty());
 
   auto shutdown = std::make_shared<SessionShutdownManager>();
@@ -172,6 +176,187 @@ TEST(SubscriptionMessageQueueTest, HandleError) {
   batch_callback(expected);
 
   EXPECT_EQ(done.get(), expected);
+}
+
+std::vector<google::pubsub::v1::ReceivedMessage> GenerateOrderKeyMessages(
+    std::string const& key, int start, int count) {
+  std::vector<google::pubsub::v1::ReceivedMessage> result;
+  for (int i = 0; i != count; ++i) {
+    auto const id = key + "-" + absl::StrFormat("%04d", start + i);
+    google::pubsub::v1::ReceivedMessage m;
+    m.mutable_message()->set_message_id("id-" + id);
+    m.mutable_message()->set_data("m-" + id);
+    m.mutable_message()->set_ordering_key(key);
+    m.set_ack_id("ack-" + id);
+    result.push_back(std::move(m));
+  }
+  return result;
+}
+
+/// @test Verify messages with ordering keys are delivered in order
+TEST(SubscriptionMessageQueueTest, RespectOrderingKeys) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriptionBatchSource>();
+  EXPECT_CALL(*mock, Shutdown).Times(1);
+  BatchCallback batch_callback;
+  EXPECT_CALL(*mock, Start).WillOnce([&](BatchCallback cb) {
+    batch_callback = std::move(cb);
+  });
+
+  EXPECT_CALL(*mock, AckMessage).Times(AtLeast(1));
+  EXPECT_CALL(*mock, NackMessage).Times(AtLeast(1));
+  EXPECT_CALL(*mock, BulkNack).Times(0);
+
+  absl::flat_hash_map<std::string, std::vector<std::string>> received;
+  auto handler = [&received](google::pubsub::v1::ReceivedMessage const& m) {
+    auto key = m.message().ordering_key();
+    received[key].push_back(m.message().message_id());
+  };
+
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+  shutdown->Start({});
+  // Create the queue and allow it to push 5 messages
+  auto uut = SubscriptionMessageQueue::Create(shutdown, mock);
+  uut->Start(handler);
+  uut->Read(5);
+
+  // Generate some messages, expecting only one for each key.
+  batch_callback(AsPullResponse(GenerateOrderKeyMessages("k0", 0, 3)));
+  batch_callback(AsPullResponse(GenerateOrderKeyMessages("k1", 0, 3)));
+  batch_callback(AsPullResponse(GenerateOrderKeyMessages({}, 0, 3)));
+
+  EXPECT_THAT(received["k0"], ElementsAre("id-k0-0000"));
+  EXPECT_THAT(received["k1"], ElementsAre("id-k1-0000"));
+  EXPECT_THAT(received[{}], ElementsAre("id--0000", "id--0001", "id--0002"));
+
+  received.clear();  // keep expectations shorter
+  uut->AckMessage("ack--0000", 0);
+  uut->AckMessage("ack--0001", 0);
+  uut->AckMessage("ack--0002", 0);
+  EXPECT_THAT(received["k0"], IsEmpty());
+  EXPECT_THAT(received["k1"], IsEmpty());
+  EXPECT_THAT(received[{}], IsEmpty());
+
+  received.clear();  // keep expectations shorter
+  uut->NackMessage("ack-k0-0000", 0);
+  uut->Read(4);
+  EXPECT_THAT(received["k0"], ElementsAre("id-k0-0001"));
+  EXPECT_THAT(received["k1"], IsEmpty());
+  EXPECT_THAT(received[{}], IsEmpty());
+
+  uut->NackMessage("ack-k1-0000", 0);
+  uut->Read(1);
+  EXPECT_THAT(received["k0"], ElementsAre("id-k0-0001"));
+  EXPECT_THAT(received["k1"], ElementsAre("id-k1-0001"));
+  EXPECT_THAT(received[{}], IsEmpty());
+
+  received.clear();  // keep expectations shorter
+  batch_callback(AsPullResponse(GenerateOrderKeyMessages({}, 3, 2)));
+  uut->AckMessage("ack-k0-0001", 0);
+  uut->AckMessage("ack-k1-0001", 0);
+  uut->Read(2);
+  EXPECT_THAT(received["k0"], ElementsAre("id-k0-0002"));
+  EXPECT_THAT(received["k1"], ElementsAre("id-k1-0002"));
+  EXPECT_THAT(received[{}], ElementsAre("id--0003", "id--0004"));
+
+  received.clear();  // keep expectations shorter
+  uut->AckMessage("ack-k0-0002", 0);
+  uut->AckMessage("ack-k1-0002", 0);
+  uut->AckMessage("ack--0003", 0);
+  uut->AckMessage("ack--0004", 0);
+  uut->Read(4);
+  EXPECT_THAT(received["k0"], IsEmpty());
+  EXPECT_THAT(received["k1"], IsEmpty());
+  EXPECT_THAT(received[{}], IsEmpty());
+
+  batch_callback(AsPullResponse(GenerateOrderKeyMessages({}, 5, 5)));
+  EXPECT_THAT(received[{}], ElementsAre("id--0005", "id--0006", "id--0007",
+                                        "id--0008", "id--0009"));
+
+  uut->Shutdown();
+}
+
+/// @test Verify messages with ordering keys are delivered in order
+TEST(SubscriptionMessageQueueTest, RespectOrderingKeysTorture) {
+  auto mock = std::make_shared<pubsub_testing::MockSubscriptionBatchSource>();
+  EXPECT_CALL(*mock, Shutdown).Times(1);
+  BatchCallback batch_callback;
+  EXPECT_CALL(*mock, Start).WillOnce([&](BatchCallback cb) {
+    batch_callback = std::move(cb);
+  });
+
+  EXPECT_CALL(*mock, AckMessage).Times(::testing::AtLeast(1));
+  EXPECT_CALL(*mock, NackMessage).Times(0);
+  EXPECT_CALL(*mock, BulkNack).Times(AtMost(1));
+
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+  shutdown->Start({});
+  // Create the queue and allow it to push many messages
+  auto uut = SubscriptionMessageQueue::Create(shutdown, mock);
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(8);
+  std::mutex mu;
+  std::condition_variable cv;
+  auto constexpr kExpectedCount = 400;
+  int received_count = 0;
+  absl::flat_hash_map<std::string, std::vector<std::string>> received;
+  auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
+  auto handler = [&](google::pubsub::v1::ReceivedMessage const& m) {
+    background.cq().RunAsync([&, m]() {
+      auto delay = [&] {
+        std::lock_guard<std::mutex> lk(mu);
+        return std::uniform_int_distribution<int>(0, 500)(generator);
+      }();
+      std::this_thread::sleep_for(std::chrono::microseconds(delay));
+      auto key = m.message().ordering_key();
+      bool notify = false;
+      {
+        std::lock_guard<std::mutex> lk(mu);
+        received[key].push_back(m.message().message_id());
+        ++received_count;
+        notify = received_count >= kExpectedCount;
+      }
+      uut->AckMessage(m.ack_id(), 0);
+      uut->Read(1);
+      if (notify) cv.notify_one();
+    });
+  };
+
+  auto constexpr kMaxCallbacks = 150;
+  uut->Start(handler);
+  uut->Read(kMaxCallbacks);
+
+  auto worker = [batch_callback](std::string const& key, int count, int step) {
+    auto gen = google::cloud::internal::DefaultPRNG(std::random_device{}());
+    for (int i = 0; i < count; i += step) {
+      batch_callback(AsPullResponse(GenerateOrderKeyMessages(key, i, step)));
+      auto delay = std::uniform_int_distribution<int>(0, 500)(gen);
+      std::this_thread::sleep_for(std::chrono::microseconds(delay));
+    }
+  };
+  std::vector<std::thread> tasks;
+  tasks.emplace_back(worker, std::string("k0"), 100, 3);
+  tasks.emplace_back(worker, std::string("k1"), 100, 5);
+  tasks.emplace_back(worker, std::string("k2"), 100, 7);
+  tasks.emplace_back(worker, std::string{}, 100, 11);
+
+  {
+    std::unique_lock<std::mutex> lk(mu);
+    cv.wait(lk, [&] { return received_count >= kExpectedCount; });
+  }
+
+  for (auto& t : tasks) t.join();
+  background.Shutdown();  // This waits for the threads
+
+  for (auto& kv : received) {
+    SCOPED_TRACE("Testing messages for key=<" + kv.first + ">");
+    EXPECT_FALSE(kv.second.empty());
+    if (kv.first.empty()) continue;
+    std::vector<std::string> ids = kv.second;
+    std::sort(ids.begin(), ids.end());
+    EXPECT_THAT(kv.second, ElementsAreArray(ids.begin(), ids.end()));
+  }
+
+  uut->Shutdown();
 }
 
 }  // namespace


### PR DESCRIPTION
Messages without an ordering key are scheduled
in parallel, and therefore can be executed out of
order. Messages with an ordering key are scheduled
in sequence for the same ordering key. That is,
messages with key `key1` will be scheduled one
at a time, but messages with other keys may be
scheduled in parallel.

Fixes #5044 and fixes #5263 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5327)
<!-- Reviewable:end -->
