### PR TITLE
test(spanner): run slow integration tests in nightly build

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -121,6 +121,7 @@ elif [[ "${BUILD_NAME}" = "integration-nightly" ]]; then
   export DISTRO_VERSION=18.04
   RUN_INTEGRATION_TESTS="yes" # Integration tests were explicitly requested.
   ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS="yes"
+  GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
   export BUILD_TOOL="Bazel"
   in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 elif [[ "${BUILD_NAME}" = "publish-refdocs" ]]; then


### PR DESCRIPTION
Run the "slow" Spanner integration tests in "integration-nightly" to
increase coverage without impacting normal pre/post-merge testing.

Before:
//google/cloud/spanner/integration_tests:backup_integration_test    0.4s
//google/cloud/spanner/samples:samples                            137.8s

After:
//google/cloud/spanner/integration_tests:backup_integration_test  676.2s
//google/cloud/spanner/samples:samples                            766.8s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5815)
<!-- Reviewable:end -->
