### PR TITLE
refactor: remove PaginationRange's dep on gRPC

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -94,11 +94,18 @@ io::log "Fetching dependencies"
   @go_sdk//... \
   @remotejdk11_linux//:jdk
 
+excluded_targets=()
+if [[ "${BUILD_NAME}" == "msan" ]]; then
+  # GoogleTest's `TYPED_TEST` causes msan to complain. Not sure why.
+  excluded_targets+=("-//google/cloud:internal_pagination_range_test")
+fi
+
 echo "================================================================"
 io::log "Compiling and running unit tests"
 echo "bazel ${BAZEL_VERB}" "${bazel_args[@]}"
 "${BAZEL_BIN}" ${BAZEL_VERB} \
-  "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
+  "${bazel_args[@]}" "--test_tag_filters=-integration-test" \
+  -- ... "${excluded_targets[@]}"
 
 should_run_integration_tests() {
   if [[ "${SOURCE_DIR:-}" == "super" ]]; then

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -141,6 +141,7 @@ add_library(
     internal/getenv.h
     internal/invoke_result.h
     internal/ios_flags_saver.h
+    internal/pagination_range.h
     internal/parse_rfc3339.cc
     internal/parse_rfc3339.h
     internal/port_platform.h
@@ -245,6 +246,7 @@ if (BUILD_TESTING)
         internal/format_time_point_test.cc
         internal/future_impl_test.cc
         internal/invoke_result_test.cc
+        internal/pagination_range_test.cc
         internal/parse_rfc3339_test.cc
         internal/random_test.cc
         internal/retry_policy_test.cc
@@ -370,7 +372,6 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/default_completion_queue_impl.h
         internal/log_wrapper.cc
         internal/log_wrapper.h
-        internal/pagination_range.h
         internal/polling_loop.h
         internal/retry_loop.h
         internal/retry_loop_helpers.cc
@@ -446,7 +447,6 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/async_retry_unary_rpc_test.cc
             internal/background_threads_impl_test.cc
             internal/log_wrapper_test.cc
-            internal/pagination_range_test.cc
             internal/polling_loop_test.cc
             internal/retry_loop_test.cc
             internal/time_utils_test.cc)

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -46,6 +46,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/getenv.h",
     "internal/invoke_result.h",
     "internal/ios_flags_saver.h",
+    "internal/pagination_range.h",
     "internal/parse_rfc3339.h",
     "internal/port_platform.h",
     "internal/random.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -31,6 +31,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/format_time_point_test.cc",
     "internal/future_impl_test.cc",
     "internal/invoke_result_test.cc",
+    "internal/pagination_range_test.cc",
     "internal/parse_rfc3339_test.cc",
     "internal/random_test.cc",
     "internal/retry_policy_test.cc",

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -35,7 +35,6 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/completion_queue_impl.h",
     "internal/default_completion_queue_impl.h",
     "internal/log_wrapper.h",
-    "internal/pagination_range.h",
     "internal/polling_loop.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -25,7 +25,6 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/async_retry_unary_rpc_test.cc",
     "internal/background_threads_impl_test.cc",
     "internal/log_wrapper_test.cc",
-    "internal/pagination_range_test.cc",
     "internal/polling_loop_test.cc",
     "internal/retry_loop_test.cc",
     "internal/time_utils_test.cc",

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/internal/pagination_range.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <gmock/gmock.h>
 
 namespace google {
@@ -27,79 +26,117 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
-using ItemType = ::google::bigtable::admin::v2::AppProfile;
-using Request = ::google::bigtable::admin::v2::ListAppProfilesRequest;
-using Response = ::google::bigtable::admin::v2::ListAppProfilesResponse;
-using TestedRange = PaginationRange<ItemType>;
 
-class MockRpc {
- public:
-  MOCK_METHOD1(Loader, StatusOr<Response>(Request const&));
-  MOCK_METHOD1(GetItems, std::vector<ItemType>(Response));
+struct Item {
+  std::string data;
 };
 
-std::vector<ItemType> GetItems(Response const& response) {
-  return std::vector<ItemType>(response.app_profiles().begin(),
-                               response.app_profiles().end());
-}
+// A generic request. Fields with a "testonly_" prefix are used for testing but
+// are not used in the real code.
+struct Request {
+  std::string testonly_page_token;
+  void set_page_token(std::string token) {
+    testonly_page_token = std::move(token);
+  }
+};
 
-TEST(RangeFromPagination, Empty) {
-  MockRpc mock;
+// Looks like a minimal protobuf response message. Fields with a "testonly_"
+// prefix are used for testing but are not used in the real code.
+struct ProtoResponse {
+  std::vector<Item> testonly_items;
+  std::string testonly_page_token;
+  std::string* mutable_next_page_token() { return &testonly_page_token; }
+
+  // Used for setting the token in tests, but it's not used in the real code.
+  void testonly_set_page_token(std::string s) {
+    testonly_page_token = std::move(s);
+  }
+};
+
+// Looks like a minimal struct response message. Fields with a "testonly_"
+// prefix are used for testing but are not used in the real code.
+struct StructResponse {
+  std::vector<Item> testonly_items;
+  std::string next_page_token;
+
+  // Used for setting the token in tests, but it's not used in the real code.
+  void testonly_set_page_token(std::string s) {
+    next_page_token = std::move(s);
+  }
+};
+
+using ItemRange = PaginationRange<Item>;
+
+template <typename Response>
+class MockRpc {
+ public:
+  MOCK_METHOD(StatusOr<Response>, Loader, (Request const&));
+};
+
+// A fixture for a "typed test". Each test below will be tested with a
+// `ProtoResponse` object and a `StructResponse` object.
+template <typename T>
+class PaginationRangeTest : public testing::Test {};
+using ResponseTypes = ::testing::Types<ProtoResponse, StructResponse>;
+TYPED_TEST_SUITE(PaginationRangeTest, ResponseTypes);
+
+TYPED_TEST(PaginationRangeTest, TypedEmpty) {
+  using ResponseType = TypeParam;
+  MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader(_)).WillOnce([](Request const& request) {
-    EXPECT_TRUE(request.page_token().empty());
-    Response response;
-    response.clear_next_page_token();
-    return response;
+    EXPECT_TRUE(request.testonly_page_token.empty());
+    return ResponseType{};
   });
-
-  auto range = MakePaginationRange<TestedRange>(
-      Request{}, [&](Request const& r) { return mock.Loader(r); }, GetItems);
+  auto range = MakePaginationRange<ItemRange>(
+      Request{}, [&mock](Request const& r) { return mock.Loader(r); },
+      [](ResponseType const& r) { return r.testonly_items; });
   EXPECT_TRUE(range.begin() == range.end());
 }
 
-TEST(RangeFromPagination, SinglePage) {
-  MockRpc mock;
+TYPED_TEST(PaginationRangeTest, SinglePage) {
+  using ResponseType = TypeParam;
+  MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader(_)).WillOnce([](Request const& request) {
-    EXPECT_TRUE(request.page_token().empty());
-    Response response;
-    response.clear_next_page_token();
-    response.add_app_profiles()->set_name("p1");
-    response.add_app_profiles()->set_name("p2");
+    EXPECT_TRUE(request.testonly_page_token.empty());
+    ResponseType response;
+    response.testonly_items.push_back(Item{"p1"});
+    response.testonly_items.push_back(Item{"p2"});
     return response;
   });
 
-  auto range = MakePaginationRange<TestedRange>(
-      Request{}, [&](Request const& r) { return mock.Loader(r); }, GetItems);
+  auto range = MakePaginationRange<ItemRange>(
+      Request{}, [&mock](Request const& r) { return mock.Loader(r); },
+      [](ResponseType const& r) { return r.testonly_items; });
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) break;
-    names.push_back(p->name());
+    names.push_back(p->data);
   }
   EXPECT_THAT(names, ElementsAre("p1", "p2"));
 }
 
-TEST(RangeFromPagination, NonProtoRange) {
-  MockRpc mock;
+TYPED_TEST(PaginationRangeTest, NonProtoRange) {
+  using ResponseType = TypeParam;
+  MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader(_)).WillOnce([](Request const& request) {
-    EXPECT_TRUE(request.page_token().empty());
-    Response response;
-    response.clear_next_page_token();
-    response.add_app_profiles()->set_name("p1");
-    response.add_app_profiles()->set_name("p2");
+    EXPECT_TRUE(request.testonly_page_token.empty());
+    ResponseType response;
+    response.testonly_items.push_back(Item{"p1"});
+    response.testonly_items.push_back(Item{"p2"});
     return response;
   });
 
   using NonProtoRange = PaginationRange<std::string>;
-
   auto range = MakePaginationRange<NonProtoRange>(
-      Request{}, [&](Request const& r) { return mock.Loader(r); },
-      [](Response const& r) {
-        std::vector<std::string> items;
-        for (auto const& i : r.app_profiles()) {
-          items.push_back(i.name());
+      Request{}, [&mock](Request const& r) { return mock.Loader(r); },
+      [](ResponseType const& r) {
+        std::vector<std::string> v;
+        for (auto const& i : r.testonly_items) {
+          v.push_back(i.data);
         }
-        return items;
+        return v;
       });
+
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) break;
@@ -108,62 +145,65 @@ TEST(RangeFromPagination, NonProtoRange) {
   EXPECT_THAT(names, ElementsAre("p1", "p2"));
 }
 
-TEST(RangeFromPagination, TwoPages) {
-  MockRpc mock;
+TYPED_TEST(PaginationRangeTest, TwoPages) {
+  using ResponseType = TypeParam;
+  MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader(_))
       .WillOnce([](Request const& request) {
-        EXPECT_TRUE(request.page_token().empty());
-        Response response;
-        response.set_next_page_token("t1");
-        response.add_app_profiles()->set_name("p1");
-        response.add_app_profiles()->set_name("p2");
+        EXPECT_TRUE(request.testonly_page_token.empty());
+        ResponseType response;
+        response.testonly_set_page_token("t1");
+        response.testonly_items.push_back(Item{"p1"});
+        response.testonly_items.push_back(Item{"p2"});
         return response;
       })
       .WillOnce([](Request const& request) {
-        EXPECT_EQ("t1", request.page_token());
-        Response response;
-        response.clear_next_page_token();
-        response.add_app_profiles()->set_name("p3");
-        response.add_app_profiles()->set_name("p4");
+        EXPECT_EQ("t1", request.testonly_page_token);
+        ResponseType response;
+        response.testonly_items.push_back(Item{"p3"});
+        response.testonly_items.push_back(Item{"p4"});
         return response;
       });
 
-  auto range = MakePaginationRange<TestedRange>(
-      Request{}, [&](Request const& r) { return mock.Loader(r); }, GetItems);
+  auto range = MakePaginationRange<ItemRange>(
+      Request{}, [&mock](Request const& r) { return mock.Loader(r); },
+      [](ResponseType const& r) { return r.testonly_items; });
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) break;
-    names.push_back(p->name());
+    names.push_back(p->data);
   }
   EXPECT_THAT(names, ElementsAre("p1", "p2", "p3", "p4"));
 }
 
-TEST(RangeFromPagination, TwoPagesWithError) {
-  MockRpc mock;
+TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
+  using ResponseType = TypeParam;
+  MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader(_))
       .WillOnce([](Request const& request) {
-        EXPECT_TRUE(request.page_token().empty());
-        Response response;
-        response.set_next_page_token("t1");
-        response.add_app_profiles()->set_name("p1");
-        response.add_app_profiles()->set_name("p2");
+        EXPECT_TRUE(request.testonly_page_token.empty());
+        ResponseType response;
+        response.testonly_set_page_token("t1");
+        response.testonly_items.push_back(Item{"p1"});
+        response.testonly_items.push_back(Item{"p2"});
         return response;
       })
       .WillOnce([](Request const& request) {
-        EXPECT_EQ("t1", request.page_token());
-        Response response;
-        response.set_next_page_token("t2");
-        response.add_app_profiles()->set_name("p3");
-        response.add_app_profiles()->set_name("p4");
+        EXPECT_EQ("t1", request.testonly_page_token);
+        ResponseType response;
+        response.testonly_set_page_token("t2");
+        response.testonly_items.push_back(Item{"p3"});
+        response.testonly_items.push_back(Item{"p4"});
         return response;
       })
       .WillOnce([](Request const& request) {
-        EXPECT_EQ("t2", request.page_token());
+        EXPECT_EQ("t2", request.testonly_page_token);
         return Status(StatusCode::kAborted, "bad-luck");
       });
 
-  auto range = MakePaginationRange<TestedRange>(
-      Request{}, [&](Request const& r) { return mock.Loader(r); }, GetItems);
+  auto range = MakePaginationRange<ItemRange>(
+      Request{}, [&mock](Request const& r) { return mock.Loader(r); },
+      [](ResponseType const& r) { return r.testonly_items; });
   std::vector<std::string> names;
   for (auto& p : range) {
     if (!p) {
@@ -171,28 +211,30 @@ TEST(RangeFromPagination, TwoPagesWithError) {
       EXPECT_THAT(p.status().message(), HasSubstr("bad-luck"));
       break;
     }
-    names.push_back(p->name());
+    names.push_back(p->data);
   }
   EXPECT_THAT(names, ElementsAre("p1", "p2", "p3", "p4"));
 }
 
-TEST(RangeFromPagination, IteratorCoverage) {
-  MockRpc mock;
+TYPED_TEST(PaginationRangeTest, IteratorCoverage) {
+  using ResponseType = TypeParam;
+  MockRpc<ResponseType> mock;
   EXPECT_CALL(mock, Loader(_))
       .WillOnce([](Request const& request) {
-        EXPECT_TRUE(request.page_token().empty());
-        Response response;
-        response.set_next_page_token("t1");
-        response.add_app_profiles()->set_name("p1");
+        EXPECT_TRUE(request.testonly_page_token.empty());
+        ResponseType response;
+        response.testonly_set_page_token("t1");
+        response.testonly_items.push_back(Item{"p1"});
         return response;
       })
       .WillOnce([](Request const& request) {
-        EXPECT_EQ("t1", request.page_token());
+        EXPECT_EQ("t1", request.testonly_page_token);
         return Status(StatusCode::kAborted, "bad-luck");
       });
 
-  auto range = MakePaginationRange<TestedRange>(
-      Request{}, [&](Request const& r) { return mock.Loader(r); }, GetItems);
+  auto range = MakePaginationRange<ItemRange>(
+      Request{}, [&mock](Request const& r) { return mock.Loader(r); },
+      [](ResponseType const& r) { return r.testonly_items; });
   auto i0 = range.begin();
   auto i1 = i0;
   EXPECT_TRUE(i0 == i1);


### PR DESCRIPTION
`PaginationRange<T>` no longer has a dep on gRPC and it can also work with `Request` and `Response` objects that are either protobufs or plain old structs. This PR should allow GCS to use this `PaginationRange<T>` without taking a dep on GRPC or proto.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5540)
<!-- Reviewable:end -->
