### PR TITLE
cleanup: include proto header w/ brackets

### DIFF
--- a/google/cloud/bigtable/cluster_list_responses.h
+++ b/google/cloud/bigtable/cluster_list_responses.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_CLUSTER_LIST_RESPONSES_H
 
 #include "google/cloud/bigtable/version.h"
-#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
+#include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_list_responses.h
+++ b/google/cloud/bigtable/instance_list_responses.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INSTANCE_LIST_RESPONSES_H
 
 #include "google/cloud/bigtable/version.h"
-#include "google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h"
+#include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
Fixes: #3598

Some `pb.h` files need to be included with double quotes, for example if
the proto is defined in our own library rather than an external library,
so I don't see any way to add a style checker to catch future
regressions. Therefore, this is just a current cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5610)
<!-- Reviewable:end -->
