### PR TITLE
refactor(pubsub): use BatchSink to send batches 

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
-#include "google/cloud/internal/async_retry_loop.h"
 
 namespace google {
 namespace cloud {
@@ -33,7 +32,7 @@ struct Batch {
     auto response = f.get();
     if (!response) {
       SatisfyAllWaiters(response.status());
-      if (auto batcher = weak.lock()) batcher->DiscardCorked(response.status());
+      if (auto batcher = weak.lock()) batcher->HandleError(response.status());
       return;
     }
     if (static_cast<std::size_t>(response->message_ids_size()) !=
@@ -51,7 +50,6 @@ struct Batch {
     for (auto& w : waiters) {
       executor.RunAsync(SetValue{std::move(w), response->message_ids(idx++)});
     }
-    if (auto batcher = weak.lock()) batcher->UnCork();
   }
 
   void SatisfyAllWaiters(Status const& status) {
@@ -72,10 +70,17 @@ future<StatusOr<std::string>> BatchingPublisherConnection::Publish(
   std::unique_lock<std::mutex> lk(mu_);
   do {
     if (!corked_on_status_.ok()) return CorkedError();
-    auto const has_capacity =
-        current_bytes_ + bytes < options_.maximum_batch_bytes();
-    if (has_capacity || waiters_.empty()) break;
-    // We need to flush the existing batch, that will release the lock.
+    // If empty we need to create the batch, even if it would be oversized,
+    // otherwise the message may be dropped.
+    if (waiters_.empty()) break;
+    auto const has_bytes_capacity =
+        current_bytes_ + bytes <= options_.maximum_batch_bytes();
+    auto const has_messages_capacity =
+        waiters_.size() < options_.maximum_batch_message_count();
+    // If there is enough room just add the message below.
+    if (has_bytes_capacity && has_messages_capacity) break;
+    // We need to flush the existing batch, that will release the lock, and then
+    // we try again.
     FlushImpl(std::move(lk));
     lk = std::unique_lock<std::mutex>(mu_);
   } while (true);
@@ -107,29 +112,23 @@ void BatchingPublisherConnection::Flush(FlushParams) {
 
 void BatchingPublisherConnection::ResumePublish(ResumePublishParams p) {
   if (ordering_key_ != p.ordering_key) return;
-  std::unique_lock<std::mutex> lk(mu_);
-  corked_on_status_ = {};
-  MaybeFlush(std::move(lk));
-}
-
-void BatchingPublisherConnection::UnCork() {
-  std::unique_lock<std::mutex> lk(mu_);
-  corked_on_pending_push_ = false;
-  MaybeFlush(std::move(lk));
-}
-
-void BatchingPublisherConnection::DiscardCorked(Status const& status) {
-  auto waiters = [&] {
+  {
     std::unique_lock<std::mutex> lk(mu_);
-    // This is the result of a request, so no longer corked waiting for it.
-    corked_on_pending_push_ = false;
-    // An error should block more messages only if ordering is required.
-    if (RequiresOrdering()) corked_on_status_ = status;
-    pending_.Clear();
-    std::vector<promise<StatusOr<std::string>>> tmp;
-    tmp.swap(waiters_);
-    return tmp;
-  }();
+    corked_on_status_ = {};
+  }
+  sink_->ResumePublish(p.ordering_key);
+}
+
+void BatchingPublisherConnection::HandleError(Status const& status) {
+  std::unique_lock<std::mutex> lk(mu_);
+  // An error should discard pending messages and block future messages only
+  // if ordering is required.
+  if (!RequiresOrdering()) return;
+  corked_on_status_ = status;
+  pending_.Clear();
+  std::vector<promise<StatusOr<std::string>>> waiters;
+  waiters.swap(waiters_);
+  lk.unlock();
   for (auto& p : waiters) {
     struct MoveCapture {
       promise<StatusOr<std::string>> p;
@@ -194,33 +193,20 @@ future<StatusOr<std::string>> BatchingPublisherConnection::CorkedError() {
 }
 
 void BatchingPublisherConnection::FlushImpl(std::unique_lock<std::mutex> lk) {
-  if (pending_.messages().empty() || IsCorked(lk)) return;
+  if (pending_.messages().empty()) return;
 
   Batch batch;
   batch.waiters.swap(waiters_);
   google::pubsub::v1::PublishRequest request;
   request.Swap(&pending_);
-  corked_on_pending_push_ = RequiresOrdering();
   current_bytes_ = 0;
   lk.unlock();
-
-  auto context = absl::make_unique<grpc::ClientContext>();
 
   batch.executor = cq_;
   batch.weak = shared_from_this();
   request.set_topic(topic_full_name_);
 
-  auto& stub = stub_;
-  google::cloud::internal::AsyncRetryLoop(
-      retry_policy_->clone(), backoff_policy_->clone(),
-      google::cloud::internal::Idempotency::kIdempotent, cq_,
-      [stub](google::cloud::CompletionQueue& cq,
-             std::unique_ptr<grpc::ClientContext> context,
-             google::pubsub::v1::PublishRequest const& request) {
-        return stub->AsyncPublish(cq, std::move(context), request);
-      },
-      std::move(request), __func__)
-      .then(std::move(batch));
+  sink_->AsyncPublish(request).then(std::move(batch));
 }
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -20,6 +20,8 @@ if (BUILD_TESTING)
         google_cloud_cpp_testing # cmake-format: sort
         assert_ok.cc
         assert_ok.h
+        async_sequencer.cc
+        async_sequencer.h
         capture_log_lines_backend.cc
         capture_log_lines_backend.h
         check_predicate_becomes_false.h

--- a/google/cloud/testing_util/async_sequencer.cc
+++ b/google/cloud/testing_util/async_sequencer.cc
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/testing_util/async_sequencer.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+future<void> AsyncSequencer::PushBack() {
+  std::unique_lock<std::mutex> lk(mu_);
+  queue_.emplace_back();
+  auto f = queue_.back().get_future();
+  lk.unlock();
+  cv_.notify_one();
+  return f;
+}
+
+promise<void> AsyncSequencer::PopFront() {
+  std::unique_lock<std::mutex> lk(mu_);
+  cv_.wait(lk, [&] { return !queue_.empty(); });
+  auto p = std::move(queue_.front());
+  queue_.pop_front();
+  return p;
+}
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/testing_util/async_sequencer.h
+++ b/google/cloud/testing_util/async_sequencer.h
@@ -29,7 +29,7 @@ namespace testing_util {
 /**
  * A helper to sequence asynchronous operations.
  *
- * Mocks for asynchronous operations often need to create futures that the the
+ * Mocks for asynchronous operations often need to create futures that the
  * test controls. The mock creates new futures by calling `PushBack()` and then
  * using `.then()` to convert the `future<void>` into the desired type. The main
  * test calls `.PopFront()` to satisfy the futures as needed.

--- a/google/cloud/testing_util/async_sequencer.h
+++ b/google/cloud/testing_util/async_sequencer.h
@@ -1,0 +1,82 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_ASYNC_SEQUENCER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_ASYNC_SEQUENCER_H
+
+#include "google/cloud/future.h"
+#include "google/cloud/version.h"
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+/**
+ * A helper to sequence asynchronous operations.
+ *
+ * Mocks for asynchronous operations often need to create futures that the the
+ * test controls. The mock creates new futures by calling `PushBack()` and then
+ * using `.then()` to convert the `future<void>` into the desired type. The main
+ * test calls `.PopFront()` to satisfy the futures as needed.
+ *
+ * @par Example
+ * @code
+ * AsyncSequencer async;
+ * EXPECT_CALL(mock, SomeFunction)
+ *   .WillOnce([&] { return async.PushBack().then([](auto) { return 42; }); })
+ *   .WillOnce([&] { return async.PushBack().then([](auto) { return 84; }); })
+ *   .WillOnce([&] { return async.PushBack().then([](auto) { return 21; }); })
+ *   ;
+ *
+ * auto f0 = mock->SomeFunction();
+ * auto f1 = mock->SomeFunction();
+ * auto f2 = mock->SomeFunction();
+ *
+ * auto p0 = async.PopFront();
+ * auto p1 = async.PopFront();
+ * auto p2 = async.PopFront();
+ *
+ * // Satisfy the futures out of order
+ * p2.set_value();
+ * EXPECT_EQ(f2.get(), 21);
+ * p0.set_value();
+ * EXPECT_EQ(f0.get(), 42);
+ * p1.set_value();
+ * EXPECT_EQ(f1.get(), 84);
+ * @endcode
+ */
+class AsyncSequencer {
+ public:
+  AsyncSequencer() = default;
+
+  future<void> PushBack();
+
+  promise<void> PopFront();
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::deque<promise<void>> queue_;
+};
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_ASYNC_SEQUENCER_H

--- a/google/cloud/testing_util/google_cloud_cpp_testing.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_testing_hdrs = [
     "assert_ok.h",
+    "async_sequencer.h",
     "capture_log_lines_backend.h",
     "check_predicate_becomes_false.h",
     "chrono_literals.h",
@@ -36,6 +37,7 @@ google_cloud_cpp_testing_hdrs = [
 
 google_cloud_cpp_testing_srcs = [
     "assert_ok.cc",
+    "async_sequencer.cc",
     "capture_log_lines_backend.cc",
     "command_line_parsing.cc",
     "crash_handler.cc",


### PR DESCRIPTION
This changes `pubsub_internal::BatchingPublisherConnection` to send
batches to a `BatchSink`. With this change the batches are always within
the constraints defined by the application.

I refactored some common testing code to `testing_utils`.

Part of the work for #5413

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5438)
<!-- Reviewable:end -->
