### PR TITLE
fix: allow DefaulBackgroundThreads to self-destroy

### DIFF
--- a/google/cloud/internal/background_threads_impl.h
+++ b/google/cloud/internal/background_threads_impl.h
@@ -47,7 +47,6 @@ class AutomaticallyCreatedBackgroundThreads : public BackgroundThreads {
   ~AutomaticallyCreatedBackgroundThreads() override;
 
   CompletionQueue cq() const override { return cq_; }
-  void Shutdown();
   std::size_t pool_size() const { return pool_.size(); }
 
  private:


### PR DESCRIPTION
The last reference to `AutomaticallyCreatedBackgroundThreads` may be in
the `CompletionQueue` owned by itself. This means that
`~AutomaticallyCreatedBackgroundThreads()` will be executed in the
thread belonging to it. Before this PR this resulted in a deadlock. This
PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5681)
<!-- Reviewable:end -->
