### PR TITLE
test: deflake completion queue test

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -704,7 +704,8 @@ TEST_P(RunAsyncTest, TortureBursts) {
   EXPECT_GE(impl->thread_pool_hwm(), kThreads / 2);
   EXPECT_GE(impl->run_async_pool_hwm(), kThreads / 2);
   EXPECT_GE(impl->notify_counter(), kBurstCount);
-  EXPECT_LE(impl->notify_counter(), kBurstCount * burst_size / 2);
+  // At least one of the notifications should be avoided (thus _LT and not _LE):
+  EXPECT_LT(impl->notify_counter(), kBurstCount * burst_size);
 }
 
 INSTANTIATE_TEST_SUITE_P(RunAsyncTest, RunAsyncTest,


### PR DESCRIPTION
Before this change the test would flake with TSAN under load (it would
not flake with `-c opt` under light load). This relaxes one of the
assertions, it still tests "something".

Fixes #5571 

Tested with 1600 iterations under TSAN:

```
CXX=clang++ CC=clang bazel test --config tsan --runs_per_test=1600 --jobs=64 --test_tag_filters=-integration-test //google/cloud:completion_queue_test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5589)
<!-- Reviewable:end -->
