### PR TITLE
cleanup(googleapis): consistent CMake target names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Changelog
 
+**FUTURE CHANGES:**
+
+* In 2022-02-15 (or around that time) we are planning to remove a number of
+  backwards compatibility targets names for Bazel and CMake.  Specifically:
+  - **Bazel Users:** applications should use the targets at the top-level
+    directory, e.g. `//:bigtable`, or `//:pubsub`.
+    - All other Bazel targets will be marked as package private in or around
+      2022-02-15.
+  - **CMake Users:** applications should use the
+    `google-cloud-cpp::*` targets (e.g. `google-cloud-cpp::pubsub`).
+    - :warning: some of these targets are not part of the current release,
+      but will be soon.
+    - The legacy CMake targets generate warnings if using CMake >= 3.17 (the
+      earliest version that supports deprecation warnings).
+    - All exported targets without a `google-cloud-cpp::` prefix will be
+      retired in or around 2022-02-15. These include, but are not limited to:
+      - Any target starting with `googleapis-c++::`
+      - Any exported targets without a prefix, including:
+        `google_cloud_cpp_common`, `google_cloud_cpp_grpc_utils`,
+        `bigtable_client`, `bigtable_protos`, `firestore_client`,
+        `pubsub_client`, `storage_client`, `spanner_client`.
+      - Some target aliases, including `bigtable::client`, `bigtable::protos`,
+        `firestore::client`
+  - **pkg-config users:** applications should use the modules starting with
+    `google_cloud_cpp`
+    - All other modules will be retired in or around 2022-02-15
+  - **Direct users of -l${library} flags:** we do not recommend that
+    applications uses `-l` flags directly, please use `pkg-config` and/or
+    the target names under CMake or Bazel. We make this recommendation because
+    we do not know of any mechanism to provide backwards compatibility for such
+    flags.
+  - If you have any feedback about this change please add comments in
+    [#5726](https://github.com/googleapis/google-cloud-cpp/issues/5726)
+
+
 ## v1.24.0 - TBD
+
+### Bazel
+
+* Starting with this release the legacy targets, such as `//google/cloud/pubsub:pubsub_client` are deprecated and
+  generate warnings recommending a replacement (such as `//:pubsub`). Note that you may be to prefix that with the
+  external package name you gave this library, e.g., `@github_com_google_cloud_cpp//:pubsub`).
 
 ### Storage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
     `google-cloud-cpp::*` targets (e.g. `google-cloud-cpp::pubsub`).
     - :warning: some of these targets are not part of the current release,
       but will be soon.
-    - The legacy CMake targets generate warnings if using CMake >= 3.17 (the
+    - The legacy CMake targets generate warnings if using CMake >= 3.18 (the
       earliest version that supports deprecation warnings).
     - All exported targets without a `google-cloud-cpp::` prefix will be
       retired in or around 2022-02-15. These include, but are not limited to:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@
 ### Bazel
 
 * Starting with this release the legacy targets, such as `//google/cloud/pubsub:pubsub_client` are deprecated and
-  generate warnings recommending a replacement (such as `//:pubsub`). Note that you may be to prefix that with the
-  external package name you gave this library, e.g., `@github_com_google_cloud_cpp//:pubsub`).
+  generate warnings recommending a replacement (such as `//:pubsub`). Note that you may have be to prefix the
+  target with the external package name you gave this library, e.g., `@github_com_google_cloud_cpp//:pubsub`).
 
 ### Storage
 

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -24,10 +24,10 @@ set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
     "ad638ad04dd649939ac2833f7908ff6dd7bbf33e74ccad5a1a2d09b4b353e04b")
 
-set(GOOGLEAPIS_CPP_SOURCE
+set(EXTERNAL_GOOGLEAPIS_SOURCE
     "${CMAKE_BINARY_DIR}/external/googleapis/src/googleapis_download")
 
-set(GOOGLEAPIS_CPP_PROTO_FILES
+set(EXTERNAL_GOOGLEAPIS_PROTO_FILES
     "google/api/http.proto"
     "google/api/annotations.proto"
     "google/api/auth.proto"
@@ -152,9 +152,10 @@ set(GOOGLEAPIS_CPP_PROTO_FILES
 # Always disable clang-tidy for this generated code.
 set(CMAKE_CXX_CLANG_TIDY "")
 
-set(GOOGLEAPIS_CPP_BYPRODUCTS)
-foreach (proto ${GOOGLEAPIS_CPP_PROTO_FILES})
-    list(APPEND GOOGLEAPIS_CPP_BYPRODUCTS "${GOOGLEAPIS_CPP_SOURCE}/${proto}")
+set(EXTERNAL_GOOGLEAPIS_BYPRODUCTS)
+foreach (proto ${EXTERNAL_GOOGLEAPIS_PROTO_FILES})
+    list(APPEND EXTERNAL_GOOGLEAPIS_BYPRODUCTS
+         "${EXTERNAL_GOOGLEAPIS_SOURCE}/${proto}")
 endforeach ()
 
 include(ExternalProject)
@@ -167,7 +168,7 @@ ExternalProject_Add(
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
-    BUILD_BYPRODUCTS ${GOOGLEAPIS_CPP_BYPRODUCTS}
+    BUILD_BYPRODUCTS ${EXTERNAL_GOOGLEAPIS_BYPRODUCTS}
     LOG_DOWNLOAD OFF)
 
 find_package(ProtobufWithTargets REQUIRED)
@@ -181,7 +182,9 @@ if (PROTO_INCLUDE_DIR)
     list(INSERT PROTOBUF_IMPORT_DIRS 0 "${PROTO_INCLUDE_DIR}")
 endif ()
 
-add_library(googleapis_cpp_common_flags INTERFACE)
+# Add flags to this library to automatically include them in all the libraries
+# in this directory.
+add_library(external_googleapis_common_flags INTERFACE)
 
 include(SelectMSVCRuntime)
 
@@ -190,7 +193,7 @@ include(CompileProtos)
 
 google_cloud_cpp_add_protos_property()
 
-function (googleapis_cpp_short_name var proto)
+function (external_googleapis_short_name var proto)
     string(REPLACE "google/" "" short_name "${proto}")
     string(REPLACE "/" "_" short_name "${short_name}")
     string(REPLACE ".proto" "_protos" short_name "${short_name}")
@@ -203,130 +206,131 @@ endfunction ()
 #
 # * proto: the filename for the proto source.
 # * (optional) ARGN: proto libraries the new library depends on.
-function (googleapis_cpp_add_library proto)
-    googleapis_cpp_short_name(short_name "${proto}")
+function (external_googleapis_add_library proto)
+    external_googleapis_short_name(short_name "${proto}")
     google_cloud_cpp_grpcpp_library(
-        googleapis_cpp_${short_name} "${GOOGLEAPIS_CPP_SOURCE}/${proto}"
-        PROTO_PATH_DIRECTORIES "${GOOGLEAPIS_CPP_SOURCE}"
+        google_cloud_cpp_${short_name} "${EXTERNAL_GOOGLEAPIS_SOURCE}/${proto}"
+        PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
         "${PROTO_INCLUDE_DIR}")
 
-    googleapis_cpp_set_version_and_alias("${short_name}")
+    external_googleapis_set_version_and_alias("${short_name}")
 
     set(public_deps)
     foreach (dep_short_name ${ARGN})
-        list(APPEND public_deps "googleapis-c++::${dep_short_name}")
+        list(APPEND public_deps "google-cloud-cpp::${dep_short_name}")
     endforeach ()
     list(LENGTH public_deps public_deps_length)
     if (public_deps_length EQUAL 0)
-        target_link_libraries("googleapis_cpp_${short_name}"
-                              PRIVATE googleapis_cpp_common_flags)
+        target_link_libraries("google_cloud_cpp_${short_name}"
+                              PRIVATE external_googleapis_common_flags)
     else ()
         target_link_libraries(
-            "googleapis_cpp_${short_name}"
+            "google_cloud_cpp_${short_name}"
             PUBLIC ${public_deps}
-            PRIVATE googleapis_cpp_common_flags)
+            PRIVATE external_googleapis_common_flags)
     endif ()
 endfunction ()
 
-function (googleapis_cpp_set_version_and_alias short_name)
-    add_dependencies("googleapis_cpp_${short_name}" googleapis_download)
+function (external_googleapis_set_version_and_alias short_name)
+    add_dependencies("google_cloud_cpp_${short_name}" googleapis_download)
     set_target_properties(
-        "googleapis_cpp_${short_name}"
-        PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION
+        "google_cloud_cpp_${short_name}"
+        PROPERTIES EXPORT_NAME google-cloud-cpp::${short_name}
+                   VERSION "${PROJECT_VERSION}" SOVERSION
                                                 ${PROJECT_VERSION_MAJOR})
-    set_target_properties("googleapis_cpp_${short_name}"
-                          PROPERTIES EXPORT_NAME googleapis-c++::${short_name})
-    add_library("googleapis-c++::${short_name}" ALIAS
-                "googleapis_cpp_${short_name}")
+    add_library("google-cloud-cpp::${short_name}" ALIAS
+                "google_cloud_cpp_${short_name}")
 endfunction ()
 
-set(googleapis_cpp_installed_libraries_list
-    googleapis_cpp_bigtable_protos
-    googleapis_cpp_cloud_bigquery_protos
-    googleapis_cpp_cloud_speech_protos
-    googleapis_cpp_cloud_texttospeech_protos
-    googleapis_cpp_iam_protos
-    googleapis_cpp_pubsub_protos
-    googleapis_cpp_spanner_protos
-    googleapis_cpp_storage_protos
-    googleapis_cpp_longrunning_operations_protos
-    googleapis_cpp_api_http_protos
-    googleapis_cpp_api_annotations_protos
-    googleapis_cpp_api_auth_protos
-    googleapis_cpp_api_client_protos
-    googleapis_cpp_api_distribution_protos
-    googleapis_cpp_api_field_behavior_protos
-    googleapis_cpp_api_label_protos
-    googleapis_cpp_api_launch_stage_protos
-    googleapis_cpp_api_metric_protos
-    googleapis_cpp_api_monitored_resource_protos
-    googleapis_cpp_api_resource_protos
-    googleapis_cpp_devtools_cloudtrace_v2_trace_protos
-    googleapis_cpp_devtools_cloudtrace_v2_tracing_protos
-    googleapis_cpp_logging_type_protos
-    googleapis_cpp_logging_protos
-    googleapis_cpp_monitoring_protos
-    googleapis_cpp_iam_v1_options_protos
-    googleapis_cpp_iam_v1_policy_protos
-    googleapis_cpp_iam_v1_iam_policy_protos
-    googleapis_cpp_rpc_error_details_protos
-    googleapis_cpp_rpc_status_protos
-    googleapis_cpp_type_calendar_period_protos
-    googleapis_cpp_type_color_protos
-    googleapis_cpp_type_date_protos
-    googleapis_cpp_type_datetime_protos
-    googleapis_cpp_type_dayofweek_protos
-    googleapis_cpp_type_expr_protos
-    googleapis_cpp_type_fraction_protos
-    googleapis_cpp_type_interval_protos
-    googleapis_cpp_type_latlng_protos
-    googleapis_cpp_type_localized_text_protos
-    googleapis_cpp_type_money_protos
-    googleapis_cpp_type_month_protos
-    googleapis_cpp_type_phone_number_protos
-    googleapis_cpp_type_postal_address_protos
-    googleapis_cpp_type_quaternion_protos
-    googleapis_cpp_type_timeofday_protos)
+set(external_googleapis_installed_libraries_list
+    google_cloud_cpp_bigtable_protos
+    google_cloud_cpp_cloud_bigquery_protos
+    google_cloud_cpp_cloud_speech_protos
+    google_cloud_cpp_cloud_texttospeech_protos
+    google_cloud_cpp_iam_protos
+    google_cloud_cpp_pubsub_protos
+    google_cloud_cpp_spanner_protos
+    google_cloud_cpp_storage_protos
+    google_cloud_cpp_longrunning_operations_protos
+    google_cloud_cpp_api_http_protos
+    google_cloud_cpp_api_annotations_protos
+    google_cloud_cpp_api_auth_protos
+    google_cloud_cpp_api_client_protos
+    google_cloud_cpp_api_distribution_protos
+    google_cloud_cpp_api_field_behavior_protos
+    google_cloud_cpp_api_label_protos
+    google_cloud_cpp_api_launch_stage_protos
+    google_cloud_cpp_api_metric_protos
+    google_cloud_cpp_api_monitored_resource_protos
+    google_cloud_cpp_api_resource_protos
+    google_cloud_cpp_devtools_cloudtrace_v2_trace_protos
+    google_cloud_cpp_devtools_cloudtrace_v2_tracing_protos
+    google_cloud_cpp_logging_type_protos
+    google_cloud_cpp_logging_protos
+    google_cloud_cpp_monitoring_protos
+    google_cloud_cpp_iam_v1_options_protos
+    google_cloud_cpp_iam_v1_policy_protos
+    google_cloud_cpp_iam_v1_iam_policy_protos
+    google_cloud_cpp_rpc_error_details_protos
+    google_cloud_cpp_rpc_status_protos
+    google_cloud_cpp_type_calendar_period_protos
+    google_cloud_cpp_type_color_protos
+    google_cloud_cpp_type_date_protos
+    google_cloud_cpp_type_datetime_protos
+    google_cloud_cpp_type_dayofweek_protos
+    google_cloud_cpp_type_expr_protos
+    google_cloud_cpp_type_fraction_protos
+    google_cloud_cpp_type_interval_protos
+    google_cloud_cpp_type_latlng_protos
+    google_cloud_cpp_type_localized_text_protos
+    google_cloud_cpp_type_money_protos
+    google_cloud_cpp_type_month_protos
+    google_cloud_cpp_type_phone_number_protos
+    google_cloud_cpp_type_postal_address_protos
+    google_cloud_cpp_type_quaternion_protos
+    google_cloud_cpp_type_timeofday_protos)
 
-googleapis_cpp_add_library("google/api/http.proto")
-googleapis_cpp_add_library("google/api/metric.proto" api_launch_stage_protos
-                           api_label_protos)
-googleapis_cpp_add_library("google/api/monitored_resource.proto"
-                           api_launch_stage_protos api_label_protos)
-googleapis_cpp_add_library("google/api/annotations.proto" api_http_protos)
-googleapis_cpp_add_library("google/api/auth.proto" api_annotations_protos)
-googleapis_cpp_add_library("google/api/client.proto")
-googleapis_cpp_add_library("google/api/distribution.proto")
-googleapis_cpp_add_library("google/api/field_behavior.proto")
-googleapis_cpp_add_library("google/api/label.proto")
-googleapis_cpp_add_library("google/api/launch_stage.proto")
-googleapis_cpp_add_library("google/api/resource.proto")
+external_googleapis_add_library("google/api/http.proto")
+external_googleapis_add_library("google/api/metric.proto"
+                                api_launch_stage_protos api_label_protos)
+external_googleapis_add_library("google/api/monitored_resource.proto"
+                                api_launch_stage_protos api_label_protos)
+external_googleapis_add_library("google/api/annotations.proto" api_http_protos)
+external_googleapis_add_library("google/api/auth.proto" api_annotations_protos)
+external_googleapis_add_library("google/api/client.proto")
+external_googleapis_add_library("google/api/distribution.proto")
+external_googleapis_add_library("google/api/field_behavior.proto")
+external_googleapis_add_library("google/api/label.proto")
+external_googleapis_add_library("google/api/launch_stage.proto")
+external_googleapis_add_library("google/api/resource.proto")
 
-googleapis_cpp_add_library("google/type/calendar_period.proto")
-googleapis_cpp_add_library("google/type/color.proto")
-googleapis_cpp_add_library("google/type/date.proto")
-googleapis_cpp_add_library("google/type/datetime.proto")
-googleapis_cpp_add_library("google/type/dayofweek.proto")
-googleapis_cpp_add_library("google/type/expr.proto")
-googleapis_cpp_add_library("google/type/fraction.proto")
-googleapis_cpp_add_library("google/type/interval.proto")
-googleapis_cpp_add_library("google/type/latlng.proto")
-googleapis_cpp_add_library("google/type/localized_text.proto")
-googleapis_cpp_add_library("google/type/money.proto")
-googleapis_cpp_add_library("google/type/month.proto")
-googleapis_cpp_add_library("google/type/phone_number.proto")
-googleapis_cpp_add_library("google/type/postal_address.proto")
-googleapis_cpp_add_library("google/type/quaternion.proto")
-googleapis_cpp_add_library("google/type/timeofday.proto")
+external_googleapis_add_library("google/type/calendar_period.proto")
+external_googleapis_add_library("google/type/color.proto")
+external_googleapis_add_library("google/type/date.proto")
+external_googleapis_add_library("google/type/datetime.proto")
+external_googleapis_add_library("google/type/dayofweek.proto")
+external_googleapis_add_library("google/type/expr.proto")
+external_googleapis_add_library("google/type/fraction.proto")
+external_googleapis_add_library("google/type/interval.proto")
+external_googleapis_add_library("google/type/latlng.proto")
+external_googleapis_add_library("google/type/localized_text.proto")
+external_googleapis_add_library("google/type/money.proto")
+external_googleapis_add_library("google/type/month.proto")
+external_googleapis_add_library("google/type/phone_number.proto")
+external_googleapis_add_library("google/type/postal_address.proto")
+external_googleapis_add_library("google/type/quaternion.proto")
+external_googleapis_add_library("google/type/timeofday.proto")
 
-googleapis_cpp_add_library("google/rpc/error_details.proto")
-googleapis_cpp_add_library("google/rpc/status.proto" rpc_error_details_protos)
+external_googleapis_add_library("google/rpc/error_details.proto")
+external_googleapis_add_library("google/rpc/status.proto"
+                                rpc_error_details_protos)
 
-googleapis_cpp_add_library("google/iam/v1/options.proto" api_annotations_protos)
-googleapis_cpp_add_library("google/iam/v1/policy.proto" api_annotations_protos
-                           type_expr_protos)
+external_googleapis_add_library("google/iam/v1/options.proto"
+                                api_annotations_protos)
+external_googleapis_add_library("google/iam/v1/policy.proto"
+                                api_annotations_protos type_expr_protos)
 
-googleapis_cpp_add_library(
+external_googleapis_add_library(
     "google/iam/v1/iam_policy.proto"
     api_annotations_protos
     api_client_protos
@@ -335,359 +339,360 @@ googleapis_cpp_add_library(
     iam_v1_options_protos
     iam_v1_policy_protos)
 
-googleapis_cpp_add_library(
+external_googleapis_add_library(
     "google/longrunning/operations.proto" api_annotations_protos
     api_client_protos rpc_status_protos)
 
-googleapis_cpp_add_library(
+external_googleapis_add_library(
     "google/devtools/cloudtrace/v2/trace.proto" api_annotations_protos
     api_field_behavior_protos api_resource_protos rpc_status_protos)
-googleapis_cpp_add_library(
+external_googleapis_add_library(
     "google/devtools/cloudtrace/v2/tracing.proto"
     devtools_cloudtrace_v2_trace_protos api_annotations_protos
     api_client_protos api_field_behavior_protos rpc_status_protos)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_cloud_bigquery_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/connection/v1beta1/connection.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/datatransfer/v1/datatransfer.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/datatransfer/v1/transfer.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/logging/v1/audit_data.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/storage/v1beta1/arrow.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/storage/v1beta1/avro.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/storage/v1beta1/read_options.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/storage/v1beta1/storage.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/storage/v1beta1/table_reference.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/encryption_config.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/model.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/model_reference.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/standard_sql.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/bigquery/v2/table_reference.proto"
+    google_cloud_cpp_cloud_bigquery_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/connection/v1beta1/connection.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/datatransfer/v1/datatransfer.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/datatransfer/v1/transfer.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/logging/v1/audit_data.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/storage/v1beta1/arrow.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/storage/v1beta1/avro.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/storage/v1beta1/read_options.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/storage/v1beta1/storage.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/storage/v1beta1/table_reference.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/v2/encryption_config.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/v2/model.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/v2/model_reference.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/v2/standard_sql.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/bigquery/v2/table_reference.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(cloud_bigquery_protos)
+external_googleapis_set_version_and_alias(cloud_bigquery_protos)
 target_link_libraries(
-    googleapis_cpp_cloud_bigquery_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_resource_protos
-           googleapis-c++::iam_v1_iam_policy_protos
-           googleapis-c++::iam_v1_policy_protos
-           googleapis-c++::rpc_status_protos
-           googleapis-c++::api_http_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_cloud_bigquery_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
+           google-cloud-cpp::iam_v1_policy_protos
+           google-cloud-cpp::rpc_status_protos
+           google-cloud-cpp::api_http_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_bigtable_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/admin/v2/bigtable_instance_admin.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/admin/v2/bigtable_table_admin.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/admin/v2/common.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/admin/v2/instance.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/admin/v2/table.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/v2/bigtable.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/bigtable/v2/data.proto"
+    google_cloud_cpp_bigtable_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/admin/v2/bigtable_instance_admin.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/admin/v2/bigtable_table_admin.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/admin/v2/common.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/admin/v2/instance.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/admin/v2/table.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/v2/bigtable.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/bigtable/v2/data.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(bigtable_protos)
+external_googleapis_set_version_and_alias(bigtable_protos)
 target_link_libraries(
-    googleapis_cpp_bigtable_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_resource_protos
-           googleapis-c++::iam_v1_iam_policy_protos
-           googleapis-c++::iam_v1_policy_protos
-           googleapis-c++::longrunning_operations_protos
-           googleapis-c++::rpc_status_protos
-           googleapis-c++::api_auth_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_bigtable_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
+           google-cloud-cpp::iam_v1_policy_protos
+           google-cloud-cpp::longrunning_operations_protos
+           google-cloud-cpp::rpc_status_protos
+           google-cloud-cpp::api_auth_protos
+    PRIVATE external_googleapis_common_flags)
 
 # TODO(#5660) - protobuf + gcc<6 + deprecated enums do not compile
 if (NOT (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
          AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)))
 
     google_cloud_cpp_grpcpp_library(
-        googleapis_cpp_cloud_dialogflow_v2_protos
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/agent.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/audio_config.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/context.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/entity_type.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/environment.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/intent.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/session.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/session_entity_type.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/validation_result.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2/webhook.proto"
+        google_cloud_cpp_cloud_dialogflow_v2_protos
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/agent.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/audio_config.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/context.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/entity_type.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/environment.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/intent.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/session.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/session_entity_type.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/validation_result.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2/webhook.proto"
         PROTO_PATH_DIRECTORIES
-        "${GOOGLEAPIS_CPP_SOURCE}"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}"
         "${PROTO_INCLUDE_DIR}")
-    googleapis_cpp_set_version_and_alias(cloud_dialogflow_v2_protos)
+    external_googleapis_set_version_and_alias(cloud_dialogflow_v2_protos)
     target_link_libraries(
-        googleapis_cpp_cloud_dialogflow_v2_protos
-        PUBLIC googleapis-c++::api_annotations_protos
-               googleapis-c++::api_client_protos
-               googleapis-c++::api_field_behavior_protos
-               googleapis-c++::api_resource_protos
-               googleapis-c++::longrunning_operations_protos
-               googleapis-c++::rpc_status_protos
-               googleapis-c++::type_latlng_protos
-        PRIVATE googleapis_cpp_common_flags)
+        google_cloud_cpp_cloud_dialogflow_v2_protos
+        PUBLIC google-cloud-cpp::api_annotations_protos
+               google-cloud-cpp::api_client_protos
+               google-cloud-cpp::api_field_behavior_protos
+               google-cloud-cpp::api_resource_protos
+               google-cloud-cpp::longrunning_operations_protos
+               google-cloud-cpp::rpc_status_protos
+               google-cloud-cpp::type_latlng_protos
+        PRIVATE external_googleapis_common_flags)
 
     google_cloud_cpp_grpcpp_library(
-        googleapis_cpp_cloud_dialogflow_v2beta1_protos
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/agent.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/audio_config.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/context.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/document.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/entity_type.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/environment.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/gcs.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/intent.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/knowledge_base.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/session.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/session_entity_type.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/validation_result.proto"
-        "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/dialogflow/v2beta1/webhook.proto"
+        google_cloud_cpp_cloud_dialogflow_v2beta1_protos
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/agent.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/audio_config.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/context.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/document.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/entity_type.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/environment.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/gcs.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/intent.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/knowledge_base.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/session.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/session_entity_type.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/validation_result.proto"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dialogflow/v2beta1/webhook.proto"
         PROTO_PATH_DIRECTORIES
-        "${GOOGLEAPIS_CPP_SOURCE}"
+        "${EXTERNAL_GOOGLEAPIS_SOURCE}"
         "${PROTO_INCLUDE_DIR}")
-    googleapis_cpp_set_version_and_alias(cloud_dialogflow_v2beta1_protos)
+    external_googleapis_set_version_and_alias(cloud_dialogflow_v2beta1_protos)
     target_link_libraries(
-        googleapis_cpp_cloud_dialogflow_v2beta1_protos
-        PUBLIC googleapis-c++::api_annotations_protos
-               googleapis-c++::api_client_protos
-               googleapis-c++::api_field_behavior_protos
-               googleapis-c++::api_resource_protos
-               googleapis-c++::longrunning_operations_protos
-               googleapis-c++::rpc_status_protos
-               googleapis-c++::type_latlng_protos
-        PRIVATE googleapis_cpp_common_flags)
+        google_cloud_cpp_cloud_dialogflow_v2beta1_protos
+        PUBLIC google-cloud-cpp::api_annotations_protos
+               google-cloud-cpp::api_client_protos
+               google-cloud-cpp::api_field_behavior_protos
+               google-cloud-cpp::api_resource_protos
+               google-cloud-cpp::longrunning_operations_protos
+               google-cloud-cpp::rpc_status_protos
+               google-cloud-cpp::type_latlng_protos
+        PRIVATE external_googleapis_common_flags)
 
-    list(APPEND googleapis_cpp_installed_libraries_list
-         googleapis_cpp_cloud_dialogflow_v2_protos
-         googleapis_cpp_cloud_dialogflow_v2beta1_protos)
+    list(APPEND external_googleapis_installed_libraries_list
+         google_cloud_cpp_cloud_dialogflow_v2_protos
+         google_cloud_cpp_cloud_dialogflow_v2beta1_protos)
 endif ()
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_cloud_speech_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/speech/v1/cloud_speech.proto"
-    PROTO_PATH_DIRECTORIES "${GOOGLEAPIS_CPP_SOURCE}" "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(cloud_speech_protos)
-target_link_libraries(
-    googleapis_cpp_cloud_speech_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::longrunning_operations_protos
-           googleapis-c++::rpc_status_protos
-    PRIVATE googleapis_cpp_common_flags)
-
-google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_cloud_texttospeech_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/cloud/texttospeech/v1/cloud_tts.proto"
-    PROTO_PATH_DIRECTORIES "${GOOGLEAPIS_CPP_SOURCE}" "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(cloud_texttospeech_protos)
-target_link_libraries(
-    googleapis_cpp_cloud_texttospeech_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-    PRIVATE googleapis_cpp_common_flags)
-
-google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_iam_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/iam/credentials/v1/iamcredentials.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/iam/credentials/v1/common.proto"
+    google_cloud_cpp_cloud_speech_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/speech/v1/cloud_speech.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(iam_protos)
+external_googleapis_set_version_and_alias(cloud_speech_protos)
 target_link_libraries(
-    googleapis_cpp_iam_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_resource_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_cloud_speech_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::longrunning_operations_protos
+           google-cloud-cpp::rpc_status_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_logging_type_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/logging/type/http_request.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/logging/type/log_severity.proto"
+    google_cloud_cpp_cloud_texttospeech_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/texttospeech/v1/cloud_tts.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(logging_type_protos)
+external_googleapis_set_version_and_alias(cloud_texttospeech_protos)
 target_link_libraries(
-    googleapis_cpp_logging_type_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_cloud_texttospeech_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_logging_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/logging/v2/log_entry.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/logging/v2/logging.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/logging/v2/logging_config.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/logging/v2/logging_metrics.proto"
+    google_cloud_cpp_iam_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/iam/credentials/v1/iamcredentials.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/iam/credentials/v1/common.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(logging_protos)
+external_googleapis_set_version_and_alias(iam_protos)
 target_link_libraries(
-    googleapis_cpp_logging_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_distribution_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_metric_protos
-           googleapis-c++::api_monitored_resource_protos
-           googleapis-c++::api_resource_protos
-           googleapis-c++::logging_type_protos
-           googleapis-c++::rpc_status_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_iam_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_resource_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_monitoring_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/alert.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/alert_service.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/common.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/dropped_labels.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/group.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/group_service.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/metric.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/metric_service.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/mutation_record.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/notification.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/notification_service.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/service.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/service_service.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/span_context.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/uptime.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/monitoring/v3/uptime_service.proto"
+    google_cloud_cpp_logging_type_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/logging/type/http_request.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/logging/type/log_severity.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(monitoring_protos)
+external_googleapis_set_version_and_alias(logging_type_protos)
 target_link_libraries(
-    googleapis_cpp_monitoring_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_distribution_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_label_protos
-           googleapis-c++::api_launch_stage_protos
-           googleapis-c++::api_metric_protos
-           googleapis-c++::api_monitored_resource_protos
-           googleapis-c++::api_resource_protos
-           googleapis-c++::rpc_status_protos
-           googleapis-c++::type_calendar_period_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_logging_type_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_pubsub_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/pubsub/v1/pubsub.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/pubsub/v1/schema.proto"
+    google_cloud_cpp_logging_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/logging/v2/log_entry.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/logging/v2/logging.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/logging/v2/logging_config.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/logging/v2/logging_metrics.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(pubsub_protos)
+external_googleapis_set_version_and_alias(logging_protos)
 target_link_libraries(
-    googleapis_cpp_pubsub_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_resource_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_logging_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_distribution_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_metric_protos
+           google-cloud-cpp::api_monitored_resource_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::logging_type_protos
+           google-cloud-cpp::rpc_status_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_spanner_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/admin/database/v1/backup.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/admin/database/v1/common.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/admin/database/v1/spanner_database_admin.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/admin/instance/v1/spanner_instance_admin.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/keys.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/mutation.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/query_plan.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/result_set.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/spanner.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/transaction.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/spanner/v1/type.proto"
+    google_cloud_cpp_monitoring_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/alert.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/alert_service.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/common.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/dropped_labels.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/group.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/group_service.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/metric.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/metric_service.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/mutation_record.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/notification.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/notification_service.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/service.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/service_service.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/span_context.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/uptime.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/monitoring/v3/uptime_service.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(spanner_protos)
+external_googleapis_set_version_and_alias(monitoring_protos)
 target_link_libraries(
-    googleapis_cpp_spanner_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_resource_protos
-           googleapis-c++::iam_v1_iam_policy_protos
-           googleapis-c++::iam_v1_policy_protos
-           googleapis-c++::longrunning_operations_protos
-           googleapis-c++::rpc_status_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_monitoring_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_distribution_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_label_protos
+           google-cloud-cpp::api_launch_stage_protos
+           google-cloud-cpp::api_metric_protos
+           google-cloud-cpp::api_monitored_resource_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::rpc_status_protos
+           google-cloud-cpp::type_calendar_period_protos
+    PRIVATE external_googleapis_common_flags)
 
 google_cloud_cpp_grpcpp_library(
-    googleapis_cpp_storage_protos
-    "${GOOGLEAPIS_CPP_SOURCE}/google/storage/v1/storage.proto"
-    "${GOOGLEAPIS_CPP_SOURCE}/google/storage/v1/storage_resources.proto"
+    google_cloud_cpp_pubsub_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/pubsub/v1/pubsub.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/pubsub/v1/schema.proto"
     PROTO_PATH_DIRECTORIES
-    "${GOOGLEAPIS_CPP_SOURCE}"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
-googleapis_cpp_set_version_and_alias(storage_protos)
+external_googleapis_set_version_and_alias(pubsub_protos)
 target_link_libraries(
-    googleapis_cpp_storage_protos
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::iam_v1_iam_policy_protos
-           googleapis-c++::iam_v1_policy_protos
-    PRIVATE googleapis_cpp_common_flags)
+    google_cloud_cpp_pubsub_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_resource_protos
+    PRIVATE external_googleapis_common_flags)
+
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_spanner_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/admin/database/v1/backup.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/admin/database/v1/common.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/admin/database/v1/spanner_database_admin.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/admin/instance/v1/spanner_instance_admin.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/keys.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/mutation.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/query_plan.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/result_set.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/spanner.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/transaction.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/spanner/v1/type.proto"
+    PROTO_PATH_DIRECTORIES
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    "${PROTO_INCLUDE_DIR}")
+external_googleapis_set_version_and_alias(spanner_protos)
+target_link_libraries(
+    google_cloud_cpp_spanner_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
+           google-cloud-cpp::iam_v1_policy_protos
+           google-cloud-cpp::longrunning_operations_protos
+           google-cloud-cpp::rpc_status_protos
+    PRIVATE external_googleapis_common_flags)
+
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_storage_protos
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/storage/v1/storage.proto"
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/storage/v1/storage_resources.proto"
+    PROTO_PATH_DIRECTORIES
+    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    "${PROTO_INCLUDE_DIR}")
+external_googleapis_set_version_and_alias(storage_protos)
+target_link_libraries(
+    google_cloud_cpp_storage_protos
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
+           google-cloud-cpp::iam_v1_policy_protos
+    PRIVATE external_googleapis_common_flags)
 
 # Install the libraries and headers in the locations determined by
 # GNUInstallDirs
 include(GNUInstallDirs)
 
 install(
-    TARGETS ${googleapis_cpp_installed_libraries_list}
-            googleapis_cpp_common_flags
+    TARGETS ${external_googleapis_installed_libraries_list}
+            external_googleapis_common_flags
     EXPORT googleapis-targets
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-foreach (target ${googleapis_cpp_installed_libraries_list})
+foreach (target ${external_googleapis_installed_libraries_list})
     google_cloud_cpp_install_proto_library_headers("${target}")
-    google_cloud_cpp_install_proto_library_protos("${target}"
-                                                  "${GOOGLEAPIS_CPP_SOURCE}")
+    google_cloud_cpp_install_proto_library_protos(
+        "${target}" "${EXTERNAL_GOOGLEAPIS_SOURCE}")
 endforeach ()
 
-# Export the CMake targets to make it easy to create configuration files.
-install(EXPORT googleapis-targets
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/googleapis")
-
 # Use a function to create a scope for the variables.
-function (googleapis_cpp_install_pc target)
-    string(REPLACE "googleapis_cpp_" "" _short_name ${target})
+function (external_googleapis_install_pc target)
+    string(REPLACE "google_cloud_cpp_" "" _short_name ${target})
     string(REPLACE "_protos" "" _short_name ${_short_name})
     set(GOOGLE_CLOUD_CPP_PC_NAME
         "The Google APIS C++ ${_short_name} Proto Library")
     set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Compiled proto for C++.")
     # Examine the target LINK_LIBRARIES property, use that to pull the
-    # dependencies between the googleapis-c++::* libraries.
+    # dependencies between the google-cloud-cpp::* libraries.
     set(_target_pc_requires)
     get_target_property(_target_deps ${target} LINK_LIBRARIES)
     foreach (dep ${_target_deps})
-        if ("${dep}" MATCHES "^googleapis-c\\+\\+::")
-            string(REPLACE "googleapis-c++::" "googleapis_cpp_" dep "${dep}")
+        if ("${dep}" MATCHES "^google-cloud-cpp::")
+            string(REPLACE "google-cloud-cpp::" "google_cloud_cpp_" dep
+                           "${dep}")
             list(APPEND _target_pc_requires " " "${dep}")
         endif ()
     endforeach ()
-    # These dependencies are required for all the googleapis-c++::* libraries.
+    # These dependencies are required for all the google-cloud-cpp::* libraries.
     list(
         APPEND
         _target_pc_requires
@@ -703,11 +708,17 @@ function (googleapis_cpp_install_pc target)
                    @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.pc"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    # TODO(#5726) - also install the module with the legacy name
+    string(REPLACE "google_cloud_cpp_" "googleapis_cpp_" legacy ${target})
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/config.pc.in" "${legacy}.pc"
+                   @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${legacy}.pc"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction ()
 
 # Create and install the pkg-config files.
-foreach (target ${googleapis_cpp_installed_libraries_list})
-    googleapis_cpp_install_pc("${target}")
+foreach (target ${external_googleapis_installed_libraries_list})
+    external_googleapis_install_pc("${target}")
 endforeach ()
 
 # Create and install the googleapis pkg-config file for backwards compatibility.
@@ -718,23 +729,23 @@ set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
 # need to add the separator ourselves.
 string(
     CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "googleapis_cpp_bigtable_protos"
-           " googleapis_cpp_cloud_bigquery_protos"
-           " googleapis_iam_protos"
-           " googleapis_pubsub_protos"
-           " googleapis_cpp_storage_protos"
-           " googleapis_cpp_logging_protos"
-           " googleapis_cpp_iam_v1_iam_policy_protos"
-           " googleapis_cpp_iam_v1_options_protos"
-           " googleapis_cpp_iam_v1_policy_protos"
-           " googleapis_cpp_longrunning_operations_protos"
-           " googleapis_cpp_api_auth_protos"
-           " googleapis_cpp_api_annotations_protos"
-           " googleapis_cpp_api_client_protos"
-           " googleapis_cpp_api_field_behavior_protos"
-           " googleapis_cpp_api_http_protos"
-           " googleapis_cpp_rpc_status_protos"
-           " googleapis_cpp_rpc_error_details_protos"
+           "google_cloud_cpp_bigtable_protos"
+           " google_cloud_cpp_cloud_bigquery_protos"
+           " google_cloud_iam_protos"
+           " google_cloud_pubsub_protos"
+           " google_cloud_cpp_storage_protos"
+           " google_cloud_cpp_oo_protos"
+           " google_cloud_cpp_iam_v1_iam_policy_protos"
+           " google_cloud_cpp_iam_v1_options_protos"
+           " google_cloud_cpp_iam_v1_policy_protos"
+           " google_cloud_cpp_longrunning_operations_protos"
+           " google_cloud_cpp_api_auth_protos"
+           " google_cloud_cpp_api_annotations_protos"
+           " google_cloud_cpp_api_client_protos"
+           " google_cloud_cpp_api_field_behavior_protos"
+           " google_cloud_cpp_api_http_protos"
+           " google_cloud_cpp_rpc_status_protos"
+           " google_cloud_cpp_rpc_error_details_protos"
            " grpc++"
            " grpc"
            " openssl"
@@ -748,17 +759,35 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/googleapis.pc"
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)
+
 configure_file("${CMAKE_CURRENT_LIST_DIR}/config.cmake.in"
+               "google_cloud_cpp_googleapis-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_googleapis-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+# Export the CMake targets to make it easy to create configuration files.
+install(EXPORT googleapis-targets
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_googleapis")
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_googleapis-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_googleapis-config-version.cmake"
+        "${PROJECT_SOURCE_DIR}/cmake/FindgRPC.cmake"
+        "${PROJECT_SOURCE_DIR}/cmake/FindProtobufWithTargets.cmake"
+        "${PROJECT_SOURCE_DIR}/cmake/CompileProtos.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_googleapis")
+
+# TODO(#5726) - we need to install the legacy CMake configuration under the
+# googleapis-c++ names:
+configure_file("${CMAKE_CURRENT_LIST_DIR}/legacy.cmake.in"
                "googleapis-config.cmake" @ONLY)
 write_basic_package_version_file(
     "googleapis-config-version.cmake"
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY ExactVersion)
 
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/googleapis-config.cmake"
-          "${CMAKE_CURRENT_BINARY_DIR}/googleapis-config-version.cmake"
-          "${PROJECT_SOURCE_DIR}/cmake/FindgRPC.cmake"
-          "${PROJECT_SOURCE_DIR}/cmake/FindProtobufWithTargets.cmake"
-          "${PROJECT_SOURCE_DIR}/cmake/CompileProtos.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/googleapis")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/googleapis-config.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/googleapis-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/googleapis")

--- a/external/googleapis/legacy.cmake.in
+++ b/external/googleapis/legacy.cmake.in
@@ -71,7 +71,7 @@ foreach (short_name ${GOOGLE_CLOUD_CPP_LEGACY_PROTO_LIBS})
     add_library(googleapis-c++::${short_name} IMPORTED INTERFACE)
     set_target_properties(googleapis-c++::${short_name} PROPERTIES
         INTERFACE_LINK_LIBRARIES google-cloud-cpp::${short_name})
-    if (CMAKE_VERSION VERSION_GREATER 3.16)
+    if (CMAKE_VERSION VERSION_GREATER 3.17)
         set_target_properties(googleapis-c++::${short_name} PROPERTIES
         DEPRECATION "This target will be removed on or about 2022-02-15, please use google-cloud-cpp::${short_name} instead")
     endif ()

--- a/external/googleapis/legacy.cmake.in
+++ b/external/googleapis/legacy.cmake.in
@@ -1,0 +1,78 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+find_dependency(google_cloud_cpp_googleapis)
+
+set(GOOGLE_CLOUD_CPP_LEGACY_PROTO_LIBS
+    bigtable_protos
+    cloud_bigquery_protos
+    cloud_speech_protos
+    cloud_texttospeech_protos
+    iam_protos
+    pubsub_protos
+    spanner_protos
+    storage_protos
+    longrunning_operations_protos
+    api_http_protos
+    api_annotations_protos
+    api_auth_protos
+    api_client_protos
+    api_distribution_protos
+    api_field_behavior_protos
+    api_label_protos
+    api_launch_stage_protos
+    api_metric_protos
+    api_monitored_resource_protos
+    api_resource_protos
+    devtools_cloudtrace_v2_trace_protos
+    devtools_cloudtrace_v2_tracing_protos
+    logging_type_protos
+    logging_protos
+    monitoring_protos
+    iam_v1_options_protos
+    iam_v1_policy_protos
+    iam_v1_iam_policy_protos
+    rpc_error_details_protos
+    rpc_status_protos
+    type_calendar_period_protos
+    type_color_protos
+    type_date_protos
+    type_datetime_protos
+    type_dayofweek_protos
+    type_expr_protos
+    type_fraction_protos
+    type_interval_protos
+    type_latlng_protos
+    type_localized_text_protos
+    type_money_protos
+    type_month_protos
+    type_phone_number_protos
+    type_postal_address_protos
+    type_quaternion_protos
+    type_timeofday_protos)
+
+foreach (short_name ${GOOGLE_CLOUD_CPP_LEGACY_PROTO_LIBS})
+    if (TARGET googleapis-c++::${short_name})
+        continue()
+    endif ()
+    add_library(googleapis-c++::${short_name} IMPORTED INTERFACE)
+    set_target_properties(googleapis-c++::${short_name} PROPERTIES
+        INTERFACE_LINK_LIBRARIES google-cloud-cpp::${short_name})
+    if (CMAKE_VERSION VERSION_GREATER 3.16)
+        set_target_properties(googleapis-c++::${short_name} PROPERTIES
+        DEPRECATION "This target will be removed on or about 2022-02-15, please use google-cloud-cpp::${short_name} instead")
+    endif ()
+endforeach ()

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -65,8 +65,8 @@ target_link_libraries(
     google_cloud_cpp_generator
     PUBLIC google_cloud_cpp_grpc_utils
            google_cloud_cpp_common
-           googleapis-c++::api_client_protos
-           googleapis-c++::longrunning_operations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::longrunning_operations_protos
            absl::str_format
            protobuf::libprotoc)
 google_cloud_cpp_add_common_options(google_cloud_cpp_generator)

--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -41,15 +41,15 @@ google_cloud_cpp_grpcpp_library(
     ${PROJECT_BINARY_DIR}/external/googleapis/src/googleapis_download)
 target_link_libraries(
     google_cloud_cpp_generator_testing_grpc_lib
-    PUBLIC googleapis-c++::api_annotations_protos
-           googleapis-c++::api_client_protos
-           googleapis-c++::api_field_behavior_protos
-           googleapis-c++::api_resource_protos
-           googleapis-c++::iam_v1_iam_policy_protos
-           googleapis-c++::iam_v1_policy_protos
-           googleapis-c++::longrunning_operations_protos
-           googleapis-c++::rpc_status_protos
-    PRIVATE googleapis_cpp_common_flags)
+    PUBLIC google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::api_field_behavior_protos
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
+           google-cloud-cpp::iam_v1_policy_protos
+           google-cloud-cpp::longrunning_operations_protos
+           google-cloud-cpp::rpc_status_protos
+    PRIVATE external_googleapis_common_flags)
 
 function (google_cloud_cpp_generator_define_integration_tests)
     # The tests require googletest to be installed. Force CMake to use the

--- a/generator/integration_tests/golden/CMakeLists.txt
+++ b/generator/integration_tests/golden/CMakeLists.txt
@@ -95,8 +95,8 @@ target_link_libraries(
     PUBLIC google_cloud_cpp_generator_testing_grpc_lib
            google_cloud_cpp_grpc_utils
            google_cloud_cpp_common
-           googleapis-c++::api_client_protos
-           googleapis-c++::longrunning_operations_protos
+           google-cloud-cpp::api_client_protos
+           google-cloud-cpp::longrunning_operations_protos
            absl::str_format
            protobuf::libprotoc)
 google_cloud_cpp_add_common_options(google_cloud_cpp_generator_golden_lib)

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -388,7 +388,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         PUBLIC absl::function_ref
                absl::memory
                absl::time
-               googleapis-c++::rpc_status_protos
+               google-cloud-cpp::rpc_status_protos
                google_cloud_cpp_common
                gRPC::grpc++
                gRPC::grpc)
@@ -471,8 +471,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
                         google_cloud_cpp_testing_grpc
                         google_cloud_cpp_testing
                         google_cloud_cpp_common
-                        googleapis-c++::bigtable_protos
-                        googleapis-c++::spanner_protos
+                        google-cloud-cpp::bigtable_protos
+                        google-cloud-cpp::spanner_protos
                         absl::variant
                         GTest::gmock_main
                         GTest::gmock

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -47,7 +47,8 @@ list(APPEND PROTOBUF_IMPORT_DIRS "${PROJECT_THIRD_PARTY_DIR}/googleapis"
 
 # Create a library with the generated files from the relevant protos.
 add_library(bigtable_protos INTERFACE)
-target_link_libraries(bigtable_protos INTERFACE googleapis-c++::bigtable_protos)
+target_link_libraries(bigtable_protos
+                      INTERFACE google-cloud-cpp::bigtable_protos)
 add_library(bigtable::protos ALIAS bigtable_protos)
 
 find_package(gRPC)

--- a/google/cloud/bigtable/benchmarks/CMakeLists.txt
+++ b/google/cloud/bigtable/benchmarks/CMakeLists.txt
@@ -55,7 +55,7 @@ if (BUILD_TESTING)
             PRIVATE bigtable_benchmark_common
                     bigtable_client
                     bigtable_client_testing
-                    bigtable_protos
+                    google-cloud-cpp::bigtable_protos
                     google_cloud_cpp_testing
                     google_cloud_cpp_common
                     google_cloud_cpp_grpc_utils

--- a/google/cloud/bigtable/config.cmake.in
+++ b/google/cloud/bigtable/config.cmake.in
@@ -13,18 +13,20 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-# googleapis finds both gRPC and Protobuf, no need to load them here.
-find_dependency(googleapis)
+# google_cloud_cpp_googleapis finds both gRPC and Protobuf, no need to load them here.
+find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
+# TODO(#5726) - this is needed to preserve backwards compatibility
+find_dependency(googleapis)
 
 include("${CMAKE_CURRENT_LIST_DIR}/bigtable-targets.cmake")
 
 if (NOT TARGET bigtable::protos)
     add_library(bigtable::protos IMPORTED INTERFACE)
     set_target_properties(bigtable::protos PROPERTIES
-        INTERFACE_LINK_LIBRARIES "bigtable_protos")
+        INTERFACE_LINK_LIBRARIES "google-cloud-cpp::bigtable_protos")
 endif ()
 
 if (NOT TARGET bigtable::client)

--- a/google/cloud/bigtable/examples/CMakeLists.txt
+++ b/google/cloud/bigtable/examples/CMakeLists.txt
@@ -20,7 +20,7 @@ if (BUILD_TESTING)
     target_link_libraries(
         bigtable_examples_common
         bigtable_client
-        bigtable_protos
+        google-cloud-cpp::bigtable_protos
         google_cloud_cpp_common
         google_cloud_cpp_testing
         google_cloud_cpp_grpc_utils

--- a/google/cloud/grpc_utils/config.cmake.in
+++ b/google/cloud/grpc_utils/config.cmake.in
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-# googleapis finds both gRPC and Protobuf, no need to load them here.
-find_dependency(googleapis)
+# google_cloud_cpp_googleapis finds both gRPC and Protobuf, no need to load them here.
+find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
+# TODO(#5726) - this is needed to preserve backwards compatibility
+find_dependency(googleapis)
 
 include("${CMAKE_CURRENT_LIST_DIR}/grpc_utils-targets.cmake")

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
     iam_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-                      googleapis-c++::iam_protos)
+                      google-cloud-cpp::iam_protos)
 google_cloud_cpp_add_common_options(iam_client)
 set_target_properties(
     iam_client PROPERTIES VERSION "${PROJECT_VERSION}"

--- a/google/cloud/iam/config.cmake.in
+++ b/google/cloud/iam/config.cmake.in
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-# googleapis finds both gRPC and Protobuf, no need to load them here.
-find_dependency(googleapis)
+# google_cloud_cpp_googleapis finds both gRPC and Protobuf, no need to load them here.
+find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
+# TODO(#5726) - this is needed to preserve backwards compatibility
+find_dependency(googleapis)
 
 include("${CMAKE_CURRENT_LIST_DIR}/iam-targets.cmake")

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -56,7 +56,7 @@ target_include_directories(
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
     logging_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-                          googleapis-c++::logging_protos)
+                          google-cloud-cpp::logging_protos)
 google_cloud_cpp_add_common_options(logging_client)
 set_target_properties(
     logging_client PROPERTIES VERSION "${PROJECT_VERSION}"

--- a/google/cloud/logging/config.cmake.in
+++ b/google/cloud/logging/config.cmake.in
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-# googleapis finds both gRPC and Protobuf, no need to load them here.
-find_dependency(googleapis)
+# google_cloud_cpp_googleapis finds both gRPC and Protobuf, no need to load them here.
+find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
+# TODO(#5726) - this is needed to preserve backwards compatibility
+find_dependency(googleapis)
 
 include("${CMAKE_CURRENT_LIST_DIR}/logging-targets.cmake")

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -131,7 +131,7 @@ target_include_directories(
            $<INSTALL_INTERFACE:include>)
 target_link_libraries(
     pubsub_client PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-                         googleapis-c++::pubsub_protos absl::flat_hash_map)
+                         google-cloud-cpp::pubsub_protos absl::flat_hash_map)
 google_cloud_cpp_add_common_options(pubsub_client)
 set_target_properties(
     pubsub_client PROPERTIES VERSION "${PROJECT_VERSION}"
@@ -195,7 +195,7 @@ function (google_cloud_cpp_pubsub_client_define_tests)
     target_link_libraries(
         pubsub_client_testing
         PUBLIC pubsub_client google_cloud_cpp_grpc_utils
-               google_cloud_cpp_common googleapis-c++::pubsub_protos
+               google_cloud_cpp_common google-cloud-cpp::pubsub_protos
                GTest::gmock GTest::gtest)
     google_cloud_cpp_add_common_options(pubsub_client_testing)
     target_compile_options(pubsub_client_testing

--- a/google/cloud/pubsub/config.cmake.in
+++ b/google/cloud/pubsub/config.cmake.in
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
-# googleapis finds both gRPC and Protobuf, no need to load them here.
-find_dependency(googleapis)
+# google_cloud_cpp_googleapis finds both gRPC and Protobuf, no need to load them here.
+find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
+# TODO(#5726) - this is needed to preserve backwards compatibility
+find_dependency(googleapis)
 
 include("${CMAKE_CURRENT_LIST_DIR}/pubsub-targets.cmake")
 

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -153,7 +153,7 @@ target_link_libraries(
            absl::time
            google_cloud_cpp_grpc_utils
            google_cloud_cpp_common
-           googleapis-c++::spanner_protos)
+           google-cloud-cpp::spanner_protos)
 set_target_properties(
     spanner_client PROPERTIES VERSION "${PROJECT_VERSION}"
                               SOVERSION "${PROJECT_VERSION_MAJOR}")

--- a/google/cloud/spanner/config.cmake.in
+++ b/google/cloud/spanner/config.cmake.in
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 include(CMakeFindDependencyMacro)
+# google_cloud_cpp_googleapis finds both gRPC and Protobuf, no need to load them here.
+find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_common)
 find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
+# TODO(#5726) - this is needed to preserve backwards compatibility
+find_dependency(googleapis)
 
 include("${CMAKE_CURRENT_LIST_DIR}/spanner-targets.cmake")
 

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -283,7 +283,7 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     set(saved_tidy "${CMAKE_CXX_CLANG_TIDY}")
     set(CMAKE_CXX_CLANG_TIDY "")
     google_cloud_cpp_proto_library(
-        google_cloud_cpp_storage_protos
+        google_cloud_cpp_storage_internal_protos
         internal/grpc_resumable_upload_session_url.proto PROTO_PATH_DIRECTORIES
         ${CMAKE_CURRENT_SOURCE_DIR}/internal LOCAL_INCLUDE)
     set(CMAKE_CXX_CLANG_TIDY "${saved_tidy}")
@@ -306,9 +306,9 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         PUBLIC storage_client
                google_cloud_cpp_grpc_utils
                google_cloud_cpp_common
-               google_cloud_cpp_storage_protos
+               google_cloud_cpp_storage_internal_protos
                nlohmann_json::nlohmann_json
-               googleapis-c++::storage_protos
+               google-cloud-cpp::storage_protos
                gRPC::grpc++
                protobuf::libprotobuf
                absl::strings

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -35,7 +35,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
     target_link_libraries(
         storage_benchmarks
         PUBLIC storage_client storage_client_testing google_cloud_cpp_testing
-               google_cloud_cpp_grpc_utils googleapis-c++::storage_protos
+               google_cloud_cpp_grpc_utils google-cloud-cpp::storage_protos
                CURL::libcurl)
     google_cloud_cpp_add_common_options(storage_benchmarks)
 

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -107,7 +107,7 @@ if (BUILD_TESTING)
     target_link_libraries(
         google_cloud_cpp_testing_grpc
         PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
-               googleapis-c++::api_annotations_protos protobuf::libprotobuf
+               google-cloud-cpp::api_annotations_protos protobuf::libprotobuf
                GTest::gmock)
     google_cloud_cpp_add_common_options(google_cloud_cpp_testing_grpc)
 


### PR DESCRIPTION
Export all the proto libraries with `google-cloud-cpp::` as a prefix.
Provide backwards compatibility targets for `googleapis-c++::`, add
warnings if those are used. Also made the analogous changes for
`pkg-config`. Changed the `{bigtable,pubsub,storage,spanner}_client`
targets to continue exporting the legacy target names.

Some additional cleanups in the `externals/googleapis/CMakeLists.txt`
file, mostly to make it easier to find `google_cloud_cpp_`.

Part of the changes for #5726

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5756)
<!-- Reviewable:end -->
