### PR TITLE
ci: fetch more dependencies for Bazel builds

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -87,7 +87,12 @@ echo "================================================================"
 io::log "Fetching dependencies"
 # retry up to 3 times with exponential backoff, initial interval 120s
 "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
-  "${BAZEL_BIN}" fetch ...
+  "${BAZEL_BIN}" fetch ... \
+  @local_config_platform//... \
+  @local_config_cc_toolchains//... \
+  @local_config_sh//... \
+  @go_sdk//... \
+  @remotejdk11_linux//:jdk
 
 echo "================================================================"
 io::log "Compiling and running unit tests"

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -70,6 +70,16 @@ fi
 build_quickstart() {
   local -r library="$1"
 
+  # Additional dependencies, these are not downloaded by `bazel fetch ...`,
+  # but are needed to compile the code
+  external=(
+    @local_config_platform//...
+    @local_config_cc_toolchains//...
+    @local_config_sh//...
+    @go_sdk//...
+    @remotejdk11_linux//:jdk
+  )
+
   pushd "${PROJECT_ROOT}/google/cloud/${library}/quickstart" >/dev/null
   trap "popd >/dev/null" RETURN
   io::log "capture bazel version"
@@ -77,7 +87,7 @@ build_quickstart() {
   io::log "fetch dependencies for ${library}'s quickstart"
   # retry up to 3 times with exponential backoff, initial interval 120s
   "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
-    "${BAZEL_BIN}" fetch ...
+    "${BAZEL_BIN}" fetch ... "${external[@]}"
 
   echo
   io::log_yellow "Compiling ${library}'s quickstart"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -74,12 +74,22 @@ fi
 echo
 echo "================================================================"
 for repeat in 1 2 3; do
+  # Additional dependencies, these are not downloaded by `bazel fetch ...`,
+  # but are needed to compile the code
+  external=(
+    @local_config_platform//...
+    @local_config_cc_toolchains//...
+    @local_config_sh//...
+    @go_sdk//...
+    @remotejdk11_macos//:jdk
+  )
   io::log_yellow "Fetch bazel dependencies [${repeat}/3]."
-  if "${BAZEL_BIN}" fetch ...; then
+  if "${BAZEL_BIN}" fetch ... "${external[@]}"; then
     break
   else
     io::log_yellow "bazel fetch failed with $?"
   fi
+  sleep $((120 * repeat ))
 done
 
 echo

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -89,7 +89,7 @@ for repeat in 1 2 3; do
   else
     io::log_yellow "bazel fetch failed with $?"
   fi
-  sleep $((120 * repeat ))
+  sleep $((120 * repeat))
 done
 
 echo

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -84,13 +84,23 @@ build_quickstart() {
   io::log "capture bazel version"
   ${BAZEL_BIN} version
   for repeat in 1 2 3; do
+    # Additional dependencies, these are not downloaded by `bazel fetch ...`,
+    # but are needed to compile the code
+    external=(
+      @local_config_platform//...
+      @local_config_cc_toolchains//...
+      @local_config_sh//...
+      @go_sdk//...
+      @remotejdk11_macos//:jdk
+    )
     echo
     io::log_yellow "Fetching deps for ${library}'s quickstart [${repeat}/3]."
-    if "${BAZEL_BIN}" fetch ...; then
+    if "${BAZEL_BIN}" fetch ... "${external[@]}"; then
       break
     else
       io::log_yellow "bazel fetch failed with $?"
     fi
+    sleep $((120 * repeat ))
   done
 
   echo

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -100,7 +100,7 @@ build_quickstart() {
     else
       io::log_yellow "bazel fetch failed with $?"
     fi
-    sleep $((120 * repeat ))
+    sleep $((120 * repeat))
   done
 
   echo

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -100,10 +100,20 @@ $env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
 
 ForEach($_ in (1, 2, 3)) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Fetch dependencies [$_]"
-    bazel $common_flags fetch ...
+    # Additional dependencies, these are not downloaded by `bazel fetch ...`,
+    # but are needed to compile the code
+    $external=@(
+        @local_config_platform//...
+        @local_config_cc_toolchains//...
+        @local_config_sh//...
+        @go_sdk//...
+        @remotejdk11_win//:jdk
+    )
+    bazel $common_flags fetch ... $external
     if ($LastExitCode -eq 0) {
         break
     }
+    Start-Sleep -Seconds (60 * $_)
 }
 
 # All the build_flags should be set by now, so we'll copy them, and add a few

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -72,8 +72,8 @@ $build_flags = @(
     "--per_file_copt=^//google/cloud@-WX",
     "--per_file_copt=^//google/cloud@-experimental:external",
     "--per_file_copt=^//google/cloud@-external:W0",
-    "--per_file_copt=^//google/cloud@-external:anglebrackets"
-# Disable warnings on generated proto files.
+    "--per_file_copt=^//google/cloud@-external:anglebrackets",
+    # Disable warnings on generated proto files.
     "--per_file_copt=.*\.pb\.cc@/wd4244"
 )
 
@@ -103,13 +103,12 @@ ForEach($_ in (1, 2, 3)) {
     # Additional dependencies, these are not downloaded by `bazel fetch ...`,
     # but are needed to compile the code
     $external=@(
-        @local_config_platform//...
-        @local_config_cc_toolchains//...
-        @local_config_sh//...
-        @go_sdk//...
-        @remotejdk11_win//:jdk
+        "@local_config_platform//...",
+        "@local_config_cc_toolchains//...",
+        "@local_config_sh//...",
+        "@go_sdk//...",
+        "@remotejdk11_win//:jdk"
     )
-    bazel $common_flags fetch ... $external
     if ($LastExitCode -eq 0) {
         break
     }

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -103,12 +103,22 @@ $quickstart_args=@{
 ForEach($library in ("bigtable", "storage", "spanner", "pubsub")) {
     Set-Location "${project_root}/google/cloud/${library}/quickstart"
     ForEach($_ in (1, 2, 3)) {
+        # Additional dependencies, these are not downloaded by `bazel fetch ...`,
+        # but are needed to compile the code
+        $external=@(
+            "@local_config_platform//...",
+            "@local_config_cc_toolchains//...",
+            "@local_config_sh//...",
+            "@go_sdk//...",
+            "@remotejdk11_win//:jdk"
+        )
         Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
             "Fetch dependencies for ${library} [$_]"
-        bazel $common_flags fetch $build_flags ...
+        bazel $common_flags fetch $build_flags ... $external
         if ($LastExitCode -eq 0) {
             break
         }
+        Start-Sleep -Seconds (60 * $_)
     }
 
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `


### PR DESCRIPTION
Sometimes the bazel builds fail because they cannot fetch some
dependencies, even after a successful `bazel fetch ...`. I found all
these additional dependencies using `bazel build --nofetch ...`, they
all seem to be SDK-type things.

Part of the work for #4045

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5346)
<!-- Reviewable:end -->
