### PR TITLE
feat(spanner): Point-In-Time Recovery (lite) throttled DB update

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -75,10 +75,10 @@ def google_cloud_cpp_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/59f97e6044a1275f83427ab7962a154c00d915b5.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/370e9f9ac14dbc73f56e15257bccc06dfebd4196.tar.gz",
             ],
-            strip_prefix = "googleapis-59f97e6044a1275f83427ab7962a154c00d915b5",
-            sha256 = "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073",
+            strip_prefix = "googleapis-370e9f9ac14dbc73f56e15257bccc06dfebd4196",
+            sha256 = "71ebb74007fd32626896fa2056c31d436c5e96774ac160482b5f25df5a90c6b9",
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -19,10 +19,10 @@ cmake_minimum_required(VERSION 3.5)
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-    "https://github.com/googleapis/googleapis/archive/59f97e6044a1275f83427ab7962a154c00d915b5.tar.gz"
+    "https://github.com/googleapis/googleapis/archive/370e9f9ac14dbc73f56e15257bccc06dfebd4196.tar.gz"
 )
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-    "5e785c25b1d57973e7481b4da226d7c73056ea22c7545bf6d14dbebf6e99b073")
+    "71ebb74007fd32626896fa2056c31d436c5e96774ac160482b5f25df5a90c6b9")
 
 set(GOOGLEAPIS_CPP_SOURCE
     "${CMAKE_BINARY_DIR}/external/googleapis/src/googleapis_download")
@@ -67,6 +67,7 @@ set(GOOGLEAPIS_CPP_PROTO_FILES
     "google/cloud/bigquery/v2/model.proto"
     "google/cloud/bigquery/v2/model_reference.proto"
     "google/cloud/bigquery/v2/standard_sql.proto"
+    "google/cloud/bigquery/v2/table_reference.proto"
     "google/pubsub/v1/pubsub.proto"
     "google/spanner/admin/database/v1/backup.proto"
     "google/spanner/admin/database/v1/common.proto"
@@ -229,6 +230,7 @@ google_cloud_cpp_grpcpp_library(
     "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/model.proto"
     "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/model_reference.proto"
     "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/standard_sql.proto"
+    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/table_reference.proto"
     PROTO_PATH_DIRECTORIES
     "${GOOGLEAPIS_CPP_SOURCE}"
     "${PROTO_INCLUDE_DIR}")

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -29,6 +29,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
+using ::testing::Contains;
 using ::testing::EndsWith;
 using ::testing::HasSubstr;
 
@@ -155,25 +156,25 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
   ASSERT_STATUS_OK(get_ddl_result);
   EXPECT_EQ(0, get_ddl_result->statements_size());
 
-  auto constexpr kCreateTableStatement = R"""(
-                             CREATE TABLE Singers (
-                                SingerId   INT64 NOT NULL,
-                                FirstName  STRING(1024),
-                                LastName   STRING(1024),
-                                SingerInfo BYTES(MAX)
-                             ) PRIMARY KEY (SingerId)
-                            )""";
-
-  auto update_future =
-      client_.UpdateDatabase(database_, {kCreateTableStatement});
+  std::vector<std::string> statements;
+  statements.emplace_back(R"""(
+        CREATE TABLE Singers (
+          SingerId   INT64 NOT NULL,
+          FirstName  STRING(1024),
+          LastName   STRING(1024),
+          SingerInfo BYTES(MAX)
+        ) PRIMARY KEY (SingerId)
+      )""");
+  auto update_future = client_.UpdateDatabase(database_, statements);
   auto metadata = update_future.get();
   ASSERT_STATUS_OK(metadata);
   EXPECT_THAT(metadata->database(), EndsWith(database_.database_id()));
-  EXPECT_EQ(1, metadata->statements_size());
-  EXPECT_EQ(1, metadata->commit_timestamps_size());
+  EXPECT_EQ(statements.size(), metadata->statements_size());
+  EXPECT_EQ(statements.size(), metadata->commit_timestamps_size());
   if (metadata->statements_size() >= 1) {
-    EXPECT_THAT(metadata->statements(0), HasSubstr("CREATE TABLE"));
+    EXPECT_THAT(metadata->statements(), Contains(HasSubstr("CREATE TABLE")));
   }
+  EXPECT_FALSE(metadata->throttled());
 
   EXPECT_TRUE(DatabaseExists()) << "Database " << database_;
   auto drop_status = client_.DropDatabase(database_);


### PR DESCRIPTION
Update the "com_google_googleapis" package to a recent snapshot.
This includes the `UpdateDatabaseDdlMetadata.throttled` field, and
requires adding `table_reference.proto` to the cmake lists.

The `UpdateDatabaseDdlMetadata.throttled` field indicates that the
`UpdateDatabase()` operation is throttled, e.g., due to resource
constraints. When resources become available the operation will
resume and the field will be false again.

This only updates an integration test. No samples are required for
this field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5562)
<!-- Reviewable:end -->
