### PR TITLE
ci: move tsan build to Ubunt:18.04

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -17,16 +17,14 @@ FROM ubuntu:${DISTRO_VERSION}
 
 RUN apt-get update && \
     apt-get --no-install-recommends install -y \
-        abi-compliance-checker \
-        abi-dumper \
         automake \
         build-essential \
         ccache \
         clang \
+        clang-9 \
         cmake \
         ctags \
         curl \
-        doxygen \
         gawk \
         git \
         gcc \
@@ -40,8 +38,8 @@ RUN apt-get update && \
         ninja-build \
         pkg-config \
         python3 \
+        python3-dev \
         python3-pip \
-        shellcheck \
         tar \
         unzip \
         wget \
@@ -49,19 +47,6 @@ RUN apt-get update && \
         apt-utils \
         ca-certificates \
         apt-transport-https
-
-# Install the the buildifier tool, which does not compile with the default
-# golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
-RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier
-RUN chmod 755 /usr/bin/buildifier
-
-# Install cmake_format to automatically format the CMake list files.
-#     https://github.com/cheshirekow/cmake_format
-# Pin this to an specific version because the formatting changes when the
-# "latest" version is updated, and we do not want the builds to break just
-# because some third party changed something.
-RUN pip3 install --upgrade pip
-RUN pip3 install cmake_format==0.6.8
 
 # Install Python packages used in the integration tests.
 RUN pip3 install setuptools wheel

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -142,12 +142,14 @@ elif [[ "${BUILD_NAME}" = "msan" ]]; then
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   # Compile with the ThreadSanitizer enabled.
-  export CC=clang
-  export CXX=clang++
-  export DISTRO=fedora
-  # Holding the TSAN build back because:
+  # We need to use clang-9 for the TSAN build because:
   #   https://github.com/google/sanitizers/issues/1259
-  export DISTRO_VERSION=31
+  # Using Fedora >= 32 will push us to clang-10, and Fedora < 32 is EOL.
+  # Fortunately, Ubuntu:18.04 is a LTS release with clang-9 as an alternative.
+  export CC=clang-9
+  export CXX=clang++-9
+  export DISTRO=ubuntu
+  export DISTRO_VERSION=18.04
   export BAZEL_CONFIG="tsan"
   export BUILD_TOOL="Bazel"
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"


### PR DESCRIPTION
The build is running on Fedora:31, which is going EOL very soon. We
cannot upgrade to Fedora:32 or 33 because they come with clang >= 10,
and there is a bug with tsan with those compilers.

Fixes #5132 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5370)
<!-- Reviewable:end -->
