### PR TITLE
doc: update the API baseline as part of releasing

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -20,6 +20,20 @@ release notes.
 Before beginning the release process, verify all CI builds are passing on
 master.
 
+### Update the API baseline
+
+Run the `update-abi` build to update the API baseline. Once you cut the release
+any new APIs are, well, released, and we should think carefully about removing
+them.
+
+```bash
+./ci/kokoro/docker/build.sh update-abi
+```
+
+This may take a while, leave it running while you perform the next step. You
+can, but are not required to, send a single PR to update the baseline and the
+`CHANGELOG.md` file.
+
 ### Update CHANGELOG.md
 
 Update `CHANGELOG.md` based on the release notes for Bigtable, Storage,


### PR DESCRIPTION
This is an item for discussion.  We may chose to *not* do this.

I think we should update the API baseline before each release.
The purpose of this baseline is to tell us if we are breaking the
API since the last release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5343)
<!-- Reviewable:end -->
