### PR TITLE
chore: explicitly avoid printf builtin

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -31,8 +31,11 @@ cd "${PROJECT_ROOT}"
 # below to time blocks of the script. A newline is automatically included.
 readonly TIMEFORMAT="... %R seconds"
 
+# To use the printf command rather than the shell builtin.
+enable -n printf
+
 problems=""
-stdbuf -o0 printf "%-30s" "Running check-include-guards:"
+printf "%-30s" "Running check-include-guards:"
 time {
   if ! git ls-files -z | grep -zE '\.h$' |
     xargs -0 awk -f "ci/check-include-guards.gawk"; then
@@ -58,7 +61,7 @@ replace_original_if_changed() {
 
 # Apply cmake_format to all the CMake list files.
 #     https://github.com/cheshirekow/cmake_format
-stdbuf -o0 printf "%-30s" "Running cmake-format:"
+printf "%-30s" "Running cmake-format:"
 time {
   git ls-files -z | grep -zE '((^|/)CMakeLists\.txt|\.cmake)$' |
     xargs -P "${NCPU}" -n 1 -0 cmake-format -i
@@ -70,7 +73,7 @@ time {
 #   https://github.com/googleapis/google-cloud-cpp/issues/4501
 # This should run before clang-format because it might alter the order of any
 # includes.
-stdbuf -o0 printf "%-30s" "Running Abseil header fixes:"
+printf "%-30s" "Running Abseil header fixes:"
 time {
   git ls-files -z |
     grep -zv 'google/cloud/internal/absl_.*quiet.h$' |
@@ -86,7 +89,7 @@ time {
 # Apply clang-format(1) to fix whitespace and other formatting rules.
 # The version of clang-format is important, different versions have slightly
 # different formatting output (sigh).
-stdbuf -o0 printf "%-30s" "Running clang-format:"
+printf "%-30s" "Running clang-format:"
 time {
   git ls-files -z | grep -zE '\.(cc|h)$' |
     xargs -P "${NCPU}" -n 50 -0 clang-format -i
@@ -94,7 +97,7 @@ time {
 
 # Apply buildifier to fix the BUILD and .bzl formatting rules.
 #    https://github.com/bazelbuild/buildtools/tree/master/buildifier
-stdbuf -o0 printf "%-30s" "Running buildifier:"
+printf "%-30s" "Running buildifier:"
 time {
   git ls-files -z | grep -zE '\.(BUILD|bzl)$' | xargs -0 buildifier -mode=fix
   git ls-files -z | grep -zE '(^|/)(BUILD|WORKSPACE)$' |
@@ -103,19 +106,19 @@ time {
 
 # Apply psf/black to format Python files.
 #    https://pypi.org/project/black/
-stdbuf -o0 printf "%-30s" "Running black:"
+printf "%-30s" "Running black:"
 time {
   git ls-files -z | grep -z '\.py$' | xargs -0 python3 -m black --quiet
 }
 
 # Apply shfmt to format all shell scripts
-stdbuf -o0 printf "%-30s" "Running shfmt:"
+printf "%-30s" "Running shfmt:"
 time {
   git ls-files -z | grep -z '\.sh$' | xargs -0 shfmt -w -i 2
 }
 
 # Apply shellcheck(1) to emit warnings for common scripting mistakes.
-stdbuf -o0 printf "%-30s" "Running shellcheck:"
+printf "%-30s" "Running shellcheck:"
 time {
   if ! git ls-files -z | grep -z '\.sh$' |
     xargs -0 shellcheck \
@@ -128,7 +131,7 @@ time {
   fi
 }
 
-stdbuf -o0 printf "%-30s" "Running cspell:"
+printf "%-30s" "Running cspell:"
 time {
   if ! git ls-files -z | grep -zE '\.(cc|h)$' |
     xargs -P "${NCPU}" -n 50 -0 cspell --no-summary -c ci/cspell.json; then
@@ -141,7 +144,7 @@ time {
 #       are obsoleted by the gRPC team, so we should not use them in our code.
 #     - Replace grpc::<BLAH> with grpc::StatusCode::<BLAH>, the aliases in the
 #       `grpc::` namespace do not exist inside google.
-stdbuf -o0 printf "%-30s" "Running include fixes:"
+printf "%-30s" "Running include fixes:"
 time {
   git ls-files -z | grep -zE '\.(cc|h)$' |
     while IFS= read -r -d $'\0' file; do
@@ -161,7 +164,7 @@ time {
 # clang-format(1) above.  For now we simply remove trailing blanks.  Note that
 # we do not expand TABs (they currently only appear in Makefiles and Makefile
 # snippets).
-stdbuf -o0 printf "%-30s" "Running whitespace fixes:"
+printf "%-30s" "Running whitespace fixes:"
 time {
   git ls-files -z | grep -zv '\.gz$' |
     while IFS= read -r -d $'\0' file; do

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -31,7 +31,9 @@ cd "${PROJECT_ROOT}"
 # below to time blocks of the script. A newline is automatically included.
 readonly TIMEFORMAT="... %R seconds"
 
-# To use the printf command rather than the shell builtin.
+# Use the printf command rather than the shell builtin, which avoids issues
+# with bash sometimes buffering output from its builtins. See
+# https://github.com/googleapis/google-cloud-cpp/issues/4152
 enable -n printf
 
 problems=""


### PR DESCRIPTION
This is a clearer way to accomplish what
https://github.com/googleapis/google-cloud-cpp/pull/5615 was trying to do.

Better fix for https://github.com/googleapis/google-cloud-cpp/issues/4152

Example output (which is good):

```console
2020-12-11T19:33:59Z: Verify formatting 
Running check-include-guards: ... 0.041 seconds
Running cmake-format:         ... 8.163 seconds
Running Abseil header fixes:  ... 3.792 seconds
Running clang-format:         ... 5.168 seconds
Running buildifier:           ... 0.039 seconds
Running black:                ... 1.069 seconds
Running shfmt:                ... 0.017 seconds
Running shellcheck:           ... 1.757 seconds
Running cspell:               ... 41.633 seconds
Running include fixes:        ... 3.837 seconds
Running whitespace fixes:     ... 5.171 seconds
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5616)
<!-- Reviewable:end -->
