### PR TITLE
cleanup(pubsub): simplify SubscriptionMessageSource

### DIFF
--- a/google/cloud/pubsub/internal/subscription_concurrency_control.h
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control.h
@@ -44,8 +44,8 @@ class SubscriptionConcurrencyControl
 
   void Start(pubsub::ApplicationCallback);
   void Shutdown();
-  void AckMessage(std::string const& ack_id, std::size_t size);
-  void NackMessage(std::string const& ack_id, std::size_t size);
+  void AckMessage(std::string const& ack_id);
+  void NackMessage(std::string const& ack_id);
 
  private:
   SubscriptionConcurrencyControl(

--- a/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
@@ -31,7 +31,6 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::StartsWith;
 
@@ -90,11 +89,11 @@ TEST_F(SubscriptionConcurrencyControlTest, MessageLifecycle) {
   }
   {
     ::testing::InSequence sequence;
-    EXPECT_CALL(*source, AckMessage("ack-0-0", _));
-    EXPECT_CALL(*source, NackMessage("ack-0-1", _));
-    EXPECT_CALL(*source, AckMessage("ack-1-0", _));
-    EXPECT_CALL(*source, NackMessage("ack-1-1", _));
-    EXPECT_CALL(*source, NackMessage("ack-1-2", _));
+    EXPECT_CALL(*source, AckMessage("ack-0-0"));
+    EXPECT_CALL(*source, NackMessage("ack-0-1"));
+    EXPECT_CALL(*source, AckMessage("ack-1-0"));
+    EXPECT_CALL(*source, NackMessage("ack-1-1"));
+    EXPECT_CALL(*source, NackMessage("ack-1-2"));
   }
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
@@ -168,11 +167,11 @@ TEST_F(SubscriptionConcurrencyControlTest, ParallelCallbacks) {
   }
   {
     ::testing::InSequence sequence;
-    EXPECT_CALL(*source, AckMessage(StartsWith("ack-0-"), _)).Times(8);
-    EXPECT_CALL(*source, AckMessage(StartsWith("ack-1-"), _)).Times(1);
-    EXPECT_CALL(*source, NackMessage(StartsWith("ack-1-"), _)).Times(1);
-    EXPECT_CALL(*source, AckMessage(StartsWith("ack-1-"), _)).Times(1);
-    EXPECT_CALL(*source, NackMessage(StartsWith("ack-1-"), _)).Times(5);
+    EXPECT_CALL(*source, AckMessage(StartsWith("ack-0-"))).Times(8);
+    EXPECT_CALL(*source, AckMessage(StartsWith("ack-1-"))).Times(1);
+    EXPECT_CALL(*source, NackMessage(StartsWith("ack-1-"))).Times(1);
+    EXPECT_CALL(*source, AckMessage(StartsWith("ack-1-"))).Times(1);
+    EXPECT_CALL(*source, NackMessage(StartsWith("ack-1-"))).Times(5);
   }
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(4);
@@ -456,9 +455,8 @@ TEST_F(SubscriptionConcurrencyControlTest, MessageContents) {
   }
   EXPECT_CALL(*source, AckMessage)
       .Times(5)
-      .WillRepeatedly([](std::string const&, std::size_t) {
-        return make_ready_future(Status{});
-      });
+      .WillRepeatedly(
+          [](std::string const&) { return make_ready_future(Status{}); });
   EXPECT_CALL(*source, Read(1)).Times(5);
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads background(4);

--- a/google/cloud/pubsub/internal/subscription_message_queue.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue.cc
@@ -44,15 +44,14 @@ void SubscriptionMessageQueue::Read(std::size_t max_callbacks) {
   DrainQueue(std::move(lk));
 }
 
-future<Status> SubscriptionMessageQueue::AckMessage(std::string const& ack_id,
-                                                    std::size_t) {
+future<Status> SubscriptionMessageQueue::AckMessage(std::string const& ack_id) {
   HandlerDone(ack_id);
   source_->AckMessage(ack_id);
   return make_ready_future(Status{});
 }
 
-future<Status> SubscriptionMessageQueue::NackMessage(std::string const& ack_id,
-                                                     std::size_t) {
+future<Status> SubscriptionMessageQueue::NackMessage(
+    std::string const& ack_id) {
   HandlerDone(ack_id);
   source_->NackMessage(ack_id);
   return make_ready_future(Status{});

--- a/google/cloud/pubsub/internal/subscription_message_queue.h
+++ b/google/cloud/pubsub/internal/subscription_message_queue.h
@@ -78,10 +78,8 @@ class SubscriptionMessageQueue
   void Start(MessageCallback cb) override;
   void Shutdown() override;
   void Read(std::size_t max_callbacks) override;
-  future<Status> AckMessage(std::string const& ack_id,
-                            std::size_t size) override;
-  future<Status> NackMessage(std::string const& ack_id,
-                             std::size_t size) override;
+  future<Status> AckMessage(std::string const& ack_id) override;
+  future<Status> NackMessage(std::string const& ack_id) override;
 
  private:
   explicit SubscriptionMessageQueue(

--- a/google/cloud/pubsub/internal/subscription_message_queue_test.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue_test.cc
@@ -151,8 +151,8 @@ TEST(SubscriptionMessageQueueTest, Basic) {
 
   EXPECT_THAT(received, ElementsAre(IsProtoEqual(messages[0]),
                                     IsProtoEqual(messages[1])));
-  uut->AckMessage("ack-m0", 0);
-  uut->NackMessage("ack-m1", 1);
+  uut->AckMessage("ack-m0");
+  uut->NackMessage("ack-m1");
 
   received.clear();
   uut->Shutdown();
@@ -247,21 +247,21 @@ TEST(SubscriptionMessageQueueTest, RespectOrderingKeys) {
               ElementsAre("id--000000", "id--000001", "id--000002"));
 
   received.clear();  // keep expectations shorter
-  uut->AckMessage("ack--000000", 0);
-  uut->AckMessage("ack--000001", 0);
-  uut->AckMessage("ack--000002", 0);
+  uut->AckMessage("ack--000000");
+  uut->AckMessage("ack--000001");
+  uut->AckMessage("ack--000002");
   EXPECT_THAT(received["k0"], IsEmpty());
   EXPECT_THAT(received["k1"], IsEmpty());
   EXPECT_THAT(received[{}], IsEmpty());
 
   received.clear();  // keep expectations shorter
-  uut->NackMessage("ack-k0-000000", 0);
+  uut->NackMessage("ack-k0-000000");
   uut->Read(4);
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000001"));
   EXPECT_THAT(received["k1"], IsEmpty());
   EXPECT_THAT(received[{}], IsEmpty());
 
-  uut->NackMessage("ack-k1-000000", 0);
+  uut->NackMessage("ack-k1-000000");
   uut->Read(1);
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000001"));
   EXPECT_THAT(received["k1"], ElementsAre("id-k1-000001"));
@@ -269,18 +269,18 @@ TEST(SubscriptionMessageQueueTest, RespectOrderingKeys) {
 
   received.clear();  // keep expectations shorter
   batch_callback(AsPullResponse(GenerateOrderKeyMessages({}, 3, 2)));
-  uut->AckMessage("ack-k0-000001", 0);
-  uut->AckMessage("ack-k1-000001", 0);
+  uut->AckMessage("ack-k0-000001");
+  uut->AckMessage("ack-k1-000001");
   uut->Read(2);
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000002"));
   EXPECT_THAT(received["k1"], ElementsAre("id-k1-000002"));
   EXPECT_THAT(received[{}], ElementsAre("id--000003", "id--000004"));
 
   received.clear();  // keep expectations shorter
-  uut->AckMessage("ack-k0-000002", 0);
-  uut->AckMessage("ack-k1-000002", 0);
-  uut->AckMessage("ack--000003", 0);
-  uut->AckMessage("ack--000004", 0);
+  uut->AckMessage("ack-k0-000002");
+  uut->AckMessage("ack-k1-000002");
+  uut->AckMessage("ack--000003");
+  uut->AckMessage("ack--000004");
   uut->Read(4);
   EXPECT_THAT(received["k0"], IsEmpty());
   EXPECT_THAT(received["k1"], IsEmpty());
@@ -333,13 +333,13 @@ TEST(SubscriptionMessageQueueTest, DuplicateMessagesNoKey) {
                                         "id--000000", "id--000001"));
 
   received.clear();  // keep expectations shorter
-  uut->AckMessage("ack--000000", 0);
-  uut->NackMessage("ack--000001", 0);
+  uut->AckMessage("ack--000000");
+  uut->NackMessage("ack--000001");
   uut->Read(2);
   EXPECT_THAT(received[{}], ElementsAre("id--000002", "id--000003"));
 
-  uut->AckMessage("ack--000000", 0);
-  uut->AckMessage("ack--000001", 0);
+  uut->AckMessage("ack--000000");
+  uut->AckMessage("ack--000001");
   uut->Read(2);
   EXPECT_THAT(received[{}], ElementsAre("id--000002", "id--000003",
                                         "id--000004", "id--000005"));
@@ -379,15 +379,15 @@ TEST(SubscriptionMessageQueueTest, DuplicateMessagesWithKey) {
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000000"));
 
   received.clear();  // keep expectations shorter
-  uut->AckMessage("ack-k0-000000", 0);
+  uut->AckMessage("ack-k0-000000");
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000000"));
 
   received.clear();  // keep expectations shorter
-  uut->AckMessage("ack-k0-000000", 0);
+  uut->AckMessage("ack-k0-000000");
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000001"));
 
   received.clear();  // keep expectations shorter
-  uut->AckMessage("ack-k0-000001", 0);
+  uut->AckMessage("ack-k0-000001");
   EXPECT_THAT(received["k0"], ElementsAre("id-k0-000002"));
 
   uut->Shutdown();
@@ -439,7 +439,7 @@ TEST_P(SubscriptionMessageQueueOrderingTest, RespectOrderingKeysTorture) {
         notify = (++received_count >= message_count);
       }
       if (notify) cv.notify_one();
-      uut->AckMessage(m.ack_id(), 0);
+      uut->AckMessage(m.ack_id());
       uut->Read(1);
     });
   };

--- a/google/cloud/pubsub/internal/subscription_message_source.h
+++ b/google/cloud/pubsub/internal/subscription_message_source.h
@@ -55,24 +55,18 @@ class SubscriptionMessageSource {
    * Positive acknowledgment the message associated with @p ack_id.
    *
    * The application has successfully handled this message and no new deliveries
-   * are necessary. The @p size parameter should be the original message size
-   * estimate. The @p size parameter may be used by the message source to flow
-   * control large messages.
+   * are necessary.
    */
-  virtual future<Status> AckMessage(std::string const& ack_id,
-                                    std::size_t size) = 0;
+  virtual future<Status> AckMessage(std::string const& ack_id) = 0;
 
   /**
-   * Negative acknowledgment for message associated with @p ack_id.
+   * Reject the message associated with @p ack_id.
    *
-   * The application was not able to handle this message. Nacking a message
+   * The application was not able to handle this message. Rejecting a message
    * allows the service to re-deliver it, subject to the topic and subscription
-   * configuration. The @p size parameter should be the original message size
-   * estimate. The @p size parameter may be used by the message source to flow
-   * control large messages.
+   * configuration.
    */
-  virtual future<Status> NackMessage(std::string const& ack_id,
-                                     std::size_t size) = 0;
+  virtual future<Status> NackMessage(std::string const& ack_id) = 0;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/testing/mock_subscription_message_source.h
+++ b/google/cloud/pubsub/testing/mock_subscription_message_source.h
@@ -30,10 +30,8 @@ class MockSubscriptionMessageSource
   MOCK_METHOD1(Start, void(pubsub_internal::MessageCallback));
   MOCK_METHOD0(Shutdown, void());
   MOCK_METHOD1(Read, void(std::size_t max_callbacks));
-  MOCK_METHOD2(AckMessage,
-               future<Status>(std::string const& ack_id, std::size_t size));
-  MOCK_METHOD2(NackMessage,
-               future<Status>(std::string const& ack_id, std::size_t size));
+  MOCK_METHOD1(AckMessage, future<Status>(std::string const& ack_id));
+  MOCK_METHOD1(NackMessage, future<Status>(std::string const& ack_id));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
Remove some unused arguments, that cleans up the internal interfaces,
and saves us some computation in the critical path. Not much, but every
bit counts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5422)
<!-- Reviewable:end -->
