### PR TITLE
test: revert service tracing for integration tests

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -138,12 +138,6 @@ if should_run_integration_tests; then
     "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
     "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
 
-    # Enable service tracing for integration tests
-    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes"
-    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc_streams"
-    "--test_env=CLOUD_STORAGE_ENABLE_CLOG=yes"
-    "--test_env=CLOUD_STORAGE_ENABLE_TRACING=http,raw-client"
-
     # Bigtable
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID}"
     "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID}"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -200,12 +200,6 @@ if [[ "${BUILD_TESTING:-}" = "yes" ]]; then
       echo "${FORCE_TEST_IN_PRODUCTION:-}" | grep -qw "$1"
     }
 
-    # Enable service tracing for integration tests
-    export GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes
-    export GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc,rpc_streams
-    export CLOUD_STORAGE_ENABLE_CLOG=yes
-    export CLOUD_STORAGE_ENABLE_TRACING=http,raw-client
-
     readonly EMULATOR_SCRIPT="run_integration_tests_emulator_cmake.sh"
 
     if ! force_on_prod "pubsub"; then


### PR DESCRIPTION
This reverts #5626 and #5627.  Some tests generate so much output
(e.g., bigtable's DataIntegrationTest.TableSampleRowKeysTest) that
it makes it difficult to see what actually went wrong.

A more selective scheme (like a circular buffer) seems warranted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5636)
<!-- Reviewable:end -->
