### PR TITLE
test: verify legacy Bazel targets remain available

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,7 +17,7 @@
 #   [1]: https://github.com/bazelbuild/bazel/issues/4341
 build --copt=-DGRPC_BAZEL_BUILD
 
-# Do not create the convenience links, they are incovenient when the build runs
+# Do not create the convenience links, they are inconvenient when the build runs
 # inside a docker image.
 build --experimental_convenience_symlinks=ignore
 

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -119,6 +119,16 @@ for library in $(quickstart::libraries); do
   fi
 done
 
+echo
+echo "================================================================"
+io::log_yellow "Verifying deprecated (but not retired) targets"
+(
+  cd ci/verify_exported_targets
+  "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
+    "${BAZEL_BIN}" fetch ... "${external[@]}"
+  "${BAZEL_BIN}" test ... "${bazel_args[@]}"
+)
+
 echo "================================================================"
 if [[ -z "${errors}" ]]; then
   io::log_green "All quickstart builds were successful"

--- a/ci/verify_exported_targets/.bazelrc
+++ b/ci/verify_exported_targets/.bazelrc
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
+# and there is (AFAIK) no way to "inherit" their definitions.
+#   [1]: https://github.com/bazelbuild/bazel/issues/4341
+build --copt=-DGRPC_BAZEL_BUILD
+
+# Do not create the convenience links, they are inconvenient when the build runs
+# inside a docker image.
+build --experimental_convenience_symlinks=ignore

--- a/ci/verify_exported_targets/BUILD
+++ b/ci/verify_exported_targets/BUILD
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+# TODO(#5726) - DO NOT CHANGE THESE TARGET NAMES These package names are
+# expected to remain usable until we have retired them. They are *deprecated*
+# (that is, we no longer recommend their use), but *NOT* retired (that is, they
+# remain available). This is a test for backwards compatibility. If you need to
+# change the test, there is good chance you are breaking something.
+DEPRECATED_TARGETS = [
+    "google/cloud:google_cloud_cpp_common",
+    "google/cloud:google_cloud_cpp_grpc_utils",
+    "google/cloud/bigtable:bigtable_client",
+    "google/cloud/firestore:firestore_client",
+    "google/cloud/pubsub:pubsub_client",
+    "google/cloud/spanner:spanner_client",
+    "google/cloud/storage:storage_client",
+]
+
+[cc_test(
+    name = "verify_" + target.replace("/", "_").replace(":", "_"),
+    srcs = [
+        "verify_exported_targets.cc",
+    ],
+    deps = [
+        "@com_github_googleapis_google_cloud_cpp//" + target,
+    ],
+) for target in DEPRECATED_TARGETS]

--- a/ci/verify_exported_targets/WORKSPACE
+++ b/ci/verify_exported_targets/WORKSPACE
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A minimal WORKSPACE file showing how to use the Google Cloud Bigtable C++
+# client library in Bazel-based projects.
+workspace(name = "com_github_googleapis_google_cloud_cpp_verify_exported_targets")
+
+# Add the necessary Starlark functions to fetch google-cloud-cpp.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+local_repository(
+    name = "com_github_googleapis_google_cloud_cpp",
+    path = "../../",
+)
+
+# Load indirect dependencies due to
+#     https://github.com/bazelbuild/bazel/issues/1943
+load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
+google_cloud_cpp_deps()
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/google/cloud/firestore/BUILD
+++ b/google/cloud/firestore/BUILD
@@ -22,7 +22,9 @@ cc_library(
     name = "firestore_client",
     srcs = firestore_client_srcs,
     hdrs = firestore_client_hdrs,
-    deps = [],
+    deps = [
+        "//google/cloud:google_cloud_cpp_common",
+    ],
 )
 
 load(":firestore_client_unit_tests.bzl", "firestore_client_unit_tests")


### PR DESCRIPTION
We are planning to deprecate and then retire some legacy targets for
Bazel, but until they are retired we need a test to verify we do not
remove them by accident.

Part of the work for #5726

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5740)
<!-- Reviewable:end -->
