### PR TITLE
cleanup(pubsub): remove unused return value

### DIFF
--- a/google/cloud/pubsub/internal/subscription_message_queue.cc
+++ b/google/cloud/pubsub/internal/subscription_message_queue.cc
@@ -44,17 +44,14 @@ void SubscriptionMessageQueue::Read(std::size_t max_callbacks) {
   DrainQueue(std::move(lk));
 }
 
-future<Status> SubscriptionMessageQueue::AckMessage(std::string const& ack_id) {
+void SubscriptionMessageQueue::AckMessage(std::string const& ack_id) {
   HandlerDone(ack_id);
   source_->AckMessage(ack_id);
-  return make_ready_future(Status{});
 }
 
-future<Status> SubscriptionMessageQueue::NackMessage(
-    std::string const& ack_id) {
+void SubscriptionMessageQueue::NackMessage(std::string const& ack_id) {
   HandlerDone(ack_id);
   source_->NackMessage(ack_id);
-  return make_ready_future(Status{});
 }
 
 void SubscriptionMessageQueue::OnRead(

--- a/google/cloud/pubsub/internal/subscription_message_queue.h
+++ b/google/cloud/pubsub/internal/subscription_message_queue.h
@@ -71,8 +71,8 @@ class SubscriptionMessageQueue
   void Start(MessageCallback cb) override;
   void Shutdown() override;
   void Read(std::size_t max_callbacks) override;
-  future<Status> AckMessage(std::string const& ack_id) override;
-  future<Status> NackMessage(std::string const& ack_id) override;
+  void AckMessage(std::string const& ack_id) override;
+  void NackMessage(std::string const& ack_id) override;
 
  private:
   explicit SubscriptionMessageQueue(

--- a/google/cloud/pubsub/internal/subscription_message_source.h
+++ b/google/cloud/pubsub/internal/subscription_message_source.h
@@ -57,7 +57,7 @@ class SubscriptionMessageSource {
    * The application has successfully handled this message and no new deliveries
    * are necessary.
    */
-  virtual future<Status> AckMessage(std::string const& ack_id) = 0;
+  virtual void AckMessage(std::string const& ack_id) = 0;
 
   /**
    * Reject the message associated with @p ack_id.
@@ -66,7 +66,7 @@ class SubscriptionMessageSource {
    * allows the service to re-deliver it, subject to the topic and subscription
    * configuration.
    */
-  virtual future<Status> NackMessage(std::string const& ack_id) = 0;
+  virtual void NackMessage(std::string const& ack_id) = 0;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS

--- a/google/cloud/pubsub/testing/mock_subscription_message_source.h
+++ b/google/cloud/pubsub/testing/mock_subscription_message_source.h
@@ -30,8 +30,8 @@ class MockSubscriptionMessageSource
   MOCK_METHOD1(Start, void(pubsub_internal::MessageCallback));
   MOCK_METHOD0(Shutdown, void());
   MOCK_METHOD1(Read, void(std::size_t max_callbacks));
-  MOCK_METHOD1(AckMessage, future<Status>(std::string const& ack_id));
-  MOCK_METHOD1(NackMessage, future<Status>(std::string const& ack_id));
+  MOCK_METHOD1(AckMessage, void(std::string const& ack_id));
+  MOCK_METHOD1(NackMessage, void(std::string const& ack_id));
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_PUBSUB_NS


### PR DESCRIPTION
I missed these in earlier cleanups, acks and nacks do not need to return
a future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5489)
<!-- Reviewable:end -->
