### PR TITLE
refactor(generator): remove generation of default destructor in mocks

### DIFF
--- a/generator/integration_tests/golden/mocks/mock_database_admin_connection.gcpcxx.pb.h
+++ b/generator/integration_tests/golden/mocks/mock_database_admin_connection.gcpcxx.pb.h
@@ -28,8 +28,6 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 
 class MockDatabaseAdminConnection : public golden::DatabaseAdminConnection {
  public:
-  ~MockDatabaseAdminConnection() = default;
-
   MOCK_METHOD(golden::ListDatabasesRange,
   ListDatabases,
   (::google::test::admin::database::v1::ListDatabasesRequest request), (override));

--- a/generator/integration_tests/golden/mocks/mock_iam_credentials_connection.gcpcxx.pb.h
+++ b/generator/integration_tests/golden/mocks/mock_iam_credentials_connection.gcpcxx.pb.h
@@ -28,8 +28,6 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 
 class MockIAMCredentialsConnection : public golden::IAMCredentialsConnection {
  public:
-  ~MockIAMCredentialsConnection() = default;
-
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::GenerateAccessTokenResponse>,
   GenerateAccessToken,
   (::google::test::admin::database::v1::GenerateAccessTokenRequest const& request), (override));

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -56,9 +56,7 @@ Status MockConnectionGenerator::GenerateHeader() {
   // Abstract interface Connection base class
   HeaderPrint(  // clang-format off
     "class $mock_connection_class_name$ : public $product_namespace$::$connection_class_name$ {\n"
-    " public:\n"
-    "  ~$mock_connection_class_name$() = default;\n"
-    "\n");
+    " public:\n");
   // clang-format on
 
   for (auto const& method : methods()) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5641)
<!-- Reviewable:end -->
