### PR TITLE
fix(storage): allow endings without \r\n in emulator multipart

### DIFF
--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -337,6 +337,7 @@ class TestCommonUtils(unittest.TestCase):
         with self.assertRaises(utils.error.RestException):
             utils.common.parse_multipart(request)
 
+
 class TestGeneration(unittest.TestCase):
     def test_extract_precondition(self):
         request = storage_pb2.CopyObjectRequest(

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -277,7 +277,7 @@ def parse_multipart(request):
     boundary = boundary.encode("utf-8")
     body = extract_media(request)
     parts = body.split(b"--" + boundary)
-    if parts[-1] != b"--\r\n":
+    if parts[-1] != b"--\r\n" and parts[-1] != b"--":
         utils.error.missing("end marker (--%s--) in media body" % boundary, None)
     resource = parse_metadata(parts[1])
     metadata = json.loads(resource)


### PR DESCRIPTION
The Storage multipart upload API allows for a multipart ending without "\r\n". The [RFC](https://tools.ietf.org/html/rfc7578) also does not specify that "\r\n” is required. This change allows for this flexibility in the emulator as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5578)
<!-- Reviewable:end -->
