### PR TITLE
ci: remove redundant vcpkg-quickstart-cache

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu
+++ b/ci/kokoro/docker/Dockerfile.ubuntu
@@ -44,6 +44,7 @@ RUN apt-get update && \
         python3-pip \
         tar \
         unzip \
+        zip \
         wget \
         zlib1g-dev \
         apt-utils \

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -50,20 +50,12 @@ else
   git -C "${vcpkg_dir}" checkout 5214a247018b3bf2d793cea188ea2f2c150daddd
 fi
 
-if [[ -d "${HOME}/vcpkg-quickstart-cache" && ! -d \
-  "${vcpkg_dir}/installed" ]]; then
-  cp -r "${HOME}/vcpkg-quickstart-cache" "${vcpkg_dir}/installed"
-fi
-
 (
   cd "${vcpkg_dir}"
   ./bootstrap-vcpkg.sh
   ./vcpkg remove --outdated --recurse
   ./vcpkg install google-cloud-cpp
 )
-# Use the new installed/ directory to create the cache.
-rm -fr "${HOME}/vcpkg-quickstart-cache"
-cp -r "${vcpkg_dir}/installed" "${HOME}/vcpkg-quickstart-cache"
 
 run_quickstart="false"
 readonly CONFIG_DIR="/c"

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -39,12 +39,7 @@ maybe_dirs=(
   # This is where ccache stores its files, if present we want to back it up
   "${HOME_DIR}/.ccache"
 
-  # The quickstart builds need to preserve the contents of the vcpkg installed/
-  # directory, but we have to separate it from the other files in `vcpkg` or
-  # things like `git clone` do not work as expected.
-  "${HOME_DIR}/vcpkg-quickstart-cache"
-
-  # Bazel, when running inside the Docker container, puts its cache here:
+  # Bazel and vcpkg put their caches within here.
   "${HOME_DIR}/.cache"
 )
 

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -33,20 +33,12 @@ else
   git -C "${vcpkg_dir}" checkout 5214a247018b3bf2d793cea188ea2f2c150daddd
 fi
 
-if [[ -d "cmake-out/vcpkg-quickstart-cache" && ! -d \
-  "${vcpkg_dir}/installed" ]]; then
-  cp -r "cmake-out/vcpkg-quickstart-cache" "${vcpkg_dir}/installed"
-fi
-
 (
   cd "${vcpkg_dir}"
   ./bootstrap-vcpkg.sh
   ./vcpkg remove --outdated --recurse
   ./vcpkg install google-cloud-cpp
 )
-# Use the new installed/ directory to create the cache.
-rm -fr "cmake-out/vcpkg-quickstart-cache"
-cp -r "${vcpkg_dir}/installed" "cmake-out/vcpkg-quickstart-cache"
 
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"


### PR DESCRIPTION
We're already caching the `$HOME/.cache` directory, which is where
vcpkg caches its data, so we don't need to cache/restore it again.

Related to https://github.com/googleapis/google-cloud-cpp/issues/5356

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5812)
<!-- Reviewable:end -->
