### PR TITLE
feat(pubsub): more throughput benchmark options

### DIFF
--- a/google/cloud/pubsub/benchmarks/throughput.cc
+++ b/google/cloud/pubsub/benchmarks/throughput.cc
@@ -599,6 +599,7 @@ google::cloud::StatusOr<Config> SelfTest(std::string const& cmd) {
           "--subscriber-thread-count=1",
           "--subscriber-io-threads=1",
           "--subscriber-io-channels=1",
+          "--subscriber-max-outstanding-messages=0",
           "--subscriber-max-outstanding-bytes=100MiB",
           "--subscriber-max-concurrency=1000",
           "--iteration-duration=1s",


### PR DESCRIPTION
Add options to control more of the low-level configuration of the client
library. Some of these have no effect at the moment (e.g.
--subscriber-io-channels), but it is easier to merge them as they are.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5419)
<!-- Reviewable:end -->
