### PR TITLE
fix(pubsub): treat some kUnavailable as success

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -196,6 +196,25 @@ void StreamingSubscriptionBatchSource::OnInitialError(RetryLoopState rs) {
 
 void StreamingSubscriptionBatchSource::OnInitialFinish(RetryLoopState rs,
                                                        Status status) {
+  if (status.code() == StatusCode::kUnavailable) {
+    // Cloud Pub/Sub terminates a streaming pull trying to get data from an
+    // empty subscription with this message. This is a retryable failure, and
+    // should be treated as-if there was at least a successful connection
+    // established once. The rationale is that we *know* we were able to connect
+    // to the service (so this is not a kUnavailable for network reasons), and
+    // we *know* this is not an error due to permissions, or resource naming, or
+    // some other kind of non-retryable error.
+    auto constexpr kProbablyEmptySubscription =
+        "The service was unable to fulfill your request."
+        " Please try again. [code=8a75]";
+    if (status.message() == kProbablyEmptySubscription) {
+      shutdown_manager_->StartOperation(__func__, "reconnect", [&] {
+        StartStream(retry_policy_->clone(), backoff_policy_->clone());
+        shutdown_manager_->FinishedOperation("reconnect");
+      });
+      return;
+    }
+  }
   if (!rs.retry_policy->OnFailure(status)) {
     OnRetryFailure(std::move(status));
     return;

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -198,12 +198,12 @@ void StreamingSubscriptionBatchSource::OnInitialFinish(RetryLoopState rs,
                                                        Status status) {
   if (status.code() == StatusCode::kUnavailable) {
     // Cloud Pub/Sub terminates a streaming pull trying to get data from an
-    // empty subscription with this message. This is a retryable failure, and
-    // should be treated as-if there was at least a successful connection
-    // established once. The rationale is that we *know* we were able to connect
-    // to the service (so this is not a kUnavailable for network reasons), and
-    // we *know* this is not an error due to permissions, or resource naming, or
-    // some other kind of non-retryable error.
+    // empty subscription with this message. This should be treated as-if there
+    // was at least a successful connection established once. The rationale is
+    // that we *know* we were able to connect to the service (so this is not a
+    // kUnavailable for network reasons), and we *know* this is not an error due
+    // to permissions, or resource naming, or some other kind of non-retryable
+    // error.
     auto constexpr kProbablyEmptySubscription =
         "The service was unable to fulfill your request."
         " Please try again. [code=8a75]";

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -263,6 +263,75 @@ TEST(StreamingSubscriptionBatchSourceTest, StartTooManyTransientFailures) {
   EXPECT_EQ(done.get(), status);
 }
 
+TEST(StreamingSubscriptionBatchSourceTest, StartWithIgnoredUnavailable) {
+  using Response = google::pubsub::v1::StreamingPullResponse;
+
+  auto subscription = pubsub::Subscription("test-project", "test-subscription");
+  std::string const client_id = "fake-client-id";
+  AutomaticallyCreatedBackgroundThreads background;
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+
+  google::cloud::testing_util::AsyncSequencer<Status> on_finish;
+  auto async_pull_mock = [&on_finish](
+                             google::cloud::CompletionQueue& cq,
+                             std::unique_ptr<grpc::ClientContext>,
+                             google::pubsub::v1::StreamingPullRequest const&) {
+    using us = std::chrono::microseconds;
+    using F = future<StatusOr<std::chrono::system_clock::time_point>>;
+    auto start_response = [cq]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](F) { return true; });
+    };
+    auto write_response = [cq](google::pubsub::v1::StreamingPullRequest const&,
+                               grpc::WriteOptions const&) mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](F) { return true; });
+    };
+    auto read_response = [cq]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then(
+          [](F) { return absl::optional<Response>{}; });
+    };
+    auto finish_response = [&on_finish]() mutable {
+      return on_finish.PushBack("Finish").then(
+          [](future<Status> f) { return f.get(); });
+    };
+
+    auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+    EXPECT_CALL(*stream, Start).WillOnce(start_response);
+    EXPECT_CALL(*stream, Write).WillRepeatedly(write_response);
+    EXPECT_CALL(*stream, Cancel).Times(AtMost(1));
+    EXPECT_CALL(*stream, Read).WillRepeatedly(read_response);
+    EXPECT_CALL(*stream, Finish).WillOnce(finish_response);
+
+    return stream;
+  };
+  EXPECT_CALL(*mock, AsyncStreamingPull)
+      .Times(AtLeast(2))
+      .WillRepeatedly(async_pull_mock);
+
+  ::testing::MockFunction<void(StatusOr<Response>)> callback;
+  EXPECT_CALL(callback, Call(StatusIs(StatusCode::kPermissionDenied)));
+
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+  auto uut = std::make_shared<StreamingSubscriptionBatchSource>(
+      background.cq(), shutdown, mock, subscription.FullName(), client_id,
+      TestSubscriptionOptions(), TestRetryPolicy(), TestBackoffPolicy(),
+      TestBatchingConfig());
+
+  auto done = shutdown->Start({});
+  uut->Start(callback.AsStdFunction());
+
+  for (int i = 0; i != 4; ++i) {
+    on_finish.PopFront().set_value(
+        Status(StatusCode::kUnavailable,
+               "The service was unable to fulfill your request."
+               " Please try again. [code=8a75]"));
+  }
+  auto const final_status = Status(StatusCode::kPermissionDenied, "uh-oh");
+  on_finish.PopFront().set_value(final_status);
+  uut->Shutdown();
+
+  EXPECT_EQ(done.get(), final_status);
+}
+
 TEST(StreamingSubscriptionBatchSourceTest, StartPermanentFailure) {
   auto subscription = pubsub::Subscription("test-project", "test-subscription");
   std::string const client_id = "fake-client-id";


### PR DESCRIPTION
The service closes streaming pull requests with `kUnavailable` if there
is no data to pull. We should not treat these as failures (not even as
transient failures), because we showed that we successfully connected to
the service, that the subscription exists, and that we have permissions
to pull data. The "problem" is that we do not have data yet.

Fixes #5506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5510)
<!-- Reviewable:end -->
