### PR TITLE
feature(generator): only include polling_loop if lro present

### DIFF
--- a/generator/integration_tests/golden/iam_credentials_connection.gcpcxx.pb.cc
+++ b/generator/integration_tests/golden/iam_credentials_connection.gcpcxx.pb.cc
@@ -18,7 +18,6 @@
 
 #include "generator/integration_tests/golden/iam_credentials_connection.gcpcxx.pb.h"
 #include "generator/integration_tests/golden/internal/iam_credentials_stub_factory.gcpcxx.pb.h"
-#include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/internal/user_agent_prefix.h"
 #include <memory>

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -194,11 +194,11 @@ Status ConnectionGenerator::GenerateCc() {
   // clang-format on
 
   // includes
-  CcLocalIncludes({vars("connection_header_path"),
-                   vars("stub_factory_header_path"),
-                   "google/cloud/internal/polling_loop.h",
-                   "google/cloud/internal/retry_loop.h",
-                   "google/cloud/internal/user_agent_prefix.h"});
+  CcLocalIncludes(
+      {vars("connection_header_path"), vars("stub_factory_header_path"),
+       HasLongrunningMethod() ? "google/cloud/internal/polling_loop.h" : "",
+       "google/cloud/internal/retry_loop.h",
+       "google/cloud/internal/user_agent_prefix.h"});
   CcSystemIncludes({"memory"});
   CcPrint("\n");
 


### PR DESCRIPTION
`google/cloud/internal/polling_loop.h` includes `google/longrunning/operations.grpc.pb.h` and it only needed if the service has longrunning operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5638)
<!-- Reviewable:end -->
