### PR TITLE
test(spanner): deflake benchmark database creation

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -188,7 +188,7 @@ int main(int argc, char* argv[]) {
     db = create_future.get();
     if (db) break;
     if (db.status().code() != google::cloud::StatusCode::kUnavailable) break;
-    std::this_thread::sleep_for(retry * std::chrono::seconds(1));
+    std::this_thread::sleep_for(retry * std::chrono::seconds(3));
   }
   std::cout << " DONE\n";
 

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -173,18 +173,26 @@ int main(int argc, char* argv[]) {
     }
     return statements;
   }();
-  auto create_future =
-      admin_client.CreateDatabase(database, additional_statements);
+
   std::cout << "# Waiting for database creation to complete " << std::flush;
-  for (;;) {
-    auto status = create_future.wait_for(std::chrono::seconds(1));
-    if (status == std::future_status::ready) break;
-    std::cout << '.' << std::flush;
+  google::cloud::StatusOr<google::spanner::admin::database::v1::Database> db;
+  int constexpr kMaxCreateDatabaseRetries = 3;
+  for (int retry = 0; retry <= kMaxCreateDatabaseRetries; ++retry) {
+    auto create_future =
+        admin_client.CreateDatabase(database, additional_statements);
+    for (;;) {
+      auto status = create_future.wait_for(std::chrono::seconds(1));
+      if (status == std::future_status::ready) break;
+      std::cout << '.' << std::flush;
+    }
+    db = create_future.get();
+    if (db) break;
+    if (db.status().code() != google::cloud::StatusCode::kUnavailable) break;
+    std::this_thread::sleep_for(retry * std::chrono::seconds(1));
   }
   std::cout << " DONE\n";
 
   bool database_created = true;
-  auto db = create_future.get();
   if (!db) {
     if (user_specified_database &&
         db.status().code() == google::cloud::StatusCode::kAlreadyExists) {

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
     db = create_future.get();
     if (db) break;
     if (db.status().code() != google::cloud::StatusCode::kUnavailable) break;
-    std::this_thread::sleep_for(retry * std::chrono::seconds(1));
+    std::this_thread::sleep_for(retry * std::chrono::seconds(3));
   }
   std::cout << " DONE\n";
 

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -99,21 +99,29 @@ int main(int argc, char* argv[]) {
   }
 
   google::cloud::spanner::DatabaseAdminClient admin_client;
-  auto create_future =
-      admin_client.CreateDatabase(database, {R"sql(CREATE TABLE KeyValue (
+
+  std::cout << "# Waiting for database creation to complete " << std::flush;
+  google::cloud::StatusOr<google::spanner::admin::database::v1::Database> db;
+  int constexpr kMaxCreateDatabaseRetries = 3;
+  for (int retry = 0; retry <= kMaxCreateDatabaseRetries; ++retry) {
+    auto create_future =
+        admin_client.CreateDatabase(database, {R"sql(CREATE TABLE KeyValue (
                                 Key   INT64 NOT NULL,
                                 Data  STRING(1024),
                              ) PRIMARY KEY (Key))sql"});
-  std::cout << "# Waiting for database creation to complete " << std::flush;
-  for (;;) {
-    auto status = create_future.wait_for(std::chrono::seconds(1));
-    if (status == std::future_status::ready) break;
-    std::cout << '.' << std::flush;
+    for (;;) {
+      auto status = create_future.wait_for(std::chrono::seconds(1));
+      if (status == std::future_status::ready) break;
+      std::cout << '.' << std::flush;
+    }
+    db = create_future.get();
+    if (db) break;
+    if (db.status().code() != google::cloud::StatusCode::kUnavailable) break;
+    std::this_thread::sleep_for(retry * std::chrono::seconds(1));
   }
   std::cout << " DONE\n";
 
   bool database_created = true;
-  auto db = create_future.get();
   if (!db) {
     if (user_specified_database &&
         db.status().code() == google::cloud::StatusCode::kAlreadyExists) {


### PR DESCRIPTION
Retry CreateDatabase() calls during benchmark setup that fail with
UNAVAILABLE. Up to three retries, with backoff intervals of 0s, 1s,
and 2s respectively.

Part of #4010.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5395)
<!-- Reviewable:end -->
