### PR TITLE
cleanup(pubsub): simplify session timer rescheduling

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session.cc
+++ b/google/cloud/pubsub/internal/subscription_session.cc
@@ -118,12 +118,10 @@ class SubscriptionSessionImpl
     GCP_LOG(TRACE) << __func__ << "()";
     using TimerArg = future<StatusOr<std::chrono::system_clock::time_point>>;
 
-    std::unique_lock<std::mutex> lk(mu_);
     auto self = shared_from_this();
-    lk.unlock();
     auto t = cq_.MakeRelativeTimer(shutdown_polling_period_)
                  .then([self](TimerArg f) { self->OnTimer(!f.get().ok()); });
-    lk.lock();
+    std::unique_lock<std::mutex> lk(mu_);
     if (shutdown_state_ == kShutdownByCompletionQueue) return;
     timer_ = std::move(t);
   }


### PR DESCRIPTION
Obviously `self = shared_from_this();` can run outside the lock,
and once you move it out, the code can be simplified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5546)
<!-- Reviewable:end -->
