### PR TITLE
fix(common): streaming RPC permanent error handling

### DIFF
--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -110,8 +110,8 @@ class ResumableStreamingReadRpc : public StreamingReadRpc<ResponseType> {
     // just aborting because the retry policy is from one hour ago.
     auto const retry_policy = retry_policy_prototype_->clone();
     auto const backoff_policy = backoff_policy_prototype_->clone();
-    while (!retry_policy->IsExhausted()
-           && (has_received_data_ || retry_policy->OnFailure(last_status))) {
+    while (!retry_policy->IsExhausted() &&
+           (has_received_data_ || retry_policy->OnFailure(last_status))) {
       sleeper_(backoff_policy->OnCompletion());
       has_received_data_ = false;
       impl_ = stream_factory_(request_);


### PR DESCRIPTION
Permanent errors in streaming RPCs can be resumed **only if** the stream
had at least some data received. Otherwise we resume each stream at
least twice, for no benefit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5801)
<!-- Reviewable:end -->
