### PR TITLE
feat(storage): add `DefaultObjectAccessControl` CRUD and List for gRPC

### DIFF
--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -89,6 +89,35 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         bucket.delete_acl(request.entity, context)
         return Empty()
 
+    def ListDefaultObjectAccessControls(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        result = resources_pb2.ListObjectAccessControlsResponse(
+            items=bucket.metadata.default_object_acl
+        )
+        return result
+
+    def InsertDefaultObjectAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.insert_default_object_acl(request, context)
+
+    def GetDefaultObjectAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.get_default_object_acl(request.entity, context)
+
+    def UpdateDefaultObjectAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.update_default_object_acl(request, request.entity, context)
+
+    def DeleteDefaultObjectAccessControl(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        bucket.delete_default_object_acl(request.entity, context)
+        return Empty()
+
     # === OBJECT === #
 
     def InsertObject(self, request_iterator, context):

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -453,28 +453,67 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchObjectAcl(
 }
 
 StatusOr<ListDefaultObjectAclResponse> GrpcClient::ListDefaultObjectAcl(
-    ListDefaultObjectAclRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+    ListDefaultObjectAclRequest const& request) {
+  grpc::ClientContext context;
+  auto proto_request = ToProto(request);
+  google::storage::v1::ListObjectAccessControlsResponse response;
+  auto status = stub_->ListDefaultObjectAccessControls(&context, proto_request,
+                                                       &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+
+  ListDefaultObjectAclResponse res;
+  for (auto& item : *response.mutable_items()) {
+    res.items.emplace_back(FromProto(std::move(item)));
+  }
+
+  return res;
 }
 
 StatusOr<ObjectAccessControl> GrpcClient::CreateDefaultObjectAcl(
-    CreateDefaultObjectAclRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+    CreateDefaultObjectAclRequest const& request) {
+  grpc::ClientContext context;
+  auto proto_request = ToProto(request);
+  google::storage::v1::ObjectAccessControl response;
+  auto status = stub_->InsertDefaultObjectAccessControl(&context, proto_request,
+                                                        &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return FromProto(std::move(response));
 }
 
 StatusOr<EmptyResponse> GrpcClient::DeleteDefaultObjectAcl(
-    DeleteDefaultObjectAclRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+    DeleteDefaultObjectAclRequest const& request) {
+  grpc::ClientContext context;
+  auto proto_request = ToProto(request);
+  google::protobuf::Empty response;
+  auto status = stub_->DeleteDefaultObjectAccessControl(&context, proto_request,
+                                                        &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+
+  return EmptyResponse{};
 }
 
 StatusOr<ObjectAccessControl> GrpcClient::GetDefaultObjectAcl(
-    GetDefaultObjectAclRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+    GetDefaultObjectAclRequest const& request) {
+  grpc::ClientContext context;
+  auto proto_request = ToProto(request);
+  google::storage::v1::ObjectAccessControl response;
+  auto status =
+      stub_->GetDefaultObjectAccessControl(&context, proto_request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+
+  return FromProto(std::move(response));
 }
 
 StatusOr<ObjectAccessControl> GrpcClient::UpdateDefaultObjectAcl(
-    UpdateDefaultObjectAclRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+    UpdateDefaultObjectAclRequest const& request) {
+  grpc::ClientContext context;
+  auto proto_request = ToProto(request);
+  google::storage::v1::ObjectAccessControl response;
+  auto status = stub_->UpdateDefaultObjectAccessControl(&context, proto_request,
+                                                        &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+
+  return FromProto(std::move(response));
 }
 
 StatusOr<ObjectAccessControl> GrpcClient::PatchDefaultObjectAcl(
@@ -1468,6 +1507,53 @@ google::storage::v1::UpdateBucketAccessControlRequest GrpcClient::ToProto(
 google::storage::v1::DeleteBucketAccessControlRequest GrpcClient::ToProto(
     DeleteBucketAclRequest const& request) {
   google::storage::v1::DeleteBucketAccessControlRequest r;
+  r.set_bucket(request.bucket_name());
+  r.set_entity(request.entity());
+  SetCommonParameters(r, request);
+  return r;
+}
+
+google::storage::v1::InsertDefaultObjectAccessControlRequest
+GrpcClient::ToProto(CreateDefaultObjectAclRequest const& request) {
+  google::storage::v1::InsertDefaultObjectAccessControlRequest r;
+  r.set_bucket(request.bucket_name());
+  r.mutable_object_access_control()->set_role(request.role());
+  r.mutable_object_access_control()->set_entity(request.entity());
+  SetCommonParameters(r, request);
+  return r;
+}
+
+google::storage::v1::ListDefaultObjectAccessControlsRequest GrpcClient::ToProto(
+    ListDefaultObjectAclRequest const& request) {
+  google::storage::v1::ListDefaultObjectAccessControlsRequest r;
+  r.set_bucket(request.bucket_name());
+  // TODO(#5680): Add `SetMetagenerationConditions`.
+  SetCommonParameters(r, request);
+  return r;
+}
+
+google::storage::v1::GetDefaultObjectAccessControlRequest GrpcClient::ToProto(
+    GetDefaultObjectAclRequest const& request) {
+  google::storage::v1::GetDefaultObjectAccessControlRequest r;
+  r.set_bucket(request.bucket_name());
+  r.set_entity(request.entity());
+  SetCommonParameters(r, request);
+  return r;
+}
+
+google::storage::v1::UpdateDefaultObjectAccessControlRequest
+GrpcClient::ToProto(UpdateDefaultObjectAclRequest const& request) {
+  google::storage::v1::UpdateDefaultObjectAccessControlRequest r;
+  r.set_bucket(request.bucket_name());
+  r.set_entity(request.entity());
+  r.mutable_object_access_control()->set_role(request.role());
+  SetCommonParameters(r, request);
+  return r;
+}
+
+google::storage::v1::DeleteDefaultObjectAccessControlRequest
+GrpcClient::ToProto(DeleteDefaultObjectAclRequest const& request) {
+  google::storage::v1::DeleteDefaultObjectAccessControlRequest r;
   r.set_bucket(request.bucket_name());
   r.set_entity(request.entity());
   SetCommonParameters(r, request);

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -262,6 +262,17 @@ class GrpcClient : public RawClient,
   static google::storage::v1::DeleteBucketAccessControlRequest ToProto(
       DeleteBucketAclRequest const& request);
 
+  static google::storage::v1::InsertDefaultObjectAccessControlRequest ToProto(
+      CreateDefaultObjectAclRequest const& request);
+  static google::storage::v1::ListDefaultObjectAccessControlsRequest ToProto(
+      ListDefaultObjectAclRequest const& request);
+  static google::storage::v1::GetDefaultObjectAccessControlRequest ToProto(
+      GetDefaultObjectAclRequest const& request);
+  static google::storage::v1::UpdateDefaultObjectAccessControlRequest ToProto(
+      UpdateDefaultObjectAclRequest const& request);
+  static google::storage::v1::DeleteDefaultObjectAccessControlRequest ToProto(
+      DeleteDefaultObjectAclRequest const& request);
+
   static google::storage::v1::InsertObjectRequest ToProto(
       InsertObjectMediaRequest const& request);
   static google::storage::v1::DeleteObjectRequest ToProto(

--- a/google/cloud/storage/internal/grpc_client_bucket_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_bucket_request_test.cc
@@ -438,6 +438,195 @@ TEST(GrpcClientBucketRequest, DeleteBucketAclRequestAllFields) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcClientBucketRequest, CreateDefaultObjectAclRequestSimple) {
+  storage_proto::InsertDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    object_access_control: {
+      role: "READER"
+      entity: "user-testuser"
+    }
+)""",
+                                                            &expected));
+
+  CreateDefaultObjectAclRequest request("test-bucket-name", "user-testuser",
+                                        "READER");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, CreateDefaultObjectAclRequestAllFields) {
+  storage_proto::InsertDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    object_access_control: {
+      role: "READER"
+      entity: "user-testuser"
+    }
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  CreateDefaultObjectAclRequest request("test-bucket-name", "user-testuser",
+                                        "READER");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, ListDefaultObjectAclRequestSimple) {
+  storage_proto::ListDefaultObjectAccessControlsRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+)""",
+                                                            &expected));
+
+  ListDefaultObjectAclRequest request("test-bucket-name");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, ListDefaultObjectAclRequestAllFields) {
+  storage_proto::ListDefaultObjectAccessControlsRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  ListDefaultObjectAclRequest request("test-bucket-name");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, GetDefaultObjectAclRequestSimple) {
+  storage_proto::GetDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+)""",
+                                                            &expected));
+
+  GetDefaultObjectAclRequest request("test-bucket-name", "user-testuser");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, GetDefaultObjectAclRequestAllFields) {
+  storage_proto::GetDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  GetDefaultObjectAclRequest request("test-bucket-name", "user-testuser");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, UpdateDefaultObjectAclRequestSimple) {
+  storage_proto::UpdateDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    object_access_control: {
+      role: "READER"
+    }
+)""",
+                                                            &expected));
+
+  UpdateDefaultObjectAclRequest request("test-bucket-name", "user-testuser",
+                                        "READER");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, UpdateDefaultObjectAclRequestAllFields) {
+  storage_proto::UpdateDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    object_access_control: {
+      role: "READER"
+    }
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  UpdateDefaultObjectAclRequest request("test-bucket-name", "user-testuser",
+                                        "READER");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, DeleteDefaultObjectAclRequestSimple) {
+  storage_proto::DeleteDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+)""",
+                                                            &expected));
+
+  DeleteDefaultObjectAclRequest request("test-bucket-name", "user-testuser");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, DeleteDefaultObjectAclRequestAllFields) {
+  storage_proto::DeleteDefaultObjectAccessControlRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    entity: "user-testuser"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  DeleteDefaultObjectAclRequest request("test-bucket-name", "user-testuser");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS


### PR DESCRIPTION
This PR:
- close #4186 (`ListDefaultObjectAcl`).
- close #4185 (`CreateDefaultObjectAcl`).
- close #4184 (`DeleteDefaultObjectAcl`).
- close #4183 (`GetDefaultObjectAcl`).
- close #4182 (`UpdateDefaultObjectAcl`).

Based on #5669

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5682)
<!-- Reviewable:end -->
