### PR TITLE
fix(generator): handle package local and non-imported deduced lro response types

### DIFF
--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -325,6 +325,17 @@ const char* const kServiceProto =
     "       get: \"/v1/{name=projects/*/instances/*/databases/*}\"\n"
     "    };\n"
     "  }\n"
+    "  // Leading comments about rpc Method7.\n"
+    "  rpc Method7(Bar) returns (google.longrunning.Operation) {\n"
+    "    option (google.api.http) = {\n"
+    "       patch: \"/v1/{parent=projects/*/instances/*}/databases\"\n"
+    "       body: \"*\"\n"
+    "    };\n"
+    "    option (google.longrunning.operation_info) = {\n"
+    "      response_type: \"Bar\"\n"
+    "      metadata_type: \"google.protobuf.Method2Metadata\"\n"
+    "    };\n"
+    "  }\n"
     "}\n";
 
 class StringSourceTree : public google::protobuf::compiler::SourceTree {
@@ -575,7 +586,25 @@ INSTANTIATE_TEST_SUITE_P(
                              "method_request_url_substitution",
                              "projects/*/instances/*/databases/*"),
         MethodVarsTestValues("google.protobuf.Service.Method6",
-                             "default_idempotency", "kIdempotent")),
+                             "default_idempotency", "kIdempotent"),
+        // Method7
+        MethodVarsTestValues("google.protobuf.Service.Method7",
+                             "longrunning_metadata_type",
+                             "::google::protobuf::Method2Metadata"),
+        MethodVarsTestValues("google.protobuf.Service.Method7",
+                             "longrunning_response_type",
+                             "::google::protobuf::Bar"),
+        MethodVarsTestValues("google.protobuf.Service.Method7",
+                             "longrunning_deduced_response_message_type",
+                             "google.protobuf.Bar"),
+        MethodVarsTestValues("google.protobuf.Service.Method7",
+                             "longrunning_deduced_response_type",
+                             "::google::protobuf::Bar"),
+        MethodVarsTestValues(
+            "google.protobuf.Service.Method7",
+            "method_longrunning_deduced_return_doxygen_link",
+            "[::google::protobuf::Bar](https://github.com/googleapis/"
+            "googleapis/blob/foo/google/foo/v1/service.proto#L12)")),
     [](const testing::TestParamInfo<CreateMethodVarsTest::ParamType>& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');
       return pieces.back() + "_" + info.param.vars_key;

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -299,7 +299,7 @@ const char* const kServiceProto =
     "    };\n"
     "    option (google.longrunning.operation_info) = {\n"
     "      response_type: \"google.protobuf.Empty\"\n"
-    "      metadata_type: \"google.protobuf.Bar\"\n"
+    "      metadata_type: \"google.protobuf.Struct\"\n"
     "    };\n"
     "  }\n"
     "  // Leading comments about rpc Method4.\n"
@@ -491,13 +491,13 @@ INSTANTIATE_TEST_SUITE_P(
         // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
-                             "::google::protobuf::Bar"),
+                             "::google::protobuf::Struct"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_response_type",
                              "::google::protobuf::Empty"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_deduced_response_type",
-                             "::google::protobuf::Bar"),
+                             "::google::protobuf::Struct"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "method_request_param_key", "parent"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
@@ -510,6 +510,9 @@ INSTANTIATE_TEST_SUITE_P(
                              "projects/*/instances/*"),
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "default_idempotency", "kIdempotent"),
+        MethodVarsTestValues("google.protobuf.Service.Method3",
+                             "method_longrunning_deduced_return_doxygen_link",
+                             "::google::protobuf::Struct"),
         // Method4
         MethodVarsTestValues("google.protobuf.Service.Method4",
                              "range_output_field_name", "repeated_field"),


### PR DESCRIPTION
When specifying the metadata_type or response_type in an `option (google.longrunning.operation_info)` annotation, the types only need to be fully qualified if they exist in a different package than the rpc. Thus, for unqualified types the generator will concatenate the rpc package with the type specified, if necessary.
Furthermore, it is not required that those types source .proto file is imported into the current file, so the generator cannot verify that the type exists at all if the source .proto is not tangentially imported somewhere in the dependency tree. The generator will make a best effort to find a descriptor for the type specified. If no descriptor can be found the generator will just handle it as a string literal.

fixes #5657 
fixes #5656

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5659)
<!-- Reviewable:end -->
