### PR TITLE
cleanup(storage): use google.storage.v1.internal for internal protos

### DIFF
--- a/google/cloud/storage/internal/grpc_resumable_upload_session_url.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_url.cc
@@ -24,6 +24,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
+using ::google::storage::v1::internal::GrpcResumableUploadSessionUrl;
+
 auto constexpr kUriScheme = "grpc://";
 
 std::string EncodeGrpcResumableUploadSessionUrl(

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_url.proto
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_url.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package google.cloud.storage.v1.internal;
+package google.storage.v1.internal;
 
 message GrpcResumableUploadSessionUrl {
   string bucket_name = 1;


### PR DESCRIPTION
Avoid `package google.cloud.storage.v1.internal` so as not to
conflict with the `google::cloud::storage::v\d+` inline namespace.
Use `package google.storage.v1.internal` instead, which creates a
sub-namespace within the existing proto `google::storage::v1`.

Fixes #5350.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5530)
<!-- Reviewable:end -->
