### PR TITLE
ci: install llvm-9 package

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -34,6 +34,7 @@ RUN apt-get update && \
         libcurl4-openssl-dev \
         libssl-dev \
         libtool \
+        llvm-9 \
         lsb-release \
         make \
         ninja-build \


### PR DESCRIPTION
This includes `llvm-symbolizer`, which is needed by the tsan build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5794)
<!-- Reviewable:end -->
