### PR TITLE
cleanup: quickstarts use google-cloud-cpp:: targets

### DIFF
--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -85,10 +85,10 @@ your own projects using `find_package()` in your `CMakeLists.txt` file:
 ```CMake
 cmake_minimum_required(VERSION 3.5)
 
-find_package(storage_client REQUIRED)
+find_package(google_cloud_storage REQUIRED)
 
 add_executable(my_program my_program.cc)
-target_link_libraries(my_program storage_client)
+target_link_libraries(my_program google-cloud-cpp::storage)
 ```
 
 You can use a similar `CMakeLists.txt` to use the Cloud Bigtable C++ client:
@@ -96,10 +96,10 @@ You can use a similar `CMakeLists.txt` to use the Cloud Bigtable C++ client:
 ```CMake
 cmake_minimum_required(VERSION 3.5)
 
-find_package(bigtable_client REQUIRED)
+find_package(google_cloud_bigtable REQUIRED)
 
 add_executable(my_program my_program.cc)
-target_link_libraries(my_program bigtable_client)
+target_link_libraries(my_program google-cloud-cpp::bigtable)
 ```
 
 ## Using `google-cloud-cpp` in Make-based projects.

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -47,7 +47,7 @@ if [[ -d "${vcpkg_dir}" ]]; then
 else
   git clone --quiet --shallow-since 2020-10-20 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
+  git -C "${vcpkg_dir}" checkout 5214a247018b3bf2d793cea188ea2f2c150daddd
 fi
 
 if [[ -d "${HOME}/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -30,7 +30,7 @@ if [[ -d "${vcpkg_dir}" ]]; then
 else
   git clone --quiet --shallow-since 2020-10-20 \
     https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-  git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
+  git -C "${vcpkg_dir}" checkout 5214a247018b3bf2d793cea188ea2f2c150daddd
 fi
 
 if [[ -d "cmake-out/vcpkg-quickstart-cache" && ! -d \

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -60,7 +60,7 @@ if (-not (Test-Path ${vcpkg_dir})) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cloning vcpkg repository."
     git clone --quiet --shallow-since 2020-10-20 `
         https://github.com/microsoft/vcpkg.git "${vcpkg_dir}"
-    git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
+    git -C "${vcpkg_dir}" checkout 5214a247018b3bf2d793cea188ea2f2c150daddd
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red `
             "vcpkg git setup failed with exit code $LastExitCode"
@@ -69,7 +69,7 @@ if (-not (Test-Path ${vcpkg_dir})) {
 } else {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Updating vcpkg repository."
     git -C "${vcpkg_dir}" pull
-    git -C "${vcpkg_dir}" checkout a84190e1deca1b6a466a82b439e5e4b9f8c41b0e
+    git -C "${vcpkg_dir}" checkout 5214a247018b3bf2d793cea188ea2f2c150daddd
 }
 if (-not (Test-Path "${vcpkg_dir}")) {
     Write-Host -ForegroundColor Red "Missing vcpkg directory (${vcpkg_dir})."

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -64,10 +64,10 @@ your own projects using `find_package()` in your `CMakeLists.txt` file:
 ```CMake
 cmake_minimum_required(VERSION 3.5)
 
-find_package(storage_client REQUIRED)
+find_package(google_cloud_storage REQUIRED)
 
 add_executable(my_program my_program.cc)
-target_link_libraries(my_program storage_client)
+target_link_libraries(my_program google-cloud-cpp::storage)
 ```
 
 You can use a similar `CMakeLists.txt` to use the Cloud Bigtable C++ client:
@@ -75,10 +75,10 @@ You can use a similar `CMakeLists.txt` to use the Cloud Bigtable C++ client:
 ```CMake
 cmake_minimum_required(VERSION 3.5)
 
-find_package(bigtable_client REQUIRED)
+find_package(google_cloud_bigtable REQUIRED)
 
 add_executable(my_program my_program.cc)
-target_link_libraries(my_program bigtable_client)
+target_link_libraries(my_program google-cloud-cpp::bigtable)
 ```
 
 ## Using `google-cloud-cpp` in Make-based projects.

--- a/google/cloud/bigtable/quickstart/CMakeLists.txt
+++ b/google/cloud/bigtable/quickstart/CMakeLists.txt
@@ -21,9 +21,7 @@ project(google-cloud-cpp-bigtable-quickstart CXX C)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Threads REQUIRED)
-# TODO(#5726) - replace with new targets after next release
-find_package(bigtable_client REQUIRED)
+find_package(google_cloud_cpp_bigtable REQUIRED)
 
 # MSVC requires some additional code to select the correct runtime library
 if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
@@ -34,4 +32,4 @@ endif ()
 
 # Once the bigtable_client package is found, define new targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart bigtable::client)
+target_link_libraries(quickstart google-cloud-cpp::bigtable)

--- a/google/cloud/pubsub/quickstart/CMakeLists.txt
+++ b/google/cloud/pubsub/quickstart/CMakeLists.txt
@@ -21,8 +21,7 @@ project(google-cloud-cpp-pubsub-quickstart CXX C)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Threads REQUIRED)
-find_package(pubsub_client REQUIRED)
+find_package(google_cloud_cpp_pubsub REQUIRED)
 
 # MSVC requires some additional code to select the correct runtime library
 if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
@@ -33,4 +32,4 @@ endif ()
 
 # Once the pubsub_client package is found, define new targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart googleapis-c++::pubsub_client)
+target_link_libraries(quickstart google-cloud-cpp::pubsub)

--- a/google/cloud/spanner/quickstart/CMakeLists.txt
+++ b/google/cloud/spanner/quickstart/CMakeLists.txt
@@ -23,9 +23,7 @@ project(google-cloud-cpp-spanner-quickstart CXX C)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Use find_package() to find a pre-installed version of google-cloud-cpp-
-# spanner:
-find_package(spanner_client REQUIRED)
+find_package(google_cloud_cpp_spanner REQUIRED)
 
 # MSVC requires some additional code to select the correct runtime library
 if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
@@ -36,4 +34,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart googleapis-c++::spanner_client)
+target_link_libraries(quickstart google-cloud-cpp::spanner)

--- a/google/cloud/storage/quickstart/CMakeLists.txt
+++ b/google/cloud/storage/quickstart/CMakeLists.txt
@@ -21,8 +21,7 @@ project(google-cloud-cpp-storage-quickstart CXX C)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(CURL REQUIRED)
-find_package(storage_client REQUIRED)
+find_package(google_cloud_cpp_storage REQUIRED)
 
 # MSVC requires some additional code to select the correct runtime library
 if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
@@ -33,4 +32,4 @@ endif ()
 
 # Once the packages are found, define the targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart storage_client)
+target_link_libraries(quickstart google-cloud-cpp::storage)


### PR DESCRIPTION
Now that the targets are in a release, and the release is published in
vcpkg, we can use the new targets.

Part of the work for #5726

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5804)
<!-- Reviewable:end -->
