### PR TITLE
cleanup: use new top-level targets for quickstart

### DIFF
--- a/google/cloud/bigtable/quickstart/BUILD
+++ b/google/cloud/bigtable/quickstart/BUILD
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:bigtable_client",
+        "@com_github_googleapis_google_cloud_cpp//:bigtable",
     ],
 )

--- a/google/cloud/bigtable/quickstart/WORKSPACE
+++ b/google/cloud/bigtable/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Bigtable C++
 # client library in Bazel-based projects.
-workspace(name = "com_github_googleapis_google_cloud_cpp_bigtable_quickstart")
+workspace(name = "google_cloud_cpp_bigtable_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/pubsub/quickstart/BUILD
+++ b/google/cloud/pubsub/quickstart/BUILD
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:pubsub_client",
+        "@com_github_googleapis_google_cloud_cpp//:pubsub",
     ],
 )

--- a/google/cloud/pubsub/quickstart/WORKSPACE
+++ b/google/cloud/pubsub/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Pub/Sub C++
 # client library in Bazel-based projects.
-workspace(name = "com_github_googleapis_google_cloud_cpp_pubsub_quickstart")
+workspace(name = "google_cloud_cpp_pubsub_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/spanner/quickstart/BUILD
+++ b/google/cloud/spanner/quickstart/BUILD
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:spanner_client",
+        "@com_github_googleapis_google_cloud_cpp//:spanner",
     ],
 )

--- a/google/cloud/spanner/quickstart/WORKSPACE
+++ b/google/cloud/spanner/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Spanner C++
 # client library in Bazel-based projects.
-workspace(name = "com_github_googleapis_google_cloud_cpp_spanner_quickstart")
+workspace(name = "google_cloud_cpp_spanner_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/storage/quickstart/BUILD
+++ b/google/cloud/storage/quickstart/BUILD
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:storage_client",
+        "@com_github_googleapis_google_cloud_cpp//:storage",
     ],
 )

--- a/google/cloud/storage/quickstart/WORKSPACE
+++ b/google/cloud/storage/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Storage C++
 # client library in Bazel-based projects.
-workspace(name = "com_github_googleapis_google_cloud_cpp_storage_quickstart")
+workspace(name = "google_cloud_cpp_storage_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -23,9 +23,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp",
-    sha256 = "914c9596ee9f271a4ba2de701388009d1f6a7eb0ea269d625aae06be1a51ee9e",
-    strip_prefix = "google-cloud-cpp-1.23.0",
-    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.23.0.tar.gz",
+    sha256 = "705992bbf5d86a5d5b4276fe249ca495bc0827f1835cb433f3f6be777072aa62",
+    strip_prefix = "google-cloud-cpp-1.24.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.24.0.tar.gz",
 )
 
 # Load indirect dependencies due to


### PR DESCRIPTION
Change the quickstart examples to use the new top-level largets (e.g.
`//:bigtable`). In the process I update the storage quickstart to
v1.24.0, and that requires shorter project names to build on Windows
:shrug:

Part of the work for #5726, fixes #5790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5792)
<!-- Reviewable:end -->
