### PR TITLE
refactor(common): move CompletionQueue mock

### DIFF
--- a/google/cloud/internal/async_read_write_stream_impl_test.cc
+++ b/google/cloud/internal/async_read_write_stream_impl_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
+#include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
@@ -28,6 +29,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::ReturnRef;
@@ -66,25 +68,6 @@ class MockStub {
  public:
   MOCK_METHOD(MockReturnType, FakeRpc,
               (grpc::ClientContext*, grpc::CompletionQueue*), ());
-};
-
-class MockCompletionQueueImpl : public CompletionQueueImpl {
- public:
-  MOCK_METHOD0(Run, void());
-  MOCK_METHOD0(Shutdown, void());
-  MOCK_METHOD0(CancelAll, void());
-  MOCK_METHOD1(MakeDeadlineTimer,
-               future<StatusOr<std::chrono::system_clock::time_point>>(
-                   std::chrono::system_clock::time_point));
-  MOCK_METHOD1(MakeRelativeTimer,
-               future<StatusOr<std::chrono::system_clock::time_point>>(
-                   std::chrono::nanoseconds));
-  MOCK_METHOD1(RunAsync, void(std::unique_ptr<RunAsyncBase>));
-
-  MOCK_METHOD2(StartOperation, void(std::shared_ptr<AsyncGrpcOperation>,
-                                    absl::FunctionRef<void(void*)>));
-
-  MOCK_METHOD0(cq, grpc::CompletionQueue&());
 };
 
 TEST(AsyncReadWriteStreamingRpcTest, Basic) {

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -98,6 +98,7 @@ if (BUILD_TESTING)
         is_proto_equal.cc
         is_proto_equal.h
         mock_async_response_reader.h
+        mock_completion_queue_impl.h
         validate_metadata.cc
         validate_metadata.h)
     target_link_libraries(

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_testing_grpc_hdrs = [
     "fake_completion_queue_impl.h",
     "is_proto_equal.h",
     "mock_async_response_reader.h",
+    "mock_completion_queue_impl.h",
     "validate_metadata.h",
 ]
 

--- a/google/cloud/testing_util/mock_completion_queue_impl.h
+++ b/google/cloud/testing_util/mock_completion_queue_impl.h
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_COMPLETION_QUEUE_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_COMPLETION_QUEUE_IMPL_H
+
+#include "google/cloud/internal/completion_queue_impl.h"
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace testing_util {
+
+class MockCompletionQueueImpl : public internal::CompletionQueueImpl {
+ public:
+  MOCK_METHOD0(Run, void());
+  MOCK_METHOD0(Shutdown, void());
+  MOCK_METHOD0(CancelAll, void());
+  MOCK_METHOD1(MakeDeadlineTimer,
+               future<StatusOr<std::chrono::system_clock::time_point>>(
+                   std::chrono::system_clock::time_point));
+  MOCK_METHOD1(MakeRelativeTimer,
+               future<StatusOr<std::chrono::system_clock::time_point>>(
+                   std::chrono::nanoseconds));
+  MOCK_METHOD1(RunAsync, void(std::unique_ptr<internal::RunAsyncBase>));
+
+  MOCK_METHOD2(StartOperation,
+               void(std::shared_ptr<internal::AsyncGrpcOperation>,
+                    absl::FunctionRef<void(void*)>));
+
+  MOCK_METHOD0(cq, grpc::CompletionQueue&());
+};
+
+}  // namespace testing_util
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_MOCK_COMPLETION_QUEUE_IMPL_H


### PR DESCRIPTION
I am going to need this class in a new test, refactor to a header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5463)
<!-- Reviewable:end -->
