### PR TITLE
test(storage): fix emulator `parse_multipart`

### DIFF
--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -30,15 +30,6 @@ BAZEL_VERB="$1"
 shift
 bazel_test_args=("$@")
 
-# Run the unittests of the emulator before running integration tests.
-"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:test_utils" \
-  "//google/cloud/storage/emulator:test_gcs"
-exit_status=$?
-
-if [[ "$exit_status" -ne 0 ]]; then
-  exit "${exit_status}"
-fi
-
 # Configure run_emulator_utils.sh to run the GCS emulator.
 source "${PROJECT_ROOT}/google/cloud/storage/tools/run_emulator_utils.sh"
 
@@ -62,6 +53,16 @@ pushd "${HOME}" >/dev/null
 # invalidated on each run.
 start_emulator 8585 8000
 popd >/dev/null
+
+# Run the unittests of the emulator before running integration tests.
+"${BAZEL_BIN}" test "${bazel_test_args[@]}" "//google/cloud/storage/emulator:test_utils" \
+  "//google/cloud/storage/emulator:test_gcs" \
+  "--test_env=CLOUD_STORAGE_EMULATOR_ENDPOINT=${CLOUD_STORAGE_EMULATOR_ENDPOINT}"
+exit_status=$?
+
+if [[ "$exit_status" -ne 0 ]]; then
+  exit "${exit_status}"
+fi
 
 excluded_targets=(
   # This test does not work with Bazel, because it depends on dynamic loading

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -58,6 +58,16 @@ def start_grpc():
     return str(grpc_port)
 
 
+@root.route("/raise_error")
+def raise_error():
+    etype = flask.request.args.get("etype")
+    msg = flask.request.args.get("msg", "")
+    if etype is not None:
+        raise TypeError(msg)
+    else:
+        raise Exception(msg)
+
+
 @root.route("/<path:object_name>", subdomain="<bucket_name>")
 def root_get_object(bucket_name, object_name):
     return xml_get_object(bucket_name, object_name)
@@ -795,6 +805,14 @@ server = DispatcherMiddleware(
         IAM_HANDLER_PATH: iam_app,
     },
 )
+
+root.register_error_handler(Exception, utils.error.RestException.handler)
+httpbin.app.register_error_handler(Exception, utils.error.RestException.handler)
+gcs.register_error_handler(Exception, utils.error.RestException.handler)
+download.register_error_handler(Exception, utils.error.RestException.handler)
+upload.register_error_handler(Exception, utils.error.RestException.handler)
+projects_app.register_error_handler(Exception, utils.error.RestException.handler)
+iam_app.register_error_handler(Exception, utils.error.RestException.handler)
 
 
 def run():

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -297,6 +297,20 @@ class TestCommonUtils(unittest.TestCase):
         self.assertDictEqual(media_header, {"content-type": "image/jpeg"})
         self.assertEqual(media, b"123456789")
 
+        # In some cases, data media contains "\r\n" which could confuse `parse_multipart`
+        request = utils.common.FakeRequest(
+            headers={"content-type": "multipart/related; boundary=1VvZTD07ltUtqMHg"},
+            data=b'--1VvZTD07ltUtqMHg\r\ncontent-type: application/json; charset=UTF-8\r\n\r\n{"crc32c":"4GEvYA=="}\r\n--1VvZTD07ltUtqMHg\r\ncontent-type: application/octet-stream\r\n\r\n\xa7#\x95\xec\xd5c\xe9\x90\xa8\xe2\xa89\xadF\xcc\x97\x12\xad\xf6\x9e\r\n\xf1Mhj\xf4W\x9f\x92T\xe3,\tm.\x1e\x04\xd0\r\n--1VvZTD07ltUtqMHg--\r\n',
+            environ={},
+        )
+        metadata, media_header, media = utils.common.parse_multipart(request)
+        self.assertDictEqual(metadata, {"crc32c": "4GEvYA=="})
+        self.assertDictEqual(media_header, {"content-type": "application/octet-stream"})
+        self.assertEqual(
+            media,
+            b"\xa7#\x95\xec\xd5c\xe9\x90\xa8\xe2\xa89\xadF\xcc\x97\x12\xad\xf6\x9e\r\n\xf1Mhj\xf4W\x9f\x92T\xe3,\tm.\x1e\x04\xd0",
+        )
+
 
 class TestGeneration(unittest.TestCase):
     def test_extract_precondition(self):

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -245,7 +245,7 @@ def parse_multipart(request):
     if boundary is None:
         utils.error.missing("boundary in content-type header in multipart upload", None)
 
-    def parse_part(part):
+    def parse_metadata(part):
         result = part.split(b"\r\n")
         if result[0] != b"" and result[-1] != b"":
             utils.error.invalid("Multipart %s" % str(part), None)
@@ -256,17 +256,33 @@ def parse_multipart(request):
         for header in result[:-1]:
             key, value = header.split(b": ")
             headers[key.decode("utf-8").lower()] = value.decode("utf-8")
-        return headers, result[-1]
+        return result[-1]
+
+    def parse_body(part):
+        if part[0:2] != b"\r\n" or part[-2:] != b"\r\n":
+            utils.error.invalid("Multipart %s" % str(part), None)
+        part = part[2:-2]
+        part.lstrip(b"\r\n")
+        content_type_index = part.find(b"\r\n")
+        if content_type_index == -1:
+            utils.error.invalid("Multipart %s" % str(part), None)
+        content_type = part[:content_type_index]
+        _, value = content_type.decode("utf-8").split(": ")
+        media = part[content_type_index + 2 :]
+        if media[:2] == b"\r\n":
+            # It is either `\r\n` or `\r\n\r\n`, we should remove at most 4 characters.
+            media = media[2:]
+        return {"content-type": value}, media
 
     boundary = boundary.encode("utf-8")
     body = extract_media(request)
     parts = body.split(b"--" + boundary)
     if parts[-1] != b"--\r\n":
         utils.error.missing("end marker (--%s--) in media body" % boundary, None)
-    _, resource = parse_part(parts[1])
+    resource = parse_metadata(parts[1])
     metadata = json.loads(resource)
-    media_headers, media = parse_part(parts[2])
-    return metadata, media_headers, media
+    content_type, media = parse_body(parts[2])
+    return metadata, content_type, media
 
 
 def extract_media(request):


### PR DESCRIPTION
3588248: 
Fix #5553 
So there is nothing to do with binary data. The real reason is in some request, data media contains `\r\n` which confuses the emulator: 
https://github.com/googleapis/google-cloud-cpp/blob/87da45a403d4022060d7d41a8b20d62791739668/google/cloud/storage/emulator/utils/common.py#L249

Fixed by using another method for parsing multipart.

be6b08b:
When `internal server error` takes place, the error message that is sent to the client library will contain the traceback.
I added a unittest for the error propagation. I move the unittests to after `start_emulator` since we need the emulator for the error propagation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5555)
<!-- Reviewable:end -->
