### PR TITLE
feat(spanner): introduce spanner::RequestPriority enum

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(
     read_options.h
     read_partition.cc
     read_partition.h
+    request_priority.h
     results.cc
     results.h
     retry_policy.h

--- a/google/cloud/spanner/commit_options.h
+++ b/google/cloud/spanner/commit_options.h
@@ -15,7 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_COMMIT_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_COMMIT_OPTIONS_H
 
+#include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/version.h"
+#include "absl/types/optional.h"
 
 namespace google {
 namespace cloud {
@@ -42,8 +44,21 @@ class CommitOptions {
   /// Whether the `CommitResult` should contain `CommitStats`.
   bool return_stats() const { return return_stats_; }
 
+  /// Set the priority of the `spanner::Client::Commit()` call.
+  CommitOptions& set_request_priority(
+      absl::optional<RequestPriority> request_priority) {
+    request_priority_ = std::move(request_priority);
+    return *this;
+  }
+
+  /// The priority of the `spanner::Client::Commit()` call.
+  absl::optional<RequestPriority> request_priority() const {
+    return request_priority_;
+  }
+
  private:
   bool return_stats_ = false;
+  absl::optional<RequestPriority> request_priority_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_QUERY_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_QUERY_OPTIONS_H
 
+#include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
 #include "absl/types/optional.h"
@@ -45,7 +46,7 @@ class QueryOptions {
   }
 
   /**
-   * Sets the optimizerion version to the specified integer string. Setting to
+   * Sets the optimizer version to the specified integer string. Setting to
    * the empty string will use the database default. Use the string "latest" to
    * use the latest available optimizer version.
    */
@@ -54,8 +55,20 @@ class QueryOptions {
     return *this;
   }
 
+  /// Returns the request priority.
+  absl::optional<RequestPriority> const& request_priority() const {
+    return request_priority_;
+  }
+
+  /// Sets the request priority.
+  QueryOptions& set_request_priority(absl::optional<RequestPriority> priority) {
+    request_priority_ = std::move(priority);
+    return *this;
+  }
+
   friend bool operator==(QueryOptions const& a, QueryOptions const& b) {
-    return a.optimizer_version_ == b.optimizer_version_;
+    return a.request_priority_ == b.request_priority_ &&
+           a.optimizer_version_ == b.optimizer_version_;
   }
 
   friend bool operator!=(QueryOptions const& a, QueryOptions const& b) {
@@ -64,6 +77,7 @@ class QueryOptions {
 
  private:
   absl::optional<std::string> optimizer_version_;
+  absl::optional<RequestPriority> request_priority_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/query_options_test.cc
+++ b/google/cloud/spanner/query_options_test.cc
@@ -22,9 +22,10 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-TEST(QueryOptionsTest, OptimizerVersion) {
+TEST(QueryOptionsTest, Values) {
   QueryOptions const default_constructed{};
   EXPECT_FALSE(default_constructed.optimizer_version().has_value());
+  EXPECT_FALSE(default_constructed.request_priority().has_value());
 
   auto copy = default_constructed;
   EXPECT_EQ(copy, default_constructed);
@@ -35,6 +36,14 @@ TEST(QueryOptionsTest, OptimizerVersion) {
   EXPECT_NE(copy, default_constructed);
 
   copy.set_optimizer_version(absl::optional<std::string>{});
+  EXPECT_EQ(copy, default_constructed);
+
+  copy.set_request_priority(RequestPriority::kLow);
+  EXPECT_NE(copy, default_constructed);
+  copy.set_request_priority(RequestPriority::kHigh);
+  EXPECT_NE(copy, default_constructed);
+
+  copy.set_request_priority(absl::optional<RequestPriority>{});
   EXPECT_EQ(copy, default_constructed);
 }
 

--- a/google/cloud/spanner/read_options.h
+++ b/google/cloud/spanner/read_options.h
@@ -15,7 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_READ_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_READ_OPTIONS_H
 
+#include "google/cloud/spanner/request_priority.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
 #include <google/spanner/v1/spanner.pb.h>
 #include <string>
 
@@ -38,10 +40,17 @@ struct ReadOptions {
    * A limit cannot be specified when calling `PartitionRead`.
    */
   std::int64_t limit = 0;
+
+  /**
+   * Priority for the read request.
+   */
+  absl::optional<RequestPriority> request_priority;
 };
 
 inline bool operator==(ReadOptions const& lhs, ReadOptions const& rhs) {
-  return lhs.limit == rhs.limit && lhs.index_name == rhs.index_name;
+  return lhs.limit == rhs.limit &&
+         lhs.request_priority == rhs.request_priority &&
+         lhs.index_name == rhs.index_name;
 }
 
 inline bool operator!=(ReadOptions const& lhs, ReadOptions const& rhs) {

--- a/google/cloud/spanner/read_options_test.cc
+++ b/google/cloud/spanner/read_options_test.cc
@@ -25,16 +25,24 @@ TEST(ReadOptionsTest, Equality) {
   ReadOptions test_options_0{};
   ReadOptions test_options_1{};
   EXPECT_EQ(test_options_0, test_options_1);
+
   test_options_0.index_name = "secondary";
   EXPECT_NE(test_options_0, test_options_1);
   test_options_1.index_name = "secondary";
   EXPECT_EQ(test_options_0, test_options_1);
+
   test_options_0.limit = 42;
   EXPECT_NE(test_options_0, test_options_1);
   test_options_1.limit = 42;
   EXPECT_EQ(test_options_0, test_options_1);
-  test_options_1 = test_options_0;
+
+  test_options_0.request_priority = RequestPriority::kLow;
+  EXPECT_NE(test_options_0, test_options_1);
+  test_options_1.request_priority = RequestPriority::kLow;
   EXPECT_EQ(test_options_0, test_options_1);
+
+  ReadOptions test_options_2 = test_options_0;
+  EXPECT_EQ(test_options_0, test_options_2);
 }
 
 }  // namespace

--- a/google/cloud/spanner/request_priority.h
+++ b/google/cloud/spanner/request_priority.h
@@ -12,32 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/spanner/commit_options.h"
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_REQUEST_PRIORITY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_REQUEST_PRIORITY_H
+
 #include "google/cloud/spanner/version.h"
-#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace {
 
-TEST(CommitOptionsTest, Defaults) {
-  CommitOptions options;
-  EXPECT_FALSE(options.return_stats());
-  EXPECT_FALSE(options.request_priority().has_value());
-}
+// The relative priority for requests.
+enum class RequestPriority {
+  kLow,
+  kMedium,
+  kHigh,
+};
 
-TEST(CommitOptionsTest, SetValues) {
-  CommitOptions options;
-  options.set_return_stats(true);
-  options.set_request_priority(RequestPriority::kLow);
-  EXPECT_TRUE(options.return_stats());
-  EXPECT_EQ(RequestPriority::kLow, *options.request_priority());
-}
-
-}  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_REQUEST_PRIORITY_H

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -68,6 +68,7 @@ spanner_client_hdrs = [
     "query_partition.h",
     "read_options.h",
     "read_partition.h",
+    "request_priority.h",
     "results.h",
     "retry_policy.h",
     "row.h",


### PR DESCRIPTION
Introduce the `spanner::RequestPriority` enum (with low, medium
and high values), and add `absl::Optional<RequestPriority>` members
to `QueryOptions`, `ReadOptions`, and `CommitOptions`. These option
fields can be set by the user to mark a variety of `spanner::Client`
calls with a lower-than-default priority.

See the `RequestOptions.priority` Spanner protobuf field, which will
be set in an upcoming change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5624)
<!-- Reviewable:end -->
