### PR TITLE
feat: allow cq actions in StartOperation

### DIFF
--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -139,6 +139,13 @@ class DefaultCompletionQueueImpl::WakeUpRunAsyncOnIdle
   grpc::Alarm alarm_;
 };
 
+DefaultCompletionQueueImpl::DefaultCompletionQueueImpl()
+    : shutdown_guard_(
+          // Capturing `this` here is safe because the lifetime of copies of
+          // this member do not outlive `StartOperation`.
+          std::shared_ptr<void>(reinterpret_cast<void*>(this),
+                                [this](void*) { cq_.Shutdown(); })) {}
+
 void DefaultCompletionQueueImpl::Run() {
   class ThreadPoolCount {
    public:
@@ -177,8 +184,8 @@ void DefaultCompletionQueueImpl::Shutdown() {
   {
     std::lock_guard<std::mutex> lk(mu_);
     shutdown_ = true;
+    shutdown_guard_.reset();
   }
-  cq_.Shutdown();
 }
 
 void DefaultCompletionQueueImpl::CancelAll() {
@@ -239,6 +246,15 @@ void DefaultCompletionQueueImpl::StartOperation(
   }
   auto ins = pending_ops_.emplace(tag, std::move(op));
   if (ins.second) {
+    // Do not start the operation with the `CompletionQueue`'s lock held. This
+    // may trigger a deadlock if that operation schedules some more work on the
+    // completion queue (e.g. a timer). We need to delay the underlying
+    // grpc::CompletionQueue::Shutdown until `start` finishes because gRPC's
+    // reaction to trying to schedule some operation on a shut down completion
+    // queue is an assertion.
+    auto shutdown_guard = shutdown_guard_;
+    lk.unlock();
+
     start(tag);
     return;
   }

--- a/google/cloud/internal/default_completion_queue_impl.h
+++ b/google/cloud/internal/default_completion_queue_impl.h
@@ -34,7 +34,7 @@ class DefaultCompletionQueueImpl
     : public CompletionQueueImpl,
       public std::enable_shared_from_this<DefaultCompletionQueueImpl> {
  public:
-  DefaultCompletionQueueImpl() = default;
+  DefaultCompletionQueueImpl();
   ~DefaultCompletionQueueImpl() override = default;
 
   /// Run the event loop until Shutdown() is called.
@@ -107,6 +107,9 @@ class DefaultCompletionQueueImpl
   bool shutdown_{false};  // GUARDED_BY(mu_)
   std::unordered_map<void*, std::shared_ptr<AsyncGrpcOperation>>
       pending_ops_;  // GUARDED_BY(mu_)
+  // This member acts as a ref counter. When it drops to 0, it calls
+  // `cq_.Shutdown()`. Look into `StartOperation` for why it is necessary.
+  std::shared_ptr<void> shutdown_guard_;
 
   // These are metrics used in testing.
   std::atomic<std::int64_t> notify_counter_{0};


### PR DESCRIPTION
Before this PR, the `StartOp` passed to
`CompletionQueueImpl::StartOperation` was called with the
`CompletionQueueImpl` lock held. This became problematic
because in #5665 we want to schedule timers on the `CompletionQueue`
when calling starting the operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5666)
<!-- Reviewable:end -->
