### PR TITLE
chore: configure snippet-bot to ignore ci directory

### DIFF
--- a/.github/snippet-bot.yml
+++ b/.github/snippet-bot.yml
@@ -1,0 +1,2 @@
+ignoreFiles:
+  - "ci/**"


### PR DESCRIPTION
Some files in the `ci` directory has things like `[START packaging.md]`
and snippet-bot thinks they're region tags which is used in our cloud documentation site.

This configuration instructs snippet-bot to ignore all the files in `ci`
directory for violation checks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5482)
<!-- Reviewable:end -->
