### PR TITLE
test(storage): add emulator unit tests and cleanup

### DIFF
--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -19,11 +19,8 @@ FROM fedora:${DISTRO_VERSION}
 RUN dnf makecache && \
     dnf install -y ccache clang clang-tools-extra cmake diffutils findutils \
         gcc-c++ git libcxx-devel libcxxabi-devel libasan libubsan libtsan \
-        llvm make openssl-devel pkgconfig python3 python3.8 python3-devel \
-        python3-pip tar unzip wget which zlib-devel
-
-# Link `python` to `python3`
-RUN ln -s $(which python3) /usr/bin/python
+        llvm make openssl-devel pkgconfig python python3.8 python3-devel \
+        python-pip tar unzip wget which zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
@@ -36,7 +33,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
 RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+    crc32c==2.1 gunicorn==20.0.4
 
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -22,6 +22,9 @@ RUN dnf makecache && \
         llvm make openssl-devel pkgconfig python3 python3.8 python3-devel \
         python3-pip tar unzip wget which zlib-devel
 
+# Link `python` to `python3`
+RUN ln -s $(which python3) /usr/bin/python
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
@@ -32,8 +35,8 @@ RUN echo 'root:' | chpasswd
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install grpcio==1.32.0 flask==1.1.2 pytest==6.0.2 httpbin==0.7.0 \
-    scalpl==0.4.0 crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
+    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
 
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -26,6 +26,9 @@ RUN dnf makecache && \
         make ninja-build npm openssl-devel pkgconfig protobuf-compiler python3 \
         python3.8 python3-pip ShellCheck tar unzip w3m wget which zlib-devel
 
+# Link `python` to `python3`
+RUN ln -s $(which python3) /usr/bin/python
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
@@ -57,8 +60,8 @@ RUN pip3 install black==19.3b0
 RUN dnf makecache && dnf install -y python3-devel
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install grpcio==1.32.0 flask==1.1.2 pytest==6.0.2 httpbin==0.7.0 \
-    scalpl==0.4.0 crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
+    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
 
 # Install cspell for spell checking.
 RUN npm install -g cspell

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -23,11 +23,8 @@ RUN dnf makecache && \
     dnf install -y abi-compliance-checker abi-dumper ccache \
         clang clang-tools-extra cmake diffutils doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins lcov libcxx-devel libcxxabi-devel libcurl-devel \
-        make ninja-build npm openssl-devel pkgconfig protobuf-compiler python3 \
-        python3.8 python3-pip ShellCheck tar unzip w3m wget which zlib-devel
-
-# Link `python` to `python3`
-RUN ln -s $(which python3) /usr/bin/python
+        make ninja-build npm openssl-devel pkgconfig protobuf-compiler python \
+        python3.8 python-pip ShellCheck tar unzip w3m wget which zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
@@ -61,7 +58,7 @@ RUN dnf makecache && dnf install -y python3-devel
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
 RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+    crc32c==2.1 gunicorn==20.0.4
 
 # Install cspell for spell checking.
 RUN npm install -g cspell

--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -19,11 +19,8 @@ FROM fedora:${DISTRO_VERSION}
 # then compile our code.
 RUN dnf makecache && \
     dnf install -y ccache clang clang-tools-extra cmake findutils gcc-c++ \
-        git llvm llvm-devel make ninja-build openssl-devel python3 python3.8 \
-        python3-devel python3-lit python3-pip tar unzip which wget xz
-
-# Link `python` to `python3`
-RUN ln -s $(which python3) /usr/bin/python
+        git llvm llvm-devel make ninja-build openssl-devel python python3.8 \
+        python3-devel python3-lit python-pip tar unzip which wget xz
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
@@ -36,7 +33,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
 RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+    crc32c==2.1 gunicorn==20.0.4
 
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/libcxx-10.0.0.src.tar.xz

--- a/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/docker/Dockerfile.fedora-libcxx-msan
@@ -22,6 +22,9 @@ RUN dnf makecache && \
         git llvm llvm-devel make ninja-build openssl-devel python3 python3.8 \
         python3-devel python3-lit python3-pip tar unzip which wget xz
 
+# Link `python` to `python3`
+RUN ln -s $(which python3) /usr/bin/python
+
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because
 # we run these containers as the invoking user's uid, which does not exist in
@@ -32,8 +35,8 @@ RUN echo 'root:' | chpasswd
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install grpcio==1.32.0 flask==1.1.2 pytest==6.0.2 httpbin==0.7.0 \
-    scalpl==0.4.0 crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
+    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
 
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/libcxx-10.0.0.src.tar.xz

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -48,11 +48,14 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
+# Link `python` to `python3`
+RUN ln -s $(which python3) /usr/bin/python
+
 # Install Python packages used in the integration tests.
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install grpcio==1.32.0 flask==1.1.2 pytest==6.0.2 httpbin==0.7.0 \
-    scalpl==0.4.0 crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
+    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
 
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.

--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -48,14 +48,12 @@ RUN apt-get update && \
         ca-certificates \
         apt-transport-https
 
-# Link `python` to `python3`
-RUN ln -s $(which python3) /usr/bin/python
-
 # Install Python packages used in the integration tests.
+RUN update-alternatives --install /usr/bin/python python $(which python3) 10
 RUN pip3 install setuptools wheel
 RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
 RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+    crc32c==2.1 gunicorn==20.0.4
 
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.

--- a/ci/kokoro/windows/build-bazel-dependencies.ps1
+++ b/ci/kokoro/windows/build-bazel-dependencies.ps1
@@ -13,10 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Stop on errors. This is similar to `set -e` on Unix shells.
-$ErrorActionPreference = "Stop"
-
-# Install dependencies for GCS emulator.
-pip install setuptools wheel
-pip install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-pip install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) No dependencies required for Bazel builds."

--- a/ci/kokoro/windows/build-bazel-dependencies.ps1
+++ b/ci/kokoro/windows/build-bazel-dependencies.ps1
@@ -13,4 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) No dependencies required for Bazel builds."
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+# Install dependencies for GCS emulator.
+pip install setuptools wheel
+pip install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
+pip install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 crc32c==2.1 gevent==20.9.0 gunicorn==20.0.4

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -30,15 +30,6 @@ BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
 
-# Run the unittests of the emulator before running integration tests.
-"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:test_utils" \
-  "//google/cloud/storage/emulator:test_gcs"
-exit_status=$?
-
-if [[ "$exit_status" -ne 0 ]]; then
-  exit "${exit_status}"
-fi
-
 # Configure run_testbench_utils.sh to run the GCS testbench.
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -31,7 +31,8 @@ shift
 bazel_test_args=("$@")
 
 # Run the unittests of the emulator before running integration tests.
-"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:all"
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:test_utils" \
+  "//google/cloud/storage/emulator:test_gcs"
 exit_status=$?
 
 if [[ "$exit_status" -ne 0 ]]; then

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -30,6 +30,14 @@ BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
 
+# Run the unittests of the emulator before running integration tests.
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:all"
+exit_status=$?
+
+if [[ "$exit_status" -ne 0 ]]; then
+  exit "${exit_status}"
+fi
+
 # Configure run_testbench_utils.sh to run the GCS testbench.
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -33,6 +33,7 @@ bazel_test_args=("$@")
 # Run the unittests of the emulator before running integration tests.
 "${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:test_utils" \
   "//google/cloud/storage/emulator:test_gcs"
+exit_status=$?
 
 if [[ "$exit_status" -ne 0 ]]; then
   exit "${exit_status}"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -30,6 +30,14 @@ BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
 
+# Run the unittests of the emulator before running integration tests.
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:test_utils" \
+  "//google/cloud/storage/emulator:test_gcs"
+
+if [[ "$exit_status" -ne 0 ]]; then
+  exit "${exit_status}"
+fi
+
 # Configure run_testbench_utils.sh to run the GCS testbench.
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_testbench_utils.sh"
 

--- a/google/cloud/storage/emulator/BUILD
+++ b/google/cloud/storage/emulator/BUILD
@@ -18,6 +18,7 @@ py_test(
     srcs = ["tests/test_gcs.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
     imports = ["."],
     main = "tests/test_gcs.py",
+    tags = ["manual"],
 )
 
 py_test(
@@ -26,4 +27,5 @@ py_test(
     srcs = ["tests/test_utils.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
     imports = ["."],
     main = "tests/test_utils.py",
+    tags = ["manual"],
 )

--- a/google/cloud/storage/emulator/BUILD
+++ b/google/cloud/storage/emulator/BUILD
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests entry"""
+py_test(
+    name = "test_gcs",
+    size = "small",
+    srcs = ["tests/test_gcs.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
+    imports = ["."],
+    main = "tests/test_gcs.py",
+)
 
-from tests import test_gcs, test_utils
-
-if __name__ == "__main__":
-    test_utils.run()
-    test_gcs.run()
+py_test(
+    name = "test_utils",
+    size = "small",
+    srcs = ["tests/test_utils.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
+    imports = ["."],
+    main = "tests/test_utils.py",
+)

--- a/google/cloud/storage/emulator/BUILD
+++ b/google/cloud/storage/emulator/BUILD
@@ -22,6 +22,7 @@ py_test(
     srcs = ["tests/test_gcs.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
     imports = ["."],
     main = "tests/test_gcs.py",
+    tags = ["manual"],
 )
 
 py_test(
@@ -30,4 +31,5 @@ py_test(
     srcs = ["tests/test_utils.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
     imports = ["."],
     main = "tests/test_utils.py",
+    tags = ["manual"],
 )

--- a/google/cloud/storage/emulator/BUILD
+++ b/google/cloud/storage/emulator/BUILD
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
 py_test(
     name = "test_gcs",
     size = "small",
     srcs = ["tests/test_gcs.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
     imports = ["."],
     main = "tests/test_gcs.py",
-    tags = ["manual"],
 )
 
 py_test(
@@ -27,5 +30,4 @@ py_test(
     srcs = ["tests/test_utils.py"] + glob(["gcs/*.py"]) + glob(["utils/*.py"]),
     imports = ["."],
     main = "tests/test_utils.py",
-    tags = ["manual"],
 )

--- a/google/cloud/storage/emulator/requirements.txt
+++ b/google/cloud/storage/emulator/requirements.txt
@@ -1,7 +1,5 @@
 git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-grpcio==1.32.0
 flask==1.1.2
-pytest==6.0.2
 httpbin==0.7.0
 scalpl==0.4.0
 crc32c==2.1

--- a/google/cloud/storage/emulator/requirements.txt
+++ b/google/cloud/storage/emulator/requirements.txt
@@ -3,5 +3,4 @@ flask==1.1.2
 httpbin==0.7.0
 scalpl==0.4.0
 crc32c==2.1
-gevent==20.9.0
 gunicorn==20.0.4

--- a/google/cloud/storage/emulator/tests/test_gcs.py
+++ b/google/cloud/storage/emulator/tests/test_gcs.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,82 +16,123 @@
 """Unit test for utils"""
 
 import json
+import unittest
 
 import gcs
-import pytest
 import utils
 
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+from google.cloud.storage_v1.proto import storage_resources_pb2 as resources_pb2
+from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 from google.protobuf import json_format
 
 
-class TestBucket:
+class TestBucket(unittest.TestCase):
     def test_init_grpc(self):
         request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
         bucket, projection = gcs.bucket.Bucket.init(request, "")
-        assert bucket.metadata.name == "bucket"
-        assert projection == 1
-        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
-            "bucket", 3, ""
+        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(projection, CommonEnums.Projection.NO_ACL)
+        self.assertListEqual(
+            list(bucket.metadata.acl),
+            utils.acl.compute_predefined_bucket_acl(
+                "bucket", CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PROJECT_PRIVATE, ""
+            ),
         )
-        assert list(
-            bucket.metadata.default_object_acl
-        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+        self.assertListEqual(
+            list(bucket.metadata.default_object_acl),
+            utils.acl.compute_predefined_default_object_acl(
+                "bucket", CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE, ""
+            ),
+        )
 
         # WITH ACL
         request = storage_pb2.InsertBucketRequest(
             bucket={
                 "name": "bucket",
-                "acl": utils.acl.compute_predefined_bucket_acl("bucket", 1, ""),
+                "acl": utils.acl.compute_predefined_bucket_acl(
+                    "bucket",
+                    CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ,
+                    "",
+                ),
             }
         )
         bucket, projection = gcs.bucket.Bucket.init(request, "")
-        assert bucket.metadata.name == "bucket"
-        assert projection == 2
-        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
-            "bucket", 1, ""
+        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(projection, CommonEnums.Projection.FULL)
+        self.assertEqual(
+            list(bucket.metadata.acl),
+            utils.acl.compute_predefined_bucket_acl(
+                "bucket",
+                CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ,
+                "",
+            ),
         )
-        assert list(
-            bucket.metadata.default_object_acl
-        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+        self.assertListEqual(
+            list(bucket.metadata.default_object_acl),
+            utils.acl.compute_predefined_default_object_acl(
+                "bucket", CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE, ""
+            ),
+        )
 
         # WITH PREDEFINED ACL
         request = storage_pb2.InsertBucketRequest(
-            bucket={"name": "bucket"}, predefined_acl=5
+            bucket={"name": "bucket"},
+            predefined_acl=CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PUBLIC_READ_WRITE,
         )
         bucket, projection = gcs.bucket.Bucket.init(request, "")
-        assert bucket.metadata.name == "bucket"
-        assert projection == 1
-        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
-            "bucket", 5, ""
+        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(projection, CommonEnums.Projection.NO_ACL)
+        self.assertEqual(
+            list(bucket.metadata.acl),
+            utils.acl.compute_predefined_bucket_acl(
+                "bucket",
+                CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PUBLIC_READ_WRITE,
+                "",
+            ),
         )
-        assert list(
-            bucket.metadata.default_object_acl
-        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+        self.assertListEqual(
+            list(bucket.metadata.default_object_acl),
+            utils.acl.compute_predefined_default_object_acl(
+                "bucket", CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE, ""
+            ),
+        )
 
         # WITH ACL AND PREDEFINED ACL
         request = storage_pb2.InsertBucketRequest(
             bucket={
                 "name": "bucket",
-                "acl": utils.acl.compute_predefined_bucket_acl("bucket", 1, ""),
+                "acl": utils.acl.compute_predefined_bucket_acl(
+                    "bucket",
+                    CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ,
+                    "",
+                ),
             },
-            predefined_acl=2,
+            predefined_acl=CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PRIVATE,
         )
         bucket, projection = gcs.bucket.Bucket.init(request, "")
-        assert bucket.metadata.name == "bucket"
-        assert projection == 2
-        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
-            "bucket", 1, ""
+        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(projection, CommonEnums.Projection.FULL)
+        self.assertEqual(
+            list(bucket.metadata.acl),
+            utils.acl.compute_predefined_bucket_acl(
+                "bucket",
+                CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ,
+                "",
+            ),
         )
-        assert list(
-            bucket.metadata.default_object_acl
-        ) == utils.acl.compute_predefined_default_object_acl("bucket", 5, "")
+        self.assertListEqual(
+            list(bucket.metadata.default_object_acl),
+            utils.acl.compute_predefined_default_object_acl(
+                "bucket", CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE, ""
+            ),
+        )
 
     def test_init_rest(self):
         request = utils.common.FakeRequest(args={}, data=json.dumps({"name": "bucket"}))
         bucket, projection = gcs.bucket.Bucket.init(request, None)
-        assert bucket.metadata.name == "bucket"
-        assert projection == "noAcl"
+        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(projection, "noAcl")
 
         request = utils.common.FakeRequest(
             args={},
@@ -107,10 +149,13 @@ class TestBucket:
             ),
         )
         bucket, projection = gcs.bucket.Bucket.init(request, None)
-        assert bucket.metadata.name == "bucket"
-        assert projection == "full"
-        assert list(bucket.metadata.acl) == utils.acl.compute_predefined_bucket_acl(
-            "bucket", "authenticatedRead", None
+        self.assertEqual(bucket.metadata.name, "bucket")
+        self.assertEqual(projection, "full")
+        self.assertEqual(
+            list(bucket.metadata.acl),
+            utils.acl.compute_predefined_bucket_acl(
+                "bucket", "authenticatedRead", None
+            ),
         )
 
     def test_patch(self):
@@ -123,11 +168,11 @@ class TestBucket:
             }
         )
         bucket, projection = gcs.bucket.Bucket.init(request, "")
-        assert bucket.metadata.labels.get("init") == "true"
-        assert bucket.metadata.labels.get("patch") == "false"
-        assert bucket.metadata.labels.get("method") is None
-        assert bucket.metadata.website.main_page_suffix == ""
-        assert bucket.metadata.website.not_found_page == "notfound.html"
+        self.assertEqual(bucket.metadata.labels.get("init"), "true")
+        self.assertEqual(bucket.metadata.labels.get("patch"), "false")
+        self.assertIsNone(bucket.metadata.labels.get("method"))
+        self.assertEqual(bucket.metadata.website.main_page_suffix, "")
+        self.assertEqual(bucket.metadata.website.not_found_page, "notfound.html")
 
         request = storage_pb2.PatchBucketRequest(
             bucket="bucket",
@@ -139,12 +184,12 @@ class TestBucket:
         )
         bucket.patch(request, "")
         # GRPC can not update a part of map field.
-        assert bucket.metadata.labels.get("init") is None
-        assert bucket.metadata.labels.get("patch") == "true"
-        assert bucket.metadata.labels.get("method") == "grpc"
-        assert bucket.metadata.website.main_page_suffix == "bucket"
+        self.assertIsNone(bucket.metadata.labels.get("init"))
+        self.assertEqual(bucket.metadata.labels.get("patch"), "true")
+        self.assertEqual(bucket.metadata.labels.get("method"), "grpc")
+        self.assertEqual(bucket.metadata.website.main_page_suffix, "bucket")
         # `update_mask` does not update `website.not_found_page`
-        assert bucket.metadata.website.not_found_page == "notfound.html"
+        self.assertEqual(bucket.metadata.website.not_found_page, "notfound.html")
 
         request = utils.common.FakeRequest(
             args={},
@@ -158,13 +203,13 @@ class TestBucket:
         )
         bucket.patch(request, None)
         # REST should only update modifiable field.
-        assert bucket.metadata.name == "bucket"
+        self.assertEqual(bucket.metadata.name, "bucket")
         # REST can update a part of map field.
-        assert bucket.metadata.labels.get("init") is None
-        assert bucket.metadata.labels.get("patch") == "true"
-        assert bucket.metadata.labels.get("method") == "rest"
-        assert bucket.metadata.website.main_page_suffix == "bucket"
-        assert bucket.metadata.website.not_found_page == "404.html"
+        self.assertIsNone(bucket.metadata.labels.get("init"))
+        self.assertEqual(bucket.metadata.labels.get("patch"), "true")
+        self.assertEqual(bucket.metadata.labels.get("method"), "rest")
+        self.assertEqual(bucket.metadata.website.main_page_suffix, "bucket")
+        self.assertEqual(bucket.metadata.website.not_found_page, "404.html")
 
     def test_acl(self):
         # Both REST and GRPC share almost the same implementation so we only test GRPC here.
@@ -178,22 +223,22 @@ class TestBucket:
         bucket.insert_acl(request, "")
 
         acl = bucket.get_acl(entity, "")
-        assert acl.entity == entity
-        assert acl.email == "bucket.acl@example.com"
-        assert acl.role == "READER"
+        self.assertEqual(acl.entity, entity)
+        self.assertEqual(acl.email, "bucket.acl@example.com")
+        self.assertEqual(acl.role, "READER")
 
         request = storage_pb2.PatchBucketAccessControlRequest(
             bucket="bucket", entity=entity, bucket_access_control={"role": "OWNER"}
         )
         bucket.patch_acl(request, entity, "")
         acl = bucket.get_acl(entity, "")
-        assert acl.entity == entity
-        assert acl.email == "bucket.acl@example.com"
-        assert acl.role == "OWNER"
+        self.assertEqual(acl.entity, entity)
+        self.assertEqual(acl.email, "bucket.acl@example.com")
+        self.assertEqual(acl.role, "OWNER")
 
         bucket.delete_acl(entity, "")
-        for acl in bucket.metadata.acl:
-            assert acl.entity != entity
+        with self.assertRaises(Exception):
+            bucket.get_acl(entity, None)
 
     def test_default_object_acl(self):
         # Both REST and GRPC share almost the same implementation so we only test GRPC here.
@@ -207,74 +252,74 @@ class TestBucket:
         bucket.insert_default_object_acl(request, "")
 
         acl = bucket.get_default_object_acl(entity, "")
-        assert acl.entity == entity
-        assert acl.email == "bucket.default_object_acl@example.com"
-        assert acl.role == "READER"
+        self.assertEqual(acl.entity, entity)
+        self.assertEqual(acl.email, "bucket.default_object_acl@example.com")
+        self.assertEqual(acl.role, "READER")
 
         request = storage_pb2.PatchDefaultObjectAccessControlRequest(
             bucket="bucket", entity=entity, object_access_control={"role": "OWNER"}
         )
         bucket.patch_default_object_acl(request, entity, "")
         acl = bucket.get_default_object_acl(entity, "")
-        assert acl.entity == entity
-        assert acl.email == "bucket.default_object_acl@example.com"
-        assert acl.role == "OWNER"
+        self.assertEqual(acl.entity, entity)
+        self.assertEqual(acl.email, "bucket.default_object_acl@example.com")
+        self.assertEqual(acl.role, "OWNER")
 
         bucket.delete_default_object_acl(entity, "")
-        for acl in bucket.metadata.default_object_acl:
-            assert acl.entity != entity
+        with self.assertRaises(Exception):
+            bucket.get_default_object_acl(entity, None)
 
 
-class TestObject:
-    def test_init_media(self):
+class TestObject(unittest.TestCase):
+    def setUp(self):
         request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, projection = gcs.bucket.Bucket.init(request, "")
+        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        self.bucket = bucket
+
+    def test_init_media(self):
         request = utils.common.FakeRequest(
             args={"name": "object"}, data=b"12345678", headers={}, environ={}
         )
-        blob, _ = gcs.object.Object.init_media(request, bucket.metadata)
-        assert blob.metadata.name == "object"
-        assert blob.media == b"12345678"
+        blob, _ = gcs.object.Object.init_media(request, self.bucket.metadata)
+        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.media, b"12345678")
 
     def test_init_multipart(self):
-        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, _ = gcs.bucket.Bucket.init(request, "")
         request = utils.common.FakeRequest(
             args={},
             headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
             data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n{"name": "object", "metadata": {"key": "value"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n123456789\r\n--foo_bar_baz--\r\n',
             environ={},
         )
-        blob, _ = gcs.object.Object.init_multipart(request, bucket.metadata)
-        assert blob.metadata.name == "object"
-        assert blob.media == b"123456789"
-        assert blob.metadata.metadata["key"] == "value"
+        blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
+        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.media, b"123456789")
+        self.assertEqual(blob.metadata.metadata["key"], "value")
 
     def test_grpc_to_rest(self):
         # Make sure that object created by `gRPC` works with `REST`'s request.
-        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, _ = gcs.bucket.Bucket.init(request, "")
-        bucket = bucket.metadata
         spec = storage_pb2.InsertObjectSpec(
             resource={"name": "object", "bucket": "bucket"}
         )
         request = storage_pb2.StartResumableWriteRequest(insert_object_spec=spec)
-        upload = gcs.holder.DataHolder.init_resumable_grpc(request, bucket, "")
+        upload = gcs.holder.DataHolder.init_resumable_grpc(
+            request, self.bucket.metadata, ""
+        )
         blob, _ = gcs.object.Object.init(
             upload.request, upload.metadata, b"123456789", upload.bucket, False, ""
         )
 
-        assert blob.rest_only == {}
-        assert blob.media == b"123456789"
-        assert blob.metadata.name == "object"
-        assert blob.metadata.bucket == "bucket"
+        self.assertDictEqual(blob.rest_only, {})
+        self.assertEqual(blob.metadata.bucket, "bucket")
+        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.media, b"123456789")
 
         # `REST` GET
 
         rest_metadata = blob.rest_metadata()
-        assert rest_metadata["name"] == "object"
-        assert rest_metadata["bucket"] == "bucket"
-        assert blob.metadata.metadata.get("method") is None
+        self.assertEqual(rest_metadata["bucket"], "bucket")
+        self.assertEqual(rest_metadata["name"], "object")
+        self.assertIsNone(blob.metadata.metadata.get("method"))
 
         # `REST` PATCH
 
@@ -282,24 +327,21 @@ class TestObject:
             args={}, data=json.dumps({"metadata": {"method": "rest"}})
         )
         blob.patch(request, None)
-
-        assert blob.metadata.metadata["method"] == "rest"
+        self.assertEqual(blob.metadata.metadata["method"], "rest")
 
     def test_rest_to_grpc(self):
         # Make sure that object created by `REST` works with `gRPC`'s request.
-        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
-        bucket, _ = gcs.bucket.Bucket.init(request, "")
         request = utils.common.FakeRequest(
             args={},
             headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
             data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n{"name": "object", "metadata": {"method": "rest"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n123456789\r\n--foo_bar_baz--\r\n',
             environ={},
         )
-        blob, _ = gcs.object.Object.init_multipart(request, bucket.metadata)
-        assert blob.metadata.bucket == "bucket"
-        assert blob.metadata.name == "object"
-        assert blob.media == b"123456789"
-        assert blob.metadata.metadata["method"] == "rest"
+        blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
+        self.assertEqual(blob.metadata.bucket, "bucket")
+        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.media, b"123456789")
+        self.assertEqual(blob.metadata.metadata["method"], "rest")
 
         # `grpc` PATCH
 
@@ -310,11 +352,49 @@ class TestObject:
             update_mask={"paths": ["metadata"]},
         )
         blob.patch(request, "")
-        assert blob.metadata.bucket == "bucket"
-        assert blob.metadata.name == "object"
-        assert blob.media == b"123456789"
-        assert blob.metadata.metadata["method"] == "grpc"
+        self.assertEqual(blob.metadata.bucket, "bucket")
+        self.assertEqual(blob.metadata.name, "object")
+        self.assertEqual(blob.media, b"123456789")
+        self.assertEqual(blob.metadata.metadata["method"], "grpc")
 
 
-def run():
-    pytest.main(["-v"])
+class TestHolder(unittest.TestCase):
+    def test_init_resumable_grpc(self):
+        request = storage_pb2.InsertBucketRequest(bucket={"name": "bucket"})
+        bucket, _ = gcs.bucket.Bucket.init(request, "")
+        bucket = bucket.metadata
+        insert_object_spec = storage_pb2.InsertObjectSpec(
+            resource={"name": "object", "bucket": "bucket"},
+            predefined_acl=CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE,
+            if_generation_not_match={"value": 1},
+            if_metageneration_match={"value": 2},
+            if_metageneration_not_match={"value": 3},
+            projection=CommonEnums.Projection.FULL,
+        )
+        request = storage_pb2.InsertObjectRequest(
+            insert_object_spec=insert_object_spec, write_offset=0
+        )
+        upload = gcs.holder.DataHolder.init_resumable_grpc(request, bucket, "")
+        self.assertEqual(
+            upload.metadata, resources_pb2.Object(name="object", bucket="bucket")
+        )
+        predefined_acl = utils.acl.extract_predefined_acl(upload.request, False, "")
+        self.assertEqual(
+            predefined_acl, CommonEnums.PredefinedObjectAcl.OBJECT_ACL_PROJECT_PRIVATE
+        )
+        match, not_match = utils.generation.extract_precondition(
+            upload.request, False, False, ""
+        )
+        self.assertIsNone(match)
+        self.assertEqual(not_match, 1)
+        match, not_match = utils.generation.extract_precondition(
+            upload.request, True, False, ""
+        )
+        self.assertEqual(match, 2)
+        self.assertEqual(not_match, 3)
+        projection = utils.common.extract_projection(upload.request, False, "")
+        self.assertEqual(projection, CommonEnums.Projection.FULL)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/google/cloud/storage/emulator/tests/test_gcs.py
+++ b/google/cloud/storage/emulator/tests/test_gcs.py
@@ -397,4 +397,4 @@ class TestHolder(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main()

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,133 +15,151 @@
 
 """Unit test for utils"""
 
-import pytest
+import unittest
+
 import utils
 
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
+from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 
 
-class TestACL:
+class TestACL(unittest.TestCase):
     def test_extract_predefined_default_object_acl(self):
         request = storage_pb2.InsertBucketRequest()
         predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
             request, ""
         )
-        assert predefined_default_object_acl == 0
+        self.assertEqual(
+            predefined_default_object_acl,
+            CommonEnums.PredefinedObjectAcl.PREDEFINED_OBJECT_ACL_UNSPECIFIED,
+        )
 
-        request.predefined_default_object_acl = 1
+        request.predefined_default_object_acl = (
+            CommonEnums.PredefinedObjectAcl.OBJECT_ACL_AUTHENTICATED_READ
+        )
         predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
             request, ""
         )
-        assert predefined_default_object_acl == 1
+        self.assertEqual(
+            predefined_default_object_acl,
+            CommonEnums.PredefinedObjectAcl.OBJECT_ACL_AUTHENTICATED_READ,
+        )
 
         request = utils.common.FakeRequest(args={})
         predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
             request, None
         )
-        assert predefined_default_object_acl == ""
+        self.assertEqual(predefined_default_object_acl, "")
 
         request.args["predefinedDefaultObjectAcl"] = "authenticatedRead"
         predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
             request, None
         )
-        assert predefined_default_object_acl == "authenticatedRead"
+        self.assertEqual(predefined_default_object_acl, "authenticatedRead")
 
     def test_extract_predefined_acl(self):
         request = storage_pb2.InsertBucketRequest()
         predefined_acl = utils.acl.extract_predefined_acl(request, False, "")
-        assert predefined_acl == 0
+        self.assertEqual(
+            predefined_acl,
+            CommonEnums.PredefinedBucketAcl.PREDEFINED_BUCKET_ACL_UNSPECIFIED,
+        )
 
-        request.predefined_acl = 1
+        request.predefined_acl = (
+            CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ
+        )
         predefined_acl = utils.acl.extract_predefined_acl(request, False, "")
-        assert predefined_acl == 1
+        self.assertEqual(
+            predefined_acl,
+            CommonEnums.PredefinedBucketAcl.BUCKET_ACL_AUTHENTICATED_READ,
+        )
 
-        request = storage_pb2.CopyObjectRequest(destination_predefined_acl=2)
+        request = storage_pb2.CopyObjectRequest(
+            destination_predefined_acl=CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PRIVATE
+        )
         predefined_acl = utils.acl.extract_predefined_acl(request, True, "")
-        assert predefined_acl == 2
+        self.assertEqual(
+            predefined_acl, CommonEnums.PredefinedBucketAcl.BUCKET_ACL_PRIVATE
+        )
 
         request = utils.common.FakeRequest(args={})
         predefined_acl = utils.acl.extract_predefined_acl(request, False, None)
-        assert predefined_acl == ""
+        self.assertEqual(predefined_acl, "")
 
         request.args["predefinedAcl"] = "authenticatedRead"
         predefined_acl = utils.acl.extract_predefined_acl(request, False, None)
-        assert predefined_acl == "authenticatedRead"
+        self.assertEqual(predefined_acl, "authenticatedRead")
 
         request.args["destinationPredefinedAcl"] = "bucketOwnerFullControl"
         predefined_acl = utils.acl.extract_predefined_acl(request, True, None)
-        assert predefined_acl == "bucketOwnerFullControl"
+        self.assertEqual(predefined_acl, "bucketOwnerFullControl")
 
     def test_compute_predefined_bucket_acl(self):
         acls = utils.acl.compute_predefined_bucket_acl(
             "bucket", "authenticatedRead", None
         )
         entities = [acl.entity for acl in acls]
-        assert entities == [
-            utils.acl.get_project_entity("owners", None),
-            "allAuthenticatedUsers",
-        ]
+        self.assertListEqual(
+            entities,
+            [utils.acl.get_project_entity("owners", None), "allAuthenticatedUsers"],
+        )
 
     def test_compute_predefined_default_object_acl(self):
         acls = utils.acl.compute_predefined_default_object_acl(
             "bucket", "authenticatedRead", None
         )
         entities = [acl.entity for acl in acls]
-        assert entities == [
-            utils.acl.get_object_entity("OWNER", None),
-            "allAuthenticatedUsers",
-        ]
+        self.assertEqual(
+            entities,
+            [utils.acl.get_object_entity("OWNER", None), "allAuthenticatedUsers"],
+        )
 
         object_names = [acl.object for acl in acls]
-        assert object_names == 2 * [""]
+        self.assertEqual(object_names, 2 * [""])
 
     def test_compute_predefined_object_acl(self):
         acls = utils.acl.compute_predefined_object_acl(
             "bucket", "object", 123456789, "authenticatedRead", None
         )
         entities = [acl.entity for acl in acls]
-        assert entities == [
-            utils.acl.get_object_entity("OWNER", None),
-            "allAuthenticatedUsers",
-        ]
+        self.assertEqual(
+            entities,
+            [utils.acl.get_object_entity("OWNER", None), "allAuthenticatedUsers"],
+        )
 
         object_names = [acl.object for acl in acls]
-        assert object_names == 2 * ["object"]
+        self.assertEqual(object_names, 2 * ["object"])
 
         generations = [acl.generation for acl in acls]
-        assert generations == 2 * [123456789]
+        self.assertEqual(generations, 2 * [123456789])
 
 
-class TestCommonUtils:
+class TestCommonUtils(unittest.TestCase):
     def test_snake_case(self):
-        assert utils.common.to_snake_case("authenticatedRead") == "authenticated_read"
-        assert (
-            utils.common.to_snake_case("allAuthenticatedUsers")
-            == "all_authenticated_users"
+        self.assertEqual(
+            utils.common.to_snake_case("authenticatedRead"), "authenticated_read"
+        )
+        self.assertEqual(
+            utils.common.to_snake_case("allAuthenticatedUsers"),
+            "all_authenticated_users",
         )
 
     def test_parse_fields(self):
         fields = "kind, items ( acl( entity, role), name, id)"
-        assert (
-            utils.common.parse_fields(fields).sort()
-            == [
-                "kind",
-                "items.acl.entity",
-                "items.acl.role",
-                "items.name",
-                "items.id",
-            ].sort()
+        self.assertCountEqual(
+            utils.common.parse_fields(fields),
+            ["kind", "items.acl.entity", "items.acl.role", "items.name", "items.id"],
         )
 
         fields = "kind, items(name, labels(number), acl(role))"
-        assert (
-            utils.common.parse_fields(fields).sort()
-            == ["kind", "items.name", "items.labels.number", "items.acl.role"].sort()
+        self.assertCountEqual(
+            utils.common.parse_fields(fields),
+            ["kind", "items.name", "items.labels.number", "items.acl.role"],
         )
 
     def test_remove_index(self):
         key = "items[1].name[0].id[0].acl"
-        assert utils.common.remove_index(key) == "items.name.id.acl"
+        self.assertEqual(utils.common.remove_index(key), "items.name.id.acl")
 
     def test_nested_key(self):
         doc = {
@@ -148,29 +167,40 @@ class TestCommonUtils:
             "acl": [{"id": 1}, {"id": 2}],
             "labels": {"first": 1, "second": [1, 2]},
         }
-        assert utils.common.nested_key(doc) == [
-            "name",
-            "acl[0].id",
-            "acl[1].id",
-            "labels.first",
-            "labels.second[0]",
-            "labels.second[1]",
-        ]
+        self.assertCountEqual(
+            utils.common.nested_key(doc),
+            [
+                "name",
+                "acl[0].id",
+                "acl[1].id",
+                "labels.first",
+                "labels.second[0]",
+                "labels.second[1]",
+            ],
+        )
 
     def test_extract_projection(self):
         request = storage_pb2.CopyObjectRequest()
-        projection = utils.common.extract_projection(request, 1, "")
-        assert projection == 1
-        request.projection = 2
-        projection = utils.common.extract_projection(request, 1, "")
-        assert projection == 2
+        projection = utils.common.extract_projection(
+            request, CommonEnums.Projection.NO_ACL, ""
+        )
+        self.assertEqual(projection, CommonEnums.Projection.NO_ACL)
+        request.projection = CommonEnums.Projection.FULL
+        projection = utils.common.extract_projection(
+            request, CommonEnums.Projection.NO_ACL, ""
+        )
+        self.assertEqual(projection, CommonEnums.Projection.FULL)
 
         request = utils.common.FakeRequest(args={})
-        projection = utils.common.extract_projection(request, 1, None)
-        assert projection == "noAcl"
+        projection = utils.common.extract_projection(
+            request, CommonEnums.Projection.NO_ACL, None
+        )
+        self.assertEqual(projection, "noAcl")
         request.args["projection"] = "full"
-        projection = utils.common.extract_projection(request, 1, None)
-        assert projection == "full"
+        projection = utils.common.extract_projection(
+            request, CommonEnums.Projection.NO_ACL, None
+        )
+        self.assertEqual(projection, "full")
 
     def test_filter_response_rest(self):
         response = {
@@ -196,26 +226,29 @@ class TestCommonUtils:
         response_full = utils.common.filter_response_rest(
             response, "full", "kind, items(name, labels(number), acl(role))"
         )
-        assert response_full == {
-            "kind": "storage#buckets",
-            "items": [
-                {
-                    "name": "bucket1",
-                    "labels": {"number": "1"},
-                    "acl": [{"role": "OWNER"}],
-                },
-                {
-                    "name": "bucket2",
-                    "labels": {"number": "2"},
-                    "acl": [{"role": "OWNER"}],
-                },
-                {
-                    "name": "bucket3",
-                    "labels": {"number": "3"},
-                    "acl": [{"role": "OWNER"}],
-                },
-            ],
-        }
+        self.assertDictEqual(
+            response_full,
+            {
+                "kind": "storage#buckets",
+                "items": [
+                    {
+                        "name": "bucket1",
+                        "labels": {"number": "1"},
+                        "acl": [{"role": "OWNER"}],
+                    },
+                    {
+                        "name": "bucket2",
+                        "labels": {"number": "2"},
+                        "acl": [{"role": "OWNER"}],
+                    },
+                    {
+                        "name": "bucket3",
+                        "labels": {"number": "3"},
+                        "acl": [{"role": "OWNER"}],
+                    },
+                ],
+            },
+        )
 
         response = {
             "kind": "storage#buckets",
@@ -240,13 +273,16 @@ class TestCommonUtils:
         response_noacl = utils.common.filter_response_rest(
             response, "noAcl", "items(name, labels)"
         )
-        assert response_noacl == {
-            "items": [
-                {"name": "bucket1", "labels": {"number": "1", "order": "1"}},
-                {"name": "bucket2", "labels": {"number": "2", "order": "2"}},
-                {"name": "bucket3", "labels": {"number": "3", "order": "3"}},
-            ]
-        }
+        self.assertDictEqual(
+            response_noacl,
+            {
+                "items": [
+                    {"name": "bucket1", "labels": {"number": "1", "order": "1"}},
+                    {"name": "bucket2", "labels": {"number": "2", "order": "2"}},
+                    {"name": "bucket3", "labels": {"number": "3", "order": "3"}},
+                ]
+            },
+        )
 
     def test_parse_multipart(self):
         request = utils.common.FakeRequest(
@@ -255,12 +291,14 @@ class TestCommonUtils:
             environ={},
         )
         metadata, media_header, media = utils.common.parse_multipart(request)
-        assert metadata == {"name": "myObject", "metadata": {"test": "test"}}
-        assert media_header == {"Content-Type": "image/jpeg"}
-        assert media == b"123456789"
+        self.assertDictEqual(
+            metadata, {"name": "myObject", "metadata": {"test": "test"}}
+        )
+        self.assertDictEqual(media_header, {"Content-Type": "image/jpeg"})
+        self.assertEqual(media, b"123456789")
 
 
-class TestGeneration:
+class TestGeneration(unittest.TestCase):
     def test_extract_precondition(self):
         request = storage_pb2.CopyObjectRequest(
             if_generation_not_match={"value": 1},
@@ -274,23 +312,23 @@ class TestGeneration:
         match, not_match = utils.generation.extract_precondition(
             request, False, False, ""
         )
-        assert match is None
-        assert not_match == 1
+        self.assertIsNone(match)
+        self.assertEqual(not_match, 1)
         match, not_match = utils.generation.extract_precondition(
             request, True, False, ""
         )
-        assert match == 2
-        assert not_match == 3
+        self.assertEqual(match, 2)
+        self.assertEqual(not_match, 3)
         match, not_match = utils.generation.extract_precondition(
             request, False, True, ""
         )
-        assert match == 4
-        assert not_match == 5
+        self.assertEqual(match, 4)
+        self.assertEqual(not_match, 5)
         match, not_match = utils.generation.extract_precondition(
             request, True, True, ""
         )
-        assert match == 6
-        assert not_match == 7
+        self.assertEqual(match, 6)
+        self.assertEqual(not_match, 7)
 
         request = utils.common.FakeRequest(
             args={
@@ -306,48 +344,48 @@ class TestGeneration:
         match, not_match = utils.generation.extract_precondition(
             request, False, False, None
         )
-        assert match is None
-        assert not_match == 1
+        self.assertIsNone(match)
+        self.assertEqual(not_match, 1)
         match, not_match = utils.generation.extract_precondition(
             request, True, False, None
         )
-        assert match == 2
-        assert not_match == 3
+        self.assertEqual(match, 2)
+        self.assertEqual(not_match, 3)
         match, not_match = utils.generation.extract_precondition(
             request, False, True, None
         )
-        assert match == 4
-        assert not_match == 5
+        self.assertEqual(match, 4)
+        self.assertEqual(not_match, 5)
         match, not_match = utils.generation.extract_precondition(
             request, True, True, None
         )
-        assert match == 6
-        assert not_match == 7
+        self.assertEqual(match, 6)
+        self.assertEqual(not_match, 7)
 
     def test_extract_generation(self):
         request = storage_pb2.GetObjectRequest()
         generation = utils.generation.extract_generation(request, False, "")
-        assert generation == 0
+        self.assertEqual(generation, 0)
 
         request.generation = 1
         generation = utils.generation.extract_generation(request, False, "")
-        assert generation == 1
+        self.assertEqual(generation, 1)
 
         request = storage_pb2.CopyObjectRequest(source_generation=2)
         generation = utils.generation.extract_generation(request, True, "")
-        assert generation == 2
+        self.assertEqual(generation, 2)
 
         request = utils.common.FakeRequest(args={})
         generation = utils.generation.extract_generation(request, False, None)
-        assert generation == 0
+        self.assertEqual(generation, 0)
 
         request.args["generation"] = 1
         request.args["sourceGeneration"] = 2
         generation = utils.generation.extract_generation(request, False, None)
-        assert generation == 1
+        self.assertEqual(generation, 1)
         generation = utils.generation.extract_generation(request, True, None)
-        assert generation == 2
+        self.assertEqual(generation, 2)
 
 
-def run():
-    pytest.main(["-v"])
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -388,4 +388,4 @@ class TestGeneration(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main()


### PR DESCRIPTION
Since `Bazel` does not fully support `pytest`, I converted all those tests to `unittest`.

I have some questions
- Should we convert all the code that are using `testbench` to `emulator` ?
- When will we remove the `testbench` directory ?

Part of #4751 

We finally reach a milestone in `Complete GCS+gRPC plugin`. From now, we could implementing `GCS+gRPC` without worrying about testing 🚀

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5453)
<!-- Reviewable:end -->
