### PR TITLE
fix(pubsub): deadlock during streaming pull shutdown

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -37,8 +37,7 @@ void StreamingSubscriptionBatchSource::Shutdown() {
   std::unique_lock<std::mutex> lk(mu_);
   if (shutdown_ || !stream_) return;
   shutdown_ = true;
-  if (stream_state_ != StreamState::kActive) return;
-  stream_->Cancel();
+  if (stream_) stream_->Cancel();
 }
 
 void StreamingSubscriptionBatchSource::AckMessage(std::string const& ack_id) {
@@ -93,12 +92,11 @@ void StreamingSubscriptionBatchSource::StartStream(
     OnRetryFailure(Status(StatusCode::kUnknown, "null stream"));
     return;
   }
-
   shutdown_manager_->StartOperation(__func__, "InitialStart", [&] {
-    RetryLoopState rs{std::move(stream), std::move(retry_policy),
-                      std::move(backoff_policy)};
+    stream_ = std::move(stream);
+    RetryLoopState rs{std::move(retry_policy), std::move(backoff_policy)};
     auto weak = WeakFromThis();
-    rs.stream->Start().then([weak, rs, request](future<bool> f) {
+    stream_->Start().then([weak, rs, request](future<bool> f) {
       if (auto s = weak.lock()) s->OnStart(rs, request, f.get());
     });
   });
@@ -129,7 +127,7 @@ void StreamingSubscriptionBatchSource::OnStart(
   }
   shutdown_manager_->StartOperation(__func__, "InitialWrite", [&] {
     auto weak = WeakFromThis();
-    rs.stream->Write(request, grpc::WriteOptions{}.set_write_through())
+    stream_->Write(request, grpc::WriteOptions{}.set_write_through())
         .then([weak, rs](future<bool> f) mutable {
           if (auto s = weak.lock()) s->OnInitialWrite(std::move(rs), f.get());
         });
@@ -145,7 +143,7 @@ void StreamingSubscriptionBatchSource::OnInitialWrite(RetryLoopState const& rs,
   }
   shutdown_manager_->StartOperation(__func__, "InitialRead", [&] {
     auto weak = WeakFromThis();
-    rs.stream->Read().then(
+    stream_->Read().then(
         [weak,
          rs](future<absl::optional<google::pubsub::v1::StreamingPullResponse>>
                  f) {
@@ -166,7 +164,6 @@ void StreamingSubscriptionBatchSource::OnInitialRead(
   std::unique_lock<std::mutex> lk(mu_);
   ChangeState(lk, StreamState::kActive, __func__, "success");
   status_ = Status{};
-  stream_ = std::move(rs.stream);
   lk.unlock();
   auto const scheduled =
       shutdown_manager_->StartOperation(__func__, "read", [&] {
@@ -184,7 +181,7 @@ void StreamingSubscriptionBatchSource::OnInitialError(RetryLoopState rs) {
   auto weak = WeakFromThis();
   auto const scheduled =
       shutdown_manager_->StartOperation(__func__, "finish", [&] {
-        rs.stream->Finish().then([weak, rs](future<Status> f) {
+        stream_->Finish().then([weak, rs](future<Status> f) {
           if (auto s = weak.lock()) s->OnInitialFinish(std::move(rs), f.get());
         });
         shutdown_manager_->FinishedOperation("finish");

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -115,7 +115,6 @@ class StreamingSubscriptionBatchSource
                    std::shared_ptr<pubsub::BackoffPolicy> backoff_policy);
 
   struct RetryLoopState {
-    std::shared_ptr<AsyncPullStream> stream;
     std::shared_ptr<pubsub::RetryPolicy> retry_policy;
     std::shared_ptr<pubsub::BackoffPolicy> backoff_policy;
   };

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -35,6 +35,7 @@ namespace {
 using ::google::cloud::internal::AutomaticallyCreatedBackgroundThreads;
 using ::google::cloud::pubsub_testing::TestBackoffPolicy;
 using ::google::cloud::pubsub_testing::TestRetryPolicy;
+using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::_;
 using ::testing::AtLeast;
@@ -97,7 +98,7 @@ class FakeStream {
 
  private:
   Status finish_;
-  google::cloud::testing_util::AsyncSequencer<bool> async_;
+  AsyncSequencer<bool> async_;
 };
 
 pubsub::SubscriberOptions TestSubscriptionOptions() {
@@ -271,7 +272,7 @@ TEST(StreamingSubscriptionBatchSourceTest, StartWithIgnoredUnavailable) {
   AutomaticallyCreatedBackgroundThreads background;
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
 
-  google::cloud::testing_util::AsyncSequencer<Status> on_finish;
+  AsyncSequencer<Status> on_finish;
   auto async_pull_mock = [&on_finish](
                              google::cloud::CompletionQueue& cq,
                              std::unique_ptr<grpc::ClientContext>,
@@ -657,7 +658,7 @@ TEST(StreamingSubscriptionBatchSourceTest, AckBatching) {
   auto subscription = pubsub::Subscription("test-project", "test-subscription");
   std::string const client_id = "fake-client-id";
 
-  google::cloud::testing_util::AsyncSequencer<void> async;
+  AsyncSequencer<void> async;
   auto cq_impl =
       std::make_shared<google::cloud::testing_util::MockCompletionQueueImpl>();
   EXPECT_CALL(*cq_impl, MakeRelativeTimer)
@@ -921,6 +922,85 @@ TEST(StreamingSubscriptionBatchSourceTest, ShutdownWithPendingRead) {
   pending_read.set_value(true);                 // Read() done
   fake_stream.WaitForAction().set_value(true);  // Finish()
   EXPECT_EQ(expected_status, done.get());
+}
+
+/// @test verify that a shutdown cancels the initial Read() call
+TEST(StreamingSubscriptionBatchSourceTest, ShutdownWithPendingReadCancel) {
+  auto subscription = pubsub::Subscription("test-project", "test-subscription");
+  std::string const client_id = "fake-client-id";
+  AutomaticallyCreatedBackgroundThreads background;
+
+  auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
+  AsyncSequencer<bool> async;
+
+  auto wait_and_check_name = [&async](std::string const& name) {
+    auto p = async.PopFrontWithName();
+    EXPECT_EQ(p.second, name);
+    return std::move(p.first);
+  };
+
+  auto async_pull_mock = [&](google::cloud::CompletionQueue&,
+                             std::unique_ptr<grpc::ClientContext>,
+                             google::pubsub::v1::StreamingPullRequest const&) {
+    using Response = google::pubsub::v1::StreamingPullResponse;
+    using Request = google::pubsub::v1::StreamingPullRequest;
+    auto start_response = [&async] {
+      return async.PushBack("Start").then(
+          [](future<bool> f) { return f.get(); });
+    };
+    auto write_response = [&async](Request const&,
+                                   grpc::WriteOptions const&) mutable {
+      return async.PushBack("Write").then(
+          [](future<bool> f) { return f.get(); });
+    };
+    auto read_response = [&] {
+      return async.PushBack("Read").then([](future<bool> f) {
+        if (f.get()) return absl::make_optional(Response{});
+        return absl::optional<Response>{};
+      });
+    };
+    auto cancel = [&] { async.PushBack("Cancel"); };
+    auto finish_response = [&] {
+      return async.PushBack("Finish").then(
+          [](future<bool>) { return Status{}; });
+    };
+
+    auto stream = absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+    EXPECT_CALL(*stream, Start).WillOnce(start_response);
+    EXPECT_CALL(*stream, Write).WillRepeatedly(write_response);
+    EXPECT_CALL(*stream, Read).WillRepeatedly(read_response);
+    EXPECT_CALL(*stream, Cancel).WillRepeatedly(cancel);
+    EXPECT_CALL(*stream, Finish).WillOnce(finish_response);
+
+    return stream;
+  };
+  EXPECT_CALL(*mock, AsyncStreamingPull).WillOnce(async_pull_mock);
+
+  using CallbackArg = StatusOr<google::pubsub::v1::StreamingPullResponse>;
+  ::testing::MockFunction<void(CallbackArg const&)> callback;
+  EXPECT_CALL(callback, Call(StatusIs(StatusCode::kOk))).Times(0);
+
+  auto shutdown = std::make_shared<SessionShutdownManager>();
+  auto uut = std::make_shared<StreamingSubscriptionBatchSource>(
+      background.cq(), shutdown, mock, subscription.FullName(), client_id,
+      TestSubscriptionOptions(), TestRetryPolicy(), TestBackoffPolicy(),
+      TestBatchingConfig());
+
+  auto done = shutdown->Start({});
+  uut->Start(callback.AsStdFunction());
+
+  wait_and_check_name("Start").set_value(true);
+  wait_and_check_name("Write").set_value(true);
+  auto read = wait_and_check_name("Read");
+
+  uut->Shutdown();
+
+  auto cancel = wait_and_check_name("Cancel");
+  read.set_value(false);
+  wait_and_check_name("Finish").set_value(true);
+
+  shutdown->MarkAsShutdown("test", Status{});
+  EXPECT_THAT(done.get(), StatusIs(StatusCode::kOk));
 }
 
 TEST(StreamingSubscriptionBatchSourceTest, StateOStream) {

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -33,6 +33,7 @@ namespace {
 using ::google::cloud::pubsub_testing::FakeAsyncStreamingPull;
 using ::google::cloud::testing_util::AsyncSequencer;
 using ::testing::AtLeast;
+using ::testing::AtMost;
 using ::testing::InSequence;
 
 /// @test Verify callbacks are scheduled in the background threads.
@@ -497,6 +498,7 @@ TEST(SubscriptionSessionTest, FireAndForgetShutdown) {
     EXPECT_CALL(*stream, Start).WillOnce(start_response);
     EXPECT_CALL(*stream, Write).WillRepeatedly(write_response);
     EXPECT_CALL(*stream, Read).WillRepeatedly(read_response);
+    EXPECT_CALL(*stream, Cancel).Times(AtMost(1));
     EXPECT_CALL(*stream, Finish).WillOnce(finish_response);
 
     return stream;


### PR DESCRIPTION
Sometimes the application may shutdown while a streaming pull is
"starting", i.e., going through the initial sequence of asynchronous
calls: `Start()` -> `Write()` -> `Read()`. The last one of these may
block basically forever. Therefore, it is necessary to have access to
the stream during this sequence to send a `Cancel()` request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5547)
<!-- Reviewable:end -->
