### PR TITLE
cleanup(spanner): plumb ConnectionOptions into admin connection classes

### DIFF
--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -624,6 +624,11 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<PollingPolicy const> polling_policy_prototype_;
+
+  // Implementations of `BackgroundThreads` typically create a pool of
+  // threads that are joined during destruction, so, to avoid ownership
+  // cycles, those threads should never assume ownership of this object
+  // (e.g., via a `std::shared_ptr<>`).
   std::unique_ptr<BackgroundThreads> background_threads_;
 };
 

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -344,12 +344,17 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::unique_ptr<PollingPolicy> polling_policy);
 
 namespace internal {
-/// Create a connection with only the retry decorator.
+
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::shared_ptr<internal::DatabaseAdminStub> stub,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    ConnectionOptions const& options);
+
+std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    std::shared_ptr<internal::DatabaseAdminStub> stub,
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
+
 }  // namespace internal
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -46,7 +46,8 @@ std::shared_ptr<DatabaseAdminConnection> CreateTestingConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   return internal::MakeDatabaseAdminConnection(
-      std::move(mock), retry.clone(), backoff.clone(), polling.clone());
+      std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
+      polling.clone());
 }
 
 /// @test Verify that successful case works.
@@ -212,8 +213,6 @@ TEST(DatabaseAdminClientTest, UpdateDatabaseSuccess) {
   EXPECT_CALL(*mock, UpdateDatabase(_, _))
       .WillOnce(
           [](grpc::ClientContext&, gcsa::UpdateDatabaseDdlRequest const&) {
-            gcsa::UpdateDatabaseDdlMetadata metadata;
-            metadata.set_database("test-db");
             google::longrunning::Operation op;
             op.set_name("test-operation-name");
             op.set_done(false);

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -302,6 +302,11 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<PollingPolicy const> polling_policy_prototype_;
+
+  // Implementations of `BackgroundThreads` typically create a pool of
+  // threads that are joined during destruction, so, to avoid ownership
+  // cycles, those threads should never assume ownership of this object
+  // (e.g., via a `std::shared_ptr<>`).
   std::unique_ptr<BackgroundThreads> background_threads_;
 };
 

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -22,6 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 namespace gcsa = ::google::spanner::admin::instance::v1;
 namespace giam = ::google::iam::v1;
 using google::cloud::internal::Idempotency;
@@ -53,17 +54,20 @@ std::unique_ptr<PollingPolicy> DefaultInstanceAdminPollingPolicy() {
 class InstanceAdminConnectionImpl : public InstanceAdminConnection {
  public:
   InstanceAdminConnectionImpl(std::shared_ptr<internal::InstanceAdminStub> stub,
+                              ConnectionOptions const& options,
                               std::unique_ptr<RetryPolicy> retry_policy,
                               std::unique_ptr<BackoffPolicy> backoff_policy,
                               std::unique_ptr<PollingPolicy> polling_policy)
       : stub_(std::move(stub)),
         retry_policy_prototype_(std::move(retry_policy)),
         backoff_policy_prototype_(std::move(backoff_policy)),
-        polling_policy_prototype_(std::move(polling_policy)) {}
+        polling_policy_prototype_(std::move(polling_policy)),
+        background_threads_(options.background_threads_factory()()) {}
 
   explicit InstanceAdminConnectionImpl(
-      std::shared_ptr<internal::InstanceAdminStub> stub)
-      : InstanceAdminConnectionImpl(std::move(stub),
+      std::shared_ptr<internal::InstanceAdminStub> stub,
+      ConnectionOptions const& options)
+      : InstanceAdminConnectionImpl(std::move(stub), options,
                                     DefaultInstanceAdminRetryPolicy(),
                                     DefaultInstanceAdminBackoffPolicy(),
                                     DefaultInstanceAdminPollingPolicy()) {}
@@ -265,7 +269,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
     promise<StatusOr<gcsa::Instance>> pr;
     auto f = pr.get_future();
 
-    // TODO(#4038) - use the (implicit) completion queue to run this loop.
+    // TODO(#4038) - use background_threads_->cq() to run this loop.
     std::thread t(
         [](std::shared_ptr<internal::InstanceAdminStub> stub,
            google::longrunning::Operation operation,
@@ -298,7 +302,9 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<PollingPolicy const> polling_policy_prototype_;
+  std::unique_ptr<BackgroundThreads> background_threads_;
 };
+
 }  // namespace
 
 InstanceAdminConnection::~InstanceAdminConnection() = default;
@@ -314,7 +320,7 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   return internal::MakeInstanceAdminConnection(
-      internal::CreateDefaultInstanceAdminStub(options),
+      internal::CreateDefaultInstanceAdminStub(options), options,
       std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
@@ -323,18 +329,19 @@ namespace internal {
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
-    ConnectionOptions const&) {
-  return std::make_shared<InstanceAdminConnectionImpl>(std::move(base_stub));
+    ConnectionOptions const& options) {
+  return std::make_shared<InstanceAdminConnectionImpl>(std::move(base_stub),
+                                                       options);
 }
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   return std::make_shared<InstanceAdminConnectionImpl>(
-      std::move(base_stub), std::move(retry_policy), std::move(backoff_policy),
-      std::move(polling_policy));
+      std::move(base_stub), options, std::move(retry_policy),
+      std::move(backoff_policy), std::move(polling_policy));
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -234,19 +234,14 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::unique_ptr<PollingPolicy> polling_policy);
 
 namespace internal {
-/**
- * Create an InstanceAdminConnection using an existing base Stub.
- *
- * Returns a new InstanceAdminConnection with all the normal decorators applied
- * to @p base_stub.
- */
+
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
     ConnectionOptions const& options);
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
 

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -51,7 +51,8 @@ std::shared_ptr<InstanceAdminConnection> MakeLimitedRetryConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   return internal::MakeInstanceAdminConnection(
-      std::move(mock), retry.clone(), backoff.clone(), polling.clone());
+      std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
+      polling.clone());
 }
 
 TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {


### PR DESCRIPTION
Salvage part of the abandoned #5112 so that `DatabaseAdminConnection`
and `InstanceAdminConnection` both have a `BackgroundThreads` handle
from which they can obtain a `CompletionQueue` to execute the pieces
of long-running operations.

Part of #4038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5519)
<!-- Reviewable:end -->
