### PR TITLE
test(storage): support csek for the new emulator

### DIFF
--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -416,7 +416,7 @@ def objects_compose(bucket_name, object_name):
             if source_object.get("objectPreconditions") is not None
             else None
         )
-        fake_request = utils.common.FakeRequest(args=dict())
+        fake_request = utils.common.FakeRequest(args=dict(), headers={})
         if generation is not None:
             fake_request.args["generation"] = generation
         if if_generation_match is not None:
@@ -443,6 +443,9 @@ def objects_copy(src_bucket_name, src_object_name, dst_bucket_name, dst_object_n
     dst_bucket = db.get_bucket_without_generation(dst_bucket_name, None).metadata
     src_object = db.get_object(
         flask.request, src_bucket_name, src_object_name, True, None
+    )
+    utils.csek.validation(
+        flask.request, src_object.metadata.customer_encryption.key_sha256, False, None
     )
     dst_metadata = resources_pb2.Object()
     dst_metadata.CopyFrom(src_object.metadata)
@@ -485,6 +488,9 @@ def objects_rewrite(src_bucket_name, src_object_name, dst_bucket_name, dst_objec
         rewrite = db.get_rewrite(token, None)
     src_object = db.get_object(
         rewrite.request, src_bucket_name, src_object_name, True, None
+    )
+    utils.csek.validation(
+        rewrite.request, src_object.metadata.customer_encryption.key_sha256, True, None
     )
     total_bytes_rewritten = len(rewrite.media)
     total_bytes_rewritten += min(
@@ -611,6 +617,9 @@ def object_get(bucket_name, object_name):
         )
     if media != "media":
         utils.error.invalid("Alt %s")
+    utils.csek.validation(
+        flask.request, blob.metadata.customer_encryption.key_sha256, False, None
+    )
     return blob.rest_media(flask.request)
 
 

--- a/google/cloud/storage/emulator/gcs/holder.py
+++ b/google/cloud/storage/emulator/gcs/holder.py
@@ -118,7 +118,13 @@ class DataHolder(types.SimpleNamespace):
         cls, request, src_bucket_name, src_object_name, dst_bucket_name, dst_object_name
     ):
         fake_request = utils.common.FakeRequest(
-            args=request.args.to_dict(), headers={}, data=request.data
+            args=request.args.to_dict(),
+            headers={
+                key.lower(): value
+                for key, value in request.headers.items()
+                if key.lower().startswith("x-")
+            },
+            data=request.data,
         )
         max_bytes_rewritten_per_call = min(
             int(fake_request.args.get("maxBytesRewrittenPerCall", 1024 * 1024)),

--- a/google/cloud/storage/emulator/utils/csek.py
+++ b/google/cloud/storage/emulator/utils/csek.py
@@ -59,3 +59,15 @@ def check(algorithm, key_b64, key_sha256_b64, context):
     if expected_sha256 != actual_sha256:
         utils.error.csek(context)
     return actual_sha256
+
+
+def validation(request, expected_sha256_b64, is_source, context):
+    algorithm, key_b64, key_sha256_b64 = extract(request, is_source, context)
+    if expected_sha256_b64 == "":
+        if key_sha256_b64 != "":
+            utils.error.csek(context)
+        else:
+            return
+    check(algorithm, key_b64, key_sha256_b64, context)
+    if expected_sha256_b64 != key_sha256_b64:
+        utils.error.csek(context)


### PR DESCRIPTION
This PR adds csek support for the new emulator.

I have some confusions. In the old testbench ( and also in the new emulator ), the base64 encoded encryption key sha256 is saved. However, on the [website](https://cloud.google.com/storage/docs/json_api/v1/objects) and [proto](https://github.com/googleapis/googleapis/blob/37ba54d7ed4da3052ceff96292631c3b6aae0e63/google/storage/v1/storage_resources.proto#L620-L621) definition file, it is written that `SHA256 hash value of the encryption key.` ( not base64 encoded ). Which one should be saved ?

Part of #4751 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5527)
<!-- Reviewable:end -->
