### PR TITLE
ci: improve install/fedora-components build

### DIFF
--- a/ci/kokoro/install/Dockerfile.fedora-components
+++ b/ci/kokoro/install/Dockerfile.fedora-components
@@ -90,7 +90,7 @@ RUN mkdir -p /h/.ccache; \
     fi; \
     true # Ignore all errors, failures in caching should not break the build
 
-RUN cmake -DSHARED_LIBS=ON -DBUILD_TESTING=OFF -H. -Bcmake-out
+RUN cmake -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 
 # This is the fun part. We will create a "stage" that contains the source


### PR DESCRIPTION
The build was not really testing the runtime components, as it used
static libraries (I mistyped `BUILD_SHARED_LIBS` as `SHARED_LIBS`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5785)
<!-- Reviewable:end -->
