### PR TITLE
ci: only cache certain .cache/ dirs

### DIFF
--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -39,8 +39,12 @@ maybe_dirs=(
   # This is where ccache stores its files, if present we want to back it up
   "${HOME_DIR}/.ccache"
 
-  # Bazel and vcpkg put their caches within here.
-  "${HOME_DIR}/.cache"
+  # Default location for vcpkg's binary cache.
+  # https://vcpkg.readthedocs.io/en/latest/specifications/binarycaching/
+  "${HOME_DIR}/.cache/vcpkg"
+
+  # This dir may contain arbitrary things that our scripts want to cache.
+  "${HOME_DIR}/.cache/google-cloud-cpp"
 )
 
 dirs=()

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -43,13 +43,12 @@ maybe_dirs=(
   # This is where ccache stores its files, if present we want to back it up
   "${HOME}/.ccache"
 
-  # This is where vcpkg caches its output.
-  "${HOME}/.cache"
+  # Default location for vcpkg's binary cache.
+  # https://vcpkg.readthedocs.io/en/latest/specifications/binarycaching/
+  "${HOME_DIR}/.cache/vcpkg"
 
-  # The quickstart builds need to preserve the contents of the vcpkg installed/
-  # directory, but we have to separate it from the other files in `vcpkg` or
-  # things like `git clone` do not work as expected.
-  "${PROJECT_ROOT}/cmake-out/upload/vcpkg-installed"
+  # This dir may contain arbitrary things that our scripts want to cache.
+  "${HOME_DIR}/.cache/google-cloud-cpp"
 )
 
 dirs=()

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -45,10 +45,10 @@ maybe_dirs=(
 
   # Default location for vcpkg's binary cache.
   # https://vcpkg.readthedocs.io/en/latest/specifications/binarycaching/
-  "${HOME_DIR}/.cache/vcpkg"
+  "${HOME}/.cache/vcpkg"
 
   # This dir may contain arbitrary things that our scripts want to cache.
-  "${HOME_DIR}/.cache/google-cloud-cpp"
+  "${HOME}/.cache/google-cloud-cpp"
 )
 
 dirs=()


### PR DESCRIPTION
Rather than caching all of ~/.cache, we only cache certain subdirs under
there. This will effectively STOP caching ~/.cache/bazel. But from the
rationale in https://github.com/googleapis/google-cloud-cpp/issues/5819,
that may be a good thing.

NOTE: This PR may make the bazel builds SLOWER, so we may end up reverting this PR. That's fine.
We won't know if this makes things slower until after this commit makes it through a full CI build where we upload 
new cache files that no longer contain the ~/.cache/bazel dir. Then the following builds will NOT be using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5822)
<!-- Reviewable:end -->
