### PR TITLE
test(pubsub): deflake unit test

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -928,9 +928,8 @@ TEST(StreamingSubscriptionBatchSourceTest, ShutdownWithPendingReadCancel) {
 
   auto cancel = wait_and_check_name("Cancel");
   read.set_value(false);
-  wait_and_check_name("Finish").set_value(true);
-
   shutdown->MarkAsShutdown("test", Status{});
+  wait_and_check_name("Finish").set_value(true);
   EXPECT_THAT(done.get(), StatusIs(StatusCode::kOk));
 }
 


### PR DESCRIPTION
This was only reported internally (see the operator handoff).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5685)
<!-- Reviewable:end -->
