### PR TITLE
ci: speed up builds with shared libraries

### DIFF
--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -33,7 +33,7 @@ readonly HOME_DIR="$3"
 
 mkdir -p "${HOME_DIR}/.cache"
 mkdir -p "${HOME_DIR}/.ccache"
-echo "max_size = 4.0G" >"${HOME_DIR}/.ccache/ccache.conf"
+echo "max_size = 5.0G" >"${HOME_DIR}/.ccache/ccache.conf"
 
 if ! cache_download_enabled; then
   exit 0

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -34,7 +34,7 @@ readonly CACHE_NAME="$2"
 
 mkdir -p "${HOME}/.ccache"
 [[ -f "${HOME}/.ccache/ccache.conf" ]] ||
-  echo "max_size = 4.0G" >"${HOME}/.ccache/ccache.conf"
+  echo "max_size = 5.0G" >"${HOME}/.ccache/ccache.conf"
 
 if ! cache_download_enabled; then
   exit 0


### PR DESCRIPTION
They are hitting the ccache size limits, and getting less than 50% cache
hits.

Note that we will need to wait for a full build before this yields any benefits. OTOH,
the cache is full, a local build on my workstation requires 4.3G.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5686)
<!-- Reviewable:end -->
