### PR TITLE
feat(pubsub): add equality to Publisher

### DIFF
--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -106,6 +106,15 @@ class Publisher {
   Publisher& operator=(Publisher&&) noexcept = default;
   //@}
 
+  //@{
+  friend bool operator==(Publisher const& a, Publisher const& b) {
+    return a.connection_ == b.connection_;
+  }
+  friend bool operator!=(Publisher const& a, Publisher const& b) {
+    return !(a == b);
+  }
+  //@}
+
   /**
    * Publishes a message to this publisher's topic
    *

--- a/google/cloud/pubsub/publisher_test.cc
+++ b/google/cloud/pubsub/publisher_test.cc
@@ -25,6 +25,28 @@ namespace {
 
 using ::testing::_;
 
+// Tests {copy,move}x{constructor,assignment} + equality.
+TEST(PublisherTest, ValueSemantics) {
+  auto mock1 = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+  auto mock2 = std::make_shared<pubsub_mocks::MockPublisherConnection>();
+
+  Publisher p1(mock1);
+  Publisher p2(mock2);
+  EXPECT_NE(p1, p2);
+
+  p2 = p1;
+  EXPECT_EQ(p1, p2);
+
+  Publisher p3 = p1;
+  EXPECT_EQ(p3, p1);
+
+  Publisher p4 = std::move(p1);
+  EXPECT_EQ(p4, p3);
+
+  p1 = std::move(p3);
+  EXPECT_EQ(p1, p2);
+}
+
 TEST(PublisherTest, PublishSimple) {
   auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
   EXPECT_CALL(*mock, Publish(_))


### PR DESCRIPTION
Part of #2310

This PR adds equality to `Publisher` only because `Publisher` is already copyable, and for the reasons in #2310, I _think_ copyability implies the need for equality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5608)
<!-- Reviewable:end -->
