### PR TITLE
test(spanner): deflake samples against production

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -109,14 +109,14 @@ std::string PickInstanceLocation(
   std::mt19937_64 generator(std::random_device{}());
   std::string ret{};
   // Exclude the regions where we keep most of our test instances.
-  std::vector<std::string> excluded{"us-central", "us-east"};
+  std::vector<std::string> excluded{"us-central1", "us-east1"};
   int i = 0;
   for (auto const& instance_config : client.ListInstanceConfigs(project_id)) {
     if (!instance_config) break;
     if (ret.empty()) ret = instance_config->name();
     auto const& name = instance_config->name();
-    // Skip non-regional configs, they are overkill for tests and too slow.
-    if (name.find("instanceConfigs/regional-") == std::string::npos) continue;
+    // Skip non-US configs, they are overkill for tests and too slow.
+    if (name.find("/regional-us-") == std::string::npos) continue;
     auto const has_excluded_substring = std::any_of(
         excluded.begin(), excluded.end(), [&name](std::string const& e) {
           return name.find(e) != std::string::npos;

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3140,7 +3140,6 @@ void RunAll(bool emulator) {
 
   std::cout << "\nRunning PickInstanceLocation()" << std::endl;
   PickInstanceLocation(instance_admin_client, project_id);
-  std::cout << "\n==============================" << std::endl;
 
   if (run_slow_instance_tests) {
     std::string crud_instance_id =


### PR DESCRIPTION
Several builds run against production and run relatively slow
operations, such as creating instances. With this change different
builds will pick a different location, and hopefully distribute the load
more fairly.

Motivated by the build breaks in #5701

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5702)
<!-- Reviewable:end -->
