### PR TITLE
feat: introduce a generic StreamRange<T>

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -373,6 +373,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/retry_loop.h
         internal/retry_loop_helpers.cc
         internal/retry_loop_helpers.h
+        internal/stream_range.h
         internal/time_utils.cc
         internal/time_utils.h)
     target_link_libraries(
@@ -447,6 +448,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/pagination_range_test.cc
             internal/polling_loop_test.cc
             internal/retry_loop_test.cc
+            internal/stream_range_test.cc
             internal/time_utils_test.cc)
 
         # Export the list of unit tests so the Bazel BUILD file can pick it up.

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -39,6 +39,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/polling_loop.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",
+    "internal/stream_range.h",
     "internal/time_utils.h",
 ]
 

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -28,5 +28,6 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/pagination_range_test.cc",
     "internal/polling_loop_test.cc",
     "internal/retry_loop_test.cc",
+    "internal/stream_range_test.cc",
     "internal/time_utils_test.cc",
 ]

--- a/google/cloud/internal/stream_range.h
+++ b/google/cloud/internal/stream_range.h
@@ -29,7 +29,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
 /// A sentinel type to indicate the successful end of stream.
-using StreamEnd = absl::monostate;
+struct StreamEnd {};
 
 /**
  * The type returned by `StreamReader<T>`.

--- a/google/cloud/internal/stream_range.h
+++ b/google/cloud/internal/stream_range.h
@@ -1,0 +1,204 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAM_RANGE_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAM_RANGE_H
+
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include "absl/types/variant.h"
+#include <functional>
+#include <iterator>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// A sentinel type to indicate the successful end of stream.
+using StreamEnd = absl::monostate;
+
+/**
+ * The type returned by `ReaderFunction<T>`.
+ *
+ * This variant may contain one of the following types:
+ *
+ * 1. A `StreamEnd` instance indicating a successful end of stream.
+ * 2. A non-OK `Status` indicating some error.
+ * 3. An instance of `T`
+ */
+template <typename T>
+using ReaderFunctionResult = absl::variant<StreamEnd, Status, T>;
+
+/**
+ * A function that takes no arguments and returns `ReaderFunctionResult<T>`.
+ *
+ * Instances of this function type must will be invoked repeatedly, until
+ * either `StreamEnd` is returned or until a (non-OK) `Status` is returned. In
+ * both cases, this function will not be invoked again.
+ *
+ * @par Example `ReaderFunction` that returns the integers from 1-10.
+ *
+ *  @code
+ *  int counter = 0;
+ *  auto reader = [&counter]() -> ReaderFunctionResult<int> {
+ *    if (counter++ < 10) return counter;
+ *    return StreamEnd{};
+ *  };
+ *  @endcode
+ */
+template <typename T>
+using ReaderFunction = ReaderFunctionResult<T>();
+
+/**
+ * A `StreamRange<T>` puts a range-like interface on a stream of `T` objects.
+ *
+ * The `T` objects are read from the caller-provided `ReaderFunction`, which is
+ * invoked repeatedly as the range is iterated. The `ReaderFunction` can return
+ * `StreamEnd` to indicate a successful end of stream, or a (non-OK) `Status`
+ * to indicate an error, or a `T`. The `ReaderFunction` will not be invoked
+ * again after it returns either `StreamEnd` or `Status`.
+ *
+ * Callers can iterate the range using its `begin()` and `end()` members to
+ * access iterators that will work with any normal C++ constructors and
+ * algorithms that accept [Input Iterators][input-iterator-link].
+ *
+ * @par Example: Printing integers from 1-10.
+ *
+ *  @code
+ *  int counter = 0;
+ *  auto reader = [&counter]() -> ReaderFunctionResult<int> {
+ *    if (counter++ < 10) return counter;
+ *    return StreamEnd{};
+ *  };
+ *  StreamReader<int> sr(std::move(reader));
+ *  for (int x : sr) {
+ *    std::cout << x << "\n";
+ *  }
+ *  @endcode
+ *
+ * [input-iterator-link]:
+ * https://en.cppreference.com/w/cpp/named_req/InputIterator
+ */
+template <typename T>
+class StreamRange {
+ public:
+  /// An input iterator for a `StreamRange<T>`
+  template <typename U>
+  class Iterator {
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = U;
+    using difference_type = std::size_t;
+    using reference = value_type&;
+    using pointer = value_type*;
+    using const_reference = value_type const&;
+    using const_pointer = value_type const*;
+
+    /// Constructs an "end" iterator.
+    explicit Iterator() = default;
+
+    reference operator*() { return owner_->current_; }
+    pointer operator->() { return &owner_->current_; }
+    const_reference operator*() const { return owner_->current_; }
+    const_pointer operator->() const { return &owner_->current_; }
+
+    Iterator& operator++() {
+      owner_->Next();
+      is_end_ = owner_->is_end_;
+      return *this;
+    }
+
+    Iterator& operator++(int) {
+      auto copy = *this;
+      ++*this;
+      return copy;
+    }
+
+    friend bool operator==(Iterator const& a, Iterator const& b) {
+      return a.is_end_ == b.is_end_;
+    }
+
+    friend bool operator!=(Iterator const& a, Iterator const& b) {
+      return !(a == b);
+    }
+
+   private:
+    friend class StreamRange;
+    explicit Iterator(StreamRange* owner)
+        : owner_(owner), is_end_(owner_->is_end_) {}
+    StreamRange* owner_;
+    bool is_end_ = true;
+  };
+
+  using value_type = StatusOr<T>;
+  using iterator = Iterator<value_type>;
+  using difference_type = typename iterator::difference_type;
+  using reference = typename iterator::reference;
+  using pointer = typename iterator::pointer;
+  using const_reference = typename iterator::const_reference;
+  using const_pointer = typename iterator::const_pointer;
+
+  /**
+   * Constructs a `StreamRange<T>` that will use the given @p reader.
+   *
+   * @param reader must not be nullptr.
+   */
+  explicit StreamRange(std::function<ReaderFunction<T>> reader)
+      : reader_(std::move(reader)) {
+    Next();
+  }
+
+  //@{
+  // @name Move-only
+  StreamRange(StreamRange const&) = delete;
+  StreamRange& operator=(StreamRange const&) = delete;
+  StreamRange(StreamRange&&) noexcept = default;
+  StreamRange& operator=(StreamRange&&) noexcept = default;
+  //@}
+
+  iterator begin() { return iterator(this); }
+  iterator end() { return iterator(); }
+
+ private:
+  void Next() {
+    // Jump to the end if we previously got an error.
+    if (!is_end_ && !current_) {
+      is_end_ = true;
+      return;
+    }
+    is_end_ = false;
+    struct UnpackVariant {
+      StreamRange& sr;
+      void operator()(StreamEnd) { sr.is_end_ = true; }
+      void operator()(Status&& status) { sr.current_ = std::move(status); }
+      void operator()(T&& t) { sr.current_ = std::move(t); }
+    };
+    auto v = reader_();
+    absl::visit(UnpackVariant{*this}, std::move(v));
+  }
+
+  StatusOr<T> current_;
+  bool is_end_ = true;
+  std::function<ReaderFunction<T>> reader_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAM_RANGE_H

--- a/google/cloud/internal/stream_range.h
+++ b/google/cloud/internal/stream_range.h
@@ -153,9 +153,11 @@ class StreamRange {
   StreamRange& operator=(StreamRange const&) = delete;
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)
   StreamRange(StreamRange&& sr) noexcept(noexcept(StatusOr<T>(
+      // NOLINTNEXTLINE(performance-noexcept-move-constructor)
       sr.current_)) && noexcept(StreamReader<T>(sr.reader_))) = default;
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)
   StreamRange& operator=(StreamRange&& sr) noexcept(noexcept(StatusOr<T>(
+      // NOLINTNEXTLINE(performance-noexcept-move-constructor)
       sr.current_)) && noexcept(StreamReader<T>(sr.reader_))) = default;
   //@}
 

--- a/google/cloud/internal/stream_range.h
+++ b/google/cloud/internal/stream_range.h
@@ -151,8 +151,10 @@ class StreamRange {
   // @name Move-only
   StreamRange(StreamRange const&) = delete;
   StreamRange& operator=(StreamRange const&) = delete;
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor)
   StreamRange(StreamRange&& sr) noexcept(noexcept(StatusOr<T>(
       sr.current_)) && noexcept(StreamReader<T>(sr.reader_))) = default;
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor)
   StreamRange& operator=(StreamRange&& sr) noexcept(noexcept(StatusOr<T>(
       sr.current_)) && noexcept(StreamReader<T>(sr.reader_))) = default;
   //@}

--- a/google/cloud/internal/stream_range.h
+++ b/google/cloud/internal/stream_range.h
@@ -122,7 +122,7 @@ class StreamRange {
       return *this;
     }
 
-    Iterator& operator++(int) {
+    Iterator operator++(int) {
       auto copy = *this;
       ++*this;
       return copy;

--- a/google/cloud/internal/stream_range_test.cc
+++ b/google/cloud/internal/stream_range_test.cc
@@ -1,0 +1,136 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/stream_range.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+#include <deque>
+#include <vector>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
+
+TEST(StreamRange, MoveOnly) {
+  auto const reader = [] { return StreamEnd{}; };
+  StreamRange<int> sr(reader);
+  StreamRange<int> move_construct = std::move(sr);
+  StreamRange<int> move_assign(reader);
+  move_assign = std::move(move_construct);
+}
+
+TEST(StreamRange, EmptyRange) {
+  StreamRange<int> sr([] { return StreamEnd{}; });
+  auto it = sr.begin();
+  auto end = sr.end();
+  EXPECT_EQ(it, end);
+  EXPECT_EQ(it, it);
+  EXPECT_EQ(end, end);
+}
+
+TEST(StreamRange, Distance) {
+  // Empty range
+  StreamRange<int> sr([] { return StreamEnd{}; });
+  EXPECT_EQ(0, std::distance(sr.begin(), sr.end()));
+
+  // Range of one element
+  auto counter = 0;
+  StreamRange<int> one([&counter]() -> ReaderFunctionResult<int> {
+    if (counter++ < 1) return counter;
+    return StreamEnd{};
+  });
+  EXPECT_EQ(1, std::distance(one.begin(), one.end()));
+
+  // Range of five elements
+  counter = 0;
+  StreamRange<int> five([&counter]() -> ReaderFunctionResult<int> {
+    if (counter++ < 5) return counter;
+    return StreamEnd{};
+  });
+  EXPECT_EQ(5, std::distance(five.begin(), five.end()));
+}
+
+TEST(StreamRange, OneElement) {
+  auto counter = 0;
+  auto reader = [&counter]() -> ReaderFunctionResult<int> {
+    if (counter++ < 1) return 42;
+    return StreamEnd{};
+  };
+
+  StreamRange<int> sr(std::move(reader));
+  auto it = sr.begin();
+  EXPECT_NE(it, sr.end());
+  EXPECT_TRUE(*it);
+  EXPECT_EQ(**it, 42);
+  ++it;
+  EXPECT_EQ(it, sr.end());
+}
+
+TEST(StreamRange, BasicIteration) {
+  auto counter = 0;
+  auto reader = [&counter]() -> ReaderFunctionResult<int> {
+    if (counter++ < 5) return counter;
+    return StreamEnd{};
+  };
+
+  StreamRange<int> sr(std::move(reader));
+  std::vector<int> v;
+  for (StatusOr<int>& x : sr) {
+    EXPECT_TRUE(x);
+    v.push_back(*x);
+  }
+  EXPECT_THAT(v, ElementsAre(1, 2, 3, 4, 5));
+}
+
+TEST(StreamRange, StreamError) {
+  auto counter = 0;
+  auto reader = [&counter]() -> ReaderFunctionResult<int> {
+    if (counter++ < 2) return counter;
+    return Status(StatusCode::kUnknown, "oops");
+  };
+
+  StreamRange<int> sr(std::move(reader));
+
+  auto it = sr.begin();
+  EXPECT_NE(it, sr.end());
+  EXPECT_TRUE(*it);
+  EXPECT_EQ(**it, 1);
+
+  ++it;
+  EXPECT_NE(it, sr.end());
+  EXPECT_TRUE(*it);
+  EXPECT_EQ(**it, 2);
+
+  // Error, but we return the bad Status; NOT END
+  ++it;
+  EXPECT_NE(it, sr.end());
+  EXPECT_FALSE(*it);
+  EXPECT_THAT(*it, StatusIs(StatusCode::kUnknown, "oops"));
+
+  // Since the previous result was an error, now we're at end.
+  ++it;
+  EXPECT_EQ(it, sr.end());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5521

This PR is part of the work needed for resumable streaming RPCs. This PR introduces a generic `StreamRange<T>`, which provides an input range of `T` and an iterator class for iterating it. This is a better, and reusable, version of the `RowStreamIterator` and `TupleStreamIterator` classes in spanner [link](https://github.com/googleapis/google-cloud-cpp/blob/43d6687ab1432ad56420c0292283cd3b615cf96f/google/cloud/spanner/row.h#L309). Indeed, those classes could easily be replaced by aliases to `StreamRange<T>`, except for small API breaks that would result, because those Spanner classes have weird constructors that this one doesn't have. We can discuss whether we want to make that change or not later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5532)
<!-- Reviewable:end -->
