### PR TITLE
cleanup(pubsub): remove obsolete TODOs

### DIFF
--- a/google/cloud/pubsub/publisher.cc
+++ b/google/cloud/pubsub/publisher.cc
@@ -19,8 +19,6 @@ namespace cloud {
 namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 
-// TODO(#4581) - use the options to setup batching
-// TODO(#4584) - use the ordering key configuration
 Publisher::Publisher(std::shared_ptr<PublisherConnection> connection,
                      PublisherOptions)
     : connection_(std::move(connection)) {}


### PR DESCRIPTION
Thanks to @remyabel for pointing these out.

I searched for others, the remaining ones seem legit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5364)
<!-- Reviewable:end -->
