### PR TITLE
feat(storage): add `Notifications` ToProto, FromProto, List, Create, Get and Delete for gRPC

### DIFF
--- a/google/cloud/storage/emulator/grpc_server.py
+++ b/google/cloud/storage/emulator/grpc_server.py
@@ -118,6 +118,32 @@ class StorageServicer(storage_pb2_grpc.StorageServicer):
         bucket.delete_default_object_acl(request.entity, context)
         return Empty()
 
+    def InsertNotification(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        return bucket.insert_notification(request, context)
+
+    def ListNotifications(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        result = resources_pb2.ListNotificationsResponse(
+            items=bucket.notifications.values()
+        )
+        return result
+
+    def GetNotification(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        notification_id = request.notification
+        return bucket.get_notification(notification_id, context)
+
+    def DeleteNotification(self, request, context):
+        bucket_name = request.bucket
+        bucket = db.get_bucket(request, bucket_name, context)
+        notification_id = request.notification
+        bucket.delete_notification(notification_id, context)
+        return Empty()
+
     # === OBJECT === #
 
     def InsertObject(self, request_iterator, context):

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -155,6 +155,10 @@ class GrpcClient : public RawClient,
   StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
   StatusOr<SignBlobResponse> SignBlob(SignBlobRequest const&) override;
 
+  static google::storage::v1::Notification ToProto(
+      NotificationMetadata const& notification);
+  static NotificationMetadata FromProto(
+      google::storage::v1::Notification notification);
   StatusOr<ListNotificationsResponse> ListNotifications(
       ListNotificationsRequest const&) override;
   StatusOr<NotificationMetadata> CreateNotification(
@@ -272,6 +276,15 @@ class GrpcClient : public RawClient,
       UpdateDefaultObjectAclRequest const& request);
   static google::storage::v1::DeleteDefaultObjectAccessControlRequest ToProto(
       DeleteDefaultObjectAclRequest const& request);
+
+  static google::storage::v1::InsertNotificationRequest ToProto(
+      CreateNotificationRequest const& request);
+  static google::storage::v1::ListNotificationsRequest ToProto(
+      ListNotificationsRequest const& request);
+  static google::storage::v1::GetNotificationRequest ToProto(
+      GetNotificationRequest const& request);
+  static google::storage::v1::DeleteNotificationRequest ToProto(
+      DeleteNotificationRequest const& request);
 
   static google::storage::v1::InsertObjectRequest ToProto(
       InsertObjectMediaRequest const& request);

--- a/google/cloud/storage/internal/grpc_client_bucket_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_bucket_request_test.cc
@@ -630,6 +630,176 @@ TEST(GrpcClientBucketRequest, DeleteDefaultObjectAclRequestAllFields) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcClientBucketRequest, CreateNotificationRequestSimple) {
+  storage_proto::InsertNotificationRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    notification {
+      topic: "test-topic"
+      event_types: "OBJECT_FINALIZE"
+      event_types: "OBJECT_METADATA_UPDATE"
+      custom_attributes: { key: "test-ca-1" value: "value1" }
+      custom_attributes: { key: "test-ca-2" value: "value2" }
+      object_name_prefix: "test-object-prefix-"
+      payload_format: "JSON_API_V1"
+    }
+)""",
+                                                            &expected));
+
+  auto notification = NotificationMetadata()
+                          .set_topic("test-topic")
+                          .append_event_type("OBJECT_FINALIZE")
+                          .append_event_type("OBJECT_METADATA_UPDATE")
+                          .upsert_custom_attributes("test-ca-1", "value1")
+                          .upsert_custom_attributes("test-ca-2", "value2")
+                          .set_object_name_prefix("test-object-prefix-")
+                          .set_payload_format("JSON_API_V1");
+  CreateNotificationRequest request("test-bucket-name", notification);
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, CreateNotificationRequestAllFields) {
+  storage_proto::InsertNotificationRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    notification {
+      topic: "test-topic"
+      event_types: "OBJECT_FINALIZE"
+      event_types: "OBJECT_METADATA_UPDATE"
+      custom_attributes: { key: "test-ca-1" value: "value1" }
+      custom_attributes: { key: "test-ca-2" value: "value2" }
+      object_name_prefix: "test-object-prefix-"
+      payload_format: "JSON_API_V1"
+    }
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  auto notification = NotificationMetadata()
+                          .set_topic("test-topic")
+                          .append_event_type("OBJECT_FINALIZE")
+                          .append_event_type("OBJECT_METADATA_UPDATE")
+                          .upsert_custom_attributes("test-ca-1", "value1")
+                          .upsert_custom_attributes("test-ca-2", "value2")
+                          .set_object_name_prefix("test-object-prefix-")
+                          .set_payload_format("JSON_API_V1");
+  CreateNotificationRequest request("test-bucket-name", notification);
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, ListNotificationsRequestSimple) {
+  storage_proto::ListNotificationsRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+)""",
+                                                            &expected));
+
+  ListNotificationsRequest request("test-bucket-name");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, ListNotificationsRequestAllFields) {
+  storage_proto::ListNotificationsRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  ListNotificationsRequest request("test-bucket-name");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, GetNotificationRequestSimple) {
+  storage_proto::GetNotificationRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    notification: "test-notification-id"
+)""",
+                                                            &expected));
+
+  GetNotificationRequest request("test-bucket-name", "test-notification-id");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, GetNotificationRequestAllFields) {
+  storage_proto::GetNotificationRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    notification: "test-notification-id"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  GetNotificationRequest request("test-bucket-name", "test-notification-id");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, DeleteNotificationRequestSimple) {
+  storage_proto::DeleteNotificationRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    notification: "test-notification-id"
+)""",
+                                                            &expected));
+
+  DeleteNotificationRequest request("test-bucket-name", "test-notification-id");
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(GrpcClientBucketRequest, DeleteNotificationRequestAllFields) {
+  storage_proto::DeleteNotificationRequest expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+    bucket: "test-bucket-name"
+    notification: "test-notification-id"
+    common_request_params: {
+      quota_user: "test-quota-user"
+      user_project: "test-user-project"
+    }
+)""",
+                                                            &expected));
+
+  DeleteNotificationRequest request("test-bucket-name", "test-notification-id");
+  request.set_multiple_options(UserProject("test-user-project"),
+                               QuotaUser("test-quota-user"),
+                               UserIp("test-user-ip"));
+
+  auto actual = GrpcClient::ToProto(request);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -60,17 +60,16 @@ class CreateNotificationRequest
     : public GenericRequest<CreateNotificationRequest, UserProject> {
  public:
   CreateNotificationRequest() = default;
-  CreateNotificationRequest(std::string bucket,
-                            NotificationMetadata const& notification)
-      : bucket_name_(std::move(bucket)),
-        json_payload_(notification.JsonPayloadForInsert()) {}
+  CreateNotificationRequest(std::string bucket, NotificationMetadata metadata)
+      : bucket_name_(std::move(bucket)), metadata_(std::move(metadata)) {}
 
   std::string const& bucket_name() const { return bucket_name_; }
-  std::string const& json_payload() const { return json_payload_; }
+  std::string json_payload() const { return metadata_.JsonPayloadForInsert(); }
+  NotificationMetadata const& metadata() const { return metadata_; }
 
  private:
   std::string bucket_name_;
-  std::string json_payload_;
+  NotificationMetadata metadata_;
 };
 
 std::ostream& operator<<(std::ostream& os, CreateNotificationRequest const& r);

--- a/google/cloud/storage/notification_metadata.h
+++ b/google/cloud/storage/notification_metadata.h
@@ -44,6 +44,9 @@ class NotificationMetadata {
  public:
   NotificationMetadata() = default;
 
+  explicit NotificationMetadata(std::string id, std::string etag)
+      : etag_(std::move(etag)), id_(std::move(id)) {}
+
   /**
    * Returns the payload for a call to `Notifications: insert`.
    */


### PR DESCRIPTION
- Close #4187 ( `ToProto/FromProto` for `NotificationMetadata` ).
- Close #4188 ( `DeleteNotification` ).
- Close #4189 ( `CreateNotification` ).
- Close #4190 ( `GetNotification` ).
- Close #4191 ( `ListNotification` ).

Here is my approach for `Notification`. I am not sure this is the best way, especially with `notification_request`. Please take a look at it !

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5687)
<!-- Reviewable:end -->
