### PR TITLE
fix(bigtable): crashes during client shutdown

### DIFF
--- a/google/cloud/completion_queue.cc
+++ b/google/cloud/completion_queue.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/async_connection_ready.h"
 #include "google/cloud/internal/default_completion_queue_impl.h"
 
 namespace google {
@@ -21,6 +22,14 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 
 CompletionQueue::CompletionQueue()
     : impl_(new internal::DefaultCompletionQueueImpl) {}
+
+future<Status> CompletionQueue::AsyncWaitConnectionReady(
+    std::shared_ptr<grpc::Channel> channel,
+    std::chrono::system_clock::time_point deadline) {
+  auto op = std::make_shared<internal::AsyncConnectionReadyFuture>(
+      impl_, std::move(channel), deadline);
+  return op->Start();
+}
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_COMPLETION_QUEUE_H
 
 #include "google/cloud/future.h"
-#include "google/cloud/internal/async_connection_ready.h"
 #include "google/cloud/internal/async_read_stream_impl.h"
 #include "google/cloud/internal/async_rpc_details.h"
 #include "google/cloud/internal/completion_queue_impl.h"
@@ -246,12 +245,7 @@ class CompletionQueue {
    */
   future<Status> AsyncWaitConnectionReady(
       std::shared_ptr<grpc::Channel> channel,
-      std::chrono::system_clock::time_point deadline) {
-    auto op = std::make_shared<internal::AsyncConnectionReadyFuture>(
-        std::move(channel), deadline);
-    impl_->StartOperation(op, [&](void* tag) { op->Start(impl_->cq(), tag); });
-    return op->GetFuture();
-  }
+      std::chrono::system_clock::time_point deadline);
 
  private:
   friend std::shared_ptr<internal::CompletionQueueImpl>

--- a/google/cloud/internal/async_connection_ready.h
+++ b/google/cloud/internal/async_connection_ready.h
@@ -15,16 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_CONNECTION_READY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_CONNECTION_READY_H
 
-#include "google/cloud/async_operation.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/completion_queue_impl.h"
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include <grpcpp/channel.h>
-#include <grpcpp/completion_queue.h>
-#include <grpcpp/generic/async_generic_service.h>
-#include <grpcpp/generic/generic_stub.h>
-#include <grpcpp/server.h>
-#include <grpcpp/server_builder.h>
 #include <chrono>
 #include <memory>
 
@@ -40,30 +35,27 @@ namespace internal {
  * well be hidden away from the header, but is useful in
  * `FakeCompletionQueueImpl`.
  */
-class AsyncConnectionReadyFuture : public internal::AsyncGrpcOperation {
+class AsyncConnectionReadyFuture
+    : public std::enable_shared_from_this<AsyncConnectionReadyFuture> {
  public:
-  AsyncConnectionReadyFuture(std::shared_ptr<grpc::Channel> channel,
-                             std::chrono::system_clock::time_point deadline);
+  AsyncConnectionReadyFuture(
+      std::shared_ptr<google::cloud::internal::CompletionQueueImpl> cq,
+      std::shared_ptr<grpc::Channel> channel,
+      std::chrono::system_clock::time_point deadline);
 
-  void Start(grpc::CompletionQueue& cq, void* tag);
-  // There doesn't seem to be a way to cancel this operation:
-  // https://github.com/grpc/grpc/issues/3064
-  void Cancel() override {}
-  /// The future will be set to whether the state changed (false means timeout).
-  future<Status> GetFuture() { return promise_.get_future(); }
+  future<Status> Start();
 
  private:
-  bool Notify(bool ok) override;
-  // Returns whether to register for state change.
-  bool HandleSingleStateChange();
+  void Notify(bool ok);
 
-  std::shared_ptr<grpc::Channel> channel_;
-  std::chrono::system_clock::time_point deadline_;
+  // gRPC uses an anonymous type for the gRPC channel state enum :shrug:.
+  using ChannelStateType = decltype(GRPC_CHANNEL_READY);
+  void RunIteration(ChannelStateType state);
+
+  std::shared_ptr<google::cloud::internal::CompletionQueueImpl> const cq_;
+  std::shared_ptr<grpc::Channel> const channel_;
+  std::chrono::system_clock::time_point const deadline_;
   promise<Status> promise_;
-  // CompletionQueue and tag are memorized on start of the operation so that it
-  // can be re-registered in the completion queue for another state change.
-  grpc::CompletionQueue* cq_;
-  void* tag_;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/async_connection_ready_test.cc
+++ b/google/cloud/internal/async_connection_ready_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
+#include <grpcpp/generic/async_generic_service.h>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
Fixes #5670.  Before this change the `data_integration_test` was failing more in 5 out of 100 runs, after this change I got 1000 runs without failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5701)
<!-- Reviewable:end -->
