### PR TITLE
feat(pubsub): split logging streaming RPCS

### DIFF
--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -101,9 +101,10 @@ SubscriberLogging::AsyncStreamingPull(
   auto prefix = std::string(__func__) + "(" + request_id + ")";
   GCP_LOG(DEBUG) << prefix
                  << " << request=" << DebugString(request, tracing_options_);
+  auto stream = child_->AsyncStreamingPull(cq, std::move(context), request);
+  if (!trace_streams_) return stream;
   return absl::make_unique<LoggingAsyncPullStream>(
-      child_->AsyncStreamingPull(cq, std::move(context), request),
-      tracing_options_, request_id);
+      std::move(stream), tracing_options_, request_id);
 }
 
 StatusOr<google::pubsub::v1::Snapshot> SubscriberLogging::CreateSnapshot(

--- a/google/cloud/pubsub/internal/subscriber_logging.h
+++ b/google/cloud/pubsub/internal/subscriber_logging.h
@@ -28,9 +28,10 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 class SubscriberLogging : public SubscriberStub {
  public:
   SubscriberLogging(std::shared_ptr<SubscriberStub> child,
-                    TracingOptions tracing_options)
+                    TracingOptions tracing_options, bool trace_streams)
       : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+        tracing_options_(std::move(tracing_options)),
+        trace_streams_(trace_streams) {}
 
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
       grpc::ClientContext& context,
@@ -88,6 +89,7 @@ class SubscriberLogging : public SubscriberStub {
  private:
   std::shared_ptr<SubscriberStub> child_;
   TracingOptions tracing_options_;
+  bool trace_streams_;
 };
 
 class LoggingAsyncPullStream : public SubscriberStub::AsyncPullStream {

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -57,7 +57,8 @@ TEST_F(SubscriberLoggingTest, CreateSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, CreateSubscription)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Subscription{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::Subscription subscription;
   auto status = stub.CreateSubscription(context, subscription);
@@ -70,7 +71,8 @@ TEST_F(SubscriberLoggingTest, GetSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, GetSubscription)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Subscription{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::GetSubscriptionRequest request;
   auto status = stub.GetSubscription(context, request);
@@ -83,7 +85,8 @@ TEST_F(SubscriberLoggingTest, UpdateSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, UpdateSubscription)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Subscription{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::UpdateSubscriptionRequest request;
   auto status = stub.UpdateSubscription(context, request);
@@ -97,7 +100,8 @@ TEST_F(SubscriberLoggingTest, ListSubscriptions) {
   EXPECT_CALL(*mock, ListSubscriptions)
       .WillOnce(Return(
           make_status_or(google::pubsub::v1::ListSubscriptionsResponse{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::ListSubscriptionsRequest request;
   request.set_project("test-project-name");
@@ -111,7 +115,8 @@ TEST_F(SubscriberLoggingTest, ListSubscriptions) {
 TEST_F(SubscriberLoggingTest, DeleteSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSubscription).WillOnce(Return(Status{}));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::DeleteSubscriptionRequest request;
   request.set_subscription("test-subscription-name");
@@ -125,7 +130,8 @@ TEST_F(SubscriberLoggingTest, DeleteSubscription) {
 TEST_F(SubscriberLoggingTest, ModifyPushConfig) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, ModifyPushConfig).WillOnce(Return(Status{}));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::ModifyPushConfigRequest request;
   request.set_subscription("test-subscription-name");
@@ -169,7 +175,8 @@ TEST_F(SubscriberLoggingTest, AsyncStreamingPull) {
         });
         return stream;
       });
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         true);
   google::cloud::CompletionQueue cq;
 
   google::pubsub::v1::StreamingPullRequest request;
@@ -208,7 +215,8 @@ TEST_F(SubscriberLoggingTest, CreateSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, CreateSnapshot)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::CreateSnapshotRequest request;
   auto status = stub.CreateSnapshot(context, request);
@@ -220,7 +228,8 @@ TEST_F(SubscriberLoggingTest, GetSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, GetSnapshot)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::GetSnapshotRequest request;
   auto status = stub.GetSnapshot(context, request);
@@ -233,7 +242,8 @@ TEST_F(SubscriberLoggingTest, ListSnapshots) {
   EXPECT_CALL(*mock, ListSnapshots)
       .WillOnce(
           Return(make_status_or(google::pubsub::v1::ListSnapshotsResponse{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::ListSnapshotsRequest request;
   request.set_project("test-project-name");
@@ -248,7 +258,8 @@ TEST_F(SubscriberLoggingTest, UpdateSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, UpdateSnapshot)
       .WillOnce(Return(make_status_or(google::pubsub::v1::Snapshot{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::UpdateSnapshotRequest request;
   auto status = stub.UpdateSnapshot(context, request);
@@ -259,7 +270,8 @@ TEST_F(SubscriberLoggingTest, UpdateSnapshot) {
 TEST_F(SubscriberLoggingTest, DeleteSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSnapshot).WillOnce(Return(Status{}));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::DeleteSnapshotRequest request;
   auto status = stub.DeleteSnapshot(context, request);
@@ -271,7 +283,8 @@ TEST_F(SubscriberLoggingTest, Seek) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, Seek)
       .WillOnce(Return(make_status_or(google::pubsub::v1::SeekResponse{})));
-  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  SubscriberLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"),
+                         false);
   grpc::ClientContext context;
   google::pubsub::v1::SeekRequest request;
   request.set_subscription("test-subscription-name");

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -108,7 +108,8 @@ std::shared_ptr<pubsub::SubscriberConnection> MakeSubscriberConnection(
   if (connection_options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), connection_options.tracing_options());
+        std::move(stub), connection_options.tracing_options(),
+        connection_options.tracing_enabled("rpc-streams"));
   }
   auto default_thread_pool_size = []() -> std::size_t {
     auto constexpr kDefaultThreadPoolSize = 4;

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -131,7 +131,8 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
       subscription, {},
       ConnectionOptions{grpc::InsecureChannelCredentials()}
           .DisableBackgroundThreads(cq)
-          .enable_tracing("rpc"),
+          .enable_tracing("rpc")
+          .enable_tracing("rpc-streams"),
       mock, pubsub_testing::TestRetryPolicy(),
       pubsub_testing::TestBackoffPolicy());
   std::atomic_flag received_one{false};

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -256,7 +256,8 @@ MakeSubscriptionAdminConnection(
   if (options.tracing_enabled("rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
     stub = std::make_shared<pubsub_internal::SubscriberLogging>(
-        std::move(stub), options.tracing_options());
+        std::move(stub), options.tracing_options(),
+        options.tracing_enabled("rpc-streams"));
   }
   return std::make_shared<SubscriptionAdminConnectionImpl>(
       std::move(stub), std::move(retry_policy), std::move(backoff_policy));


### PR DESCRIPTION
The streaming RPCs produce an overwhelming amount of logging. Sometimes
it is useful to just log the start of the stream, leaving out the
details of each `Read()` and `Write()` call. We already have a
documented way to split the configuration, so I just re-used it in
Pub/Sub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5391)
<!-- Reviewable:end -->
