### PR TITLE
fix: only build gRPC testing utilities if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ endforeach ()
 # Enable building the gRPC utilities library if any of its dependents are
 # enabled.
 set(GOOGLE_CLOUD_CPP_ENABLE_GRPC_EXPRESSION OFF)
-foreach (_library bigquery bigtable storage spanner pubsub generator)
+foreach (_library bigquery bigtable spanner pubsub generator)
     if (_library IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
         set(GOOGLE_CLOUD_CPP_ENABLE_GRPC_EXPRESSION ON)
         break()
@@ -172,7 +172,7 @@ endforeach ()
 
 cmake_dependent_option(
     GOOGLE_CLOUD_CPP_ENABLE_GRPC "Enable building the gRPC utilities library."
-    ON "${GOOGLE_CLOUD_CPP_ENABLE_GRPC_EXPRESSION}" OFF)
+    ON "GOOGLE_CLOUD_CPP_ENABLE_GRPC_EXPRESSION" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_GRPC)
 
 # Building this target results in all protobufs being compiled.

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-if (BUILD_TESTING)
+if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
     # TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl
     # release
     set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -89,6 +89,10 @@ if (BUILD_TESTING)
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 
+    if (NOT GOOGLE_CLOUD_CPP_ENABLE_GRPC)
+        return()
+    endif ()
+
     find_package(ProtobufWithTargets REQUIRED)
     add_library(
         google_cloud_cpp_testing_grpc # cmake-format: sort
@@ -132,79 +136,4 @@ if (BUILD_TESTING)
         endif ()
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
-
-    # Export the CMake targets to make it easy to create configuration files.
-    install(
-        EXPORT google_cloud_cpp_testing-targets
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_testing")
-
-    # Install the libraries and headers in the locations determined by
-    # GNUInstallDirs
-    install(
-        TARGETS google_cloud_cpp_testing google_cloud_cpp_testing_grpc
-        EXPORT google_cloud_cpp_testing-targets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                COMPONENT google_cloud_cpp_runtime
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_runtime
-                NAMELINK_SKIP
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_development)
-    # With CMake-3.12 and higher we could avoid this separate command (and the
-    # duplication).
-    install(
-        TARGETS google_cloud_cpp_testing google_cloud_cpp_testing_grpc
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_development
-                NAMELINK_ONLY
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_development)
-
-    google_cloud_cpp_install_headers(google_cloud_cpp_testing
-                                     include/google/cloud/testing_util)
-    google_cloud_cpp_install_headers(google_cloud_cpp_testing_grpc
-                                     include/google/cloud/testing_util)
-
-    # Setup global variables used in the following *.in files.
-    set(GOOGLE_CLOUD_CPP_PC_NAME
-        "Google Cloud C++ Client Library Testing Utilities")
-    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-        "Testing Utilities used by the Google Cloud C++ Client Libraries.")
-
-    # Create and install the pkg-config files. First for testing_util:
-    google_cloud_cpp_absl_pkg_config(absl_pkg_config google_cloud_cpp_testing)
-    string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_testing"
-                  ${absl_pkg_config})
-    set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common")
-    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
-                   "google_cloud_cpp_testing.pc" @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_testing.pc"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-    # Then for testing_grpc:
-    google_cloud_cpp_absl_pkg_config(absl_pkg_config
-                                     google_cloud_cpp_testing_grpc)
-    string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_testing_grpc"
-                  ${absl_pkg_config})
-    set(GOOGLE_CLOUD_CPP_PC_REQUIRES
-        "google_cloud_cpp_testing google_cloud_cpp_common")
-    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
-                   "google_cloud_cpp_testing_grpc.pc" @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_testing_grpc.pc"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-
-    # Create and install the CMake configuration files.
-    include(CMakePackageConfigHelpers)
-    configure_file("config.cmake.in" "google_cloud_cpp_testing-config.cmake"
-                   @ONLY)
-    write_basic_package_version_file(
-        "google_cloud_cpp_testing-config-version.cmake"
-        VERSION ${GOOGLE_CLOUD_CPP_VERSION}
-        COMPATIBILITY ExactVersion)
-
-    install(
-        FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_testing-config.cmake"
-            "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_testing-config-version.cmake"
-            "${PROJECT_SOURCE_DIR}/cmake/FindGMockWithTargets.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_testing")
 endif ()


### PR DESCRIPTION
Our customers can enable only specific libraries, for example, they can
enable only the `storage` library. As the storage library does not
require gRPC, we should stop downloading and installing the gRPC
dependencies too (this is one of the main motivations to disable the
other libraries). In this PR we make 3 changes to make this easier to
use:

- Do not build the testing support libraries for gRPC unless gRPC is
  needed by one of the top-level libraries.

- Do not build the storage benchmarks if gRPC is disabled, as they
  depend directly on gRPC.

- Do not install the testing support libraries. These libraries are not
  part of the public API, so installing them is not needed (it used to be,
  to support `google-cloud-cpp-spanner` and other split repos). The other
  changes are easier to implement if installation is disabled.

This was motivated by #5590 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5594)
<!-- Reviewable:end -->
