### PR TITLE
fix(googleapis): install directories for protos

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -520,11 +520,6 @@ if [[ "${TEST_INSTALL:-}" == "yes" ]]; then
   if comm -23 \
     <(/usr/bin/printf '%s\n' "${EXPECTED_INCLUDE_DIRS[@]}") \
     <(/usr/bin/printf '%s\n' "${ACTUAL_INCLUDE_DIRS[@]}") | grep -q /var/tmp; then
-    io::log_red "DEBUG DEBUG EXPECTED"
-    /usr/bin/printf '%s\n' "${EXPECTED_INCLUDE_DIRS[@]}"
-    io::log_red "DEBUG DEBUG ACTUAL"
-    /usr/bin/printf '%s\n' "${ACTUAL_INCLUDE_DIRS[@]}"
-    io::log_red "Installed proto directories do not match expectation:"
     io::log_red "Installed include directories do not match expectation:"
     diff -u \
       <(/usr/bin/printf '%s\n' "${EXPECTED_INCLUDE_DIRS[@]}") \
@@ -532,7 +527,7 @@ if [[ "${TEST_INSTALL:-}" == "yes" ]]; then
     exit 1
   fi
 
-  io::log_yellow "Verify only files with expected extensions are created installed."
+  io::log_yellow "Verify only files with expected extensions are installed."
   export PKG_CONFIG_PATH="/var/tmp/staging/${libdir}/pkgconfig:${PKG_CONFIG_PATH:-}"
 
   # Get the version of one of the libraries. These should all be the same, so

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -233,14 +233,15 @@ function (google_cloud_cpp_install_proto_library_headers target)
 endfunction ()
 
 # Install protos for a C++ proto library.
-function (google_cloud_cpp_install_proto_library_protos target)
+function (google_cloud_cpp_install_proto_library_protos target source_dir)
     get_target_property(target_protos ${target} PROTO_SOURCES)
     foreach (header ${target_protos})
         # Skip anything that is not a header file.
         if (NOT "${header}" MATCHES "\\.proto$")
             continue()
         endif ()
-        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" relative "${header}")
+        string(REPLACE "${source_dir}/" "" relative "${header}")
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" relative "${relative}")
         get_filename_component(dir "${relative}" DIRECTORY)
         # This is modeled after the Protobuf library, it installs the basic
         # protos (think google/protobuf/any.proto) in the include directory for


### PR DESCRIPTION
Fix the destination directory for `.proto` files. Improve the
`clang-tidy` build to better detect such problems in the future.

Fixes #5708

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5783)
<!-- Reviewable:end -->
