### PR TITLE
test: enable RPC tracing for integration tests

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -138,6 +138,10 @@ if should_run_integration_tests; then
     "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
     "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
 
+    # Enable RPC tracing for integration tests (with default tracing options)
+    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes"
+    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc_streams"
+
     # Bigtable
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID}"
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID}"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -200,6 +200,10 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
       echo "${FORCE_TEST_IN_PRODUCTION:-}" | grep -qw "$1"
     }
 
+    # Enable RPC tracing for integration tests (with default tracing options)
+    export GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes
+    export GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc_streams
+
     readonly EMULATOR_SCRIPT="run_integration_tests_emulator_cmake.sh"
 
     if ! force_on_prod "pubsub"; then


### PR DESCRIPTION
This will facilitate the debugging of flakes by giving visibility
into calls prior to the failing one.

The tracing options are left at their default values of (currently):
```
single_line_mode=on
use_short_repeated_primitives=on
truncate_string_field_longer_than=128
```

Tested by injecting an error into an integration test and observing
the error report.

Fixes #4034.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5626)
<!-- Reviewable:end -->
