### PR TITLE
feat(storage): propagate custom header with resumable upload PUT requests

### DIFF
--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -679,7 +679,7 @@ def resumable_upload_chunk(bucket_name):
     if content_length != len(data):
         utils.error.invalid("content-length header", None)
     content_range = request.headers.get("content-range")
-    custom_header_value = request.headers.get("custom_header_key")
+    custom_header_value = request.headers.get("x-goog-emulator-custom-header")
     if content_range is not None:
         items = list(utils.common.content_range_split.match(content_range).groups())
         if len(items) != 2 or (items[0] == items[1] and items[0] != "*"):
@@ -749,7 +749,7 @@ def resumable_upload_chunk(bucket_name):
             upload.transfer
         )
         blob.metadata.metadata["x_emulator_upload"] = "resumable"
-        blob.metadata.metadata["x-goog-emulator-custom-header"] = str(custom_header_value)
+        blob.metadata.metadata["x_emulator_custom_header"] = str(custom_header_value)
         db.insert_object(upload.request, bucket_name, blob, None)
         projection = utils.common.extract_projection(
             upload.request, CommonEnums.Projection.NO_ACL, None

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -749,7 +749,7 @@ def resumable_upload_chunk(bucket_name):
             upload.transfer
         )
         blob.metadata.metadata["x_emulator_upload"] = "resumable"
-        blob.metadata.metadata["x_emulator_debug_custom_header"] = str(custom_header_value)
+        blob.metadata.metadata["x-goog-emulator-custom-header"] = str(custom_header_value)
         db.insert_object(upload.request, bucket_name, blob, None)
         projection = utils.common.extract_projection(
             upload.request, CommonEnums.Projection.NO_ACL, None

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -749,7 +749,7 @@ def resumable_upload_chunk(bucket_name):
             upload.transfer
         )
         blob.metadata.metadata["x_emulator_upload"] = "resumable"
-        blob.metadata.metadata["x_emulator_debug_custom_header"] = custom_header_value
+        blob.metadata.metadata["x_emulator_debug_custom_header"] = str(custom_header_value)
         db.insert_object(upload.request, bucket_name, blob, None)
         projection = utils.common.extract_projection(
             upload.request, CommonEnums.Projection.NO_ACL, None

--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -679,6 +679,7 @@ def resumable_upload_chunk(bucket_name):
     if content_length != len(data):
         utils.error.invalid("content-length header", None)
     content_range = request.headers.get("content-range")
+    custom_header_value = request.headers.get("custom_header_key")
     if content_range is not None:
         items = list(utils.common.content_range_split.match(content_range).groups())
         if len(items) != 2 or (items[0] == items[1] and items[0] != "*"):
@@ -748,6 +749,7 @@ def resumable_upload_chunk(bucket_name):
             upload.transfer
         )
         blob.metadata.metadata["x_emulator_upload"] = "resumable"
+        blob.metadata.metadata["x_emulator_debug_custom_header"] = custom_header_value
         db.insert_object(upload.request, bucket_name, blob, None)
         projection = utils.common.extract_projection(
             upload.request, CommonEnums.Projection.NO_ACL, None

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -273,11 +273,6 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   // We need to explicitly disable chunked transfer encoding. libcurl uses is by
   // default (at least in this case), and that wastes bandwidth as the content
   // length is known.
-    if (request.custom_header().has_value()){
-    builder.AddHeader(request.custom_header().custom_header_name() + ": " +
-    request.custom_header().value());
-  }
-  // We need to validate if custom header is present before adding in request header
   builder.AddHeader("Transfer-Encoding:");
   auto response = builder.BuildRequest().MakeUploadRequest(request.payload());
   if (!response.ok()) {

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -22,7 +22,8 @@ namespace internal {
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
-  UploadChunkRequest request(session_id_, next_expected_, custom_header_, buffers);
+  UploadChunkRequest request(session_id_, next_expected_, buffers);
+  request.set_option(custom_header());
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -30,8 +31,8 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& buffers, std::uint64_t upload_size) {
-  UploadChunkRequest request(session_id_, next_expected_, custom_header_, buffers,
-                             upload_size);
+  UploadChunkRequest request(session_id_, next_expected_, buffers, upload_size);
+  request.set_option(custom_header());
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -22,7 +22,7 @@ namespace internal {
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
-  UploadChunkRequest request(session_id_, next_expected_, buffers);
+  UploadChunkRequest request(session_id_, next_expected_, custom_header_, buffers);
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -30,7 +30,8 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& buffers, std::uint64_t upload_size) {
-  UploadChunkRequest request(session_id_, next_expected_, buffers, upload_size);
+  UploadChunkRequest request(session_id_, next_expected_, custom_header_, buffers,
+                             upload_size);
   auto result = client_->UploadChunk(request);
   Update(result, TotalBytes(buffers));
   return result;

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -29,9 +29,12 @@ namespace internal {
  */
 class CurlResumableUploadSession : public ResumableUploadSession {
  public:
-  explicit CurlResumableUploadSession(std::shared_ptr<CurlClient> client,
-                                      std::string session_id, CustomHeader custom_header = CustomHeader())
-      : client_(std::move(client)), session_id_(std::move(session_id)), custom_header_(custom_header) {}
+  explicit CurlResumableUploadSession(
+      std::shared_ptr<CurlClient> client, std::string session_id,
+      CustomHeader custom_header = CustomHeader())
+      : client_(std::move(client)),
+        session_id_(std::move(session_id)),
+        custom_header_(custom_header) {}
 
   StatusOr<ResumableUploadResponse> UploadChunk(
       ConstBufferSequence const& buffers) override;

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -30,8 +30,8 @@ namespace internal {
 class CurlResumableUploadSession : public ResumableUploadSession {
  public:
   explicit CurlResumableUploadSession(std::shared_ptr<CurlClient> client,
-                                      std::string session_id)
-      : client_(std::move(client)), session_id_(std::move(session_id)) {}
+                                      std::string session_id, CustomHeader custom_header = CustomHeader())
+      : client_(std::move(client)), session_id_(std::move(session_id)), custom_header_(custom_header) {}
 
   StatusOr<ResumableUploadResponse> UploadChunk(
       ConstBufferSequence const& buffers) override;
@@ -45,6 +45,8 @@ class CurlResumableUploadSession : public ResumableUploadSession {
 
   std::string const& session_id() const override { return session_id_; }
 
+  CustomHeader const& custom_header() const { return custom_header_; }
+
   bool done() const override { return done_; }
 
   StatusOr<ResumableUploadResponse> const& last_response() const override {
@@ -57,6 +59,7 @@ class CurlResumableUploadSession : public ResumableUploadSession {
 
   std::shared_ptr<CurlClient> client_;
   std::string session_id_;
+  CustomHeader custom_header_;
   std::uint64_t next_expected_ = 0;
   bool done_ = false;
   StatusOr<ResumableUploadResponse> last_response_;

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -34,7 +34,7 @@ class CurlResumableUploadSession : public ResumableUploadSession {
       CustomHeader custom_header = CustomHeader())
       : client_(std::move(client)),
         session_id_(std::move(session_id)),
-        custom_header_(custom_header) {}
+        custom_header_(std::move(custom_header)) {}
 
   StatusOr<ResumableUploadResponse> UploadChunk(
       ConstBufferSequence const& buffers) override;

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -381,23 +381,20 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
  public:
   UploadChunkRequest() = default;
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
-                     CustomHeader custom_header, ConstBufferSequence payload)
+                     ConstBufferSequence payload)
       : upload_session_url_(std::move(upload_session_url)),
         range_begin_(range_begin),
         payload_(std::move(payload)) {}
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
-                     CustomHeader custom_header, ConstBufferSequence payload,
-                     std::uint64_t source_size)
+                     ConstBufferSequence payload, std::uint64_t source_size)
       : upload_session_url_(std::move(upload_session_url)),
         range_begin_(range_begin),
-        custom_header_(custom_header),
         source_size_(source_size),
         last_chunk_(true),
         payload_(std::move(payload)) {}
 
   std::string const& upload_session_url() const { return upload_session_url_; }
   std::uint64_t range_begin() const { return range_begin_; }
-  CustomHeader const& custom_header() const { return custom_header_; }
   std::uint64_t range_end() const { return range_begin_ + payload_size() - 1; }
   std::uint64_t source_size() const { return source_size_; }
   std::size_t payload_size() const { return TotalBytes(payload_); }
@@ -422,7 +419,6 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
  private:
   std::string upload_session_url_;
   std::uint64_t range_begin_ = 0;
-  CustomHeader custom_header_;
   std::uint64_t source_size_ = 0;
   bool last_chunk_ = false;
   ConstBufferSequence payload_;

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -381,20 +381,23 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
  public:
   UploadChunkRequest() = default;
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
-                     ConstBufferSequence payload)
+                     CustomHeader custom_header, ConstBufferSequence payload)
       : upload_session_url_(std::move(upload_session_url)),
         range_begin_(range_begin),
         payload_(std::move(payload)) {}
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
-                     ConstBufferSequence payload, std::uint64_t source_size)
+                     CustomHeader custom_header, ConstBufferSequence payload,
+                     std::uint64_t source_size)
       : upload_session_url_(std::move(upload_session_url)),
         range_begin_(range_begin),
+        custom_header_(custom_header),
         source_size_(source_size),
         last_chunk_(true),
         payload_(std::move(payload)) {}
 
   std::string const& upload_session_url() const { return upload_session_url_; }
   std::uint64_t range_begin() const { return range_begin_; }
+  CustomHeader const& custom_header() const { return custom_header_; }
   std::uint64_t range_end() const { return range_begin_ + payload_size() - 1; }
   std::uint64_t source_size() const { return source_size_; }
   std::size_t payload_size() const { return TotalBytes(payload_); }
@@ -419,6 +422,7 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
  private:
   std::string upload_session_url_;
   std::uint64_t range_begin_ = 0;
+  CustomHeader custom_header_;
   std::uint64_t source_size_ = 0;
   bool last_chunk_ = false;
   ConstBufferSequence payload_;

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -625,6 +625,51 @@ TEST_F(ObjectFileIntegrationTest, UploadPortionRegularFile) {
   EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
+TEST_F(ObjectFileIntegrationTest, ResumableUploadFileCustomHeader) {
+  // Test relies on emulator for capturing custom header
+  if (!UsingEmulator()) GTEST_SKIP();
+ 
+  StatusOr<Client> client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+ 
+  auto file_name = ::testing::TempDir() + MakeRandomFilename();
+  auto object_name = MakeRandomObjectName();
+ 
+  // We will construct the expected response while streaming the data up.
+  std::ostringstream expected;
+  // Create a file with the contents to upload.
+  std::ofstream os(file_name, std::ios::binary);
+  WriteRandomLines(os, expected);
+  os.close();
+ 
+  // Create a CustomHeader object to send in request.
+  CustomHeader custom_header("custom_header_key","custom_header_value");
+ 
+  StatusOr<ObjectMetadata> meta = client->UploadFile(
+      file_name, bucket_name_, object_name, custom_header,
+      IfGenerationMatch(0), NewResumableUploadSession());
+ 
+  ASSERT_STATUS_OK(meta);
+  EXPECT_EQ(object_name, meta->name());
+  EXPECT_EQ(bucket_name_, meta->bucket());
+  auto expected_str = expected.str();
+  ASSERT_EQ(expected_str.size(), meta->size());
+ 
+  ASSERT_TRUE(meta->has_metadata("x_emulator_debug_custom_header"));
+  EXPECT_EQ("custom_header_value", meta->metadata("x_emulator_debug_custom_header"));
+ 
+  // Create an iostream to read the object back.
+  auto stream = client->ReadObject(bucket_name_, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  ASSERT_FALSE(actual.empty());
+  EXPECT_EQ(expected_str.size(), actual.size()) << " meta=" << *meta;
+  EXPECT_EQ(expected_str, actual);
+ 
+  auto status = client->DeleteObject(bucket_name_, object_name);
+  EXPECT_STATUS_OK(status);
+  EXPECT_EQ(0, std::remove(file_name.c_str()));
+}
+
 }  // anonymous namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -655,8 +655,8 @@ TEST_F(ObjectFileIntegrationTest, ResumableUploadFileCustomHeader) {
   auto expected_str = expected.str();
   ASSERT_EQ(expected_str.size(), meta->size());
  
-  ASSERT_TRUE(meta->has_metadata("x_emulator_debug_custom_header"));
-  EXPECT_EQ("custom_header_value", meta->metadata("x_emulator_debug_custom_header"));
+  ASSERT_TRUE(meta->has_metadata("x-goog-emulator-custom-header"));
+  EXPECT_EQ("custom_header_value", meta->metadata("x-goog-emulator-custom-header"));
  
   // Create an iostream to read the object back.
   auto stream = client->ReadObject(bucket_name_, object_name);


### PR DESCRIPTION
The Pull Request consists of below addition:

1. Propagate Custom Header in subsequent PUT requests when using Resumable uploads
2. Test case using GCS emulator

Fixes #5421

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5632)
<!-- Reviewable:end -->
