### PR TITLE
test: fix unnecessary name attribute from submit

### DIFF
--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -102,7 +102,7 @@ void CreatePolicyDocumentFormV4(google::cloud::storage::Client client,
       os << "  <input name='" << field.first << "' value='" << field.second
          << "' type='hidden' />\n";
     }
-    os << "  <input type='submit' value='Upload File' name='submit' /><br />\n"
+    os << "  <input type='submit' value='Upload File' /><br />\n"
        << "  <input type='file' name='file' /><br />\n"
        << "</form>";
 


### PR DESCRIPTION
The submit element shouldn't have the `name` attribute - otherwise the
browser generates a respective field in the POST request and violates
the policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5348)
<!-- Reviewable:end -->
