### PR TITLE
feat: implement generic ResumableStreamingReadRpc

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -376,6 +376,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/log_wrapper.cc
         internal/log_wrapper.h
         internal/polling_loop.h
+        internal/resumable_streaming_read_rpc.h
         internal/retry_loop.h
         internal/retry_loop_helpers.cc
         internal/retry_loop_helpers.h
@@ -454,6 +455,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/background_threads_impl_test.cc
             internal/log_wrapper_test.cc
             internal/polling_loop_test.cc
+            internal/resumable_streaming_read_rpc_test.cc
             internal/retry_loop_test.cc
             internal/streaming_read_rpc_test.cc
             internal/time_utils_test.cc)

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -37,6 +37,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/default_completion_queue_impl.h",
     "internal/log_wrapper.h",
     "internal/polling_loop.h",
+    "internal/resumable_streaming_read_rpc.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",
     "internal/streaming_read_rpc.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -27,6 +27,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/background_threads_impl_test.cc",
     "internal/log_wrapper_test.cc",
     "internal/polling_loop_test.cc",
+    "internal/resumable_streaming_read_rpc_test.cc",
     "internal/retry_loop_test.cc",
     "internal/streaming_read_rpc_test.cc",
     "internal/time_utils_test.cc",

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -1,0 +1,138 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RESUMABLE_STREAMING_READ_RPC_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RESUMABLE_STREAMING_READ_RPC_H
+
+#include "google/cloud/internal/streaming_read_rpc.h"
+#include "google/cloud/version.h"
+#include <memory>
+#include <thread>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+template <typename ResponseType, typename RequestType>
+using StreamFactory =
+    std::function<std::unique_ptr<StreamingReadRpc<ResponseType>>(RequestType)>;
+
+template <typename ResponseType, typename RequestType>
+using RequestUpdater = std::function<void(RequestType&, ResponseType const&)>;
+
+/**
+ * A StreamingReadRpc that resumes on transient failures.
+ *
+ *
+ */
+template <typename ResponseType, typename RequestType, typename RetryPolicy,
+          typename BackoffPolicy, typename Sleeper>
+class ResumableStreamingReadRpc : public StreamingReadRpc<ResponseType> {
+ public:
+  ResumableStreamingReadRpc(
+      std::unique_ptr<RetryPolicy const> retry_policy,
+      std::unique_ptr<BackoffPolicy const> backoff_policy, Sleeper sleeper,
+      StreamFactory<ResponseType, RequestType> stream_factory,
+      RequestUpdater<ResponseType, RequestType> updater, RequestType request)
+      : retry_policy_prototype_(std::move(retry_policy)),
+        backoff_policy_prototype_(std::move(backoff_policy)),
+        sleeper_(std::move(sleeper)),
+        stream_factory_(std::move(stream_factory)),
+        updater_(std::move(updater)),
+        request_(std::move(request)),
+        impl_(stream_factory_(request_)) {}
+
+  void Cancel() override { impl_->Cancel(); }
+
+  absl::variant<Status, ResponseType> Read() override {
+    auto response = impl_->Read();
+    if (absl::holds_alternative<ResponseType>(response)) {
+      updater_(request_, absl::get<ResponseType>(response));
+      return response;
+    }
+    auto last_status = absl::get<Status>(std::move(response));
+    if (last_status.ok()) return last_status;
+    // Need to start a retry loop to connect again. Note that we *retry* to
+    // start a streaming read, but once the streaming read succeeds at least
+    // once we *resume* the read using *fresh* retry and backoff policies.
+    //
+    // This is important because streaming reads can last very long, many
+    // minutes or hours, maybe much longer than the retry policy. For example,
+    // consider a retry policy of "try for 5 minutes" and a streaming read that
+    // works for 1 hours and then gets interrupted, in this case it would be
+    // better to resume the read, giving up after 5 minutes of retries, than
+    // just aborting because the retry policy is from one hour ago.
+    auto const retry_policy = retry_policy_prototype_->clone();
+    auto const backoff_policy = backoff_policy_prototype_->clone();
+    while (!retry_policy->IsExhausted()) {
+      impl_ = stream_factory_(request_);
+      auto r = impl_->Read();
+      if (absl::holds_alternative<ResponseType>(r)) {
+        updater_(request_, absl::get<ResponseType>(r));
+        return r;
+      }
+      last_status = absl::get<Status>(std::move(r));
+      if (!retry_policy->OnFailure(last_status)) return last_status;
+      sleeper_(backoff_policy->OnCompletion());
+    }
+    return last_status;
+  }
+
+ private:
+  std::unique_ptr<RetryPolicy const> const retry_policy_prototype_;
+  std::unique_ptr<BackoffPolicy const> const backoff_policy_prototype_;
+  Sleeper sleeper_;
+  StreamFactory<ResponseType, RequestType> const stream_factory_;
+  RequestUpdater<ResponseType, RequestType> const updater_;
+  RequestType request_;
+  std::unique_ptr<StreamingReadRpc<ResponseType>> impl_;
+};
+
+/// A helper to apply type deduction.
+template <typename ResponseType, typename RequestType, typename RetryPolicy,
+          typename BackoffPolicy, typename Sleeper>
+std::shared_ptr<StreamingReadRpc<ResponseType>> MakeResumableStreamingReadRpc(
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy, Sleeper&& sleeper,
+    StreamFactory<ResponseType, RequestType> stream_factory,
+    RequestUpdater<ResponseType, RequestType> updater, RequestType request) {
+  return std::make_shared<
+      ResumableStreamingReadRpc<ResponseType, RequestType, RetryPolicy,
+                                BackoffPolicy, absl::decay_t<Sleeper>>>(
+      std::move(retry_policy), std::move(backoff_policy),
+      std::forward<Sleeper>(sleeper), std::move(stream_factory),
+      std::move(updater), std::forward<RequestType>(request));
+}
+
+/// A helper to apply type deduction, with the default sleeping strategy.
+template <typename ResponseType, typename RequestType, typename RetryPolicy,
+          typename BackoffPolicy>
+std::shared_ptr<StreamingReadRpc<ResponseType>> MakeResumableStreamingReadRpc(
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    StreamFactory<ResponseType, RequestType> stream_factory,
+    RequestUpdater<ResponseType, RequestType> updater, RequestType request) {
+  return MakeResumableStreamingReadRpc(
+      std::move(retry_policy), std::move(backoff_policy),
+      [](std::chrono::milliseconds d) { std::this_thread::sleep_for(d); },
+      std::move(stream_factory), std::move(updater), std::move(request));
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_RESUMABLE_STREAMING_READ_RPC_H

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -53,7 +53,7 @@ using RequestUpdater = std::function<void(ResponseType const&, RequestType&)>;
  * over potentially unbounded amounts of data. Many services provide a mechanism
  * to "resume" these streaming RPCs if the operation is interrupted in the
  * middle. That is, the service may be able to restart the streaming RPC from
- * the item following the last received entry. This is useful because once may
+ * the item following the last received entry. This is useful because one may
  * not want to perform one half of a large download (think TiBs of data) more
  * than once.
  *
@@ -84,6 +84,9 @@ class ResumableStreamingReadRpc : public StreamingReadRpc<ResponseType> {
         request_(std::move(request)),
         impl_(stream_factory_(request_)) {}
 
+  ResumableStreamingReadRpc(ResumableStreamingReadRpc&&) = delete;
+  ResumableStreamingReadRpc& operator=(ResumableStreamingReadRpc&&) = delete;
+
   void Cancel() override { impl_->Cancel(); }
 
   absl::variant<Status, ResponseType> Read() override {
@@ -101,7 +104,7 @@ class ResumableStreamingReadRpc : public StreamingReadRpc<ResponseType> {
     // This is important because streaming reads can last very long, many
     // minutes or hours, maybe much longer than the retry policy. For example,
     // consider a retry policy of "try for 5 minutes" and a streaming read that
-    // works for 1 hours and then gets interrupted, in this case it would be
+    // works for 1 hour and then gets interrupted, in this case it would be
     // better to resume the read, giving up after 5 minutes of retries, than
     // just aborting because the retry policy is from one hour ago.
     auto const retry_policy = retry_policy_prototype_->clone();

--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -1,0 +1,250 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/resumable_streaming_read_rpc.h"
+#include "google/cloud/backoff_policy.h"
+#include "google/cloud/internal/retry_policy.h"
+#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::Return;
+
+struct FakeRequest {
+  std::string key;
+  std::string token;
+};
+
+struct FakeResponse {
+  std::string value;
+  std::string token;
+};
+
+using MockReturnType =
+    std::unique_ptr<grpc::ClientReaderInterface<FakeResponse>>;
+
+using ReadReturn = absl::variant<Status, FakeResponse>;
+
+class MockStreamingReadRpc : public StreamingReadRpc<FakeResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(ReadReturn, Read, (), (override));
+};
+
+struct TestRetryablePolicy {
+  static bool IsPermanentFailure(google::cloud::Status const& s) {
+    return !s.ok() &&
+           (s.code() == google::cloud::StatusCode::kPermissionDenied);
+  }
+};
+
+ReadReturn AsReadReturn(FakeResponse response) { return response; }
+
+ReadReturn StreamSuccess() { return Status{}; }
+
+ReadReturn TransientFailure() {
+  return Status(StatusCode::kUnavailable, "try-again");
+}
+
+ReadReturn PermanentFailure() {
+  return Status(StatusCode::kPermissionDenied, "uh-oh");
+}
+
+class MockStub {
+ public:
+  MOCK_METHOD(std::unique_ptr<StreamingReadRpc<FakeResponse>>, StreamingRead,
+              (FakeRequest const&), ());
+};
+
+using RetryPolicyForTest =
+    google::cloud::internal::TraitBasedRetryPolicy<TestRetryablePolicy>;
+using LimitedTimeRetryPolicyForTest =
+    google::cloud::internal::LimitedTimeRetryPolicy<TestRetryablePolicy>;
+using LimitedErrorCountRetryPolicyForTest =
+    google::cloud::internal::LimitedErrorCountRetryPolicy<TestRetryablePolicy>;
+
+std::unique_ptr<RetryPolicyForTest> DefaultRetryPolicy() {
+  // With maximum_failures==2 it tolerates up to 2 failures, so the *third*
+  // failure is an error.
+  return LimitedErrorCountRetryPolicyForTest(/*maximum_failures=*/2).clone();
+}
+
+std::unique_ptr<BackoffPolicy> DefaultBackoffPolicy() {
+  using us = std::chrono::microseconds;
+  return ExponentialBackoffPolicy(/*initial_delay=*/us(10),
+                                  /*maximum_delay=*/us(40), /*scaling=*/2.0)
+      .clone();
+}
+
+void DefaultUpdater(FakeRequest& request, FakeResponse const& response) {
+  request.token = response.token;
+}
+
+TEST(ResumableStreamingReadRpc, ResumeWithPartials) {
+  MockStub mock;
+  EXPECT_CALL(mock, StreamingRead)
+      .WillOnce([](FakeRequest const& request) {
+        EXPECT_EQ(request.key, "test-key");
+        EXPECT_THAT(request.token, IsEmpty());
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(AsReadReturn(FakeResponse{"value-0", "token-1"})))
+            .WillOnce(Return(AsReadReturn(FakeResponse{"value-1", "token-2"})))
+            .WillOnce(Return(TransientFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const& request) {
+        EXPECT_EQ(request.key, "test-key");
+        EXPECT_THAT(request.token, "token-2");
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(AsReadReturn(FakeResponse{"value-2", "token-2"})))
+            .WillOnce(Return(StreamSuccess()));
+        return stream;
+      });
+  auto reader = MakeResumableStreamingReadRpc<FakeResponse, FakeRequest>(
+      DefaultRetryPolicy(), DefaultBackoffPolicy(),
+      [](std::chrono::milliseconds) {},
+      [&mock](FakeRequest const& request) {
+        return mock.StreamingRead(request);
+      },
+      DefaultUpdater, FakeRequest{"test-key", {}});
+
+  std::vector<std::string> values;
+  for (;;) {
+    auto v = reader->Read();
+    if (absl::holds_alternative<FakeResponse>(v)) {
+      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
+      continue;
+    }
+    EXPECT_THAT(absl::get<Status>(std::move(v)), StatusIs(StatusCode::kOk));
+    break;
+  }
+  EXPECT_THAT(values, ElementsAre("value-0", "value-1", "value-2"));
+}
+
+TEST(ResumableStreamingReadRpc, TooManyTransientFailures) {
+  MockStub mock;
+  EXPECT_CALL(mock, StreamingRead)
+      .WillOnce([](FakeRequest const&) {
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const&) {
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const&) {
+        // Event though this stream ends with a failure it will be resumed
+        // because its successful Read() resets the retry policy.
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(AsReadReturn(FakeResponse{"value-0", "token-1"})))
+            .WillOnce(Return(TransientFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const&) {
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const&) {
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const&) {
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(TransientFailure()));
+        return stream;
+      });
+  auto reader = MakeResumableStreamingReadRpc<FakeResponse, FakeRequest>(
+      DefaultRetryPolicy(), DefaultBackoffPolicy(),
+      [](std::chrono::milliseconds) {},
+      [&mock](FakeRequest const& request) {
+        return mock.StreamingRead(request);
+      },
+      DefaultUpdater, FakeRequest{"test-key", {}});
+
+  std::vector<std::string> values;
+  for (;;) {
+    auto v = reader->Read();
+    if (absl::holds_alternative<FakeResponse>(v)) {
+      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
+      continue;
+    }
+    EXPECT_THAT(absl::get<Status>(std::move(v)),
+                StatusIs(StatusCode::kUnavailable, HasSubstr("try-again")));
+    break;
+  }
+  EXPECT_THAT(values, ElementsAre("value-0"));
+}
+
+TEST(ResumableStreamingReadRpc, PermanenetFailure) {
+  MockStub mock;
+  EXPECT_CALL(mock, StreamingRead)
+      .WillOnce([](FakeRequest const&) {
+        // Event though this stream ends with a failure it will be resumed
+        // because its successful Read() resets the retry policy.
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read)
+            .WillOnce(Return(AsReadReturn(FakeResponse{"value-0", "token-1"})))
+            .WillOnce(Return(PermanentFailure()));
+        return stream;
+      })
+      .WillOnce([](FakeRequest const&) {
+        auto stream = absl::make_unique<MockStreamingReadRpc>();
+        EXPECT_CALL(*stream, Read).WillOnce(Return(PermanentFailure()));
+        return stream;
+      });
+  auto reader = MakeResumableStreamingReadRpc<FakeResponse, FakeRequest>(
+      DefaultRetryPolicy(), DefaultBackoffPolicy(),
+      [](std::chrono::milliseconds) {},
+      [&mock](FakeRequest const& request) {
+        return mock.StreamingRead(request);
+      },
+      DefaultUpdater, FakeRequest{"test-key", {}});
+
+  std::vector<std::string> values;
+  for (;;) {
+    auto v = reader->Read();
+    if (absl::holds_alternative<FakeResponse>(v)) {
+      values.push_back(absl::get<FakeResponse>(std::move(v)).value);
+      continue;
+    }
+    EXPECT_THAT(absl::get<Status>(std::move(v)),
+                StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
+    break;
+  }
+  EXPECT_THAT(values, ElementsAre("value-0"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -98,7 +98,7 @@ std::unique_ptr<BackoffPolicy> DefaultBackoffPolicy() {
       .clone();
 }
 
-void DefaultUpdater(FakeRequest& request, FakeResponse const& response) {
+void DefaultUpdater(FakeResponse const& response, FakeRequest& request) {
   request.token = response.token;
 }
 


### PR DESCRIPTION
Usually streaming read RPCs need to be **resumed** if they fail in the
middle of the stream. This change introduces a class to implement the
"resume loop", an analog to the retry loop used for regular RPCs. The
differences between "resuming" and "retrying" are:

- Usually there is a token or some other indication sent to the service
  to signal that a streaming RPC should start from the last message
  received by a previous streaming RPC.
- Resuming making sense after *any* failures, and *any number* of
  failures. Streaming RPCs typically represent downloads, or large reads
  (otherwise pagination or a simple RPC would have been used), and it is
  desirable to continue these operations as long as any progress is
  made.
  
Fixes #5727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5752)
<!-- Reviewable:end -->
