### PR TITLE
doc(storage): announce removal of bucket_policy_only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+**FUTURE BREAKING CHANGES:**
+
+* **Storage:** on or about 2021-01-15 we are planning to remove the
+  `bucket_policy_only` attribute from `storage::BucketIamConfiguration` struct.
+  This attribute represents the pre-GA name for "Uniform Bucket Level Access"
+  becoming GA, applications can use `uniform_bucket_level_access`.
+
 ## v1.20.0 - TBD
 
 ### Storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * **Storage:** on or about 2021-01-15 we are planning to remove the
   `bucket_policy_only` attribute from `storage::BucketIamConfiguration` struct.
   This attribute represents the pre-GA name for "Uniform Bucket Level Access"
-  becoming GA, applications can use `uniform_bucket_level_access`.
+  becoming GA. Applications should use `uniform_bucket_level_access` instead.
 
 ## v1.20.0 - TBD
 

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -198,9 +198,6 @@ std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs);
  * Currently this only holds the BucketOnlyPolicy. In the future, we may define
  * additional IAM which would be included in this object.
  *
- * @warning this is a Beta feature of Google Cloud Storage, it is not subject
- *     to the deprecation policy and subject to change without notice.
- *
  * @see Before enabling Uniform Bucket Level Access please review the
  *     [feature documentation][ubla-link], as well as
  *     ["Should you use uniform bucket-level access ?"][ubla-should-link].
@@ -211,6 +208,8 @@ std::ostream& operator<<(std::ostream& os, BucketPolicyOnly const& rhs);
  * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
  */
 struct BucketIamConfiguration {
+  /// @deprecated this field will be removed on or about 2021-01-15, use
+  ///     `uniform_bucket_level_access`
   absl::optional<BucketPolicyOnly> bucket_policy_only;
   absl::optional<UniformBucketLevelAccess> uniform_bucket_level_access;
 };
@@ -648,9 +647,6 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   //@{
   /**
    * @name Get and set the IAM configuration.
-   *
-   * @warning this is a Beta feature of Google Cloud Storage, it is not
-   *     subject to the deprecation policy and subject to change without notice.
    *
    * @see Before enabling Uniform Bucket Level Access please review the
    *     [feature documentation][ubla-link], as well as


### PR DESCRIPTION
Before GA the "Uniform Bucket Level Access" feature went by another name
(Bucket Policy Only), the corresponding field was (more or less) born
deprecated, and has not worked quite right since inception. This PR
announces that we will remove it in the release about 90 days from now.

I also noticed that UBLA was still marked "not GA", which was simply
wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5381)
<!-- Reviewable:end -->
