### PR TITLE
ci: update vcpkg version

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -47,7 +47,7 @@ if [[ -d "${vcpkg_dir}" ]]; then
 else
   git clone --quiet --shallow-since 2020-10-20 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
+  git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
 fi
 
 if [[ -d "${HOME}/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -30,7 +30,7 @@ if [[ -d "${vcpkg_dir}" ]]; then
 else
   git clone --quiet --shallow-since 2020-10-20 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
+  git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
 fi
 
 if [[ -d "cmake-out/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -60,7 +60,7 @@ if (-not (Test-Path ${vcpkg_dir})) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cloning vcpkg repository."
     git clone --quiet --shallow-since 2020-10-20 `
         https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-    git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
+    git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red `
             "vcpkg git setup failed with exit code $LastExitCode"
@@ -69,7 +69,7 @@ if (-not (Test-Path ${vcpkg_dir})) {
 } else {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating vcpkg repository."
     git -C "${vcpkg_dir}" pull
-    git -C "${vcpkg_dir}" checkout 79e72302cdbbf8ca646879b13cd84ebd68707abf
+    git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
 }
 if (-not (Test-Path "${vcpkg_dir}")) {
     Write-Host -ForegroundColor Red "Missing vcpkg directory (${vcpkg_dir})."


### PR DESCRIPTION
In https://github.com/googleapis/google-cloud-cpp/pull/5791 we upgraded
grpc and Abseil, and then in
https://github.com/googleapis/google-cloud-cpp/pull/5799 we changed some
code to rely on new Abseil behavior. This broke tests on Windows because
they were pinned to an older version of vcpkg and therefore and older
version of Abseil.

This PR bumps our vcpkg snapshot to its current head. This should pull
in a newer version of Abseil and grpc that should make our test pass.
However, the newer versions are still not quite as new as we use in our
other builds, because vcpkg does not have the absolute newest releases
of grpc and Abseil. This should be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5802)
<!-- Reviewable:end -->
