### PR TITLE
test(storage): add support for grpc

### DIFF
--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -90,4 +90,9 @@ testbench_args=(
   "${excluded_targets[@]}"
 exit_status=$?
 
+if [[ "$exit_status" -ne 0 ]]; then
+  source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+  dump_log testbench.log
+fi
+
 exit "${exit_status}"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -35,11 +35,9 @@ source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 
 # These can only run against production
 production_only_targets=(
-  "//google/cloud/storage/examples:storage_grpc_samples"
   "//google/cloud/storage/examples:storage_policy_doc_samples"
   "//google/cloud/storage/examples:storage_signed_url_v2_samples"
   "//google/cloud/storage/examples:storage_signed_url_v4_samples"
-  "//google/cloud/storage/tests:grpc_integration_test"
   "//google/cloud/storage/tests:key_file_integration_test"
   "//google/cloud/storage/tests:signed_url_integration_test"
 )
@@ -72,6 +70,7 @@ done
 # are missing too.
 testbench_args=(
   "--test_env=CLOUD_STORAGE_TESTBENCH_ENDPOINT=${CLOUD_STORAGE_TESTBENCH_ENDPOINT}"
+  "--test_env=CLOUD_STORAGE_GRPC_ENDPOINT=${CLOUD_STORAGE_GRPC_ENDPOINT}"
   "--test_env=HTTPBIN_ENDPOINT=${HTTPBIN_ENDPOINT}"
   "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT=fake-service-account-sign@example.com"
   "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -51,7 +51,7 @@ production_only_targets=(
 pushd "${HOME}" >/dev/null
 # Start the testbench on a fixed port, otherwise the Bazel cache gets
 # invalidated on each run.
-start_testbench 8585
+start_testbench 8585 8000
 popd >/dev/null
 
 excluded_targets=(

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -62,4 +62,9 @@ exit_status=$?
 kill_testbench
 trap '' EXIT
 
+if [[ "$exit_status" -ne 0 ]]; then
+  source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+  dump_log testbench.log
+fi
+
 exit "${exit_status}"

--- a/google/cloud/storage/emulator/database.py
+++ b/google/cloud/storage/emulator/database.py
@@ -33,6 +33,13 @@ class Database:
     def init(cls):
         return cls({}, {}, {}, {}, {})
 
+    def raii(self, grpc_server):
+        self.grpc_server = grpc_server
+
+    def __del__(self):
+        if hasattr(self, "grpc_server") and self.grpc_server is not None:
+            self.grpc_server.stop(None)
+
     # === BUCKET === #
 
     def __check_bucket_metageneration(self, request, bucket, context):

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -43,6 +43,14 @@ def index():
 
 @root.route("/start_grpc")
 def start_grpc():
+    # The reason is `Gunicorn` will spawn a new subprocess ( a worker )
+    # when running `Flask` server. If we start `gRPC` server before
+    # the spawn of the subprocess, it's nearly impossible to share
+    # the `database` with the new subprocess because Python will copy
+    # everything in the memory from the parent process to the subprocess
+    # ( So we have 2 separate instance of `database` ). The endpoint
+    # will start the `gRPC` server in the same subprocess
+    # so there is only one instance of `database`.
     global grpc_port
     if grpc_port == 0:
         port = flask.request.args.get("port", "0")

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -29,7 +29,7 @@ from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 from google.protobuf import json_format
 
 db = None
-grpc_is_running = False
+grpc_port = 0
 
 # === DEFAULT ENTRY FOR REST SERVER === #
 root = flask.Flask(__name__)
@@ -43,11 +43,12 @@ def index():
 
 @root.route("/start_grpc")
 def start_grpc():
-    global grpc_is_running
-    if not grpc_is_running:
-        port = flask.request.args.get("port", "8000")
-        grpc_server.run(port, db)
-    return "OK"
+    global grpc_port
+    if grpc_port == 0:
+        port = flask.request.args.get("port", "0")
+        grpc_port = grpc_server.run(port, db)
+        return str(grpc_port)
+    return str(grpc_port)
 
 
 @root.route("/<path:object_name>", subdomain="<bucket_name>")

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -18,6 +18,7 @@ import logging
 import database
 import flask
 import gcs as gcs_type
+import grpc_server
 import httpbin
 import utils
 from werkzeug import serving
@@ -28,6 +29,7 @@ from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 from google.protobuf import json_format
 
 db = None
+grpc_is_running = False
 
 # === DEFAULT ENTRY FOR REST SERVER === #
 root = flask.Flask(__name__)
@@ -36,6 +38,15 @@ root.debug = True
 
 @root.route("/")
 def index():
+    return "OK"
+
+
+@root.route("/start_grpc")
+def start_grpc():
+    global grpc_is_running
+    if not grpc_is_running:
+        port = flask.request.args.get("port", "8000")
+        grpc_server.run(port, db)
     return "OK"
 
 
@@ -773,8 +784,6 @@ def run():
     global db
     logging.basicConfig()
     db = database.Database.init()
-    # grpc_port = int(os.getenv("GOOGLE_CLOUD_CPP_STORAGE_EMULATOR_GRPC_PORT", 8000))
-    # grpc_server.run(grpc_port, db)
     return server
 
 

--- a/google/cloud/storage/emulator/gcs/holder.py
+++ b/google/cloud/storage/emulator/gcs/holder.py
@@ -86,12 +86,14 @@ class DataHolder(types.SimpleNamespace):
         )
 
     @classmethod
-    def init_resumable_grpc(cls, request, bucket):
+    def init_resumable_grpc(cls, request, bucket, context):
         metadata = request.insert_object_spec.resource
         upload_id = hashlib.sha256(
             ("%s/o/%s" % (bucket.name, metadata.name)).encode("utf-8")
         ).hexdigest()
-        return cls.init_upload(request, metadata, bucket, "", upload_id)
+        fake_request = utils.common.FakeRequest.init_protobuf(request, context)
+        fake_request.update_protobuf(request.insert_object_spec, context)
+        return cls.init_upload(fake_request, metadata, bucket, "", upload_id)
 
     def resumable_status_rest(self):
         response = flask.make_response()

--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -110,7 +110,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             else:
                 return
         blob, _ = gcs_type.object.Object.init(
-            upload.request, upload.metadata, upload.media, upload.bucket, False, None
+            upload.request, upload.metadata, upload.media, upload.bucket, False, context
         )
         db.insert_object(upload.request, upload.bucket.name, blob, context)
         return blob.metadata
@@ -151,6 +151,6 @@ def run(port, database):
     global db
     db = database
     storage_pb2_grpc.add_StorageServicer_to_server(StorageServicer(), server)
-    server.add_insecure_port("[::]:" + port)
+    server.add_insecure_port("localhost:" + port)
     db.raii(server)
     server.start()

--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -110,12 +110,7 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
             else:
                 return
         blob, _ = gcs_type.object.Object.init(
-            upload.request,
-            upload.metadata,
-            upload.media,
-            upload.bucket,
-            False,
-            None,
+            upload.request, upload.metadata, upload.media, upload.bucket, False, None
         )
         db.insert_object(upload.request, upload.bucket.name, blob, context)
         return blob.metadata

--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -151,6 +151,7 @@ def run(port, database):
     global db
     db = database
     storage_pb2_grpc.add_StorageServicer_to_server(StorageServicer(), server)
-    server.add_insecure_port("localhost:" + port)
+    port = server.add_insecure_port("localhost:" + port)
     db.raii(server)
     server.start()
+    return port

--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -1,0 +1,161 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from concurrent import futures
+
+import crc32c
+import gcs as gcs_type
+import grpc
+import utils
+
+from google.cloud.storage_v1.proto import storage_pb2, storage_pb2_grpc
+from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
+from google.protobuf.empty_pb2 import Empty
+
+server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+db = None
+
+
+class StorageServicer(storage_pb2_grpc.StorageServicer):
+
+    # === BUCKET ===#
+
+    def ListBuckets(self, request, context):
+        db.insert_test_bucket(context)
+        result = resources_pb2.ListBucketsResponse(next_page_token="", items=[])
+        for bucket in db.list_bucket(request, request.project, context):
+            result.items.append(bucket.metadata)
+        return result
+
+    def InsertBucket(self, request, context):
+        db.insert_test_bucket(context)
+        bucket, projection = gcs_type.bucket.Bucket.init(request, context)
+        db.insert_bucket(request, bucket, context)
+        return bucket.metadata
+
+    def GetBucket(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.metadata
+
+    def DeleteBucket(self, request, context):
+        bucket_name = request.bucket
+        db.delete_bucket(request, bucket_name, context)
+        return Empty()
+
+    # === OBJECT === #
+
+    def InsertObject(self, request_iterator, context):
+        db.insert_test_bucket(context)
+        upload, is_resumable = None, False
+        for request in request_iterator:
+            first_message = request.WhichOneof("first_message")
+            if first_message == "upload_id":
+                upload = db.get_upload(request.upload_id, context)
+                if upload.complete:
+                    utils.error.invalid(
+                        "Uploading to a completed upload %s" % upload.upload_id, context
+                    )
+                is_resumable = True
+            elif first_message == "insert_object_spec":
+                bucket = db.get_bucket_without_generation(
+                    request.insert_object_spec.resource.bucket, context
+                ).metadata
+                upload = gcs_type.holder.DataHolder.init_resumable_grpc(
+                    request, bucket, context
+                )
+            data = request.WhichOneof("data")
+            checksummed_data = None
+            if data == "checksummed_data":
+                checksummed_data = request.checksummed_data
+            elif data == "reference":
+                checksummed_data = self.GetObjectMedia(
+                    data.reference, context
+                ).checksummed_data
+            else:
+                continue
+            content = checksummed_data.content
+            crc32c_hash = (
+                checksummed_data.crc32c.value
+                if checksummed_data.HasField("crc32c")
+                else None
+            )
+            if crc32c_hash is not None:
+                actual_crc32c = crc32c.crc32(content)
+                if actual_crc32c != crc32c_hash:
+                    utils.error.mismatch(
+                        "crc32c in checksummed data",
+                        crc32c_hash,
+                        actual_crc32c,
+                        context,
+                    )
+            upload.media += checksummed_data.content
+            if request.finish_write:
+                upload.complete = True
+                break
+        if not upload.complete:
+            if not is_resumable:
+                utils.error.missing("finish_write in request", context)
+            else:
+                return
+        blob, _ = gcs_type.object.Object.init(
+            upload.request,
+            upload.metadata,
+            upload.media,
+            upload.bucket,
+            False,
+            None,
+        )
+        db.insert_object(upload.request, upload.bucket.name, blob, context)
+        return blob.metadata
+
+    def GetObjectMedia(self, request, context):
+        blob = db.get_object(request, request.bucket, request.object, False, context)
+        yield storage_pb2.GetObjectMediaResponse(
+            checksummed_data={
+                "content": blob.media,
+                "crc32c": {"value": crc32c.crc32(blob.media)},
+            },
+            metadata=blob.metadata,
+        )
+
+    def DeleteObject(self, request, context):
+        db.delete_object(request, request.bucket, request.object, context)
+        return Empty()
+
+    def StartResumableWrite(self, request, context):
+        bucket = db.get_bucket_without_generation(
+            request.insert_object_spec.resource.bucket, context
+        ).metadata
+        upload = gcs_type.holder.DataHolder.init_resumable_grpc(
+            request, bucket, context
+        )
+        upload.metadata.metadata["x_testbench_upload"] = "resumable"
+        db.insert_upload(upload)
+        return storage_pb2.StartResumableWriteResponse(upload_id=upload.upload_id)
+
+    def QueryWriteStatus(self, request, context):
+        upload = db.get_upload(request.upload_id, context)
+        return storage_pb2.QueryWriteStatusResponse(
+            committed_size=len(upload.media), complete=upload.complete
+        )
+
+
+def run(port, database):
+    global db
+    db = database
+    storage_pb2_grpc.add_StorageServicer_to_server(StorageServicer(), server)
+    server.add_insecure_port("[::]:" + port)
+    db.raii(server)
+    server.start()

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -59,6 +59,7 @@ class FakeRequest(types.SimpleNamespace):
         "destination_predefined_acl": "destinationPredefinedAcl",
         "generation": "generation",
         "source_generation": "sourceGeneration",
+        "projection": "projection",
     }
 
     def __init__(self, **kwargs):
@@ -292,11 +293,7 @@ def extract_media(request):
 
 def extract_projection(request, default, context):
     if context is not None:
-        return (
-            request.projection
-            if hasattr(request, "projection") and request.projection != 0
-            else default
-        )
+        return request.projection if request.projection != 0 else default
     else:
         projection_map = ["noAcl", "full"]
         projection = request.args.get("projection")

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -43,6 +43,24 @@ def remove_index(string):
 
 
 class FakeRequest(types.SimpleNamespace):
+    protobuf_wrapper_to_json_args = {
+        "if_generation_match": "ifGenerationMatch",
+        "if_generation_not_match": "ifGenerationNotMatch",
+        "if_metageneration_match": "ifMetagenerationMatch",
+        "if_metageneration_not_match": "ifMetagenerationNotMatch",
+        "if_source_generation_match": "ifSourceGenerationMatch",
+        "if_source_generation_not_match": "ifSourceGenerationNotMatch",
+        "if_source_metageneration_match": "ifSourceMetagenerationMatch",
+        "if_source_metageneration_not_match": "ifSourceMetagenerationNotMatch",
+    }
+
+    protobuf_scalar_to_json_args = {
+        "predefined_acl": "predefinedAcl",
+        "destination_predefined_acl": "destinationPredefinedAcl",
+        "generation": "generation",
+        "source_generation": "sourceGeneration",
+    }
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -69,6 +87,41 @@ class FakeRequest(types.SimpleNamespace):
             if field_xml in headers:
                 args[field_json] = headers[field_xml]
         return args
+
+    def HasField(self, field):
+        return hasattr(self, field) and getattr(self, field) is not None
+
+    @classmethod
+    def init_protobuf(cls, request, context):
+        fake_request = FakeRequest(args={}, headers={})
+        fake_request.update_protobuf(request, context)
+        return fake_request
+
+    def update_protobuf(self, request, context):
+        for (
+            proto_field,
+            args_field,
+        ) in FakeRequest.protobuf_wrapper_to_json_args.items():
+            if hasattr(request, proto_field) and request.HasField(proto_field):
+                self.args[args_field] = getattr(request, proto_field).value
+                setattr(self, proto_field, getattr(request, proto_field))
+        csek_field = "common_object_request_params"
+        if hasattr(request, csek_field):
+            algorithm, key_b64, key_sha256_b64 = utils.csek.extract(
+                request, False, context
+            )
+            self.headers["x-goog-encryption-algorithm"] = algorithm
+            self.headers["x-goog-encryption-key"] = key_b64
+            self.headers["x-goog-encryption-key-sha256"] = key_sha256_b64
+            setattr(self, csek_field, getattr(request, csek_field))
+        elif not hasattr(self, csek_field):
+            setattr(
+                self,
+                csek_field,
+                types.SimpleNamespace(
+                    encryption_algorithm="", encryption_key="", encryption_key_sha256=""
+                ),
+            )
 
 
 # === REST === #

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -105,6 +105,13 @@ class FakeRequest(types.SimpleNamespace):
             if hasattr(request, proto_field) and request.HasField(proto_field):
                 self.args[args_field] = getattr(request, proto_field).value
                 setattr(self, proto_field, getattr(request, proto_field))
+        for (
+            proto_field,
+            args_field,
+        ) in FakeRequest.protobuf_scalar_to_json_args.items():
+            if hasattr(request, proto_field):
+                self.args[args_field] = getattr(request, proto_field)
+                setattr(self, proto_field, getattr(request, proto_field))
         csek_field = "common_object_request_params"
         if hasattr(request, csek_field):
             algorithm, key_b64, key_sha256_b64 = utils.csek.extract(
@@ -285,7 +292,11 @@ def extract_media(request):
 
 def extract_projection(request, default, context):
     if context is not None:
-        return request.projection if request.projection != 0 else default
+        return (
+            request.projection
+            if hasattr(request, "projection") and request.projection != 0
+            else default
+        )
     else:
         projection_map = ["noAcl", "full"]
         projection = request.args.get("projection")

--- a/google/cloud/storage/examples/CMakeLists.txt
+++ b/google/cloud/storage/examples/CMakeLists.txt
@@ -97,8 +97,8 @@ if (BUILD_TESTING)
     # We just know that these tests need to be run against production.
     set(storage_integration_tests_production
         # cmake-format: sort
-        storage_grpc_samples.cc storage_policy_doc_samples.cc
-        storage_signed_url_v2_samples.cc storage_signed_url_v4_samples.cc)
+        storage_policy_doc_samples.cc storage_signed_url_v2_samples.cc
+        storage_signed_url_v4_samples.cc)
     foreach (fname ${storage_integration_tests_production})
         google_cloud_cpp_set_target_name(target "storage_examples" "${fname}")
         set_tests_properties(

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -101,11 +101,8 @@ foreach (fname ${storage_client_integration_tests})
 endforeach ()
 
 # We just know that these tests need to be run against production.
-foreach (
-    fname
-    # cmake-format: sort
-    grpc_integration_test.cc key_file_integration_test.cc
-    signed_url_integration_test.cc)
+foreach (fname # cmake-format: sort
+               key_file_integration_test.cc signed_url_integration_test.cc)
     google_cloud_cpp_set_target_name(target "storage" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -106,8 +106,17 @@ start_testbench() {
     echo "Successfully connected to testbench [${TESTBENCH_PID}]"
   fi
 
-  grpc_port=8000
-  curl "http://localhost:${testbench_port}/start_grpc?port=${grpc_port}"
+  port="${2:-0}"
+  local grpc_port=""
+  grpc_port=$(curl -s "http://localhost:${testbench_port}/start_grpc?port=${port}")
+
+  if [[ "$grpc_port" -eq "$grpc_port" ]]; then
+    echo "Successfully connected to gRPC server at port ${grpc_port}"
+  else
+    echo "${IO_COLOR_RED}Cannot connect to gRPC server; aborting test.${IO_COLOR_RESET}" >&2
+    cat testbench.log
+    exit 1
+  fi
   export CLOUD_STORAGE_GRPC_ENDPOINT="localhost:${grpc_port}"
 
   echo "${IO_COLOR_GREEN}[ ======== ]${IO_COLOR_RESET} Integration test environment set-up."

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -108,7 +108,7 @@ start_testbench() {
 
   port="${2:-0}"
   local grpc_port=""
-  grpc_port=$(curl -s "http://localhost:${testbench_port}/start_grpc?port=${port}")
+  grpc_port=$(curl -s --retry 5 --retry-max-time 40 "http://localhost:${testbench_port}/start_grpc?port=${port}")
 
   if [[ "$grpc_port" -eq "$grpc_port" ]]; then
     echo "Successfully connected to gRPC server at port ${grpc_port}"

--- a/google/cloud/storage/tools/run_testbench_utils.sh
+++ b/google/cloud/storage/tools/run_testbench_utils.sh
@@ -60,7 +60,8 @@ start_testbench() {
   trap kill_testbench EXIT
 
   gunicorn --bind "0.0.0.0:${port}" \
-    --worker-class gevent \
+    --worker-class sync \
+    --threads 10 \
     --access-logfile - \
     --chdir "${PROJECT_ROOT}/google/cloud/storage/emulator" \
     "emulator:run()" \
@@ -104,6 +105,10 @@ start_testbench() {
   else
     echo "Successfully connected to testbench [${TESTBENCH_PID}]"
   fi
+
+  grpc_port=8000
+  curl "http://localhost:${testbench_port}/start_grpc?port=${grpc_port}"
+  export CLOUD_STORAGE_GRPC_ENDPOINT="localhost:${grpc_port}"
 
   echo "${IO_COLOR_GREEN}[ ======== ]${IO_COLOR_RESET} Integration test environment set-up."
 }


### PR DESCRIPTION
This PR:
- adds support for grpc.
- makes `grpc_integration_test` testing with both `media` and `metadata` since it is our ultimate goal.
- `CI` changes

`gevent` and `gRPC` can not work together, so I change the worker to `sync` and use `threads`. I also add a endpoint `start_grpc` to start the grpc server. The reason is `Gunicorn` will spawn a new subprocess when running `Flask` server. If we start `gRPC` server before the spawn of the subprocess, it's nearly impossible to share the `database` with the new subprocess because Python will copy everything in the memory from the parent process to the subprocess ( So we have 2 separate instance of `database` ). The endpoint will start the `gRPC` server in the same subprocess so there is only one instance of `database`.

Part of #4751 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5414)
<!-- Reviewable:end -->
