### PR TITLE
cleanup(pubsub): no pure virtuals in `*Connection`

### DIFF
--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -216,6 +216,22 @@ class PaginationRange {
   bool on_last_page_;
 };
 
+template <typename T>
+struct UnimplementedPaginationRange {};
+
+template <typename T, typename Request, typename Response>
+struct UnimplementedPaginationRange<PaginationRange<T, Request, Response>> {
+  static PaginationRange<T, Request, Response> Create() {
+    return PaginationRange<T, Request, Response>(
+        Request{},
+        [](Request const&) {
+          return StatusOr<Response>(
+              Status{StatusCode::kUnimplemented, "needs-override"});
+        },
+        [](Response) { return std::vector<T>{}; });
+  }
+};
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/pagination_range.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <gmock/gmock.h>
 
@@ -22,6 +23,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
@@ -205,6 +207,15 @@ TEST(RangeFromPagination, IteratorCoverage) {
   EXPECT_THAT(item.status().message(), HasSubstr("bad-luck"));
   ++i1;
   EXPECT_TRUE(i1 == range.end());
+}
+
+TEST(RangeFromPagination, Unimplemented) {
+  using NonProtoRange = PaginationRange<std::string, Request, Response>;
+
+  NonProtoRange range = UnimplementedPaginationRange<NonProtoRange>::Create();
+  auto i = range.begin();
+  EXPECT_NE(i, range.end());
+  EXPECT_THAT(*i, StatusIs(StatusCode::kUnimplemented));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/ack_handler.h
+++ b/google/cloud/pubsub/ack_handler.h
@@ -64,13 +64,13 @@ class AckHandler {
    public:
     virtual ~Impl() = 0;
     /// The implementation for `AckHandler::ack()`
-    virtual void ack() = 0;
+    virtual void ack() {}
     /// The implementation for `AckHandler::nack()`
-    virtual void nack() = 0;
+    virtual void nack() {}
     /// The implementation for `AckHandler::ack_id()`
-    virtual std::string ack_id() const = 0;
+    virtual std::string ack_id() const { return {}; }
     /// The implementation for `AckHandler::delivery_attempt()`
-    virtual std::int32_t delivery_attempt() const = 0;
+    virtual std::int32_t delivery_attempt() const { return 0; }
   };
 
   /**

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -53,6 +53,17 @@ class ContainingPublisherConnection : public PublisherConnection {
 
 PublisherConnection::~PublisherConnection() = default;
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+future<StatusOr<std::string>> PublisherConnection::Publish(PublishParams) {
+  return make_ready_future(StatusOr<std::string>(
+      Status{StatusCode::kUnimplemented, "needs-override"}));
+}
+
+void PublisherConnection::Flush(FlushParams) {}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void PublisherConnection::ResumePublish(ResumePublishParams) {}
+
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, PublisherOptions options, ConnectionOptions connection_options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -74,13 +74,13 @@ class PublisherConnection {
   //@}
 
   /// Defines the interface for `Publisher::Publish()`
-  virtual future<StatusOr<std::string>> Publish(PublishParams p) = 0;
+  virtual future<StatusOr<std::string>> Publish(PublishParams p);
 
   /// Defines the interface for `Publisher::Flush()`
-  virtual void Flush(FlushParams) = 0;
+  virtual void Flush(FlushParams);
 
   /// Defines the interface for `Publisher::ResumePublish()`
-  virtual void ResumePublish(ResumePublishParams p) = 0;
+  virtual void ResumePublish(ResumePublishParams p);
 };
 
 /**

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -29,6 +29,12 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 SubscriberConnection::~SubscriberConnection() = default;
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+future<Status> SubscriberConnection::Subscribe(SubscribeParams) {
+  return make_ready_future(
+      Status{StatusCode::kUnimplemented, "needs-override"});
+}
+
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription, SubscriberOptions options,
     ConnectionOptions connection_options,

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -68,7 +68,7 @@ class SubscriberConnection {
   //@}
 
   /// Defines the interface for `Subscriber::Subscribe()`
-  virtual future<Status> Subscribe(SubscribeParams p) = 0;
+  virtual future<Status> Subscribe(SubscribeParams p);
 };
 
 /**

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -282,8 +282,73 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
 
 SubscriptionAdminConnection::~SubscriptionAdminConnection() = default;
 
+StatusOr<google::pubsub::v1::Subscription>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+SubscriptionAdminConnection::CreateSubscription(CreateSubscriptionParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Subscription>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+SubscriptionAdminConnection::GetSubscription(GetSubscriptionParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Subscription>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+SubscriptionAdminConnection::UpdateSubscription(UpdateSubscriptionParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+ListSubscriptionsRange SubscriptionAdminConnection::ListSubscriptions(
+    ListSubscriptionsParams) {  // NOLINT(performance-unnecessary-value-param)
+  return internal::UnimplementedPaginationRange<
+      ListSubscriptionsRange>::Create();
+}
+
+Status SubscriptionAdminConnection::DeleteSubscription(
+    DeleteSubscriptionParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Status SubscriptionAdminConnection::ModifyPushConfig(ModifyPushConfigParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Snapshot>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+SubscriptionAdminConnection::CreateSnapshot(CreateSnapshotParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Snapshot> SubscriptionAdminConnection::GetSnapshot(
+    GetSnapshotParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Snapshot>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+SubscriptionAdminConnection::UpdateSnapshot(UpdateSnapshotParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+ListSnapshotsRange SubscriptionAdminConnection::ListSnapshots(
+    ListSnapshotsParams) {  // NOLINT(performance-unnecessary-value-param)
+  return internal::UnimplementedPaginationRange<ListSnapshotsRange>::Create();
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Status SubscriptionAdminConnection::DeleteSnapshot(DeleteSnapshotParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::SeekResponse> SubscriptionAdminConnection::Seek(
+    SeekParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS
 }  // namespace pubsub
-
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -153,45 +153,44 @@ class SubscriptionAdminConnection {
 
   /// Defines the interface for `SubscriptionAdminClient::CreateSubscription()`
   virtual StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
-      CreateSubscriptionParams) = 0;
+      CreateSubscriptionParams);
 
   /// Defines the interface for `SubscriptionAdminClient::GetSubscription()`
   virtual StatusOr<google::pubsub::v1::Subscription> GetSubscription(
-      GetSubscriptionParams) = 0;
+      GetSubscriptionParams);
 
   /// Defines the interface for `SubscriptionAdminClient::UpdateSubscription()`
   virtual StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
-      UpdateSubscriptionParams) = 0;
+      UpdateSubscriptionParams);
 
   /// Defines the interface for `SubscriptionAdminClient::ListSubscriptions()`
-  virtual ListSubscriptionsRange ListSubscriptions(ListSubscriptionsParams) = 0;
+  virtual ListSubscriptionsRange ListSubscriptions(ListSubscriptionsParams);
 
   /// Defines the interface for `SubscriptionAdminClient::DeleteSubscription()`
-  virtual Status DeleteSubscription(DeleteSubscriptionParams) = 0;
+  virtual Status DeleteSubscription(DeleteSubscriptionParams);
 
   /// Defines the interface for `SubscriptionAdminClient::ModifyPushConfig()`
-  virtual Status ModifyPushConfig(ModifyPushConfigParams) = 0;
+  virtual Status ModifyPushConfig(ModifyPushConfigParams);
 
   /// Defines the interface for `SnapshotAdminClient::CreateSnapshot()`
   virtual StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
-      CreateSnapshotParams) = 0;
+      CreateSnapshotParams);
 
   /// Defines the interface for `SnapshotAdminClient::GetSnapshot()`
-  virtual StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
-      GetSnapshotParams) = 0;
+  virtual StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(GetSnapshotParams);
 
   /// Defines the interface for `SnapshotAdminClient::UpdateSnapshot()`
   virtual StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
-      UpdateSnapshotParams) = 0;
+      UpdateSnapshotParams);
 
   /// Defines the interface for `SubscriptionAdminClient::ListSnapshots()`
-  virtual ListSnapshotsRange ListSnapshots(ListSnapshotsParams) = 0;
+  virtual ListSnapshotsRange ListSnapshots(ListSnapshotsParams);
 
   /// Defines the interface for `SnapshotAdminClient::DeleteSnapshot()`
-  virtual Status DeleteSnapshot(DeleteSnapshotParams) = 0;
+  virtual Status DeleteSnapshot(DeleteSnapshotParams);
 
   /// Defines the interface for `SubscriptionAdminClient::Seek()`
-  virtual StatusOr<google::pubsub::v1::SeekResponse> Seek(SeekParams) = 0;
+  virtual StatusOr<google::pubsub::v1::SeekResponse> Seek(SeekParams);
 };
 
 /**

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -243,6 +243,50 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
 TopicAdminConnection::~TopicAdminConnection() = default;
 
+StatusOr<google::pubsub::v1::Topic> TopicAdminConnection::CreateTopic(
+    CreateTopicParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Topic> TopicAdminConnection::GetTopic(
+    GetTopicParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::Topic> TopicAdminConnection::UpdateTopic(
+    UpdateTopicParams) {  // NOLINT(performance-unnecessary-value-param)
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+ListTopicsRange TopicAdminConnection::ListTopics(ListTopicsParams) {
+  return internal::UnimplementedPaginationRange<ListTopicsRange>::Create();
+}
+
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Status TopicAdminConnection::DeleteTopic(DeleteTopicParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+TopicAdminConnection::DetachSubscription(DetachSubscriptionParams) {
+  return Status{StatusCode::kUnimplemented, "needs-override"};
+}
+
+ListTopicSubscriptionsRange TopicAdminConnection::ListTopicSubscriptions(
+    ListTopicSubscriptionsParams) {  // NOLINT(performance-unnecessary-value-param)
+  return internal::UnimplementedPaginationRange<
+      ListTopicSubscriptionsRange>::Create();
+}
+
+ListTopicSnapshotsRange TopicAdminConnection::ListTopicSnapshots(
+    ListTopicSnapshotsParams) {  // NOLINT(performance-unnecessary-value-param)
+
+  return internal::UnimplementedPaginationRange<
+      ListTopicSnapshotsRange>::Create();
+}
+
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
     ConnectionOptions const& options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy,

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -141,33 +141,30 @@ class TopicAdminConnection {
   //@}
 
   /// Defines the interface for `TopicAdminClient::CreateTopic()`
-  virtual StatusOr<google::pubsub::v1::Topic> CreateTopic(
-      CreateTopicParams) = 0;
+  virtual StatusOr<google::pubsub::v1::Topic> CreateTopic(CreateTopicParams);
 
   /// Defines the interface for `TopicAdminClient::GetTopic()`
-  virtual StatusOr<google::pubsub::v1::Topic> GetTopic(GetTopicParams) = 0;
+  virtual StatusOr<google::pubsub::v1::Topic> GetTopic(GetTopicParams);
 
   /// Defines the interface for `TopicAdminClient::UpdateTopic()`
-  virtual StatusOr<google::pubsub::v1::Topic> UpdateTopic(
-      UpdateTopicParams) = 0;
+  virtual StatusOr<google::pubsub::v1::Topic> UpdateTopic(UpdateTopicParams);
 
   /// Defines the interface for `TopicAdminClient::ListTopics()`
-  virtual ListTopicsRange ListTopics(ListTopicsParams) = 0;
+  virtual ListTopicsRange ListTopics(ListTopicsParams);
 
   /// Defines the interface for `TopicAdminClient::DeleteTopic()`
-  virtual Status DeleteTopic(DeleteTopicParams) = 0;
+  virtual Status DeleteTopic(DeleteTopicParams);
 
   /// Defines the interface for `TopicAdminClient::DetachSubscriptions()`
   virtual StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
-      DetachSubscription(DetachSubscriptionParams) = 0;
+      DetachSubscription(DetachSubscriptionParams);
 
   /// Defines the interface for `TopicAdminClient::ListTopicSubscriptions()`
   virtual ListTopicSubscriptionsRange ListTopicSubscriptions(
-      ListTopicSubscriptionsParams) = 0;
+      ListTopicSubscriptionsParams);
 
   /// Defines the interface for `TopicAdminClient::ListTopicSnapshots()`
-  virtual ListTopicSnapshotsRange ListTopicSnapshots(
-      ListTopicSnapshotsParams) = 0;
+  virtual ListTopicSnapshotsRange ListTopicSnapshots(ListTopicSnapshotsParams);
 };
 
 /**


### PR DESCRIPTION
We expect applications to derive (typically mocks) from the
`*Connection` classes. To prevent breaking such applications in the
future these classes should not use pure-virtual functions, they should
return `kUnimplemented`.

Fixes #4817

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5329)
<!-- Reviewable:end -->
