### PR TITLE
feat(bigtable): better control over channel refresh

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -32,7 +32,8 @@ std::shared_ptr<grpc::ChannelCredentials> BigtableDefaultCredentials() {
 auto constexpr kDefaultMaxRefreshPeriod =
     std::chrono::milliseconds(std::chrono::minutes(3));
 
-// As learned from experiments, idle gRPC connections enter IDLE state after 4m.
+// Applications with hundreds of clients seem to work better with a longer
+// delay for the initial refresh. As there is no particular rush, start with 1m.
 auto constexpr kDefaultMinRefreshPeriod =
     std::chrono::milliseconds(std::chrono::minutes(1));
 

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -425,6 +425,35 @@ TEST(ClientOptionsTest, UserAgentPrefix) {
   EXPECT_THAT(actual, HasSubstr("gcloud-cpp/"));
 }
 
+TEST(ClientOptionsTest, RefreshPeriod) {
+  auto options = bigtable::ClientOptions();
+  EXPECT_LE(options.min_conn_refresh_period(),
+            options.max_conn_refresh_period());
+  using ms = std::chrono::milliseconds;
+
+  options.set_min_conn_refresh_period(ms(1000));
+  EXPECT_EQ(1000, options.min_conn_refresh_period().count());
+
+  options.set_max_conn_refresh_period(ms(2000));
+  EXPECT_EQ(2000, options.max_conn_refresh_period().count());
+
+  options.set_min_conn_refresh_period(ms(3000));
+  EXPECT_EQ(3000, options.min_conn_refresh_period().count());
+  EXPECT_EQ(3000, options.max_conn_refresh_period().count());
+
+  options.set_max_conn_refresh_period(ms(1500));
+  EXPECT_EQ(1500, options.min_conn_refresh_period().count());
+  EXPECT_EQ(1500, options.max_conn_refresh_period().count());
+
+  options.set_max_conn_refresh_period(ms(5000));
+  EXPECT_EQ(1500, options.min_conn_refresh_period().count());
+  EXPECT_EQ(5000, options.max_conn_refresh_period().count());
+
+  options.set_min_conn_refresh_period(ms(1000));
+  EXPECT_EQ(1000, options.min_conn_refresh_period().count());
+  EXPECT_EQ(5000, options.max_conn_refresh_period().count());
+}
+
 }  // namespace
 }  // namespace BIGTABLE_CLIENT_NS
 }  // namespace bigtable

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -74,12 +74,14 @@ class ConnectionRefreshState {
  public:
   explicit ConnectionRefreshState(
       std::shared_ptr<CompletionQueue> const& cq,
+      std::chrono::milliseconds min_conn_refresh_period,
       std::chrono::milliseconds max_conn_refresh_period);
   std::chrono::milliseconds RandomizedRefreshDelay();
   OutstandingTimers& timers() { return *timers_; }
 
  private:
   std::mutex mu_;
+  std::chrono::milliseconds min_conn_refresh_period_;
   std::chrono::milliseconds max_conn_refresh_period_;
   google::cloud::internal::DefaultPRNG rng_;
   std::shared_ptr<OutstandingTimers> timers_;
@@ -124,7 +126,8 @@ class CommonClient {
             google::cloud::internal::DefaultBackgroundThreads(1)),
         cq_(std::make_shared<CompletionQueue>(background_threads_->cq())),
         refresh_state_(std::make_shared<ConnectionRefreshState>(
-            cq_, options_.max_conn_refresh_period())) {}
+            cq_, options_.min_conn_refresh_period(),
+            options_.max_conn_refresh_period())) {}
 
   ~CommonClient() {
     // This will stop the refresh of the channels.


### PR DESCRIPTION
Some applications (mostly tests it seems) create hundreds of clients,
and they need the initial refresh times to be longer.

Fixes #5723

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5753)
<!-- Reviewable:end -->
