### PR TITLE
feat: a wrapper for streaming read RPCs

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -379,6 +379,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/retry_loop.h
         internal/retry_loop_helpers.cc
         internal/retry_loop_helpers.h
+        internal/streaming_read_rpc.cc
+        internal/streaming_read_rpc.h
         internal/time_utils.cc
         internal/time_utils.h)
     target_link_libraries(
@@ -453,6 +455,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/log_wrapper_test.cc
             internal/polling_loop_test.cc
             internal/retry_loop_test.cc
+            internal/streaming_read_rpc_test.cc
             internal/time_utils_test.cc)
 
         # Export the list of unit tests so the Bazel BUILD file can pick it up.

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -39,6 +39,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/polling_loop.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",
+    "internal/streaming_read_rpc.h",
     "internal/time_utils.h",
 ]
 
@@ -51,5 +52,6 @@ google_cloud_cpp_grpc_utils_srcs = [
     "internal/default_completion_queue_impl.cc",
     "internal/log_wrapper.cc",
     "internal/retry_loop_helpers.cc",
+    "internal/streaming_read_rpc.cc",
     "internal/time_utils.cc",
 ]

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -28,5 +28,6 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/log_wrapper_test.cc",
     "internal/polling_loop_test.cc",
     "internal/retry_loop_test.cc",
+    "internal/streaming_read_rpc_test.cc",
     "internal/time_utils_test.cc",
 ]

--- a/google/cloud/internal/streaming_read_rpc.cc
+++ b/google/cloud/internal/streaming_read_rpc.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/async_read_write_stream_impl.h"
+#include "google/cloud/log.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+void StreamingReadRpcReportUnhandledError(Status const& status,
+                                          char const* tname) {
+  GCP_LOG(WARNING) << "unhandled error for StreamingReadRpcImpl< " << tname
+                   << " > - status=" << status;
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/streaming_read_rpc.h
+++ b/google/cloud/internal/streaming_read_rpc.h
@@ -1,0 +1,106 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_H
+
+#include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/status.h"
+#include "google/cloud/version.h"
+#include "absl/types/variant.h"
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/sync_stream.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/**
+ * Defines the interface for wrappers around gRPC streaming read RPCs.
+ *
+ * We wrap the gRPC classes used for streaming read RPCs to (a) simplify the
+ * memory management of auxiliary data structures, (b) enforce the "rules"
+ * around calling `Finish()` before deleting an RPC, (c) allow us to mock the
+ * classes, and (d) allow us to decorate the streaming RPCs, for example for
+ * logging.
+ *
+ * This class defines the interface for these wrappers.  The canonical
+ * implementation is `StreamingReadRpcImpl<ResponseType>`
+ */
+template <typename ResponseType>
+class StreamingReadRpc {
+ public:
+  virtual ~StreamingReadRpc() = default;
+
+  /// Cancel the RPC, this is needed to terminate the RPC "early".
+  virtual void Cancel() = 0;
+
+  /// Return the next element, or the final RPC status.
+  virtual absl::variant<Status, ResponseType> Read() = 0;
+};
+
+/// Report the errors in a standalone function to minimize includes
+void StreamingReadRpcReportUnhandledError(Status const& status,
+                                          char const* tname);
+
+/**
+ * Implement `StreamingReadRpc<ResponseType>` using the gRPC abstractions.
+ *
+ * @note this class is thread compatible, but it is not thread safe. It should
+ *   not be used from multiple threads at the same time.
+ */
+template <typename ResponseType>
+class StreamingReadRpcImpl : public StreamingReadRpc<ResponseType> {
+ public:
+  StreamingReadRpcImpl(
+      std::unique_ptr<grpc::ClientContext> context,
+      std::unique_ptr<grpc::ClientReaderInterface<ResponseType>> stream)
+      : context_(std::move(context)), stream_(std::move(stream)) {}
+
+  ~StreamingReadRpcImpl() override {
+    if (finished_) return;
+    Cancel();
+    auto status = Finish();
+    if (status.ok()) return;
+    StreamingReadRpcReportUnhandledError(status, typeid(ResponseType).name());
+  }
+
+  void Cancel() override { context_->TryCancel(); }
+
+  absl::variant<Status, ResponseType> Read() override {
+    ResponseType response;
+    if (stream_->Read(&response)) return response;
+    return Finish();
+  }
+
+ private:
+  Status Finish() {
+    auto status = MakeStatusFromRpcError(stream_->Finish());
+    finished_ = true;
+    return status;
+  }
+
+  std::unique_ptr<grpc::ClientContext> const context_;
+  std::unique_ptr<grpc::ClientReaderInterface<ResponseType>> const stream_;
+  bool finished_ = false;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_H

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -46,8 +46,10 @@ class MockReader : public grpc::ClientReaderInterface<FakeResponse> {
   MOCK_METHOD(grpc::Status, Finish, (), (override));
 
   // Unused. We define them (as then are pure virtual), but not as mocks.
-  bool NextMessageSize(std::uint32_t*) override { return true; }
-  void WaitForInitialMetadata() override {}
+  bool NextMessageSize(std::uint32_t*) override {  // LCOV_EXCL_LINE
+    return true;                                   // LCOV_EXCL_LINE
+  }
+  void WaitForInitialMetadata() override {}  // LCOV_EXCL_LINE
 };
 
 TEST(StreamingReadRpcImpl, SuccessfulStream) {

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -45,11 +45,9 @@ class MockReader : public grpc::ClientReaderInterface<FakeResponse> {
   MOCK_METHOD(bool, Read, (FakeResponse*), (override));
   MOCK_METHOD(grpc::Status, Finish, (), (override));
 
-  // Unused. We define them (as then are pure virtual), but not as mocks.
-  bool NextMessageSize(std::uint32_t*) override {  // LCOV_EXCL_LINE
-    return true;                                   // LCOV_EXCL_LINE
-  }
-  void WaitForInitialMetadata() override {}  // LCOV_EXCL_LINE
+  // Unused. We define them (as they are pure virtual), but not as mocks.
+  bool NextMessageSize(std::uint32_t*) override { return true; }
+  void WaitForInitialMetadata() override {}
 };
 
 TEST(StreamingReadRpcImpl, SuccessfulStream) {

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/streaming_read_rpc.h"
+#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::Return;
+
+struct FakeRequest {
+  std::string key;
+};
+
+struct FakeResponse {
+  std::string value;
+};
+
+using MockReturnType =
+    std::unique_ptr<grpc::ClientReaderInterface<FakeResponse>>;
+
+class MockReader : public grpc::ClientReaderInterface<FakeResponse> {
+ public:
+  MOCK_METHOD(bool, Read, (FakeResponse*), (override));
+  MOCK_METHOD(grpc::Status, Finish, (), (override));
+
+  // Unused. We define them (as then are pure virtual), but not as mocks.
+  bool NextMessageSize(std::uint32_t*) override { return true; }
+  void WaitForInitialMetadata() override {}
+};
+
+TEST(StreamingReadRpcImpl, SuccessfulStream) {
+  auto mock = absl::make_unique<MockReader>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce([](FakeResponse* r) {
+        r->value = "value-0";
+        return true;
+      })
+      .WillOnce([](FakeResponse* r) {
+        r->value = "value-1";
+        return true;
+      })
+      .WillOnce([](FakeResponse* r) {
+        r->value = "value-2";
+        return true;
+      })
+      .WillOnce(Return(false));
+  EXPECT_CALL(*mock, Finish).WillOnce(Return(grpc::Status::OK));
+
+  StreamingReadRpcImpl<FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+  std::vector<std::string> values;
+  for (;;) {
+    auto v = impl.Read();
+    if (absl::holds_alternative<FakeResponse>(v)) {
+      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
+      continue;
+    }
+    EXPECT_THAT(absl::get<Status>(std::move(v)), StatusIs(StatusCode::kOk));
+    break;
+  }
+  EXPECT_THAT(values, ElementsAre("value-0", "value-1", "value-2"));
+}
+
+TEST(StreamingReadRpcImpl, EmptyStream) {
+  auto mock = absl::make_unique<MockReader>();
+  EXPECT_CALL(*mock, Read).WillOnce(Return(false));
+  EXPECT_CALL(*mock, Finish).WillOnce(Return(grpc::Status::OK));
+
+  StreamingReadRpcImpl<FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+  auto v = impl.Read();
+  ASSERT_FALSE(absl::holds_alternative<FakeResponse>(v));
+  EXPECT_THAT(absl::get<Status>(std::move(v)), StatusIs(StatusCode::kOk));
+}
+
+TEST(StreamingReadRpcImpl, EmptyWithError) {
+  auto mock = absl::make_unique<MockReader>();
+  EXPECT_CALL(*mock, Read).WillOnce(Return(false));
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
+
+  StreamingReadRpcImpl<FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+  auto v = impl.Read();
+  ASSERT_FALSE(absl::holds_alternative<FakeResponse>(v));
+  EXPECT_THAT(absl::get<Status>(std::move(v)),
+              StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
+TEST(StreamingReadRpcImpl, ErrorAfterData) {
+  auto mock = absl::make_unique<MockReader>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce([](FakeResponse* r) {
+        r->value = "test-value-0";
+        return true;
+      })
+      .WillOnce(Return(false));
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
+
+  StreamingReadRpcImpl<FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(mock));
+  std::vector<std::string> values;
+  for (;;) {
+    auto v = impl.Read();
+    if (absl::holds_alternative<FakeResponse>(v)) {
+      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
+      continue;
+    }
+    EXPECT_THAT(absl::get<Status>(std::move(v)),
+                StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
+    break;
+  }
+  EXPECT_THAT(values, ElementsAre("test-value-0"));
+}
+
+TEST(StreamingReadRpcImpl, HandleUnfinished) {
+  auto mock = absl::make_unique<MockReader>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce([](FakeResponse* r) {
+        r->value = "value-0";
+        return true;
+      })
+      .WillOnce([](FakeResponse* r) {
+        r->value = "value-1";
+        return true;
+      });
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(
+          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
+
+  auto backend =
+      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
+  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+
+  {
+    StreamingReadRpcImpl<FakeResponse> impl(
+        absl::make_unique<grpc::ClientContext>(), std::move(mock));
+    std::vector<std::string> values;
+    values.push_back(absl::get<FakeResponse>(impl.Read()).value);
+    values.push_back(absl::get<FakeResponse>(impl.Read()).value);
+    EXPECT_THAT(values, ElementsAre("value-0", "value-1"));
+  }
+  EXPECT_THAT(backend->ClearLogLines(),
+              Contains(AllOf(HasSubstr("unhandled error"), HasSubstr("status="),
+                             HasSubstr("uh-oh"))));
+
+  google::cloud::LogSink::Instance().RemoveBackend(id);
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Introduce a wrapper for gRPC's streaming read RPCs. Mostly because these
are easier to mock and decorate than the native gRPC types.

Part of the work for #5727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5751)
<!-- Reviewable:end -->
