### PR TITLE
test: avoid breaking exported targets

### DIFF
--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -138,6 +138,11 @@ RUN cmake --build cmake-out --target install
 
 ## [END packaging.md]
 
+WORKDIR /home/build/verify-exported-targets
+COPY ci/verify_exported_targets /home/build/verify-exported-targets
+RUN cmake -H. -B/i/verify-exported-targets -Wno-dev
+RUN cmake --build /i/verify-exported-targets
+
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
 # Verify that the installed files are actually usable

--- a/ci/verify_exported_targets/CMakeLists.txt
+++ b/ci/verify_exported_targets/CMakeLists.txt
@@ -1,0 +1,82 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.6)
+project(verify-exported-targets CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# CMake can use pkg-config to find dependencies. We recommend using CMake
+# targets, but we want to verify our pkg-config files remain usable and
+# backwards compatible.
+find_package(PkgConfig REQUIRED)
+
+find_package(Threads REQUIRED)
+# TODO(#5726) - DO NOT CHANGE THESE PACKAGE NAMES These package names are
+# expected to remain usable until we have retired them.  This is a test for
+# backwards compatibility, if you need to change the test, there is good chance
+# you are breaking something.
+find_package(bigtable_client REQUIRED)
+find_package(firestore_client REQUIRED)
+find_package(storage_client REQUIRED)
+find_package(spanner_client REQUIRED)
+find_package(pubsub_client REQUIRED)
+pkg_check_modules(google_cloud_cpp_common IMPORTED_TARGET REQUIRED
+                  google_cloud_cpp_common)
+pkg_check_modules(google_cloud_cpp_grpc_utils IMPORTED_TARGET REQUIRED
+                  google_cloud_cpp_grpc_utils)
+pkg_check_modules(bigtable_client IMPORTED_TARGET REQUIRED bigtable_client)
+pkg_check_modules(firestore_client IMPORTED_TARGET REQUIRED firestore_client)
+pkg_check_modules(pubsub_client IMPORTED_TARGET REQUIRED pubsub_client)
+pkg_check_modules(spanner_client IMPORTED_TARGET REQUIRED spanner_client)
+pkg_check_modules(storage_client IMPORTED_TARGET REQUIRED storage_client)
+
+include(CTest)
+
+function (add_test_case name)
+    add_executable("${name}" verify_exported_targets.cc)
+    target_link_libraries("${name}" PRIVATE ${ARGN})
+    add_test(NAME "${name}" COMMAND "${name}")
+endfunction ()
+
+# TODO(#5726) - DO NOT CHANGE THESE TARGET NAMES These package names are
+# expected to remain usable until we have retired them.  This is a test for
+# backwards compatibility, if you need to change the test, there is good chance
+# you are breaking something.
+add_test_case(t010 google_cloud_cpp_common)
+add_test_case(t020 google_cloud_cpp_grpc_utils)
+add_test_case(t030 bigtable_client)
+add_test_case(t040 bigtable::client)
+add_test_case(t050 bigtable_protos google_cloud_cpp_common)
+add_test_case(t060 bigtable::protos google_cloud_cpp_common)
+add_test_case(t070 firestore_client google_cloud_cpp_common)
+add_test_case(t080 firestore::client google_cloud_cpp_common)
+add_test_case(t090 googleapis-c++::pubsub_client)
+add_test_case(t100 pubsub_client)
+# add_test_case(t110 googleapis-c++::storage_client)
+add_test_case(t120 storage_client)
+add_test_case(t130 googleapis-c++::spanner_client)
+add_test_case(t140 spanner_client)
+
+add_test_case(t200 PkgConfig::google_cloud_cpp_common)
+add_test_case(t210 PkgConfig::google_cloud_cpp_grpc_utils)
+add_test_case(t220 PkgConfig::bigtable_client)
+add_test_case(t230 PkgConfig::firestore_client
+              PkgConfig::google_cloud_cpp_common)
+add_test_case(t240 PkgConfig::pubsub_client)
+add_test_case(t250 PkgConfig::spanner_client)
+add_test_case(t260 PkgConfig::storage_client)

--- a/ci/verify_exported_targets/CMakeLists.txt
+++ b/ci/verify_exported_targets/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(PkgConfig REQUIRED)
 find_package(Threads REQUIRED)
 # TODO(#5726) - DO NOT CHANGE THESE PACKAGE NAMES These package names are
 # expected to remain usable until we have retired them.  This is a test for
-# backwards compatibility, if you need to change the test, there is good chance
+# backwards compatibility. If you need to change the test, there is good chance
 # you are breaking something.
 find_package(bigtable_client REQUIRED)
 find_package(firestore_client REQUIRED)
@@ -55,7 +55,7 @@ endfunction ()
 
 # TODO(#5726) - DO NOT CHANGE THESE TARGET NAMES These package names are
 # expected to remain usable until we have retired them.  This is a test for
-# backwards compatibility, if you need to change the test, there is good chance
+# backwards compatibility. If you need to change the test, there is good chance
 # you are breaking something.
 add_test_case(t010 google_cloud_cpp_common)
 add_test_case(t020 google_cloud_cpp_grpc_utils)
@@ -67,7 +67,6 @@ add_test_case(t070 firestore_client google_cloud_cpp_common)
 add_test_case(t080 firestore::client google_cloud_cpp_common)
 add_test_case(t090 googleapis-c++::pubsub_client)
 add_test_case(t100 pubsub_client)
-# add_test_case(t110 googleapis-c++::storage_client)
 add_test_case(t120 storage_client)
 add_test_case(t130 googleapis-c++::spanner_client)
 add_test_case(t140 spanner_client)

--- a/ci/verify_exported_targets/verify_exported_targets.cc
+++ b/ci/verify_exported_targets/verify_exported_targets.cc
@@ -1,0 +1,21 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/version.h"
+#include <iostream>
+
+int main() {
+  std::cout << "Hello: " << google::cloud::version_string() << "\n";
+  return 0;
+}

--- a/google/cloud/firestore/CMakeLists.txt
+++ b/google/cloud/firestore/CMakeLists.txt
@@ -99,7 +99,7 @@ google_cloud_cpp_install_headers(firestore_client
 set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Firestore C++ Client Library")
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Firestore.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lfirestore_client -lfirestore_protos")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lfirestore_client")
 
 # Install the pkg-config files.
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"

--- a/google/cloud/firestore/config.cmake.in
+++ b/google/cloud/firestore/config.cmake.in
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-find_dependency(protobuf)
-find_dependency(gRPC)
+find_dependency(google_cloud_cpp_common)
+find_dependency(google_cloud_cpp_grpc_utils)
+find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/firestore-targets.cmake")
 


### PR DESCRIPTION
This change introduces a test to verify our exported targets remain
backwards compatible, that is, we do not accidentally remove a target
that we have exported in previous versions.

Part of the work for #5726

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5739)
<!-- Reviewable:end -->
