### PR TITLE
feature(generator): add doxygen permalinks for proto message types

### DIFF
--- a/generator/generator_test.cc
+++ b/generator/generator_test.cc
@@ -102,9 +102,11 @@ TEST_F(GeneratorTest, GenerateServicesSuccess) {
 
   std::string actual_error;
   Generator generator;
-  auto result = generator.Generate(service_file_descriptor,
-                                   {"product_path=google/cloud/foo"},
-                                   context_.get(), &actual_error);
+  auto result = generator.Generate(
+      service_file_descriptor,
+      {"product_path=google/cloud/"
+       "foo,googleapis_commit_hash=59f97e6044a1275f83427ab7962a154c00d915b5"},
+      context_.get(), &actual_error);
   EXPECT_TRUE(result);
   EXPECT_TRUE(actual_error.empty());
 }

--- a/generator/integration_tests/generator_integration_test.cc
+++ b/generator/integration_tests/generator_integration_test.cc
@@ -92,6 +92,7 @@ class GeneratorIntegrationTest
                           "Codegen C++ Generator");
 
     product_path_ = "generator/integration_tests/golden/";
+    googleapis_commit_hash_ = "59f97e6044a1275f83427ab7962a154c00d915b5";
 
     std::vector<std::string> args;
     // empty arg keeps first real arg from being ignored.
@@ -101,6 +102,8 @@ class GeneratorIntegrationTest
     args.emplace_back("--proto_path=" + code_path);
     args.emplace_back("--cpp_codegen_out=" + output_path_);
     args.emplace_back("--cpp_codegen_opt=product_path=" + product_path_);
+    args.emplace_back("--cpp_codegen_opt=googleapis_commit_hash=" +
+                      googleapis_commit_hash_);
     args.emplace_back("generator/integration_tests/test.proto");
 
     std::vector<char const*> c_args;
@@ -119,6 +122,7 @@ class GeneratorIntegrationTest
   std::string product_path_;
   std::string output_path_;
   std::string golden_path_;
+  std::string googleapis_commit_hash_;
 };
 
 TEST_P(GeneratorIntegrationTest, CompareGeneratedToGolden) {

--- a/generator/integration_tests/golden/database_admin_client.gcpcxx.pb.h
+++ b/generator/integration_tests/golden/database_admin_client.gcpcxx.pb.h
@@ -88,6 +88,7 @@ class DatabaseAdminClient {
    *  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
    *  If the database ID is a reserved word or if it contains a hyphen, the
    *  database ID must be enclosed in backticks (`` ` ``).
+   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L326)
    */
   future<StatusOr<::google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement);
@@ -97,6 +98,7 @@ class DatabaseAdminClient {
    *
    * @param name  Required. The name of the requested database. Values are of the form
    *  `projects/<project>/instances/<instance>/databases/<database>`.
+   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L326)
    */
   StatusOr<::google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name);
@@ -112,6 +114,7 @@ class DatabaseAdminClient {
    *
    * @param database  Required. The database to update.
    * @param statements  Required. DDL statements to be applied to the database.
+   * @return [::google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L503)
    */
   future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements);
@@ -132,6 +135,7 @@ class DatabaseAdminClient {
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
    * @param database  Required. The database whose schema we wish to get.
+   * @return [::google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L542)
    */
   StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database);
@@ -151,6 +155,7 @@ class DatabaseAdminClient {
    *  the policy is limited to a few 10s of KB. An empty policy is a
    *  valid policy but certain Cloud Platform services (such as Projects)
    *  might reject them.
+   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
   StatusOr<::google::iam::v1::Policy>
   SetIamPolicy(std::string const& resource, ::google::iam::v1::Policy const& policy);
@@ -167,6 +172,7 @@ class DatabaseAdminClient {
    *
    * @param resource  REQUIRED: The resource for which the policy is being requested.
    *  See the operation documentation for the appropriate value for this field.
+   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
   StatusOr<::google::iam::v1::Policy>
   GetIamPolicy(std::string const& resource);
@@ -189,6 +195,7 @@ class DatabaseAdminClient {
    *  wildcards (such as '*' or 'storage.*') are not allowed. For more
    *  information see
    *  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+   * @return [::google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
    */
   StatusOr<::google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions);
@@ -217,6 +224,7 @@ class DatabaseAdminClient {
    * @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
    *  `parent` forms the full backup name of the form
    *  `projects/<project>/instances/<instance>/backups/<backup_id>`.
+   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
   future<StatusOr<::google::test::admin::database::v1::Backup>>
   CreateBackup(std::string const& parent, ::google::test::admin::database::v1::Backup const& backup, std::string const& backup_id);
@@ -227,6 +235,7 @@ class DatabaseAdminClient {
    * @param name  Required. Name of the backup.
    *  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
+   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
   StatusOr<::google::test::admin::database::v1::Backup>
   GetBackup(std::string const& name);
@@ -243,6 +252,7 @@ class DatabaseAdminClient {
    *  resource, not to the request message. The field mask must always be
    *  specified; this prevents any future fields from being erased accidentally
    *  by clients that do not know about them.
+   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
   StatusOr<::google::test::admin::database::v1::Backup>
   UpdateBackup(::google::test::admin::database::v1::Backup const& backup, ::google::protobuf::FieldMask const& update_mask);
@@ -298,6 +308,7 @@ class DatabaseAdminClient {
    *  `projects/<project>/instances/<instance>/databases/<database_id>`.
    * @param backup  Name of the backup from which to restore.  Values are of the form
    *  `projects/<project>/instances/<instance>/backups/<backup>`.
+   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L326)
    */
   future<StatusOr<::google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup);
@@ -339,7 +350,7 @@ class DatabaseAdminClient {
   /**
    * Lists Cloud Test databases.
    *
-   * @param request `::google::test::admin::database::v1::ListDatabasesRequest`
+   * @param request [::google::test::admin::database::v1::ListDatabasesRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L374)
    */
   ListDatabasesRange
   ListDatabases(::google::test::admin::database::v1::ListDatabasesRequest request);
@@ -354,7 +365,8 @@ class DatabaseAdminClient {
    * [response][google.longrunning.Operation.response] field type is
    * [Database][google.test.admin.database.v1.Database], if successful.
    *
-   * @param request `::google::test::admin::database::v1::CreateDatabaseRequest`
+   * @param request [::google::test::admin::database::v1::CreateDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L406)
+   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L326)
    */
   future<StatusOr<::google::test::admin::database::v1::Database>>
   CreateDatabase(::google::test::admin::database::v1::CreateDatabaseRequest const& request);
@@ -362,7 +374,8 @@ class DatabaseAdminClient {
   /**
    * Gets the state of a Cloud Test database.
    *
-   * @param request `::google::test::admin::database::v1::GetDatabaseRequest`
+   * @param request [::google::test::admin::database::v1::GetDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L440)
+   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L326)
    */
   StatusOr<::google::test::admin::database::v1::Database>
   GetDatabase(::google::test::admin::database::v1::GetDatabaseRequest const& request);
@@ -376,7 +389,8 @@ class DatabaseAdminClient {
    * [metadata][google.longrunning.Operation.metadata] field type is
    * [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
    *
-   * @param request `::google::test::admin::database::v1::UpdateDatabaseDdlRequest`
+   * @param request [::google::test::admin::database::v1::UpdateDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L467)
+   * @return [::google::test::admin::database::v1::UpdateDatabaseDdlMetadata](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L503)
    */
   future<StatusOr<::google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(::google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request);
@@ -386,7 +400,7 @@ class DatabaseAdminClient {
    * Completed backups for the database will be retained according to their
    * `expire_time`.
    *
-   * @param request `::google::test::admin::database::v1::DropDatabaseRequest`
+   * @param request [::google::test::admin::database::v1::DropDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L520)
    */
   Status
   DropDatabase(::google::test::admin::database::v1::DropDatabaseRequest const& request);
@@ -396,7 +410,8 @@ class DatabaseAdminClient {
    * DDL statements. This method does not show pending schema updates, those may
    * be queried using the [Operations][google.longrunning.Operations] API.
    *
-   * @param request `::google::test::admin::database::v1::GetDatabaseDdlRequest`
+   * @param request [::google::test::admin::database::v1::GetDatabaseDdlRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L531)
+   * @return [::google::test::admin::database::v1::GetDatabaseDdlResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L542)
    */
   StatusOr<::google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(::google::test::admin::database::v1::GetDatabaseDdlRequest const& request);
@@ -410,7 +425,8 @@ class DatabaseAdminClient {
    * For backups, authorization requires `test.backups.setIamPolicy`
    * permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
    *
-   * @param request `::google::iam::v1::SetIamPolicyRequest`
+   * @param request [::google::iam::v1::SetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L98)
+   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
   StatusOr<::google::iam::v1::Policy>
   SetIamPolicy(::google::iam::v1::SetIamPolicyRequest const& request);
@@ -425,7 +441,8 @@ class DatabaseAdminClient {
    * For backups, authorization requires `test.backups.getIamPolicy`
    * permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
    *
-   * @param request `::google::iam::v1::GetIamPolicyRequest`
+   * @param request [::google::iam::v1::GetIamPolicyRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L113)
+   * @return [::google::iam::v1::Policy](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/policy.proto#L88)
    */
   StatusOr<::google::iam::v1::Policy>
   GetIamPolicy(::google::iam::v1::GetIamPolicyRequest const& request);
@@ -442,7 +459,8 @@ class DatabaseAdminClient {
    * result in a NOT_FOUND error if the user has
    * `test.backups.list` permission on the containing instance.
    *
-   * @param request `::google::iam::v1::TestIamPermissionsRequest`
+   * @param request [::google::iam::v1::TestIamPermissionsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L126)
+   * @return [::google::iam::v1::TestIamPermissionsResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/google/iam/v1/iam_policy.proto#L141)
    */
   StatusOr<::google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(::google::iam::v1::TestIamPermissionsRequest const& request);
@@ -461,7 +479,8 @@ class DatabaseAdminClient {
    * There can be only one pending backup creation per database. Backup creation
    * of different databases can run concurrently.
    *
-   * @param request `::google::test::admin::database::v1::CreateBackupRequest`
+   * @param request [::google::test::admin::database::v1::CreateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L110)
+   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
   future<StatusOr<::google::test::admin::database::v1::Backup>>
   CreateBackup(::google::test::admin::database::v1::CreateBackupRequest const& request);
@@ -469,7 +488,8 @@ class DatabaseAdminClient {
   /**
    * Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request `::google::test::admin::database::v1::GetBackupRequest`
+   * @param request [::google::test::admin::database::v1::GetBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L177)
+   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
   StatusOr<::google::test::admin::database::v1::Backup>
   GetBackup(::google::test::admin::database::v1::GetBackupRequest const& request);
@@ -477,7 +497,8 @@ class DatabaseAdminClient {
   /**
    * Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request `::google::test::admin::database::v1::UpdateBackupRequest`
+   * @param request [::google::test::admin::database::v1::UpdateBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L161)
+   * @return [::google::test::admin::database::v1::Backup](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L36)
    */
   StatusOr<::google::test::admin::database::v1::Backup>
   UpdateBackup(::google::test::admin::database::v1::UpdateBackupRequest const& request);
@@ -485,7 +506,7 @@ class DatabaseAdminClient {
   /**
    * Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
    *
-   * @param request `::google::test::admin::database::v1::DeleteBackupRequest`
+   * @param request [::google::test::admin::database::v1::DeleteBackupRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L190)
    */
   Status
   DeleteBackup(::google::test::admin::database::v1::DeleteBackupRequest const& request);
@@ -495,7 +516,7 @@ class DatabaseAdminClient {
    * Backups returned are ordered by `create_time` in descending order,
    * starting from the most recent `create_time`.
    *
-   * @param request `::google::test::admin::database::v1::ListBackupsRequest`
+   * @param request [::google::test::admin::database::v1::ListBackupsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L203)
    */
   ListBackupsRange
   ListBackups(::google::test::admin::database::v1::ListBackupsRequest request);
@@ -519,7 +540,8 @@ class DatabaseAdminClient {
    * initiated, without waiting for the optimize operation associated with the
    * first restore to complete.
    *
-   * @param request `::google::test::admin::database::v1::RestoreDatabaseRequest`
+   * @param request [::google::test::admin::database::v1::RestoreDatabaseRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L631)
+   * @return [::google::test::admin::database::v1::Database](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L326)
    */
   future<StatusOr<::google::test::admin::database::v1::Database>>
   RestoreDatabase(::google::test::admin::database::v1::RestoreDatabaseRequest const& request);
@@ -534,7 +556,7 @@ class DatabaseAdminClient {
    * include those that have completed/failed/canceled within the last 7 days,
    * and pending operations.
    *
-   * @param request `::google::test::admin::database::v1::ListDatabaseOperationsRequest`
+   * @param request [::google::test::admin::database::v1::ListDatabaseOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L550)
    */
   ListDatabaseOperationsRange
   ListDatabaseOperations(::google::test::admin::database::v1::ListDatabaseOperationsRequest request);
@@ -551,7 +573,7 @@ class DatabaseAdminClient {
    * `operation.metadata.value.progress.start_time` in descending order starting
    * from the most recently started operation.
    *
-   * @param request `::google::test::admin::database::v1::ListBackupOperationsRequest`
+   * @param request [::google::test::admin::database::v1::ListBackupOperationsRequest](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/backup.proto#L274)
    */
   ListBackupOperationsRange
   ListBackupOperations(::google::test::admin::database::v1::ListBackupOperationsRequest request);

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -94,7 +94,8 @@ Status ClientGenerator::GenerateHeader() {
           method,
           {MethodPattern(
                {
-                   {"  $method_signature_comment_block$\n"},
+                   {FormatMethodCommentsFromRpcComments(
+                       method, MethodParameterStyle::kApiMethodSignature)},
                    {IsResponseTypeEmpty,
                     // clang-format off
                    "  Status\n",
@@ -106,7 +107,8 @@ Status ClientGenerator::GenerateHeader() {
                    Not(IsPaginated))),
            MethodPattern(
                {
-                   {"  $method_signature_comment_block$\n"},
+                   {FormatMethodCommentsFromRpcComments(
+                       method, MethodParameterStyle::kApiMethodSignature)},
                    {IsResponseTypeEmpty,
                     // clang-format off
                     "  future<Status>\n",
@@ -118,8 +120,9 @@ Status ClientGenerator::GenerateHeader() {
            MethodPattern(
                {
                    // clang-format off
-                   {"  $method_signature_comment_block$\n"
-                    "  $method_name$Range\n"},
+                   {FormatMethodCommentsFromRpcComments(
+                     method, MethodParameterStyle::kApiMethodSignature)},
+                   {"  $method_name$Range\n"},
                    {method_string},
                    // clang-format on
                },
@@ -133,7 +136,8 @@ Status ClientGenerator::GenerateHeader() {
         method,
         {MethodPattern(
              {
-                 {"  $request_comment_block$\n"},
+                 {FormatMethodCommentsFromRpcComments(
+                     method, MethodParameterStyle::kProtobufReqeust)},
                  {IsResponseTypeEmpty,
                   // clang-format off
     "  Status\n",
@@ -146,7 +150,8 @@ Status ClientGenerator::GenerateHeader() {
                  Not(IsPaginated))),
          MethodPattern(
              {
-                 {"  $request_comment_block$\n"},
+                 {FormatMethodCommentsFromRpcComments(
+                     method, MethodParameterStyle::kProtobufReqeust)},
                  {IsResponseTypeEmpty,
                   // clang-format off
     "  future<Status>\n",
@@ -159,7 +164,8 @@ Status ClientGenerator::GenerateHeader() {
          MethodPattern(
              {
                  // clang-format off
-                  {"  $request_comment_block$\n"},
+                 {FormatMethodCommentsFromRpcComments(
+        method, MethodParameterStyle::kProtobufReqeust)},
    {"  $method_name$Range\n"
     "  $method_name$($request_type$ request);\n\n"},
                  // clang-format on

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -41,7 +41,8 @@ VarsDictionary CreateServiceVars(
  * Extracts method specific substitution data for each method in the service.
  */
 std::map<std::string, VarsDictionary> CreateMethodVars(
-    google::protobuf::ServiceDescriptor const& service);
+    google::protobuf::ServiceDescriptor const& service,
+    VarsDictionary const& service_vars);
 
 /**
  * Creates and initializes the collection of ClassGenerators necessary to
@@ -68,6 +69,15 @@ Status PrintMethod(google::protobuf::MethodDescriptor const& method,
                    Printer& printer, VarsDictionary const& vars,
                    std::vector<MethodPattern> const& patterns, char const* file,
                    int line);
+
+enum class MethodParameterStyle { kApiMethodSignature, kProtobufReqeust };
+/**
+ * Formats comments from the source .proto file into Doxygen compatible
+ * function headers, including param and return lines as necessary.
+ */
+std::string FormatMethodCommentsFromRpcComments(
+    google::protobuf::MethodDescriptor const& method,
+    MethodParameterStyle parameter_style);
 
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -21,6 +21,7 @@
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 #include "generator/internal/descriptor_utils.h"
+#include "google/cloud/log.h"
 #include "absl/strings/str_split.h"
 #include "generator/testing/printer_mocks.h"
 #include <google/api/client.pb.h>
 #include <google/longrunning/operations.pb.h>
+#include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/descriptor_database.h>
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 
@@ -142,6 +145,215 @@ INSTANTIATE_TEST_SUITE_P(
       return std::get<0>(info.param);
     });
 
+const char* const kHttpProto =
+    "syntax = \"proto3\";\n"
+    "package google.api;\n"
+    "option cc_enable_arenas = true;\n"
+    "message Http {\n"
+    "  repeated HttpRule rules = 1;\n"
+    "  bool fully_decode_reserved_expansion = 2;\n"
+    "}\n"
+    "message HttpRule {\n"
+    "  string selector = 1;\n"
+    "  oneof pattern {\n"
+    "    string get = 2;\n"
+    "    string put = 3;\n"
+    "    string post = 4;\n"
+    "    string delete = 5;\n"
+    "    string patch = 6;\n"
+    "    CustomHttpPattern custom = 8;\n"
+    "  }\n"
+    "  string body = 7;\n"
+    "  string response_body = 12;\n"
+    "  repeated HttpRule additional_bindings = 11;\n"
+    "}\n"
+    "message CustomHttpPattern {\n"
+    "  string kind = 1;\n"
+    "  string path = 2;\n"
+    "}\n";
+
+const char* const kAnnotationsProto =
+    "syntax = \"proto3\";\n"
+    "package google.api;\n"
+    "import \"google/api/http.proto\";\n"
+    "import \"google/protobuf/descriptor.proto\";\n"
+    "extend google.protobuf.MethodOptions {\n"
+    "  // See `HttpRule`.\n"
+    "  HttpRule http = 72295728;\n"
+    "}\n";
+
+const char* const kClientProto =
+    "syntax = \"proto3\";\n"
+    "package google.api;\n"
+    "import \"google/protobuf/descriptor.proto\";\n"
+    "extend google.protobuf.MethodOptions {\n"
+    "  repeated string method_signature = 1051;\n"
+    "}\n"
+    "extend google.protobuf.ServiceOptions {\n"
+    "  string default_host = 1049;\n"
+    "  string oauth_scopes = 1050;\n"
+    "}\n";
+
+const char* const kLongrunningOperationsProto =
+    "syntax = \"proto3\";\n"
+    "package google.longrunning;\n"
+    "import \"google/protobuf/descriptor.proto\";\n"
+    "extend google.protobuf.MethodOptions {\n"
+    "  google.longrunning.OperationInfo operation_info = 1049;\n"
+    "}\n"
+    "message Operation {\n"
+    "  string blah = 1;\n"
+    "}\n"
+    "message OperationInfo {\n"
+    "  string response_type = 1;\n"
+    "  string metadata_type = 2;\n"
+    "}\n";
+
+const char* const kSourceLocationTestInput =
+    "syntax = \"proto3\";\n"
+    "import \"google/api/annotations.proto\";\n"
+    "message A {\n"
+    "  int32 a = 1;\n"
+    "}\n"
+    "message B {\n"
+    "  int32 b = 1;\n"
+    "}\n"
+    "service S {\n"
+    "  rpc Method(A) returns (B) {\n"
+    "    option (google.api.http) = {\n"
+    "      get: \"/v1/{parent=projects/*/instances/*}/databases\"\n"
+    "    };\n"
+    "  }\n"
+    "  rpc OtherMethod(A) returns (A) {\n"
+    "    option (google.api.http) = {\n"
+    "      get: \"/v1/{parent=projects/*/instances/*}/databases\"\n"
+    "    };\n"
+    "  }\n"
+    "}\n";
+
+const char* const kServiceProto =
+    "syntax = \"proto3\";\n"
+    "package google.protobuf;\n"
+    "import \"google/api/annotations.proto\";\n"
+    "import \"google/api/client.proto\";\n"
+    "import \"google/api/http.proto\";\n"
+    "import \"google/longrunning/operation.proto\";\n"
+    "// Leading comments about message Foo.\n"
+    "message Foo {\n"
+    "  string baz = 1;\n"
+    "}\n"
+    "// Leading comments about message Bar.\n"
+    "message Bar {\n"
+    "  int32 number = 1;\n"
+    "  string name = 2;\n"
+    "  Foo widget = 3;\n"
+    "  bool toggle = 4;\n"
+    "  string title = 5;\n"
+    "}\n"
+    "// Leading comments about message Empty.\n"
+    "message Empty {}\n"
+    "// Leading comments about message PaginatedInput.\n"
+    "message PaginatedInput {\n"
+    "  int32 page_size = 1;\n"
+    "  string page_token = 2;\n"
+    "}\n"
+    "// Leading comments about message PaginatedOutput.\n"
+    "message PaginatedOutput {\n"
+    "  string next_page_token = 1;\n"
+    "  repeated Bar repeated_field = 2;\n"
+    "}\n"
+    "// Leading comments about service Service.\n"
+    "service Service {\n"
+    "  // Leading comments about rpc Method0.\n"
+    "  rpc Method0(Bar) returns (Empty) {\n"
+    "    option (google.api.http) = {\n"
+    "       delete: \"/v1/{name=projects/*/instances/*/backups/*}\"\n"
+    "    };\n"
+    "  }\n"
+    "  // Leading comments about rpc Method1.\n"
+    "  rpc Method1(Bar) returns (Bar) {\n"
+    "    option (google.api.http) = {\n"
+    "       delete: \"/v1/{name=projects/*/instances/*/backups/*}\"\n"
+    "    };\n"
+    "  }\n"
+    "  // Leading comments about rpc Method2.\n"
+    "  rpc Method2(Bar) returns (google.longrunning.Operation) {\n"
+    "    option (google.api.http) = {\n"
+    "       patch: \"/v1/{parent=projects/*/instances/*}/databases\"\n"
+    "       body: \"*\"\n"
+    "    };\n"
+    "    option (google.longrunning.operation_info) = {\n"
+    "      response_type: \"google.protobuf.Bar\"\n"
+    "      metadata_type: \"google.protobuf.Method2Metadata\"\n"
+    "    };\n"
+    "  }\n"
+    "  // Leading comments about rpc Method3.\n"
+    "  rpc Method3(Bar) returns (google.longrunning.Operation) {\n"
+    "    option (google.api.http) = {\n"
+    "       put: \"/v1/{parent=projects/*/instances/*}/databases\"\n"
+    "    };\n"
+    "    option (google.longrunning.operation_info) = {\n"
+    "      response_type: \"google.protobuf.Empty\"\n"
+    "      metadata_type: \"google.protobuf.Bar\"\n"
+    "    };\n"
+    "  }\n"
+    "  // Leading comments about rpc Method4.\n"
+    "  rpc Method4(PaginatedInput) returns (PaginatedOutput) {\n"
+    "    option (google.api.http) = {\n"
+    "       delete: \"/v1/{name=projects/*/instances/*/backups/*}\"\n"
+    "    };\n"
+    "  }\n"
+    "  // Leading comments about rpc Method5.\n"
+    "  rpc Method5(Bar) returns (Empty) {\n"
+    "    option (google.api.http) = {\n"
+    "       post: \"/v1/{parent=projects/*/instances/*}/databases\"\n"
+    "       body: \"*\"\n"
+    "    };\n"
+    "    option (google.api.method_signature) = \"name\";\n"
+    "    option (google.api.method_signature) = \"number,widget\";\n"
+    "    option (google.api.method_signature) = \"toggle\";\n"
+    "    option (google.api.method_signature) = \"name,title\";\n"
+    "  }\n"
+    "  // Leading comments about rpc Method6.\n"
+    "  rpc Method6(Bar) returns (Empty) {\n"
+    "    option (google.api.http) = {\n"
+    "       get: \"/v1/{name=projects/*/instances/*/databases/*}\"\n"
+    "    };\n"
+    "  }\n"
+    "}\n";
+
+class StringSourceTree : public google::protobuf::compiler::SourceTree {
+ public:
+  explicit StringSourceTree(std::map<std::string, std::string> files)
+      : files_(std::move(files)) {}
+
+  google::protobuf::io::ZeroCopyInputStream* Open(
+      const std::string& filename) override {
+    return files_.count(filename) == 1
+               ? new google::protobuf::io::ArrayInputStream(
+                     files_[filename].data(),
+                     static_cast<int>(files_[filename].size()))
+               : nullptr;
+  }
+
+ private:
+  std::map<std::string, std::string> files_;
+};
+
+class AbortingErrorCollector : public DescriptorPool::ErrorCollector {
+ public:
+  AbortingErrorCollector() = default;
+  AbortingErrorCollector(AbortingErrorCollector const&) = delete;
+  AbortingErrorCollector& operator=(AbortingErrorCollector const&) = delete;
+
+  void AddError(const std::string& filename, const std::string& element_name,
+                const google::protobuf::Message*, ErrorLocation,
+                const std::string& error_message) override {
+    GCP_LOG(FATAL) << "AddError() called unexpectedly: " << filename << " ["
+                   << element_name << "]: " << error_message;
+  }
+};
+
 struct MethodVarsTestValues {
   MethodVarsTestValues(std::string m, std::string k, std::string v)
       : method(std::move(m)),
@@ -154,158 +366,54 @@ struct MethodVarsTestValues {
 
 class CreateMethodVarsTest
     : public testing::TestWithParam<MethodVarsTestValues> {
- protected:
-  static void SetUpTestSuite() {
-    FileDescriptorProto longrunning_file;
-    auto constexpr kLongrunningText = R"pb(
-      name: "google/longrunning/operation.proto"
-      package: "google.longrunning"
-      message_type { name: "Operation" }
-    )pb";
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        kLongrunningText, &longrunning_file));
-
-    google::protobuf::FileDescriptorProto service_file;
-    /// @cond
-    auto constexpr kServiceText = R"pb(
-      name: "google/foo/v1/service.proto"
-      package: "google.protobuf"
-      dependency: "google/longrunning/operation.proto"
-      message_type {
-        name: "Bar"
-        field { name: "number" number: 1 type: TYPE_INT32 }
-        field { name: "name" number: 2 type: TYPE_STRING }
-        field {
-          name: "widget"
-          number: 3
-          type: TYPE_MESSAGE
-          type_name: "google.protobuf.Bar"
-        }
-        field { name: "toggle" number: 4 type: TYPE_BOOL }
-        field { name: "title" number: 5 type: TYPE_STRING }
-      }
-      message_type { name: "Empty" }
-      message_type {
-        name: "PaginatedInput"
-        field { name: "page_size" number: 1 type: TYPE_INT32 }
-        field { name: "page_token" number: 2 type: TYPE_STRING }
-      }
-      message_type {
-        name: "PaginatedOutput"
-        field { name: "next_page_token" number: 1 type: TYPE_STRING }
-        field {
-          name: "repeated_field"
-          number: 2
-          label: LABEL_REPEATED
-          type: TYPE_MESSAGE
-          type_name: "google.protobuf.Bar"
-        }
-      }
-      service {
-        name: "Service"
-        method {
-          name: "Method0"
-          input_type: "google.protobuf.Bar"
-          output_type: "google.protobuf.Empty"
-          options {
-            [google.api.http] {
-              delete: "/v1/{name=projects/*/instances/*/backups/*}"
-            }
-          }
-        }
-        method {
-          name: "Method1"
-          input_type: "google.protobuf.Bar"
-          output_type: "google.protobuf.Bar"
-          options {
-            [google.api.http] {
-              delete: "/v1/{name=projects/*/instances/*/backups/*}"
-            }
-          }
-        }
-        method {
-          name: "Method2"
-          input_type: "google.protobuf.Bar"
-          output_type: "google.longrunning.Operation"
-          options {
-            [google.longrunning.operation_info] {
-              response_type: "google.protobuf.Method2Response"
-              metadata_type: "google.protobuf.Method2Metadata"
-            }
-            [google.api.http] {
-              patch: "/v1/{parent=projects/*/instances/*}/databases"
-            }
-          }
-        }
-        method {
-          name: "Method3"
-          input_type: "google.protobuf.Bar"
-          output_type: "google.longrunning.Operation"
-          options {
-            [google.longrunning.operation_info] {
-              response_type: "google.protobuf.Empty"
-              metadata_type: "google.protobuf.Method2Metadata"
-            }
-            [google.api.http] {
-              put: "/v1/{parent=projects/*/instances/*}/databases"
-            }
-          }
-        }
-        method {
-          name: "Method4"
-          input_type: "google.protobuf.PaginatedInput"
-          output_type: "google.protobuf.PaginatedOutput"
-          options {
-            [google.api.http] {
-              delete: "/v1/{name=projects/*/instances/*/backups/*}"
-            }
-          }
-        }
-        method {
-          name: "Method5"
-          input_type: "google.protobuf.Bar"
-          output_type: "google.protobuf.Empty"
-          options {
-            [google.api.method_signature]: "name"
-            [google.api.method_signature]: "number,widget"
-            [google.api.method_signature]: "toggle"
-            [google.api.method_signature]: "name,title"
-            [google.api.http] {
-              post: "/v1/{parent=projects/*/instances/*}/databases"
-              body: "*"
-            }
-          }
-        }
-        method {
-          name: "Method6"
-          input_type: "google.protobuf.Bar"
-          output_type: "google.protobuf.Empty"
-          options {
-            [google.api.http] {
-              get: "/v1/{name=projects/*/instances/*/databases/*}"
-            }
-          }
-        }
-
-      }
-    )pb";
-    /// @endcond
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kServiceText,
-                                                              &service_file));
-
-    DescriptorPool pool;
-    pool.BuildFile(longrunning_file);
-    const FileDescriptor* service_file_descriptor =
-        pool.BuildFile(service_file);
-    vars_ = CreateMethodVars(*service_file_descriptor->service(0));
+ public:
+  CreateMethodVarsTest()
+      : source_tree_(std::map<std::string, std::string>{
+            {std::string("google/api/client.proto"), kClientProto},
+            {std::string("google/api/http.proto"), kHttpProto},
+            {std::string("google/api/annotations.proto"), kAnnotationsProto},
+            {std::string("google/longrunning/operation.proto"),
+             kLongrunningOperationsProto},
+            {std::string("test/test.proto"), kSourceLocationTestInput},
+            {std::string("google/foo/v1/service.proto"), kServiceProto}}),
+        source_tree_db_(&source_tree_),
+        merged_db_(&simple_db_, &source_tree_db_),
+        pool_(&merged_db_, &collector_) {
+    // we need descriptor.proto to be accessible by the pool
+    // since our test file imports it
+    FileDescriptorProto::descriptor()->file()->CopyTo(&file_proto_);
+    simple_db_.Add(file_proto_);
+    service_vars_ = {{"googleapis_commit_hash", "foo"}};
   }
 
-  static std::map<std::string, VarsDictionary> vars_;
+ private:
+  FileDescriptorProto file_proto_;
+  AbortingErrorCollector collector_;
+  StringSourceTree source_tree_;
+  google::protobuf::SimpleDescriptorDatabase simple_db_;
+  google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db_;
+  google::protobuf::MergedDescriptorDatabase merged_db_;
+
+ protected:
+  DescriptorPool pool_;
+  std::map<std::string, VarsDictionary> vars_;
+  VarsDictionary service_vars_;
 };
 
-std::map<std::string, VarsDictionary> CreateMethodVarsTest::vars_;
+TEST_F(CreateMethodVarsTest, FilesParseSuccessfully) {
+  EXPECT_NE(nullptr, pool_.FindFileByName("google/api/client.proto"));
+  EXPECT_NE(nullptr, pool_.FindFileByName("google/api/http.proto"));
+  EXPECT_NE(nullptr, pool_.FindFileByName("google/api/annotations.proto"));
+  EXPECT_NE(nullptr,
+            pool_.FindFileByName("google/longrunning/operation.proto"));
+  EXPECT_NE(nullptr, pool_.FindFileByName("test/test.proto"));
+  EXPECT_NE(nullptr, pool_.FindFileByName("google/foo/v1/service.proto"));
+}
 
 TEST_P(CreateMethodVarsTest, KeySetCorrectly) {
+  const FileDescriptor* service_file_descriptor =
+      pool_.FindFileByName("google/foo/v1/service.proto");
+  vars_ = CreateMethodVars(*service_file_descriptor->service(0), service_vars_);
   auto method_iter = vars_.find(GetParam().method);
   EXPECT_TRUE(method_iter != vars_.end());
   auto iter = method_iter->second.find(GetParam().vars_key);
@@ -315,16 +423,24 @@ TEST_P(CreateMethodVarsTest, KeySetCorrectly) {
 INSTANTIATE_TEST_SUITE_P(
     MethodVars, CreateMethodVarsTest,
     testing::Values(
+        // Method0
         MethodVarsTestValues("google.protobuf.Service.Method0", "method_name",
                              "Method0"),
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "method_name_snake", "method0"),
         MethodVarsTestValues("google.protobuf.Service.Method0", "request_type",
                              "::google::protobuf::Bar"),
+        MethodVarsTestValues("google.protobuf.Service.Method0",
+                             "response_message_type", "google.protobuf.Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method0", "response_type",
                              "::google::protobuf::Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method0",
                              "default_idempotency", "kNonIdempotent"),
+        MethodVarsTestValues(
+            "google.protobuf.Service.Method0", "method_return_doxygen_link",
+            "[::google::protobuf::Empty](https://github.com/googleapis/"
+            "googleapis/blob/foo/google/foo/v1/service.proto#L20)"),
+        // Method1
         MethodVarsTestValues("google.protobuf.Service.Method1", "method_name",
                              "Method1"),
         MethodVarsTestValues("google.protobuf.Service.Method1",
@@ -333,15 +449,23 @@ INSTANTIATE_TEST_SUITE_P(
                              "::google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method1", "response_type",
                              "::google::protobuf::Bar"),
+        MethodVarsTestValues(
+            "google.protobuf.Service.Method1", "method_return_doxygen_link",
+            "[::google::protobuf::Bar](https://github.com/googleapis/"
+            "googleapis/blob/foo/google/foo/v1/service.proto#L12)"),
+        // Method2
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_metadata_type",
                              "::google::protobuf::Method2Metadata"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_response_type",
-                             "::google::protobuf::Method2Response"),
+                             "::google::protobuf::Bar"),
+        MethodVarsTestValues("google.protobuf.Service.Method2",
+                             "longrunning_deduced_response_message_type",
+                             "google.protobuf.Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_deduced_response_type",
-                             "::google::protobuf::Method2Response"),
+                             "::google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "method_request_param_key", "parent"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
@@ -354,15 +478,21 @@ INSTANTIATE_TEST_SUITE_P(
                              "projects/*/instances/*"),
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "default_idempotency", "kNonIdempotent"),
+        MethodVarsTestValues(
+            "google.protobuf.Service.Method2",
+            "method_longrunning_deduced_return_doxygen_link",
+            "[::google::protobuf::Bar](https://github.com/googleapis/"
+            "googleapis/blob/foo/google/foo/v1/service.proto#L12)"),
+        // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
-                             "::google::protobuf::Method2Metadata"),
+                             "::google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_response_type",
                              "::google::protobuf::Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_deduced_response_type",
-                             "::google::protobuf::Method2Metadata"),
+                             "::google::protobuf::Bar"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "method_request_param_key", "parent"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
@@ -375,6 +505,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "projects/*/instances/*"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "default_idempotency", "kIdempotent"),
+        // Method4
         MethodVarsTestValues("google.protobuf.Service.Method4",
                              "range_output_field_name", "repeated_field"),
         MethodVarsTestValues("google.protobuf.Service.Method4",
@@ -391,12 +522,13 @@ INSTANTIATE_TEST_SUITE_P(
                              "projects/*/instances/*/backups/*"),
         MethodVarsTestValues("google.protobuf.Service.Method4",
                              "default_idempotency", "kNonIdempotent"),
+        // Method5
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature0", "std::string const& name"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature1",
                              "std::int32_t number, "
-                             "::google::protobuf::Bar const& widget"),
+                             "::google::protobuf::Foo const& widget"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "method_signature2", "bool toggle"),
         MethodVarsTestValues(
@@ -423,6 +555,7 @@ INSTANTIATE_TEST_SUITE_P(
                              "method_request_body", "*"),
         MethodVarsTestValues("google.protobuf.Service.Method5",
                              "default_idempotency", "kNonIdempotent"),
+        // Method6
         MethodVarsTestValues("google.protobuf.Service.Method6",
                              "method_request_param_key", "name"),
         MethodVarsTestValues("google.protobuf.Service.Method6",


### PR DESCRIPTION
- plumbed new plugin argument googleapis_commit_hash to CreateMethodVars via service_vars.
- used hash and GetSourceLocation to format permalinks to github.com/googleapis/googleapis
- changed doxygen param tags and added return tags using links where appropriate in Client class documentation
- had to rework test setups to use actual proto "files" so that GetSourceLocation would function
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5570)
<!-- Reviewable:end -->
