### PR TITLE
chore(spanner): rename spanner::internal -> spanner::spanner_internal

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -468,18 +468,18 @@ class ExperimentImpl {
   }
 
   std::pair<std::vector<spanner::Client>,
-            std::vector<std::shared_ptr<spanner::internal::SpannerStub>>>
+            std::vector<std::shared_ptr<spanner_internal::SpannerStub>>>
   CreateClientsAndStubs(Config const& config,
                         spanner::Database const& database) {
     std::vector<spanner::Client> clients;
-    std::vector<std::shared_ptr<spanner::internal::SpannerStub>> stubs;
+    std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
     std::cout << "# Creating clients and stubs " << std::flush;
     for (int i = 0; i != config.maximum_clients; ++i) {
       auto options = spanner::ConnectionOptions().set_channel_pool_domain(
           "task:" + std::to_string(i));
       clients.emplace_back(
           spanner::Client(spanner::MakeConnection(database, options)));
-      stubs.emplace_back(spanner::internal::CreateDefaultSpannerStub(
+      stubs.emplace_back(spanner_internal::CreateDefaultSpannerStub(
           database, options, /*channel_id=*/0));
       std::cout << '.' << std::flush;
     }
@@ -591,7 +591,7 @@ class ReadExperiment : public Experiment {
   Status Run(Config const& config, spanner::Database const& database) override {
     // Create enough clients and stubs for the worst case
     std::vector<spanner::Client> clients;
-    std::vector<std::shared_ptr<spanner::internal::SpannerStub>> stubs;
+    std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
     std::tie(clients, stubs) = impl_.CreateClientsAndStubs(config, database);
 
     // Capture some overall getrusage() statistics as comments.
@@ -602,7 +602,7 @@ class ReadExperiment : public Experiment {
       auto const thread_count = impl_.ThreadCount(config);
       auto const client_count = impl_.ClientCount(config);
       if (use_stubs) {
-        std::vector<std::shared_ptr<spanner::internal::SpannerStub>>
+        std::vector<std::shared_ptr<spanner_internal::SpannerStub>>
             iteration_stubs(stubs.begin(), stubs.begin() + client_count);
         RunIterationViaStubs(config, iteration_stubs, thread_count);
         continue;
@@ -619,7 +619,7 @@ class ReadExperiment : public Experiment {
  private:
   void RunIterationViaStubs(
       Config const& config,
-      std::vector<std::shared_ptr<spanner::internal::SpannerStub>> const& stubs,
+      std::vector<std::shared_ptr<spanner_internal::SpannerStub>> const& stubs,
       int thread_count) {
     std::vector<std::future<std::vector<RowCpuSample>>> tasks(thread_count);
     int task_id = 0;
@@ -639,7 +639,7 @@ class ReadExperiment : public Experiment {
   std::vector<RowCpuSample> ReadRowsViaStub(
       Config const& config, int thread_count, int client_count,
       spanner::Database const& database,
-      std::shared_ptr<spanner::internal::SpannerStub> const& stub) {
+      std::shared_ptr<spanner_internal::SpannerStub> const& stub) {
     auto session = [&]() -> google::cloud::StatusOr<std::string> {
       Status last_status;
       for (int i = 0; i != 10; ++i) {
@@ -686,7 +686,7 @@ class ReadExperiment : public Experiment {
       for (auto const& name : columns) {
         request.add_columns(name);
       }
-      *request.mutable_key_set() = spanner::internal::ToProto(key);
+      *request.mutable_key_set() = spanner_internal::ToProto(key);
 
       int row_count = 0;
       google::spanner::v1::PartialResultSet result;
@@ -812,7 +812,7 @@ class SelectExperiment : public Experiment {
 
   Status Run(Config const& config, spanner::Database const& database) override {
     std::vector<spanner::Client> clients;
-    std::vector<std::shared_ptr<spanner::internal::SpannerStub>> stubs;
+    std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
     std::tie(clients, stubs) = impl_.CreateClientsAndStubs(config, database);
 
     // Capture some overall getrusage() statistics as comments.
@@ -823,7 +823,7 @@ class SelectExperiment : public Experiment {
       auto const thread_count = impl_.ThreadCount(config);
       auto const client_count = impl_.ClientCount(config);
       if (use_stubs) {
-        std::vector<std::shared_ptr<spanner::internal::SpannerStub>>
+        std::vector<std::shared_ptr<spanner_internal::SpannerStub>>
             iteration_stubs(stubs.begin(), stubs.begin() + client_count);
         RunIterationViaStubs(config, iteration_stubs, thread_count);
         continue;
@@ -840,7 +840,7 @@ class SelectExperiment : public Experiment {
  private:
   void RunIterationViaStubs(
       Config const& config,
-      std::vector<std::shared_ptr<spanner::internal::SpannerStub>> const& stubs,
+      std::vector<std::shared_ptr<spanner_internal::SpannerStub>> const& stubs,
       int thread_count) {
     std::vector<std::future<std::vector<RowCpuSample>>> tasks(thread_count);
     int task_id = 0;
@@ -860,7 +860,7 @@ class SelectExperiment : public Experiment {
   std::vector<RowCpuSample> ViaStub(
       Config const& config, int thread_count, int client_count,
       spanner::Database const& database,
-      std::shared_ptr<spanner::internal::SpannerStub> const& stub) {
+      std::shared_ptr<spanner_internal::SpannerStub> const& stub) {
     auto session = [&]() -> google::cloud::StatusOr<std::string> {
       Status last_status;
       for (int i = 0; i != ExperimentImpl<Traits>::kColumnCount; ++i) {
@@ -902,13 +902,13 @@ class SelectExperiment : public Experiment {
           ->mutable_read_only()
           ->Clear();
       request.set_sql(statement);
-      auto begin_type_value = spanner::internal::ToProto(spanner::Value(key));
+      auto begin_type_value = spanner_internal::ToProto(spanner::Value(key));
       (*request.mutable_param_types())["begin"] =
           std::move(begin_type_value.first);
       (*request.mutable_params()->mutable_fields())["begin"] =
           std::move(begin_type_value.second);
       auto end_type_value =
-          spanner::internal::ToProto(spanner::Value(key + config.query_size));
+          spanner_internal::ToProto(spanner::Value(key + config.query_size));
       (*request.mutable_param_types())["end"] = std::move(end_type_value.first);
       (*request.mutable_params()->mutable_fields())["end"] =
           std::move(end_type_value.second);
@@ -1051,7 +1051,7 @@ class UpdateExperiment : public Experiment {
 
   Status Run(Config const& config, spanner::Database const& database) override {
     std::vector<spanner::Client> clients;
-    std::vector<std::shared_ptr<spanner::internal::SpannerStub>> stubs;
+    std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
     std::tie(clients, stubs) = impl_.CreateClientsAndStubs(config, database);
 
     // Capture some overall getrusage() statistics as comments.
@@ -1062,7 +1062,7 @@ class UpdateExperiment : public Experiment {
       auto const thread_count = impl_.ThreadCount(config);
       auto const client_count = impl_.ClientCount(config);
       if (use_stubs) {
-        std::vector<std::shared_ptr<spanner::internal::SpannerStub>>
+        std::vector<std::shared_ptr<spanner_internal::SpannerStub>>
             iteration_stubs(stubs.begin(), stubs.begin() + client_count);
         RunIterationViaStubs(config, iteration_stubs, thread_count);
         continue;
@@ -1079,7 +1079,7 @@ class UpdateExperiment : public Experiment {
  private:
   void RunIterationViaStubs(
       Config const& config,
-      std::vector<std::shared_ptr<spanner::internal::SpannerStub>> const& stubs,
+      std::vector<std::shared_ptr<spanner_internal::SpannerStub>> const& stubs,
       int thread_count) {
     std::vector<std::future<std::vector<RowCpuSample>>> tasks(thread_count);
     int task_id = 0;
@@ -1099,7 +1099,7 @@ class UpdateExperiment : public Experiment {
   std::vector<RowCpuSample> UpdateRowsViaStub(
       Config const& config, int thread_count, int client_count,
       spanner::Database const& database,
-      std::shared_ptr<spanner::internal::SpannerStub> const& stub) {
+      std::shared_ptr<spanner_internal::SpannerStub> const& stub) {
     std::string const statement = CreateStatement();
 
     auto session = [&]() -> google::cloud::StatusOr<std::string> {
@@ -1151,13 +1151,13 @@ class UpdateExperiment : public Experiment {
           ->mutable_read_write()
           ->Clear();
       request.set_sql(statement);
-      auto key_type_value = spanner::internal::ToProto(spanner::Value(key));
+      auto key_type_value = spanner_internal::ToProto(spanner::Value(key));
       (*request.mutable_param_types())["key"] = std::move(key_type_value.first);
       (*request.mutable_params()->mutable_fields())["key"] =
           std::move(key_type_value.second);
 
       for (int i = 0; i != 10; ++i) {
-        auto tv = spanner::internal::ToProto(spanner::Value(values[i]));
+        auto tv = spanner_internal::ToProto(spanner::Value(values[i]));
         auto name = "v" + std::to_string(i);
         (*request.mutable_param_types())[name] = std::move(tv.first);
         (*request.mutable_params()->mutable_fields())[name] =
@@ -1314,7 +1314,7 @@ class MutationExperiment : public Experiment {
 
   Status Run(Config const& config, spanner::Database const& database) override {
     std::vector<spanner::Client> clients;
-    std::vector<std::shared_ptr<spanner::internal::SpannerStub>> stubs;
+    std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
     std::tie(clients, stubs) = impl_.CreateClientsAndStubs(config, database);
 
     random_keys_.resize(config.table_size);
@@ -1330,7 +1330,7 @@ class MutationExperiment : public Experiment {
       auto const thread_count = impl_.ThreadCount(config);
       auto const client_count = impl_.ClientCount(config);
       if (use_stubs) {
-        std::vector<std::shared_ptr<spanner::internal::SpannerStub>>
+        std::vector<std::shared_ptr<spanner_internal::SpannerStub>>
             iteration_stubs(stubs.begin(), stubs.begin() + client_count);
         RunIterationViaStubs(config, iteration_stubs, thread_count);
         continue;
@@ -1347,7 +1347,7 @@ class MutationExperiment : public Experiment {
  private:
   void RunIterationViaStubs(
       Config const& config,
-      std::vector<std::shared_ptr<spanner::internal::SpannerStub>> const& stubs,
+      std::vector<std::shared_ptr<spanner_internal::SpannerStub>> const& stubs,
       int thread_count) {
     std::vector<std::future<std::vector<RowCpuSample>>> tasks(thread_count);
     int task_id = 0;
@@ -1367,7 +1367,7 @@ class MutationExperiment : public Experiment {
   std::vector<RowCpuSample> InsertRowsViaStub(
       Config const& config, int thread_count, int client_count,
       spanner::Database const& database,
-      std::shared_ptr<spanner::internal::SpannerStub> const& stub) {
+      std::shared_ptr<spanner_internal::SpannerStub> const& stub) {
     std::vector<std::string> const column_names{
         "Key",   "Data0", "Data1", "Data2", "Data3", "Data4",
         "Data5", "Data6", "Data7", "Data8", "Data9"};
@@ -1438,7 +1438,7 @@ class MutationExperiment : public Experiment {
       row.add_values()->set_string_value(std::to_string(key));
       for (auto v : values) {
         *row.add_values() =
-            spanner::internal::ToProto(spanner::Value(std::move(v))).second;
+            spanner_internal::ToProto(spanner::Value(std::move(v))).second;
       }
       auto response = stub->Commit(context, commit_request);
 

--- a/google/cloud/spanner/bytes.cc
+++ b/google/cloud/spanner/bytes.cc
@@ -141,7 +141,7 @@ void Bytes::Decoder::Iterator::Fill() {
   }
 }
 
-namespace internal {
+namespace spanner_internal {
 
 // Construction from a base64-encoded US-ASCII `std::string`.
 StatusOr<Bytes> BytesFromBase64(std::string input) {
@@ -181,7 +181,7 @@ StatusOr<Bytes> BytesFromBase64(std::string input) {
 // Conversion to a base64-encoded US-ASCII `std::string`.
 std::string BytesToBase64(Bytes b) { return std::move(b.base64_rep_); }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/bytes.h
+++ b/google/cloud/spanner/bytes.h
@@ -31,10 +31,10 @@ inline namespace SPANNER_CLIENT_NS {
 class Bytes;  // defined below
 
 // Internal forward declarations to befriend.
-namespace internal {
+namespace spanner_internal {
 StatusOr<Bytes> BytesFromBase64(std::string input);
 std::string BytesToBase64(Bytes b);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * A representation of the Spanner BYTES type: variable-length binary data.
@@ -87,8 +87,8 @@ class Bytes {
   friend std::ostream& operator<<(std::ostream& os, Bytes const& bytes);
 
  private:
-  friend StatusOr<Bytes> internal::BytesFromBase64(std::string input);
-  friend std::string internal::BytesToBase64(Bytes b);
+  friend StatusOr<Bytes> spanner_internal::BytesFromBase64(std::string input);
+  friend std::string spanner_internal::BytesToBase64(Bytes b);
 
   struct Encoder {
     explicit Encoder(std::string& rep) : rep_(rep), len_(0) {}

--- a/google/cloud/spanner/bytes_benchmark.cc
+++ b/google/cloud/spanner/bytes_benchmark.cc
@@ -77,7 +77,7 @@ void BM_BytesGet(benchmark::State& state) {
     benchmark::DoNotOptimize(b.get<std::string>());
   }
   state.SetBytesProcessed(state.iterations() *
-                          internal::BytesToBase64(b).size());
+                          spanner_internal::BytesToBase64(b).size());
 }
 BENCHMARK(BM_BytesGet);
 

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -394,7 +394,8 @@ TEST(ClientTest, MakeConnectionOptionalArguments) {
 }
 
 TEST(ClientTest, CommitMutatorSuccess) {
-  auto timestamp = internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
+  auto timestamp =
+      spanner_internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
   ASSERT_STATUS_OK(timestamp);
 
   auto conn = std::make_shared<MockConnection>();
@@ -598,7 +599,8 @@ TEST(ClientTest, CommitMutatorRuntimeStatusException) {
 #endif
 
 TEST(ClientTest, CommitMutatorRerunTransientFailures) {
-  auto timestamp = internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
+  auto timestamp =
+      spanner_internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
   ASSERT_STATUS_OK(timestamp);
 
   auto conn = std::make_shared<MockConnection>();
@@ -673,7 +675,8 @@ TEST(ClientTest, CommitMutatorPermanentFailure) {
 TEST(ClientTest, CommitMutations) {
   auto conn = std::make_shared<MockConnection>();
   auto mutation = MakeDeleteMutation("table", KeySet::All());
-  auto timestamp = internal::TimestampFromRFC3339("2020-02-28T04:49:17.335Z");
+  auto timestamp =
+      spanner_internal::TimestampFromRFC3339("2020-02-28T04:49:17.335Z");
   ASSERT_STATUS_OK(timestamp);
   EXPECT_CALL(*conn, Commit(_))
       .WillOnce([&mutation, &timestamp](Connection::CommitParams const& cp) {
@@ -688,9 +691,9 @@ TEST(ClientTest, CommitMutations) {
 }
 
 MATCHER(DoesNotHaveSession, "not bound to a session") {
-  return internal::Visit(
+  return spanner_internal::Visit(
       arg,
-      [&](internal::SessionHolder& session,
+      [&](spanner_internal::SessionHolder& session,
           StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t) {
         if (session) {
           *result_listener << "has session " << session->session_name();
@@ -701,9 +704,9 @@ MATCHER(DoesNotHaveSession, "not bound to a session") {
 }
 
 MATCHER_P(HasSession, name, "bound to expected session") {
-  return internal::Visit(
+  return spanner_internal::Visit(
       arg,
-      [&](internal::SessionHolder& session,
+      [&](spanner_internal::SessionHolder& session,
           StatusOr<google::spanner::v1::TransactionSelector>&, std::int64_t) {
         if (!session) {
           *result_listener << "has no session but expected " << name;
@@ -719,9 +722,9 @@ MATCHER_P(HasSession, name, "bound to expected session") {
 }
 
 MATCHER(HasBegin, "not bound to a transaction-id nor invalidated") {
-  return internal::Visit(
+  return spanner_internal::Visit(
       arg,
-      [&](internal::SessionHolder&,
+      [&](spanner_internal::SessionHolder&,
           StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
         if (!s) {
           *result_listener << "has status " << s.status();
@@ -740,18 +743,19 @@ MATCHER(HasBegin, "not bound to a transaction-id nor invalidated") {
 }
 
 bool SetSessionName(Transaction const& txn, std::string name) {
-  return internal::Visit(
-      txn, [&name](internal::SessionHolder& session,
+  return spanner_internal::Visit(
+      txn, [&name](spanner_internal::SessionHolder& session,
                    StatusOr<google::spanner::v1::TransactionSelector>&,
                    std::int64_t) {
-        session = internal::MakeDissociatedSessionHolder(std::move(name));
+        session =
+            spanner_internal::MakeDissociatedSessionHolder(std::move(name));
         return true;
       });
 }
 
 bool SetTransactionId(Transaction const& txn, std::string id) {
-  return internal::Visit(
-      txn, [&id](internal::SessionHolder&,
+  return spanner_internal::Visit(
+      txn, [&id](spanner_internal::SessionHolder&,
                  StatusOr<google::spanner::v1::TransactionSelector>& s,
                  std::int64_t) {
         s->set_id(std::move(id));  // only valid when s.ok()
@@ -766,7 +770,8 @@ TEST(ClientTest, CommitMutatorSessionAffinity) {
   // should see the same session in a new transaction on every rerun.
   std::string const session_name = "CommitMutatorLockPriority.Session";
 
-  auto timestamp = internal::TimestampFromRFC3339("2019-11-11T20:05:36.345Z");
+  auto timestamp =
+      spanner_internal::TimestampFromRFC3339("2019-11-11T20:05:36.345Z");
   ASSERT_STATUS_OK(timestamp);
 
   auto conn = std::make_shared<MockConnection>();
@@ -808,7 +813,8 @@ TEST(ClientTest, CommitMutatorSessionAffinity) {
 }
 
 TEST(ClientTest, CommitMutatorSessionNotFound) {
-  auto timestamp = internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
+  auto timestamp =
+      spanner_internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
   ASSERT_STATUS_OK(timestamp);
 
   auto conn = std::make_shared<MockConnection>();
@@ -833,7 +839,8 @@ TEST(ClientTest, CommitMutatorSessionNotFound) {
 }
 
 TEST(ClientTest, CommitSessionNotFound) {
-  auto timestamp = internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
+  auto timestamp =
+      spanner_internal::TimestampFromRFC3339("2019-08-14T21:16:21.123Z");
   ASSERT_STATUS_OK(timestamp);
 
   auto conn = std::make_shared<MockConnection>();

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -37,7 +37,7 @@ std::string ConnectionOptionsTraits::user_agent_prefix() {
 
 int ConnectionOptionsTraits::default_num_channels() { return 4; }
 
-namespace internal {
+namespace spanner_internal {
 
 // Override connection endpoint and credentials with values appropriate for
 // an emulated backend. This should be done after any user code that could
@@ -52,7 +52,7 @@ ConnectionOptions EmulatorOverrides(ConnectionOptions options) {
   return options;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -45,9 +45,9 @@ struct ConnectionOptionsTraits {
 using ConnectionOptions =
     google::cloud::ConnectionOptions<ConnectionOptionsTraits>;
 
-namespace internal {
+namespace spanner_internal {
 ConnectionOptions EmulatorOverrides(ConnectionOptions options);
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -69,7 +69,7 @@ TEST(EmulatorOverrides, EnvironmentWorks) {
   // grpc::InsecureChannelCredentials().
   ScopedEnvironment env("SPANNER_EMULATOR_HOST", "localhost:9010");
   ConnectionOptions options(std::shared_ptr<grpc::ChannelCredentials>{});
-  options = internal::EmulatorOverrides(options);
+  options = spanner_internal::EmulatorOverrides(options);
   EXPECT_NE(std::shared_ptr<grpc::ChannelCredentials>{}, options.credentials());
   EXPECT_EQ("localhost:9010", options.endpoint());
 }

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -96,7 +96,7 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
     Database const& db, IamUpdater const& updater,
     std::unique_ptr<TransactionRerunPolicy> rerun_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
-  using RerunnablePolicy = internal::SafeTransactionRerun;
+  using RerunnablePolicy = spanner_internal::SafeTransactionRerun;
 
   Status last_status;
   do {

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -129,7 +129,7 @@ std::unique_ptr<PollingPolicy> DefaultAdminPollingPolicy() {
 class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
  public:
   explicit DatabaseAdminConnectionImpl(
-      std::shared_ptr<internal::DatabaseAdminStub> stub,
+      std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
       ConnectionOptions const& options,
       std::unique_ptr<RetryPolicy> retry_policy,
       std::unique_ptr<BackoffPolicy> backoff_policy,
@@ -141,7 +141,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         background_threads_(options.background_threads_factory()()) {}
 
   explicit DatabaseAdminConnectionImpl(
-      std::shared_ptr<internal::DatabaseAdminStub> stub,
+      std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
       ConnectionOptions const& options)
       : DatabaseAdminConnectionImpl(
             std::move(stub), options, DefaultAdminRetryPolicy(),
@@ -520,7 +520,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
     // TODO(#4038) - use background_threads_->cq() to run this loop.
     std::thread t(
-        [](std::shared_ptr<internal::DatabaseAdminStub> stub,
+        [](std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
            google::longrunning::Operation operation,
            std::unique_ptr<PollingPolicy> polling_policy,
            google::cloud::promise<StatusOr<gcsa::Database>> promise,
@@ -555,7 +555,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
     // TODO(#4038) - use background_threads_->cq() to run this loop.
     std::thread t(
-        [](std::shared_ptr<internal::DatabaseAdminStub> stub,
+        [](std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
            google::longrunning::Operation operation,
            std::unique_ptr<PollingPolicy> polling_policy,
            promise<StatusOr<gcsa::UpdateDatabaseDdlMetadata>> promise,
@@ -586,7 +586,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       google::longrunning::Operation operation) {
     // Create a local copy of stub because `this` might get out of scope when
     // the callback will be called.
-    std::shared_ptr<internal::DatabaseAdminStub> cancel_stub(stub_);
+    std::shared_ptr<spanner_internal::DatabaseAdminStub> cancel_stub(stub_);
     // Create a promise with a cancellation callback.
     promise<StatusOr<gcsa::Backup>> pr([cancel_stub, operation]() {
       grpc::ClientContext context;
@@ -598,7 +598,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
     // TODO(#4038) - use background_threads_->cq() to run this loop.
     std::thread t(
-        [](std::shared_ptr<internal::DatabaseAdminStub> stub,
+        [](std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
            google::longrunning::Operation operation,
            std::unique_ptr<PollingPolicy> polling_policy,
            google::cloud::promise<StatusOr<gcsa::Backup>> promise,
@@ -624,7 +624,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
     return f;
   }
 
-  std::shared_ptr<internal::DatabaseAdminStub> stub_;
+  std::shared_ptr<spanner_internal::DatabaseAdminStub> stub_;
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<PollingPolicy const> polling_policy_prototype_;
@@ -642,31 +642,31 @@ DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     ConnectionOptions const& options) {
-  return internal::MakeDatabaseAdminConnection(
-      internal::CreateDefaultDatabaseAdminStub(options), options);
+  return spanner_internal::MakeDatabaseAdminConnection(
+      spanner_internal::CreateDefaultDatabaseAdminStub(options), options);
 }
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
-  return internal::MakeDatabaseAdminConnection(
-      internal::CreateDefaultDatabaseAdminStub(options), options,
+  return spanner_internal::MakeDatabaseAdminConnection(
+      spanner_internal::CreateDefaultDatabaseAdminStub(options), options,
       std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
 
-namespace internal {
+namespace spanner_internal {
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<internal::DatabaseAdminStub> stub,
+    std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
     ConnectionOptions const& options) {
   return std::make_shared<DatabaseAdminConnectionImpl>(std::move(stub),
                                                        options);
 }
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<internal::DatabaseAdminStub> stub,
+    std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
@@ -675,7 +675,7 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
       std::move(backoff_policy), std::move(polling_policy));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -335,19 +335,19 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
 
-namespace internal {
+namespace spanner_internal {
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<internal::DatabaseAdminStub> stub,
+    std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
     ConnectionOptions const& options);
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<internal::DatabaseAdminStub> stub,
+    std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -38,14 +38,14 @@ using ::testing::Return;
 namespace gcsa = ::google::spanner::admin::database::v1;
 
 std::shared_ptr<DatabaseAdminConnection> CreateTestingConnection(
-    std::shared_ptr<internal::DatabaseAdminStub> mock) {
+    std::shared_ptr<spanner_internal::DatabaseAdminStub> mock) {
   LimitedErrorCountRetryPolicy retry(/*maximum_failures=*/2);
   ExponentialBackoffPolicy backoff(
       /*initial_delay=*/std::chrono::microseconds(1),
       /*maximum_delay=*/std::chrono::microseconds(1),
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
-  return internal::MakeDatabaseAdminConnection(
+  return spanner_internal::MakeDatabaseAdminConnection(
       std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
       polling.clone());
 }

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -89,7 +89,7 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     Instance const& in, IamUpdater const& updater,
     std::unique_ptr<TransactionRerunPolicy> rerun_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
-  using RerunnablePolicy = internal::SafeTransactionRerun;
+  using RerunnablePolicy = spanner_internal::SafeTransactionRerun;
 
   Status last_status;
   do {

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -53,11 +53,12 @@ std::unique_ptr<PollingPolicy> DefaultInstanceAdminPollingPolicy() {
 
 class InstanceAdminConnectionImpl : public InstanceAdminConnection {
  public:
-  InstanceAdminConnectionImpl(std::shared_ptr<internal::InstanceAdminStub> stub,
-                              ConnectionOptions const& options,
-                              std::unique_ptr<RetryPolicy> retry_policy,
-                              std::unique_ptr<BackoffPolicy> backoff_policy,
-                              std::unique_ptr<PollingPolicy> polling_policy)
+  InstanceAdminConnectionImpl(
+      std::shared_ptr<spanner_internal::InstanceAdminStub> stub,
+      ConnectionOptions const& options,
+      std::unique_ptr<RetryPolicy> retry_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy,
+      std::unique_ptr<PollingPolicy> polling_policy)
       : stub_(std::move(stub)),
         retry_policy_prototype_(std::move(retry_policy)),
         backoff_policy_prototype_(std::move(backoff_policy)),
@@ -65,7 +66,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         background_threads_(options.background_threads_factory()()) {}
 
   explicit InstanceAdminConnectionImpl(
-      std::shared_ptr<internal::InstanceAdminStub> stub,
+      std::shared_ptr<spanner_internal::InstanceAdminStub> stub,
       ConnectionOptions const& options)
       : InstanceAdminConnectionImpl(std::move(stub), options,
                                     DefaultInstanceAdminRetryPolicy(),
@@ -272,7 +273,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
     // TODO(#4038) - use background_threads_->cq() to run this loop.
     std::thread t(
-        [](std::shared_ptr<internal::InstanceAdminStub> stub,
+        [](std::shared_ptr<spanner_internal::InstanceAdminStub> stub,
            google::longrunning::Operation operation,
            std::unique_ptr<PollingPolicy> polling_policy,
            google::cloud::promise<StatusOr<gcsa::Instance>> promise,
@@ -299,7 +300,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
     return f;
   }
-  std::shared_ptr<internal::InstanceAdminStub> stub_;
+  std::shared_ptr<spanner_internal::InstanceAdminStub> stub_;
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<PollingPolicy const> polling_policy_prototype_;
@@ -317,31 +318,31 @@ InstanceAdminConnection::~InstanceAdminConnection() = default;
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     ConnectionOptions const& options) {
-  return internal::MakeInstanceAdminConnection(
-      internal::CreateDefaultInstanceAdminStub(options), options);
+  return spanner_internal::MakeInstanceAdminConnection(
+      spanner_internal::CreateDefaultInstanceAdminStub(options), options);
 }
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
-  return internal::MakeInstanceAdminConnection(
-      internal::CreateDefaultInstanceAdminStub(options), options,
+  return spanner_internal::MakeInstanceAdminConnection(
+      spanner_internal::CreateDefaultInstanceAdminStub(options), options,
       std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
 
-namespace internal {
+namespace spanner_internal {
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<internal::InstanceAdminStub> base_stub,
+    std::shared_ptr<spanner_internal::InstanceAdminStub> base_stub,
     ConnectionOptions const& options) {
   return std::make_shared<InstanceAdminConnectionImpl>(std::move(base_stub),
                                                        options);
 }
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<internal::InstanceAdminStub> base_stub,
+    std::shared_ptr<spanner_internal::InstanceAdminStub> base_stub,
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
@@ -350,7 +351,7 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
       std::move(backoff_policy), std::move(polling_policy));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -229,19 +229,19 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
 
-namespace internal {
+namespace spanner_internal {
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<internal::InstanceAdminStub> base_stub,
+    std::shared_ptr<spanner_internal::InstanceAdminStub> base_stub,
     ConnectionOptions const& options);
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<internal::InstanceAdminStub> base_stub,
+    std::shared_ptr<spanner_internal::InstanceAdminStub> base_stub,
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -50,7 +50,7 @@ std::shared_ptr<InstanceAdminConnection> MakeLimitedRetryConnection(
       /*maximum_delay=*/std::chrono::microseconds(1),
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
-  return internal::MakeInstanceAdminConnection(
+  return spanner_internal::MakeInstanceAdminConnection(
       std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
       polling.clone());
 }

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -179,9 +179,10 @@ TEST_F(DataTypeIntegrationTest, WriteReadBytes) {
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadTimestamp) {
-  auto min = internal::TimestampFromRFC3339("0001-01-01T00:00:00Z");
+  auto min = spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00Z");
   ASSERT_STATUS_OK(min);
-  auto max = internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z");
+  auto max =
+      spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z");
   ASSERT_STATUS_OK(max);
   auto now = MakeTimestamp(std::chrono::system_clock::now());
   ASSERT_STATUS_OK(now);

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -21,7 +21,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 struct SessionPoolFriendForTest {
   static future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(std::shared_ptr<SessionPool> const& session_pool,
@@ -110,7 +110,7 @@ TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/channel.h
+++ b/google/cloud/spanner/internal/channel.h
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * `Channel` represents a single gRPC Channel/Stub.
@@ -41,7 +41,7 @@ struct Channel {
   int session_count = 0;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/clock.h
+++ b/google/cloud/spanner/internal/clock.h
@@ -22,7 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * A simple `Clock` class that can be overridden for testing.
@@ -46,17 +46,17 @@ class Clock {
  * `SteadyClock` is a monotonic clock where time points cannot decrease as
  * physical time moves forward. It is not related to wall clock time.
  */
-using SteadyClock =
-    ::google::cloud::spanner::internal::Clock<std::chrono::steady_clock>;
+using SteadyClock = ::google::cloud::spanner::spanner_internal::Clock<
+    std::chrono::steady_clock>;
 
 /**
  * `SystemClock` represents the system-wide real time wall clock.
  * It may not be monotonic.
  */
-using SystemClock =
-    ::google::cloud::spanner::internal::Clock<std::chrono::system_clock>;
+using SystemClock = ::google::cloud::spanner::spanner_internal::Clock<
+    std::chrono::system_clock>;
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/clock_test.cc
+++ b/google/cloud/spanner/internal/clock_test.cc
@@ -21,7 +21,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::cloud::spanner_testing::FakeClock;
@@ -63,7 +63,7 @@ TEST(Clock, FakeClock) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -38,7 +38,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /// Return the default retry policy for `ConnectionImpl`
 std::unique_ptr<RetryPolicy> DefaultConnectionRetryPolicy();
@@ -191,7 +191,7 @@ class ConnectionImpl : public Connection {
   TracingOptions tracing_options_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_logging.cc
+++ b/google/cloud/spanner/internal/database_admin_logging.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace gcsa = ::google::spanner::admin::database::v1;
 using ::google::cloud::internal::LogWrapper;
@@ -234,7 +234,7 @@ Status DatabaseAdminLogging::CancelOperation(
       context, request, __func__, tracing_options_);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_logging.h
+++ b/google/cloud/spanner/internal/database_admin_logging.h
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * Implements the logging Decorator for DatabaseAdminStub.
@@ -143,7 +143,7 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
   TracingOptions tracing_options_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::testing::_;
@@ -337,7 +337,7 @@ TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_metadata.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace gcsa = ::google::spanner::admin::database::v1;
 
@@ -168,7 +168,7 @@ void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context,
   context.AddMetadata("x-goog-api-client", api_client_header_);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_metadata.h
+++ b/google/cloud/spanner/internal/database_admin_metadata.h
@@ -22,7 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 /**
  * Implements the metadata Decorator for DatabaseAdminStub.
  */
@@ -138,7 +138,7 @@ class DatabaseAdminMetadata : public DatabaseAdminStub {
   std::string api_client_header_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
@@ -429,7 +429,7 @@ TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace gcsa = ::google::spanner::admin::database::v1;
 
@@ -276,7 +276,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
 std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
     ConnectionOptions options) {
-  options = internal::EmulatorOverrides(std::move(options));
+  options = spanner_internal::EmulatorOverrides(std::move(options));
   auto channel =
       grpc::CreateCustomChannel(options.endpoint(), options.credentials(),
                                 options.CreateChannelArguments());
@@ -298,7 +298,7 @@ std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
   return stub;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -25,7 +25,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 /**
  * Defines the low-level interface for database administration RPCs.
  */
@@ -150,7 +150,7 @@ class DatabaseAdminStub {
 std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
     ConnectionOptions options);
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_logging.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace gcsa = ::google::spanner::admin::instance::v1;
 using ::google::cloud::internal::LogWrapper;
@@ -142,7 +142,7 @@ StatusOr<google::longrunning::Operation> InstanceAdminLogging::GetOperation(
       context, request, __func__, tracing_options_);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * Implements the logging Decorator for InstanceAdminStub.
@@ -104,7 +104,7 @@ class InstanceAdminLogging : public InstanceAdminStub {
   TracingOptions tracing_options_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::testing::_;
@@ -209,7 +209,7 @@ TEST_F(InstanceAdminLoggingTest, TestIamPermissions) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace gcsa = ::google::spanner::admin::instance::v1;
 
@@ -108,7 +108,7 @@ void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context,
   context.AddMetadata("x-goog-api-client", api_client_header_);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -22,7 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * Implements the metadata Decorator for InstanceAdminStub.
@@ -99,7 +99,7 @@ class InstanceAdminMetadata : public InstanceAdminStub {
   std::string api_client_header_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
@@ -256,7 +256,7 @@ TEST_F(InstanceAdminMetadataTest, TestIamPermissions) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace gcsa = ::google::spanner::admin::instance::v1;
 namespace giam = ::google::iam::v1;
@@ -174,7 +174,7 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
 
 std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
     ConnectionOptions options) {
-  options = internal::EmulatorOverrides(std::move(options));
+  options = spanner_internal::EmulatorOverrides(std::move(options));
   auto channel =
       grpc::CreateCustomChannel(options.endpoint(), options.credentials(),
                                 options.CreateChannelArguments());
@@ -196,7 +196,7 @@ std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
   return stub;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -25,7 +25,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * Defines the low-level interface for instance administration RPCs.
@@ -88,7 +88,7 @@ class InstanceAdminStub {
 std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
     ConnectionOptions options);
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/logging_result_set_reader.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 using ::google::cloud::internal::DebugString;
 
@@ -49,7 +49,7 @@ Status LoggingResultSetReader::Finish() {
   return status;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -25,7 +25,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 class LoggingResultSetReader : public PartialResultSetReader {
  public:
@@ -43,7 +43,7 @@ class LoggingResultSetReader : public PartialResultSetReader {
   TracingOptions tracing_options_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -25,7 +25,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::testing::Contains;
@@ -102,7 +102,7 @@ TEST_F(LoggingResultSetReaderTest, Finish) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/logging_spanner_stub.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace spanner_proto = ::google::spanner::v1;
 using ::google::cloud::internal::LogWrapper;
@@ -226,7 +226,7 @@ StatusOr<spanner_proto::PartitionResponse> LoggingSpannerStub::PartitionRead(
       client_context, request, __func__, tracing_options_);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/logging_spanner_stub.h
+++ b/google/cloud/spanner/internal/logging_spanner_stub.h
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * A SpannerStub that logs each request.
@@ -104,7 +104,7 @@ class LoggingSpannerStub : public SpannerStub {
   TracingOptions tracing_options_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::testing::_;
@@ -274,7 +274,7 @@ TEST_F(LoggingSpannerStubTest, PartitionRead) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/merge_chunk.cc
+++ b/google/cloud/spanner/internal/merge_chunk.cc
@@ -18,7 +18,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 Status MergeChunk(google::protobuf::Value& value,  // NOLINT(misc-no-recursion)
                   google::protobuf::Value&& chunk) {
@@ -74,7 +74,7 @@ Status MergeChunk(google::protobuf::Value& value,  // NOLINT(misc-no-recursion)
   return Status(StatusCode::kUnknown, "unknown Value type");
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/merge_chunk.h
+++ b/google/cloud/spanner/internal/merge_chunk.h
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * Merges @p chunk into @p value, or returns an error.
@@ -48,7 +48,7 @@ namespace internal {
 Status MergeChunk(google::protobuf::Value& value,
                   google::protobuf::Value&& chunk);
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/merge_chunk_benchmark.cc
+++ b/google/cloud/spanner/internal/merge_chunk_benchmark.cc
@@ -20,7 +20,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 //
@@ -30,7 +30,7 @@ namespace {
 
 google::protobuf::Value MakeProtoValue(Value v) {
   google::protobuf::Value value;
-  std::tie(std::ignore, value) = internal::ToProto(std::move(v));
+  std::tie(std::ignore, value) = spanner_internal::ToProto(std::move(v));
   return value;
 }
 
@@ -117,7 +117,7 @@ void BM_MergeChunkListsOfListOfString(benchmark::State& state) {
 BENCHMARK(BM_MergeChunkListsOfListOfString);
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/merge_chunk_test.cc
+++ b/google/cloud/spanner/internal/merge_chunk_test.cc
@@ -26,7 +26,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
@@ -40,7 +40,7 @@ using ::testing::Not;
 
 google::protobuf::Value MakeProtoValue(Value v) {
   google::protobuf::Value value;
-  std::tie(std::ignore, value) = internal::ToProto(std::move(v));
+  std::tie(std::ignore, value) = spanner_internal::ToProto(std::move(v));
   return value;
 }
 
@@ -222,7 +222,7 @@ TEST(MergeChunk, CannotMergeStruct) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -21,7 +21,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace spanner_proto = ::google::spanner::v1;
 
@@ -169,7 +169,7 @@ void MetadataSpannerStub::SetMetadata(grpc::ClientContext& context,
   context.AddMetadata("google-cloud-resource-prefix", resource_prefix_header_);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -22,7 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * A SpannerStub that decorates the ClientContext with the right metadata.
@@ -104,7 +104,7 @@ class MetadataSpannerStub : public SpannerStub {
   std::string resource_prefix_header_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -24,7 +24,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
@@ -261,7 +261,7 @@ TEST_F(MetadataSpannerStubTest, PartitionRead) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -27,7 +27,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * Wrap `grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>`.
@@ -46,7 +46,7 @@ class PartialResultSetReader {
   virtual Status Finish() = 0;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_resume.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 void PartialResultSetResume::TryCancel() { child_->TryCancel(); }
 
@@ -54,7 +54,7 @@ Status PartialResultSetResume::Finish() {
   return *last_status_;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -28,7 +28,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /// Create a new PartialResultSetReader given a resume token value.
 using PartialResultSetReaderFactory =
@@ -65,7 +65,7 @@ class PartialResultSetResume : public PartialResultSetReader {
   absl::optional<Status> last_status_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -29,7 +29,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
@@ -298,7 +298,7 @@ TEST(PartialResultSetResume, TooManyTransients) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -20,7 +20,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 StatusOr<std::unique_ptr<ResultSourceInterface>> PartialResultSetSource::Create(
     std::unique_ptr<PartialResultSetReader> reader) {
@@ -77,7 +77,7 @@ StatusOr<Row> PartialResultSetSource::NextRow() {
     ++iter;
   }
   buffer_.erase(buffer_.begin(), iter);
-  return internal::MakeRow(std::move(values), columns_);
+  return spanner_internal::MakeRow(std::move(values), columns_);
 }
 
 PartialResultSetSource::~PartialResultSetSource() {
@@ -180,7 +180,7 @@ Status PartialResultSetSource::ReadFromStream() {
   return {};  // OK
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -32,14 +32,14 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * This class serves as a bridge between the gRPC `PartialResultSet` streaming
  * reader and the spanner `ResultSet`, which is used to iterate over the rows
  * returned from a read operation.
  */
-class PartialResultSetSource : public internal::ResultSourceInterface {
+class PartialResultSetSource : public spanner_internal::ResultSourceInterface {
  public:
   /// Factory method to create a PartialResultSetSource.
   static StatusOr<std::unique_ptr<ResultSourceInterface>> Create(
@@ -73,7 +73,7 @@ class PartialResultSetSource : public internal::ResultSourceInterface {
   bool finished_ = false;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -30,7 +30,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
@@ -717,7 +717,7 @@ TEST(PartialResultSetSourceTest, ErrorOnIncompleteRow) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/session.cc
+++ b/google/cloud/spanner/internal/session.cc
@@ -18,7 +18,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 SessionHolder MakeDissociatedSessionHolder(std::string session_name) {
   return SessionHolder(
@@ -26,7 +26,7 @@ SessionHolder MakeDissociatedSessionHolder(std::string session_name) {
       std::default_delete<Session>());
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -28,7 +28,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * A class that represents a Session.
@@ -37,7 +37,7 @@ namespace internal {
  */
 class Session {
  public:
-  using Clock = ::google::cloud::spanner::internal::SteadyClock;
+  using Clock = ::google::cloud::spanner::spanner_internal::SteadyClock;
   Session(std::string session_name, std::shared_ptr<Channel> channel,
           std::shared_ptr<Clock> clock = std::make_shared<Clock>())
       : session_name_(std::move(session_name)),
@@ -90,7 +90,7 @@ using SessionHolder = std::shared_ptr<Session>;
  */
 SessionHolder MakeDissociatedSessionHolder(std::string session_name);
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -32,7 +32,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 namespace spanner_proto = ::google::spanner::v1;
 
@@ -488,7 +488,7 @@ Status SessionPool::HandleBatchCreateSessionsDone(
   return Status();
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -43,7 +43,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 struct SessionPoolFriendForTest;
 
 /**
@@ -206,7 +206,7 @@ std::shared_ptr<SessionPool> MakeSessionPool(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::shared_ptr<Session::Clock> clock = std::make_shared<Session::Clock>());
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -36,7 +36,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::cloud::spanner_testing::FakeSteadyClock;
@@ -463,7 +463,7 @@ TEST(SessionPool, SessionRefresh) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 namespace spanner_proto = ::google::spanner::v1;
@@ -287,7 +287,7 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(Database const& db,
                                                       ConnectionOptions options,
                                                       int channel_id) {
-  options = internal::EmulatorOverrides(std::move(options));
+  options = spanner_internal::EmulatorOverrides(std::move(options));
 
   grpc::ChannelArguments channel_arguments = options.CreateChannelArguments();
   // Newer versions of gRPC include a macro (`GRPC_ARG_CHANNEL_ID`) but use
@@ -310,7 +310,7 @@ std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(Database const& db,
   return stub;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -30,7 +30,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /**
  * SpannerStub is a thin stub layer over the Cloud Spanner API to avoid
@@ -127,7 +127,7 @@ std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(Database const& db,
                                                       ConnectionOptions options,
                                                       int channel_id);
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -22,7 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
@@ -65,7 +65,7 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/status_utils.cc
+++ b/google/cloud/spanner/internal/status_utils.cc
@@ -19,7 +19,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 bool IsSessionNotFound(google::cloud::Status const& status) {
   // "Session not found" in the status message is an API guarantee.
@@ -27,7 +27,7 @@ bool IsSessionNotFound(google::cloud::Status const& status) {
          status.message().find("Session not found") != std::string::npos;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/status_utils.h
+++ b/google/cloud/spanner/internal/status_utils.h
@@ -22,12 +22,12 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 /// Determine if `status` represents a "Session not found" error.
 bool IsSessionNotFound(google::cloud::Status const& status);
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/status_utils_test.cc
+++ b/google/cloud/spanner/internal/status_utils_test.cc
@@ -24,15 +24,15 @@ namespace {
 TEST(StatusUtils, SessionNotFound) {
   google::cloud::Status const session_not_found(StatusCode::kNotFound,
                                                 "Session not found");
-  EXPECT_TRUE(internal::IsSessionNotFound(session_not_found));
+  EXPECT_TRUE(spanner_internal::IsSessionNotFound(session_not_found));
 
   google::cloud::Status const other_not_found(StatusCode::kNotFound,
                                               "Other not found");
-  EXPECT_FALSE(internal::IsSessionNotFound(other_not_found));
+  EXPECT_FALSE(spanner_internal::IsSessionNotFound(other_not_found));
 
   google::cloud::Status const not_not_found(StatusCode::kUnavailable,
                                             "Session not found");
-  EXPECT_FALSE(internal::IsSessionNotFound(not_not_found));
+  EXPECT_FALSE(spanner_internal::IsSessionNotFound(not_not_found));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/transaction_impl.cc
+++ b/google/cloud/spanner/internal/transaction_impl.cc
@@ -18,11 +18,11 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 TransactionImpl::~TransactionImpl() = default;
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -30,7 +30,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 template <typename Functor>
 using VisitInvokeResult = ::google::cloud::internal::invoke_result_t<
@@ -140,7 +140,7 @@ class TransactionImpl {
   std::int64_t seqno_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -30,7 +30,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 namespace {
 
 using ::google::spanner::v1::TransactionSelector;
@@ -82,7 +82,7 @@ class Client {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
-      return internal::Visit(std::move(txn), std::move(read));
+      return spanner_internal::Visit(std::move(txn), std::move(read));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     } catch (char const*) {
       return {};
@@ -134,7 +134,8 @@ ResultSet Client::Read(SessionHolder& session,
     if (selector->begin().has_read_only() &&
         selector->begin().read_only().has_read_timestamp()) {
       auto const& proto = selector->begin().read_only().read_timestamp();
-      if (internal::TimestampFromProto(proto).value() == read_timestamp_ &&
+      if (spanner_internal::TimestampFromProto(proto).value() ==
+              read_timestamp_ &&
           seqno > 0) {
         std::unique_lock<std::mutex> lock(mu_);
         switch (mode_) {
@@ -153,7 +154,7 @@ ResultSet Client::Read(SessionHolder& session,
     switch (mode_) {
       case Mode::kReadSucceeds:
         // `begin` -> `id`, calls now parallelized
-        session = internal::MakeDissociatedSessionHolder(session_id_);
+        session = spanner_internal::MakeDissociatedSessionHolder(session_id_);
         selector->set_id(txn_id_);
         break;
       case Mode::kReadFailsAndTxnRemainsBegin:
@@ -251,7 +252,7 @@ TEST(InternalTransaction, ReadFailsAndTxnInvalidated) {
 }
 
 }  // namespace
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -23,7 +23,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace internal {
+namespace spanner_internal {
 
 // The implementation for `IsTuple<T>` (below).
 template <typename T>
@@ -69,7 +69,7 @@ typename std::enable_if<I == TupleSize<T>::value, void>::type ForEach(
 //     };
 //     auto tup = std::make_tuple(true, 42);
 //     std::vector<std::string> v;
-//     internal::ForEach(tup, Stringify{}, v);
+//     spanner_internal::ForEach(tup, Stringify{}, v);
 //     EXPECT_THAT(v, testing::ElementsAre("1", "42"));
 //
 template <std::size_t I = 0, typename T, typename F, typename... Args>
@@ -81,7 +81,7 @@ typename std::enable_if<(I < TupleSize<T>::value), void>::type ForEach(
                  std::forward<Args>(args)...);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -24,23 +24,23 @@ inline namespace SPANNER_CLIENT_NS {
 
 TEST(TupleUtils, IsTuple) {
   using T0 = std::tuple<>;
-  static_assert(internal::IsTuple<T0>::value, "");
-  static_assert(internal::IsTuple<T0 const>::value, "");
-  static_assert(internal::IsTuple<T0 const&>::value, "");
+  static_assert(spanner_internal::IsTuple<T0>::value, "");
+  static_assert(spanner_internal::IsTuple<T0 const>::value, "");
+  static_assert(spanner_internal::IsTuple<T0 const&>::value, "");
 
   using T1 = std::tuple<int>;
-  static_assert(internal::IsTuple<T1>::value, "");
-  static_assert(internal::IsTuple<T1 const>::value, "");
-  static_assert(internal::IsTuple<T1 const&>::value, "");
+  static_assert(spanner_internal::IsTuple<T1>::value, "");
+  static_assert(spanner_internal::IsTuple<T1 const>::value, "");
+  static_assert(spanner_internal::IsTuple<T1 const&>::value, "");
 
   using TN = std::tuple<int, bool, char>;
-  static_assert(internal::IsTuple<TN>::value, "");
-  static_assert(internal::IsTuple<TN const>::value, "");
-  static_assert(internal::IsTuple<TN const&>::value, "");
+  static_assert(spanner_internal::IsTuple<TN>::value, "");
+  static_assert(spanner_internal::IsTuple<TN const>::value, "");
+  static_assert(spanner_internal::IsTuple<TN const&>::value, "");
 
-  static_assert(!internal::IsTuple<int>::value, "");
-  static_assert(!internal::IsTuple<char>::value, "");
-  static_assert(!internal::IsTuple<std::vector<int>>::value, "");
+  static_assert(!spanner_internal::IsTuple<int>::value, "");
+  static_assert(!spanner_internal::IsTuple<char>::value, "");
+  static_assert(!spanner_internal::IsTuple<std::vector<int>>::value, "");
 }
 
 // Helper functor used to test the `ForEach` function. Uses a templated
@@ -55,14 +55,14 @@ struct Stringify {
 TEST(TupleUtils, ForEachMultipleTypes) {
   auto tup = std::make_tuple(true, 42);
   std::vector<std::string> v;
-  internal::ForEach(tup, Stringify{}, v);
+  spanner_internal::ForEach(tup, Stringify{}, v);
   EXPECT_THAT(v, testing::ElementsAre("1", "42"));
 }
 
 TEST(TupleUtils, ForEachMutate) {
   auto add_one = [](int& x) { x += 1; };
   auto tup = std::make_tuple(1, 2, 3);
-  internal::ForEach(tup, add_one);
+  spanner_internal::ForEach(tup, add_one);
   EXPECT_EQ(tup, std::make_tuple(2, 3, 4));
 }
 

--- a/google/cloud/spanner/keys.cc
+++ b/google/cloud/spanner/keys.cc
@@ -26,12 +26,12 @@ namespace {
 // Appends the values in the given `key` to the `lv` proto.
 void AppendKey(google::protobuf::ListValue& lv, Key&& key) {
   for (auto& v : key) {
-    *lv.add_values() = internal::ToProto(std::move(v)).second;
+    *lv.add_values() = spanner_internal::ToProto(std::move(v)).second;
   }
 }
 }  // namespace
 
-namespace internal {
+namespace spanner_internal {
 
 ::google::spanner::v1::KeySet ToProto(KeySet ks) {
   return std::move(ks.proto_);
@@ -41,7 +41,7 @@ KeySet FromProto(::google::spanner::v1::KeySet proto) {
   return KeySet(std::move(proto));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 bool operator==(KeyBound const& a, KeyBound const& b) {
   return a.key_ == b.key_ && a.bound_ == b.bound_;

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -133,10 +133,10 @@ KeyBound MakeKeyBoundOpen(Ts&&... ts) {
 }
 
 class KeySet;
-namespace internal {
+namespace spanner_internal {
 ::google::spanner::v1::KeySet ToProto(KeySet);
 KeySet FromProto(::google::spanner::v1::KeySet);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * The `KeySet` class is a regular type that represents a collection of `Key`s.
@@ -201,8 +201,8 @@ class KeySet {
   ///@}
 
  private:
-  friend ::google::spanner::v1::KeySet internal::ToProto(KeySet);
-  friend KeySet internal::FromProto(::google::spanner::v1::KeySet);
+  friend ::google::spanner::v1::KeySet spanner_internal::ToProto(KeySet);
+  friend KeySet spanner_internal::FromProto(::google::spanner::v1::KeySet);
   explicit KeySet(google::spanner::v1::KeySet proto)
       : proto_(std::move(proto)) {}
 

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -122,9 +122,9 @@ TEST(KeySetTest, NoKeys) {
   ::google::spanner::v1::KeySet expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString("", &expected));
   KeySet no_keys;
-  ::google::spanner::v1::KeySet result = internal::ToProto(no_keys);
+  ::google::spanner::v1::KeySet result = spanner_internal::ToProto(no_keys);
   EXPECT_THAT(result, IsProtoEqual(expected));
-  EXPECT_EQ(internal::FromProto(expected), no_keys);
+  EXPECT_EQ(spanner_internal::FromProto(expected), no_keys);
 }
 
 TEST(KeySetTest, AllKeys) {
@@ -134,9 +134,9 @@ TEST(KeySetTest, AllKeys) {
   ::google::spanner::v1::KeySet expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &expected));
   auto all_keys = KeySet::All();
-  ::google::spanner::v1::KeySet result = internal::ToProto(all_keys);
+  ::google::spanner::v1::KeySet result = spanner_internal::ToProto(all_keys);
   EXPECT_THAT(result, IsProtoEqual(expected));
-  EXPECT_EQ(internal::FromProto(expected), all_keys);
+  EXPECT_EQ(spanner_internal::FromProto(expected), all_keys);
 }
 
 TEST(KeySetTest, EqualityEmpty) {
@@ -210,7 +210,7 @@ TEST(KeySetTest, RoundTripProtos) {
   };
 
   for (auto const& tc : test_cases) {
-    EXPECT_EQ(tc, internal::FromProto(internal::ToProto(tc)));
+    EXPECT_EQ(tc, spanner_internal::FromProto(spanner_internal::ToProto(tc)));
   }
 }
 

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -64,7 +64,8 @@ class MockConnection : public spanner::Connection {
  *
  * @see @ref spanner-mocking for an example using this class.
  */
-class MockResultSetSource : public spanner_internal::ResultSourceInterface {
+class MockResultSetSource
+    : public spanner::spanner_internal::ResultSourceInterface {
  public:
   MOCK_METHOD0(NextRow, StatusOr<spanner::Row>());
   MOCK_METHOD0(Metadata,

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -64,7 +64,7 @@ class MockConnection : public spanner::Connection {
  *
  * @see @ref spanner-mocking for an example using this class.
  */
-class MockResultSetSource : public spanner::internal::ResultSourceInterface {
+class MockResultSetSource : public spanner_internal::ResultSourceInterface {
  public:
   MOCK_METHOD0(NextRow, StatusOr<spanner::Row>());
   MOCK_METHOD0(Metadata,

--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -26,11 +26,11 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-namespace internal {
+namespace spanner_internal {
 template <typename Op>
 class WriteMutationBuilder;
 class DeleteMutationBuilder;
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * A wrapper for Cloud Spanner mutations.
@@ -82,8 +82,8 @@ class Mutation {
   google::spanner::v1::Mutation& proto() & { return m_; }
 
   template <typename Op>
-  friend class internal::WriteMutationBuilder;
-  friend class internal::DeleteMutationBuilder;
+  friend class spanner_internal::WriteMutationBuilder;
+  friend class spanner_internal::DeleteMutationBuilder;
   explicit Mutation(google::spanner::v1::Mutation m) : m_(std::move(m)) {}
 
   google::spanner::v1::Mutation m_;
@@ -97,7 +97,7 @@ using Mutations = std::vector<Mutation>;
 
 // This namespace contains implementation details. It is not part of the public
 // API, and subject to change without notice.
-namespace internal {
+namespace spanner_internal {
 
 template <typename Op>
 class WriteMutationBuilder {
@@ -118,7 +118,8 @@ class WriteMutationBuilder {
   WriteMutationBuilder& AddRow(std::vector<Value> values) & {
     auto& lv = *Op::mutable_field(m_.proto()).add_values();
     for (auto& v : values) {
-      std::tie(std::ignore, *lv.add_values()) = internal::ToProto(std::move(v));
+      std::tie(std::ignore, *lv.add_values()) =
+          spanner_internal::ToProto(std::move(v));
     }
     return *this;
   }
@@ -174,7 +175,7 @@ class DeleteMutationBuilder {
   DeleteMutationBuilder(std::string table_name, KeySet keys) {
     auto& field = *m_.proto().mutable_delete_();
     field.set_table(std::move(table_name));
-    *field.mutable_key_set() = internal::ToProto(std::move(keys));
+    *field.mutable_key_set() = spanner_internal::ToProto(std::move(keys));
   }
 
   Mutation Build() const& { return m_; }
@@ -184,7 +185,7 @@ class DeleteMutationBuilder {
   Mutation m_;
 };
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * A helper class to construct "insert" mutations.
@@ -199,7 +200,7 @@ class DeleteMutationBuilder {
  *   for more information about the Cloud Spanner mutation API.
  */
 using InsertMutationBuilder =
-    internal::WriteMutationBuilder<internal::InsertOp>;
+    spanner_internal::WriteMutationBuilder<spanner_internal::InsertOp>;
 
 /**
  * Creates a simple insert mutation for the values in @p values.
@@ -234,7 +235,7 @@ Mutation MakeInsertMutation(std::string table_name,
  *   for more information about the Cloud Spanner mutation API.
  */
 using UpdateMutationBuilder =
-    internal::WriteMutationBuilder<internal::UpdateOp>;
+    spanner_internal::WriteMutationBuilder<spanner_internal::UpdateOp>;
 
 /**
  * Creates a simple update mutation for the values in @p values.
@@ -269,7 +270,7 @@ Mutation MakeUpdateMutation(std::string table_name,
  *   for more information about the Cloud Spanner mutation API.
  */
 using InsertOrUpdateMutationBuilder =
-    internal::WriteMutationBuilder<internal::InsertOrUpdateOp>;
+    spanner_internal::WriteMutationBuilder<spanner_internal::InsertOrUpdateOp>;
 
 /**
  * Creates a simple "insert or update" mutation for the values in @p values.
@@ -306,7 +307,7 @@ Mutation MakeInsertOrUpdateMutation(std::string table_name,
  *   for more information about the Cloud Spanner mutation API.
  */
 using ReplaceMutationBuilder =
-    internal::WriteMutationBuilder<internal::ReplaceOp>;
+    spanner_internal::WriteMutationBuilder<spanner_internal::ReplaceOp>;
 
 /**
  * Creates a simple "replace" mutation for the values in @p values.
@@ -340,7 +341,7 @@ Mutation MakeReplaceMutation(std::string table_name,
  * @see https://cloud.google.com/spanner/docs/modify-mutation-api
  *   for more information about the Cloud Spanner mutation API.
  */
-using DeleteMutationBuilder = internal::DeleteMutationBuilder;
+using DeleteMutationBuilder = spanner_internal::DeleteMutationBuilder;
 
 /**
  * Creates a simple "delete" mutation for the values in @p keys.

--- a/google/cloud/spanner/numeric.cc
+++ b/google/cloud/spanner/numeric.cc
@@ -105,7 +105,7 @@ void Round(std::deque<char>& int_rep, std::deque<char>& frac_rep,
 
 }  // namespace
 
-namespace internal {
+namespace spanner_internal {
 
 std::string ToString(absl::int128 value) {
   std::ostringstream ss;
@@ -231,7 +231,7 @@ StatusOr<Numeric> MakeNumeric(std::string s, int exponent) {
   return MakeNumeric(std::move(s));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 constexpr std::size_t Numeric::kIntPrec;
 constexpr std::size_t Numeric::kFracPrec;
@@ -239,7 +239,7 @@ constexpr std::size_t Numeric::kFracPrec;
 Numeric::Numeric() : rep_("0") {}
 
 StatusOr<Numeric> MakeNumeric(std::string s) {
-  return internal::MakeNumeric(std::move(s));
+  return spanner_internal::MakeNumeric(std::move(s));
 }
 
 StatusOr<Numeric> MakeNumeric(double d) {
@@ -248,7 +248,7 @@ StatusOr<Numeric> MakeNumeric(double d) {
   ss << std::setprecision(std::numeric_limits<double>::digits10 + 1) << d;
   std::string s = std::move(ss).str();
   if (!std::isfinite(d)) return OutOfRange(std::move(s));
-  return internal::MakeNumeric(std::move(s));
+  return spanner_internal::MakeNumeric(std::move(s));
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/numeric.h
+++ b/google/cloud/spanner/numeric.h
@@ -35,9 +35,9 @@ inline namespace SPANNER_CLIENT_NS {
 class Numeric;  // defined below
 
 // Internal forward declarations to befriend.
-namespace internal {
+namespace spanner_internal {
 StatusOr<Numeric> MakeNumeric(std::string s);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * A representation of the Spanner NUMERIC type: an exact numeric value with
@@ -113,12 +113,12 @@ class Numeric {
   }
 
  private:
-  friend StatusOr<Numeric> internal::MakeNumeric(std::string s);
+  friend StatusOr<Numeric> spanner_internal::MakeNumeric(std::string s);
   explicit Numeric(std::string rep) : rep_(std::move(rep)) {}
   std::string rep_;  // a valid and canonical NUMERIC representation
 };
 
-namespace internal {
+namespace spanner_internal {
 
 // Like `std::to_string`, but also supports Abseil 128-bit integers.
 template <typename T>
@@ -132,7 +132,7 @@ std::string ToString(absl::uint128 value);
 Status DataLoss(std::string message);
 StatusOr<Numeric> MakeNumeric(std::string s, int exponent);
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * Construction from a string, in decimal fixed- or floating-point formats.
@@ -168,7 +168,7 @@ StatusOr<Numeric> MakeNumeric(double d);
 template <typename T, typename std::enable_if<
                           std::numeric_limits<T>::is_integer, int>::type = 0>
 StatusOr<Numeric> MakeNumeric(T i, int exponent = 0) {
-  return internal::MakeNumeric(internal::ToString(i), exponent);
+  return spanner_internal::MakeNumeric(spanner_internal::ToString(i), exponent);
 }
 
 /**
@@ -205,7 +205,7 @@ StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
     Numeric const& n, int exponent = 0) {
   std::string const& rep = n.ToString();
   if (exponent != 0) {
-    auto const en = internal::MakeNumeric(rep, exponent);
+    auto const en = spanner_internal::MakeNumeric(rep, exponent);
     return en ? ToInteger<T>(*en, 0) : en.status();
   }
   T v = 0;
@@ -216,19 +216,19 @@ StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
     auto const* dp = std::strchr(kDigits, ch);
     if (state == kFracPart) {
       if (dp - kDigits >= 5) {  // dp != nullptr
-        if (v == kMax) return internal::DataLoss(rep);
+        if (v == kMax) return spanner_internal::DataLoss(rep);
         v = static_cast<T>(v + 1);
       }
       break;
     }
     if (dp == nullptr) {
-      if (ch == '-') return internal::DataLoss(rep);
+      if (ch == '-') return spanner_internal::DataLoss(rep);
       state = kFracPart;  // ch == '.'
     } else {
-      if (v > kMax / 10) return internal::DataLoss(rep);
+      if (v > kMax / 10) return spanner_internal::DataLoss(rep);
       v = static_cast<T>(v * 10);
       auto d = static_cast<T>(dp - kDigits);
-      if (v > kMax - d) return internal::DataLoss(rep);
+      if (v > kMax - d) return spanner_internal::DataLoss(rep);
       v = static_cast<T>(v + d);
     }
   }
@@ -243,7 +243,7 @@ StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
     Numeric const& n, int exponent = 0) {
   std::string const& rep = n.ToString();
   if (exponent != 0) {
-    auto const en = internal::MakeNumeric(rep, exponent);
+    auto const en = spanner_internal::MakeNumeric(rep, exponent);
     return en ? ToInteger<T>(*en, 0) : en.status();
   }
   T v = 0;
@@ -255,7 +255,7 @@ StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
     auto const* dp = std::strchr(kDigits, ch);
     if (state == kFracPart) {
       if (dp - kDigits >= 5) {  // dp != nullptr
-        if (v == kMin) return internal::DataLoss(rep);
+        if (v == kMin) return spanner_internal::DataLoss(rep);
         v = static_cast<T>(v - 1);
       }
       break;
@@ -267,16 +267,16 @@ StatusOr<T> ToInteger(  // NOLINT(misc-no-recursion)
         state = kFracPart;  // ch == '.'
       }
     } else {
-      if (v < kMin / 10) return internal::DataLoss(rep);
+      if (v < kMin / 10) return spanner_internal::DataLoss(rep);
       v = static_cast<T>(v * 10);
       auto d = static_cast<T>(dp - kDigits);
-      if (v < kMin + d) return internal::DataLoss(rep);
+      if (v < kMin + d) return spanner_internal::DataLoss(rep);
       v = static_cast<T>(v - d);
     }
   }
   if (!negate) return v;
   constexpr auto kMax = (std::numeric_limits<T>::max)();
-  if (kMin != -kMax && v == kMin) return internal::DataLoss(rep);
+  if (kMin != -kMax && v == kMin) return spanner_internal::DataLoss(rep);
   return static_cast<T>(-v);
 }
 ///@}

--- a/google/cloud/spanner/partition_options.cc
+++ b/google/cloud/spanner/partition_options.cc
@@ -19,7 +19,7 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-namespace internal {
+namespace spanner_internal {
 
 google::spanner::v1::PartitionOptions ToProto(PartitionOptions const& po) {
   google::spanner::v1::PartitionOptions proto;
@@ -30,7 +30,7 @@ google::spanner::v1::PartitionOptions ToProto(PartitionOptions const& po) {
   return proto;
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/partition_options.h
+++ b/google/cloud/spanner/partition_options.h
@@ -63,9 +63,9 @@ inline bool operator!=(PartitionOptions const& a, PartitionOptions const& b) {
   return !(a == b);
 }
 
-namespace internal {
+namespace spanner_internal {
 google::spanner::v1::PartitionOptions ToProto(PartitionOptions const&);
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/partition_options_test.cc
+++ b/google/cloud/spanner/partition_options_test.cc
@@ -42,7 +42,7 @@ TEST(PartitionOptionsTest, Regular) {
 
 TEST(PartitionOptionsTest, Proto) {
   PartitionOptions po{1, 2};
-  auto proto = internal::ToProto(po);
+  auto proto = spanner_internal::ToProto(po);
   EXPECT_EQ(*po.partition_size_bytes, proto.partition_size_bytes());
   EXPECT_EQ(*po.max_partitions, proto.max_partitions());
 }

--- a/google/cloud/spanner/query_partition.cc
+++ b/google/cloud/spanner/query_partition.cc
@@ -46,7 +46,7 @@ StatusOr<std::string> SerializeQueryPartition(
 
   for (auto const& param : query_partition.sql_statement_.params()) {
     auto const& param_name = param.first;
-    auto const& type_value = internal::ToProto(param.second);
+    auto const& type_value = spanner_internal::ToProto(param.second);
     (*proto.mutable_params()->mutable_fields())[param_name] = type_value.second;
     (*proto.mutable_param_types())[param_name] = type_value.first;
   }
@@ -76,7 +76,7 @@ StatusOr<QueryPartition> DeserializeQueryPartition(
         auto const& param_type = iter->second;
         sql_parameters.insert(std::make_pair(
             param_name,
-            internal::FromProto(param_type, std::move(param.second))));
+            spanner_internal::FromProto(param_type, std::move(param.second))));
       }
     }
   }
@@ -87,7 +87,7 @@ StatusOr<QueryPartition> DeserializeQueryPartition(
   return query_partition;
 }
 
-namespace internal {
+namespace spanner_internal {
 QueryPartition MakeQueryPartition(std::string const& transaction_id,
                                   std::string const& session_id,
                                   std::string const& partition_token,
@@ -97,13 +97,13 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
 }
 
 Connection::SqlParams MakeSqlParams(QueryPartition const& query_partition) {
-  return {internal::MakeTransactionFromIds(query_partition.session_id(),
-                                           query_partition.transaction_id()),
+  return {spanner_internal::MakeTransactionFromIds(
+              query_partition.session_id(), query_partition.transaction_id()),
           query_partition.sql_statement(), QueryOptions{},
           query_partition.partition_token()};
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -72,13 +72,13 @@ StatusOr<QueryPartition> DeserializeQueryPartition(
     std::string const& serialized_query_partition);
 
 // Internal implementation details that callers should not use.
-namespace internal {
+namespace spanner_internal {
 QueryPartition MakeQueryPartition(std::string const& transaction_id,
                                   std::string const& session_id,
                                   std::string const& partition_token,
                                   SqlStatement const& sql_statement);
 Connection::SqlParams MakeSqlParams(QueryPartition const& query_partition);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * The `QueryPartition` class is a regular type that represents a single slice
@@ -119,10 +119,10 @@ class QueryPartition {
 
  private:
   friend class QueryPartitionTester;
-  friend QueryPartition internal::MakeQueryPartition(
+  friend QueryPartition spanner_internal::MakeQueryPartition(
       std::string const& transaction_id, std::string const& session_id,
       std::string const& partition_token, SqlStatement const& sql_statement);
-  friend Connection::SqlParams internal::MakeSqlParams(
+  friend Connection::SqlParams spanner_internal::MakeSqlParams(
       QueryPartition const& query_partition);
   friend StatusOr<std::string> SerializeQueryPartition(
       QueryPartition const& query_partition);

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -53,7 +53,7 @@ TEST(QueryPartitionTest, MakeQueryPartition) {
   std::string session_id("session");
   std::string transaction_id("foo");
 
-  QueryPartitionTester actual_partition(internal::MakeQueryPartition(
+  QueryPartitionTester actual_partition(spanner_internal::MakeQueryPartition(
       transaction_id, session_id, partition_token, SqlStatement(stmt, params)));
   EXPECT_EQ(stmt, actual_partition.Statement().sql());
   EXPECT_EQ(params, actual_partition.Statement().params());
@@ -69,7 +69,7 @@ TEST(QueryPartitionTest, Constructor) {
   std::string session_id("session");
   std::string transaction_id("foo");
 
-  QueryPartitionTester actual_partition(internal::MakeQueryPartition(
+  QueryPartitionTester actual_partition(spanner_internal::MakeQueryPartition(
       transaction_id, session_id, partition_token, SqlStatement(stmt, params)));
   EXPECT_EQ(stmt, actual_partition.Statement().sql());
   EXPECT_EQ(params, actual_partition.Statement().params());
@@ -85,7 +85,7 @@ TEST(QueryPartitionTester, RegularSemantics) {
   std::string session_id("session");
   std::string transaction_id("foo");
 
-  QueryPartition query_partition(internal::MakeQueryPartition(
+  QueryPartition query_partition(spanner_internal::MakeQueryPartition(
       transaction_id, session_id, partition_token, SqlStatement(stmt, params)));
 
   EXPECT_NE(query_partition, QueryPartition());
@@ -102,7 +102,7 @@ TEST(QueryPartitionTester, RegularSemantics) {
 }
 
 TEST(QueryPartitionTest, SerializeDeserialize) {
-  QueryPartitionTester expected_partition(internal::MakeQueryPartition(
+  QueryPartitionTester expected_partition(spanner_internal::MakeQueryPartition(
       "foo", "session", "token",
       SqlStatement("select * from foo where name = @name",
                    {{"name", Value("Bob")}})));
@@ -130,13 +130,13 @@ TEST(QueryPartitionTest, FailedDeserialize) {
 }
 
 TEST(QueryPartitionTest, MakeSqlParams) {
-  QueryPartitionTester expected_partition(internal::MakeQueryPartition(
+  QueryPartitionTester expected_partition(spanner_internal::MakeQueryPartition(
       "foo", "session", "token",
       SqlStatement("select * from foo where name = @name",
                    {{"name", Value("Bob")}})));
 
   Connection::SqlParams params =
-      internal::MakeSqlParams(expected_partition.Partition());
+      spanner_internal::MakeSqlParams(expected_partition.Partition());
 
   EXPECT_EQ(params.statement,
             SqlStatement("select * from foo where name = @name",

--- a/google/cloud/spanner/read_partition.cc
+++ b/google/cloud/spanner/read_partition.cc
@@ -33,7 +33,7 @@ ReadPartition::ReadPartition(std::string transaction_id, std::string session_id,
   for (auto& column : column_names) {
     *proto_.mutable_columns()->Add() = std::move(column);
   }
-  *proto_.mutable_key_set() = internal::ToProto(std::move(key_set));
+  *proto_.mutable_key_set() = spanner_internal::ToProto(std::move(key_set));
   proto_.set_limit(read_options.limit);
   proto_.set_partition_token(std::move(partition_token));
 }
@@ -67,7 +67,7 @@ StatusOr<ReadPartition> DeserializeReadPartition(
   return ReadPartition(std::move(proto));
 }
 
-namespace internal {
+namespace spanner_internal {
 ReadPartition MakeReadPartition(std::string transaction_id,
                                 std::string session_id,
                                 std::string partition_token,
@@ -91,7 +91,7 @@ Connection::ReadParams MakeReadParams(ReadPartition const& read_partition) {
       read_partition.PartitionToken()};
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -73,7 +73,7 @@ StatusOr<ReadPartition> DeserializeReadPartition(
     std::string const& serialized_read_partition);
 
 // Internal implementation details that callers should not use.
-namespace internal {
+namespace spanner_internal {
 ReadPartition MakeReadPartition(std::string transaction_id,
                                 std::string session_id,
                                 std::string partition_token,
@@ -81,7 +81,7 @@ ReadPartition MakeReadPartition(std::string transaction_id,
                                 std::vector<std::string> column_names,
                                 ReadOptions read_options = {});
 Connection::ReadParams MakeReadParams(ReadPartition const& read_partition);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * The `ReadPartition` class is a regular type that represents a single
@@ -127,12 +127,12 @@ class ReadPartition {
 
  private:
   friend class ReadPartitionTester;
-  friend ReadPartition internal::MakeReadPartition(
+  friend ReadPartition spanner_internal::MakeReadPartition(
       std::string transaction_id, std::string session_id,
       std::string partition_token, std::string table_name, KeySet key_set,
       std::vector<std::string> column_names,
       google::cloud::spanner::ReadOptions read_options);
-  friend Connection::ReadParams internal::MakeReadParams(
+  friend Connection::ReadParams spanner_internal::MakeReadParams(
       ReadPartition const& read_partition);
   friend StatusOr<std::string> SerializeReadPartition(
       ReadPartition const& read_partition);

--- a/google/cloud/spanner/read_partition_test.cc
+++ b/google/cloud/spanner/read_partition_test.cc
@@ -57,16 +57,16 @@ TEST(ReadPartitionTest, MakeReadPartition) {
   std::string table_name("Students");
   std::vector<std::string> column_names = {"LastName", "FirstName"};
 
-  ReadPartitionTester actual_partition(
-      internal::MakeReadPartition(transaction_id, session_id, partition_token,
-                                  table_name, KeySet::All(), column_names));
+  ReadPartitionTester actual_partition(spanner_internal::MakeReadPartition(
+      transaction_id, session_id, partition_token, table_name, KeySet::All(),
+      column_names));
 
   EXPECT_EQ(partition_token, actual_partition.PartitionToken());
   EXPECT_EQ(transaction_id, actual_partition.TransactionId());
   EXPECT_EQ(session_id, actual_partition.SessionId());
   EXPECT_EQ(table_name, actual_partition.TableName());
   EXPECT_THAT(actual_partition.KeySet(),
-              IsProtoEqual(internal::ToProto(KeySet::All())));
+              IsProtoEqual(spanner_internal::ToProto(KeySet::All())));
   EXPECT_EQ(column_names, actual_partition.ColumnNames());
 }
 
@@ -80,7 +80,7 @@ TEST(ReadPartitionTest, Constructor) {
   read_options.index_name = "secondary";
   read_options.limit = 42;
 
-  ReadPartitionTester actual_partition(internal::MakeReadPartition(
+  ReadPartitionTester actual_partition(spanner_internal::MakeReadPartition(
       transaction_id, session_id, partition_token, table_name, KeySet::All(),
       column_names, read_options));
   EXPECT_EQ(partition_token, actual_partition.PartitionToken());
@@ -88,7 +88,7 @@ TEST(ReadPartitionTest, Constructor) {
   EXPECT_EQ(session_id, actual_partition.SessionId());
   EXPECT_EQ(table_name, actual_partition.TableName());
   EXPECT_THAT(actual_partition.KeySet(),
-              IsProtoEqual(internal::ToProto(KeySet::All())));
+              IsProtoEqual(spanner_internal::ToProto(KeySet::All())));
   EXPECT_EQ(column_names, actual_partition.ColumnNames());
   EXPECT_EQ(read_options, actual_partition.ReadOptions());
 }
@@ -103,7 +103,7 @@ TEST(ReadPartitionTest, RegularSemantics) {
   read_options.index_name = "secondary";
   read_options.limit = 42;
 
-  ReadPartition read_partition(internal::MakeReadPartition(
+  ReadPartition read_partition(spanner_internal::MakeReadPartition(
       transaction_id, session_id, partition_token, table_name, KeySet::All(),
       column_names, read_options));
 
@@ -121,7 +121,7 @@ TEST(ReadPartitionTest, RegularSemantics) {
 }
 
 TEST(ReadPartitionTest, SerializeDeserialize) {
-  ReadPartitionTester expected_partition(internal::MakeReadPartition(
+  ReadPartitionTester expected_partition(spanner_internal::MakeReadPartition(
       "foo", "session", "token", "Students", KeySet::All(),
       std::vector<std::string>{"LastName", "FirstName"}));
 
@@ -151,11 +151,11 @@ TEST(ReadPartitionTest, FailedDeserialize) {
 
 TEST(ReadPartitionTest, MakeReadParams) {
   std::vector<std::string> columns = {"LastName", "FirstName"};
-  ReadPartitionTester expected_partition(internal::MakeReadPartition(
+  ReadPartitionTester expected_partition(spanner_internal::MakeReadPartition(
       "foo", "session", "token", "Students", KeySet::All(), columns));
 
   Connection::ReadParams params =
-      internal::MakeReadParams(expected_partition.Partition());
+      spanner_internal::MakeReadParams(expected_partition.Partition());
 
   EXPECT_EQ(*params.partition_token, "token");
   EXPECT_EQ(params.keys, KeySet::All());

--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -26,25 +26,25 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 absl::optional<Timestamp> GetReadTimestamp(
-    std::unique_ptr<internal::ResultSourceInterface> const& source) {
+    std::unique_ptr<spanner_internal::ResultSourceInterface> const& source) {
   auto metadata = source->Metadata();
   absl::optional<Timestamp> timestamp;
   if (metadata.has_value() && metadata->has_transaction() &&
       metadata->transaction().has_read_timestamp()) {
-    auto ts =
-        internal::TimestampFromProto(metadata->transaction().read_timestamp());
+    auto ts = spanner_internal::TimestampFromProto(
+        metadata->transaction().read_timestamp());
     if (ts) timestamp = *std::move(ts);
   }
   return timestamp;
 }
 
 std::int64_t GetRowsModified(
-    std::unique_ptr<internal::ResultSourceInterface> const& source) {
+    std::unique_ptr<spanner_internal::ResultSourceInterface> const& source) {
   return source->Stats()->row_count_exact();
 }
 
 absl::optional<std::unordered_map<std::string, std::string>> GetExecutionStats(
-    std::unique_ptr<internal::ResultSourceInterface> const& source) {
+    std::unique_ptr<spanner_internal::ResultSourceInterface> const& source) {
   auto stats = source->Stats();
   if (stats && stats->has_query_stats()) {
     std::unordered_map<std::string, std::string> execution_stats;
@@ -58,7 +58,7 @@ absl::optional<std::unordered_map<std::string, std::string>> GetExecutionStats(
 }
 
 absl::optional<spanner::ExecutionPlan> GetExecutionPlan(
-    std::unique_ptr<internal::ResultSourceInterface> const& source) {
+    std::unique_ptr<spanner_internal::ResultSourceInterface> const& source) {
   auto stats = source->Stats();
   if (stats && stats->has_query_plan()) {
     return source->Stats()->query_plan();

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -41,7 +41,7 @@ inline namespace SPANNER_CLIENT_NS {
  */
 using ExecutionPlan = ::google::spanner::v1::QueryPlan;
 
-namespace internal {
+namespace spanner_internal {
 class ResultSourceInterface {
  public:
   virtual ~ResultSourceInterface() = default;
@@ -50,7 +50,7 @@ class ResultSourceInterface {
   virtual absl::optional<google::spanner::v1::ResultSetMetadata> Metadata() = 0;
   virtual absl::optional<google::spanner::v1::ResultSetStats> Stats() const = 0;
 };
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * Represents the stream of `Rows` returned from `spanner::Client::Read()` or
@@ -70,7 +70,8 @@ class ResultSourceInterface {
 class RowStream {
  public:
   RowStream() = default;
-  explicit RowStream(std::unique_ptr<internal::ResultSourceInterface> source)
+  explicit RowStream(
+      std::unique_ptr<spanner_internal::ResultSourceInterface> source)
       : source_(std::move(source)) {}
 
   // This class is movable but not copyable.
@@ -94,7 +95,7 @@ class RowStream {
   absl::optional<Timestamp> ReadTimestamp() const;
 
  private:
-  std::unique_ptr<internal::ResultSourceInterface> source_;
+  std::unique_ptr<spanner_internal::ResultSourceInterface> source_;
 };
 
 /**
@@ -112,7 +113,8 @@ class RowStream {
 class DmlResult {
  public:
   DmlResult() = default;
-  explicit DmlResult(std::unique_ptr<internal::ResultSourceInterface> source)
+  explicit DmlResult(
+      std::unique_ptr<spanner_internal::ResultSourceInterface> source)
       : source_(std::move(source)) {}
 
   // This class is movable but not copyable.
@@ -128,7 +130,7 @@ class DmlResult {
   std::int64_t RowsModified() const;
 
  private:
-  std::unique_ptr<internal::ResultSourceInterface> source_;
+  std::unique_ptr<spanner_internal::ResultSourceInterface> source_;
 };
 
 /**
@@ -153,7 +155,7 @@ class ProfileQueryResult {
  public:
   ProfileQueryResult() = default;
   explicit ProfileQueryResult(
-      std::unique_ptr<internal::ResultSourceInterface> source)
+      std::unique_ptr<spanner_internal::ResultSourceInterface> source)
       : source_(std::move(source)) {}
 
   // This class is movable but not copyable.
@@ -192,7 +194,7 @@ class ProfileQueryResult {
   absl::optional<spanner::ExecutionPlan> ExecutionPlan() const;
 
  private:
-  std::unique_ptr<internal::ResultSourceInterface> source_;
+  std::unique_ptr<spanner_internal::ResultSourceInterface> source_;
 };
 
 /**
@@ -212,7 +214,7 @@ class ProfileDmlResult {
  public:
   ProfileDmlResult() = default;
   explicit ProfileDmlResult(
-      std::unique_ptr<internal::ResultSourceInterface> source)
+      std::unique_ptr<spanner_internal::ResultSourceInterface> source)
       : source_(std::move(source)) {}
 
   // This class is movable but not copyable.
@@ -242,7 +244,7 @@ class ProfileDmlResult {
   absl::optional<spanner::ExecutionPlan> ExecutionPlan() const;
 
  private:
-  std::unique_ptr<internal::ResultSourceInterface> source_;
+  std::unique_ptr<spanner_internal::ResultSourceInterface> source_;
 };
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -144,7 +144,7 @@ TEST(RowStream, TimestampPresent) {
   transaction_with_timestamp.mutable_transaction()->set_id("dummy2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
-      internal::TimestampToProto(timestamp);
+      spanner_internal::TimestampToProto(timestamp);
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_with_timestamp));
 
@@ -158,7 +158,7 @@ TEST(ProfileQueryResult, TimestampPresent) {
   transaction_with_timestamp.mutable_transaction()->set_id("dummy2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
-      internal::TimestampToProto(timestamp);
+      spanner_internal::TimestampToProto(timestamp);
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_with_timestamp));
 

--- a/google/cloud/spanner/retry_policy.h
+++ b/google/cloud/spanner/retry_policy.h
@@ -26,7 +26,7 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-namespace internal {
+namespace spanner_internal {
 /// Define the gRPC status code semantics for retrying requests.
 struct SafeGrpcRetry {
   static inline bool IsOk(google::cloud::Status const& status) {
@@ -68,34 +68,34 @@ struct SafeTransactionRerun {
     return !IsOk(status) && !IsTransientFailure(status);
   }
 };
-}  // namespace internal
+}  // namespace spanner_internal
 
 /// The base class for retry policies.
-using RetryPolicy =
-    google::cloud::internal::TraitBasedRetryPolicy<internal::SafeGrpcRetry>;
+using RetryPolicy = google::cloud::internal::TraitBasedRetryPolicy<
+    spanner_internal::SafeGrpcRetry>;
 
 /// A retry policy that limits based on time.
-using LimitedTimeRetryPolicy =
-    google::cloud::internal::LimitedTimeRetryPolicy<internal::SafeGrpcRetry>;
+using LimitedTimeRetryPolicy = google::cloud::internal::LimitedTimeRetryPolicy<
+    spanner_internal::SafeGrpcRetry>;
 
 /// A retry policy that limits the number of times a request can fail.
 using LimitedErrorCountRetryPolicy =
     google::cloud::internal::LimitedErrorCountRetryPolicy<
-        internal::SafeGrpcRetry>;
+        spanner_internal::SafeGrpcRetry>;
 
 /// The base class for transaction rerun policies.
 using TransactionRerunPolicy = google::cloud::internal::TraitBasedRetryPolicy<
-    internal::SafeTransactionRerun>;
+    spanner_internal::SafeTransactionRerun>;
 
 /// A transaction rerun policy that limits the duration of the rerun loop.
 using LimitedTimeTransactionRerunPolicy =
     google::cloud::internal::LimitedTimeRetryPolicy<
-        internal::SafeTransactionRerun>;
+        spanner_internal::SafeTransactionRerun>;
 
 /// A transaction rerun policy that limits the number of failures.
 using LimitedErrorCountTransactionRerunPolicy =
     google::cloud::internal::LimitedErrorCountRetryPolicy<
-        internal::SafeTransactionRerun>;
+        spanner_internal::SafeTransactionRerun>;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/retry_policy_test.cc
+++ b/google/cloud/spanner/retry_policy_test.cc
@@ -22,30 +22,31 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 TEST(RetryPolicyTest, PermanentFailure) {
-  EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(Status()));
-  EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(
+  EXPECT_FALSE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(Status()));
+  EXPECT_FALSE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kUnavailable, "try again")));
-  EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(
+  EXPECT_FALSE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kResourceExhausted, "slow down please")));
-  EXPECT_TRUE(internal::SafeGrpcRetry::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kDeadlineExceeded, "not enough time")));
-  EXPECT_TRUE(internal::SafeGrpcRetry::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kAborted, "nothing done")));
-  EXPECT_TRUE(internal::SafeGrpcRetry::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kPermissionDenied, "uh oh")));
 }
 
 TEST(TransactionRerunPolicyTest, PermanentFailure) {
-  EXPECT_FALSE(internal::SafeTransactionRerun::IsPermanentFailure(Status()));
-  EXPECT_FALSE(internal::SafeTransactionRerun::IsPermanentFailure(
+  EXPECT_FALSE(
+      spanner_internal::SafeTransactionRerun::IsPermanentFailure(Status()));
+  EXPECT_FALSE(spanner_internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kAborted, "nothing done")));
-  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kUnavailable, "try again")));
-  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kResourceExhausted, "slow down please")));
-  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kDeadlineExceeded, "not enough time")));
-  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
+  EXPECT_TRUE(spanner_internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kPermissionDenied, "uh oh")));
 }
 

--- a/google/cloud/spanner/row.cc
+++ b/google/cloud/spanner/row.cc
@@ -25,12 +25,12 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-namespace internal {
+namespace spanner_internal {
 Row MakeRow(std::vector<Value> values,
             std::shared_ptr<const std::vector<std::string>> columns) {
   return Row(std::move(values), std::move(columns));
 }
-}  // namespace internal
+}  // namespace spanner_internal
 
 Row MakeTestRow(std::vector<std::pair<std::string, Value>> pairs) {
   auto values = std::vector<Value>{};
@@ -39,7 +39,7 @@ Row MakeTestRow(std::vector<std::pair<std::string, Value>> pairs) {
     values.emplace_back(std::move(p.second));
     columns->emplace_back(std::move(p.first));
   }
-  return internal::MakeRow(std::move(values), std::move(columns));
+  return spanner_internal::MakeRow(std::move(values), std::move(columns));
 }
 
 Row::Row() : Row({}, std::make_shared<std::vector<std::string>>()) {}

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -35,10 +35,10 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 class Row;
-namespace internal {
+namespace spanner_internal {
 Row MakeRow(std::vector<Value>,
             std::shared_ptr<const std::vector<std::string>>);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * A `Row` is a sequence of columns each with a name and an associated `Value`.
@@ -134,7 +134,7 @@ class Row {
     Tuple tup;
     auto it = values_.begin();
     Status status;
-    internal::ForEach(tup, ExtractValue{status}, it);
+    spanner_internal::ForEach(tup, ExtractValue{status}, it);
     if (!status.ok()) return status;
     return tup;
   }
@@ -154,7 +154,7 @@ class Row {
     Tuple tup;
     auto it = std::make_move_iterator(values_.begin());
     Status status;
-    internal::ForEach(tup, ExtractValue{status}, it);
+    spanner_internal::ForEach(tup, ExtractValue{status}, it);
     if (!status.ok()) return status;
     return tup;
   }
@@ -166,8 +166,8 @@ class Row {
   ///@}
 
  private:
-  friend Row internal::MakeRow(std::vector<Value>,
-                               std::shared_ptr<const std::vector<std::string>>);
+  friend Row spanner_internal::MakeRow(
+      std::vector<Value>, std::shared_ptr<const std::vector<std::string>>);
   struct ExtractValue {
     Status& status;
     template <typename T, typename It>
@@ -224,7 +224,7 @@ Row MakeTestRow(Ts&&... ts) {
     columns->emplace_back(std::to_string(i));
   }
   std::vector<Value> v{Value(std::forward<Ts>(ts))...};
-  return internal::MakeRow(std::move(v), std::move(columns));
+  return spanner_internal::MakeRow(std::move(v), std::move(columns));
 }
 
 /**
@@ -402,7 +402,7 @@ template <typename Tuple>
 class TupleStream {
  public:
   using iterator = TupleStreamIterator<Tuple>;
-  static_assert(internal::IsTuple<Tuple>::value,
+  static_assert(spanner_internal::IsTuple<Tuple>::value,
                 "TupleStream<T> requires a std::tuple parameter");
 
   iterator begin() const { return begin_; }

--- a/google/cloud/spanner/sql_statement.cc
+++ b/google/cloud/spanner/sql_statement.cc
@@ -20,7 +20,7 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-namespace internal {
+namespace spanner_internal {
 SqlStatementProto ToProto(SqlStatement s) {
   SqlStatementProto statement_proto;
   statement_proto.set_sql(std::move(s.statement_));
@@ -28,14 +28,14 @@ SqlStatementProto ToProto(SqlStatement s) {
     auto& values = *statement_proto.mutable_params()->mutable_fields();
     auto& types = *statement_proto.mutable_param_types();
     for (auto& param : s.params_) {
-      auto type_and_value = internal::ToProto(std::move(param.second));
+      auto type_and_value = spanner_internal::ToProto(std::move(param.second));
       values[param.first] = std::move(type_and_value.second);
       types[param.first] = std::move(type_and_value.first);
     }
   }
   return statement_proto;
 }
-}  // namespace internal
+}  // namespace spanner_internal
 
 std::vector<std::string> SqlStatement::ParameterNames() const {
   std::vector<std::string> keys;

--- a/google/cloud/spanner/sql_statement.h
+++ b/google/cloud/spanner/sql_statement.h
@@ -30,13 +30,13 @@ inline namespace SPANNER_CLIENT_NS {
 class SqlStatement;  // Defined later in this file.
 
 // Internal implementation details that callers should not use.
-namespace internal {
+namespace spanner_internal {
 // Use this proto type because it conveniently wraps all three attributes
 // required to represent a SQL statement.
 using SqlStatementProto =
     google::spanner::v1::ExecuteBatchDmlRequest::Statement;
 SqlStatementProto ToProto(SqlStatement s);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * Represents a potentially parameterized SQL statement.
@@ -113,7 +113,8 @@ class SqlStatement {
   friend std::ostream& operator<<(std::ostream& os, SqlStatement const& stmt);
 
  private:
-  friend internal::SqlStatementProto internal::ToProto(SqlStatement s);
+  friend spanner_internal::SqlStatementProto spanner_internal::ToProto(
+      SqlStatement s);
 
   std::string statement_;
   ParamType params_;

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -115,9 +115,10 @@ TEST(SqlStatementTest, Equality) {
 TEST(SqlStatementTest, ToProtoStatementOnly) {
   SqlStatement stmt("select * from foo");
   auto constexpr kText = R"pb(sql: "select * from foo")pb";
-  internal::SqlStatementProto expected;
+  spanner_internal::SqlStatementProto expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
-  EXPECT_THAT(internal::ToProto(std::move(stmt)), IsProtoEqual(expected));
+  EXPECT_THAT(spanner_internal::ToProto(std::move(stmt)),
+              IsProtoEqual(expected));
 }
 
 TEST(SqlStatementTest, ToProtoWithParams) {
@@ -157,9 +158,10 @@ TEST(SqlStatementTest, ToProtoWithParams) {
       value: { code: STRING }
     }
   )pb";
-  internal::SqlStatementProto expected;
+  spanner_internal::SqlStatementProto expected;
   ASSERT_TRUE(TextFormat::ParseFromString(text, &expected));
-  EXPECT_THAT(internal::ToProto(std::move(stmt)), IsProtoEqual(expected));
+  EXPECT_THAT(spanner_internal::ToProto(std::move(stmt)),
+              IsProtoEqual(expected));
 }
 
 }  // namespace

--- a/google/cloud/spanner/testing/fake_clock.h
+++ b/google/cloud/spanner/testing/fake_clock.h
@@ -31,8 +31,8 @@ inline namespace SPANNER_CLIENT_NS {
  * The `time_point` returned from `Now()` only changes via explicit calls to
  * `SetTime` or `AdvanceTime`.
  *
- * `RealClock` should be an `internal::Clock<TrivialClock>` type that is being
- * faked - see `internal/clock.h` for details.
+ * `RealClock` should be an `spanner_internal::Clock<TrivialClock>` type that is
+ * being faked - see `internal/clock.h` for details.
  */
 template <typename RealClock>
 class FakeClock : public RealClock {
@@ -62,10 +62,10 @@ class FakeClock : public RealClock {
 };
 
 using FakeSteadyClock =
-    FakeClock<google::cloud::spanner::internal::SteadyClock>;
+    FakeClock<google::cloud::spanner::spanner_internal::SteadyClock>;
 
 using FakeSystemClock =
-    FakeClock<google::cloud::spanner::internal::SystemClock>;
+    FakeClock<google::cloud::spanner::spanner_internal::SystemClock>;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_testing

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -32,9 +32,9 @@ inline namespace SPANNER_CLIENT_NS {
 MATCHER_P2(
     HasSessionAndTransactionId, session_id, transaction_id,
     "Verifies a Transaction has the expected Session and Transaction IDs") {
-  return google::cloud::spanner::internal::Visit(
+  return google::cloud::spanner::spanner_internal::Visit(
       arg,
-      [&](google::cloud::spanner::internal::SessionHolder& session,
+      [&](google::cloud::spanner::spanner_internal::SessionHolder& session,
           StatusOr<google::spanner::v1::TransactionSelector>& s, std::int64_t) {
         bool result = true;
         if (!session) {

--- a/google/cloud/spanner/testing/mock_database_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_database_admin_stub.h
@@ -25,7 +25,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 class MockDatabaseAdminStub
-    : public google::cloud::spanner::internal::DatabaseAdminStub {
+    : public google::cloud::spanner::spanner_internal::DatabaseAdminStub {
  public:
   MOCK_METHOD2(
       CreateDatabase,

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -25,7 +25,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 class MockInstanceAdminStub
-    : public google::cloud::spanner::internal::InstanceAdminStub {
+    : public google::cloud::spanner::spanner_internal::InstanceAdminStub {
  public:
   MOCK_METHOD2(
       GetInstance,

--- a/google/cloud/spanner/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/spanner/testing/mock_partial_result_set_reader.h
@@ -25,7 +25,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 class MockPartialResultSetReader
-    : public spanner_internal::PartialResultSetReader {
+    : public spanner::spanner_internal::PartialResultSetReader {
  public:
   MOCK_METHOD0(TryCancel, void());
   MOCK_METHOD0(Read, absl::optional<google::spanner::v1::PartialResultSet>());

--- a/google/cloud/spanner/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/spanner/testing/mock_partial_result_set_reader.h
@@ -25,7 +25,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 class MockPartialResultSetReader
-    : public spanner::internal::PartialResultSetReader {
+    : public spanner_internal::PartialResultSetReader {
  public:
   MOCK_METHOD0(TryCancel, void());
   MOCK_METHOD0(Read, absl::optional<google::spanner::v1::PartialResultSet>());

--- a/google/cloud/spanner/testing/mock_spanner_stub.h
+++ b/google/cloud/spanner/testing/mock_spanner_stub.h
@@ -24,7 +24,8 @@ namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
-class MockSpannerStub : public google::cloud::spanner::internal::SpannerStub {
+class MockSpannerStub
+    : public google::cloud::spanner::spanner_internal::SpannerStub {
  public:
   MOCK_METHOD2(CreateSession,
                StatusOr<google::spanner::v1::Session>(

--- a/google/cloud/spanner/timestamp.cc
+++ b/google/cloud/spanner/timestamp.cc
@@ -67,10 +67,10 @@ StatusOr<Timestamp> MakeTimestamp(absl::Time t) {
 }
 
 std::ostream& operator<<(std::ostream& os, Timestamp ts) {
-  return os << internal::TimestampToRFC3339(ts);
+  return os << spanner_internal::TimestampToRFC3339(ts);
 }
 
-namespace internal {
+namespace spanner_internal {
 
 // Timestamp objects are always formatted in UTC, and we always format them
 // with a trailing 'Z'. However, we're a bit more liberal in the UTC offsets we
@@ -99,7 +99,7 @@ protobuf::Timestamp TimestampToProto(Timestamp ts) {
   return google::cloud::internal::ToProtoTimestamp(t);
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/timestamp.h
+++ b/google/cloud/spanner/timestamp.h
@@ -181,14 +181,14 @@ struct CommitTimestamp {
   friend bool operator!=(CommitTimestamp, CommitTimestamp) { return false; }
 };
 
-namespace internal {
+namespace spanner_internal {
 
 StatusOr<Timestamp> TimestampFromRFC3339(std::string const&);
 std::string TimestampToRFC3339(Timestamp);
 StatusOr<Timestamp> TimestampFromProto(protobuf::Timestamp const&);
 protobuf::Timestamp TimestampToProto(Timestamp);
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/timestamp_test.cc
+++ b/google/cloud/spanner/timestamp_test.cc
@@ -50,7 +50,7 @@ google::protobuf::Timestamp MakeProtoTimestamp(std::int64_t seconds,
 
 TEST(Timestamp, RegularSemantics) {
   Timestamp const ts =
-      internal::TimestampFromProto(MakeProtoTimestamp(0, 0)).value();
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(0, 0)).value();
 
   Timestamp const copy1(ts);
   EXPECT_EQ(copy1, ts);
@@ -64,293 +64,348 @@ TEST(Timestamp, RegularSemantics) {
 }
 
 TEST(Timestamp, RelationalOperators) {
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
-  EXPECT_LE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
-  EXPECT_GE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
+  EXPECT_LE(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
+  EXPECT_GE(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
 
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668))
-          .value());
-  EXPECT_LT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668))
-          .value());
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667))
-          .value());
-  EXPECT_LT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667))
-          .value());
+  EXPECT_NE(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422668))
+                .value());
+  EXPECT_LT(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422668))
+                .value());
+  EXPECT_NE(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030525, 611422667))
+                .value());
+  EXPECT_LT(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030525, 611422667))
+                .value());
 
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
-  EXPECT_GT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
-  EXPECT_GT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667))
-          .value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667))
-          .value());
+  EXPECT_NE(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422668))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
+  EXPECT_GT(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422668))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
+  EXPECT_NE(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030525, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
+  EXPECT_GT(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030525, 611422667))
+                .value(),
+            spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1576030524, 611422667))
+                .value());
 }
 
 TEST(Timestamp, OutputStreaming) {
   std::ostringstream os;
-  os << internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456789))
+  os << spanner_internal::TimestampFromProto(
+            MakeProtoTimestamp(1561135942, 123456789))
             .value();
   EXPECT_EQ("2019-06-21T16:52:22.123456789Z", os.str());
 }
 
 TEST(Timestamp, FromRFC3339) {
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 0)).value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 9)).value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000009Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 89)).value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000089Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 789)).value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000789Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 6789))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 0))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.000006789Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 56789))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 9))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.000056789Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000009Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 456789))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 89))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.000456789Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000089Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 3456789))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.003456789Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 23456789))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 6789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.023456789Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000006789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456789))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 56789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456789Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000056789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456780))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 456789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345678Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000456789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456700))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 3456789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234567Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.003456789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456000))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 23456789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.023456789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123450000))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 123456789))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456789Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123400000))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 123456780))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345678Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123000000))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 123456700))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.123Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234567Z")
+          .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 120000000))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 123456000))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.12Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456Z")
+          .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1561135942, 123450000))
+                .value(),
+            spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345Z")
+                .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1561135942, 123400000))
+                .value(),
+            spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234Z")
+                .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1561135942, 123000000))
+                .value(),
+            spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.123Z")
+                .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1561135942, 120000000))
+                .value(),
+            spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.12Z")
+                .value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 100000000))
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(1561135942, 100000000))
           .value(),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.1Z").value());
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.1Z").value());
 }
 
 TEST(Timestamp, FromRFC3339Offset) {
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1546398245, 0)).value(),
-      internal::TimestampFromRFC3339("2019-01-02T03:04:05+00:00").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(
-          MakeProtoTimestamp(1546398245 + 3600 + 120, 0))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1546398245, 0))
           .value(),
-      internal::TimestampFromRFC3339("2019-01-02T03:04:05-01:02").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(
-          MakeProtoTimestamp(1546398245 - 3600 - 120, 0))
-          .value(),
-      internal::TimestampFromRFC3339("2019-01-02T03:04:05+01:02").value());
+      spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05+00:00")
+          .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1546398245 + 3600 + 120, 0))
+                .value(),
+            spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05-01:02")
+                .value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(1546398245 - 3600 - 120, 0))
+                .value(),
+            spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05+01:02")
+                .value());
 }
 
 TEST(Timestamp, FromRFC3339Failure) {
-  EXPECT_FALSE(internal::TimestampFromRFC3339(""));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("garbage in"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22.9"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22.Z"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22ZX"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:-22Z"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339(""));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("garbage in"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.9"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.Z"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22ZX"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:-22Z"));
 
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22+0:"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22+:0"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22+0:-0"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22x00:00"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22+ab:cd"));
-  EXPECT_FALSE(internal::TimestampFromRFC3339("2019-06-21T16:52:22-24:60"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22+0:"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22+:0"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22+0:-0"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22x00:00"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22+ab:cd"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22-24:60"));
 }
 
 TEST(Timestamp, FromRFC3339Limit) {
   // Verify Spanner range requirements.
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0)).value(),
-      internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(253402300799, 999999999))
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0))
           .value(),
-      internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value());
+      spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z")
+          .value());
+  EXPECT_EQ(
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(253402300799, 999999999))
+          .value(),
+      spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
+          .value());
 
   // One nanosecond before the lower bound is invalid.
-  EXPECT_FALSE(internal::TimestampFromRFC3339("0-12-31T23:59:59.999999999Z"));
+  EXPECT_FALSE(
+      spanner_internal::TimestampFromRFC3339("0-12-31T23:59:59.999999999Z"));
 
   // One nanosecond past the upper bound is invalid.
-  EXPECT_FALSE(internal::TimestampFromRFC3339("10000-01-01T00:00:00Z"));
+  EXPECT_FALSE(spanner_internal::TimestampFromRFC3339("10000-01-01T00:00:00Z"));
 }
 
 TEST(Timestamp, ToRFC3339) {
-  EXPECT_EQ("2019-06-21T16:52:22Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 0))
-                    .value()));
+  EXPECT_EQ("2019-06-21T16:52:22Z", spanner_internal::TimestampToRFC3339(
+                                        spanner_internal::TimestampFromProto(
+                                            MakeProtoTimestamp(1561135942, 0))
+                                            .value()));
   EXPECT_EQ("2019-06-21T16:52:22.000000009Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 9))
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 9))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.000000089Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 89))
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 89))
                     .value()));
-  EXPECT_EQ(
-      "2019-06-21T16:52:22.000000789Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 789))
-              .value()));
-  EXPECT_EQ(
-      "2019-06-21T16:52:22.000006789Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 6789))
-              .value()));
-  EXPECT_EQ(
-      "2019-06-21T16:52:22.000056789Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 56789))
-              .value()));
-  EXPECT_EQ(
-      "2019-06-21T16:52:22.000456789Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 456789))
-              .value()));
-  EXPECT_EQ(
-      "2019-06-21T16:52:22.003456789Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 3456789))
-              .value()));
-  EXPECT_EQ(
-      "2019-06-21T16:52:22.023456789Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 23456789))
-              .value()));
+  EXPECT_EQ("2019-06-21T16:52:22.000000789Z",
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 789))
+                    .value()));
+  EXPECT_EQ("2019-06-21T16:52:22.000006789Z",
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 6789))
+                    .value()));
+  EXPECT_EQ("2019-06-21T16:52:22.000056789Z",
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 56789))
+                    .value()));
+  EXPECT_EQ("2019-06-21T16:52:22.000456789Z",
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 456789))
+                    .value()));
+  EXPECT_EQ("2019-06-21T16:52:22.003456789Z",
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 3456789))
+                    .value()));
+  EXPECT_EQ("2019-06-21T16:52:22.023456789Z",
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
+                    MakeProtoTimestamp(1561135942, 23456789))
+                    .value()));
   EXPECT_EQ("2019-06-21T16:52:22.123456789Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123456789))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.12345678Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123456780))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.1234567Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123456700))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.123456Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123456000))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.12345Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123450000))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.1234Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123400000))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.123Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 123000000))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.12Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 120000000))
                     .value()));
   EXPECT_EQ("2019-06-21T16:52:22.1Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(1561135942, 100000000))
                     .value()));
 }
 
 TEST(Timestamp, ToRFC3339Limit) {
   // Spanner range requirements.
-  EXPECT_EQ(
-      "0001-01-01T00:00:00Z",
-      internal::TimestampToRFC3339(
-          internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0))
-              .value()));
+  EXPECT_EQ("0001-01-01T00:00:00Z", spanner_internal::TimestampToRFC3339(
+                                        spanner_internal::TimestampFromProto(
+                                            MakeProtoTimestamp(-62135596800, 0))
+                                            .value()));
   EXPECT_EQ("9999-12-31T23:59:59.999999999Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(
                     MakeProtoTimestamp(253402300799, 999999999))
                     .value()));
 }
@@ -358,56 +413,63 @@ TEST(Timestamp, ToRFC3339Limit) {
 TEST(Timestamp, FromProto) {
   auto proto = MakeProtoTimestamp(0, 0);
   EXPECT_EQ("1970-01-01T00:00:00Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(proto).value()));
 
   proto = MakeProtoTimestamp(1576030524, 611422667);
   EXPECT_EQ("2019-12-11T02:15:24.611422667Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(proto).value()));
 
   proto = MakeProtoTimestamp(-62135596800, 0);
   EXPECT_EQ("0001-01-01T00:00:00Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(proto).value()));
 
   proto = MakeProtoTimestamp(253402300799, 999999999);
   EXPECT_EQ("9999-12-31T23:59:59.999999999Z",
-            internal::TimestampToRFC3339(
-                internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(
+                spanner_internal::TimestampFromProto(proto).value()));
 }
 
 TEST(Timestamp, FromProtoLimit) {
   // The min/max values that are allowed to be encoded in a Timestamp proto:
   // ["0001-01-01T00:00:00Z", "9999-12-31T23:59:59.999999999Z"]
   // Note: These values can be computed with `date +%s --date="YYYY-MM-...Z"`
-  EXPECT_EQ(internal::TimestampFromRFC3339("0001-01-01T00:00:00Z").value(),
-            internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0))
-                .value());
   EXPECT_EQ(
-      internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value(),
-      internal::TimestampFromProto(MakeProtoTimestamp(253402300799, 999999999))
+      spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00Z").value(),
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0))
+          .value());
+  EXPECT_EQ(
+      spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
+          .value(),
+      spanner_internal::TimestampFromProto(
+          MakeProtoTimestamp(253402300799, 999999999))
           .value());
 }
 
 TEST(Timestamp, ToProto) {
-  auto proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("1970-01-01T00:00:00.000000000Z").value());
+  auto proto = spanner_internal::TimestampToProto(
+      spanner_internal::TimestampFromRFC3339("1970-01-01T00:00:00.000000000Z")
+          .value());
   EXPECT_EQ(0, proto.seconds());
   EXPECT_EQ(0, proto.nanos());
 
-  proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("2019-12-11T02:15:24.611422667Z").value());
+  proto = spanner_internal::TimestampToProto(
+      spanner_internal::TimestampFromRFC3339("2019-12-11T02:15:24.611422667Z")
+          .value());
   EXPECT_EQ(1576030524, proto.seconds());
   EXPECT_EQ(611422667, proto.nanos());
 
-  proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z").value());
+  proto = spanner_internal::TimestampToProto(
+      spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z")
+          .value());
   EXPECT_EQ(-62135596800, proto.seconds());
   EXPECT_EQ(0, proto.nanos());
 
-  proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value());
+  proto = spanner_internal::TimestampToProto(
+      spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
+          .value());
   EXPECT_EQ(253402300799, proto.seconds());
   EXPECT_EQ(999999999, proto.nanos());
 }
@@ -415,51 +477,51 @@ TEST(Timestamp, ToProto) {
 TEST(Timestamp, FromChrono) {  // i.e., MakeTimestamp(sys_time<Duration>)
   auto const tp1 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123456789))
-          .value(),
-      MakeTimestamp(tp1).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(2123456789, 123456789))
+                .value(),
+            MakeTimestamp(tp1).value());
 
   auto const tp2 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::microseconds(123456);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123456000))
-          .value(),
-      MakeTimestamp(tp2).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(2123456789, 123456000))
+                .value(),
+            MakeTimestamp(tp2).value());
 
   auto const tp3 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::milliseconds(123);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123000000))
-          .value(),
-      MakeTimestamp(tp3).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(2123456789, 123000000))
+                .value(),
+            MakeTimestamp(tp3).value());
 
   auto const tp4 = kUnixEpoch + std::chrono::minutes(2123456789);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789LL * 60, 0))
-          .value(),
-      MakeTimestamp(tp4).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(2123456789LL * 60, 0))
+                .value(),
+            MakeTimestamp(tp4).value());
 
   auto const tp5 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123456789))
-          .value(),
-      MakeTimestamp(tp5).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(-2123456789, 123456789))
+                .value(),
+            MakeTimestamp(tp5).value());
 
   auto const tp6 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::microseconds(123456);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123456000))
-          .value(),
-      MakeTimestamp(tp6).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(-2123456789, 123456000))
+                .value(),
+            MakeTimestamp(tp6).value());
 
   auto const tp7 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::milliseconds(123);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123000000))
-          .value(),
-      MakeTimestamp(tp7).value());
+  EXPECT_EQ(spanner_internal::TimestampFromProto(
+                MakeProtoTimestamp(-2123456789, 123000000))
+                .value(),
+            MakeTimestamp(tp7).value());
 }
 
 TEST(Timestamp, FromChronoOverflow) {
@@ -478,9 +540,9 @@ TEST(Timestamp, FromChronoOverflow) {
 }
 
 TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
-  auto const ts_pos =
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123456789))
-          .value();
+  auto const ts_pos = spanner_internal::TimestampFromProto(
+                          MakeProtoTimestamp(2123456789, 123456789))
+                          .value();
 
   auto const tp1 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
@@ -500,9 +562,9 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
   auto const tp5 = kUnixEpoch + std::chrono::hours(2123456789 / 60 / 60);
   EXPECT_EQ(tp5, ts_pos.get<sys_time<std::chrono::hours>>().value());
 
-  auto const ts_neg =
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123456789))
-          .value();
+  auto const ts_neg = spanner_internal::TimestampFromProto(
+                          MakeProtoTimestamp(-2123456789, 123456789))
+                          .value();
 
   auto const tp6 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
@@ -527,9 +589,9 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
 
   // The limit of a 64-bit count of nanoseconds (assuming the system_clock
   // epoch is the Unix epoch).
-  auto const ts11 =
-      internal::TimestampFromProto(MakeProtoTimestamp(9223372036, 854775807))
-          .value();
+  auto const ts11 = spanner_internal::TimestampFromProto(
+                        MakeProtoTimestamp(9223372036, 854775807))
+                        .value();
   auto const tp11 = kUnixEpoch + std::chrono::seconds(9223372036) +
                     std::chrono::nanoseconds(854775807);
   EXPECT_EQ(tp11, ts11.get<sys_time<std::chrono::nanoseconds>>().value());
@@ -537,13 +599,15 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
 
 TEST(Timestamp, ToChronoOverflow) {
   auto const ts1 =
-      internal::TimestampFromProto(MakeProtoTimestamp(20000000000, 0)).value();
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(20000000000, 0))
+          .value();
   auto const tp1 = ts1.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp1,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
 
   auto const ts2 =
-      internal::TimestampFromProto(MakeProtoTimestamp(-20000000000, 0)).value();
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-20000000000, 0))
+          .value();
   auto const tp2 = ts2.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp2,
               StatusIs(Not(StatusCode::kOk), HasSubstr("negative overflow")));
@@ -551,9 +615,9 @@ TEST(Timestamp, ToChronoOverflow) {
   // One beyond the limit of a 64-bit count of nanoseconds (assuming the
   // system_clock epoch is the Unix epoch). This overflow is detected in a
   // different code path to the "positive overflow" above.
-  auto const ts3 =
-      internal::TimestampFromProto(MakeProtoTimestamp(9223372036, 854775808))
-          .value();
+  auto const ts3 = spanner_internal::TimestampFromProto(
+                       MakeProtoTimestamp(9223372036, 854775808))
+                       .value();
   auto const tp3 = ts3.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp3,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
@@ -562,20 +626,20 @@ TEST(Timestamp, ToChronoOverflow) {
   // detect potential overflow into the Duration's rep.
   using Sec8Bit = std::chrono::duration<std::int8_t, std::ratio<1>>;
   auto const ts4 =
-      internal::TimestampFromProto(MakeProtoTimestamp(127, 0)).value();
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(127, 0)).value();
   auto const tp4 = ts4.get<sys_time<Sec8Bit>>();
   EXPECT_TRUE(tp4);  // An in-range value succeeds.
 
   // One beyond the capacity for (signed) 8-bits of seconds would overflow.
   auto const ts5 =
-      internal::TimestampFromProto(MakeProtoTimestamp(128, 0)).value();
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(128, 0)).value();
   auto const tp5 = ts5.get<sys_time<Sec8Bit>>();
   EXPECT_THAT(tp5,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
 
   // One less than the capacity for (signed) 8-bits of seconds would overflow.
   auto const ts6 =
-      internal::TimestampFromProto(MakeProtoTimestamp(-129, 0)).value();
+      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-129, 0)).value();
   auto const tp6 = ts6.get<sys_time<Sec8Bit>>();
   EXPECT_THAT(tp6,
               StatusIs(Not(StatusCode::kOk), HasSubstr("negative overflow")));
@@ -609,7 +673,7 @@ TEST(Timestamp, AbslTimeRoundTrip) {  // i.e., `MakeTimestamp(absl::Time)`
   for (auto const& tc : round_trip_cases) {
     SCOPED_TRACE("Time: " + absl::FormatTime(tc.t));
     auto const ts = MakeTimestamp(tc.t).value();
-    EXPECT_EQ(ts, internal::TimestampFromProto(tc.proto).value());
+    EXPECT_EQ(ts, spanner_internal::TimestampFromProto(tc.proto).value());
     auto const t = ts.get<absl::Time>().value();
     EXPECT_EQ(t, tc.t);
   }
@@ -617,9 +681,10 @@ TEST(Timestamp, AbslTimeRoundTrip) {  // i.e., `MakeTimestamp(absl::Time)`
 
 TEST(Timestamp, FromAbslTimeOverflow) {  // i.e., `MakeTimestamp(absl::Time)`
   auto const min_timestamp =
-      internal::TimestampFromRFC3339("0001-01-01T00:00:00Z").value();
+      spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00Z").value();
   auto const max_timestamp =
-      internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value();
+      spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
+          .value();
 
   auto const min_time = min_timestamp.get<absl::Time>().value();
   auto const max_time = max_timestamp.get<absl::Time>().value();

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -57,7 +57,7 @@ Transaction::ReadOnlyOptions::ReadOnlyOptions() {
 
 Transaction::ReadOnlyOptions::ReadOnlyOptions(Timestamp read_timestamp) {
   *ro_opts_.mutable_read_timestamp() =
-      internal::TimestampToProto(read_timestamp);
+      spanner_internal::TimestampToProto(read_timestamp);
   ro_opts_.set_return_read_timestamp(true);
 }
 
@@ -75,7 +75,7 @@ Transaction::SingleUseOptions::SingleUseOptions(ReadOnlyOptions opts) {
 
 Transaction::SingleUseOptions::SingleUseOptions(Timestamp min_read_timestamp) {
   *ro_opts_.mutable_min_read_timestamp() =
-      internal::TimestampToProto(min_read_timestamp);
+      spanner_internal::TimestampToProto(min_read_timestamp);
   ro_opts_.set_return_read_timestamp(true);
 }
 
@@ -88,46 +88,49 @@ Transaction::SingleUseOptions::SingleUseOptions(
 Transaction::Transaction(ReadOnlyOptions opts) {
   google::spanner::v1::TransactionSelector selector;
   *selector.mutable_begin() = MakeOpts(std::move(opts.ro_opts_));
-  impl_ = std::make_shared<internal::TransactionImpl>(std::move(selector));
+  impl_ =
+      std::make_shared<spanner_internal::TransactionImpl>(std::move(selector));
 }
 
 Transaction::Transaction(ReadWriteOptions opts) {
   google::spanner::v1::TransactionSelector selector;
   *selector.mutable_begin() = MakeOpts(std::move(opts.rw_opts_));
-  impl_ = std::make_shared<internal::TransactionImpl>(std::move(selector));
+  impl_ =
+      std::make_shared<spanner_internal::TransactionImpl>(std::move(selector));
 }
 
 Transaction::Transaction(Transaction const& txn, ReadWriteOptions opts) {
   google::spanner::v1::TransactionSelector selector;
   *selector.mutable_begin() = MakeOpts(std::move(opts.rw_opts_));
-  impl_ = std::make_shared<internal::TransactionImpl>(*txn.impl_,
-                                                      std::move(selector));
+  impl_ = std::make_shared<spanner_internal::TransactionImpl>(
+      *txn.impl_, std::move(selector));
 }
 
 Transaction::Transaction(SingleUseOptions opts) {
   google::spanner::v1::TransactionSelector selector;
   *selector.mutable_single_use() = MakeOpts(std::move(opts.ro_opts_));
-  impl_ = std::make_shared<internal::TransactionImpl>(std::move(selector));
+  impl_ =
+      std::make_shared<spanner_internal::TransactionImpl>(std::move(selector));
 }
 
 Transaction::Transaction(std::string session_id, std::string transaction_id) {
   google::spanner::v1::TransactionSelector selector;
   selector.set_id(std::move(transaction_id));
-  impl_ = std::make_shared<internal::TransactionImpl>(
-      internal::MakeDissociatedSessionHolder(std::move(session_id)),
+  impl_ = std::make_shared<spanner_internal::TransactionImpl>(
+      spanner_internal::MakeDissociatedSessionHolder(std::move(session_id)),
       std::move(selector));
 }
 
 Transaction::~Transaction() = default;
 
-namespace internal {
+namespace spanner_internal {
 
 Transaction MakeTransactionFromIds(std::string session_id,
                                    std::string transaction_id) {
   return Transaction(std::move(session_id), std::move(transaction_id));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -31,14 +31,14 @@ inline namespace SPANNER_CLIENT_NS {
 class Transaction;  // defined below
 
 // Internal forward declarations to befriend.
-namespace internal {
+namespace spanner_internal {
 template <typename T>
 Transaction MakeSingleUseTransaction(T&&);
 template <typename Functor>
 VisitInvokeResult<Functor> Visit(Transaction, Functor&&);
 Transaction MakeTransactionFromIds(std::string session_id,
                                    std::string transaction_id);
-}  // namespace internal
+}  // namespace spanner_internal
 
 /**
  * The representation of a Cloud Spanner transaction.
@@ -163,11 +163,11 @@ class Transaction {
  private:
   // Friendship for access by internal helpers.
   template <typename T>
-  friend Transaction internal::MakeSingleUseTransaction(T&&);
+  friend Transaction spanner_internal::MakeSingleUseTransaction(T&&);
   template <typename Functor>
-  friend internal::VisitInvokeResult<Functor> internal::Visit(Transaction,
-                                                              Functor&&);
-  friend Transaction internal::MakeTransactionFromIds(
+  friend spanner_internal::VisitInvokeResult<Functor> spanner_internal::Visit(
+      Transaction, Functor&&);
+  friend Transaction spanner_internal::MakeTransactionFromIds(
       std::string session_id, std::string transaction_id);
 
   // Construction of a single-use transaction.
@@ -175,7 +175,7 @@ class Transaction {
   // Construction of a transaction with existing IDs.
   Transaction(std::string session_id, std::string transaction_id);
 
-  std::shared_ptr<internal::TransactionImpl> impl_;
+  std::shared_ptr<spanner_internal::TransactionImpl> impl_;
 };
 
 /**
@@ -209,7 +209,7 @@ inline Transaction MakeReadWriteTransaction(
   return Transaction(txn, std::move(opts));
 }
 
-namespace internal {
+namespace spanner_internal {
 
 template <typename T>
 Transaction MakeSingleUseTransaction(T&& opts) {
@@ -227,7 +227,7 @@ VisitInvokeResult<Functor> Visit(Transaction txn, Functor&& f) {
   return txn.impl_->Visit(std::forward<Functor>(f));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -66,8 +66,8 @@ TEST(Transaction, RegularSemantics) {
   EXPECT_EQ(g, f);
   EXPECT_NE(g, e);
 
-  Transaction h = internal::MakeSingleUseTransaction(strong);
-  Transaction i = internal::MakeSingleUseTransaction(strong);
+  Transaction h = spanner_internal::MakeSingleUseTransaction(strong);
+  Transaction i = spanner_internal::MakeSingleUseTransaction(strong);
   EXPECT_NE(h, i);
 
   Transaction j = i;  // NOLINT(performance-unnecessary-copy-initialization)
@@ -78,8 +78,8 @@ TEST(Transaction, RegularSemantics) {
 TEST(Transaction, Visit) {
   Transaction a = MakeReadOnlyTransaction();
   std::int64_t a_seqno;
-  internal::Visit(
-      a, [&a_seqno](internal::SessionHolder& /*session*/,
+  spanner_internal::Visit(
+      a, [&a_seqno](spanner_internal::SessionHolder& /*session*/,
                     StatusOr<google::spanner::v1::TransactionSelector>& s,
                     std::int64_t seqno) {
         EXPECT_TRUE(s->has_begin());
@@ -88,8 +88,8 @@ TEST(Transaction, Visit) {
         a_seqno = seqno;
         return 0;
       });
-  internal::Visit(
-      a, [a_seqno](internal::SessionHolder& /*session*/,
+  spanner_internal::Visit(
+      a, [a_seqno](spanner_internal::SessionHolder& /*session*/,
                    StatusOr<google::spanner::v1::TransactionSelector>& s,
                    std::int64_t seqno) {
         EXPECT_EQ("test-txn-id", s->id());
@@ -99,10 +99,11 @@ TEST(Transaction, Visit) {
 }
 
 TEST(Transaction, SessionAffinity) {
-  auto a_session = internal::MakeDissociatedSessionHolder("SessionAffinity");
+  auto a_session =
+      spanner_internal::MakeDissociatedSessionHolder("SessionAffinity");
   Transaction a = MakeReadWriteTransaction();
-  internal::Visit(
-      a, [&a_session](internal::SessionHolder& session,
+  spanner_internal::Visit(
+      a, [&a_session](spanner_internal::SessionHolder& session,
                       StatusOr<google::spanner::v1::TransactionSelector>& s,
                       std::int64_t) {
         EXPECT_FALSE(session);
@@ -112,8 +113,8 @@ TEST(Transaction, SessionAffinity) {
         return 0;
       });
   Transaction b = MakeReadWriteTransaction(a);
-  internal::Visit(
-      b, [&a_session](internal::SessionHolder& session,
+  spanner_internal::Visit(
+      b, [&a_session](spanner_internal::SessionHolder& session,
                       StatusOr<google::spanner::v1::TransactionSelector>& s,
                       std::int64_t) {
         EXPECT_EQ(a_session, session);  // session affinity

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -121,10 +121,11 @@ std::ostream& StreamHelper(std::ostream& os,  // NOLINT(misc-no-recursion)
       return os << v.bool_value();
 
     case google::spanner::v1::TypeCode::INT64:
-      return os << internal::FromProto(t, v).get<std::int64_t>().value();
+      return os
+             << spanner_internal::FromProto(t, v).get<std::int64_t>().value();
 
     case google::spanner::v1::TypeCode::FLOAT64:
-      return os << internal::FromProto(t, v).get<double>().value();
+      return os << spanner_internal::FromProto(t, v).get<double>().value();
 
     case google::spanner::v1::TypeCode::STRING:
       switch (mode) {
@@ -138,14 +139,15 @@ std::ostream& StreamHelper(std::ostream& os,  // NOLINT(misc-no-recursion)
       return os;  // Unreachable, but quiets warning.
 
     case google::spanner::v1::TypeCode::BYTES:
-      return os << internal::BytesFromBase64(v.string_value()).value();
+      return os << spanner_internal::BytesFromBase64(v.string_value()).value();
 
     case google::spanner::v1::TypeCode::TIMESTAMP:
     case google::spanner::v1::TypeCode::NUMERIC:
       return os << v.string_value();
 
     case google::spanner::v1::TypeCode::DATE:
-      return os << internal::FromProto(t, v).get<absl::CivilDay>().value();
+      return os
+             << spanner_internal::FromProto(t, v).get<absl::CivilDay>().value();
 
     case google::spanner::v1::TypeCode::ARRAY: {
       const char* delimiter = "";
@@ -183,7 +185,7 @@ std::ostream& StreamHelper(std::ostream& os,  // NOLINT(misc-no-recursion)
 
 }  // namespace
 
-namespace internal {
+namespace spanner_internal {
 
 Value FromProto(google::spanner::v1::Type t, google::protobuf::Value v) {
   return Value(std::move(t), std::move(v));
@@ -193,7 +195,7 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v) {
   return std::make_pair(std::move(v.type_), std::move(v.value_));
 }
 
-}  // namespace internal
+}  // namespace spanner_internal
 
 bool operator==(Value const& a, Value const& b) {
   return Equal(a.type_, a.value_, b.type_, b.value_);
@@ -347,7 +349,7 @@ google::protobuf::Value Value::MakeValueProto(std::string s) {
 
 google::protobuf::Value Value::MakeValueProto(Bytes bytes) {
   google::protobuf::Value v;
-  v.set_string_value(internal::BytesToBase64(std::move(bytes)));
+  v.set_string_value(spanner_internal::BytesToBase64(std::move(bytes)));
   return v;
 }
 
@@ -359,7 +361,7 @@ google::protobuf::Value Value::MakeValueProto(Numeric n) {
 
 google::protobuf::Value Value::MakeValueProto(Timestamp ts) {
   google::protobuf::Value v;
-  v.set_string_value(internal::TimestampToRFC3339(ts));
+  v.set_string_value(spanner_internal::TimestampToRFC3339(ts));
   return v;
 }
 
@@ -463,7 +465,7 @@ StatusOr<Bytes> Value::GetValue(Bytes const&, google::protobuf::Value const& pv,
   if (pv.kind_case() != google::protobuf::Value::kStringValue) {
     return Status(StatusCode::kUnknown, "missing BYTES");
   }
-  auto decoded = internal::BytesFromBase64(pv.string_value());
+  auto decoded = spanner_internal::BytesFromBase64(pv.string_value());
   if (!decoded) return decoded.status();
   return *decoded;
 }
@@ -485,7 +487,7 @@ StatusOr<Timestamp> Value::GetValue(Timestamp,
   if (pv.kind_case() != google::protobuf::Value::kStringValue) {
     return Status(StatusCode::kUnknown, "missing TIMESTAMP");
   }
-  return internal::TimestampFromRFC3339(pv.string_value());
+  return spanner_internal::TimestampFromRFC3339(pv.string_value());
 }
 
 StatusOr<CommitTimestamp> Value::GetValue(CommitTimestamp,


### PR DESCRIPTION
Related to #3046

This naming is also the direction we are moving now with new libraries.

/cc: @scotthart, for consideration w/ the generator

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5609)
<!-- Reviewable:end -->
