### PR TITLE
cleanup(pubsub): disable trace logs

### DIFF
--- a/google/cloud/pubsub/internal/session_shutdown_manager.cc
+++ b/google/cloud/pubsub/internal/session_shutdown_manager.cc
@@ -34,7 +34,7 @@ std::string FormatOps(std::unordered_map<std::string, int> const& ops) {
 
 SessionShutdownManager::~SessionShutdownManager() {
   if (signaled_) return;
-  GCP_LOG(DEBUG) << __func__ << "() - do signal"
+  GCP_LOG(TRACE) << __func__ << "() - do signal"
                  << ", shutdown=" << shutdown_ << ", signaled=" << signaled_
                  << ", outstanding_operations=" << outstanding_operations_
                  << ", result=" << result_ << ", ops=" << FormatOps(ops_);
@@ -44,7 +44,7 @@ SessionShutdownManager::~SessionShutdownManager() {
 
 void SessionShutdownManager::LogStart(const char* caller, const char* name) {
   auto increase_count = [&] { return ++ops_[name]; };
-  GCP_LOG(DEBUG) << "operation <" << name << "> starting from " << caller
+  GCP_LOG(TRACE) << "operation <" << name << "> starting from " << caller
                  << ", shutdown=" << shutdown_ << ", signaled=" << signaled_
                  << ", outstanding_operations=" << outstanding_operations_
                  << ", result=" << result_ << ", count=" << increase_count();
@@ -53,7 +53,7 @@ void SessionShutdownManager::LogStart(const char* caller, const char* name) {
 bool SessionShutdownManager::FinishedOperation(char const* name) {
   std::unique_lock<std::mutex> lk(mu_);
   auto decrease_count = [&] { return --ops_[name]; };
-  GCP_LOG(DEBUG) << "operation <" << name << "> finished"
+  GCP_LOG(TRACE) << "operation <" << name << "> finished"
                  << ", shutdown=" << shutdown_ << ", signaled=" << signaled_
                  << ", outstanding_operations=" << outstanding_operations_
                  << ", result=" << result_ << ", count=" << decrease_count();
@@ -65,7 +65,7 @@ bool SessionShutdownManager::FinishedOperation(char const* name) {
 
 void SessionShutdownManager::MarkAsShutdown(char const* caller, Status status) {
   std::unique_lock<std::mutex> lk(mu_);
-  GCP_LOG(DEBUG) << __func__ << "() - from " << caller << "() - shutting down"
+  GCP_LOG(TRACE) << __func__ << "() - from " << caller << "() - shutting down"
                  << ", shutdown=" << shutdown_ << ", signaled=" << signaled_
                  << ", outstanding_operations=" << outstanding_operations_
                  << ", result=" << result_ << ", status=" << status;
@@ -75,7 +75,7 @@ void SessionShutdownManager::MarkAsShutdown(char const* caller, Status status) {
 }
 
 void SessionShutdownManager::SignalOnShutdown(std::unique_lock<std::mutex> lk) {
-  GCP_LOG(DEBUG) << __func__ << "() - maybe signal"
+  GCP_LOG(TRACE) << __func__ << "() - maybe signal"
                  << ", shutdown=" << shutdown_ << ", signaled=" << signaled_
                  << ", outstanding_operations=" << outstanding_operations_
                  << ", result=" << result_ << ", ops=" << FormatOps(ops_);

--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -73,7 +73,7 @@ class SubscriptionSessionImpl
 
  private:
   void InitiateApplicationShutdown() {
-    GCP_LOG(DEBUG) << __func__ << "()";
+    GCP_LOG(TRACE) << __func__ << "()";
     std::unique_lock<std::mutex> lk(mu_);
     std::shared_ptr<SubscriptionConcurrencyControl> p = pipeline_;
     switch (shutdown_state_) {
@@ -91,7 +91,7 @@ class SubscriptionSessionImpl
   }
 
   void ShutdownCompleted() {
-    GCP_LOG(DEBUG) << __func__ << "()";
+    GCP_LOG(TRACE) << __func__ << "()";
     std::lock_guard<std::mutex> lk(mu_);
     pipeline_.reset();
     shutdown_state_ = kShutdownCompleted;
@@ -99,7 +99,7 @@ class SubscriptionSessionImpl
   }
 
   void ScheduleTimer() {
-    GCP_LOG(DEBUG) << __func__ << "()";
+    GCP_LOG(TRACE) << __func__ << "()";
     using TimerArg = future<StatusOr<std::chrono::system_clock::time_point>>;
 
     std::unique_lock<std::mutex> lk(mu_);
@@ -113,7 +113,7 @@ class SubscriptionSessionImpl
   }
 
   void OnTimer(bool cancelled) {
-    GCP_LOG(DEBUG) << __func__ << "(" << cancelled << ")";
+    GCP_LOG(TRACE) << __func__ << "(" << cancelled << ")";
     if (!cancelled) {
       ScheduleTimer();
       return;


### PR DESCRIPTION
During development I left a number of (optional) logging messages, most
of these are not useful for customers, so I am either deleting them (if
I thought even we would not need them), or moving them to `TRACE` level,
which is compiled-out anyway.

Fixes #4934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5330)
<!-- Reviewable:end -->
