### PR TITLE
test(storage): enable `TEST_F(ObjectFileIntegrationTest, UploadFileBinary)` against emulator

### DIFF
--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -214,8 +214,6 @@ TEST_F(ObjectFileIntegrationTest, UploadFile) {
 }
 
 TEST_F(ObjectFileIntegrationTest, UploadFileBinary) {
-  // The testbench does not support binary payloads.
-  if (UsingTestbench()) GTEST_SKIP();
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
I am trying to split unrelated change out of #5518 

This enables `TEST_F(ObjectFileIntegrationTest, UploadFileBinary)` against emulator since the new emulator has already supported binary data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5520)
<!-- Reviewable:end -->
