### PR TITLE
feat(storage): gRPC clients can have their own channel

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -333,6 +333,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
 #else
       case ApiName::kApiGrpc:
       case ApiName::kApiRawGrpc:
+        (void)thread_id;
         break;
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
       case ApiName::kApiXml:

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -246,20 +246,23 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
   ApiName api_;
 };
 
-std::shared_ptr<grpc::ChannelInterface> CreateGcsChannel() {
+std::shared_ptr<grpc::ChannelInterface> CreateGcsChannel(int thread_id) {
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   gcs::ClientOptions options{gcs::oauth2::GoogleDefaultCredentials().value()};
-  return gcs::internal::CreateGrpcChannel(options);
+  return gcs::internal::CreateGrpcChannel(options, thread_id);
 #else
-  return grpc::CreateChannel("storage.googleapis.com",
-                             grpc::GoogleDefaultCredentials());
+  grpc::ChannelArguments args;
+  args.SetInt("grpc.channel_id", thread_id);
+  return grpc::CreateCustomChannel("storage.googleapis.com",
+                                   grpc::GoogleDefaultCredentials(), args);
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 }
 
 class DownloadObjectRawGrpc : public ThroughputExperiment {
  public:
-  DownloadObjectRawGrpc()
-      : stub_(google::storage::v1::Storage::NewStub(CreateGcsChannel())) {}
+  explicit DownloadObjectRawGrpc(int thread_id)
+      : stub_(google::storage::v1::Storage::NewStub(
+            CreateGcsChannel(thread_id))) {}
   ~DownloadObjectRawGrpc() override = default;
 
   ThroughputResult Run(std::string const& bucket_name,
@@ -304,7 +307,8 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
 
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options) {
+    google::cloud::storage::ClientOptions const& client_options,
+    int thread_id) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto contents = MakeRandomData(generator, options.maximum_write_size);
   gcs::Client rest_client(client_options);
@@ -317,14 +321,14 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
       case ApiName::kApiRawGrpc: {
         gcs::Client grpc_client =
             google::cloud::storage_experimental::DefaultGrpcClient(
-                client_options);
+                client_options, thread_id);
         result.push_back(
             absl::make_unique<UploadObject>(grpc_client, a, contents, false));
         result.push_back(
             absl::make_unique<UploadObject>(grpc_client, a, contents, true));
       }
       // this comment keeps clang-format from merging to previous line
-      // we thing `} break;` is just weird.
+      // methinks `} break;` is just weird.
       break;
 #else
       case ApiName::kApiGrpc:
@@ -347,7 +351,8 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
 
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options) {
+    google::cloud::storage::ClientOptions const& client_options,
+    int thread_id) {
   gcs::Client rest_client(client_options);
 
   std::vector<std::unique_ptr<ThroughputExperiment>> result;
@@ -373,7 +378,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
         result.push_back(absl::make_unique<DownloadObjectLibcurl>(a));
         break;
       case ApiName::kApiRawGrpc:
-        result.push_back(absl::make_unique<DownloadObjectRawGrpc>());
+        result.push_back(absl::make_unique<DownloadObjectRawGrpc>(thread_id));
         break;
     }
   }

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -55,7 +55,7 @@ class ThroughputExperiment {
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options);
+    google::cloud::storage::ClientOptions const& client_options, int thread_id);
 
 /**
  * Create the list of download experiments based on the @p options.
@@ -65,7 +65,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
     ThroughputOptions const& options,
-    google::cloud::storage::ClientOptions const& client_options);
+    google::cloud::storage::ClientOptions const& client_options, int thread_id);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -52,7 +52,8 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   options.enabled_apis = {GetParam()};
 
   auto const& client_options = client->raw_client()->client_options();
-  auto experiments = CreateUploadExperiments(options, client_options);
+  auto experiments =
+      CreateUploadExperiments(options, client_options, /*thread_id=*/0);
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
     ThroughputExperimentConfig config{OpType::kOpInsert,
@@ -81,7 +82,8 @@ TEST_P(ThroughputExperimentIntegrationTest, Download) {
   options.enabled_apis = {GetParam()};
 
   auto const& client_options = client->raw_client()->client_options();
-  auto experiments = CreateDownloadExperiments(options, client_options);
+  auto experiments =
+      CreateDownloadExperiments(options, client_options, /*thread_id=*/0);
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
 

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -39,13 +39,13 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient() {
 }
 
 google::cloud::storage::Client DefaultGrpcClient(
-    google::cloud::storage::ClientOptions options) {
+    google::cloud::storage::ClientOptions options, int channel_id) {
   if (UseGrpcForMetadata()) {
-    return storage::Client(
-        std::make_shared<storage::internal::GrpcClient>(std::move(options)));
+    return storage::Client(std::make_shared<storage::internal::GrpcClient>(
+        std::move(options), channel_id));
   }
-  return storage::Client(
-      std::make_shared<storage::internal::HybridClient>(std::move(options)));
+  return storage::Client(std::make_shared<storage::internal::HybridClient>(
+      std::move(options), channel_id));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -33,6 +33,23 @@ inline namespace STORAGE_CLIENT_NS {
 /**
  * Create a `google::cloud::storage::Client` object configured to use gRPC.
  *
+ * @note the Credentials parameter in the configuration is ignored. The gRPC
+ *     client only supports Google Default Credentials.
+ *
+ * @param options the configuration parameters for the Client.
+ * @param channel_id set the `grpc.channel_id` attribute in the underlying
+ *   gRPC channel, this can be used to segregate the gRPC channels for different
+ *   clients.
+ *
+ * @warning this is an experimental feature, and subject to change without
+ *     notice.
+ */
+google::cloud::storage::Client DefaultGrpcClient(
+    google::cloud::storage::ClientOptions options, int channel_id);
+
+/**
+ * Create a `google::cloud::storage::Client` object configured to use gRPC.
+ *
  * @warning this is an experimental feature, and subject to change without
  *     notice.
  *
@@ -52,8 +69,10 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient();
  * @warning this is an experimental feature, and subject to change without
  *     notice.
  */
-google::cloud::storage::Client DefaultGrpcClient(
-    google::cloud::storage::ClientOptions options);
+inline google::cloud::storage::Client DefaultGrpcClient(
+    google::cloud::storage::ClientOptions options) {
+  return DefaultGrpcClient(std::move(options), 0);
+}
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage_experimental

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -71,7 +71,13 @@ std::shared_ptr<grpc::ChannelCredentials> GrpcCredentials(
 
 std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
     ClientOptions const& options) {
+  return CreateGrpcChannel(options, 0);
+}
+
+std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
+    ClientOptions const& options, int channel_id) {
   grpc::ChannelArguments args;
+  args.SetInt("grpc.channel_id", channel_id);
   if (DirectPathEnabled()) {
     args.SetServiceConfigJSON(R"json({
       "loadBalancingConfig": [{
@@ -91,6 +97,11 @@ GrpcClient::GrpcClient(ClientOptions options)
     : options_(std::move(options)),
       stub_(google::storage::v1::Storage::NewStub(CreateGrpcChannel(options))) {
 }
+
+GrpcClient::GrpcClient(ClientOptions options, int channel_id)
+    : options_(std::move(options)),
+      stub_(google::storage::v1::Storage::NewStub(
+          CreateGrpcChannel(options, channel_id))) {}
 
 std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
     grpc::ClientContext& context, google::storage::v1::Object& result) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -30,11 +30,14 @@ namespace internal {
 bool DirectPathEnabled();
 
 std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(ClientOptions const&);
+std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(ClientOptions const&,
+                                                          int channel_id);
 
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
   explicit GrpcClient(ClientOptions options);
+  explicit GrpcClient(ClientOptions options, int channel_id);
   ~GrpcClient() override = default;
 
   //@{

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -25,6 +25,10 @@ HybridClient::HybridClient(ClientOptions options)
     : grpc_(std::make_shared<GrpcClient>(options)),
       curl_(CurlClient::Create(std::move(options))) {}
 
+HybridClient::HybridClient(ClientOptions options, int channel_id)
+    : grpc_(std::make_shared<GrpcClient>(options, channel_id)),
+      curl_(CurlClient::Create(std::move(options))) {}
+
 ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();
 }

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -29,6 +29,7 @@ namespace internal {
 class HybridClient : public RawClient {
  public:
   explicit HybridClient(ClientOptions options);
+  explicit HybridClient(ClientOptions options, int channel_id);
   ~HybridClient() override = default;
 
   ClientOptions const& client_options() const override;


### PR DESCRIPTION
This is useful in benchmarks (to isolate gRPC demuxing effects), and may
be useful for applications that want to keep traffic separated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5838)
<!-- Reviewable:end -->
