### PR TITLE
fix: inspect returned grpc::Status

### DIFF
--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -296,7 +296,8 @@ TEST(LogWrapper, StatusValue) {
   grpc::ClientContext context;
   btproto::MutateRowRequest request;
   btproto::MutateRowResponse response;
-  LogWrapper(mock, &context, request, &response, "in-test", {});
+  auto const r = LogWrapper(mock, &context, request, &response, "in-test", {});
+  EXPECT_TRUE(r.ok());
 
   auto const log_lines = backend->ClearLogLines();
 
@@ -317,7 +318,9 @@ TEST(LogWrapper, StatusValueError) {
   grpc::ClientContext context;
   btproto::MutateRowRequest request;
   btproto::MutateRowResponse response;
-  LogWrapper(mock, &context, request, &response, "in-test", {});
+  auto const r = LogWrapper(mock, &context, request, &response, "in-test", {});
+  EXPECT_EQ(r.error_code(), status.error_code());
+  EXPECT_EQ(r.error_message(), status.error_message());
 
   std::ostringstream os;
   os << status.error_message();


### PR DESCRIPTION
In some environments `grpc::Status` is marked as "must_use_result", and
these test lines would cause a breakage due to `-Wunused-result` if we
didn't do something with the `grpc::Status` that's returned from these
`LogWrapper()` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5558)
<!-- Reviewable:end -->
