### PR TITLE
fix(pubsub): keep corked after ResumePublish

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -71,6 +71,12 @@ class BatchingPublisherConnection
   void MaybeFlush(std::unique_lock<std::mutex> lk);
   void FlushImpl(std::unique_lock<std::mutex> lk);
 
+  bool RequiresOrdering() const { return !ordering_key_.empty(); }
+
+  bool IsCorked(std::unique_lock<std::mutex> const&) const {
+    return corked_on_pending_push_ || !corked_on_status_.ok();
+  }
+
   pubsub::Topic const topic_;
   std::string const topic_full_name_;
   pubsub::PublisherOptions const options_;
@@ -85,8 +91,8 @@ class BatchingPublisherConnection
   google::pubsub::v1::PublishRequest pending_;
   std::size_t current_bytes_ = 0;
   std::chrono::system_clock::time_point batch_expiration_;
-  bool corked_ = false;
-  Status corked_status_;
+  bool corked_on_pending_push_ = false;
+  Status corked_on_status_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -838,7 +838,7 @@ TEST(BatchingPublisherConnectionTest, OrderingBatchDiscardOnError) {
     using ms = std::chrono::milliseconds;
     EXPECT_EQ(std::future_status::timeout, r.wait_for(ms(0)));
   }
-  // Trigger the first response, the should all fail with the error response.
+  // Trigger the first response. They should all fail with the error response.
   wait_pending().set_value();
   for (auto& r : responses) {
     EXPECT_THAT(


### PR DESCRIPTION
We were flushing after each `Publisher::ResumePublish()` which could
reorder messages. We need to track "corked because there was an error"
(which is affected by `Publisher::ResumePublish()`) and "corked because
we are waiting for a response", which should not.

Fixes #5412

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5415)
<!-- Reviewable:end -->
