### PR TITLE
feat(pubsub): improve lease management performance

### DIFF
--- a/google/cloud/pubsub/internal/subscription_lease_management.h
+++ b/google/cloud/pubsub/internal/subscription_lease_management.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/internal/subscription_batch_source.h"
 #include "google/cloud/pubsub/version.h"
+#include "absl/container/flat_hash_map.h"
 #include <chrono>
 #include <memory>
 
@@ -123,7 +124,7 @@ class SubscriptionLeaseManagement
     std::chrono::system_clock::time_point estimated_server_deadline;
     std::chrono::system_clock::time_point handling_deadline;
   };
-  std::map<std::string, LeaseStatus> leases_;
+  absl::flat_hash_map<std::string, LeaseStatus> leases_;
 
   bool refreshing_leases_ = false;
   future<void> refresh_timer_;

--- a/google/cloud/pubsub/internal/subscription_lease_management_test.cc
+++ b/google/cloud/pubsub/internal/subscription_lease_management_test.cc
@@ -26,7 +26,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::ElementsAre;
+using ::testing::UnorderedElementsAre;
 
 google::pubsub::v1::StreamingPullResponse GenerateMessages(
     std::string const& prefix, int count) {
@@ -61,7 +61,7 @@ TEST(SubscriptionLeaseManagementTest, NormalLifecycle) {
         // messages.
         .WillOnce([&](std::vector<std::string> const& ack_ids,
                       std::chrono::seconds extension) {
-          EXPECT_THAT(ack_ids, ElementsAre("ack-0-0", "ack-0-2"));
+          EXPECT_THAT(ack_ids, UnorderedElementsAre("ack-0-0", "ack-0-2"));
           EXPECT_LE(std::abs((kTestDeadline - extension).count()), 2);
           return make_ready_future(Status{});
         });
@@ -71,12 +71,12 @@ TEST(SubscriptionLeaseManagementTest, NormalLifecycle) {
         // The a simulated timer refreshes the leases.
         .WillOnce([&](std::vector<std::string> const& ack_ids,
                       std::chrono::seconds extension) {
-          EXPECT_THAT(ack_ids, ElementsAre("ack-0-0"));
+          EXPECT_THAT(ack_ids, UnorderedElementsAre("ack-0-0"));
           EXPECT_LE(std::abs((kTestDeadline - extension).count()), 2);
           return make_ready_future(Status{});
         });
     // Then all unhandled messages are nacked on shutdown.
-    EXPECT_CALL(*mock, BulkNack(ElementsAre("ack-0-0")))
+    EXPECT_CALL(*mock, BulkNack(UnorderedElementsAre("ack-0-0")))
         .WillOnce([](std::vector<std::string> const&) {
           return make_ready_future(Status{});
         });


### PR DESCRIPTION
Use `absl::flat_hash_map<>` instead of `std::map<>`, most of the time
the number of items is small, but this yields (by my measurement) a 3%
improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5454)
<!-- Reviewable:end -->
