### PR TITLE
refactor!: PaginationRange<T> is now an alias to StreamRange<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@
 
 ## v1.21.0 - TBD
 
+**BREAKING CHANGES:**
+* Some "Range" types used in the Pub/Sub and Spanner APIs lost a constructor
+  that was never intended to be part of their public APIs. Users who were not
+  directly constructing these ranges will not be affected. All uses of these
+  types that was _intended_ to be public will continue to work, i.e., they will
+  all continue to work as ranges in for loops, etc. The affected types are:
+  * `google/cloud/pubsub/subscription_admin_connection.h`
+    * `using ListSubscriptionsRange = google::cloud::internal::PaginationRange`
+    * `using ListSnapshotsRange = google::cloud::internal::PaginationRange`
+  * `google/cloud/pubsub/topic_admin_connection.h`
+    * `using ListTopicsRange = google::cloud::internal::PaginationRange`
+    * `using ListTopicSubscriptionsRange = google::cloud::internal::PaginationRange`
+    * `using ListTopicSnapshotsRange = google::cloud::internal::PaginationRange`
+  * `google/cloud/spanner/database_admin_connection.h`
+    * `using ListDatabaseRange = google::cloud::internal::PaginationRange`
+    * `using ListBackupOperationsRange = google::cloud::internal::PaginationRange`
+    * `using ListDatabaseOperationsRange = google::cloud::internal::PaginationRange`
+    * `using ListBackupsRange = google::cloud::internal::PaginationRange`
+  * `google/cloud/spanner/instance_admin_connection.h`
+    * `using ListInstancesRange = google::cloud::internal::PaginationRange`
+    * `using ListInstanceConfigsRange = google::cloud::internal::PaginationRange`
+
 ## v1.20.0 - 2020-11
 
 ### Bigtable

--- a/generator/integration_tests/golden/database_admin_connection.gcpcxx.pb.cc
+++ b/generator/integration_tests/golden/database_admin_connection.gcpcxx.pb.cc
@@ -31,10 +31,10 @@ DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 
 ListDatabasesRange DatabaseAdminConnection::ListDatabases(
     ::google::test::admin::database::v1::ListDatabasesRequest request) {
-  return ListDatabasesRange(
+  return google::cloud::internal::MakePaginationRange<ListDatabasesRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListDatabasesRequest const&) {
-      return ::google::test::admin::database::v1::ListDatabasesResponse();
+      return StatusOr<::google::test::admin::database::v1::ListDatabasesResponse>{};
     },
     [](::google::test::admin::database::v1::ListDatabasesResponse const&) {
       return std::vector<::google::test::admin::database::v1::Database>();
@@ -121,10 +121,10 @@ DatabaseAdminConnection::DeleteBackup(
 
 ListBackupsRange DatabaseAdminConnection::ListBackups(
     ::google::test::admin::database::v1::ListBackupsRequest request) {
-  return ListBackupsRange(
+  return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListBackupsRequest const&) {
-      return ::google::test::admin::database::v1::ListBackupsResponse();
+      return StatusOr<::google::test::admin::database::v1::ListBackupsResponse>();
     },
     [](::google::test::admin::database::v1::ListBackupsResponse const&) {
       return std::vector<::google::test::admin::database::v1::Backup>();
@@ -141,10 +141,10 @@ DatabaseAdminConnection::RestoreDatabase(
 
 ListDatabaseOperationsRange DatabaseAdminConnection::ListDatabaseOperations(
     ::google::test::admin::database::v1::ListDatabaseOperationsRequest request) {
-  return ListDatabaseOperationsRange(
+  return google::cloud::internal::MakePaginationRange<ListDatabaseOperationsRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListDatabaseOperationsRequest const&) {
-      return ::google::test::admin::database::v1::ListDatabaseOperationsResponse();
+      return StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>();
     },
     [](::google::test::admin::database::v1::ListDatabaseOperationsResponse const&) {
       return std::vector<::google::longrunning::Operation>();
@@ -153,10 +153,10 @@ ListDatabaseOperationsRange DatabaseAdminConnection::ListDatabaseOperations(
 
 ListBackupOperationsRange DatabaseAdminConnection::ListBackupOperations(
     ::google::test::admin::database::v1::ListBackupOperationsRequest request) {
-  return ListBackupOperationsRange(
+  return google::cloud::internal::MakePaginationRange<ListBackupOperationsRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListBackupOperationsRequest const&) {
-      return ::google::test::admin::database::v1::ListBackupOperationsResponse();
+      return StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>();
     },
     [](::google::test::admin::database::v1::ListBackupOperationsResponse const&) {
       return std::vector<::google::longrunning::Operation>();
@@ -219,7 +219,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
     auto idempotency = idempotency_policy_->ListDatabases(request);
     char const* function_name = __func__;
-    return ListDatabasesRange(
+    return google::cloud::internal::MakePaginationRange<ListDatabasesRange>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
           (::google::test::admin::database::v1::ListDatabasesRequest const& r) {
@@ -423,7 +423,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
     auto idempotency = idempotency_policy_->ListBackups(request);
     char const* function_name = __func__;
-    return ListBackupsRange(
+    return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
           (::google::test::admin::database::v1::ListBackupsRequest const& r) {
@@ -472,7 +472,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
     auto idempotency = idempotency_policy_->ListDatabaseOperations(request);
     char const* function_name = __func__;
-    return ListDatabaseOperationsRange(
+    return google::cloud::internal::MakePaginationRange<ListDatabaseOperationsRange>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
           (::google::test::admin::database::v1::ListDatabaseOperationsRequest const& r) {
@@ -502,7 +502,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
     auto idempotency = idempotency_policy_->ListBackupOperations(request);
     char const* function_name = __func__;
-    return ListBackupOperationsRange(
+    return google::cloud::internal::MakePaginationRange<ListBackupOperationsRange>(
         std::move(request),
         [stub, retry, backoff, idempotency, function_name]
           (::google::test::admin::database::v1::ListBackupOperationsRequest const& r) {

--- a/generator/integration_tests/golden/database_admin_connection.gcpcxx.pb.cc
+++ b/generator/integration_tests/golden/database_admin_connection.gcpcxx.pb.cc
@@ -124,7 +124,7 @@ ListBackupsRange DatabaseAdminConnection::ListBackups(
   return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListBackupsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListBackupsResponse>();
+      return StatusOr<::google::test::admin::database::v1::ListBackupsResponse>{};
     },
     [](::google::test::admin::database::v1::ListBackupsResponse const&) {
       return std::vector<::google::test::admin::database::v1::Backup>();
@@ -144,7 +144,7 @@ ListDatabaseOperationsRange DatabaseAdminConnection::ListDatabaseOperations(
   return google::cloud::internal::MakePaginationRange<ListDatabaseOperationsRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListDatabaseOperationsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>();
+      return StatusOr<::google::test::admin::database::v1::ListDatabaseOperationsResponse>{};
     },
     [](::google::test::admin::database::v1::ListDatabaseOperationsResponse const&) {
       return std::vector<::google::longrunning::Operation>();
@@ -156,7 +156,7 @@ ListBackupOperationsRange DatabaseAdminConnection::ListBackupOperations(
   return google::cloud::internal::MakePaginationRange<ListBackupOperationsRange>(
     std::move(request),
     [](::google::test::admin::database::v1::ListBackupOperationsRequest const&) {
-      return StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>();
+      return StatusOr<::google::test::admin::database::v1::ListBackupOperationsResponse>{};
     },
     [](::google::test::admin::database::v1::ListBackupOperationsResponse const&) {
       return std::vector<::google::longrunning::Operation>();

--- a/generator/integration_tests/golden/database_admin_connection.gcpcxx.pb.h
+++ b/generator/integration_tests/golden/database_admin_connection.gcpcxx.pb.h
@@ -37,24 +37,16 @@ namespace golden {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
 using ListDatabasesRange = google::cloud::internal::PaginationRange<
-    ::google::test::admin::database::v1::Database,
-    ::google::test::admin::database::v1::ListDatabasesRequest,
-    ::google::test::admin::database::v1::ListDatabasesResponse>;
+    ::google::test::admin::database::v1::Database>;
 
 using ListBackupsRange = google::cloud::internal::PaginationRange<
-    ::google::test::admin::database::v1::Backup,
-    ::google::test::admin::database::v1::ListBackupsRequest,
-    ::google::test::admin::database::v1::ListBackupsResponse>;
+    ::google::test::admin::database::v1::Backup>;
 
 using ListDatabaseOperationsRange = google::cloud::internal::PaginationRange<
-    ::google::longrunning::Operation,
-    ::google::test::admin::database::v1::ListDatabaseOperationsRequest,
-    ::google::test::admin::database::v1::ListDatabaseOperationsResponse>;
+    ::google::longrunning::Operation>;
 
 using ListBackupOperationsRange = google::cloud::internal::PaginationRange<
-    ::google::longrunning::Operation,
-    ::google::test::admin::database::v1::ListBackupOperationsRequest,
-    ::google::test::admin::database::v1::ListBackupOperationsResponse>;
+    ::google::longrunning::Operation>;
 
 class DatabaseAdminConnection {
  public:

--- a/generator/integration_tests/golden/golden_client_test.cc
+++ b/generator/integration_tests/golden/golden_client_test.cc
@@ -70,7 +70,7 @@ TEST(GoldenClientTest, ListDatabases) {
                                               ListDatabasesRequest const &r) {
         EXPECT_EQ(expected_instance, r.parent());
 
-        return ListDatabasesRange(
+        return google::cloud::internal::MakePaginationRange<ListDatabasesRange>(
             ::google::test::admin::database::v1::ListDatabasesRequest{},
             [](::google::test::admin::database::v1::ListDatabasesRequest const
                    &) {
@@ -497,7 +497,7 @@ TEST(GoldenClientTest, ListBackups) {
       .WillRepeatedly([expected_instance](::google::test::admin::database::v1::
                                               ListBackupsRequest const &r) {
         EXPECT_EQ(expected_instance, r.parent());
-        return ListBackupsRange(
+        return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
             ::google::test::admin::database::v1::ListBackupsRequest{},
             [](::google::test::admin::database::v1::ListBackupsRequest const
                    &) {
@@ -577,7 +577,7 @@ TEST(GoldenClientTest, ListDatabaseOperations) {
           [expected_instance](::google::test::admin::database::v1::
                                   ListDatabaseOperationsRequest const &r) {
             EXPECT_EQ(expected_instance, r.parent());
-            return ListDatabaseOperationsRange(
+            return google::cloud::internal::MakePaginationRange<ListDatabaseOperationsRange>(
                 ::google::test::admin::database::v1::
                     ListDatabaseOperationsRequest{},
                 [](::google::test::admin::database::v1::
@@ -614,7 +614,7 @@ TEST(GoldenClientTest, ListBackupOperations) {
                           ::google::test::admin::database::v1::
                               ListBackupOperationsRequest const &r) {
         EXPECT_EQ(expected_instance, r.parent());
-        return ListBackupOperationsRange(
+        return google::cloud::internal::MakePaginationRange<ListBackupOperationsRange>(
             ::google::test::admin::database::v1::ListBackupOperationsRequest{},
             [](::google::test::admin::database::v1::
                    ListBackupOperationsRequest const &) {

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -67,10 +67,7 @@ Status ConnectionGenerator::GenerateHeader() {
             {
                 // clang-format off
    {"using $method_name$Range = "
-    "google::cloud::internal::PaginationRange<\n"
-    "    $range_output_type$,\n"
-    "    $request_type$,\n"
-    "    $response_type$>;\n\n"},
+    "google::cloud::internal::PaginationRange<$range_output_type$>;\n\n"},
                 // clang-format on
             },
             All(IsNonStreaming, Not(IsLongrunningOperation), IsPaginated))},
@@ -220,10 +217,10 @@ Status ConnectionGenerator::GenerateCc() {
                  // clang-format off
    {"$method_name$Range $connection_class_name$::$method_name$(\n"
     "    $request_type$ request) {\n"
-    "  return $method_name$Range(\n"
+    "  return google::cloud::internal::MakePaginationRange<$method_name$Range>(\n"
     "    std::move(request),\n"
     "    []($request_type$ const&) {\n"
-    "      return $response_type$();\n"
+    "      return StatusOr<$response_type$>();\n"
     "    },\n"
     "    []($response_type$ const&) {\n"
     "      return std::vector<$range_output_type$>();\n"
@@ -359,7 +356,7 @@ Status ConnectionGenerator::GenerateCc() {
     "        backoff_policy_prototype_->clone());\n"
     "    auto idempotency = idempotency_policy_->$method_name$(request);\n"
     "    char const* function_name = __func__;\n"
-    "    return $method_name$Range(\n"
+    "    return google::cloud::internal::MakePaginationRange<$method_name$Range>(\n"
     "        std::move(request),\n"
     "        [stub, retry, backoff, idempotency, function_name]\n"
     "          ($request_type$ const& r) {\n"

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -67,7 +67,8 @@ Status ConnectionGenerator::GenerateHeader() {
             {
                 // clang-format off
    {"using $method_name$Range = "
-    "google::cloud::internal::PaginationRange<$range_output_type$>;\n\n"},
+    "google::cloud::internal::PaginationRange<\n"
+    "    $range_output_type$>;\n\n"},
                 // clang-format on
             },
             All(IsNonStreaming, Not(IsLongrunningOperation), IsPaginated))},
@@ -220,7 +221,7 @@ Status ConnectionGenerator::GenerateCc() {
     "  return google::cloud::internal::MakePaginationRange<$method_name$Range>(\n"
     "    std::move(request),\n"
     "    []($request_type$ const&) {\n"
-    "      return StatusOr<$response_type$>();\n"
+    "      return StatusOr<$response_type$>{};\n"
     "    },\n"
     "    []($response_type$ const&) {\n"
     "      return std::vector<$range_output_type$>();\n"

--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -19,9 +19,9 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <functional>
+#include <memory>
 #include <string>
 #include <utility>
-#include <memory>
 #include <vector>
 
 namespace google {
@@ -54,15 +54,15 @@ class PagedStreamReader {
    * @param get_items extracts the items from the response using native C++
    *     types (as opposed to the proto types used in `Response`).
    */
-   PagedStreamReader(Request request,
-             std::function<StatusOr<Response>(Request const& r)> loader,
-             std::function<std::vector<T>(Response r)> get_items)
-       : request_(std::move(request)),
-         next_page_loader_(std::move(loader)),
-         get_items_(std::move(get_items)),
-         on_last_page_(false) {
-     current_ = current_page_.begin();
-   }
+  PagedStreamReader(Request request,
+                    std::function<StatusOr<Response>(Request const& r)> loader,
+                    std::function<std::vector<T>(Response r)> get_items)
+      : request_(std::move(request)),
+        next_page_loader_(std::move(loader)),
+        get_items_(std::move(get_items)),
+        on_last_page_(false) {
+    current_ = current_page_.begin();
+  }
 
   /**
    * Fetches (or returns if already fetched) the next object from the stream.

--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PAGINATION_RANGE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PAGINATION_RANGE_H
 
+#include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/stream_range.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -139,9 +140,9 @@ class PagedStreamReader {
 template <typename Range, typename Request, typename Loader, typename Extractor>
 Range MakePaginationRange(Request request, Loader loader, Extractor extractor) {
   using ValueType = typename Range::value_type::value_type;
-  using LoaderResult = typename std::result_of<Loader(Request)>::type;
+  using LoaderResult = invoke_result_t<Loader, Request>;
   using Response = typename LoaderResult::value_type;
-  using ExtractorResult = typename std::result_of<Extractor(Response)>::type;
+  using ExtractorResult = invoke_result_t<Extractor, Response>;
   // Some static asserts to make compiler errors easier to diagnose.
   static_assert(std::is_same<Range, PaginationRange<ValueType>>::value,
                 "Expected Range is of type PaginationRange<ValueType>");

--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -36,7 +37,26 @@ namespace internal {
  * pagination APIs. The application calls a `List*()` RPC which returns
  * a "page" of elements and a token, calling the same `List*()` RPC with the
  * token returns the next "page". We want to expose these APIs as input ranges
- * in the C++ client libraries. This class performs that work.
+ * in the C++ client libraries.
+ *
+ * To construct instances of `PaginationRange<T>`, use the
+ * `MakePaginationRange()` function defined below.
+ *
+ * @tparam T the type of the items, typically a proto describing the resources
+ */
+template <typename T>
+using PaginationRange = StreamRange<T>;
+
+/**
+ * Returns `T`s one at a time from pages of responses.
+ *
+ * This class is an implementation detail. An instance of this class is wrapped
+ * in a lambda and passed as the `StreamReader<T>` to the `PaginationRange<T>`
+ * constructor. This class is responsible for loading pages and returning the
+ * next `T`.
+ *
+ * Users should not use this class directly. Use the `MakePaginationRange()`
+ * function (defined below) instead.
  *
  * @tparam T the type of the items, typically a proto describing the resources
  * @tparam Request the type of the request object for the `List` RPC.
@@ -46,83 +66,103 @@ template <typename T, typename Request, typename Response>
 class PagedStreamReader {
  public:
   /**
-   * Create a new range to paginate over some elements.
+   * Create a new object.
    *
    * @param request the first request to start the iteration, the library may
    *    initialize this request with any filtering constraints.
    * @param loader makes the RPC request to fetch a new page of items.
-   * @param get_items extracts the items from the response using native C++
+   * @param extractor extracts the items from the response using native C++
    *     types (as opposed to the proto types used in `Response`).
    */
   PagedStreamReader(Request request,
-                    std::function<StatusOr<Response>(Request const& r)> loader,
-                    std::function<std::vector<T>(Response r)> get_items)
+                    std::function<StatusOr<Response>(Request const&)> loader,
+                    std::function<std::vector<T>(Response)> extractor)
       : request_(std::move(request)),
-        next_page_loader_(std::move(loader)),
-        get_items_(std::move(get_items)),
-        on_last_page_(false) {
-    current_ = current_page_.begin();
+        loader_(std::move(loader)),
+        extractor_(std::move(extractor)),
+        last_page_(false) {
+    current_ = page_.begin();
   }
 
   /**
    * Fetches (or returns if already fetched) the next object from the stream.
    *
-   * @return An iterator pointing to the next element in the stream. On error,
-   *   it returns an iterator that is different from `.end()`, but has an error
-   *   status. If the stream is exhausted, it returns the `.end()` iterator.
+   * @return the next available `T`, if one exists (or can be loaded). Returns
+   *   a non-OK `Status` to indicate an error, and an OK `Status` to indicate a
+   *   successful end of stream.
    */
   typename StreamReader<T>::result_type GetNext() {
-    if (current_page_.end() == current_) {
-      if (on_last_page_) return Status{};  // End of stream
-      request_.set_page_token(std::move(next_page_token_));
-      auto response = next_page_loader_(request_);
-      if (!response.ok()) {
-        next_page_token_.clear();
-        current_page_.clear();
-        on_last_page_ = true;
-        current_ = current_page_.begin();
-        return std::move(response).status();
-      }
-      next_page_token_ = std::move(*response->mutable_next_page_token());
-      current_page_ = get_items_(*std::move(response));
-      current_ = current_page_.begin();
-      if (next_page_token_.empty()) on_last_page_ = true;
-      if (current_page_.end() == current_) return Status{};  // End of stream
+    if (current_ == page_.end()) {
+      if (last_page_) return Status{};
+      request_.set_page_token(std::move(token_));
+      auto response = loader_(request_);
+      if (!response.ok()) return std::move(response).status();
+      token_ = std::move(*response->mutable_next_page_token());
+      if (token_.empty()) last_page_ = true;
+      page_ = extractor_(*std::move(response));
+      current_ = page_.begin();
+      if (current_ == page_.end()) return Status{};
     }
     return std::move(*current_++);
   }
 
  private:
   Request request_;
-  std::function<StatusOr<Response>(Request const& r)> next_page_loader_;
-  std::function<std::vector<T>(Response r)> get_items_;
-  std::vector<T> current_page_;
+  std::function<StatusOr<Response>(Request const&)> loader_;
+  std::function<std::vector<T>(Response)> extractor_;
+  std::vector<T> page_;
   typename std::vector<T>::iterator current_;
-  std::string next_page_token_;
-  bool on_last_page_;
+  std::string token_;
+  bool last_page_;
 };
 
-template <typename T>
-using PaginationRange = StreamRange<T>;
-
-template <typename Range, typename Request, typename Loader, typename Extractor,
-          typename ValueType = typename Range::value_type::value_type,
-          typename Response =
-              typename std::result_of<Loader(Request)>::type::value_type>
+/**
+ * A factory function for creating `PaginationRange<T>` instances.
+ *
+ * This function creates a `PaginationRange<T>` instance that will be fed from
+ * a `PagedStreamReader` (defined above).
+ *
+ * @par Example
+ *
+ * @code
+ *  auto loader = [](MyRequestProto const& r) -> StatusOr<MyResponseProto> {
+ *    ...
+ *  };
+ *  auto extractor = [](MyResponseProto r) -> std::vector<Foo> {
+ *    ...
+ *  };
+ *  using MyFooRange = PaginationRange<Foo>;
+ *  auto range = MakePaginationRange<MyFooRange>(
+ *      MyRequestProto{}, std::move(loader), std::move(extractor));
+ * @endcode
+ */
+template <typename Range, typename Request, typename Loader, typename Extractor>
 Range MakePaginationRange(Request request, Loader loader, Extractor extractor) {
-  auto reader =
-      std::make_shared<PagedStreamReader<ValueType, Request, Response>>(
-          std::move(request), std::move(loader), std::move(extractor));
-  return Range([reader]() mutable ->
-               typename StreamReader<ValueType>::result_type {
-                 return reader->GetNext();
-               });
+  using ValueType = typename Range::value_type::value_type;
+  using LoaderResult = typename std::result_of<Loader(Request)>::type;
+  using Response = typename LoaderResult::value_type;
+  using ExtractorResult = typename std::result_of<Extractor(Response)>::type;
+  // Some static asserts to make compiler errors easier to diagnose.
+  static_assert(std::is_same<Range, PaginationRange<ValueType>>::value,
+                "Expected Range is of type PaginationRange<ValueType>");
+  static_assert(std::is_same<LoaderResult, StatusOr<Response>>::value,
+                "Expected loader functor like StatusOr<Response>(Request)");
+  static_assert(std::is_same<ExtractorResult, std::vector<ValueType>>::value,
+                "Expected extractor functor like vector<ValueType>(Response)");
+  using ReaderType = PagedStreamReader<ValueType, Request, Response>;
+  auto reader = std::make_shared<ReaderType>(
+      std::move(request), std::move(loader), std::move(extractor));
+  return Range{[reader]() mutable { return reader->GetNext(); }};
 }
 
+/**
+ * A convenient function to make a `PaginationRange<T>` that contains a single
+ * error indicating "unimplemented".
+ */
 template <typename Range>
 Range MakeUnimplementedPaginationRange() {
-  return Range{[]() -> typename StreamReader<
-                        typename Range::value_type::value_type>::result_type {
+  using ValueType = typename Range::value_type::value_type;
+  return Range{[]() -> typename StreamReader<ValueType>::result_type {
     return Status{StatusCode::kUnimplemented, "needs-override"};
   }};
 }

--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -153,7 +153,8 @@ Range MakePaginationRange(Request request, Loader loader, Extractor extractor) {
   using ReaderType = PagedStreamReader<ValueType, Request, Response>;
   auto reader = std::make_shared<ReaderType>(
       std::move(request), std::move(loader), std::move(extractor));
-  return Range{[reader]() mutable { return reader->GetNext(); }};
+  return MakeStreamRange<ValueType>(
+      {[reader]() mutable { return reader->GetNext(); }});
 }
 
 /**
@@ -163,9 +164,10 @@ Range MakePaginationRange(Request request, Loader loader, Extractor extractor) {
 template <typename Range>
 Range MakeUnimplementedPaginationRange() {
   using ValueType = typename Range::value_type::value_type;
-  return Range{[]() -> typename StreamReader<ValueType>::result_type {
-    return Status{StatusCode::kUnimplemented, "needs-override"};
-  }};
+  return MakeStreamRange<ValueType>(
+      []() -> typename StreamReader<ValueType>::result_type {
+        return Status{StatusCode::kUnimplemented, "needs-override"};
+      });
 }
 
 }  // namespace internal

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -30,7 +30,7 @@ using ::testing::HasSubstr;
 using ItemType = ::google::bigtable::admin::v2::AppProfile;
 using Request = ::google::bigtable::admin::v2::ListAppProfilesRequest;
 using Response = ::google::bigtable::admin::v2::ListAppProfilesResponse;
-using TestedRange = StreamRange<ItemType>;
+using TestedRange = PaginationRange<ItemType>;
 
 class MockRpc {
  public:

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -211,7 +211,7 @@ TEST(RangeFromPagination, IteratorCoverage) {
 
 TEST(RangeFromPagination, Unimplemented) {
   using NonProtoRange = PaginationRange<std::string>;
-  auto range = MakePaginationRange<NonProtoRange>();
+  auto range = MakeUnimplementedPaginationRange<NonProtoRange>();
   auto i = range.begin();
   EXPECT_NE(i, range.end());
   EXPECT_THAT(*i, StatusIs(StatusCode::kUnimplemented));

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -30,7 +30,6 @@ using ::testing::HasSubstr;
 using ItemType = ::google::bigtable::admin::v2::AppProfile;
 using Request = ::google::bigtable::admin::v2::ListAppProfilesRequest;
 using Response = ::google::bigtable::admin::v2::ListAppProfilesResponse;
-/* using TestedRange = PaginationRange<ItemType, Request, Response>; */
 using TestedRange = StreamRange<ItemType>;
 
 class MockRpc {

--- a/google/cloud/pubsub/subscription_admin_client_test.cc
+++ b/google/cloud/pubsub/subscription_admin_client_test.cc
@@ -100,24 +100,23 @@ TEST(SubscriptionAdminClient, ListSubscriptions) {
   auto const s1 = Subscription("test-project", "s1");
   auto const s2 = Subscription("test-project", "s2");
   EXPECT_CALL(*mock, ListSubscriptions)
-      .WillOnce(
-          [&](SubscriptionAdminConnection::ListSubscriptionsParams const& p) {
-            EXPECT_EQ("projects/test-project", p.project_id);
-            return internal::MakePaginationRange<
-                pubsub::ListSubscriptionsRange>(
-                google::pubsub::v1::ListSubscriptionsRequest{},
-                [&](google::pubsub::v1::ListSubscriptionsRequest const&) {
-                  google::pubsub::v1::ListSubscriptionsResponse response;
-                  response.add_subscriptions()->set_name(s1.FullName());
-                  response.add_subscriptions()->set_name(s2.FullName());
-                  return make_status_or(response);
-                },
-                [](google::pubsub::v1::ListSubscriptionsResponse const& r) {
-                  std::vector<google::pubsub::v1::Subscription> items;
-                  for (auto const& s : r.subscriptions()) items.push_back(s);
-                  return items;
-                });
-          });
+      .WillOnce([&](SubscriptionAdminConnection::ListSubscriptionsParams const&
+                        p) {
+        EXPECT_EQ("projects/test-project", p.project_id);
+        return internal::MakePaginationRange<pubsub::ListSubscriptionsRange>(
+            google::pubsub::v1::ListSubscriptionsRequest{},
+            [&](google::pubsub::v1::ListSubscriptionsRequest const&) {
+              google::pubsub::v1::ListSubscriptionsResponse response;
+              response.add_subscriptions()->set_name(s1.FullName());
+              response.add_subscriptions()->set_name(s2.FullName());
+              return make_status_or(response);
+            },
+            [](google::pubsub::v1::ListSubscriptionsResponse const& r) {
+              std::vector<google::pubsub::v1::Subscription> items;
+              for (auto const& s : r.subscriptions()) items.push_back(s);
+              return items;
+            });
+      });
   SubscriptionAdminClient client(mock);
   std::vector<std::string> names;
   for (auto const& t : client.ListSubscriptions("test-project")) {

--- a/google/cloud/pubsub/subscription_admin_client_test.cc
+++ b/google/cloud/pubsub/subscription_admin_client_test.cc
@@ -103,7 +103,8 @@ TEST(SubscriptionAdminClient, ListSubscriptions) {
       .WillOnce(
           [&](SubscriptionAdminConnection::ListSubscriptionsParams const& p) {
             EXPECT_EQ("projects/test-project", p.project_id);
-            return pubsub::ListSubscriptionsRange(
+            return internal::MakePaginationRange<
+                pubsub::ListSubscriptionsRange>(
                 google::pubsub::v1::ListSubscriptionsRequest{},
                 [&](google::pubsub::v1::ListSubscriptionsRequest const&) {
                   google::pubsub::v1::ListSubscriptionsResponse response;
@@ -219,7 +220,7 @@ TEST(SubscriptionAdminClient, ListSnapshots) {
   EXPECT_CALL(*mock, ListSnapshots)
       .WillOnce([&](SubscriptionAdminConnection::ListSnapshotsParams const& p) {
         EXPECT_EQ("projects/test-project", p.project_id);
-        return pubsub::ListSnapshotsRange(
+        return internal::MakePaginationRange<pubsub::ListSnapshotsRange>(
             google::pubsub::v1::ListSnapshotsRequest{},
             [&](google::pubsub::v1::ListSnapshotsRequest const&) {
               google::pubsub::v1::ListSnapshotsResponse response;

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -104,7 +104,7 @@ class SubscriptionAdminConnectionImpl
               request, function_name);
         };
 
-    return pubsub::ListSubscriptionsRange(
+    return internal::MakePaginationRange<pubsub::ListSubscriptionsRange>(
         std::move(request), std::move(list_functor),
         [](google::pubsub::v1::ListSubscriptionsResponse response) {
           std::vector<google::pubsub::v1::Subscription> items;
@@ -191,7 +191,7 @@ class SubscriptionAdminConnectionImpl
               request, function_name);
         };
 
-    return pubsub::ListSnapshotsRange(
+    return internal::MakePaginationRange<pubsub::ListSnapshotsRange>(
         std::move(request), std::move(list_functor),
         [](google::pubsub::v1::ListSnapshotsResponse response) {
           std::vector<google::pubsub::v1::Snapshot> items;
@@ -303,8 +303,7 @@ SubscriptionAdminConnection::UpdateSubscription(UpdateSubscriptionParams) {
 
 ListSubscriptionsRange SubscriptionAdminConnection::ListSubscriptions(
     ListSubscriptionsParams) {  // NOLINT(performance-unnecessary-value-param)
-  return internal::UnimplementedPaginationRange<
-      ListSubscriptionsRange>::Create();
+  return internal::MakeUnimplementedPaginationRange<ListSubscriptionsRange>();
 }
 
 Status SubscriptionAdminConnection::DeleteSubscription(
@@ -336,7 +335,7 @@ SubscriptionAdminConnection::UpdateSnapshot(UpdateSnapshotParams) {
 
 ListSnapshotsRange SubscriptionAdminConnection::ListSnapshots(
     ListSnapshotsParams) {  // NOLINT(performance-unnecessary-value-param)
-  return internal::UnimplementedPaginationRange<ListSnapshotsRange>::Create();
+  return internal::MakeUnimplementedPaginationRange<ListSnapshotsRange>();
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -41,10 +41,8 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListSubscriptionsRange = google::cloud::internal::PaginationRange<
-    google::pubsub::v1::Subscription,
-    google::pubsub::v1::ListSubscriptionsRequest,
-    google::pubsub::v1::ListSubscriptionsResponse>;
+using ListSubscriptionsRange =
+    google::cloud::internal::PaginationRange<google::pubsub::v1::Subscription>;
 
 /**
  * An input range to stream Cloud Pub/Sub snapshots.
@@ -55,9 +53,8 @@ using ListSubscriptionsRange = google::cloud::internal::PaginationRange<
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListSnapshotsRange = google::cloud::internal::PaginationRange<
-    google::pubsub::v1::Snapshot, google::pubsub::v1::ListSnapshotsRequest,
-    google::pubsub::v1::ListSnapshotsResponse>;
+using ListSnapshotsRange =
+    google::cloud::internal::PaginationRange<google::pubsub::v1::Snapshot>;
 
 /**
  * A connection to Cloud Pub/Sub for subscription-related administrative

--- a/google/cloud/pubsub/topic_admin_client_test.cc
+++ b/google/cloud/pubsub/topic_admin_client_test.cc
@@ -88,7 +88,7 @@ TEST(TopicAdminClient, ListTopics) {
   EXPECT_CALL(*mock, ListTopics)
       .WillOnce([&](TopicAdminConnection::ListTopicsParams const& p) {
         EXPECT_EQ("projects/test-project", p.project_id);
-        return pubsub::ListTopicsRange(
+        return internal::MakePaginationRange<pubsub::ListTopicsRange>(
             google::pubsub::v1::ListTopicsRequest{},
             [&](google::pubsub::v1::ListTopicsRequest const&) {
               google::pubsub::v1::ListTopicsResponse response;
@@ -146,7 +146,8 @@ TEST(TopicAdminClient, ListTopicSubscriptions) {
       .WillOnce([&](TopicAdminConnection::ListTopicSubscriptionsParams const&
                         p) {
         EXPECT_EQ(topic.FullName(), p.topic_full_name);
-        return pubsub::ListTopicSubscriptionsRange(
+        return internal::MakePaginationRange<
+            pubsub::ListTopicSubscriptionsRange>(
             google::pubsub::v1::ListTopicSubscriptionsRequest{},
             [&](google::pubsub::v1::ListTopicSubscriptionsRequest const&) {
               google::pubsub::v1::ListTopicSubscriptionsResponse response;
@@ -177,7 +178,7 @@ TEST(TopicAdminClient, ListTopicSnapshots) {
   EXPECT_CALL(*mock, ListTopicSnapshots)
       .WillOnce([&](TopicAdminConnection::ListTopicSnapshotsParams const& p) {
         EXPECT_EQ(topic.FullName(), p.topic_full_name);
-        return pubsub::ListTopicSnapshotsRange(
+        return internal::MakePaginationRange<pubsub::ListTopicSnapshotsRange>(
             google::pubsub::v1::ListTopicSnapshotsRequest{},
             [&](google::pubsub::v1::ListTopicSnapshotsRequest const&) {
               google::pubsub::v1::ListTopicSnapshotsResponse response;

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -276,7 +276,8 @@ TopicAdminConnection::DetachSubscription(DetachSubscriptionParams) {
 
 ListTopicSubscriptionsRange TopicAdminConnection::ListTopicSubscriptions(
     ListTopicSubscriptionsParams) {  // NOLINT(performance-unnecessary-value-param)
-  return internal::MakeUnimplementedPaginationRange<ListTopicSubscriptionsRange>();
+  return internal::MakeUnimplementedPaginationRange<
+      ListTopicSubscriptionsRange>();
 }
 
 ListTopicSnapshotsRange TopicAdminConnection::ListTopicSnapshots(

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -102,7 +102,7 @@ class TopicAdminConnectionImpl : public pubsub::TopicAdminConnection {
               },
               request, function_name);
         };
-    return pubsub::ListTopicsRange(
+    return internal::MakePaginationRange<pubsub::ListTopicsRange>(
         std::move(request), list_functor,
         [](google::pubsub::v1::ListTopicsResponse response) {
           std::vector<google::pubsub::v1::Topic> items;
@@ -166,7 +166,7 @@ class TopicAdminConnectionImpl : public pubsub::TopicAdminConnection {
               },
               request, function_name);
         };
-    return pubsub::ListTopicSubscriptionsRange(
+    return internal::MakePaginationRange<pubsub::ListTopicSubscriptionsRange>(
         std::move(request), std::move(list_functor),
         [](google::pubsub::v1::ListTopicSubscriptionsResponse response) {
           std::vector<std::string> items;
@@ -201,7 +201,7 @@ class TopicAdminConnectionImpl : public pubsub::TopicAdminConnection {
               },
               request, function_name);
         };
-    return pubsub::ListTopicSnapshotsRange(
+    return internal::MakePaginationRange<pubsub::ListTopicSnapshotsRange>(
         std::move(request), list_functor,
         [](google::pubsub::v1::ListTopicSnapshotsResponse response) {
           std::vector<std::string> items;
@@ -260,7 +260,7 @@ StatusOr<google::pubsub::v1::Topic> TopicAdminConnection::UpdateTopic(
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 ListTopicsRange TopicAdminConnection::ListTopics(ListTopicsParams) {
-  return internal::UnimplementedPaginationRange<ListTopicsRange>::Create();
+  return internal::MakeUnimplementedPaginationRange<ListTopicsRange>();
 }
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
@@ -276,15 +276,12 @@ TopicAdminConnection::DetachSubscription(DetachSubscriptionParams) {
 
 ListTopicSubscriptionsRange TopicAdminConnection::ListTopicSubscriptions(
     ListTopicSubscriptionsParams) {  // NOLINT(performance-unnecessary-value-param)
-  return internal::UnimplementedPaginationRange<
-      ListTopicSubscriptionsRange>::Create();
+  return internal::MakeUnimplementedPaginationRange<ListTopicSubscriptionsRange>();
 }
 
 ListTopicSnapshotsRange TopicAdminConnection::ListTopicSnapshots(
     ListTopicSnapshotsParams) {  // NOLINT(performance-unnecessary-value-param)
-
-  return internal::UnimplementedPaginationRange<
-      ListTopicSnapshotsRange>::Create();
+  return internal::MakeUnimplementedPaginationRange<ListTopicSnapshotsRange>();
 }
 
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -41,9 +41,8 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListTopicsRange = google::cloud::internal::PaginationRange<
-    google::pubsub::v1::Topic, google::pubsub::v1::ListTopicsRequest,
-    google::pubsub::v1::ListTopicsResponse>;
+using ListTopicsRange =
+    google::cloud::internal::PaginationRange<google::pubsub::v1::Topic>;
 
 /**
  * An input range to stream the Cloud Pub/Sub subscriptions of a topic.
@@ -54,9 +53,8 @@ using ListTopicsRange = google::cloud::internal::PaginationRange<
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListTopicSubscriptionsRange = google::cloud::internal::PaginationRange<
-    std::string, google::pubsub::v1::ListTopicSubscriptionsRequest,
-    google::pubsub::v1::ListTopicSubscriptionsResponse>;
+using ListTopicSubscriptionsRange =
+    google::cloud::internal::PaginationRange<std::string>;
 
 /**
  * An input range to stream the Cloud Pub/Sub snapshots of a topic.
@@ -67,9 +65,8 @@ using ListTopicSubscriptionsRange = google::cloud::internal::PaginationRange<
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListTopicSnapshotsRange = google::cloud::internal::PaginationRange<
-    std::string, google::pubsub::v1::ListTopicSnapshotsRequest,
-    google::pubsub::v1::ListTopicSnapshotsResponse>;
+using ListTopicSnapshotsRange =
+    google::cloud::internal::PaginationRange<std::string>;
 
 /**
  * A connection to Cloud Pub/Sub for topic-related administrative operations.

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -139,7 +139,7 @@ TEST(DatabaseAdminClientTest, ListDatabases) {
                     DatabaseAdminConnection::ListDatabasesParams const& p) {
         EXPECT_EQ(expected_instance, p.instance);
 
-        return ListDatabaseRange(
+        return google::cloud::internal::MakePaginationRange<ListDatabaseRange>(
             gcsa::ListDatabasesRequest{},
             [](gcsa::ListDatabasesRequest const&) {
               return StatusOr<gcsa::ListDatabasesResponse>(
@@ -494,7 +494,7 @@ TEST(DatabaseAdminClientTest, ListBackups) {
         EXPECT_EQ(expected_instance, p.instance);
         EXPECT_EQ(expected_filter, p.filter);
 
-        return ListBackupsRange(
+        return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
             gcsa::ListBackupsRequest{},
             [](gcsa::ListBackupsRequest const&) {
               return StatusOr<gcsa::ListBackupsResponse>(
@@ -585,7 +585,8 @@ TEST(DatabaseAdminClientTest, ListBackupOperations) {
             EXPECT_EQ(expected_instance, p.instance);
             EXPECT_EQ(expected_filter, p.filter);
 
-            return ListBackupOperationsRange(
+            return google::cloud::internal::MakePaginationRange<
+                ListBackupOperationsRange>(
                 gcsa::ListBackupOperationsRequest{},
                 [](gcsa::ListBackupOperationsRequest const&) {
                   return StatusOr<gcsa::ListBackupOperationsResponse>(
@@ -614,7 +615,8 @@ TEST(DatabaseAdminClientTest, ListDatabaseOperations) {
             EXPECT_EQ(expected_instance, p.instance);
             EXPECT_EQ(expected_filter, p.filter);
 
-            return ListDatabaseOperationsRange(
+            return google::cloud::internal::MakePaginationRange<
+                ListDatabaseOperationsRange>(
                 gcsa::ListDatabaseOperationsRequest{},
                 [](gcsa::ListDatabaseOperationsRequest const&) {
                   return StatusOr<gcsa::ListDatabaseOperationsResponse>(

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -57,7 +57,7 @@ Status DatabaseAdminConnection::DeleteBackup(DeleteBackupParams) {
 
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 ListBackupsRange DatabaseAdminConnection::ListBackups(ListBackupsParams) {
-  return ListBackupsRange(
+  return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
       gcsa::ListBackupsRequest{},
       [](gcsa::ListBackupsRequest const&) {
         return StatusOr<gcsa::ListBackupsResponse>(
@@ -77,7 +77,8 @@ DatabaseAdminConnection::UpdateBackup(UpdateBackupParams) {
 ListBackupOperationsRange DatabaseAdminConnection::ListBackupOperations(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     ListBackupOperationsParams) {
-  return ListBackupOperationsRange(
+  return google::cloud::internal::MakePaginationRange<
+      ListBackupOperationsRange>(
       gcsa::ListBackupOperationsRequest{},
       [](gcsa::ListBackupOperationsRequest const&) {
         return StatusOr<gcsa::ListBackupOperationsResponse>(
@@ -91,7 +92,8 @@ ListBackupOperationsRange DatabaseAdminConnection::ListBackupOperations(
 ListDatabaseOperationsRange DatabaseAdminConnection::ListDatabaseOperations(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     ListDatabaseOperationsParams) {
-  return ListDatabaseOperationsRange(
+  return google::cloud::internal::MakePaginationRange<
+      ListDatabaseOperationsRange>(
       gcsa::ListDatabaseOperationsRequest{},
       [](gcsa::ListDatabaseOperationsRequest const&) {
         return StatusOr<gcsa::ListDatabaseOperationsResponse>(
@@ -251,7 +253,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
 
     char const* function_name = __func__;
-    return ListDatabaseRange(
+    return google::cloud::internal::MakePaginationRange<ListDatabaseRange>(
         std::move(request),
         [stub, retry, backoff,
          function_name](gcsa::ListDatabasesRequest const& r) {
@@ -406,7 +408,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
 
     char const* function_name = __func__;
-    return ListBackupsRange(
+    return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
         std::move(request),
         [stub, retry, backoff,
          function_name](gcsa::ListBackupsRequest const& r) {
@@ -452,7 +454,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
 
     char const* function_name = __func__;
-    return ListBackupOperationsRange(
+    return google::cloud::internal::MakePaginationRange<
+        ListBackupOperationsRange>(
         std::move(request),
         [stub, retry, backoff,
          function_name](gcsa::ListBackupOperationsRequest const& r) {
@@ -487,7 +490,8 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         backoff_policy_prototype_->clone());
 
     char const* function_name = __func__;
-    return ListDatabaseOperationsRange(
+    return google::cloud::internal::MakePaginationRange<
+        ListDatabaseOperationsRange>(
         std::move(request),
         [stub, retry, backoff,
          function_name](gcsa::ListDatabaseOperationsRequest const& r) {

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -43,9 +43,7 @@ inline namespace SPANNER_CLIENT_NS {
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
 using ListDatabaseRange = google::cloud::internal::PaginationRange<
-    google::spanner::admin::database::v1::Database,
-    google::spanner::admin::database::v1::ListDatabasesRequest,
-    google::spanner::admin::database::v1::ListDatabasesResponse>;
+    google::spanner::admin::database::v1::Database>;
 
 /**
  * An input range to stream backup operations in Cloud Spanner instance.
@@ -56,10 +54,8 @@ using ListDatabaseRange = google::cloud::internal::PaginationRange<
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListBackupOperationsRange = google::cloud::internal::PaginationRange<
-    google::longrunning::Operation,
-    google::spanner::admin::database::v1::ListBackupOperationsRequest,
-    google::spanner::admin::database::v1::ListBackupOperationsResponse>;
+using ListBackupOperationsRange =
+    google::cloud::internal::PaginationRange<google::longrunning::Operation>;
 
 /**
  * An input range to stream database operations in Cloud Spanner instance.
@@ -70,10 +66,8 @@ using ListBackupOperationsRange = google::cloud::internal::PaginationRange<
  *
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
-using ListDatabaseOperationsRange = google::cloud::internal::PaginationRange<
-    google::longrunning::Operation,
-    google::spanner::admin::database::v1::ListDatabaseOperationsRequest,
-    google::spanner::admin::database::v1::ListDatabaseOperationsResponse>;
+using ListDatabaseOperationsRange =
+    google::cloud::internal::PaginationRange<google::longrunning::Operation>;
 
 /**
  * An input range to stream backups in Cloud Spanner instance.
@@ -85,9 +79,7 @@ using ListDatabaseOperationsRange = google::cloud::internal::PaginationRange<
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
 using ListBackupsRange = google::cloud::internal::PaginationRange<
-    google::spanner::admin::database::v1::Backup,
-    google::spanner::admin::database::v1::ListBackupsRequest,
-    google::spanner::admin::database::v1::ListBackupsResponse>;
+    google::spanner::admin::database::v1::Backup>;
 
 /**
  * A connection to the Cloud Spanner instance administration service.

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -93,7 +93,8 @@ TEST(InstanceAdminClientTest, ListInstanceConfigs) {
       .WillOnce(
           [](InstanceAdminConnection::ListInstanceConfigsParams const& p) {
             EXPECT_EQ("test-project", p.project_id);
-            return ListInstanceConfigsRange(
+            return google::cloud::internal::MakePaginationRange<
+                ListInstanceConfigsRange>(
                 gcsa::ListInstanceConfigsRequest{},
                 [](gcsa::ListInstanceConfigsRequest const&) {
                   return StatusOr<gcsa::ListInstanceConfigsResponse>(
@@ -119,7 +120,7 @@ TEST(InstanceAdminClientTest, ListInstances) {
         EXPECT_EQ("test-project", p.project_id);
         EXPECT_EQ("labels.test-key:test-value", p.filter);
 
-        return ListInstancesRange(
+        return google::cloud::internal::MakePaginationRange<ListInstancesRange>(
             gcsa::ListInstancesRequest{},
             [](gcsa::ListInstancesRequest const&) {
               return StatusOr<gcsa::ListInstancesResponse>(

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -163,7 +163,8 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         std::shared_ptr<BackoffPolicy>(backoff_policy_prototype_->clone());
 
     char const* function_name = __func__;
-    return ListInstanceConfigsRange(
+    return google::cloud::internal::MakePaginationRange<
+        ListInstanceConfigsRange>(
         std::move(request),
         [stub, retry, backoff,
          function_name](gcsa::ListInstanceConfigsRequest const& r) {
@@ -196,7 +197,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         std::shared_ptr<BackoffPolicy>(backoff_policy_prototype_->clone());
 
     char const* function_name = __func__;
-    return ListInstancesRange(
+    return google::cloud::internal::MakePaginationRange<ListInstancesRange>(
         std::move(request),
         [stub, retry, backoff,
          function_name](gcsa::ListInstancesRequest const& r) {

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -39,9 +39,7 @@ inline namespace SPANNER_CLIENT_NS {
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
 using ListInstancesRange = google::cloud::internal::PaginationRange<
-    google::spanner::admin::instance::v1::Instance,
-    google::spanner::admin::instance::v1::ListInstancesRequest,
-    google::spanner::admin::instance::v1::ListInstancesResponse>;
+    google::spanner::admin::instance::v1::Instance>;
 
 /**
  * An input range to stream all the instance configs in a Cloud project.
@@ -53,9 +51,7 @@ using ListInstancesRange = google::cloud::internal::PaginationRange<
  * [cppref-input-range]: https://en.cppreference.com/w/cpp/ranges/input_range
  */
 using ListInstanceConfigsRange = google::cloud::internal::PaginationRange<
-    google::spanner::admin::instance::v1::InstanceConfig,
-    google::spanner::admin::instance::v1::ListInstanceConfigsRequest,
-    google::spanner::admin::instance::v1::ListInstanceConfigsResponse>;
+    google::spanner::admin::instance::v1::InstanceConfig>;
 
 /**
  * A connection to the Cloud Spanner instance administration service.

--- a/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
@@ -42,7 +42,8 @@ TEST(CleanupStaleDatabases, Empty) {
               spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
             EXPECT_EQ(expected_instance, p.instance);
 
-            return google::cloud::spanner::ListDatabaseRange(
+            return google::cloud::internal::MakePaginationRange<
+                google::cloud::spanner::ListDatabaseRange>(
                 gcsa::ListDatabasesRequest{},
                 [](gcsa::ListDatabasesRequest const&) {
                   gcsa::ListDatabasesResponse response;
@@ -68,7 +69,8 @@ TEST(CleanupStaleDatabases, ListError) {
               spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
             EXPECT_EQ(expected_instance, p.instance);
 
-            return google::cloud::spanner::ListDatabaseRange(
+            return google::cloud::internal::MakePaginationRange<
+                google::cloud::spanner::ListDatabaseRange>(
                 gcsa::ListDatabasesRequest{},
                 [](gcsa::ListDatabasesRequest const&) {
                   return StatusOr<gcsa::ListDatabasesResponse>(
@@ -111,7 +113,8 @@ TEST(CleanupStaleDatabases, RemovesMatching) {
           [&](spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
             EXPECT_EQ(expected_instance, p.instance);
 
-            return google::cloud::spanner::ListDatabaseRange(
+            return google::cloud::internal::MakePaginationRange<
+                google::cloud::spanner::ListDatabaseRange>(
                 gcsa::ListDatabasesRequest{},
                 [&](gcsa::ListDatabasesRequest const&) {
                   gcsa::ListDatabasesResponse response;


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/5537

**BREAKING CHANGE**

This change removes a constructor that not intended to be part of the public API from several "Range" types in the Pub/Sub and Spanner APIs. The affected types are:

  * `google/cloud/pubsub/subscription_admin_connection.h`
    * `using ListSubscriptionsRange = google::cloud::internal::PaginationRange`
    * `using ListSnapshotsRange = google::cloud::internal::PaginationRange`
  * `google/cloud/pubsub/topic_admin_connection.h`
    * `using ListTopicsRange = google::cloud::internal::PaginationRange`
    * `using ListTopicSubscriptionsRange = google::cloud::internal::PaginationRange`
    * `using ListTopicSnapshotsRange = google::cloud::internal::PaginationRange`
  * `google/cloud/spanner/database_admin_connection.h`
    * `using ListDatabaseRange = google::cloud::internal::PaginationRange`
    * `using ListBackupOperationsRange = google::cloud::internal::PaginationRange`
    * `using ListDatabaseOperationsRange = google::cloud::internal::PaginationRange`
    * `using ListBackupsRange = google::cloud::internal::PaginationRange`
  * `google/cloud/spanner/instance_admin_connection.h`
    * `using ListInstancesRange = google::cloud::internal::PaginationRange`
    * `using ListInstanceConfigsRange = google::cloud::internal::PaginationRange`

All normal usage of these types will continue to work, i.e., they will all continue to work as ranges. However, the following constructor was removed:

https://github.com/googleapis/google-cloud-cpp/blob/d7d3576c6533dc15bd656b74bed8fc73e7400980/google/cloud/internal/pagination_range.h#L142-L144



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5538)
<!-- Reviewable:end -->
