### PR TITLE
feat(pubsub): reduce default channel count

### DIFF
--- a/google/cloud/pubsub/connection_options.cc
+++ b/google/cloud/pubsub/connection_options.cc
@@ -31,7 +31,7 @@ std::string ConnectionOptionsTraits::user_agent_prefix() {
 
 int ConnectionOptionsTraits::default_num_channels() {
   auto const ncores = std::thread::hardware_concurrency();
-  return ncores == 0 ? 4 : static_cast<int>(ncores * 4);
+  return ncores == 0 ? 4 : static_cast<int>(ncores);
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
My experiments (unpublished, in a branch), show that we hardly ever need
as many channels as the previous default set this to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5402)
<!-- Reviewable:end -->
