### PR TITLE
cleanup(bigtable): Move bigtable tests to the right namespace

### DIFF
--- a/google/cloud/bigtable/admin_client_test.cc
+++ b/google/cloud/bigtable/admin_client_test.cc
@@ -15,11 +15,15 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(AdminClientTest, Default) {
-  auto admin_client = bigtable::CreateDefaultAdminClient(
-      "test-project", bigtable::ClientOptions().set_connection_pool_size(1));
+  auto admin_client = CreateDefaultAdminClient(
+      "test-project", ClientOptions().set_connection_pool_size(1));
   ASSERT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
 
@@ -34,3 +38,9 @@ TEST(AdminClientTest, Default) {
   EXPECT_TRUE(channel1);
   EXPECT_NE(channel0.get(), channel1.get());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -17,11 +17,11 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
-using ::google::cloud::bigtable::benchmarks::Benchmark;
-using ::google::cloud::bigtable::benchmarks::BenchmarkResult;
-using ::google::cloud::bigtable::benchmarks::kBulkSize;
-using ::google::cloud::bigtable::benchmarks::MakeBenchmarkSetup;
-using ::google::cloud::bigtable::benchmarks::OperationResult;
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+
 using ::testing::HasSubstr;
 
 namespace {
@@ -33,7 +33,7 @@ char arg4[] = "4";
 char arg5[] = "300";
 char arg6[] = "10000";
 char arg7[] = "True";
-}  // anonymous namespace
+}  // namespace
 
 TEST(BenchmarkTest, Create) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
@@ -139,7 +139,7 @@ TEST(BenchmarkTest, PrintLatencyResult) {
   result.operations.resize(100);
   int count = 0;
   std::generate(result.operations.begin(), result.operations.end(), [&count]() {
-    return OperationResult{google::cloud::Status{},
+    return OperationResult{::google::cloud::Status{},
                            std::chrono::microseconds(++count * 100)};
   });
 
@@ -174,7 +174,7 @@ TEST(BenchmarkTest, PrintCsv) {
   result.operations.resize(100);
   int count = 0;
   std::generate(result.operations.begin(), result.operations.end(), [&count]() {
-    return OperationResult{google::cloud::Status{},
+    return OperationResult{::google::cloud::Status{},
                            std::chrono::microseconds(++count * 100)};
   });
 
@@ -192,9 +192,9 @@ TEST(BenchmarkTest, PrintCsv) {
   // fairly minimal.
 
   // The output includes the version and compiler info.
-  EXPECT_THAT(output, HasSubstr(google::cloud::bigtable::version_string()));
-  EXPECT_THAT(output, HasSubstr(google::cloud::internal::compiler()));
-  EXPECT_THAT(output, HasSubstr(google::cloud::internal::compiler_flags()));
+  EXPECT_THAT(output, HasSubstr(version_string()));
+  EXPECT_THAT(output, HasSubstr(::google::cloud::internal::compiler()));
+  EXPECT_THAT(output, HasSubstr(::google::cloud::internal::compiler_flags()));
 
   // The output includes the latency results.
   EXPECT_THAT(output, HasSubstr(",100,"));    // p0
@@ -204,3 +204,8 @@ TEST(BenchmarkTest, PrintCsv) {
   // The output includes the throughput.
   EXPECT_THAT(output, HasSubstr(",123,"));
 }
+
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
+++ b/google/cloud/bigtable/benchmarks/bigtable_benchmark_test.cc
@@ -21,10 +21,10 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace benchmarks {
+namespace {
 
 using ::testing::HasSubstr;
 
-namespace {
 char arg0[] = "program";
 char arg1[] = "foo";
 char arg2[] = "bar";
@@ -33,7 +33,6 @@ char arg4[] = "4";
 char arg5[] = "300";
 char arg6[] = "10000";
 char arg7[] = "True";
-}  // namespace
 
 TEST(BenchmarkTest, Create) {
   char* argv[] = {arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7};
@@ -205,6 +204,7 @@ TEST(BenchmarkTest, PrintCsv) {
   EXPECT_THAT(output, HasSubstr(",123,"));
 }
 
+}  // namespace
 }  // namespace benchmarks
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -23,6 +23,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace benchmarks {
+namespace {
 
 using std::chrono::milliseconds;
 
@@ -145,6 +146,7 @@ TEST(EmbeddedServer, ReadRows100) {
   wait_thread.join();
 }
 
+}  // namespace
 }  // namespace benchmarks
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -19,8 +19,11 @@
 #include <gmock/gmock.h>
 #include <thread>
 
-namespace bigtable = google::cloud::bigtable;
-using bigtable::benchmarks::CreateEmbeddedServer;
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+
 using std::chrono::milliseconds;
 
 TEST(EmbeddedServer, WaitAndShutdown) {
@@ -39,15 +42,14 @@ TEST(EmbeddedServer, Admin) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  bigtable::ClientOptions options(grpc::InsecureChannelCredentials());
+  ClientOptions options(grpc::InsecureChannelCredentials());
   options.set_admin_endpoint(server->address());
-  bigtable::TableAdmin admin(
-      bigtable::CreateDefaultAdminClient("fake-project", options),
-      "fake-instance");
+  TableAdmin admin(CreateDefaultAdminClient("fake-project", options),
+                   "fake-instance");
 
-  auto gc = bigtable::GcRule::MaxNumVersions(42);
+  auto gc = GcRule::MaxNumVersions(42);
   EXPECT_EQ(0, server->create_table_count());
-  admin.CreateTable("fake-table-01", bigtable::TableConfig({{"fam", gc}}, {}));
+  admin.CreateTable("fake-table-01", TableConfig({{"fam", gc}}, {}));
   EXPECT_EQ(1, server->create_table_count());
 
   EXPECT_EQ(0, server->delete_table_count());
@@ -62,15 +64,14 @@ TEST(EmbeddedServer, TableApply) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  bigtable::ClientOptions options(grpc::InsecureChannelCredentials());
+  ClientOptions options(grpc::InsecureChannelCredentials());
   options.set_data_endpoint(server->address());
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            "fake-project", "fake-instance", options),
-                        "fake-table");
+  Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
+              "fake-table");
 
-  bigtable::SingleRowMutation mutation(
-      "row1", {bigtable::SetCell("fam", "col", milliseconds(0), "val"),
-               bigtable::SetCell("fam", "col", milliseconds(0), "val")});
+  SingleRowMutation mutation("row1",
+                             {SetCell("fam", "col", milliseconds(0), "val"),
+                              SetCell("fam", "col", milliseconds(0), "val")});
 
   EXPECT_EQ(0, server->mutate_row_count());
   auto status = table.Apply(std::move(mutation));
@@ -85,17 +86,16 @@ TEST(EmbeddedServer, TableBulkApply) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  bigtable::ClientOptions options(grpc::InsecureChannelCredentials());
+  ClientOptions options(grpc::InsecureChannelCredentials());
   options.set_data_endpoint(server->address());
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            "fake-project", "fake-instance", options),
-                        "fake-table");
+  Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
+              "fake-table");
 
-  bigtable::BulkMutation bulk;
-  bulk.emplace_back(bigtable::SingleRowMutation(
-      "row1", {bigtable::SetCell("fam", "col", milliseconds(0), "val")}));
-  bulk.emplace_back(bigtable::SingleRowMutation(
-      "row2", {bigtable::SetCell("fam", "col", milliseconds(0), "val")}));
+  BulkMutation bulk;
+  bulk.emplace_back(SingleRowMutation(
+      "row1", {SetCell("fam", "col", milliseconds(0), "val")}));
+  bulk.emplace_back(SingleRowMutation(
+      "row2", {SetCell("fam", "col", milliseconds(0), "val")}));
 
   EXPECT_EQ(0, server->mutate_rows_count());
   auto failures = table.BulkApply(std::move(bulk));
@@ -110,15 +110,13 @@ TEST(EmbeddedServer, ReadRows1) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  bigtable::ClientOptions options(grpc::InsecureChannelCredentials());
+  ClientOptions options(grpc::InsecureChannelCredentials());
   options.set_data_endpoint(server->address());
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            "fake-project", "fake-instance", options),
-                        "fake-table");
+  Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
+              "fake-table");
 
   EXPECT_EQ(0, server->read_rows_count());
-  auto reader = table.ReadRows(bigtable::RowSet("row1"), 1,
-                               bigtable::Filter::PassAllFilter());
+  auto reader = table.ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   auto count = std::distance(reader.begin(), reader.end());
   EXPECT_EQ(1, count);
   EXPECT_EQ(1, server->read_rows_count());
@@ -131,16 +129,14 @@ TEST(EmbeddedServer, ReadRows100) {
   auto server = CreateEmbeddedServer();
   std::thread wait_thread([&server]() { server->Wait(); });
 
-  bigtable::ClientOptions options(grpc::InsecureChannelCredentials());
+  ClientOptions options(grpc::InsecureChannelCredentials());
   options.set_data_endpoint(server->address());
-  bigtable::Table table(bigtable::CreateDefaultDataClient(
-                            "fake-project", "fake-instance", options),
-                        "fake-table");
+  Table table(CreateDefaultDataClient("fake-project", "fake-instance", options),
+              "fake-table");
 
   EXPECT_EQ(0, server->read_rows_count());
-  auto reader =
-      table.ReadRows(bigtable::RowSet(bigtable::RowRange::StartingAt("foo")),
-                     100, bigtable::Filter::PassAllFilter());
+  auto reader = table.ReadRows(RowSet(RowRange::StartingAt("foo")), 100,
+                               Filter::PassAllFilter());
   auto count = std::distance(reader.begin(), reader.end());
   EXPECT_EQ(100, count);
   EXPECT_EQ(1, server->read_rows_count());
@@ -148,3 +144,8 @@ TEST(EmbeddedServer, ReadRows100) {
   server->Shutdown();
   wait_thread.join();
 }
+
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/format_duration_test.cc
+++ b/google/cloud/bigtable/benchmarks/format_duration_test.cc
@@ -15,7 +15,11 @@
 #include "google/cloud/bigtable/benchmarks/benchmark.h"
 #include <gmock/gmock.h>
 
-using ::google::cloud::bigtable::benchmarks::FormatDuration;
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+
 using ::std::chrono::hours;
 using ::std::chrono::microseconds;
 using ::std::chrono::milliseconds;
@@ -93,3 +97,8 @@ TEST(BenchmarksFormatDuration, NoMillis) {
   os << FormatDuration(duration);
   EXPECT_EQ("1h2m3s", os.str());
 }
+
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/benchmarks/format_duration_test.cc
+++ b/google/cloud/bigtable/benchmarks/format_duration_test.cc
@@ -19,6 +19,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace benchmarks {
+namespace {
 
 using ::std::chrono::hours;
 using ::std::chrono::microseconds;
@@ -98,6 +99,7 @@ TEST(BenchmarksFormatDuration, NoMillis) {
   EXPECT_EQ("1h2m3s", os.str());
 }
 
+}  // namespace
 }  // namespace benchmarks
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/benchmarks/setup_test.cc
+++ b/google/cloud/bigtable/benchmarks/setup_test.cc
@@ -21,10 +21,10 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace benchmarks {
+namespace {
 
 using ::testing::HasSubstr;
 
-namespace {
 char arg0[] = "program";
 char arg1[] = "foo";
 char arg2[] = "bar";
@@ -35,7 +35,6 @@ char arg6[] = "10000";
 char arg7[] = "True";
 char arg8[] = "20";
 char arg9[] = "Unused";
-}  // namespace
 
 TEST(BenchmarksSetup, Basic) {
   char* argv[] = {arg0, arg1, arg2, arg3};
@@ -222,6 +221,7 @@ TEST(BenchmarkSetup, TableSize) {
   EXPECT_FALSE(MakeBenchmarkSetup("table-size", argc, argv));
 }
 
+}  // namespace
 }  // namespace benchmarks
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/benchmarks/setup_test.cc
+++ b/google/cloud/bigtable/benchmarks/setup_test.cc
@@ -17,11 +17,11 @@
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 
-using ::google::cloud::bigtable::benchmarks::kDefaultTableSize;
-using ::google::cloud::bigtable::benchmarks::kDefaultTestDuration;
-using ::google::cloud::bigtable::benchmarks::kDefaultThreads;
-using ::google::cloud::bigtable::benchmarks::kTableIdRandomLetters;
-using ::google::cloud::bigtable::benchmarks::MakeBenchmarkSetup;
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace benchmarks {
+
 using ::testing::HasSubstr;
 
 namespace {
@@ -35,7 +35,7 @@ char arg6[] = "10000";
 char arg7[] = "True";
 char arg8[] = "20";
 char arg9[] = "Unused";
-}  // anonymous namespace
+}  // namespace
 
 TEST(BenchmarksSetup, Basic) {
   char* argv[] = {arg0, arg1, arg2, arg3};
@@ -137,7 +137,7 @@ TEST(BenchmarkSetup, Test3) {
 }
 
 TEST(BenchmarkSetup, Test2) {
-  google::cloud::testing_util::ScopedEnvironment env(
+  ::google::cloud::testing_util::ScopedEnvironment env(
       "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES", "no");
   char* argv[] = {arg0, arg1, arg2};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -145,7 +145,7 @@ TEST(BenchmarkSetup, Test2) {
 }
 
 TEST(BenchmarkSetup, Test1) {
-  google::cloud::testing_util::ScopedEnvironment env(
+  ::google::cloud::testing_util::ScopedEnvironment env(
       "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES", "no");
   char* argv[] = {arg0, arg1};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -153,7 +153,7 @@ TEST(BenchmarkSetup, Test1) {
 }
 
 TEST(BenchmarkSetup, Test0) {
-  google::cloud::testing_util::ScopedEnvironment env(
+  ::google::cloud::testing_util::ScopedEnvironment env(
       "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES", "no");
   char* argv[] = {arg0};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -161,11 +161,11 @@ TEST(BenchmarkSetup, Test0) {
 }
 
 TEST(BenchmarkSetup, TestAutoRun) {
-  google::cloud::testing_util::ScopedEnvironment auto_run(
+  ::google::cloud::testing_util::ScopedEnvironment auto_run(
       "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES", "yes");
-  google::cloud::testing_util::ScopedEnvironment project_id(
+  ::google::cloud::testing_util::ScopedEnvironment project_id(
       "GOOGLE_CLOUD_PROJECT", "test-unused-project");
-  google::cloud::testing_util::ScopedEnvironment instance_id(
+  ::google::cloud::testing_util::ScopedEnvironment instance_id(
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID", "test-instance");
   char* argv[] = {arg0};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -176,11 +176,11 @@ TEST(BenchmarkSetup, TestAutoRun) {
 }
 
 TEST(BenchmarkSetup, TestAutoRunMissingProject) {
-  google::cloud::testing_util::ScopedEnvironment auto_run(
+  ::google::cloud::testing_util::ScopedEnvironment auto_run(
       "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES", "yes");
-  google::cloud::testing_util::ScopedEnvironment project_id(
+  ::google::cloud::testing_util::ScopedEnvironment project_id(
       "GOOGLE_CLOUD_PROJECT", {});
-  google::cloud::testing_util::ScopedEnvironment instance_id(
+  ::google::cloud::testing_util::ScopedEnvironment instance_id(
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID", "test-instance");
   char* argv[] = {arg0};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -190,11 +190,11 @@ TEST(BenchmarkSetup, TestAutoRunMissingProject) {
 }
 
 TEST(BenchmarkSetup, TestAutoRunMissingInstanceId) {
-  google::cloud::testing_util::ScopedEnvironment auto_run(
+  ::google::cloud::testing_util::ScopedEnvironment auto_run(
       "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES", "yes");
-  google::cloud::testing_util::ScopedEnvironment project_id(
+  ::google::cloud::testing_util::ScopedEnvironment project_id(
       "GOOGLE_CLOUD_PROJECT", "test-unused-project");
-  google::cloud::testing_util::ScopedEnvironment instance_id(
+  ::google::cloud::testing_util::ScopedEnvironment instance_id(
       "GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID", {});
   char* argv[] = {arg0};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -221,3 +221,8 @@ TEST(BenchmarkSetup, TableSize) {
   // TableSize parameter should be >= 100.
   EXPECT_FALSE(MakeBenchmarkSetup("table-size", argc, argv));
 }
+
+}  // namespace benchmarks
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/cell_test.cc
+++ b/google/cloud/bigtable/cell_test.cc
@@ -16,7 +16,11 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gtest/gtest.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 /// @test Verify Cell instantiation and trivial accessors.
 TEST(CellTest, Simple) {
@@ -26,7 +30,7 @@ TEST(CellTest, Simple) {
   std::int64_t timestamp = 42;
   std::string value = "value";
 
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
+  Cell cell(row_key, family_name, column_qualifier, timestamp, value);
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
@@ -42,7 +46,7 @@ TEST(CellTest, SimpleNumericValue) {
   std::string column_qualifier = "column";
   std::int64_t timestamp = 42;
   std::int64_t value = 343321020;
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
+  Cell cell(row_key, family_name, column_qualifier, timestamp, value);
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
@@ -60,7 +64,7 @@ TEST(CellTest, SimpleNumericNegativeValue) {
   std::string column_qualifier = "column";
   std::int64_t timestamp = 42;
   std::int64_t value = -343321020;
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
+  Cell cell(row_key, family_name, column_qualifier, timestamp, value);
   EXPECT_EQ(row_key, cell.row_key());
   EXPECT_EQ(family_name, cell.family_name());
   EXPECT_EQ(column_qualifier, cell.column_qualifier());
@@ -79,13 +83,19 @@ TEST(CellTest, RValueRefAccessors) {
   std::int64_t timestamp = 42;
   std::string value = "value";
 
-  bigtable::Cell cell(row_key, family_name, column_qualifier, timestamp, value);
+  Cell cell(row_key, family_name, column_qualifier, timestamp, value);
 
   static_assert(
-      !std::is_lvalue_reference<decltype(bigtable::Cell(cell).value())>::value,
+      !std::is_lvalue_reference<decltype(Cell(cell).value())>::value,
       "Member function `value` is expected to return a value from an r-value "
       "reference to row.");
 
   auto moved_value = std::move(cell).value();
   EXPECT_EQ(value, moved_value);
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/cluster_config_test.cc
+++ b/google/cloud/bigtable/cluster_config_test.cc
@@ -15,25 +15,35 @@
 #include "google/cloud/bigtable/cluster_config.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(ClusterConfigTest, Constructor) {
-  bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::SSD);
+  ClusterConfig config("somewhere", 7, ClusterConfig::SSD);
   auto const& proto = config.as_proto();
   EXPECT_EQ("somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
-  EXPECT_EQ(bigtable::ClusterConfig::SSD, proto.default_storage_type());
+  EXPECT_EQ(ClusterConfig::SSD, proto.default_storage_type());
 }
 
 TEST(ClusterConfigTest, Move) {
-  bigtable::ClusterConfig config("somewhere", 7, bigtable::ClusterConfig::HDD);
+  ClusterConfig config("somewhere", 7, ClusterConfig::HDD);
   auto proto = std::move(config).as_proto();
   // Verify that as_proto() for rvalue-references returns the right type.
-  static_assert(std::is_rvalue_reference<decltype(
-                    std::move(std::declval<bigtable::ClusterConfig>())
-                        .as_proto())>::value,
-                "Return type from as_proto() must be rvalue-reference");
+  static_assert(
+      std::is_rvalue_reference<decltype(
+          std::move(std::declval<ClusterConfig>()).as_proto())>::value,
+      "Return type from as_proto() must be rvalue-reference");
   EXPECT_EQ("somewhere", proto.location());
   EXPECT_EQ(7, proto.serve_nodes());
-  EXPECT_EQ(bigtable::ClusterConfig::HDD, proto.default_storage_type());
+  EXPECT_EQ(ClusterConfig::HDD, proto.default_storage_type());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/column_family_test.cc
+++ b/google/cloud/bigtable/column_family_test.cc
@@ -16,7 +16,11 @@
 #include "google/cloud/testing_util/chrono_literals.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _h;
 using ::google::cloud::testing_util::chrono_literals::operator"" _min;
@@ -25,48 +29,48 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ns;
 
 TEST(GcRule, MaxNumVersions) {
-  auto proto = bigtable::GcRule::MaxNumVersions(3).as_proto();
+  auto proto = GcRule::MaxNumVersions(3).as_proto();
   EXPECT_EQ(3, proto.max_num_versions());
 }
 
 TEST(GcRule, MaxAgeHours) {
-  auto proto = bigtable::GcRule::MaxAge(1_h).as_proto();
+  auto proto = GcRule::MaxAge(1_h).as_proto();
   EXPECT_EQ(3600, proto.max_age().seconds());
   EXPECT_EQ(0, proto.max_age().nanos());
 }
 
 TEST(GcRule, MaxAgeMinutes) {
-  auto proto = bigtable::GcRule::MaxAge(2_min).as_proto();
+  auto proto = GcRule::MaxAge(2_min).as_proto();
   EXPECT_EQ(120, proto.max_age().seconds());
   EXPECT_EQ(0, proto.max_age().nanos());
 }
 
 TEST(GcRule, MaxAgeSeconds) {
-  auto proto = bigtable::GcRule::MaxAge(3_s).as_proto();
+  auto proto = GcRule::MaxAge(3_s).as_proto();
   EXPECT_EQ(3, proto.max_age().seconds());
   EXPECT_EQ(0, proto.max_age().nanos());
 }
 
 TEST(GcRule, MaxAgeMicroseconds) {
-  auto proto = bigtable::GcRule::MaxAge(5_us).as_proto();
+  auto proto = GcRule::MaxAge(5_us).as_proto();
   EXPECT_EQ(0, proto.max_age().seconds());
   EXPECT_EQ(5000, proto.max_age().nanos());
 }
 
 TEST(GcRule, MaxAgeNanoseconds) {
-  auto proto = bigtable::GcRule::MaxAge(6_ns).as_proto();
+  auto proto = GcRule::MaxAge(6_ns).as_proto();
   EXPECT_EQ(0, proto.max_age().seconds());
   EXPECT_EQ(6, proto.max_age().nanos());
 }
 
 TEST(GcRule, MaxAgeMixed) {
-  auto proto = bigtable::GcRule::MaxAge(1_min + 2_s + 7_ns).as_proto();
+  auto proto = GcRule::MaxAge(1_min + 2_s + 7_ns).as_proto();
   EXPECT_EQ(62, proto.max_age().seconds());
   EXPECT_EQ(7, proto.max_age().nanos());
 }
 
 TEST(GcRule, IntersectionSingle) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   auto proto = GC::Intersection(GC::MaxNumVersions(42)).as_proto();
   EXPECT_TRUE(proto.has_intersection());
   EXPECT_EQ(1, proto.intersection().rules_size());
@@ -74,7 +78,7 @@ TEST(GcRule, IntersectionSingle) {
 }
 
 TEST(GcRule, IntersectionMultiple) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   auto proto = GC::Intersection(GC::MaxNumVersions(42), GC::MaxAge(2_s + 3_us))
                    .as_proto();
   EXPECT_TRUE(proto.has_intersection());
@@ -85,14 +89,14 @@ TEST(GcRule, IntersectionMultiple) {
 }
 
 TEST(GcRule, IntersectionNone) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   auto proto = GC::Intersection().as_proto();
   EXPECT_TRUE(proto.has_intersection());
   EXPECT_EQ(0, proto.intersection().rules_size());
 }
 
 TEST(GcRule, UnionSingle) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   auto proto = GC::Union(GC::MaxNumVersions(42)).as_proto();
   EXPECT_TRUE(proto.has_union_());
   EXPECT_EQ(1, proto.union_().rules_size());
@@ -100,7 +104,7 @@ TEST(GcRule, UnionSingle) {
 }
 
 TEST(GcRule, UnionMultiple) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   auto proto =
       GC::Union(GC::MaxNumVersions(42), GC::MaxAge(2_s + 3_us)).as_proto();
   EXPECT_TRUE(proto.has_union_());
@@ -111,15 +115,15 @@ TEST(GcRule, UnionMultiple) {
 }
 
 TEST(GcRule, UnionNone) {
-  using GC = bigtable::GcRule;
+  using GC = GcRule;
   auto proto = GC::Union().as_proto();
   EXPECT_TRUE(proto.has_union_());
   EXPECT_EQ(0, proto.union_().rules_size());
 }
 
 TEST(ColumnFamilyModification, Create) {
-  using M = bigtable::ColumnFamilyModification;
-  using GC = bigtable::GcRule;
+  using M = ColumnFamilyModification;
+  using GC = GcRule;
   auto proto = M::Create("foo", GC::MaxNumVersions(2)).as_proto();
   ASSERT_TRUE(proto.has_create());
   EXPECT_EQ("foo", proto.id());
@@ -127,8 +131,8 @@ TEST(ColumnFamilyModification, Create) {
 }
 
 TEST(ColumnFamilyModification, Update) {
-  using M = bigtable::ColumnFamilyModification;
-  using GC = bigtable::GcRule;
+  using M = ColumnFamilyModification;
+  using GC = GcRule;
   auto proto = M::Update("foo", GC::MaxNumVersions(2)).as_proto();
   ASSERT_TRUE(proto.has_update());
   EXPECT_EQ("foo", proto.id());
@@ -136,8 +140,14 @@ TEST(ColumnFamilyModification, Update) {
 }
 
 TEST(ColumnFamilyModification, Drop) {
-  using M = bigtable::ColumnFamilyModification;
+  using M = ColumnFamilyModification;
   auto proto = M::Drop("foo").as_proto();
   EXPECT_TRUE(proto.drop());
   EXPECT_EQ("foo", proto.id());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/data_client_test.cc
+++ b/google/cloud/bigtable/data_client_test.cc
@@ -15,12 +15,16 @@
 #include "google/cloud/bigtable/data_client.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(DataClientTest, Default) {
-  auto data_client = bigtable::CreateDefaultDataClient(
-      "test-project", "test-instance",
-      bigtable::ClientOptions().set_connection_pool_size(1));
+  auto data_client =
+      CreateDefaultDataClient("test-project", "test-instance",
+                              ClientOptions().set_connection_pool_size(1));
   ASSERT_TRUE(data_client);
   EXPECT_EQ("test-project", data_client->project_id());
   EXPECT_EQ("test-instance", data_client->instance_id());
@@ -36,3 +40,9 @@ TEST(DataClientTest, Default) {
   EXPECT_TRUE(channel1);
   EXPECT_NE(channel0.get(), channel1.get());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -17,39 +17,44 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 namespace btproto = ::google::bigtable::v2;
-namespace bigtable = google::cloud::bigtable;
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 
 TEST(FiltersTest, PassAllFilter) {
-  auto proto = bigtable::Filter::PassAllFilter().as_proto();
+  auto proto = Filter::PassAllFilter().as_proto();
   EXPECT_TRUE(proto.pass_all_filter());
 }
 
 TEST(FiltersTest, BlockAllFilter) {
-  auto proto = bigtable::Filter::BlockAllFilter().as_proto();
+  auto proto = Filter::BlockAllFilter().as_proto();
   EXPECT_TRUE(proto.block_all_filter());
 }
 
 TEST(FiltersTest, Latest) {
-  auto proto = bigtable::Filter::Latest(3).as_proto();
+  auto proto = Filter::Latest(3).as_proto();
   EXPECT_EQ(3, proto.cells_per_column_limit_filter());
 }
 
 TEST(FiltersTest, FamilyRegex) {
-  auto proto = bigtable::Filter::FamilyRegex("fam[123]").as_proto();
+  auto proto = Filter::FamilyRegex("fam[123]").as_proto();
   EXPECT_EQ("fam[123]", proto.family_name_regex_filter());
 }
 
 TEST(FiltersTest, ColumnRegex) {
-  auto proto = bigtable::Filter::ColumnRegex("col[A-E]").as_proto();
+  auto proto = Filter::ColumnRegex("col[A-E]").as_proto();
   EXPECT_EQ("col[A-E]", proto.column_qualifier_regex_filter());
 }
 
 TEST(FiltersTest, ColumnRange) {
-  auto proto = bigtable::Filter::ColumnRange("fam", "colA", "colF").as_proto();
+  auto proto = Filter::ColumnRange("fam", "colA", "colF").as_proto();
   EXPECT_EQ("fam", proto.column_range_filter().family_name());
   EXPECT_EQ(btproto::ColumnRange::kStartQualifierClosed,
             proto.column_range_filter().start_qualifier_case());
@@ -60,53 +65,51 @@ TEST(FiltersTest, ColumnRange) {
 }
 
 TEST(FiltersTest, ColumnName) {
-  auto proto = bigtable::Filter::ColumnName("fam", "colA").as_proto();
+  auto proto = Filter::ColumnName("fam", "colA").as_proto();
   EXPECT_EQ("fam", proto.column_range_filter().family_name());
   EXPECT_EQ("colA", proto.column_range_filter().start_qualifier_closed());
   EXPECT_EQ("colA", proto.column_range_filter().end_qualifier_closed());
 }
 
 TEST(FiltersTest, TimestampRangeMicros) {
-  auto proto = bigtable::Filter::TimestampRangeMicros(0, 10).as_proto();
+  auto proto = Filter::TimestampRangeMicros(0, 10).as_proto();
   EXPECT_EQ(0, proto.timestamp_range_filter().start_timestamp_micros());
   EXPECT_EQ(10, proto.timestamp_range_filter().end_timestamp_micros());
 }
 
 TEST(FiltersTest, TimestampRange) {
-  auto proto = bigtable::Filter::TimestampRange(10_us, 10_ms).as_proto();
+  auto proto = Filter::TimestampRange(10_us, 10_ms).as_proto();
   EXPECT_EQ(10, proto.timestamp_range_filter().start_timestamp_micros());
   EXPECT_EQ(10000, proto.timestamp_range_filter().end_timestamp_micros());
 }
 
 TEST(FiltersTest, RowKeysRegex) {
-  auto proto =
-      bigtable::Filter::RowKeysRegex("[A-Za-z][A-Za-z0-9_]*").as_proto();
+  auto proto = Filter::RowKeysRegex("[A-Za-z][A-Za-z0-9_]*").as_proto();
   EXPECT_EQ("[A-Za-z][A-Za-z0-9_]*", proto.row_key_regex_filter());
 }
 
 TEST(FiltersTest, CellsRowLimit) {
-  auto proto = bigtable::Filter::CellsRowLimit(3).as_proto();
+  auto proto = Filter::CellsRowLimit(3).as_proto();
   EXPECT_EQ(3, proto.cells_per_row_limit_filter());
 }
 
 TEST(FiltersTest, ValueRegex) {
-  auto proto = bigtable::Filter::ValueRegex("foo:\\n  'bar.*'").as_proto();
+  auto proto = Filter::ValueRegex("foo:\\n  'bar.*'").as_proto();
   EXPECT_EQ("foo:\\n  'bar.*'", proto.value_regex_filter());
 }
 
 TEST(FiltersTest, CellsRowOffset) {
-  auto proto = bigtable::Filter::CellsRowOffset(42).as_proto();
+  auto proto = Filter::CellsRowOffset(42).as_proto();
   EXPECT_EQ(42, proto.cells_per_row_offset_filter());
 }
 
 TEST(FiltersTEst, RowSample) {
-  auto proto = bigtable::Filter::RowSample(0.5).as_proto();
+  auto proto = Filter::RowSample(0.5).as_proto();
   ASSERT_DOUBLE_EQ(0.5, proto.row_sample_filter());
 }
 
 TEST(FiltersTest, ValueRangeLeftOpen) {
-  auto proto =
-      bigtable::Filter::ValueRangeLeftOpen("2017-02", "2017-09").as_proto();
+  auto proto = Filter::ValueRangeLeftOpen("2017-02", "2017-09").as_proto();
   ASSERT_EQ(btproto::ValueRange::kStartValueOpen,
             proto.value_range_filter().start_value_case());
   ASSERT_EQ(btproto::ValueRange::kEndValueClosed,
@@ -116,7 +119,7 @@ TEST(FiltersTest, ValueRangeLeftOpen) {
 }
 
 TEST(FiltersTest, ValueRangeRightOpen) {
-  auto proto = bigtable::Filter::ValueRangeRightOpen("2017", "2018").as_proto();
+  auto proto = Filter::ValueRangeRightOpen("2017", "2018").as_proto();
   ASSERT_EQ(btproto::ValueRange::kStartValueClosed,
             proto.value_range_filter().start_value_case());
   ASSERT_EQ(btproto::ValueRange::kEndValueOpen,
@@ -126,7 +129,7 @@ TEST(FiltersTest, ValueRangeRightOpen) {
 }
 
 TEST(FiltersTest, ValueRangeClosed) {
-  auto proto = bigtable::Filter::ValueRangeClosed("2017", "2018").as_proto();
+  auto proto = Filter::ValueRangeClosed("2017", "2018").as_proto();
   ASSERT_EQ(btproto::ValueRange::kStartValueClosed,
             proto.value_range_filter().start_value_case());
   ASSERT_EQ(btproto::ValueRange::kEndValueClosed,
@@ -136,7 +139,7 @@ TEST(FiltersTest, ValueRangeClosed) {
 }
 
 TEST(FiltersTest, ValueRangeOpen) {
-  auto proto = bigtable::Filter::ValueRangeOpen("2016", "2019").as_proto();
+  auto proto = Filter::ValueRangeOpen("2016", "2019").as_proto();
   ASSERT_EQ(btproto::ValueRange::kStartValueOpen,
             proto.value_range_filter().start_value_case());
   ASSERT_EQ(btproto::ValueRange::kEndValueOpen,
@@ -146,8 +149,7 @@ TEST(FiltersTest, ValueRangeOpen) {
 }
 
 TEST(FiltersTest, ColumnRangeRightOpen) {
-  auto proto =
-      bigtable::Filter::ColumnRangeRightOpen("fam", "col1", "col3").as_proto();
+  auto proto = Filter::ColumnRangeRightOpen("fam", "col1", "col3").as_proto();
   ASSERT_EQ(btproto::ColumnRange::kStartQualifierClosed,
             proto.column_range_filter().start_qualifier_case());
   ASSERT_EQ(btproto::ColumnRange::kEndQualifierOpen,
@@ -158,8 +160,7 @@ TEST(FiltersTest, ColumnRangeRightOpen) {
 }
 
 TEST(FiltersTest, ColumnRangeLeftOpen) {
-  auto proto =
-      bigtable::Filter::ColumnRangeLeftOpen("fam", "col1", "col3").as_proto();
+  auto proto = Filter::ColumnRangeLeftOpen("fam", "col1", "col3").as_proto();
   ASSERT_EQ(btproto::ColumnRange::kStartQualifierOpen,
             proto.column_range_filter().start_qualifier_case());
   ASSERT_EQ(btproto::ColumnRange::kEndQualifierClosed,
@@ -170,8 +171,7 @@ TEST(FiltersTest, ColumnRangeLeftOpen) {
 }
 
 TEST(FiltersTest, ColumnRangeClosed) {
-  auto proto =
-      bigtable::Filter::ColumnRangeClosed("fam", "col1", "col3").as_proto();
+  auto proto = Filter::ColumnRangeClosed("fam", "col1", "col3").as_proto();
   ASSERT_EQ(btproto::ColumnRange::kStartQualifierClosed,
             proto.column_range_filter().start_qualifier_case());
   ASSERT_EQ(btproto::ColumnRange::kEndQualifierClosed,
@@ -182,8 +182,7 @@ TEST(FiltersTest, ColumnRangeClosed) {
 }
 
 TEST(FiltersTest, ColumnRangeOpen) {
-  auto proto =
-      bigtable::Filter::ColumnRangeOpen("fam", "col1", "col3").as_proto();
+  auto proto = Filter::ColumnRangeOpen("fam", "col1", "col3").as_proto();
   ASSERT_EQ(btproto::ColumnRange::kStartQualifierOpen,
             proto.column_range_filter().start_qualifier_case());
   ASSERT_EQ(btproto::ColumnRange::kEndQualifierOpen,
@@ -194,18 +193,18 @@ TEST(FiltersTest, ColumnRangeOpen) {
 }
 
 TEST(FiltersTest, StripValueTransformer) {
-  auto proto = bigtable::Filter::StripValueTransformer().as_proto();
+  auto proto = Filter::StripValueTransformer().as_proto();
   EXPECT_TRUE(proto.strip_value_transformer());
 }
 
 TEST(FiltersTest, ApplyLabelTransformer) {
-  auto proto = bigtable::Filter::ApplyLabelTransformer("foo").as_proto();
+  auto proto = Filter::ApplyLabelTransformer("foo").as_proto();
   EXPECT_EQ("foo", proto.apply_label_transformer());
 }
 
 /// @test Verify that `bigtable::Filter::Condition` works as expected.
 TEST(FiltersTest, Condition) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Condition(F::ColumnRegex("foo"), F::CellsRowLimit(1),
                              F::CellsRowOffset(2));
   auto const& proto = filter.as_proto();
@@ -220,7 +219,7 @@ TEST(FiltersTest, Condition) {
 
 /// @test Verify that `bigtable::Filter::Chain` works as expected.
 TEST(FiltersTest, ChainMultipleArgs) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Chain(F::FamilyRegex("fam"), F::ColumnRegex("col"),
                          F::CellsRowOffset(2), F::Latest(1));
   auto const& proto = filter.as_proto();
@@ -235,7 +234,7 @@ TEST(FiltersTest, ChainMultipleArgs) {
 
 /// @test Verify that `bigtable::Filter::Chain` works as expected.
 TEST(FiltersTest, ChainNoArgs) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Chain();
   auto const& proto = filter.as_proto();
   ASSERT_TRUE(proto.has_chain());
@@ -245,7 +244,7 @@ TEST(FiltersTest, ChainNoArgs) {
 
 /// @test Verify that `bigtable::Filter::Chain` works as expected.
 TEST(FiltersTest, ChainOneArg) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Chain(F::Latest(2));
   auto const& proto = filter.as_proto();
   ASSERT_TRUE(proto.has_chain());
@@ -256,7 +255,7 @@ TEST(FiltersTest, ChainOneArg) {
 
 /// @test Verify that `bigtable::Filter::ChainFromRange` works as expected.
 TEST(FiltersTest, ChainFromRangeMany) {
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{F::FamilyRegex("fam"), F::ColumnRegex("col"),
                                    F::CellsRowOffset(2), F::Latest(1)};
   auto filter =
@@ -273,7 +272,7 @@ TEST(FiltersTest, ChainFromRangeMany) {
 
 /// @test Verify that `bigtable::Filter::ChainFromRange` works as expected.
 TEST(FiltersTest, ChainFromRangeEmpty) {
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{};
   auto filter =
       F::ChainFromRange(filter_collection.begin(), filter_collection.end());
@@ -285,7 +284,7 @@ TEST(FiltersTest, ChainFromRangeEmpty) {
 
 /// @test Verify that `bigtable::Filter::ChainFromRange` works as expected.
 TEST(FiltersTest, ChainFromRangeSingle) {
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{F::Latest(2)};
   auto filter =
       F::ChainFromRange(filter_collection.begin(), filter_collection.end());
@@ -298,7 +297,7 @@ TEST(FiltersTest, ChainFromRangeSingle) {
 
 /// @test Verify that `bigtable::Filter::Interleave` works as expected.
 TEST(FiltersTest, InterleaveMultipleArgs) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Interleave(F::FamilyRegex("fam"), F::ColumnRegex("col"),
                               F::CellsRowOffset(2), F::Latest(1));
   auto const& proto = filter.as_proto();
@@ -313,7 +312,7 @@ TEST(FiltersTest, InterleaveMultipleArgs) {
 
 /// @test Verify that `bigtable::Filter::Interleave` works as expected.
 TEST(FiltersTest, InterleaveNoArgs) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Interleave();
   auto const& proto = filter.as_proto();
   ASSERT_TRUE(proto.has_interleave());
@@ -323,7 +322,7 @@ TEST(FiltersTest, InterleaveNoArgs) {
 
 /// @test Verify that `bigtable::Filter::Interleave` works as expected.
 TEST(FiltersTest, InterleaveOneArg) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Interleave(F::Latest(2));
   auto const& proto = filter.as_proto();
   ASSERT_TRUE(proto.has_interleave());
@@ -334,7 +333,7 @@ TEST(FiltersTest, InterleaveOneArg) {
 
 /// @test Verify that `bigtable::Filter::InterleaveFromRange` works as expected.
 TEST(FiltersTest, InterleaveFromRangeMany) {
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{F::FamilyRegex("fam"), F::ColumnRegex("col"),
                                    F::CellsRowOffset(2), F::Latest(1)};
   auto filter = F::InterleaveFromRange(filter_collection.begin(),
@@ -351,7 +350,7 @@ TEST(FiltersTest, InterleaveFromRangeMany) {
 
 /// @test Verify that `bigtable::Filter::InterleaveFromRange` works as expected.
 TEST(FiltersTest, InterleaveFromRangeEmpty) {
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{};
   auto filter = F::InterleaveFromRange(filter_collection.begin(),
                                        filter_collection.end());
@@ -363,7 +362,7 @@ TEST(FiltersTest, InterleaveFromRangeEmpty) {
 
 /// @test Verify that `bigtable::Filter::InterleaveFromRange` works as expected.
 TEST(FiltersTest, InterleaveFromRangeSingle) {
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{F::Latest(2)};
   auto filter = F::InterleaveFromRange(filter_collection.begin(),
                                        filter_collection.end());
@@ -376,14 +375,14 @@ TEST(FiltersTest, InterleaveFromRangeSingle) {
 
 /// @test Verify that `bigtable::Filter::Sink` works as expected.
 TEST(FiltersTest, Sink) {
-  auto filter = bigtable::Filter::Sink();
+  auto filter = Filter::Sink();
   auto const& proto = filter.as_proto();
   ASSERT_TRUE(proto.sink());
 }
 
 /// @test Verify that `bigtable::Filter::as_proto` works as expected.
 TEST(FiltersTest, MoveProto) {
-  using F = bigtable::Filter;
+  using F = Filter;
   auto filter = F::Chain(F::FamilyRegex("fam"), F::ColumnRegex("col"),
                          F::CellsRowOffset(2), F::Latest(1));
   auto proto_copy = filter.as_proto();
@@ -404,7 +403,7 @@ TEST(FiltersTest, MoveProto) {
 
 /// @test Verify that the ctor receiving a v2 RowFilter works as expected.
 TEST(FiltersTest, RowFilterCtor) {
-  using F = bigtable::Filter;
+  using F = Filter;
   // We use a simple filter just as a sanity check.
   btproto::RowFilter row_filter;
   row_filter.set_row_key_regex_filter("[A-Za-z][A-Za-z0-9_]*");
@@ -414,3 +413,9 @@ TEST(FiltersTest, RowFilterCtor) {
   differencer.ReportDifferencesToString(&delta);
   EXPECT_TRUE(differencer.Compare(row_filter, filter.as_proto())) << delta;
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/idempotent_mutation_policy_test.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy_test.cc
@@ -16,34 +16,43 @@
 #include "google/cloud/testing_util/chrono_literals.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 
 /// @test Verify that the default policy works as expected.
 TEST(IdempotentMutationPolicyTest, Simple) {
-  auto policy = bigtable::DefaultIdempotentMutationPolicy();
-  EXPECT_TRUE(policy->is_idempotent(
-      bigtable::DeleteFromColumn("fam", "col", 0_us, 10_us).op));
-  EXPECT_TRUE(policy->is_idempotent(bigtable::DeleteFromFamily("fam").op));
-
+  auto policy = DefaultIdempotentMutationPolicy();
   EXPECT_TRUE(
-      policy->is_idempotent(bigtable::SetCell("fam", "col", 0_ms, "v1").op));
-  EXPECT_FALSE(policy->is_idempotent(bigtable::SetCell("fam", "c2", "v2").op));
+      policy->is_idempotent(DeleteFromColumn("fam", "col", 0_us, 10_us).op));
+  EXPECT_TRUE(policy->is_idempotent(DeleteFromFamily("fam").op));
+
+  EXPECT_TRUE(policy->is_idempotent(SetCell("fam", "col", 0_ms, "v1").op));
+  EXPECT_FALSE(policy->is_idempotent(SetCell("fam", "c2", "v2").op));
 }
 
 /// @test Verify that bigtable::AlwaysRetryMutationPolicy works as expected.
 TEST(IdempotentMutationPolicyTest, AlwaysRetry) {
-  bigtable::AlwaysRetryMutationPolicy policy;
-  EXPECT_TRUE(policy.is_idempotent(
-      bigtable::DeleteFromColumn("fam", "col", 0_us, 10_us).op));
-  EXPECT_TRUE(policy.is_idempotent(bigtable::DeleteFromFamily("fam").op));
-
+  AlwaysRetryMutationPolicy policy;
   EXPECT_TRUE(
-      policy.is_idempotent(bigtable::SetCell("fam", "col", 0_ms, "v1").op));
-  EXPECT_TRUE(policy.is_idempotent(bigtable::SetCell("fam", "c2", "v2").op));
+      policy.is_idempotent(DeleteFromColumn("fam", "col", 0_us, 10_us).op));
+  EXPECT_TRUE(policy.is_idempotent(DeleteFromFamily("fam").op));
+
+  EXPECT_TRUE(policy.is_idempotent(SetCell("fam", "col", 0_ms, "v1").op));
+  EXPECT_TRUE(policy.is_idempotent(SetCell("fam", "c2", "v2").op));
 
   auto clone = policy.clone();
-  EXPECT_TRUE(clone->is_idempotent(bigtable::SetCell("f", "c", "v").op));
-  EXPECT_TRUE(clone->is_idempotent(bigtable::SetCell("f", "c", 10_ms, "v").op));
+  EXPECT_TRUE(clone->is_idempotent(SetCell("f", "c", "v").op));
+  EXPECT_TRUE(clone->is_idempotent(SetCell("f", "c", 10_ms, "v").op));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_admin_client_test.cc
+++ b/google/cloud/bigtable/instance_admin_client_test.cc
@@ -15,11 +15,15 @@
 #include "google/cloud/bigtable/instance_admin_client.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(InstanceAdminClientTest, Default) {
-  auto admin_client = bigtable::CreateDefaultInstanceAdminClient(
-      "test-project", bigtable::ClientOptions().set_connection_pool_size(1));
+  auto admin_client = CreateDefaultInstanceAdminClient(
+      "test-project", ClientOptions().set_connection_pool_size(1));
   ASSERT_TRUE(admin_client);
   EXPECT_EQ("test-project", admin_client->project());
 
@@ -34,3 +38,9 @@ TEST(InstanceAdminClientTest, Default) {
   EXPECT_TRUE(stub1);
   EXPECT_NE(stub0.get(), stub1.get());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -26,11 +26,16 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 namespace {
-namespace btadmin = google::bigtable::admin::v2;
-namespace bigtable = google::cloud::bigtable;
 
-using MockAdminClient = bigtable::testing::MockInstanceAdminClient;
+namespace btadmin = ::google::bigtable::admin::v2;
+
+using MockAdminClient =
+    ::google::cloud::bigtable::testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
@@ -192,26 +197,24 @@ struct MockRpcFactory {
   }
 };
 
-}  // anonymous namespace
-
 /// @test Verify basic functionality in the `bigtable::InstanceAdmin` class.
 TEST_F(InstanceAdminTest, Default) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_EQ("the-project", tested.project_id());
 }
 
 TEST_F(InstanceAdminTest, CopyConstructor) {
-  bigtable::InstanceAdmin source(client_);
+  InstanceAdmin source(client_);
   std::string const& expected = source.project_id();
   // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-  bigtable::InstanceAdmin copy(source);
+  InstanceAdmin copy(source);
   EXPECT_EQ(expected, copy.project_id());
 }
 
 TEST_F(InstanceAdminTest, MoveConstructor) {
-  bigtable::InstanceAdmin source(client_);
+  InstanceAdmin source(client_);
   std::string expected = source.project_id();
-  bigtable::InstanceAdmin copy(std::move(source));
+  InstanceAdmin copy(std::move(source));
   EXPECT_EQ(expected, copy.project_id());
 }
 
@@ -220,11 +223,11 @@ TEST_F(InstanceAdminTest, CopyAssignment) {
       std::make_shared<MockAdminClient>();
   std::string other_project = "other-project";
   EXPECT_CALL(*other_client, project())
-      .WillRepeatedly(testing::ReturnRef(other_project));
+      .WillRepeatedly(ReturnRef(other_project));
 
-  bigtable::InstanceAdmin source(client_);
+  InstanceAdmin source(client_);
   std::string const& expected = source.project_id();
-  bigtable::InstanceAdmin dest(other_client);
+  InstanceAdmin dest(other_client);
   EXPECT_NE(expected, dest.project_id());
   dest = source;
   EXPECT_EQ(expected, dest.project_id());
@@ -235,11 +238,11 @@ TEST_F(InstanceAdminTest, MoveAssignment) {
       std::make_shared<MockAdminClient>();
   std::string other_project = "other-project";
   EXPECT_CALL(*other_client, project())
-      .WillRepeatedly(testing::ReturnRef(other_project));
+      .WillRepeatedly(ReturnRef(other_project));
 
-  bigtable::InstanceAdmin source(client_);
+  InstanceAdmin source(client_);
   std::string expected = source.project_id();
-  bigtable::InstanceAdmin dest(other_client);
+  InstanceAdmin dest(other_client);
   EXPECT_NE(expected, dest.project_id());
   dest = std::move(source);
   EXPECT_EQ(expected, dest.project_id());
@@ -248,7 +251,7 @@ TEST_F(InstanceAdminTest, MoveAssignment) {
 /// @test Verify that `bigtable::InstanceAdmin::ListInstances` works in the easy
 /// case.
 TEST_F(InstanceAdminTest, ListInstances) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_list_instances = create_list_instances_lambda("", "", {"t0", "t1"});
   EXPECT_CALL(*client_, ListInstances(_, _, _)).WillOnce(mock_list_instances);
 
@@ -264,7 +267,7 @@ TEST_F(InstanceAdminTest, ListInstances) {
 
 /// @test Verify that `bigtable::InstanceAdmin::ListInstances` handles failures.
 TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      btadmin::ListInstancesRequest const&,
                                      btadmin::ListInstancesResponse*) {
@@ -300,7 +303,7 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
  * unrecoverable failures.
  */
 TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, ListInstances(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
@@ -309,10 +312,10 @@ TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
   EXPECT_FALSE(tested.ListInstances());
 }
 
-/// @test Verify that DeleteInstance works in the positive case.
+/// @test Verify that `bigtable::DeleteInstance` works in the positive case.
 TEST_F(InstanceAdminTest, DeleteInstance) {
   using google::protobuf::Empty;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string expected_text = R"""(
   name: 'projects/the-project/instances/the-instance'
       )""";
@@ -326,7 +329,7 @@ TEST_F(InstanceAdminTest, DeleteInstance) {
 
 /// @test Verify unrecoverable error for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteInstance(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
@@ -336,7 +339,7 @@ TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
 
 /// @test Verify that recoverable error for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstanceRecoverableError) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteInstance(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
@@ -348,7 +351,7 @@ TEST_F(InstanceAdminTest, DeleteInstanceRecoverableError) {
 /// @test Verify that `bigtable::InstanceAdmin::ListClusters` works in the easy
 /// case.
 TEST_F(InstanceAdminTest, ListClusters) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string const& instance_id = "the-instance";
   auto mock_list_clusters =
       create_list_clusters_lambda("", "", instance_id, {"t0", "t1"});
@@ -365,7 +368,7 @@ TEST_F(InstanceAdminTest, ListClusters) {
 
 /// @test Verify that `bigtable::InstanceAdmin::ListClusters` handles failures.
 TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      btadmin::ListClustersRequest const&,
                                      btadmin::ListClustersResponse*) {
@@ -403,7 +406,7 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
  * unrecoverable failures.
  */
 TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, ListClusters(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
@@ -413,9 +416,9 @@ TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
   EXPECT_FALSE(tested.ListClusters(instance_id));
 }
 
-/// @test Verify positive scenario for GetCluster
+/// @test Verify positive scenario for `bigtable::GetCluster`
 TEST_F(InstanceAdminTest, GetCluster) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock = create_get_cluster_mock();
   EXPECT_CALL(*client_, GetCluster(_, _, _)).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
@@ -427,7 +430,7 @@ TEST_F(InstanceAdminTest, GetCluster) {
 
 /// @test Verify unrecoverable error for GetCluster
 TEST_F(InstanceAdminTest, GetClusterUnrecoverableError) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, GetCluster(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
@@ -436,7 +439,7 @@ TEST_F(InstanceAdminTest, GetClusterUnrecoverableError) {
 
 /// @test Verify recoverable errors for GetCluster
 TEST_F(InstanceAdminTest, GetClusterRecoverableError) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      btadmin::GetClusterRequest const&,
                                      btadmin::Cluster*) {
@@ -462,7 +465,7 @@ TEST_F(InstanceAdminTest, GetClusterRecoverableError) {
 /// @test Verify that DeleteCluster works in the positive case.
 TEST_F(InstanceAdminTest, DeleteCluster) {
   using google::protobuf::Empty;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string expected_text = R"""(
   name: 'projects/the-project/instances/the-instance/clusters/the-cluster'
       )""";
@@ -476,7 +479,7 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
 
 /// @test Verify unrecoverable error for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
@@ -486,7 +489,7 @@ TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
 
 /// @test Verify that recoverable error for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, DeleteCluster(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
@@ -499,7 +502,7 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
 TEST_F(InstanceAdminTest, GetIamPolicy) {
   using ::testing::_;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_policy = create_get_policy_mock();
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
@@ -511,7 +514,7 @@ TEST_F(InstanceAdminTest, GetIamPolicy) {
 TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
   using ::testing::_;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
       .WillOnce([](grpc::ClientContext* context,
                    ::google::iam::v1::GetIamPolicyRequest const&,
@@ -543,7 +546,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyUnrecoverableError) {
   using ::testing::_;
   using ::testing::Return;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
       .WillRepeatedly(
@@ -559,7 +562,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      iamproto::GetIamPolicyRequest const&,
@@ -583,7 +586,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
 TEST_F(InstanceAdminTest, GetNativeIamPolicy) {
   using ::testing::_;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_policy = create_get_policy_mock();
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
@@ -599,7 +602,7 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyUnrecoverableError) {
   using ::testing::_;
   using ::testing::Return;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
       .WillRepeatedly(
@@ -615,7 +618,7 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      iamproto::GetIamPolicyRequest const&,
@@ -639,7 +642,7 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
 }
 
 using MockAsyncIamPolicyReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
         ::google::iam::v1::Policy>;
 
 class AsyncGetIamPolicyTest : public ::testing::Test {
@@ -647,7 +650,7 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
   AsyncGetIamPolicyTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new bigtable::testing::MockInstanceAdminClient),
+        client_(new MockAdminClient),
         reader_(new MockAsyncIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncGetIamPolicy(_, _, _))
@@ -668,18 +671,18 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
 
  protected:
   void Start() {
-    bigtable::InstanceAdmin instance_admin(client_);
+    InstanceAdmin instance_admin(client_);
     user_future_ = instance_admin.AsyncGetIamPolicy(cq_, "test-instance");
   }
   void StartNative() {
-    bigtable::InstanceAdmin instance_admin(client_);
+    InstanceAdmin instance_admin(client_);
     user_native_future_ =
         instance_admin.AsyncGetNativeIamPolicy(cq_, "test-instance");
   }
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
-  bigtable::CompletionQueue cq_;
-  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client_;
+  CompletionQueue cq_;
+  std::shared_ptr<MockAdminClient> client_;
   google::cloud::future<google::cloud::StatusOr<google::cloud::IamPolicy>>
       user_future_;
   google::cloud::future<google::cloud::StatusOr<google::iam::v1::Policy>>
@@ -691,7 +694,7 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
 TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -715,7 +718,7 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
 TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -738,7 +741,7 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
 TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicy) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -762,7 +765,7 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicy) {
 TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicyUnrecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -785,7 +788,7 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicyUnrecoverableError) {
 TEST_F(InstanceAdminTest, SetIamPolicy) {
   using ::testing::_;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_policy = create_policy_with_params();
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
@@ -804,7 +807,7 @@ TEST_F(InstanceAdminTest, SetIamPolicyUnrecoverableError) {
   using ::testing::_;
   using ::testing::Return;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
       .WillRepeatedly(
@@ -821,7 +824,7 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      iamproto::SetIamPolicyRequest const&,
@@ -851,14 +854,14 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
 TEST_F(InstanceAdminTest, SetNativeIamPolicy) {
   using ::testing::_;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   auto mock_policy = create_policy_with_params();
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
-  auto iam_policy = bigtable::IamPolicy(
-      {bigtable::IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
-      "test-tag", 0);
+  auto iam_policy =
+      IamPolicy({IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
+                "test-tag", 0);
   auto policy = tested.SetIamPolicy(resource, iam_policy);
   ASSERT_STATUS_OK(policy);
 
@@ -871,16 +874,16 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyUnrecoverableError) {
   using ::testing::_;
   using ::testing::Return;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
   std::string resource = "test-resource";
-  auto iam_policy = bigtable::IamPolicy(
-      {bigtable::IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
-      "test-tag", 0);
+  auto iam_policy =
+      IamPolicy({IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
+                "test-tag", 0);
   EXPECT_FALSE(tested.SetIamPolicy(resource, iam_policy));
 }
 
@@ -889,7 +892,7 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      iamproto::SetIamPolicyRequest const&,
@@ -906,9 +909,9 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
       .WillOnce(mock_policy);
 
   std::string resource = "test-resource";
-  auto iam_policy = bigtable::IamPolicy(
-      {bigtable::IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
-      "test-tag", 0);
+  auto iam_policy =
+      IamPolicy({IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
+                "test-tag", 0);
   auto policy = tested.SetIamPolicy(resource, iam_policy);
   ASSERT_STATUS_OK(policy);
 
@@ -919,7 +922,7 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
 TEST_F(InstanceAdminTest, TestIamPermissions) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   auto mock_permission_set =
       [](grpc::ClientContext* context,
@@ -952,7 +955,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsUnrecoverableError) {
   using ::testing::_;
   using ::testing::Return;
 
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
       .WillRepeatedly(
@@ -968,7 +971,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsUnrecoverableError) {
 TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   auto mock_recoverable_failure = [](grpc::ClientContext* context,
                                      iamproto::TestIamPermissionsRequest const&,
@@ -1007,7 +1010,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
 }
 
 using MockAsyncDeleteClusterReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
         ::google::protobuf::Empty>;
 
 class AsyncDeleteClusterTest : public ::testing::Test {
@@ -1015,7 +1018,7 @@ class AsyncDeleteClusterTest : public ::testing::Test {
   AsyncDeleteClusterTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new bigtable::testing::MockInstanceAdminClient),
+        client_(new MockAdminClient),
         reader_(new MockAsyncDeleteClusterReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncDeleteCluster(_, _, _))
@@ -1038,14 +1041,14 @@ class AsyncDeleteClusterTest : public ::testing::Test {
 
  protected:
   void Start() {
-    bigtable::InstanceAdmin instance_admin(client_);
+    InstanceAdmin instance_admin(client_);
     user_future_ =
         instance_admin.AsyncDeleteCluster(cq_, "test-instance", "the-cluster");
   }
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
-  bigtable::CompletionQueue cq_;
-  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client_;
+  CompletionQueue cq_;
+  std::shared_ptr<MockAdminClient> client_;
   google::cloud::future<google::cloud::Status> user_future_;
   std::unique_ptr<MockAsyncDeleteClusterReader> reader_;
 };
@@ -1053,7 +1056,7 @@ class AsyncDeleteClusterTest : public ::testing::Test {
 /// @test Verify that AsyncDeleteCluster works in simple case.
 TEST_F(AsyncDeleteClusterTest, AsyncDeleteCluster) {
   using ::testing::_;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce(
@@ -1073,7 +1076,7 @@ TEST_F(AsyncDeleteClusterTest, AsyncDeleteCluster) {
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncDeleteCluster.
 TEST_F(AsyncDeleteClusterTest, AsyncDeleteClusterUnrecoverableError) {
   using ::testing::_;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce(
@@ -1092,7 +1095,7 @@ TEST_F(AsyncDeleteClusterTest, AsyncDeleteClusterUnrecoverableError) {
 }
 
 using MockAsyncSetIamPolicyReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
         ::google::iam::v1::Policy>;
 
 class AsyncSetIamPolicyTest : public ::testing::Test {
@@ -1100,7 +1103,7 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
   AsyncSetIamPolicyTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new bigtable::testing::MockInstanceAdminClient),
+        client_(new MockAdminClient),
         reader_(new MockAsyncSetIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncSetIamPolicy(_, _, _))
@@ -1121,7 +1124,7 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
 
  protected:
   void Start() {
-    bigtable::InstanceAdmin instance_admin(client_);
+    InstanceAdmin instance_admin(client_);
     user_future_ = instance_admin.AsyncSetIamPolicy(
         cq_, "test-instance",
         google::cloud::IamBindings("writer",
@@ -1130,17 +1133,16 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
   }
 
   void StartNative() {
-    bigtable::InstanceAdmin instance_admin(client_);
+    InstanceAdmin instance_admin(client_);
     user_native_future_ = instance_admin.AsyncSetIamPolicy(
         cq_, "test-instance",
-        bigtable::IamPolicy({bigtable::IamBinding(
-                                "writer", {"abc@gmail.com", "xyz@gmail.com"})},
-                            "test-tag", 0));
+        IamPolicy({IamBinding("writer", {"abc@gmail.com", "xyz@gmail.com"})},
+                  "test-tag", 0));
   }
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
-  bigtable::CompletionQueue cq_;
-  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client_;
+  CompletionQueue cq_;
+  std::shared_ptr<MockAdminClient> client_;
   google::cloud::future<google::cloud::StatusOr<google::cloud::IamPolicy>>
       user_future_;
   google::cloud::future<google::cloud::StatusOr<google::iam::v1::Policy>>
@@ -1152,7 +1154,7 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
 TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -1181,7 +1183,7 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
 TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -1204,7 +1206,7 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
 TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicy) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -1233,7 +1235,7 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicy) {
 TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicyUnrecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
@@ -1253,7 +1255,7 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicyUnrecoverableError) {
 }
 
 using MockAsyncTestIamPermissionsReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
         ::google::iam::v1::TestIamPermissionsResponse>;
 
 class AsyncTestIamPermissionsTest : public ::testing::Test {
@@ -1261,7 +1263,7 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
   AsyncTestIamPermissionsTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new bigtable::testing::MockInstanceAdminClient),
+        client_(new MockAdminClient),
         reader_(new MockAsyncTestIamPermissionsReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
     EXPECT_CALL(*client_, AsyncTestIamPermissions(_, _, _))
@@ -1285,14 +1287,14 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
 
  protected:
   void Start(std::vector<std::string> const& permissions) {
-    bigtable::InstanceAdmin instance_admin(client_);
+    InstanceAdmin instance_admin(client_);
     user_future_ = instance_admin.AsyncTestIamPermissions(cq_, "the-resource",
                                                           permissions);
   }
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
-  bigtable::CompletionQueue cq_;
-  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client_;
+  CompletionQueue cq_;
+  std::shared_ptr<MockAdminClient> client_;
   google::cloud::future<google::cloud::StatusOr<std::vector<std::string>>>
       user_future_;
   std::unique_ptr<MockAsyncTestIamPermissionsReader> reader_;
@@ -1302,7 +1304,7 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
 TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::TestIamPermissionsResponse* response,
@@ -1326,7 +1328,7 @@ TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
 TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissionsUnrecoverableError) {
   using ::testing::_;
   namespace iamproto = ::google::iam::v1;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
 
   EXPECT_CALL(*reader_, Finish(_, _, _))
       .WillOnce([](iamproto::TestIamPermissionsResponse* response,
@@ -1351,10 +1353,9 @@ class ValidContextMdAsyncTest : public ::testing::Test {
   ValidContextMdAsyncTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new bigtable::testing::MockInstanceAdminClient) {
-    EXPECT_CALL(*client_, project())
-        .WillRepeatedly(::testing::ReturnRef(kProjectId));
-    instance_admin_ = absl::make_unique<bigtable::InstanceAdmin>(client_);
+        client_(new MockAdminClient) {
+    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
+    instance_admin_ = absl::make_unique<InstanceAdmin>(client_);
   }
 
  protected:
@@ -1370,14 +1371,14 @@ class ValidContextMdAsyncTest : public ::testing::Test {
   }
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
-  bigtable::CompletionQueue cq_;
-  std::shared_ptr<bigtable::testing::MockInstanceAdminClient> client_;
-  std::unique_ptr<bigtable::InstanceAdmin> instance_admin_;
+  CompletionQueue cq_;
+  std::shared_ptr<MockAdminClient> client_;
+  std::unique_ptr<InstanceAdmin> instance_admin_;
 };
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::CreateAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateAppProfile(_, _, _))
@@ -1389,13 +1390,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateAppProfile"));
   FinishTest(instance_admin_->AsyncCreateAppProfile(
-      cq_, "the-instance",
-      bigtable::AppProfileConfig::MultiClusterUseAny("prof")));
+      cq_, "the-instance", AppProfileConfig::MultiClusterUseAny("prof")));
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::DeleteAppProfileRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteAppProfile(_, _, _))
@@ -1416,8 +1416,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::DeleteInstanceRequest,
-                                                google::protobuf::Empty>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::DeleteInstanceRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteInstance(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1435,8 +1435,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::GetAppProfileRequest,
-                                                btadmin::AppProfile>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::GetAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetAppProfile(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1450,8 +1450,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::GetClusterRequest,
-                                                btadmin::Cluster>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::GetClusterRequest, btadmin::Cluster>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetCluster(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1465,8 +1465,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::GetInstanceRequest,
-                                                btadmin::Instance>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::GetInstanceRequest, btadmin::Instance>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetInstance(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1479,8 +1479,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::CreateClusterRequest,
-                                                google::longrunning::Operation>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::CreateClusterRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateCluster(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1495,14 +1495,14 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateCluster"));
   FinishTest(instance_admin_->AsyncCreateCluster(
-      cq_, bigtable::ClusterConfig("loc1", 3, bigtable::ClusterConfig::SSD),
-      "the-instance", "the-cluster"));
+      cq_, ClusterConfig("loc1", 3, ClusterConfig::SSD), "the-instance",
+      "the-cluster"));
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::CreateInstanceRequest,
-                                                google::longrunning::Operation>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::CreateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateInstance(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1513,12 +1513,12 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateInstance"));
   FinishTest(instance_admin_->AsyncCreateInstance(
-      cq_, bigtable::InstanceConfig("the-instance", "Displayed instance", {})));
+      cq_, InstanceConfig("the-instance", "Displayed instance", {})));
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::UpdateAppProfileRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateAppProfile(_, _, _))
@@ -1530,13 +1530,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin.UpdateAppProfile"));
   FinishTest(instance_admin_->AsyncUpdateAppProfile(
-      cq_, "the-instance", "the-profile", bigtable::AppProfileUpdateConfig()));
+      cq_, "the-instance", "the-profile", AppProfileUpdateConfig()));
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<btadmin::Cluster,
-                                                google::longrunning::Operation>
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+      btadmin::Cluster, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateCluster(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -1547,18 +1547,16 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
               name: "projects/the-project/instances/the-instance/clusters/the-cluster"
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin.UpdateCluster"));
-  auto cluster =
-      bigtable::ClusterConfig("loc1", 3, bigtable::ClusterConfig::SSD)
-          .as_proto();
+  auto cluster = ClusterConfig("loc1", 3, ClusterConfig::SSD).as_proto();
   cluster.set_name(
       "projects/the-project/instances/the-instance/clusters/the-cluster");
   FinishTest(instance_admin_->AsyncUpdateCluster(
-      cq_, bigtable::ClusterConfig(std::move(cluster))));
+      cq_, ClusterConfig(std::move(cluster))));
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateInstance) {
   using ::testing::_;
-  bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::PartialUpdateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateInstance(_, _, _))
@@ -1570,14 +1568,14 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateInstance) {
           )""",
           "google.bigtable.admin.v2.BigtableInstanceAdmin."
           "PartialUpdateInstance"));
-  bigtable::Instance instance;
+  Instance instance;
   instance.set_name("projects/the-project/instances/the-instance");
   FinishTest(instance_admin_->AsyncUpdateInstance(
-      cq_, bigtable::InstanceUpdateConfig(std::move(instance))));
+      cq_, InstanceUpdateConfig(std::move(instance))));
 }
 
 TEST_F(InstanceAdminTest, CreateAppProfile) {
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string expected_text = R"""(
       parent: "projects/the-project/instances/the-instance"
       app_profile_id: "prof"
@@ -1589,12 +1587,12 @@ TEST_F(InstanceAdminTest, CreateAppProfile) {
              "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateAppProfile");
   EXPECT_CALL(*client_, CreateAppProfile(_, _, _)).WillOnce(mock);
   ASSERT_STATUS_OK(tested.CreateAppProfile(
-      "the-instance", bigtable::AppProfileConfig::MultiClusterUseAny("prof")));
+      "the-instance", AppProfileConfig::MultiClusterUseAny("prof")));
 }
 
 TEST_F(InstanceAdminTest, DeleteAppProfile) {
   using google::protobuf::Empty;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string expected_text = R"""(
       name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
       ignore_warnings: true
@@ -1608,7 +1606,7 @@ TEST_F(InstanceAdminTest, DeleteAppProfile) {
 
 TEST_F(InstanceAdminTest, GetAppProfile) {
   using google::protobuf::Empty;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string expected_text = R"""(
       name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
       )""";
@@ -1623,7 +1621,7 @@ TEST_F(InstanceAdminTest, GetAppProfile) {
 
 TEST_F(InstanceAdminTest, GetInstance) {
   using google::protobuf::Empty;
-  bigtable::InstanceAdmin tested(client_);
+  InstanceAdmin tested(client_);
   std::string expected_text = R"""(
       name: "projects/the-project/instances/the-instance"
       )""";
@@ -1634,3 +1632,9 @@ TEST_F(InstanceAdminTest, GetInstance) {
   EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(mock);
   ASSERT_STATUS_OK(tested.GetInstance("the-instance"));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_config_test.cc
+++ b/google/cloud/bigtable/instance_config_test.cc
@@ -15,12 +15,15 @@
 #include "google/cloud/bigtable/instance_config.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(InstanceConfigTest, Constructor) {
-  bigtable::InstanceConfig config(
-      "my-instance", "pretty name",
-      {{"my-cluster", {"somewhere", 7, bigtable::ClusterConfig::SSD}}});
+  InstanceConfig config("my-instance", "pretty name",
+                        {{"my-cluster", {"somewhere", 7, ClusterConfig::SSD}}});
   auto const& proto = config.as_proto();
   EXPECT_EQ("my-instance", proto.instance_id());
   EXPECT_EQ("pretty name", proto.instance().display_name());
@@ -28,17 +31,16 @@ TEST(InstanceConfigTest, Constructor) {
   auto cluster = proto.clusters().at("my-cluster");
   EXPECT_EQ("somewhere", cluster.location());
   EXPECT_EQ(7, cluster.serve_nodes());
-  EXPECT_EQ(bigtable::ClusterConfig::SSD, cluster.default_storage_type());
+  EXPECT_EQ(ClusterConfig::SSD, cluster.default_storage_type());
 }
 
 TEST(InstanceConfigTest, ConstructorManyClusters) {
-  bigtable::InstanceConfig config(
-      "my-instance", "pretty name",
-      {
-          {"cluster-1", {"somewhere", 7, bigtable::ClusterConfig::SSD}},
-          {"cluster-2", {"elsewhere", 7, bigtable::ClusterConfig::HDD}},
-          {"cluster-3", {"nowhere", 17, bigtable::ClusterConfig::HDD}},
-      });
+  InstanceConfig config("my-instance", "pretty name",
+                        {
+                            {"cluster-1", {"somewhere", 7, ClusterConfig::SSD}},
+                            {"cluster-2", {"elsewhere", 7, ClusterConfig::HDD}},
+                            {"cluster-3", {"nowhere", 17, ClusterConfig::HDD}},
+                        });
   auto const& proto = config.as_proto();
   EXPECT_EQ("my-instance", proto.instance_id());
   EXPECT_EQ("pretty name", proto.instance().display_name());
@@ -47,20 +49,19 @@ TEST(InstanceConfigTest, ConstructorManyClusters) {
   auto c1 = proto.clusters().at("cluster-1");
   EXPECT_EQ("somewhere", c1.location());
   EXPECT_EQ(7, c1.serve_nodes());
-  EXPECT_EQ(bigtable::ClusterConfig::SSD, c1.default_storage_type());
+  EXPECT_EQ(ClusterConfig::SSD, c1.default_storage_type());
 
   auto c3 = proto.clusters().at("cluster-3");
   EXPECT_EQ("nowhere", c3.location());
   EXPECT_EQ(17, c3.serve_nodes());
-  EXPECT_EQ(bigtable::ClusterConfig::HDD, c3.default_storage_type());
+  EXPECT_EQ(ClusterConfig::HDD, c3.default_storage_type());
 }
 
 TEST(InstanceConfigTest, SetLabels) {
-  bigtable::InstanceConfig config(
-      "my-instance", "pretty name",
-      {
-          {"cluster-1", {"somewhere", 7, bigtable::ClusterConfig::SSD}},
-      });
+  InstanceConfig config("my-instance", "pretty name",
+                        {
+                            {"cluster-1", {"somewhere", 7, ClusterConfig::SSD}},
+                        });
 
   config.insert_label("foo", "bar").emplace_label("baz", "qux");
 
@@ -73,3 +74,9 @@ TEST(InstanceConfigTest, SetLabels) {
   EXPECT_EQ("bar", proto.instance().labels().at("foo"));
   EXPECT_EQ("qux", proto.instance().labels().at("baz"));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/instance_update_config_test.cc
+++ b/google/cloud/bigtable/instance_update_config_test.cc
@@ -16,8 +16,13 @@
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 namespace btadmin = ::google::bigtable::admin::v2;
-namespace bigtable = google::cloud::bigtable;
 
 TEST(InstanceUpdateConfigTest, Constructor) {
   std::string instance_text = R"(
@@ -36,9 +41,9 @@ TEST(InstanceUpdateConfigTest, Constructor) {
   )";
 
   btadmin::Instance instance;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(instance_text, &instance));
-  bigtable::InstanceUpdateConfig config(std::move(instance));
+  ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(instance_text,
+                                                              &instance));
+  InstanceUpdateConfig config(std::move(instance));
   auto const& proto = config.as_proto();
   EXPECT_EQ("projects/my-project/instances/test-instance",
             proto.instance().name());
@@ -63,9 +68,9 @@ TEST(InstanceUpdateConfigTest, UpdateMask) {
   )";
 
   btadmin::Instance instance;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(instance_text, &instance));
-  bigtable::InstanceUpdateConfig config(std::move(instance));
+  ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(instance_text,
+                                                              &instance));
+  InstanceUpdateConfig config(std::move(instance));
   config.set_display_name("foo1");
   auto proto = config.as_proto();
   EXPECT_EQ("projects/my-project/instances/test-instance",
@@ -89,9 +94,9 @@ TEST(InstanceUpdateConfigTest, SetLabels) {
   )";
 
   btadmin::Instance instance;
-  ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(instance_text, &instance));
-  bigtable::InstanceUpdateConfig config(std::move(instance));
+  ASSERT_TRUE(::google::protobuf::TextFormat::ParseFromString(instance_text,
+                                                              &instance));
+  InstanceUpdateConfig config(std::move(instance));
 
   config.insert_label("foo", "bar").emplace_label("baz", "qux");
 
@@ -103,3 +108,9 @@ TEST(InstanceUpdateConfigTest, SetLabels) {
   EXPECT_EQ("bar", proto.instance().labels().at("foo"));
   EXPECT_EQ("qux", proto.instance().labels().at("baz"));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/prefix_range_end_test.cc
+++ b/google/cloud/bigtable/internal/prefix_range_end_test.cc
@@ -18,8 +18,8 @@
 namespace google {
 namespace cloud {
 namespace bigtable {
-namespace internal {
 inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
 namespace {
 
 TEST(PrefixRangeEndTest, Simple) {
@@ -42,8 +42,8 @@ TEST(PrefixRangeEndTest, MostlyFFs) {
 }
 
 }  // namespace
-}  // namespace BIGTABLE_CLIENT_NS
 }  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/prefix_range_end_test.cc
+++ b/google/cloud/bigtable/internal/prefix_range_end_test.cc
@@ -15,23 +15,35 @@
 #include "google/cloud/bigtable/internal/prefix_range_end.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace internal {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(PrefixRangeEndTest, Simple) {
   // This test assumes ASCII.
-  EXPECT_EQ("foo0", bigtable::internal::PrefixRangeEnd("foo/"));
-  EXPECT_EQ("fop", bigtable::internal::PrefixRangeEnd("foo"));
+  EXPECT_EQ("foo0", PrefixRangeEnd("foo/"));
+  EXPECT_EQ("fop", PrefixRangeEnd("foo"));
 }
 
 TEST(PrefixRangeEndTest, AllFFs) {
   char const* all_ff = "\xFF\xFF\xFF";
-  auto actual = bigtable::internal::PrefixRangeEnd(std::string(all_ff, 3));
+  auto actual = PrefixRangeEnd(std::string(all_ff, 3));
   EXPECT_EQ("", actual);
 }
 
 TEST(PrefixRangeEndTest, MostlyFFs) {
   char const* mostly_ff = "\xA0\xFF\xFF";
   char const* expected = "\xA1\x00\x00";
-  auto actual = bigtable::internal::PrefixRangeEnd(std::string(mostly_ff, 3));
+  auto actual = PrefixRangeEnd(std::string(mostly_ff, 3));
   EXPECT_EQ(std::string(expected, 3), actual);
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace internal
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -24,8 +24,15 @@
 #include <sstream>
 #include <vector>
 
-using google::bigtable::v2::ReadRowsResponse_CellChunk;
-using google::cloud::bigtable::internal::ReadRowsParser;
+namespace google {
+namespace cloud {
+namespace bigtable {
+namespace internal {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
+using ::google::bigtable::v2::ReadRowsResponse_CellChunk;
+using ::google::cloud::bigtable::internal::ReadRowsParser;
 
 TEST(ReadRowsParserTest, NoChunksNoRowsSucceeds) {
   grpc::Status status;
@@ -134,11 +141,6 @@ TEST(ReadRowsParserTest, NextWithNoDataThrows) {
 }
 
 // **** Acceptance tests helpers ****
-
-namespace google {
-namespace cloud {
-namespace bigtable {
-
 // Can also be used by gtest to print Cell values
 void PrintTo(Cell const& c, std::ostream* os) {
   *os << "rk: " << std::string(c.row_key()) << "\n";
@@ -161,10 +163,6 @@ std::string CellToString(Cell const& cell) {
   return ss.str();
 }
 
-}  // namespace bigtable
-}  // namespace cloud
-}  // namespace google
-
 class AcceptanceTest : public ::testing::Test {
  protected:
   std::vector<std::string> ExtractCells() {
@@ -172,8 +170,7 @@ class AcceptanceTest : public ::testing::Test {
 
     for (auto const& r : rows_) {
       std::transform(r.cells().begin(), r.cells().end(),
-                     std::back_inserter(cells),
-                     google::cloud::bigtable::CellToString);
+                     std::back_inserter(cells), CellToString);
     }
     return cells;
   }
@@ -223,3 +220,10 @@ class AcceptanceTest : public ::testing::Test {
 
 // Auto-generated acceptance tests
 #include "google/cloud/bigtable/internal/readrowsparser_acceptance_tests.inc"
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace internal
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -32,7 +32,6 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 using ::google::bigtable::v2::ReadRowsResponse_CellChunk;
-using ::google::cloud::bigtable::internal::ReadRowsParser;
 
 TEST(ReadRowsParserTest, NoChunksNoRowsSucceeds) {
   grpc::Status status;

--- a/google/cloud/bigtable/internal/readrowsparser_test.cc
+++ b/google/cloud/bigtable/internal/readrowsparser_test.cc
@@ -27,8 +27,8 @@
 namespace google {
 namespace cloud {
 namespace bigtable {
-namespace internal {
 inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
 namespace {
 
 using ::google::bigtable::v2::ReadRowsResponse_CellChunk;
@@ -221,8 +221,8 @@ class AcceptanceTest : public ::testing::Test {
 #include "google/cloud/bigtable/internal/readrowsparser_acceptance_tests.inc"
 
 }  // namespace
-}  // namespace BIGTABLE_CLIENT_NS
 }  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -21,20 +21,21 @@
 #include <map>
 #include <thread>
 
-namespace bigtable = google::cloud::bigtable;
-
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 namespace {
-class MetadataUpdatePolicyTest
-    : public bigtable::testing::EmbeddedServerTestFixture {};
-}  // anonymous namespace
+
+class MetadataUpdatePolicyTest : public testing::EmbeddedServerTestFixture {};
 
 using ::testing::HasSubstr;
 
 /// @test A test for setting metadata for admin operations.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServer) {
   grpc::string expected = "parent=" + std::string(kInstanceName);
-  auto gc = bigtable::GcRule::MaxNumVersions(42);
-  admin_->CreateTable(kTableName, bigtable::TableConfig({{"fam", gc}}, {}));
+  auto gc = GcRule::MaxNumVersions(42);
+  admin_->CreateTable(kTableName, TableConfig({{"fam", gc}}, {}));
   // Get metadata from embedded server
   auto client_metadata = admin_service_.client_metadata();
   auto range = client_metadata.equal_range("x-goog-request-params");
@@ -56,8 +57,7 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerLazyMetadata) {
 /// @test A test for setting metadata when table is known.
 TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
   grpc::string expected = "table_name=" + std::string(kTableName);
-  auto reader = table_->ReadRows(bigtable::RowSet("row1"), 1,
-                                 bigtable::Filter::PassAllFilter());
+  auto reader = table_->ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
   // lets make the RPC call to send metadata
   reader.begin();
   // Get metadata from embedded server
@@ -70,11 +70,16 @@ TEST_F(MetadataUpdatePolicyTest, RunWithEmbeddedServerParamTableName) {
 /// @test A cloning test for normal construction of metadata .
 TEST_F(MetadataUpdatePolicyTest, SimpleDefault) {
   auto const x_google_request_params = "parent=" + std::string(kInstanceName);
-  bigtable::MetadataUpdatePolicy created(kInstanceName,
-                                         bigtable::MetadataParamTypes::PARENT);
+  MetadataUpdatePolicy created(kInstanceName, MetadataParamTypes::PARENT);
   EXPECT_EQ(x_google_request_params, created.value());
   EXPECT_THAT(created.api_client_header(), HasSubstr("gl-cpp/"));
   EXPECT_THAT(created.api_client_header(), HasSubstr("gccl/"));
   EXPECT_THAT(created.api_client_header(),
               ::testing::AnyOf(HasSubstr("-noex-"), HasSubstr("-ex-")));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/read_modify_write_rule_test.cc
+++ b/google/cloud/bigtable/read_modify_write_rule_test.cc
@@ -15,13 +15,17 @@
 #include "google/cloud/bigtable/read_modify_write_rule.h"
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 namespace btproto = ::google::bigtable::v2;
-namespace bigtable = google::cloud::bigtable;
 
 TEST(ReadModifyWriteRuleTest, AppendValue) {
   auto const proto =
-      bigtable::ReadModifyWriteRule::AppendValue("fam", "col", "foo")
-          .as_proto();
+      ReadModifyWriteRule::AppendValue("fam", "col", "foo").as_proto();
   EXPECT_EQ(btproto::ReadModifyWriteRule::kAppendValue, proto.rule_case());
   EXPECT_EQ("foo", proto.append_value());
   EXPECT_EQ("fam", proto.family_name());
@@ -30,10 +34,15 @@ TEST(ReadModifyWriteRuleTest, AppendValue) {
 
 TEST(ReadModifyWriteRuleTest, IncrementAmount) {
   auto const proto =
-      bigtable::ReadModifyWriteRule::IncrementAmount("fam", "col", 42)
-          .as_proto();
+      ReadModifyWriteRule::IncrementAmount("fam", "col", 42).as_proto();
   EXPECT_EQ(btproto::ReadModifyWriteRule::kIncrementAmount, proto.rule_case());
   EXPECT_EQ(42, proto.increment_amount());
   EXPECT_EQ("fam", proto.family_name());
   EXPECT_EQ("col", proto.column_qualifier());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_range_test.cc
+++ b/google/cloud/bigtable/row_range_test.cc
@@ -15,31 +15,36 @@
 #include "google/cloud/bigtable/row_range.h"
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 namespace btproto = ::google::bigtable::v2;
-namespace bigtable = google::cloud::bigtable;
 
 TEST(RowRangeTest, InfiniteRange) {
-  auto proto = bigtable::RowRange::InfiniteRange().as_proto();
+  auto proto = RowRange::InfiniteRange().as_proto();
   EXPECT_EQ(btproto::RowRange::START_KEY_NOT_SET, proto.start_key_case());
   EXPECT_EQ(btproto::RowRange::END_KEY_NOT_SET, proto.end_key_case());
 }
 
 TEST(RowRangeTest, StartingAt) {
-  auto proto = bigtable::RowRange::StartingAt("foo").as_proto();
+  auto proto = RowRange::StartingAt("foo").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyClosed, proto.start_key_case());
   EXPECT_EQ("foo", proto.start_key_closed());
   EXPECT_EQ(btproto::RowRange::END_KEY_NOT_SET, proto.end_key_case());
 }
 
 TEST(RowRangeTest, EndingAt) {
-  auto proto = bigtable::RowRange::EndingAt("foo").as_proto();
+  auto proto = RowRange::EndingAt("foo").as_proto();
   EXPECT_EQ(btproto::RowRange::START_KEY_NOT_SET, proto.start_key_case());
   EXPECT_EQ(btproto::RowRange::kEndKeyClosed, proto.end_key_case());
   EXPECT_EQ("foo", proto.end_key_closed());
 }
 
 TEST(RowRangeTest, Range) {
-  auto proto = bigtable::RowRange::Range("bar", "foo").as_proto();
+  auto proto = RowRange::Range("bar", "foo").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyClosed, proto.start_key_case());
   EXPECT_EQ("bar", proto.start_key_closed());
   EXPECT_EQ(btproto::RowRange::kEndKeyOpen, proto.end_key_case());
@@ -47,7 +52,7 @@ TEST(RowRangeTest, Range) {
 }
 
 TEST(RowRangeTest, Prefix) {
-  auto proto = bigtable::RowRange::Prefix("bar/baz/").as_proto();
+  auto proto = RowRange::Prefix("bar/baz/").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyClosed, proto.start_key_case());
   EXPECT_EQ("bar/baz/", proto.start_key_closed());
   EXPECT_EQ(btproto::RowRange::kEndKeyOpen, proto.end_key_case());
@@ -55,7 +60,7 @@ TEST(RowRangeTest, Prefix) {
 }
 
 TEST(RowRangeTest, RightOpen) {
-  auto proto = bigtable::RowRange::RightOpen("bar", "foo").as_proto();
+  auto proto = RowRange::RightOpen("bar", "foo").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyClosed, proto.start_key_case());
   EXPECT_EQ("bar", proto.start_key_closed());
   EXPECT_EQ(btproto::RowRange::kEndKeyOpen, proto.end_key_case());
@@ -63,7 +68,7 @@ TEST(RowRangeTest, RightOpen) {
 }
 
 TEST(RowRangeTest, LeftOpen) {
-  auto proto = bigtable::RowRange::LeftOpen("bar", "foo").as_proto();
+  auto proto = RowRange::LeftOpen("bar", "foo").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyOpen, proto.start_key_case());
   EXPECT_EQ("bar", proto.start_key_open());
   EXPECT_EQ(btproto::RowRange::kEndKeyClosed, proto.end_key_case());
@@ -71,7 +76,7 @@ TEST(RowRangeTest, LeftOpen) {
 }
 
 TEST(RowRangeTest, Open) {
-  auto proto = bigtable::RowRange::Open("bar", "foo").as_proto();
+  auto proto = RowRange::Open("bar", "foo").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyOpen, proto.start_key_case());
   EXPECT_EQ("bar", proto.start_key_open());
   EXPECT_EQ(btproto::RowRange::kEndKeyOpen, proto.end_key_case());
@@ -79,7 +84,7 @@ TEST(RowRangeTest, Open) {
 }
 
 TEST(RowRangeTest, Closed) {
-  auto proto = bigtable::RowRange::Closed("bar", "foo").as_proto();
+  auto proto = RowRange::Closed("bar", "foo").as_proto();
   EXPECT_EQ(btproto::RowRange::kStartKeyClosed, proto.start_key_case());
   EXPECT_EQ("bar", proto.start_key_closed());
   EXPECT_EQ(btproto::RowRange::kEndKeyClosed, proto.end_key_case());
@@ -87,21 +92,21 @@ TEST(RowRangeTest, Closed) {
 }
 
 TEST(RowRangeTest, IsEmpty) {
-  EXPECT_TRUE(bigtable::RowRange::Empty().IsEmpty());
-  EXPECT_FALSE(bigtable::RowRange::InfiniteRange().IsEmpty());
-  EXPECT_FALSE(bigtable::RowRange::StartingAt("bar").IsEmpty());
-  EXPECT_FALSE(bigtable::RowRange::Range("bar", "foo").IsEmpty());
-  EXPECT_TRUE(bigtable::RowRange::Range("foo", "foo").IsEmpty());
-  EXPECT_TRUE(bigtable::RowRange::Range("foo", "bar").IsEmpty());
-  EXPECT_FALSE(bigtable::RowRange::StartingAt("").IsEmpty());
+  EXPECT_TRUE(RowRange::Empty().IsEmpty());
+  EXPECT_FALSE(RowRange::InfiniteRange().IsEmpty());
+  EXPECT_FALSE(RowRange::StartingAt("bar").IsEmpty());
+  EXPECT_FALSE(RowRange::Range("bar", "foo").IsEmpty());
+  EXPECT_TRUE(RowRange::Range("foo", "foo").IsEmpty());
+  EXPECT_TRUE(RowRange::Range("foo", "bar").IsEmpty());
+  EXPECT_FALSE(RowRange::StartingAt("").IsEmpty());
 
   std::string const only_00 = std::string("\0", 1);
-  EXPECT_FALSE(bigtable::RowRange::RightOpen("", only_00).IsEmpty());
-  EXPECT_TRUE(bigtable::RowRange::Open("", only_00).IsEmpty());
+  EXPECT_FALSE(RowRange::RightOpen("", only_00).IsEmpty());
+  EXPECT_TRUE(RowRange::Open("", only_00).IsEmpty());
 }
 
 TEST(RowRangeTest, ContainsRightOpen) {
-  auto range = bigtable::RowRange::RightOpen("bar", "foo");
+  auto range = RowRange::RightOpen("bar", "foo");
   EXPECT_FALSE(range.Contains("baq"));
   EXPECT_TRUE(range.Contains("bar"));
   EXPECT_FALSE(range.Contains("foo"));
@@ -110,7 +115,7 @@ TEST(RowRangeTest, ContainsRightOpen) {
 }
 
 TEST(RowRangeTest, ContainsLeftOpen) {
-  auto range = bigtable::RowRange::LeftOpen("bar", "foo");
+  auto range = RowRange::LeftOpen("bar", "foo");
   EXPECT_FALSE(range.Contains("baq"));
   EXPECT_FALSE(range.Contains("bar"));
   EXPECT_TRUE(range.Contains("foo"));
@@ -119,7 +124,7 @@ TEST(RowRangeTest, ContainsLeftOpen) {
 }
 
 TEST(RowRangeTest, ContainsOpen) {
-  auto range = bigtable::RowRange::Open("bar", "foo");
+  auto range = RowRange::Open("bar", "foo");
   EXPECT_FALSE(range.Contains("baq"));
   EXPECT_FALSE(range.Contains("bar"));
   EXPECT_FALSE(range.Contains("foo"));
@@ -128,7 +133,7 @@ TEST(RowRangeTest, ContainsOpen) {
 }
 
 TEST(RowRangeTest, ContainsClosed) {
-  auto range = bigtable::RowRange::Closed("bar", "foo");
+  auto range = RowRange::Closed("bar", "foo");
   EXPECT_FALSE(range.Contains("baq"));
   EXPECT_TRUE(range.Contains("bar"));
   EXPECT_TRUE(range.Contains("foo"));
@@ -137,7 +142,7 @@ TEST(RowRangeTest, ContainsClosed) {
 }
 
 TEST(RowRangeTest, ContainsPrefix) {
-  auto range = bigtable::RowRange::Prefix("foo");
+  auto range = RowRange::Prefix("foo");
   EXPECT_FALSE(range.Contains("fop"));
   EXPECT_TRUE(range.Contains("foo"));
   EXPECT_TRUE(range.Contains("foo-bar"));
@@ -148,7 +153,7 @@ TEST(RowRangeTest, ContainsPrefix) {
 
 TEST(RowRangeTest, ContainsPrefixWithFFFF) {
   std::string many_ffs("\xFF\xFF\xFF\xFF\xFF", 5);
-  auto range = bigtable::RowRange::Prefix(many_ffs);
+  auto range = RowRange::Prefix(many_ffs);
   EXPECT_FALSE(range.Contains(std::string("\xFF\xFF\xFF\xFF\xFE", 5)));
   EXPECT_TRUE(range.Contains(std::string("\xFF\xFF\xFF\xFF\xFF", 5)));
   EXPECT_TRUE(range.Contains(std::string("\xFF\xFF\xFF\xFF\xFF/")));
@@ -157,7 +162,7 @@ TEST(RowRangeTest, ContainsPrefixWithFFFF) {
 }
 
 TEST(RowRangeTest, ContainsStartingAt) {
-  auto range = bigtable::RowRange::StartingAt("foo");
+  auto range = RowRange::StartingAt("foo");
   EXPECT_FALSE(range.Contains(""));
   EXPECT_FALSE(range.Contains("fon"));
   EXPECT_TRUE(range.Contains("foo"));
@@ -165,7 +170,7 @@ TEST(RowRangeTest, ContainsStartingAt) {
 }
 
 TEST(RowRangeTest, ContainsEndingAt) {
-  auto range = bigtable::RowRange::EndingAt("foo");
+  auto range = RowRange::EndingAt("foo");
   EXPECT_TRUE(range.Contains(""));
   EXPECT_TRUE(range.Contains(std::string("\x01", 1)));
   EXPECT_TRUE(range.Contains("foo"));
@@ -174,37 +179,37 @@ TEST(RowRangeTest, ContainsEndingAt) {
 
 TEST(RowRangeTest, StreamingRightOpen) {
   std::ostringstream os;
-  os << bigtable::RowRange::RightOpen("a", "b");
+  os << RowRange::RightOpen("a", "b");
   EXPECT_EQ("['a', 'b')", os.str());
 }
 
 TEST(RowRangeTest, StreamingLeftOpen) {
   std::ostringstream os;
-  os << bigtable::RowRange::LeftOpen("a", "b");
+  os << RowRange::LeftOpen("a", "b");
   EXPECT_EQ("('a', 'b']", os.str());
 }
 
 TEST(RowRangeTest, StreamingClosed) {
   std::ostringstream os;
-  os << bigtable::RowRange::Closed("a", "b");
+  os << RowRange::Closed("a", "b");
   EXPECT_EQ("['a', 'b']", os.str());
 }
 
 TEST(RowRangeTest, StreamingOpen) {
   std::ostringstream os;
-  os << bigtable::RowRange::Open("a", "b");
+  os << RowRange::Open("a", "b");
   EXPECT_EQ("('a', 'b')", os.str());
 }
 
 TEST(RowRangeTest, StreamingStartingAt) {
   std::ostringstream os;
-  os << bigtable::RowRange::StartingAt("a");
+  os << RowRange::StartingAt("a");
   EXPECT_EQ("['a', '')", os.str());
 }
 
 TEST(RowRangeTest, StreamingEndingAt) {
   std::ostringstream os;
-  os << bigtable::RowRange::EndingAt("a");
+  os << RowRange::EndingAt("a");
   EXPECT_EQ("['', 'a']", os.str());
 }
 
@@ -214,7 +219,7 @@ std::string const kC00 = std::string("c\x00", 2);
 std::string const kAFFFF00 = std::string("a\xFF\xFF\x00", 4);
 
 TEST(RowRangeTest, EqualsRightOpen) {
-  using R = bigtable::RowRange;
+  using R = RowRange;
   EXPECT_EQ(R::RightOpen("a", "d"), R::RightOpen("a", "d"));
   EXPECT_NE(R::RightOpen("a", "d"), R::RightOpen("a", "c"));
   EXPECT_NE(R::RightOpen("a", "d"), R::RightOpen("b", "d"));
@@ -229,7 +234,7 @@ TEST(RowRangeTest, EqualsRightOpen) {
 }
 
 TEST(RowRangeTest, EqualsLeftOpen) {
-  using R = bigtable::RowRange;
+  using R = RowRange;
   EXPECT_EQ(R::LeftOpen("a", "d"), R::LeftOpen("a", "d"));
   EXPECT_NE(R::LeftOpen("a", "d"), R::LeftOpen("a", "c"));
   EXPECT_NE(R::LeftOpen("a", "d"), R::LeftOpen("b", "d"));
@@ -244,7 +249,7 @@ TEST(RowRangeTest, EqualsLeftOpen) {
 }
 
 TEST(RowRangeTest, EqualsClosed) {
-  using R = bigtable::RowRange;
+  using R = RowRange;
   EXPECT_EQ(R::Closed("a", "d"), R::Closed("a", "d"));
   EXPECT_NE(R::Closed("a", "d"), R::Closed("a", "c"));
   EXPECT_NE(R::Closed("a", "d"), R::Closed("b", "d"));
@@ -259,7 +264,7 @@ TEST(RowRangeTest, EqualsClosed) {
 }
 
 TEST(RowRangeTest, EqualsOpen) {
-  using R = bigtable::RowRange;
+  using R = RowRange;
   EXPECT_EQ(R::Open("a", "d"), R::Open("a", "d"));
   EXPECT_NE(R::Open("a", "d"), R::Open("a", "c"));
   EXPECT_NE(R::Open("a", "d"), R::Open("b", "d"));
@@ -274,7 +279,7 @@ TEST(RowRangeTest, EqualsOpen) {
 }
 
 TEST(RowRangeTest, EqualsStartingAt) {
-  using R = bigtable::RowRange;
+  using R = RowRange;
   EXPECT_EQ(R::StartingAt("a"), R::StartingAt("a"));
   EXPECT_EQ(R::StartingAt("a"), R::RightOpen("a", ""));
   EXPECT_NE(R::StartingAt("a"), R::StartingAt("b"));
@@ -289,7 +294,7 @@ TEST(RowRangeTest, EqualsStartingAt) {
 }
 
 TEST(RowRangeTest, EqualsEndingAt) {
-  using R = bigtable::RowRange;
+  using R = RowRange;
   EXPECT_EQ(R::EndingAt("b"), R::EndingAt("b"));
   EXPECT_NE(R::EndingAt("b"), R::Closed("", "b"));
   EXPECT_NE(R::EndingAt("b"), R::EndingAt("a"));
@@ -305,7 +310,7 @@ TEST(RowRangeTest, EqualsEndingAt) {
 
 // This is a fairly exhausting (and maybe exhaustive) set of cases for
 // intersecting a RightOpen range against other ranges.
-using R = bigtable::RowRange;
+using R = RowRange;
 
 TEST(RowRangeTest, IntersectRightOpenEmpty) {
   auto tuple = R::RightOpen("c", "m").Intersect(R::Empty());
@@ -729,3 +734,9 @@ TEST(RowRangeTest, IntersectEndingAtEndingAt) {
   EXPECT_TRUE(std::get<0>(tuple));
   EXPECT_EQ(R::EndingAt("k"), std::get<1>(tuple));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_set_test.cc
+++ b/google/cloud/bigtable/row_set_test.cc
@@ -15,23 +15,27 @@
 #include "google/cloud/bigtable/row_set.h"
 #include <gmock/gmock.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 TEST(RowSetTest, DefaultConstructor) {
-  auto proto = bigtable::RowSet().as_proto();
+  auto proto = RowSet().as_proto();
   EXPECT_EQ(0, proto.row_keys_size());
   EXPECT_EQ(0, proto.row_ranges_size());
 }
 
 TEST(RowSetTest, AppendRange) {
-  bigtable::RowSet row_set;
-  row_set.Append(bigtable::RowRange::Range("a", "b"));
+  RowSet row_set;
+  row_set.Append(RowRange::Range("a", "b"));
   auto proto = row_set.as_proto();
   ASSERT_EQ(1, proto.row_ranges_size());
   EXPECT_EQ("a", proto.row_ranges(0).start_key_closed());
   EXPECT_EQ("b", proto.row_ranges(0).end_key_open());
 
-  row_set.Append(bigtable::RowRange::Range("f", "k"));
+  row_set.Append(RowRange::Range("f", "k"));
   proto = row_set.as_proto();
   ASSERT_EQ(2, proto.row_ranges_size());
   EXPECT_EQ("f", proto.row_ranges(1).start_key_closed());
@@ -39,7 +43,7 @@ TEST(RowSetTest, AppendRange) {
 }
 
 TEST(RowSetTest, AppendRowKey) {
-  bigtable::RowSet row_set;
+  RowSet row_set;
   row_set.Append(std::string("foo"));
   auto proto = row_set.as_proto();
   ASSERT_EQ(1, proto.row_keys_size());
@@ -52,9 +56,9 @@ TEST(RowSetTest, AppendRowKey) {
 }
 
 TEST(RowSetTest, AppendMixed) {
-  bigtable::RowSet row_set;
+  RowSet row_set;
   row_set.Append("foo");
-  row_set.Append(bigtable::RowRange::Range("a", "b"));
+  row_set.Append(RowRange::Range("a", "b"));
 
   auto proto = row_set.as_proto();
   ASSERT_EQ(1, proto.row_ranges_size());
@@ -62,9 +66,8 @@ TEST(RowSetTest, AppendMixed) {
 }
 
 TEST(RowSetTest, VariadicConstructor) {
-  using R = bigtable::RowRange;
-  bigtable::RowSet row_set(R::Range("a", "b"), "foo", R::LeftOpen("k", "m"),
-                           "bar");
+  using R = RowRange;
+  RowSet row_set(R::Range("a", "b"), "foo", R::LeftOpen("k", "m"), "bar");
   auto const& proto = row_set.as_proto();
   ASSERT_EQ(2, proto.row_ranges_size());
   EXPECT_EQ(R::Range("a", "b"), R(proto.row_ranges(0)));
@@ -73,13 +76,12 @@ TEST(RowSetTest, VariadicConstructor) {
   EXPECT_EQ("foo", proto.row_keys(0));
   EXPECT_EQ("bar", proto.row_keys(1));
 
-  EXPECT_TRUE(bigtable::RowSet(R::Empty()).IsEmpty());
+  EXPECT_TRUE(RowSet(R::Empty()).IsEmpty());
 }
 
 TEST(RowSetTest, IntersectRightOpen) {
-  using R = bigtable::RowRange;
-  bigtable::RowSet row_set(R::Range("a", "b"), "foo", R::LeftOpen("k", "m"),
-                           "zzz");
+  using R = RowRange;
+  RowSet row_set(R::Range("a", "b"), "foo", R::LeftOpen("k", "m"), "zzz");
 
   auto proto = row_set.Intersect(R::StartingAt("l")).as_proto();
   ASSERT_EQ(1, proto.row_ranges_size());
@@ -89,13 +91,12 @@ TEST(RowSetTest, IntersectRightOpen) {
 }
 
 TEST(RowSetTest, DefaultSetNotEmpty) {
-  bigtable::RowSet row_set;
+  RowSet row_set;
   EXPECT_FALSE(row_set.IsEmpty());
 }
 
 TEST(RowSetTest, IntersectDefaultSetKeepsArgument) {
-  using R = bigtable::RowRange;
-  using bigtable::RowSet;
+  using R = RowRange;
   auto proto = RowSet().Intersect(R::Range("a", "b")).as_proto();
   EXPECT_TRUE(proto.row_keys().empty());
   ASSERT_EQ(1, proto.row_ranges_size());
@@ -103,15 +104,19 @@ TEST(RowSetTest, IntersectDefaultSetKeepsArgument) {
 }
 
 TEST(RowSetTest, IntersectWithEmptyIsEmpty) {
-  using R = bigtable::RowRange;
-  using bigtable::RowSet;
+  using R = RowRange;
   EXPECT_TRUE(RowSet().Intersect(R::Empty()).IsEmpty());
   EXPECT_TRUE(RowSet("a", R::Range("a", "b")).Intersect(R::Empty()).IsEmpty());
 }
 
 TEST(RowSetTest, IntersectWithDisjointIsEmpty) {
-  using R = bigtable::RowRange;
-  using bigtable::RowSet;
+  using R = RowRange;
   EXPECT_TRUE(
       RowSet("a", R::Range("a", "b")).Intersect(R::Range("c", "d")).IsEmpty());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_test.cc
+++ b/google/cloud/bigtable/row_test.cc
@@ -15,41 +15,51 @@
 #include "google/cloud/bigtable/row.h"
 #include <gtest/gtest.h>
 
-namespace bigtable = google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
 
 /// @test Verify Row instantiation and trivial accessors.
 TEST(RowTest, RowInstantiation) {
   std::string row_key = "row";
-  bigtable::Cell cell(row_key, "family", "column", 42, "value");
-  bigtable::Row row(row_key, {cell});
+  Cell cell(row_key, "family", "column", 42, "value");
+  Row row(row_key, {cell});
 
   EXPECT_EQ(1, row.cells().size());
   EXPECT_EQ(row_key, row.cells().begin()->row_key());
 
-  bigtable::Row empty_row(row_key, {});
+  Row empty_row(row_key, {});
   EXPECT_EQ(0, empty_row.cells().size());
   EXPECT_EQ(empty_row.cells().begin(), empty_row.cells().end());
 
-  bigtable::Cell cell2(row_key, "family", "column", 43, "val");
-  bigtable::Row two_cells_row(row_key, {cell, cell2});
+  Cell cell2(row_key, "family", "column", 43, "val");
+  Row two_cells_row(row_key, {cell, cell2});
   EXPECT_EQ(2, two_cells_row.cells().size());
   EXPECT_EQ(std::next(two_cells_row.cells().begin())->value(), cell2.value());
 }
 
 TEST(RowTest, MoveOverload) {
   std::string row_key = "row";
-  bigtable::Cell cell(row_key, "family", "column", 42, "value");
-  bigtable::Row row(row_key, {cell});
+  Cell cell(row_key, "family", "column", 42, "value");
+  Row row(row_key, {cell});
 
   static_assert(
       !std::is_lvalue_reference<decltype(std::move(row).cells())>::value,
       "Member function `cells` is expected to return a value from an r-value "
       "reference to row.");
 
-  std::vector<bigtable::Cell> moved_cells = std::move(row).cells();
+  std::vector<Cell> moved_cells = std::move(row).cells();
   EXPECT_EQ(1U, moved_cells.size());
   EXPECT_EQ("family", moved_cells[0].family_name());
   EXPECT_EQ("column", moved_cells[0].column_qualifier());
   EXPECT_EQ(42, moved_cells[0].timestamp().count());
   EXPECT_EQ("value", moved_cells[0].value());
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/rpc_backoff_policy_test.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy_test.cc
@@ -18,20 +18,22 @@
 #include <chrono>
 #include <vector>
 
-namespace bigtable = ::google::cloud::bigtable;
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 
-namespace {
 /// Create a grpc::Status with a status code for transient errors.
 grpc::Status CreateTransientError() {
   return grpc::Status(grpc::StatusCode::UNAVAILABLE, "please try again");
 }
 
-}  // anonymous namespace
-
 /// @test A simple test for the ExponentialBackoffRetryPolicy.
 TEST(ExponentialBackoffRetryPolicy, Simple) {
-  bigtable::ExponentialBackoffPolicy tested(10_ms, 500_ms);
+  ExponentialBackoffPolicy tested(10_ms, 500_ms);
 
   EXPECT_GE(10_ms, tested.OnCompletion(CreateTransientError()));
   EXPECT_NE(500_ms, tested.OnCompletion(CreateTransientError()));
@@ -45,7 +47,7 @@ TEST(ExponentialBackoffRetryPolicy, Simple) {
 
 /// @test Test cloning for ExponentialBackoffRetryPolicy.
 TEST(ExponentialBackoffRetryPolicy, Clone) {
-  bigtable::ExponentialBackoffPolicy original(10_ms, 50_ms);
+  ExponentialBackoffPolicy original(10_ms, 50_ms);
   auto tested = original.clone();
 
   EXPECT_GE(10_ms, tested->OnCompletion(CreateTransientError()));
@@ -55,8 +57,8 @@ TEST(ExponentialBackoffRetryPolicy, Clone) {
 /// @test Test for testing randomness for 2 objects of
 /// ExponentialBackoffRetryPolicy such that no two clients have same sleep time.
 TEST(ExponentialBackoffRetryPolicy, Randomness) {
-  bigtable::ExponentialBackoffPolicy test_object1(10_ms, 1500_ms);
-  bigtable::ExponentialBackoffPolicy test_object2(10_ms, 1500_ms);
+  ExponentialBackoffPolicy test_object1(10_ms, 1500_ms);
+  ExponentialBackoffPolicy test_object2(10_ms, 1500_ms);
   std::vector<std::chrono::milliseconds::rep> output1;
   std::vector<std::chrono::milliseconds::rep> output2;
 
@@ -70,3 +72,9 @@ TEST(ExponentialBackoffRetryPolicy, Randomness) {
   }
   EXPECT_NE(output1, output2);
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -19,7 +19,12 @@
 #include <chrono>
 #include <thread>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 namespace {
+
 /// Create a grpc::Status with a status code for transient errors.
 grpc::Status CreateTransientError() {
   return grpc::Status(grpc::StatusCode::UNAVAILABLE, "please try again");
@@ -30,7 +35,6 @@ grpc::Status CreatePermanentError() {
   return grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "failed");
 }
 
-namespace bigtable = google::cloud::bigtable;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 
 auto const kLimitedTimeTestPeriod = 50_ms;
@@ -41,7 +45,7 @@ auto const kLimitedTimeTolerance = 10_ms;
  *
  * This eliminates some amount of code duplication in the following tests.
  */
-void CheckLimitedTime(bigtable::RPCRetryPolicy& tested) {
+void CheckLimitedTime(RPCRetryPolicy& tested) {
   google::cloud::testing_util::CheckPredicateBecomesFalse(
       [&tested] {
         return tested.OnFailure(
@@ -51,17 +55,15 @@ void CheckLimitedTime(bigtable::RPCRetryPolicy& tested) {
       kLimitedTimeTolerance);
 }
 
-}  // anonymous namespace
-
 /// @test A simple test for the LimitedTimeRetryPolicy.
 TEST(LimitedTimeRetryPolicy, Simple) {
-  bigtable::LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
+  LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
   CheckLimitedTime(tested);
 }
 
 /// @test A simple test for grpc::StatusCode::OK is not Permanent Error.
 TEST(LimitedTimeRetryPolicy, PermanentFailureCheck) {
-  bigtable::LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
+  LimitedTimeRetryPolicy tested(kLimitedTimeTestPeriod);
   EXPECT_FALSE(tested.IsPermanentFailure(grpc::Status::OK));
   EXPECT_FALSE(tested.IsPermanentFailure(CreateTransientError()));
   EXPECT_TRUE(tested.IsPermanentFailure(CreatePermanentError()));
@@ -69,20 +71,20 @@ TEST(LimitedTimeRetryPolicy, PermanentFailureCheck) {
 
 /// @test Test cloning for LimitedTimeRetryPolicy.
 TEST(LimitedTimeRetryPolicy, Clone) {
-  bigtable::LimitedTimeRetryPolicy original(kLimitedTimeTestPeriod);
+  LimitedTimeRetryPolicy original(kLimitedTimeTestPeriod);
   auto tested = original.clone();
   CheckLimitedTime(*tested);
 }
 
 /// @test Verify that non-retryable errors cause an immediate failure.
 TEST(LimitedTimeRetryPolicy, OnNonRetryable) {
-  bigtable::LimitedTimeRetryPolicy tested(10_ms);
+  LimitedTimeRetryPolicy tested(10_ms);
   EXPECT_FALSE(tested.OnFailure(CreatePermanentError()));
 }
 
 /// @test A simple test for the LimitedErrorCountRetryPolicy.
 TEST(LimitedErrorCountRetryPolicy, Simple) {
-  bigtable::LimitedErrorCountRetryPolicy tested(3);
+  LimitedErrorCountRetryPolicy tested(3);
   EXPECT_TRUE(tested.OnFailure(CreateTransientError()));
   EXPECT_TRUE(tested.OnFailure(CreateTransientError()));
   EXPECT_TRUE(tested.OnFailure(CreateTransientError()));
@@ -92,7 +94,7 @@ TEST(LimitedErrorCountRetryPolicy, Simple) {
 
 /// @test Test cloning for LimitedErrorCountRetryPolicy.
 TEST(LimitedErrorCountRetryPolicy, Clone) {
-  bigtable::LimitedErrorCountRetryPolicy original(3);
+  LimitedErrorCountRetryPolicy original(3);
   auto tested = original.clone();
   EXPECT_TRUE(tested->OnFailure(CreateTransientError()));
   EXPECT_TRUE(tested->OnFailure(CreateTransientError()));
@@ -103,6 +105,12 @@ TEST(LimitedErrorCountRetryPolicy, Clone) {
 
 /// @test Verify that non-retryable errors cause an immediate failure.
 TEST(LimitedErrorCountRetryPolicy, OnNonRetryable) {
-  bigtable::LimitedErrorCountRetryPolicy tested(3);
+  LimitedErrorCountRetryPolicy tested(3);
   EXPECT_FALSE(tested.OnFailure(CreatePermanentError()));
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/table_config_test.cc
+++ b/google/cloud/bigtable/table_config_test.cc
@@ -17,20 +17,25 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace {
+
 namespace btadmin = ::google::bigtable::admin::v2;
-namespace bigtable = google::cloud::bigtable;
 
 TEST(TableConfig, Simple) {
-  bigtable::TableConfig config;
+  TableConfig config;
   EXPECT_TRUE(config.column_families().empty());
   EXPECT_TRUE(config.initial_splits().empty());
-  EXPECT_EQ(bigtable::TableConfig::TIMESTAMP_GRANULARITY_UNSPECIFIED,
+  EXPECT_EQ(TableConfig::TIMESTAMP_GRANULARITY_UNSPECIFIED,
             config.timestamp_granularity());
 
-  config.add_column_family("fam", bigtable::GcRule::MaxNumVersions(2));
+  config.add_column_family("fam", GcRule::MaxNumVersions(2));
   config.add_initial_split("foo");
   config.add_initial_split("qux");
-  config.set_timestamp_granularity(bigtable::TableConfig::MILLIS);
+  config.set_timestamp_granularity(TableConfig::MILLIS);
 
   auto const& families = config.column_families();
   auto it = families.find("fam");
@@ -65,8 +70,7 @@ initial_splits { key: 'qux' }
 }
 
 TEST(TableConfig, ComplexConstructor) {
-  bigtable::TableConfig config({{"fam", bigtable::GcRule::MaxNumVersions(3)}},
-                               {"foo", "qux"});
+  TableConfig config({{"fam", GcRule::MaxNumVersions(3)}}, {"foo", "qux"});
 
   auto const& families = config.column_families();
   auto it = families.find("fam");
@@ -77,3 +81,9 @@ TEST(TableConfig, ComplexConstructor) {
   EXPECT_EQ("foo", splits[0]);
   EXPECT_EQ("qux", splits[1]);
 }
+
+}  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -16,10 +16,14 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
 namespace {
-namespace bigtable = google::cloud::bigtable;
 
-using FilterIntegrationTest = bigtable::testing::TableIntegrationTest;
+using FilterIntegrationTest =
+    ::google::cloud::bigtable::testing::TableIntegrationTest;
 
 /**
  * Create some complex rows in @p table.
@@ -50,7 +54,7 @@ using FilterIntegrationTest = bigtable::testing::TableIntegrationTest;
  * | "{prefix}/complex"      | family2 | col9   | cell @ 3000, 6000 |
  *
  */
-void CreateComplexRows(bigtable::Table& table, std::string const& prefix) {
+void CreateComplexRows(Table& table, std::string const& prefix) {
   namespace bt = bigtable;
   using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 
@@ -91,7 +95,7 @@ void CreateComplexRows(bigtable::Table& table, std::string const& prefix) {
 TEST_F(FilterIntegrationTest, PassAll) {
   auto table = GetTable();
   std::string const row_key = "pass-all-row-key";
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, "family1", "c", 0, "v-c-0-0"},
       {row_key, "family1", "c", 1000, "v-c-0-1"},
       {row_key, "family1", "c", 2000, "v-c-0-2"},
@@ -101,14 +105,14 @@ TEST_F(FilterIntegrationTest, PassAll) {
   };
   CreateCells(table, expected);
 
-  auto actual = ReadRows(table, bigtable::Filter::PassAllFilter());
+  auto actual = ReadRows(table, Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, BlockAll) {
   auto table = GetTable();
   std::string const row_key = "block-all-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key, "family1", "c", 0, "v-c-0-0"},
       {row_key, "family1", "c", 1000, "v-c-0-1"},
       {row_key, "family1", "c", 2000, "v-c-0-2"},
@@ -117,16 +121,16 @@ TEST_F(FilterIntegrationTest, BlockAll) {
       {row_key, "family2", "c1", 2000, "v-c1-0-2"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{};
+  std::vector<Cell> expected{};
 
-  auto actual = ReadRows(table, bigtable::Filter::BlockAllFilter());
+  auto actual = ReadRows(table, Filter::BlockAllFilter());
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, Latest) {
   auto table = GetTable();
   std::string const row_key = "latest-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key, "family1", "c", 0, "v-c-0-0"},
       {row_key, "family1", "c", 1000, "v-c-0-1"},
       {row_key, "family1", "c", 2000, "v-c-0-2"},
@@ -136,7 +140,7 @@ TEST_F(FilterIntegrationTest, Latest) {
       {row_key, "family2", "c1", 3000, "v-c1-0-3"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, "family1", "c", 1000, "v-c-0-1"},
       {row_key, "family1", "c", 2000, "v-c-0-2"},
       {row_key, "family2", "c0", 0, "v-c0-0-0"},
@@ -144,14 +148,14 @@ TEST_F(FilterIntegrationTest, Latest) {
       {row_key, "family2", "c1", 3000, "v-c1-0-3"},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::Latest(2));
+  auto actual = ReadRows(table, Filter::Latest(2));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, FamilyRegex) {
   auto table = GetTable();
   std::string const row_key = "family-regex-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key, "family1", "c2", 0, "bar"},
       {row_key, "family1", "c", 0, "bar"},
       {row_key, "family2", "c", 0, "bar"},
@@ -160,21 +164,21 @@ TEST_F(FilterIntegrationTest, FamilyRegex) {
       {row_key, "family4", "c2", 0, "bar"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, "family1", "c2", 0, "bar"},
       {row_key, "family1", "c", 0, "bar"},
       {row_key, "family3", "c", 0, "bar"},
       {row_key, "family3", "c2", 0, "bar"},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::FamilyRegex("family[13]"));
+  auto actual = ReadRows(table, Filter::FamilyRegex("family[13]"));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, ColumnRegex) {
   auto table = GetTable();
   std::string const row_key = "column-regex-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key, "family1", "abc", 0, "bar"},
       {row_key, "family2", "bcd", 0, "bar"},
       {row_key, "family3", "abc", 0, "bar"},
@@ -183,21 +187,21 @@ TEST_F(FilterIntegrationTest, ColumnRegex) {
       {row_key, "family2", "hij", 0, "bar"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, "family1", "abc", 0, "bar"},
       {row_key, "family3", "abc", 0, "bar"},
       {row_key, "family1", "fgh", 0, "bar"},
       {row_key, "family2", "hij", 0, "bar"},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::ColumnRegex("(abc|.*h.*)"));
+  auto actual = ReadRows(table, Filter::ColumnRegex("(abc|.*h.*)"));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, ColumnRange) {
   auto table = GetTable();
   std::string const row_key = "column-range-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key, "family1", "a00", 0, "bar"},
       {row_key, "family1", "b00", 0, "bar"},
       {row_key, "family1", "b01", 0, "bar"},
@@ -207,20 +211,19 @@ TEST_F(FilterIntegrationTest, ColumnRange) {
       {row_key, "family2", "b00", 0, "bar"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, "family1", "b00", 0, "bar"},
       {row_key, "family1", "b01", 0, "bar"},
   };
 
-  auto actual =
-      ReadRows(table, bigtable::Filter::ColumnRange("family1", "b00", "b02"));
+  auto actual = ReadRows(table, Filter::ColumnRange("family1", "b00", "b02"));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, TimestampRange) {
   auto table = GetTable();
   std::string const row_key = "timestamp-range-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key, "family1", "c0", 1000, "v1000"},
       {row_key, "family2", "c1", 2000, "v2000"},
       {row_key, "family3", "c2", 3000, "v3000"},
@@ -229,22 +232,22 @@ TEST_F(FilterIntegrationTest, TimestampRange) {
       {row_key, "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key, "family3", "c2", 3000, "v3000"},
       {row_key, "family1", "c3", 4000, "v4000"},
       {row_key, "family2", "c4", 4000, "v5000"},
   };
 
-  auto actual = ReadRows(
-      table, bigtable::Filter::TimestampRange(std::chrono::milliseconds(3),
-                                              std::chrono::milliseconds(6)));
+  auto actual =
+      ReadRows(table, Filter::TimestampRange(std::chrono::milliseconds(3),
+                                             std::chrono::milliseconds(6)));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, RowKeysRegex) {
   auto table = GetTable();
   std::string const row_key = "row-key-regex-row-key";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {row_key + "/abc0", "family1", "c0", 1000, "v1000"},
       {row_key + "/bcd0", "family2", "c1", 2000, "v2000"},
       {row_key + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -253,19 +256,18 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
       {row_key + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {row_key + "/bcd0", "family2", "c1", 2000, "v2000"},
   };
 
-  auto actual =
-      ReadRows(table, bigtable::Filter::RowKeysRegex(row_key + "/bc.*"));
+  auto actual = ReadRows(table, Filter::RowKeysRegex(row_key + "/bc.*"));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, ValueRegex) {
   auto table = GetTable();
   std::string const prefix = "value-regex-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -274,19 +276,19 @@ TEST_F(FilterIntegrationTest, ValueRegex) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
       {prefix + "/fgh0", "family1", "c3", 4000, "v4000"},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::ValueRegex("v[34][0-9].*"));
+  auto actual = ReadRows(table, Filter::ValueRegex("v[34][0-9].*"));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, ValueRange) {
   auto table = GetTable();
   std::string const prefix = "value-range-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -295,14 +297,14 @@ TEST_F(FilterIntegrationTest, ValueRange) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
       {prefix + "/fgh0", "family1", "c3", 4000, "v4000"},
       {prefix + "/hij0", "family2", "c4", 4000, "v5000"},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::ValueRange("v2000", "v6000"));
+  auto actual = ReadRows(table, Filter::ValueRange("v2000", "v6000"));
   CheckEqualUnordered(expected, actual);
 }
 
@@ -311,19 +313,18 @@ TEST_F(FilterIntegrationTest, CellsRowLimit) {
   std::string const prefix = "cell-row-limit-prefix";
   ASSERT_NO_FATAL_FAILURE(CreateComplexRows(table, prefix));
 
-  auto result = ReadRows(table, bigtable::Filter::CellsRowLimit(3));
+  auto result = ReadRows(table, Filter::CellsRowLimit(3));
 
-  std::map<bigtable::RowKeyType, int> actual;
+  std::map<RowKeyType, int> actual;
   for (auto const& cell : result) {
     auto inserted = actual.emplace(cell.row_key(), 0);
     inserted.first->second++;
   }
-  std::map<bigtable::RowKeyType, int> expected{
-      {bigtable::RowKeyType(prefix + "/one-cell"), 1},
-      {bigtable::RowKeyType(prefix + "/two-cells"), 2},
-      {bigtable::RowKeyType(prefix + "/many"), 3},
-      {bigtable::RowKeyType(prefix + "/many-columns"), 3},
-      {bigtable::RowKeyType(prefix + "/complex"), 3}};
+  std::map<RowKeyType, int> expected{{RowKeyType(prefix + "/one-cell"), 1},
+                                     {RowKeyType(prefix + "/two-cells"), 2},
+                                     {RowKeyType(prefix + "/many"), 3},
+                                     {RowKeyType(prefix + "/many-columns"), 3},
+                                     {RowKeyType(prefix + "/complex"), 3}};
 
   EXPECT_THAT(expected, ::testing::ContainerEq(actual));
 }
@@ -335,17 +336,16 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
 
   // Search in the range [row_key_prefix, row_key_prefix + "0"), we used '/' as
   // the separator and the successor of "/" is "0".
-  auto result = ReadRows(table, bigtable::Filter::CellsRowOffset(2));
+  auto result = ReadRows(table, Filter::CellsRowOffset(2));
 
-  std::map<bigtable::RowKeyType, int> actual;
+  std::map<RowKeyType, int> actual;
   for (auto const& cell : result) {
     auto inserted = actual.emplace(cell.row_key(), 0);
     inserted.first->second++;
   }
-  std::map<bigtable::RowKeyType, int> expected{
-      {bigtable::RowKeyType(prefix + "/many"), 2},
-      {bigtable::RowKeyType(prefix + "/many-columns"), 2},
-      {bigtable::RowKeyType(prefix + "/complex"), 78}};
+  std::map<RowKeyType, int> expected{{RowKeyType(prefix + "/many"), 2},
+                                     {RowKeyType(prefix + "/many-columns"), 2},
+                                     {RowKeyType(prefix + "/complex"), 78}};
 
   EXPECT_THAT(expected, ::testing::ContainerEq(actual));
 }
@@ -361,11 +361,11 @@ TEST_F(FilterIntegrationTest, RowSample) {
   std::string const prefix = "row-sample-prefix";
 
   int constexpr kRowCount = 20000;
-  bigtable::BulkMutation bulk;
+  BulkMutation bulk;
   for (int row = 0; row != kRowCount; ++row) {
     std::string row_key = prefix + "/" + std::to_string(row);
-    bulk.emplace_back(bigtable::SingleRowMutation(
-        row_key, bigtable::SetCell("family1", "col", 4_ms, "foo")));
+    bulk.emplace_back(
+        SingleRowMutation(row_key, SetCell("family1", "col", 4_ms, "foo")));
   }
   auto failures = table.BulkApply(std::move(bulk));
   ASSERT_TRUE(failures.empty());
@@ -406,7 +406,7 @@ TEST_F(FilterIntegrationTest, RowSample) {
 
   // Search in the range [row_key_prefix, row_key_prefix + "0"), we used '/' as
   // the separator and the successor of "/" is "0".
-  auto result = ReadRows(table, bigtable::Filter::RowSample(kSampleRate));
+  auto result = ReadRows(table, Filter::RowSample(kSampleRate));
   EXPECT_LE(min_count, result.size());
   EXPECT_GE(max_count, result.size());
 }
@@ -414,7 +414,7 @@ TEST_F(FilterIntegrationTest, RowSample) {
 TEST_F(FilterIntegrationTest, StripValueTransformer) {
   auto table = GetTable();
   std::string const prefix = "strip-value-transformer-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -423,7 +423,7 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/abc0", "family1", "c0", 1000, ""},
       {prefix + "/bcd0", "family2", "c1", 2000, ""},
       {prefix + "/abc1", "family3", "c2", 3000, ""},
@@ -432,7 +432,7 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
       {prefix + "/hij1", "family3", "c5", 6000, ""},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::StripValueTransformer());
+  auto actual = ReadRows(table, Filter::StripValueTransformer());
   CheckEqualUnordered(expected, actual);
 }
 
@@ -444,7 +444,7 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
 
   auto table = GetTable();
   std::string const prefix = "apply-label-transformer-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -453,7 +453,7 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000", {"foo"}},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000", {"foo"}},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000", {"foo"}},
@@ -462,14 +462,14 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000", {"foo"}},
   };
 
-  auto actual = ReadRows(table, bigtable::Filter::ApplyLabelTransformer("foo"));
+  auto actual = ReadRows(table, Filter::ApplyLabelTransformer("foo"));
   CheckEqualUnordered(expected, actual);
 }
 
 TEST_F(FilterIntegrationTest, Condition) {
   auto table = GetTable();
   std::string const prefix = "condition-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -478,7 +478,7 @@ TEST_F(FilterIntegrationTest, Condition) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, ""},
       {prefix + "/abc1", "family3", "c2", 3000, ""},
@@ -486,7 +486,7 @@ TEST_F(FilterIntegrationTest, Condition) {
       {prefix + "/hij0", "family2", "c4", 4000, "v5000"},
   };
 
-  using F = bigtable::Filter;
+  using F = Filter;
   auto actual =
       ReadRows(table, F::Condition(F::ValueRangeClosed("v2000", "v4000"),
                                    F::StripValueTransformer(),
@@ -497,7 +497,7 @@ TEST_F(FilterIntegrationTest, Condition) {
 TEST_F(FilterIntegrationTest, Chain) {
   auto table = GetTable();
   std::string const prefix = "chain-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -506,11 +506,11 @@ TEST_F(FilterIntegrationTest, Chain) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/fgh0", "family1", "c3", 4000, ""},
   };
 
-  using F = bigtable::Filter;
+  using F = Filter;
   auto actual =
       ReadRows(table, F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                                F::StripValueTransformer(),
@@ -521,7 +521,7 @@ TEST_F(FilterIntegrationTest, Chain) {
 TEST_F(FilterIntegrationTest, ChainFromRange) {
   auto table = GetTable();
   std::string const prefix = "chain-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -530,11 +530,11 @@ TEST_F(FilterIntegrationTest, ChainFromRange) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/fgh0", "family1", "c3", 4000, ""},
   };
 
-  using F = bigtable::Filter;
+  using F = Filter;
   auto range = {F::ValueRangeClosed("v2000", "v5000"),
                 F::StripValueTransformer(),
                 F::ColumnRangeClosed("family1", "c2", "c3")};
@@ -545,7 +545,7 @@ TEST_F(FilterIntegrationTest, ChainFromRange) {
 TEST_F(FilterIntegrationTest, Interleave) {
   auto table = GetTable();
   std::string const prefix = "interleave-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -554,7 +554,7 @@ TEST_F(FilterIntegrationTest, Interleave) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/bcd0", "family2", "c1", 2000, ""},
       {prefix + "/abc1", "family3", "c2", 3000, ""},
       {prefix + "/fgh0", "family1", "c3", 4000, ""},
@@ -562,7 +562,7 @@ TEST_F(FilterIntegrationTest, Interleave) {
       {prefix + "/hij0", "family2", "c4", 4000, ""},
   };
 
-  using F = bigtable::Filter;
+  using F = Filter;
   auto actual = ReadRows(
       table, F::Interleave(F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                                     F::StripValueTransformer()),
@@ -573,7 +573,7 @@ TEST_F(FilterIntegrationTest, Interleave) {
 TEST_F(FilterIntegrationTest, InterleaveFromRange) {
   auto table = GetTable();
   std::string const prefix = "interleave-prefix";
-  std::vector<bigtable::Cell> created{
+  std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
       {prefix + "/bcd0", "family2", "c1", 2000, "v2000"},
       {prefix + "/abc1", "family3", "c2", 3000, "v3000"},
@@ -582,7 +582,7 @@ TEST_F(FilterIntegrationTest, InterleaveFromRange) {
       {prefix + "/hij1", "family3", "c5", 6000, "v6000"},
   };
   CreateCells(table, created);
-  std::vector<bigtable::Cell> expected{
+  std::vector<Cell> expected{
       {prefix + "/bcd0", "family2", "c1", 2000, ""},
       {prefix + "/abc1", "family3", "c2", 3000, ""},
       {prefix + "/fgh0", "family1", "c3", 4000, ""},
@@ -590,7 +590,7 @@ TEST_F(FilterIntegrationTest, InterleaveFromRange) {
       {prefix + "/hij0", "family2", "c4", 4000, ""},
   };
 
-  using F = bigtable::Filter;
+  using F = Filter;
   std::vector<F> filter_collection{
       F::Chain(F::ValueRangeClosed("v2000", "v5000"),
                F::StripValueTransformer()),
@@ -600,12 +600,17 @@ TEST_F(FilterIntegrationTest, InterleaveFromRange) {
                                              filter_collection.end()));
   CheckEqualUnordered(expected, actual);
 }
+
 }  // namespace
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
 
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new ::bigtable::testing::TableTestEnvironment);
+      new ::google::cloud::bigtable::testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Fixes: #5353

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5420)
<!-- Reviewable:end -->
