### PR TITLE
fix(generator): correct method signature handling of pod values

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -54,6 +54,8 @@ std::string CppTypeToString(FieldDescriptor const* field) {
     case FieldDescriptor::CPPTYPE_FLOAT:
     case FieldDescriptor::CPPTYPE_BOOL:
     case FieldDescriptor::CPPTYPE_ENUM:
+      return std::string(field->cpp_type_name());
+
     case FieldDescriptor::CPPTYPE_STRING:
       return std::string("std::") + std::string(field->cpp_type_name());
 
@@ -121,7 +123,16 @@ void SetMethodSignatureMethodVars(
         method_request_setters += absl::StrFormat("  request.set_%s(%s);\n",
                                                   parameters[j], parameters[j]);
       }
-      method_signature += absl::StrFormat(" const& %s", parameters[j]);
+
+      switch (parameter_descriptor->cpp_type()) {
+        case FieldDescriptor::CPPTYPE_STRING:
+        case FieldDescriptor::CPPTYPE_MESSAGE:
+          method_signature += absl::StrFormat(" const& %s", parameters[j]);
+          break;
+        default:
+          method_signature += absl::StrFormat(" %s", parameters[j]);
+      }
+
       if (j < parameters.size() - 1) {
         method_signature += ", ";
       }

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -176,6 +176,8 @@ class CreateMethodVarsTest
           type: TYPE_MESSAGE
           type_name: "google.protobuf.Bar"
         }
+        field { name: "toggle" number: 4 type: TYPE_BOOL }
+        field { name: "title" number: 5 type: TYPE_STRING }
       }
       message_type { name: "Empty" }
       message_type {
@@ -261,6 +263,8 @@ class CreateMethodVarsTest
           options {
             [google.api.method_signature]: "name"
             [google.api.method_signature]: "number,widget"
+            [google.api.method_signature]: "toggle"
+            [google.api.method_signature]: "name,title"
             [google.api.http] {
               post: "/v1/{parent=projects/*/instances/*}/databases"
               body: "*"
@@ -386,8 +390,13 @@ INSTANTIATE_TEST_SUITE_P(
                              "method_signature0", "std::string const& name"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature1",
-                             "std::int32_t const& number, "
+                             "std::int32_t number, "
                              "::google::protobuf::Bar const& widget"),
+        MethodVarsTestValues("google.protobuf.Service.Method5",
+                             "method_signature2", "bool toggle"),
+        MethodVarsTestValues(
+            "google.protobuf.Service.Method5", "method_signature3",
+            "std::string const& name, std::string const& title"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_request_setters0",
                              "  request.set_name(name);\n"),


### PR DESCRIPTION
Correct std::bool const& to just bool (and double, float, and enums)
Correct std::int32_t const& to just std::int32_t. (and all integral types)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5480)
<!-- Reviewable:end -->
