### PR TITLE
chore: update vcpkg-based to get newest gRPC

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -45,9 +45,9 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 if [[ -d "${vcpkg_dir}" ]]; then
   git -C "${vcpkg_dir}" pull --quiet
 else
-  git clone --quiet --shallow-since 2020-10-01 \
+  git clone --quiet --shallow-since 2020-10-20 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout b999dfdfec58560df7978bd9e8bdb7476d29ef5f
+  git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
 fi
 
 if [[ -d "${HOME}/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -28,9 +28,9 @@ vcpkg_dir="cmake-out/vcpkg-quickstart"
 if [[ -d "${vcpkg_dir}" ]]; then
   git -C "${vcpkg_dir}" pull --quiet
 else
-  git clone --quiet --shallow-since 2020-10-01 \
+  git clone --quiet --shallow-since 2020-10-20 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout b999dfdfec58560df7978bd9e8bdb7476d29ef5f
+  git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
 fi
 
 if [[ -d "cmake-out/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -58,9 +58,9 @@ if ($RunningCI -and (Test-Path "${vcpkg_dir}")) {
 }
 if (-not (Test-Path ${vcpkg_dir})) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cloning vcpkg repository."
-    git clone --quiet --shallow-since 2020-10-01 `
+    git clone --quiet --shallow-since 2020-10-20 `
         https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-    git -C "${vcpkg_dir}" checkout b999dfdfec58560df7978bd9e8bdb7476d29ef5f
+    git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red `
             "vcpkg git setup failed with exit code $LastExitCode"
@@ -69,6 +69,7 @@ if (-not (Test-Path ${vcpkg_dir})) {
 } else {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating vcpkg repository."
     git -C "${vcpkg_dir}" pull
+    git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
 }
 if (-not (Test-Path "${vcpkg_dir}")) {
     Write-Host -ForegroundColor Red "Missing vcpkg directory (${vcpkg_dir})."


### PR DESCRIPTION
Update vcpkg-based builds to get gRPC-1.33.x, this version includes
fixes for crashes during shutdown on some MSVC configurations.

Part of the work for #3933. I think it fixes it, but we need to wait after merging this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5354)
<!-- Reviewable:end -->
