### PR TITLE
fix: get the code to compile with MSVC 2017

### DIFF
--- a/google/cloud/spanner/numeric.cc
+++ b/google/cloud/spanner/numeric.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/status.h"
 #include "absl/strings/string_view.h"
 #include <algorithm>
+#include <cctype>
 #include <cerrno>
 #include <cmath>
 #include <cstddef>

--- a/google/cloud/testing_util/command_line_parsing.cc
+++ b/google/cloud/testing_util/command_line_parsing.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "absl/strings/match.h"
 #include "absl/time/time.h"
+#include <cctype>
 #include <iomanip>
 #include <sstream>
 


### PR DESCRIPTION
The code compiles and the unit tests run with MSVC 2017, specifically,
with:

```
cl.exe -?
Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27044 for x64
```

I did not run the integration tests. Note that I only tested in 64-bit
mode (x64), I did not try a 32-bit build.

I think this answers the question in #5573

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5574)
<!-- Reviewable:end -->
