### PR TITLE
test(storage): add emulator rewrite, iam, project

### DIFF
--- a/google/cloud/storage/emulator/database.py
+++ b/google/cloud/storage/emulator/database.py
@@ -20,15 +20,16 @@ from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
 
 
 class Database:
-    def __init__(self, buckets, objects, live_generations, uploads):
+    def __init__(self, buckets, objects, live_generations, uploads, rewrites):
         self.buckets = buckets
         self.objects = objects
         self.live_generations = live_generations
         self.uploads = uploads
+        self.rewrites = rewrites
 
     @classmethod
     def init(cls):
-        return cls({}, {}, {}, {})
+        return cls({}, {}, {}, {}, {})
 
     # === BUCKET === #
 
@@ -64,7 +65,7 @@ class Database:
 
     def delete_bucket(self, request, bucket_name, context):
         bucket = self.get_bucket(request, bucket_name, context)
-        if len(self.objects[bucket.metadata.name]) > 0:
+        if len(self.live_generations[bucket.metadata.name]) > 0:
             utils.error.invalid("Deleting non-empty bucket", context)
         del self.buckets[bucket.metadata.name]
         del self.objects[bucket.metadata.name]
@@ -120,6 +121,7 @@ class Database:
             end_offset,
         ) = self.__extract_list_object_request(request, context)
         items = []
+        customTimes = []
         prefixes = set()
         for obj in bucket.values():
             generation = obj.metadata.generation
@@ -139,7 +141,8 @@ class Database:
                 prefixes.add(name[: delimiter_index + 1])
                 continue
             items.append(obj.metadata)
-        return items, list(prefixes)
+            customTimes.append(obj.customTime)
+        return items, list(prefixes), customTimes
 
     def check_object_generation(
         self, request, bucket_name, object_name, is_source, context
@@ -188,19 +191,20 @@ class Database:
         self.live_generations[bucket_name][name] = generation
 
     def delete_object(self, request, bucket_name, object_name, context):
-        blob = self.get_object(request, bucket_name, object_name, False, context)
-        generation = blob.metadata.generation
-        live_generation = self.live_generations[bucket_name][object_name]
-        if generation == live_generation:
-            del self.live_generations[bucket_name][object_name]
-        del self.objects[bucket_name]["%s#%d" % (object_name, generation)]
+        _ = self.get_object(request, bucket_name, object_name, False, context)
+        generation = utils.generation.extract_generation(request, False, context)
+        live_generation = self.live_generations[bucket_name].get(object_name)
+        if generation == 0 or live_generation == generation:
+            self.live_generations[bucket_name].pop(object_name, None)
+        if generation != 0:
+            del self.objects[bucket_name]["%s#%d" % (object_name, generation)]
 
     # === UPLOAD === #
 
     def get_upload(self, upload_id, context):
         upload = self.uploads.get(upload_id)
         if upload is None:
-            utils.error.notfound("Upload %s does not exist." % upload_id, context)
+            utils.error.notfound("Upload %s" % upload_id, context)
         return upload
 
     def insert_upload(self, upload):
@@ -209,3 +213,18 @@ class Database:
     def delete_upload(self, upload_id, context):
         self.get_upload(upload_id, context)
         del self.uploads[upload_id]
+
+    # === REWRITE === #
+
+    def get_rewrite(self, token, context):
+        rewrite = self.rewrites.get(token)
+        if rewrite is None:
+            utils.error.notfound(404, "Rewrite %s" % token, context)
+        return rewrite
+
+    def insert_rewrite(self, rewrite):
+        self.rewrites[rewrite.token] = rewrite
+
+    def delete_rewrite(self, token, context):
+        self.get_rewrite(token, context)
+        del self.rewrites[token]

--- a/google/cloud/storage/emulator/gcs/__init__.py
+++ b/google/cloud/storage/emulator/gcs/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gcs import bucket, object, holder
+from gcs import bucket, object, holder, project, iam

--- a/google/cloud/storage/emulator/gcs/bucket.py
+++ b/google/cloud/storage/emulator/gcs/bucket.py
@@ -359,7 +359,7 @@ class Bucket:
         else:
             payload = simdjson.loads(request.data)
             role = payload["role"]
-        return self.__upsert_acl(entity, role, True, context)
+        return self.__upsert_acl(entity, role, False, context)
 
     def patch_acl(self, request, entity, context):
         role = ""
@@ -368,7 +368,7 @@ class Bucket:
         else:
             payload = simdjson.loads(request.data)
             role = payload["role"]
-        return self.__upsert_acl(entity, role, True, context)
+        return self.__upsert_acl(entity, role, False, context)
 
     def delete_acl(self, entity, context):
         del self.metadata.acl[self.__search_acl(entity, True, context)]
@@ -419,7 +419,7 @@ class Bucket:
         else:
             payload = simdjson.loads(request.data)
             role = payload["role"]
-        return self.__upsert_default_object_acl(entity, role, True, context)
+        return self.__upsert_default_object_acl(entity, role, False, context)
 
     def patch_default_object_acl(self, request, entity, context):
         role = ""
@@ -428,7 +428,7 @@ class Bucket:
         else:
             payload = simdjson.loads(request.data)
             role = payload["role"]
-        return self.__upsert_default_object_acl(entity, role, True, context)
+        return self.__upsert_default_object_acl(entity, role, False, context)
 
     def delete_default_object_acl(self, entity, context):
         del self.metadata.default_object_acl[

--- a/google/cloud/storage/emulator/gcs/holder.py
+++ b/google/cloud/storage/emulator/gcs/holder.py
@@ -27,8 +27,12 @@ class DataHolder(types.SimpleNamespace):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+    # === UPLOAD === #
+
     @classmethod
-    def init_upload(cls, request, metadata, bucket, location, upload_id):
+    def init_upload(
+        cls, request, metadata, bucket, location, upload_id, customTime=None
+    ):
         return cls(
             request=request,
             metadata=metadata,
@@ -38,15 +42,18 @@ class DataHolder(types.SimpleNamespace):
             media=b"",
             complete=False,
             transfer=set(),
+            customTime=customTime,
         )
 
     @classmethod
     def init_resumable_rest(cls, request, bucket):
         name = request.args.get("name", "")
+        customTime = None
         if len(request.data) > 0:
             if name != "":
                 utils.error.invalid("name argument in non-empty payload", None)
             data = simdjson.loads(request.data)
+            customTime = data.pop("customTime", None)
             metadata = json_format.ParseDict(data, resources_pb2.Object())
         else:
             metadata = resources_pb2.Object()
@@ -71,7 +78,9 @@ class DataHolder(types.SimpleNamespace):
         request = utils.common.FakeRequest(
             args=request.args.to_dict(), headers=headers, data=b""
         )
-        return cls.init_upload(request, metadata, bucket, location, upload_id)
+        return cls.init_upload(
+            request, metadata, bucket, location, upload_id, customTime
+        )
 
     @classmethod
     def init_resumable_grpc(cls, request, bucket):
@@ -87,3 +96,33 @@ class DataHolder(types.SimpleNamespace):
             response.headers["Range"] = "bytes=0-%d" % (len(self.media) - 1)
         response.status_code = 308
         return response
+
+    # === REWRITE === #
+
+    @classmethod
+    def init_rewrite_rest(
+        cls, request, src_bucket_name, src_object_name, dst_bucket_name, dst_object_name
+    ):
+        fake_request = utils.common.FakeRequest(
+            args=request.args.to_dict(), headers={}, data=request.data
+        )
+        max_bytes_rewritten_per_call = min(
+            int(fake_request.args.get("maxBytesRewrittenPerCall", 1024 * 1024)),
+            1024 * 1024,
+        )
+        token = hashlib.sha256(
+            (
+                "%s/o/%s/rewriteTo/b/%s/o/%s"
+                % (src_bucket_name, src_object_name, dst_bucket_name, dst_object_name)
+            ).encode("utf-8")
+        ).hexdigest()
+        return cls(
+            request=fake_request,
+            src_bucket_name=src_bucket_name,
+            src_object_name=src_object_name,
+            dst_bucket_name=dst_bucket_name,
+            dst_object_name=dst_object_name,
+            token=token,
+            media=b"",
+            max_bytes_rewritten_per_call=max_bytes_rewritten_per_call,
+        )

--- a/google/cloud/storage/emulator/gcs/iam.py
+++ b/google/cloud/storage/emulator/gcs/iam.py
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simulate IAM operations."""
+
+import base64
+import utils
+import flask
+import simdjson
+
+IAM_HANDLER_PATH = "/iamapi"
+iam = flask.Flask(__name__)
+iam.debug = True
+
+
+@iam.route("/projects/-/serviceAccounts/<service_account>:signBlob", methods=["POST"])
+def sign_blob(service_account):
+    """Implement the `projects.serviceAccounts.signBlob` API."""
+    payload = simdjson.loads(flask.request.data)
+    if payload.get("payload") is None:
+        utils.error.missing("payload in the payload")
+    try:
+        blob = base64.b64decode(payload.get("payload"))
+    except TypeError:
+        utils.error.invalid("non base64-encoded payload")
+    blob = b"signed: " + blob
+    response = {
+        "keyId": "fake-key-id-123",
+        "signedBlob": base64.b64encode(blob).decode("utf-8"),
+    }
+    return simdjson.dumps(response)
+
+
+def get_iam_app():
+    return IAM_HANDLER_PATH, iam

--- a/google/cloud/storage/emulator/gcs/project.py
+++ b/google/cloud/storage/emulator/gcs/project.py
@@ -1,0 +1,283 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implement a class to simulate projects (service accounts and HMAC keys)."""
+
+import base64
+import flask
+import simdjson
+import random
+import time
+import utils
+
+
+class ServiceAccount(object):
+    """Represent a service account and its HMAC keys."""
+
+    key_id_generator = 20000
+
+    @classmethod
+    def next_key_id(cls):
+        cls.key_id_generator += 1
+        return "key-id-%d" % cls.key_id_generator
+
+    def __init__(self, email):
+        self.email = email
+        self.keys = {}
+
+    def insert_key(self, project_id):
+        """Insert a new HMAC key to the service account."""
+        key_id = ServiceAccount.next_key_id()
+        secret = "".join(
+            [random.choice("abcdefghijklmnopqrstuvwxyz0123456789") for _ in range(40)]
+        )
+        now = time.gmtime(time.time())
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
+        return self.keys.setdefault(
+            key_id,
+            {
+                "kind": "storage#hmacKeyCreate",
+                "secret": base64.b64encode(bytearray(secret, "utf-8")).decode("utf-8"),
+                "generator": 1,
+                "metadata": {
+                    "accessId": "%s:%s" % (self.email, key_id),
+                    "etag": base64.b64encode(bytearray("%d" % 1, "utf-8")).decode(
+                        "utf-8"
+                    ),
+                    "id": key_id,
+                    "kind": "storage#hmacKey",
+                    "projectId": project_id,
+                    "serviceAccountEmail": self.email,
+                    "state": "ACTIVE",
+                    "timeCreated": timestamp,
+                    "updated": timestamp,
+                },
+            },
+        )
+
+    def key_items(self):
+        """Return the keys in this service account as a list of JSON objects."""
+        return [k.get("metadata") for k in self.keys.values()]
+
+    def delete_key(self, key_id):
+        """Delete an existing HMAC key from the service account."""
+        key = self.keys.get(key_id)
+        if key is None:
+            utils.error.notfound("key %s" % key_id)
+        resource = key.get("metadata")
+        if resource is None:
+            utils.error.missing("resource for HMAC key %s" % key_id)
+        if resource.get("state") == "ACTIVE":
+            utils.error.invalid("Deleteing ACTIVE key %s" % key_id)
+        resource["state"] = "DELETED"
+        self.keys.pop(key_id)
+        return resource
+
+    def get_key(self, key_id):
+        """Get an existing HMAC key from the service account."""
+        key = self.keys.get(key_id)
+        if key is None:
+            utils.error.notfound("key %s" % key_id)
+        metadata = key.get("metadata")
+        if metadata is None:
+            utils.error.missing("resource for HMAC key %s" % key_id)
+        return metadata
+
+    def _check_etag(self, key_resource, etag, where):
+        """Verify that ETag values match the current ETag."""
+        expected = key_resource.get("etag")
+        if etag is None or etag == expected:
+            return
+        utils.error.mismatch(
+            "ETag for `HmacKeys: update` in %s" % where, expected, etag
+        )
+
+    def update_key(self, key_id, payload):
+        """Get an existing HMAC key from the service account."""
+        key = self.keys.get(key_id)
+        if key is None:
+            utils.error.notfound("key %s" % key_id)
+        metadata = key.get("metadata")
+        if metadata is None:
+            utils.error.missing("resource for HMAC key %s" % key_id)
+        self._check_etag(metadata, payload.get("etag"), "payload")
+        self._check_etag(metadata, flask.request.headers.get("if-match-etag"), "header")
+
+        state = payload.get("state")
+        if state not in ("ACTIVE", "INACTIVE"):
+            utils.error.invalid("state `HmacKeys: update` request %s" % key_id)
+        if metadata.get("state") == "DELETED":
+            utils.error.invalid(
+                "Resotoring DELETE key in `HmacKeys: update` request %s" % key_id
+            )
+        key["generator"] += 1
+        metadata["state"] = state
+        metadata["etag"] = base64.b64encode(
+            bytearray("%d" % key["generator"], "utf-8")
+        ).decode("utf-8")
+        now = time.gmtime(time.time())
+        metadata["updated"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
+        return metadata
+
+
+class GcsProject(object):
+    """Represent a GCS project."""
+
+    project_number_generator = 100000
+
+    @classmethod
+    def next_project_number(cls):
+        cls.project_number_generator += 1
+        return cls.project_number_generator
+
+    def __init__(self, project_id):
+        self.project_id = project_id
+        self.project_number = GcsProject.next_project_number()
+        self.service_accounts = {}
+
+    def service_account_email(self):
+        """Return the GCS service account email for this project."""
+        username = "service-%d" % self.project_number
+        domain = "gs-project-accounts.iam.gserviceaccount.com"
+        return "%s@%s" % (username, domain)
+
+    def insert_hmac_key(self, service_account):
+        """Insert a new HMAC key (or an error)."""
+        sa = self.service_accounts.setdefault(
+            service_account, ServiceAccount(service_account)
+        )
+        return sa.insert_key(self.project_id)
+
+    def service_account(self, service_account_email):
+        """Return a ServiceAccount object given its email."""
+        return self.service_accounts.get(service_account_email)
+
+    def delete_hmac_key(self, access_id):
+        """Remove a key from the project."""
+        (service_account, key_id) = access_id.split(":", 2)
+        sa = self.service_accounts.get(service_account)
+        if sa is None:
+            utils.error.notfound("service account for key=%s" % access_id)
+        return sa.delete_key(key_id)
+
+    def get_hmac_key(self, access_id):
+        """Get an existing key in the project."""
+        (service_account, key_id) = access_id.split(":", 2)
+        sa = self.service_accounts.get(service_account)
+        if sa is None:
+            utils.error.notfound("service account for key=%s" % access_id)
+        return sa.get_key(key_id)
+
+    def update_hmac_key(self, access_id, payload):
+        """Update an existing key in the project."""
+        (service_account, key_id) = access_id.split(":", 2)
+        sa = self.service_accounts.get(service_account)
+        if sa is None:
+            utils.error.notfound("service account for key=%s" % access_id)
+        return sa.update_key(key_id, payload)
+
+
+PROJECTS_HANDLER_PATH = "/storage/v1/projects"
+projects = flask.Flask(__name__)
+projects.debug = True
+
+VALID_PROJECTS = {}
+
+
+def get_project(project_id):
+    """Find a project and return the GcsProject object."""
+    # Dynamically create the projects. The GCS testbench does not have functions
+    # to create projects, nor do we want to create such functions. The point is
+    # to test the GCS client library, not the IAM client library.
+    return VALID_PROJECTS.setdefault(project_id, GcsProject(project_id))
+
+
+@projects.route("/<project_id>/serviceAccount")
+def projects_get(project_id):
+    """Implement the `Projects.serviceAccount: get` API."""
+    project = get_project(project_id)
+    email = project.service_account_email()
+    response = {"kind": "storage#serviceAccount", "email_address": email}
+    fields = flask.request.args.get("fields", None)
+    return utils.common.filter_response_rest(response, None, fields)
+
+
+@projects.route("/<project_id>/hmacKeys", methods=["POST"])
+def hmac_keys_insert(project_id):
+    """Implement the `HmacKeys: insert` API."""
+    project = get_project(project_id)
+    service_account = flask.request.args.get("serviceAccountEmail")
+    if service_account is None:
+        utils.error.missing("serviceAccount")
+    response = project.insert_hmac_key(service_account)
+    fields = flask.request.args.get("fields", None)
+    return utils.common.filter_response_rest(response, None, fields)
+
+
+@projects.route("/<project_id>/hmacKeys")
+def hmac_keys_list(project_id):
+    """Implement the 'HmacKeys: list' API: return the HMAC keys in a project."""
+    # Lookup the bucket, if this fails the bucket does not exist, and this
+    # function should return an error.
+    project = get_project(project_id)
+    result = {"kind": "storage#hmacKeysMetadata", "next_page_token": "", "items": []}
+
+    state_filter = lambda x: x.get("state") != "DELETED"
+    if flask.request.args.get("deleted") == "true":
+        state_filter = lambda x: True
+
+    items = []
+    if flask.request.args.get("serviceAccountEmail"):
+        sa = flask.request.args.get("serviceAccountEmail")
+        service_account = project.service_account(sa)
+        if service_account:
+            items = service_account.key_items()
+    else:
+        for sa in project.service_accounts.values():
+            items.extend(sa.key_items())
+
+    result["items"] = [i for i in items if state_filter(i)]
+    fields = flask.request.args.get("fields", None)
+    return utils.common.filter_response_rest(result, None, fields)
+
+
+@projects.route("/<project_id>/hmacKeys/<access_id>", methods=["DELETE"])
+def hmac_keys_delete(project_id, access_id):
+    """Implement the `HmacKeys: delete` API."""
+    project = get_project(project_id)
+    project.delete_hmac_key(access_id)
+    return ""
+
+
+@projects.route("/<project_id>/hmacKeys/<access_id>")
+def hmac_keys_get(project_id, access_id):
+    """Implement the `HmacKeys: delete` API."""
+    project = get_project(project_id)
+    response = project.get_hmac_key(access_id)
+    fields = flask.request.args.get("fields", None)
+    return utils.common.filter_response_rest(response, None, fields)
+
+
+@projects.route("/<project_id>/hmacKeys/<access_id>", methods=["PUT"])
+def hmac_keys_update(project_id, access_id):
+    """Implement the `HmacKeys: delete` API."""
+    project = get_project(project_id)
+    payload = simdjson.loads(flask.request.data)
+    response = project.update_hmac_key(access_id, payload)
+    fields = flask.request.args.get("fields", None)
+    return utils.common.filter_response_rest(response, None, fields)
+
+
+def get_projects_app():
+    return PROJECTS_HANDLER_PATH, projects


### PR DESCRIPTION
This PR adds:
- Object rewrite
- GCS IAM ( copied from the old testbench )
- GCS Project ( copied from the old testbench )
- Temporary workaround for `customTime`
- Fix the behavior of `delete_object`. It should only delete the live version and keep the noncurrent versions. When deleting a bucket, we only check if there is any live version.

I would like to ask some questions:

- Why this sample uses `PatchBucketAcl` instead of `CreateBucketAcl`
https://github.com/googleapis/google-cloud-cpp/blob/7557959a25c7d94070a11ce90bf0a3140ef359b1/google/cloud/storage/examples/storage_bucket_acl_samples.cc#L166-L184

- In addition, I run `clang-tidy` with the new emulator and all the tests passed. Do you prefer a PR to turn the integrations test to the new emulator before of after adding `gRPC` server ( since the `gRPC` tests are running against production now , it won't affect anything )