### PR TITLE
feat: add value_type to StatusOr<T>

### DIFF
--- a/google/cloud/status_or.h
+++ b/google/cloud/status_or.h
@@ -87,6 +87,13 @@ template <typename T>
 class StatusOr final {
  public:
   /**
+   * A `value_type` member for use in generic programming.
+   *
+   * This is analogous to that of `std::optional::value_type`.
+   */
+  using value_type = T;
+
+  /**
    * Initializes with an error status (UNKNOWN).
    *
    * TODO(#548) - currently storage::Status does not define the status codes,

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -17,12 +17,20 @@
 #include "google/cloud/testing_util/expect_exception.h"
 #include "google/cloud/testing_util/testing_types.h"
 #include <gmock/gmock.h>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 using ::testing::HasSubstr;
+
+TEST(StatusOrTest, ValueType) {
+  struct Foo {};
+  static_assert(std::is_same<StatusOr<int>::value_type, int>::value, "");
+  static_assert(std::is_same<StatusOr<char>::value_type, char>::value, "");
+  static_assert(std::is_same<StatusOr<Foo>::value_type, Foo>::value, "");
+}
 
 TEST(StatusOrTest, DefaultConstructor) {
   StatusOr<int> actual;

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -30,6 +30,10 @@ TEST(StatusOrTest, ValueType) {
   static_assert(std::is_same<StatusOr<int>::value_type, int>::value, "");
   static_assert(std::is_same<StatusOr<char>::value_type, char>::value, "");
   static_assert(std::is_same<StatusOr<Foo>::value_type, Foo>::value, "");
+
+  static_assert(!std::is_same<StatusOr<int>::value_type, char>::value, "");
+  static_assert(!std::is_same<StatusOr<char>::value_type, Foo>::value, "");
+  static_assert(!std::is_same<StatusOr<Foo>::value_type, int>::value, "");
 }
 
 TEST(StatusOrTest, DefaultConstructor) {


### PR DESCRIPTION
This member is useful in generic programming, and it follows the
precedent set by `std::optional::value_type` and
[absl::StatusOr::value_type](https://github.com/abseil/abseil-cpp/blob/e19260fd7dbef881492fd73891e0be5bd4a09b95/absl/status/statusor.h#L184-L187)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5535)
<!-- Reviewable:end -->
