### PR TITLE
fix(pubsub): deadlock during fire & forget shutdown

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -467,7 +467,6 @@ TEST(SubscriptionSessionTest, FireAndForgetShutdown) {
 
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   AsyncSequencer<bool> on_read;
-  AsyncSequencer<void> on_cancel;
   AsyncSequencer<Status> on_finish;
 
   auto async_pull_mock = [&](google::cloud::CompletionQueue& cq,
@@ -497,9 +496,6 @@ TEST(SubscriptionSessionTest, FireAndForgetShutdown) {
     auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
     EXPECT_CALL(*stream, Start).WillOnce(start_response);
     EXPECT_CALL(*stream, Write).WillRepeatedly(write_response);
-    EXPECT_CALL(*stream, Cancel).WillRepeatedly([&on_cancel] {
-      on_cancel.PushBack();
-    });
     EXPECT_CALL(*stream, Read).WillRepeatedly(read_response);
     EXPECT_CALL(*stream, Finish).WillOnce(finish_response);
 

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include <gmock/gmock.h>
 #include <atomic>
@@ -30,6 +31,7 @@ inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
 using ::google::cloud::pubsub_testing::FakeAsyncStreamingPull;
+using ::google::cloud::testing_util::AsyncSequencer;
 using ::testing::AtLeast;
 using ::testing::InSequence;
 
@@ -457,6 +459,82 @@ TEST(SubscriptionSessionTest, FireAndForget) {
     std::unique_lock<std::mutex> lk(mu);
     EXPECT_STATUS_OK(status);
   }
+}
+
+/// @test Verify sessions shutdown properly even if future is released.
+TEST(SubscriptionSessionTest, FireAndForgetShutdown) {
+  pubsub::Subscription const subscription("test-project", "test-subscription");
+
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  AsyncSequencer<bool> on_read;
+  AsyncSequencer<void> on_cancel;
+  AsyncSequencer<Status> on_finish;
+
+  auto async_pull_mock = [&](google::cloud::CompletionQueue& cq,
+                             std::unique_ptr<grpc::ClientContext>,
+                             google::pubsub::v1::StreamingPullRequest const&) {
+    using us = std::chrono::microseconds;
+    using F = future<StatusOr<std::chrono::system_clock::time_point>>;
+    using Response = google::pubsub::v1::StreamingPullResponse;
+    auto start_response = [cq]() mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](F) { return true; });
+    };
+    auto write_response = [cq](google::pubsub::v1::StreamingPullRequest const&,
+                               grpc::WriteOptions const&) mutable {
+      return cq.MakeRelativeTimer(us(10)).then([](F) { return true; });
+    };
+    auto read_response = [&] {
+      return on_read.PushBack("Read").then([](future<bool> f) {
+        if (f.get()) return absl::make_optional(Response{});
+        return absl::optional<Response>{};
+      });
+    };
+    auto finish_response = [&] {
+      return on_finish.PushBack("Finish").then(
+          [](future<Status> f) { return f.get(); });
+    };
+
+    auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+    EXPECT_CALL(*stream, Start).WillOnce(start_response);
+    EXPECT_CALL(*stream, Write).WillRepeatedly(write_response);
+    EXPECT_CALL(*stream, Cancel).WillRepeatedly([&on_cancel] {
+      on_cancel.PushBack();
+    });
+    EXPECT_CALL(*stream, Read).WillRepeatedly(read_response);
+    EXPECT_CALL(*stream, Finish).WillOnce(finish_response);
+
+    return stream;
+  };
+  EXPECT_CALL(*mock, AsyncStreamingPull).WillRepeatedly(async_pull_mock);
+
+  promise<Status> shutdown_completed;
+  auto background =
+      absl::make_unique<internal::AutomaticallyCreatedBackgroundThreads>(1);
+  {
+    auto handler = [&](pubsub::Message const&, pubsub::AckHandler) {};
+    (void)CreateSubscriptionSession(
+        subscription,
+        pubsub::SubscriberOptions{}.set_shutdown_polling_period(
+            std::chrono::milliseconds(100)),
+        mock, background->cq(), "fake-client-id", {handler},
+        pubsub_testing::TestRetryPolicy(), pubsub_testing::TestBackoffPolicy())
+        .then([&shutdown_completed](future<Status> f) {
+          shutdown_completed.set_value(f.get());
+        });
+  }
+  // Make the first Read() call fail and then wait before returning from
+  // Finish()
+  on_read.PopFront().set_value(false);
+  auto finish = on_finish.PopFront();
+  // Shutdown the completion queue, this will disable the timers for the second
+  // async_pull
+  background->cq().Shutdown();
+  finish.set_value(Status{});
+
+  // At this point the streaming pull cannot restart, so there are no pending
+  // operations.  Eventually the session will be finished.
+  shutdown_completed.get_future().get();
+  background.reset(nullptr);
 }
 
 }  // namespace


### PR DESCRIPTION
In very rare circumstances (maybe as evidenced by the test) the library
would deadlock trying to shutdown a subscription. I noticed this in less
than 1 run over 10,000, and only when compiled with optimizations (TSAN
and ASAN masked the problem).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5541)
<!-- Reviewable:end -->
