### PR TITLE
ci: support configuring MSVC version in CI scripts

### DIFF
--- a/ci/kokoro/windows/bazel-debug-2017-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-debug-2017-presubmit.cfg
@@ -13,21 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
-timeout_mins: 180
-
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.p12"
-
 env_vars {
     key: "MSVC_VERSION"
-    value: "2019"
-}
-
-action {
-  define_artifacts {
-    regex: "**/win_minidumps/*.dmp"
-  }
+    value: "2017"
 }

--- a/ci/kokoro/windows/bazel-debug-2017.cfg
+++ b/ci/kokoro/windows/bazel-debug-2017.cfg
@@ -13,21 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
-timeout_mins: 180
-
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.p12"
-
 env_vars {
     key: "MSVC_VERSION"
-    value: "2019"
-}
-
-action {
-  define_artifacts {
-    regex: "**/win_minidumps/*.dmp"
-  }
+    value: "2017"
 }

--- a/ci/kokoro/windows/bazel-release-2017-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-release-2017-presubmit.cfg
@@ -13,21 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
-timeout_mins: 180
-
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.p12"
-
 env_vars {
     key: "MSVC_VERSION"
-    value: "2019"
-}
-
-action {
-  define_artifacts {
-    regex: "**/win_minidumps/*.dmp"
-  }
+    value: "2017"
 }

--- a/ci/kokoro/windows/bazel-release-2017.cfg
+++ b/ci/kokoro/windows/bazel-release-2017.cfg
@@ -13,21 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-build_file: "google-cloud-cpp/ci/kokoro/windows/build.bat"
-timeout_mins: 180
-
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-setup-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.json"
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/kokoro-run-key.p12"
-
 env_vars {
     key: "MSVC_VERSION"
-    value: "2019"
-}
-
-action {
-  define_artifacts {
-    regex: "**/win_minidumps/*.dmp"
-  }
+    value: "2017"
 }

--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -23,8 +23,11 @@ bazel version
 @REM shutdown afterwards otherwise the server locks files
 bazel shutdown
 
+REM TODO(#5575) - remove this and use the Kokoro configuration
+set MSVC_VERSION=2019
+
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%

--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -23,9 +23,6 @@ bazel version
 @REM shutdown afterwards otherwise the server locks files
 bazel shutdown
 
-REM TODO(#5575) - remove this and use the Kokoro configuration
-set MSVC_VERSION=2019
-
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
 

--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -24,7 +24,7 @@ bazel version
 bazel shutdown
 
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
-call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
+call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars32.bat"
 
 REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -96,7 +96,7 @@ if ($BuildName -eq "bazel-release") {
     $build_flags += ("-c", "opt")
 }
 
-$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:BAZEL_VC}\Community\VC"
+$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
 
 ForEach($_ in (1, 2, 3)) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Fetch dependencies [$_]"

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -96,7 +96,7 @@ if ($BuildName -eq "bazel-release") {
     $build_flags += ("-c", "opt")
 }
 
-$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
+$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:BAZEL_VC}\Community\VC"
 
 ForEach($_ in (1, 2, 3)) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Fetch dependencies [$_]"
@@ -128,6 +128,7 @@ if ($LastExitCode) {
 }
 
 Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling extra programs"
+Write-Host -ForegroundColor Yellow bazel $common_flags build $build_flags ...
 bazel $common_flags build $build_flags ...
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "bazel test failed with exit code ${LastExitCode}."

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -67,7 +67,7 @@ if ((Test-Path env:KOKORO_GFILE_DIR) -and
     $build_flags += @("--experimental_guard_against_concurrent_changes")
 }
 
-$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
+$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
 
 $project_root = (Get-Item -Path ".\" -Verbose).FullName
 # If at all possible, load the configuration for the integration tests and

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -23,16 +23,6 @@ bazel version
 @REM shutdown afterwards otherwise the server locks files
 bazel shutdown
 
-@REM TODO(#5575) - remove this and use the Kokoro configuration
-set MSVC_VERSION=2017
-
-REM DEBUG DEBUG DEBUG Show available MSVC versions
-REM DEBUG DEBUG DEBUG Show available MSVC versions
-dir "c:\Program Files (x86)\Microsoft Visual Studio\"
-dir "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\"
-dir "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\"
-REM DEBUG DEBUG DEBUG Show available MSVC versions
-
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
 

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -24,7 +24,7 @@ bazel version
 bazel shutdown
 
 @REM TODO(#5575) - remove this and use the Kokoro configuration
-set MSVC_VERSION=2019
+set MSVC_VERSION=2017
 
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 REM DEBUG DEBUG DEBUG Show available MSVC versions

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -23,8 +23,16 @@ bazel version
 @REM shutdown afterwards otherwise the server locks files
 bazel shutdown
 
+@REM TODO(#5575) - remove this and use the Kokoro configuration
+set MSVC_VERSION=2019
+
+REM DEBUG DEBUG DEBUG Show available MSVC versions
+REM DEBUG DEBUG DEBUG Show available MSVC versions
+dir "c:\Program Files (x86)\Microsoft Visual Studio\"
+REM DEBUG DEBUG DEBUG Show available MSVC versions
+
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 REM The remaining of the build script is implemented in PowerShell.
 echo %date% %time%

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -29,8 +29,8 @@ set MSVC_VERSION=2017
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 dir "c:\Program Files (x86)\Microsoft Visual Studio\"
-call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\"
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\"
+dir "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\"
+dir "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\"
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -29,9 +29,11 @@ set MSVC_VERSION=2019
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 dir "c:\Program Files (x86)\Microsoft Visual Studio\"
+call "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\"
+call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\"
 REM DEBUG DEBUG DEBUG Show available MSVC versions
 
-REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
+REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
 
 REM The remaining of the build script is implemented in PowerShell.

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -85,6 +85,12 @@ if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
 } elseif ($BuildName -eq "bazel-release") {
     $DependencyScript = "build-bazel-dependencies.ps1"
     $BuildScript = "build-bazel.ps1"
+} elseif ($BuildName -eq "bazel-debug-2017") {
+    $DependencyScript = "build-bazel-dependencies.ps1"
+    $BuildScript = "build-bazel.ps1"
+} elseif ($BuildName -eq "bazel-release-2017") {
+    $DependencyScript = "build-bazel-dependencies.ps1"
+    $BuildScript = "build-bazel.ps1"
 } elseif ($BuildName -eq "quickstart-bazel") {
     $DependencyScript = "build-bazel-dependencies.ps1"
     $BuildScript = "build-quickstart-bazel.ps1"


### PR DESCRIPTION
Also included the configuration files for MSVC 2017 builds in this PR, I can split them if needed.

Part of the work for #5575.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5577)
<!-- Reviewable:end -->
