### PR TITLE
feat: Cancel all connection refresh timers in dtor

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -257,6 +257,7 @@ if (BUILD_TESTING)
         internal/async_retry_multi_page_test.cc
         internal/async_retry_unary_rpc_and_poll_test.cc
         internal/bulk_mutator_test.cc
+        internal/common_client_test.cc
         internal/google_bytes_traits_test.cc
         internal/logging_admin_client_test.cc
         internal/logging_data_client_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -46,6 +46,7 @@ bigtable_client_unit_tests = [
     "internal/async_retry_multi_page_test.cc",
     "internal/async_retry_unary_rpc_and_poll_test.cc",
     "internal/bulk_mutator_test.cc",
+    "internal/common_client_test.cc",
     "internal/google_bytes_traits_test.cc",
     "internal/logging_admin_client_test.cc",
     "internal/logging_data_client_test.cc",

--- a/google/cloud/bigtable/internal/common_client.cc
+++ b/google/cloud/bigtable/internal/common_client.cc
@@ -20,9 +20,11 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
 ConnectionRefreshState::ConnectionRefreshState(
+    std::shared_ptr<CompletionQueue> const& cq,
     std::chrono::milliseconds max_conn_refresh_period)
     : max_conn_refresh_period_(max_conn_refresh_period),
-      rng_(std::random_device{}()) {}
+      rng_(std::random_device{}()),
+      timers_(std::make_shared<OutstandingTimers>(cq)) {}
 
 std::chrono::milliseconds ConnectionRefreshState::RandomizedRefreshDelay() {
   std::lock_guard<std::mutex> lk(mu_);
@@ -37,38 +39,87 @@ void ScheduleChannelRefresh(
     std::shared_ptr<grpc::Channel> const& channel) {
   // The timers will only hold weak pointers to the channel or to the
   // completion queue, so if either of them are destroyed, the timer chain
-  // will simply not continue. Unfortunately, that means that some stray
-  // timers may remain in the `CompletionQueue` for a while, but this is
-  // generally unavoidable because there is no way to cancel individual
-  // timers.
+  // will simply not continue.
   std::weak_ptr<grpc::Channel> weak_channel(channel);
   std::weak_ptr<CompletionQueue> weak_cq(cq);
   using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
-  cq->MakeRelativeTimer(state->RandomizedRefreshDelay())
-      .then([weak_channel, weak_cq, state](TimerFuture fut) {
-        if (!fut.get()) {
-          // Timer cancelled.
-          return;
-        }
-        auto channel = weak_channel.lock();
-        if (!channel) return;
-        auto cq = weak_cq.lock();
-        if (!cq) return;
-        cq->AsyncWaitConnectionReady(channel, std::chrono::system_clock::now() +
-                                                  kConnectionReadyTimeout)
-            .then([weak_channel, weak_cq, state](future<Status> fut) {
-              auto conn_status = fut.get();
-              if (!conn_status.ok()) {
-                GCP_LOG(WARNING)
-                    << "Failed to refresh connection. Error: " << conn_status;
-              }
-              auto channel = weak_channel.lock();
-              if (!channel) return;
-              auto cq = weak_cq.lock();
-              if (!cq) return;
-              ScheduleChannelRefresh(cq, state, channel);
-            });
-      });
+  auto timer_future =
+      cq->MakeRelativeTimer(state->RandomizedRefreshDelay())
+          .then([weak_channel, weak_cq, state](TimerFuture fut) {
+            if (!fut.get()) {
+              // Timer cancelled.
+              return;
+            }
+            auto channel = weak_channel.lock();
+            if (!channel) return;
+            auto cq = weak_cq.lock();
+            if (!cq) return;
+            cq->AsyncWaitConnectionReady(
+                  channel,
+                  std::chrono::system_clock::now() + kConnectionReadyTimeout)
+                .then([weak_channel, weak_cq, state](future<Status> fut) {
+                  auto conn_status = fut.get();
+                  if (!conn_status.ok()) {
+                    GCP_LOG(WARNING) << "Failed to refresh connection. Error: "
+                                     << conn_status;
+                  }
+                  auto channel = weak_channel.lock();
+                  if (!channel) return;
+                  auto cq = weak_cq.lock();
+                  if (!cq) return;
+                  ScheduleChannelRefresh(cq, state, channel);
+                });
+          });
+  state->timers().RegisterTimer(std::move(timer_future));
+}
+
+void OutstandingTimers::RegisterTimer(future<void> fut) {
+  std::unique_lock<std::mutex> lk(mu_);
+  if (shutdown_) {
+    lk.unlock();
+    fut.cancel();
+    return;
+  }
+
+  auto id = id_generator_++;
+  auto self = shared_from_this();
+  auto timer = fut.then([self, id](future<void>) {
+    // If the completion queue is being destroyed, we can afford not
+    // ignoring this continuation. Most likely nobody cares anymore.
+    auto cq = self->weak_cq_.lock();
+    if (!cq) return;
+    // Do not run in-line to avoid deadlocks when the timer is immediately
+    // satisfied.
+    cq->RunAsync([self, id] { self->DeregisterTimer(id); });
+  });
+  bool const inserted =
+      timers_.emplace(std::make_pair(id, std::move(timer))).second;
+  if (!inserted) Terminate("Duplicate timer identifier");
+}
+
+void OutstandingTimers::DeregisterTimer(std::uint64_t id) {
+  std::unique_lock<std::mutex> lk(mu_);
+  // `CancelAll` might have emptied the `timers_` map, so `id` might not point
+  // to a valid timer, but it's OK.
+  timers_.erase(id);
+}
+
+void OutstandingTimers::CancelAll() {
+  absl::flat_hash_map<std::uint64_t, future<void>> to_cancel;
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    if (shutdown_) {
+      // Already cancelled
+      return;
+    }
+    shutdown_ = true;
+    // We don't want to fire the timer continuations with the lock held to avoid
+    // deadlocks, so we shouldn't call `cancel()` here.
+    to_cancel.swap(timers_);
+  }
+  for (auto& fut : to_cancel) {
+    fut.second.cancel();
+  }
 }
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -18,10 +18,12 @@
 #include "google/cloud/bigtable/client_options.h"
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/connection_options.h"
+#include "google/cloud/internal/absl_flat_hash_map_quiet.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
 #include "google/cloud/status_or.h"
 #include <grpcpp/grpcpp.h>
+#include <list>
 
 namespace google {
 namespace cloud {
@@ -38,6 +40,30 @@ namespace internal {
  */
 std::chrono::seconds constexpr kConnectionReadyTimeout(10);
 
+class OutstandingTimers
+    : public std::enable_shared_from_this<OutstandingTimers> {
+ public:
+  explicit OutstandingTimers(std::shared_ptr<CompletionQueue> const& cq)
+      : weak_cq_(cq) {}
+  // Register a timer. It will automatically deregister on completion.
+  void RegisterTimer(future<void> fut);
+  // Cancel all currently registered timers and all which will be registered in
+  // the future.
+  void CancelAll();
+
+ private:
+  void DeregisterTimer(std::uint64_t id);
+  std::mutex mu_;
+  bool shutdown_ = false;           // GUARDED_BY(mu_)
+  std::uint64_t id_generator_ = 0;  // GUARDED_BY(mu_)
+  absl::flat_hash_map<std::uint64_t,
+                      future<void>> timers_;  // GUARDED_BY(mu_)
+  // Object of this class is owned by timers continuations, which means it
+  // cannot have an owning reference to the `CompletionQueue` because  it would
+  // otherwise create a risk of a deadlock on the completion queue destruction.
+  std::weak_ptr<CompletionQueue> weak_cq_;  // GUARDED_BY(mu_)
+};
+
 /**
  * State required by timers scheduled by `CommonClient`.
  *
@@ -47,13 +73,16 @@ std::chrono::seconds constexpr kConnectionReadyTimeout(10);
 class ConnectionRefreshState {
  public:
   explicit ConnectionRefreshState(
+      std::shared_ptr<CompletionQueue> const& cq,
       std::chrono::milliseconds max_conn_refresh_period);
   std::chrono::milliseconds RandomizedRefreshDelay();
+  OutstandingTimers& timers() { return *timers_; }
 
  private:
   std::mutex mu_;
   std::chrono::milliseconds max_conn_refresh_period_;
   google::cloud::internal::DefaultPRNG rng_;
+  std::shared_ptr<OutstandingTimers> timers_;
 };
 
 /**
@@ -95,14 +124,13 @@ class CommonClient {
             google::cloud::internal::DefaultBackgroundThreads(1)),
         cq_(std::make_shared<CompletionQueue>(background_threads_->cq())),
         refresh_state_(std::make_shared<ConnectionRefreshState>(
-            options_.max_conn_refresh_period())) {}
+            cq_, options_.max_conn_refresh_period())) {}
 
   ~CommonClient() {
     // This will stop the refresh of the channels.
     channels_.clear();
-    // TODO(2567): remove this call when the user will have to provide their own
-    // `CompletionQueues`
-    background_threads_->cq().CancelAll();
+    // This will cancel all pending timers.
+    refresh_state_->timers().CancelAll();
   }
 
   /**

--- a/google/cloud/bigtable/internal/common_client_test.cc
+++ b/google/cloud/bigtable/internal/common_client_test.cc
@@ -1,0 +1,111 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+
+#include "google/cloud/bigtable/internal/common_client.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+inline namespace BIGTABLE_CLIENT_NS {
+namespace internal {
+
+using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
+
+class OutstandingTimersTest : public ::testing::Test {
+ public:
+  OutstandingTimersTest() : thread_([this] { cq_.Run(); }) {}
+  ~OutstandingTimersTest() override {
+    cq_.Shutdown();
+    thread_.join();
+  }
+
+ protected:
+  CompletionQueue cq_;
+  std::thread thread_;
+};
+
+TEST_F(OutstandingTimersTest, Trivial) {
+  std::make_shared<OutstandingTimers>(std::make_shared<CompletionQueue>(cq_));
+}
+
+TEST_F(OutstandingTimersTest, TimerFinishes) {
+  auto registry = std::make_shared<OutstandingTimers>(
+      std::make_shared<CompletionQueue>(cq_));
+  promise<void> continuation_promise;
+  auto t = cq_.MakeRelativeTimer(std::chrono::milliseconds(2))
+               .then([&](TimerFuture fut) {
+                 EXPECT_STATUS_OK(fut.get());
+                 continuation_promise.set_value();
+               });
+  registry->RegisterTimer(std::move(t));
+  continuation_promise.get_future().get();
+  // This should be a noop.
+  registry->CancelAll();
+  // Calling it twice shouldn't hurt.
+  registry->CancelAll();
+}
+
+TEST_F(OutstandingTimersTest, TimerIsCancelled) {
+  auto registry = std::make_shared<OutstandingTimers>(
+      std::make_shared<CompletionQueue>(cq_));
+  promise<void> continuation_promise;
+  auto t =
+      cq_.MakeRelativeTimer(std::chrono::hours(10)).then([&](TimerFuture fut) {
+        auto res = fut.get();
+        EXPECT_FALSE(res);
+        EXPECT_EQ(StatusCode::kCancelled, res.status().code());
+        continuation_promise.set_value();
+      });
+  registry->RegisterTimer(std::move(t));
+  registry->CancelAll();
+  continuation_promise.get_future().get();
+}
+
+TEST_F(OutstandingTimersTest, TimerOutlivesRegistry) {
+  auto registry = std::make_shared<OutstandingTimers>(
+      std::make_shared<CompletionQueue>(cq_));
+  promise<void> continuation_promise;
+  auto t = cq_.MakeRelativeTimer(std::chrono::milliseconds(10))
+               .then([&](TimerFuture fut) {
+                 auto res = fut.get();
+                 EXPECT_STATUS_OK(res);
+                 continuation_promise.set_value();
+               });
+  registry->RegisterTimer(std::move(t));
+  registry.reset();
+  continuation_promise.get_future().get();
+}
+
+TEST_F(OutstandingTimersTest, TimerRegisteredAfterCancelAllGetCancelled) {
+  auto registry = std::make_shared<OutstandingTimers>(
+      std::make_shared<CompletionQueue>(cq_));
+  promise<void> continuation_promise;
+  auto t =
+      cq_.MakeRelativeTimer(std::chrono::hours(10)).then([&](TimerFuture fut) {
+        auto res = fut.get();
+        EXPECT_FALSE(res);
+        EXPECT_EQ(StatusCode::kCancelled, res.status().code());
+        continuation_promise.set_value();
+      });
+  registry->CancelAll();
+  registry->RegisterTimer(std::move(t));
+  continuation_promise.get_future().get();
+}
+
+}  // namespace internal
+}  // namespace BIGTABLE_CLIENT_NS
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
This is a part of #2567.

Timers created by `CommonClient` to refresh connections are now
cancelled in the `CommonClient` dtor. This is needed to make sure that
no stray timers remain in the completion queue after the destruction of
`CommonClient`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5667)
<!-- Reviewable:end -->
