### PR TITLE
fix: don't wait for state change on shut down CQ

### DIFF
--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -248,8 +248,8 @@ class CompletionQueue {
       std::shared_ptr<grpc::Channel> channel,
       std::chrono::system_clock::time_point deadline) {
     auto op = std::make_shared<internal::AsyncConnectionReadyFuture>(
-        std::move(channel), deadline);
-    impl_->StartOperation(op, [&](void* tag) { op->Start(impl_->cq(), tag); });
+        std::move(channel), deadline, impl_);
+    impl_->StartOperation(op, [&](void* tag) { op->Start(tag, impl_->cq()); });
     return op->GetFuture();
   }
 

--- a/google/cloud/internal/async_connection_ready_test.cc
+++ b/google/cloud/internal/async_connection_ready_test.cc
@@ -15,15 +15,24 @@
 #include "google/cloud/internal/async_connection_ready.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/fake_completion_queue_impl.h"
 #include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
+
+class CompletionQueueTest : public ::testing::Test {
+ protected:
+  static void CallNotify(AsyncConnectionReadyFuture& op, bool ok) {
+    op.Notify(ok);
+  }
+};
+
 namespace {
 
-TEST(CompletionQueueTest, WaitingForFailingConnection) {
+TEST_F(CompletionQueueTest, WaitingForFailingConnection) {
   auto channel = grpc::CreateChannel("some_nonexistent.address",
                                      grpc::InsecureChannelCredentials());
   CompletionQueue cq;
@@ -45,7 +54,7 @@ TEST(CompletionQueueTest, WaitingForFailingConnection) {
   t.join();
 }
 
-TEST(CompletionQueueTest, SuccessfulWaitingForConnection) {
+TEST_F(CompletionQueueTest, SuccessfulWaitingForConnection) {
   grpc::ServerBuilder builder;
   grpc::AsyncGenericService generic_service;
   builder.RegisterAsyncGenericService(&generic_service);
@@ -83,6 +92,25 @@ TEST(CompletionQueueTest, SuccessfulWaitingForConnection) {
 
   cli_cq.Shutdown();
   cli_thread.join();
+}
+
+TEST_F(CompletionQueueTest, DisappearingCompletionQueue) {
+  auto channel = grpc::CreateChannel("some_nonexistent.address",
+                                     grpc::InsecureChannelCredentials());
+  auto cq_impl = std::make_shared<
+      ::google::cloud::testing_util::FakeCompletionQueueImpl>();
+  AsyncConnectionReadyFuture op(
+      channel, std::chrono::system_clock::now() + std::chrono::hours(10),
+      cq_impl);
+  cq_impl.reset();
+  // The connection doesn't try to connect to the endpoint unless there's a
+  // method call or `GetState(true)` is called, so we can safely expect IDLE
+  // state here.
+  EXPECT_EQ(GRPC_CHANNEL_IDLE, channel->GetState(false));
+  CallNotify(op, true);
+  auto status = op.GetFuture().get();
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(StatusCode::kCancelled, status.code());
 }
 
 }  // namespace


### PR DESCRIPTION
This fixes #5670.

Before this PR, `NotifyOnStateChange()` could be called on a
`grpc::CompletionQueue` which was shut down via `Shutdown()`. This PR
makes `AsyncConnectionReadyFuture` use
`CompletionQueueImpl::StartOperation` to make sure that the whole
operation either fails with `StatusCode::kCancelled` or there is a
guarantee that the `CompletionQueue` is not shut down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5676)
<!-- Reviewable:end -->
