### PR TITLE
feat(storage): add `BucketAccessControl` CRUD and List for gRPC

### DIFF
--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -60,6 +60,35 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         db.delete_bucket(request, bucket_name, context)
         return Empty()
 
+    def ListBucketAccessControls(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        result = resources_pb2.ListBucketAccessControlsResponse(
+            items=bucket.metadata.acl
+        )
+        return result
+
+    def InsertBucketAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.insert_acl(request, context)
+
+    def GetBucketAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.get_acl(request.entity, context)
+
+    def UpdateBucketAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.update_acl(request, request.entity, context)
+
+    def DeleteBucketAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        bucket.delete_acl(request.entity, context)
+        return Empty()
+
     # === OBJECT === #
 
     def InsertObject(self, request_iterator, context):

--- a/google/cloud/storage/emulator/utils/generation.py
+++ b/google/cloud/storage/emulator/utils/generation.py
@@ -44,12 +44,12 @@ def extract_precondition(request, is_meta, is_source, context):
         not_match_field = utils.common.to_snake_case(not_match_field)
         match = (
             getattr(request, match_field, None).value
-            if request.HasField(match_field)
+            if hasattr(request, match_field) and request.HasField(match_field)
             else None
         )
         not_match = (
             getattr(request, not_match_field, None).value
-            if request.HasField(not_match_field)
+            if hasattr(request, not_match_field) and request.HasField(not_match_field)
             else None
         )
     else:

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -251,6 +251,17 @@ class GrpcClient : public RawClient,
   static google::storage::v1::DeleteBucketRequest ToProto(
       DeleteBucketRequest const& request);
 
+  static google::storage::v1::InsertBucketAccessControlRequest ToProto(
+      CreateBucketAclRequest const& request);
+  static google::storage::v1::ListBucketAccessControlsRequest ToProto(
+      ListBucketAclRequest const& request);
+  static google::storage::v1::GetBucketAccessControlRequest ToProto(
+      GetBucketAclRequest const& request);
+  static google::storage::v1::UpdateBucketAccessControlRequest ToProto(
+      UpdateBucketAclRequest const& request);
+  static google::storage::v1::DeleteBucketAccessControlRequest ToProto(
+      DeleteBucketAclRequest const& request);
+
   static google::storage::v1::InsertObjectRequest ToProto(
       InsertObjectMediaRequest const& request);
   static google::storage::v1::DeleteObjectRequest ToProto(

--- a/google/cloud/storage/internal/grpc_client_bucket_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_bucket_request_test.cc
@@ -253,6 +253,191 @@ TEST(GrpcClientBucketRequest, DeleteBucketRequestAllFields) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcClientBucketRequest, CreateBucketAclRequestSimple) {
+  storage_proto::InsertBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    bucket_access_control: {
+      role: "READER"
+      entity: "user-testuser"
+    }
+)""",
+                                                            &expected));
+
+  CreateBucketAclRequest request("test-bucket-name", "user-testuser", "READER");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, CreateBucketAclRequestAllFields) {
+  storage_proto::InsertBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    bucket_access_control: {
+      role: "READER"
+      entity: "user-testuser"
+    }
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  CreateBucketAclRequest request("test-bucket-name", "user-testuser", "READER");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, ListBucketAclRequestSimple) {
+  storage_proto::ListBucketAccessControlsRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+)""",
+                                                            &expected));
+
+  ListBucketAclRequest request("test-bucket-name");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, ListBucketAclRequestAllFields) {
+  storage_proto::ListBucketAccessControlsRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  ListBucketAclRequest request("test-bucket-name");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, GetBucketAclRequestSimple) {
+  storage_proto::GetBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+)""",
+                                                            &expected));
+
+  GetBucketAclRequest request("test-bucket-name", "user-testuser");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, GetBucketAclRequestAllFields) {
+  storage_proto::GetBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  GetBucketAclRequest request("test-bucket-name", "user-testuser");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, UpdateBucketAclRequestSimple) {
+  storage_proto::UpdateBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    bucket_access_control: {
+      role: "READER"
+    }
+)""",
+                                                            &expected));
+
+  UpdateBucketAclRequest request("test-bucket-name", "user-testuser", "READER");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, UpdateBucketAclRequestAllFields) {
+  storage_proto::UpdateBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    bucket_access_control: {
+      role: "READER"
+    }
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  UpdateBucketAclRequest request("test-bucket-name", "user-testuser", "READER");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, DeleteBucketAclRequestSimple) {
+  storage_proto::DeleteBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+)""",
+                                                            &expected));
+
+  DeleteBucketAclRequest request("test-bucket-name", "user-testuser");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, DeleteBucketAclRequestAllFields) {
+  storage_proto::DeleteBucketAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  DeleteBucketAclRequest request("test-bucket-name", "user-testuser");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/contains_once.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <crc32c/crc32c.h>
 #include <gmock/gmock.h>
@@ -39,6 +40,8 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::storage::testing::AclEntityNames;
+using ::google::cloud::testing_util::ContainsOnce;
 using ::testing::Contains;
 using ::testing::Not;
 
@@ -60,6 +63,11 @@ class GrpcIntegrationTest
     ASSERT_FALSE(project_id_.empty()) << "GOOGLE_CLOUD_PROJECT is not set";
   }
   std::string project_id() const { return project_id_; }
+
+  std::string MakeEntityName() {
+    // We always use the viewers for the project because it is known to exist.
+    return "project-viewers-" + project_id_;
+  }
 
  private:
   std::string project_id_;
@@ -110,6 +118,68 @@ TEST_P(GrpcIntegrationTest, BucketCRUD) {
   auto delete_status = client->DeleteBucket(bucket_name);
   EXPECT_STATUS_OK(delete_status);
   EXPECT_THAT(list_bucket_names(), Not(Contains(bucket_name)));
+}
+
+TEST_P(GrpcIntegrationTest, BucketAccessControlCRUD) {
+  StatusOr<Client> client = MakeBucketIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  // Create a new bucket to run the test, with the "private" PredefinedAcl so
+  // we know what the contents of the ACL will be.
+  std::string bucket_name = MakeRandomBucketName();
+  auto meta = client->CreateBucketForProject(
+      bucket_name, project_id(), BucketMetadata(), PredefinedAcl("private"),
+      Projection("full"));
+  ASSERT_STATUS_OK(meta);
+
+  auto entity_name = MakeEntityName();
+
+  ASSERT_FALSE(meta->acl().empty())
+      << "Test aborted. Empty ACL returned from newly created bucket <"
+      << bucket_name << "> even though we requested the <full> projection.";
+  ASSERT_THAT(AclEntityNames(meta->acl()), Not(Contains(entity_name)))
+      << "Test aborted. The bucket <" << bucket_name << "> has <" << entity_name
+      << "> in its ACL.  This is unexpected because the bucket was just"
+      << " created with a predefine ACL which should preclude this result.";
+
+  StatusOr<BucketAccessControl> result =
+      client->CreateBucketAcl(bucket_name, entity_name, "OWNER");
+  ASSERT_STATUS_OK(result);
+  EXPECT_EQ("OWNER", result->role());
+
+  StatusOr<std::vector<BucketAccessControl>> current_acl =
+      client->ListBucketAcl(bucket_name);
+  ASSERT_STATUS_OK(current_acl);
+  EXPECT_FALSE(current_acl->empty());
+  // Search using the entity name returned by the request, because we use
+  // 'project-editors-<project_id>' this different than the original entity
+  // name, the server "translates" the project id to a project number.
+  EXPECT_THAT(AclEntityNames(*current_acl), ContainsOnce(result->entity()));
+
+  StatusOr<BucketAccessControl> get_result =
+      client->GetBucketAcl(bucket_name, entity_name);
+  ASSERT_STATUS_OK(get_result);
+  EXPECT_EQ(*get_result, *result);
+
+  BucketAccessControl new_acl = *get_result;
+  new_acl.set_role("READER");
+  auto updated_result = client->UpdateBucketAcl(bucket_name, new_acl);
+  ASSERT_STATUS_OK(updated_result);
+  EXPECT_EQ("READER", updated_result->role());
+
+  get_result = client->GetBucketAcl(bucket_name, entity_name);
+  ASSERT_STATUS_OK(get_result);
+  EXPECT_EQ(*get_result, *updated_result);
+
+  auto status = client->DeleteBucketAcl(bucket_name, entity_name);
+  ASSERT_STATUS_OK(status);
+
+  current_acl = client->ListBucketAcl(bucket_name);
+  ASSERT_STATUS_OK(current_acl);
+  EXPECT_THAT(AclEntityNames(*current_acl), Not(Contains(result->entity())));
+
+  status = client->DeleteBucket(bucket_name);
+  ASSERT_STATUS_OK(status);
 }
 
 TEST_P(GrpcIntegrationTest, ObjectCRUD) {

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -121,6 +121,8 @@ TEST_P(GrpcIntegrationTest, BucketCRUD) {
 }
 
 TEST_P(GrpcIntegrationTest, BucketAccessControlCRUD) {
+  // TODO(#5673): Enable this.
+  if (!UsingEmulator()) GTEST_SKIP();
   StatusOr<Client> client = MakeBucketIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
This PR:
- close #4180 (`ListBucketAcl`).
- close #4179 (`CreateBucketAcl`).
- close #4178 (`DeleteBucketAcl`).
- close #4177 (`GetBucketAcl`).
- close #4176 (`UpdateBucketAcl`).
- Fix an error in `SetPredefinedDefaultObjectAcl`.
- Fix an error in storage emulator which some messages raise because they don't have `if_generation_match` in their proto structure.

This PR is big. But we need `ListBucketAcl` for testing CRUD and vice versa. In addition, the code logic is short, the test is larger, but the test is quite repetitive or it is just a copy from an another test ( `BucketAccessControlCRUD` copied from `bucket_integration_test` ), so I think we could implement all these functions in one PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5669)
<!-- Reviewable:end -->
