### PR TITLE
ci: deflake downloads for roots.pem

### DIFF
--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -67,7 +67,7 @@ if [[ -r "${CREDENTIALS_FILE}" ]]; then
   bazel_args+=("--experimental_guard_against_concurrent_changes")
   if [[ -r "${CONFIG_DIR}/roots.pem" ]]; then
     run_quickstart="true"
-  elif wget -O "${CONFIG_DIR}/roots.pem" -q "${ROOTS_PEM_SOURCE}"; then
+  elif curl -sSL --retry 10 -o "${CONFIG_DIR}/roots.pem" "${ROOTS_PEM_SOURCE}"; then
     run_quickstart="true"
   fi
 fi

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -55,7 +55,7 @@ readonly ROOTS_PEM_SOURCE="https://raw.githubusercontent.com/grpc/grpc/master/et
 if [[ -r "${CREDENTIALS_FILE}" ]]; then
   if [[ -r "${CONFIG_DIR}/roots.pem" ]]; then
     run_quickstart="true"
-  elif wget -O "${CONFIG_DIR}/roots.pem" -q "${ROOTS_PEM_SOURCE}"; then
+  elif curl -sSL --retry 10 -o "${CONFIG_DIR}/roots.pem" "${ROOTS_PEM_SOURCE}"; then
     run_quickstart="true"
   fi
 fi

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -104,8 +104,8 @@ echo "================================================================"
 io::log_yellow "getting roots.pem for gRPC."
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${KOKORO_GFILE_DIR}/roots.pem"
 rm -f "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
-wget -O "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
-  -q https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+curl -sSL --retry 10 -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
+  https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
 
 BRANCH="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
 readonly BRANCH

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -149,9 +149,21 @@ if (Integration-Tests-Enabled) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running integration tests $env:CONFIG"
     $integration_tests_config="${PROJECT_ROOT}/ci/etc/integration-tests-config.ps1"
     . "${integration_tests_config}"
-    (New-Object System.Net.WebClient).Downloadfile(
-        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
-         "${env:KOKORO_GFILE_DIR}/roots.pem")
+    ForEach($_ in (1, 2, 3)) {
+        if ( $_ -ne 1) {
+            Start-Sleep -Seconds (60 * $_)
+        }
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "Downloading roots.pem [$_]"
+        try {
+            (New-Object System.Net.WebClient).Downloadfile(
+                    'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                    "${env:KOKORO_GFILE_DIR}/roots.pem")
+            break
+        } catch {
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) download error"
+        }
+    }
     ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
     $enable_bigtable_admin_integration_tests="no"
     if (Test-Path env:ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS) {

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -115,9 +115,21 @@ if (Integration-Tests-Enabled) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running integration tests $env:CONFIG"
     $integration_tests_config="${project_root}/ci/etc/integration-tests-config.ps1"
     . "${integration_tests_config}"
-    (New-Object System.Net.WebClient).Downloadfile(
-        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
-         "${env:KOKORO_GFILE_DIR}/roots.pem")
+    ForEach($_ in (1, 2, 3)) {
+        if ( $_ -ne 1) {
+            Start-Sleep -Seconds (60 * $_)
+        }
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "Downloading roots.pem [$_]"
+        try {
+            (New-Object System.Net.WebClient).Downloadfile(
+                    'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                    "${env:KOKORO_GFILE_DIR}/roots.pem")
+            break
+        } catch {
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) download error"
+        }
+    }
     ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
     ${env:GOOGLE_APPLICATION_CREDENTIALS}="${env:KOKORO_GFILE_DIR}/kokoro-run-key.json"
     ${env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES}="yes"

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -85,9 +85,21 @@ if (-not (Test-Path env:KOKORO_GFILE_DIR)) {
         . "${integration_tests_config}"
         ${env:GOOGLE_APPLICATION_CREDENTIALS}="${test_key_file_json}"
         ${env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES}="yes"
-        (New-Object System.Net.WebClient).Downloadfile(
-            'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
-             "${env:KOKORO_GFILE_DIR}/roots.pem")
+        ForEach($_ in (1, 2, 3)) {
+            if ( $_ -ne 1) {
+                Start-Sleep -Seconds (60 * $_)
+            }
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "Downloading roots.pem [$_]"
+            try {
+                (New-Object System.Net.WebClient).Downloadfile(
+                        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                        "${env:KOKORO_GFILE_DIR}/roots.pem")
+                break
+            } catch {
+                Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) download error"
+            }
+        }
         ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
         ${env:RUN_INTEGRATION_TESTS}="true"
     }

--- a/ci/kokoro/windows/build-quickstart-cmake.ps1
+++ b/ci/kokoro/windows/build-quickstart-cmake.ps1
@@ -45,9 +45,21 @@ if (-not (Test-Path env:KOKORO_GFILE_DIR)) {
         . "${integration_tests_config}"
         ${env:GOOGLE_APPLICATION_CREDENTIALS}="${test_key_file_json}"
         ${env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES}="yes"
-        (New-Object System.Net.WebClient).Downloadfile(
-            'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
-             "${env:KOKORO_GFILE_DIR}/roots.pem")
+        ForEach($_ in (1, 2, 3)) {
+            if ( $_ -ne 1) {
+                Start-Sleep -Seconds (60 * $_)
+            }
+            Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) " `
+            "Downloading roots.pem [$_]"
+            try {
+                (New-Object System.Net.WebClient).Downloadfile(
+                        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                        "${env:KOKORO_GFILE_DIR}/roots.pem")
+                break
+            } catch {
+                Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) download error"
+            }
+        }
         ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
         ${env:RUN_INTEGRATION_TESTS}="true"
     }


### PR DESCRIPTION
Windows and macOS builds need to download the `roots.pem` file from the
gRPC GitHub repository. This rarely fails, but when it does, we should
retry a couple of times.

Fixes #5699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5826)
<!-- Reviewable:end -->
