### PR TITLE
ci: only update ABI if there were changes

### DIFF
--- a/ci/kokoro/docker/check-abi.sh
+++ b/ci/kokoro/docker/check-abi.sh
@@ -53,12 +53,15 @@ if [[ "${UPDATE_ABI}" == "yes" ]]; then
     -lver "expected" \
     -o "${ACTUAL_DUMP_PATH}" &&
     gzip -c "${ACTUAL_DUMP_PATH}" >"${EXPECTED_DUMP_PATH}.tmp"
-  if zdiff "${EXPECTED_DUMP_PATH}.tmp" "${EXPECTED_DUMP_PATH}"; then
-    rm -f "${EXPECTED_DUMP_PATH}.tmp"
-  else
-    mv -f "${EXPECTED_DUMP_PATH}.tmp" "${EXPECTED_DUMP_PATH}"
+  exit_status=$?
+  if [[ $exit_status -eq 0 ]]; then
+    if zdiff "${EXPECTED_DUMP_PATH}.tmp" "${EXPECTED_DUMP_PATH}"; then
+      rm -f "${EXPECTED_DUMP_PATH}.tmp"
+    else
+      mv -f "${EXPECTED_DUMP_PATH}.tmp" "${EXPECTED_DUMP_PATH}"
+    fi
   fi
-  exit $?
+  exit $exit_status
 fi
 
 io::log "Checking ABI of ${LIBRARY}"

--- a/ci/kokoro/docker/check-abi.sh
+++ b/ci/kokoro/docker/check-abi.sh
@@ -52,7 +52,12 @@ if [[ "${UPDATE_ABI}" == "yes" ]]; then
     -public-headers "${INCLUDEDIR}" \
     -lver "expected" \
     -o "${ACTUAL_DUMP_PATH}" &&
-    gzip -c "${ACTUAL_DUMP_PATH}" >"${EXPECTED_DUMP_PATH}"
+    gzip -c "${ACTUAL_DUMP_PATH}" >"${EXPECTED_DUMP_PATH}.tmp"
+  if zdiff "${EXPECTED_DUMP_PATH}.tmp" "${EXPECTED_DUMP_PATH}"; then
+    rm -f "${EXPECTED_DUMP_PATH}.tmp"
+  else
+    mv -f "${EXPECTED_DUMP_PATH}.tmp" "${EXPECTED_DUMP_PATH}"
+  fi
   exit $?
 fi
 


### PR DESCRIPTION
Fixes: #5470

`gzip` files are binary and the default diff tool will show them as different
even if they are "identical". This uses `zdiff` to compare them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5472)
<!-- Reviewable:end -->
