### PR TITLE
cleanup(storage): error streams cannot validate data

### DIFF
--- a/google/cloud/storage/internal/object_streambuf.cc
+++ b/google/cloud/storage/internal/object_streambuf.cc
@@ -27,17 +27,16 @@ namespace internal {
 ObjectReadStreambuf::ObjectReadStreambuf(
     ReadObjectRangeRequest const& request,
     std::unique_ptr<ObjectReadSource> source, std::streamoff pos_in_stream)
-    : source_(std::move(source)), source_pos_(pos_in_stream) {
-  hash_validator_ = CreateHashValidator(request);
-}
+    : source_(std::move(source)),
+      source_pos_(pos_in_stream),
+      hash_validator_(CreateHashValidator(request)) {}
 
-ObjectReadStreambuf::ObjectReadStreambuf(ReadObjectRangeRequest const& request,
+ObjectReadStreambuf::ObjectReadStreambuf(ReadObjectRangeRequest const&,
                                          Status status)
-    : source_(new ObjectReadErrorSource(status)), source_pos_(-1) {
-  // TODO(coryan) - revisit this, we probably do not need the validator.
-  hash_validator_ = CreateHashValidator(request);
-  status_ = std::move(status);
-}
+    : source_(new ObjectReadErrorSource(status)),
+      source_pos_(-1),
+      hash_validator_(absl::make_unique<NullHashValidator>()),
+      status_(std::move(status)) {}
 
 bool ObjectReadStreambuf::IsOpen() const { return source_->IsOpen(); }
 


### PR DESCRIPTION
Remove TODO() for myself, and it was simple to actually take the action
suggested in the TODO.

Part of the fixes for #5109

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5829)
<!-- Reviewable:end -->
