### PR TITLE
chore: moved stream_range to common to avoid grpc dep

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -149,6 +149,7 @@ add_library(
     internal/retry_policy.h
     internal/setenv.cc
     internal/setenv.h
+    internal/stream_range.h
     internal/strerror.cc
     internal/strerror.h
     internal/throw_delegate.cc
@@ -247,6 +248,7 @@ if (BUILD_TESTING)
         internal/parse_rfc3339_test.cc
         internal/random_test.cc
         internal/retry_policy_test.cc
+        internal/stream_range_test.cc
         internal/strerror_test.cc
         internal/throw_delegate_test.cc
         internal/tuple_test.cc
@@ -373,7 +375,6 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/retry_loop.h
         internal/retry_loop_helpers.cc
         internal/retry_loop_helpers.h
-        internal/stream_range.h
         internal/time_utils.cc
         internal/time_utils.h)
     target_link_libraries(
@@ -448,7 +449,6 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/pagination_range_test.cc
             internal/polling_loop_test.cc
             internal/retry_loop_test.cc
-            internal/stream_range_test.cc
             internal/time_utils_test.cc)
 
         # Export the list of unit tests so the Bazel BUILD file can pick it up.

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -51,6 +51,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/random.h",
     "internal/retry_policy.h",
     "internal/setenv.h",
+    "internal/stream_range.h",
     "internal/strerror.h",
     "internal/throw_delegate.h",
     "internal/tuple.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -34,6 +34,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/parse_rfc3339_test.cc",
     "internal/random_test.cc",
     "internal/retry_policy_test.cc",
+    "internal/stream_range_test.cc",
     "internal/strerror_test.cc",
     "internal/throw_delegate_test.cc",
     "internal/tuple_test.cc",

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -39,7 +39,6 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/polling_loop.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",
-    "internal/stream_range.h",
     "internal/time_utils.h",
 ]
 

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -28,6 +28,5 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/pagination_range_test.cc",
     "internal/polling_loop_test.cc",
     "internal/retry_loop_test.cc",
-    "internal/stream_range_test.cc",
     "internal/time_utils_test.cc",
 ]


### PR DESCRIPTION
`StreamRange<T>` doesn't need gRPC, so moving to the "common" target will minimze its deps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5534)
<!-- Reviewable:end -->
