### PR TITLE
feat: introduce a dynamic Options class that all services can use

### DIFF
--- a/google/cloud/BUILD
+++ b/google/cloud/BUILD
@@ -42,6 +42,7 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:any",
         "@com_google_absl//absl/types:optional",
     ],
 )

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -166,6 +166,7 @@ add_library(
     log.cc
     log.h
     optional.h
+    options.h
     polling_policy.h
     status.cc
     status.h
@@ -178,7 +179,7 @@ add_library(
     version.cc
     version.h)
 target_link_libraries(
-    google_cloud_cpp_common PUBLIC absl::flat_hash_map absl::memory
+    google_cloud_cpp_common PUBLIC absl::any absl::flat_hash_map absl::memory
                                    absl::optional absl::time Threads::Threads)
 google_cloud_cpp_add_common_options(google_cloud_cpp_common)
 target_include_directories(
@@ -260,6 +261,7 @@ if (BUILD_TESTING)
         internal/utility_test.cc
         kms_key_name_test.cc
         log_test.cc
+        options_test.cc
         status_or_test.cc
         status_test.cc
         stream_range_test.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -61,6 +61,7 @@ google_cloud_cpp_common_hdrs = [
     "kms_key_name.h",
     "log.h",
     "optional.h",
+    "options.h",
     "polling_policy.h",
     "status.h",
     "status_or.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -42,6 +42,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/utility_test.cc",
     "kms_key_name_test.cc",
     "log_test.cc",
+    "options_test.cc",
     "status_or_test.cc",
     "status_test.cc",
     "stream_range_test.cc",

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -1,0 +1,130 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONS_H
+
+#include "google/cloud/internal/absl_flat_hash_map_quiet.h"
+#include "google/cloud/version.h"
+#include "absl/types/any.h"
+#include "absl/types/optional.h"
+#include <typeindex>
+#include <typeinfo>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+/**
+ * A class that holds option structs indexed by their type.
+ *
+ * An "Option" can be any unique struct, but by convention these structs tend
+ * to have a single data member named "value" and a name like "FooOption".
+ * Each library (e.g., spanner, storage) may define their own set of options.
+ * Additionally, various common classes may define options. All these options
+ * may be set in a single `Options` instance, and each library will look at the
+ * options that it needs.
+ *
+ * @par Example:
+ *
+ * @code
+ * // Given
+ * struct EndpointOption {
+ *   std::string value;
+ * };
+ * struct FooOption {
+ *   int value;
+ * };
+ * struct BarOption {
+ *   double value;
+ * };
+ * ...
+ * auto opts = Options{}
+ *                 .set<EndpointOption>("blah.googleapis.com")
+ *                 .set<FooOption>(42);
+ * absl::optional<FooOption> foo = opts.get<FooOption>();
+ * assert(foo.has_value());
+ * assert(foo->value == 42);
+ *
+ * BarOption bar = opts.get_or<BarOption>(3.14);
+ * assert(bar.value == 3.14);
+ * @endcode
+ */
+class Options {
+ public:
+  /// Constructs an empty instance.
+  Options() = default;
+
+  Options(Options const&) = default;
+  Options& operator=(Options const&) = default;
+  Options(Options&&) = default;
+  Options& operator=(Options&&) = default;
+
+  /**
+   * Returns true iff no options are currently set.
+   */
+  bool empty() const { return m_.empty(); }
+
+  /**
+   * Sets the specified option and returns a reference to `*this`.
+   *
+   * The optional arguments to `set(...)` will be used to construct the `T`
+   * option.
+   */
+  template <typename T, typename... U>
+  Options& set(U&&... u) {
+    m_[typeid(T)] = T{std::forward<U>(u)...};
+    return *this;
+  }
+
+  /**
+   * Erases the option specified by the type `T`.
+   */
+  template <typename T>
+  void unset() {
+    m_.erase(typeid(T));
+  }
+
+  /**
+   * Gets the option specified by its type `T`, if it was set.
+   */
+  template <typename T>
+  absl::optional<T> get() const {
+    auto it = m_.find(typeid(T));
+    if (it == m_.end()) return {};
+    return absl::any_cast<T>(it->second);
+  }
+
+  /**
+   * Gets the option of type `T` if set, else a newly constructed default `T`.
+   *
+   * If the specified option `T` is not set, a new `T` will be constructed with
+   * the optional arguments @p u.
+   */
+  template <typename T, typename... U>
+  T get_or(U&&... u) const {
+    auto v = get<T>();
+    if (v) return *v;
+    return {std::forward<U>(u)...};
+  }
+
+ private:
+  absl::flat_hash_map<std::type_index, absl::any> m_;
+};
+
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONS_H

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_OPTIONS_H
 
-#include "google/cloud/internal/absl_flat_hash_map_quiet.h"
 #include "google/cloud/version.h"
 #include "absl/types/any.h"
 #include "absl/types/optional.h"
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
 
 namespace google {
 namespace cloud {
@@ -120,7 +120,7 @@ class Options {
   }
 
  private:
-  absl::flat_hash_map<std::type_index, absl::any> m_;
+  std::unordered_map<std::type_index, absl::any> m_;
 };
 
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -102,7 +102,7 @@ class Options {
   template <typename T>
   absl::optional<T> get() const {
     auto it = m_.find(typeid(T));
-    if (it == m_.end()) return {};
+    if (it == m_.end()) return absl::nullopt;
     return absl::any_cast<T>(it->second);
   }
 
@@ -116,7 +116,7 @@ class Options {
   T get_or(U&&... u) const {
     auto v = get<T>();
     if (v) return *v;
-    return {std::forward<U>(u)...};
+    return T{std::forward<U>(u)...};
   }
 
  private:

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -1,0 +1,138 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/options.h"
+#include <gmock/gmock.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+struct IntOption {
+  int value;
+};
+
+struct BoolOption {
+  bool value;
+};
+
+struct StringOption {
+  std::string value;
+};
+
+struct DefaultedOption {
+  int value = 123;
+};
+
+TEST(Options, Empty) {
+  Options opts{};
+  EXPECT_TRUE(opts.empty());
+}
+
+TEST(Options, GetWithDefault) {
+  Options opts{};
+
+  // Get the specified default value.
+  EXPECT_EQ(opts.get_or<IntOption>(42).value, 42);
+}
+
+TEST(Options, DefaultedOption) {
+  Options opts{};
+
+  // Set doesn't need an argument since a default constructed option is fine.
+  opts.set<DefaultedOption>();
+  EXPECT_EQ(123, opts.get<DefaultedOption>()->value);
+
+  opts.unset<DefaultedOption>();
+  EXPECT_EQ(123, opts.get_or<DefaultedOption>().value);
+}
+
+TEST(Options, MutateOption) {
+  Options opts{};
+  opts.set<StringOption>("test1");
+  EXPECT_EQ("test1", opts.get<StringOption>()->value);
+
+  auto v = opts.get_or<StringOption>("");
+  opts.set<StringOption>(v.value + ",test2");
+
+  EXPECT_EQ("test1,test2", opts.get<StringOption>()->value);
+}
+
+TEST(Options, Copy) {
+  auto a = Options{}.set<IntOption>(42).set<BoolOption>(true).set<StringOption>(
+      "foo");
+
+  auto copy = a;  // NOLINT(performance-unnecessary-copy-initialization)
+  EXPECT_FALSE(copy.empty());
+  EXPECT_TRUE(copy.get<IntOption>().has_value());
+  EXPECT_TRUE(copy.get<BoolOption>().has_value());
+  EXPECT_TRUE(copy.get<StringOption>().has_value());
+  EXPECT_EQ(copy.get<IntOption>()->value, 42);
+  EXPECT_EQ(copy.get<BoolOption>()->value, true);
+  EXPECT_EQ(copy.get<StringOption>()->value, "foo");
+}
+
+TEST(Options, Move) {
+  auto a = Options{}.set<IntOption>(42).set<BoolOption>(true).set<StringOption>(
+      "foo");
+
+  auto moved = std::move(a);
+  EXPECT_FALSE(moved.empty());
+  EXPECT_TRUE(moved.get<IntOption>().has_value());
+  EXPECT_TRUE(moved.get<BoolOption>().has_value());
+  EXPECT_TRUE(moved.get<StringOption>().has_value());
+  EXPECT_EQ(moved.get<IntOption>()->value, 42);
+  EXPECT_EQ(moved.get<BoolOption>()->value, true);
+  EXPECT_EQ(moved.get<StringOption>()->value, "foo");
+}
+
+TEST(Options, BasicOperations) {
+  Options opts{};
+  EXPECT_TRUE(opts.empty());
+  EXPECT_FALSE(opts.get<IntOption>().has_value());
+
+  opts.set<IntOption>(42);
+  EXPECT_FALSE(opts.empty());
+  EXPECT_TRUE(opts.get<IntOption>().has_value());
+  EXPECT_EQ(opts.get<IntOption>()->value, 42);
+
+  opts.set<IntOption>(123);
+  EXPECT_FALSE(opts.empty());
+  EXPECT_TRUE(opts.get<IntOption>().has_value());
+  EXPECT_EQ(opts.get<IntOption>()->value, 123);
+
+  opts.set<BoolOption>(true).set<StringOption>("foo");
+  EXPECT_FALSE(opts.empty());
+  EXPECT_TRUE(opts.get<IntOption>().has_value());
+  EXPECT_TRUE(opts.get<BoolOption>().has_value());
+  EXPECT_TRUE(opts.get<StringOption>().has_value());
+  EXPECT_EQ(opts.get<IntOption>()->value, 123);
+  EXPECT_EQ(opts.get<BoolOption>()->value, true);
+  EXPECT_EQ(opts.get<StringOption>()->value, "foo");
+
+  opts.unset<IntOption>();
+  EXPECT_FALSE(opts.empty());
+  EXPECT_FALSE(opts.get<IntOption>().has_value());
+  EXPECT_TRUE(opts.get<BoolOption>().has_value());
+  EXPECT_TRUE(opts.get<StringOption>().has_value());
+  EXPECT_EQ(opts.get<BoolOption>()->value, true);
+  EXPECT_EQ(opts.get<StringOption>()->value, "foo");
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -33,7 +33,14 @@ struct StringOption {
   std::string value;
 };
 
+// Let's test an option struct that has a default value. In this case, the
+// struct will no longer support aggregate initialization [1], so we'll need to
+// add back a 1-arg and default constructors.
+//
+// [1]: https://en.cppreference.com/w/cpp/language/aggregate_initialization
 struct DefaultedOption {
+  explicit DefaultedOption(int v) : value(v) {}
+  DefaultedOption() = default;
   int value = 123;
 };
 
@@ -58,6 +65,7 @@ TEST(Options, DefaultedOption) {
 
   opts.unset<DefaultedOption>();
   EXPECT_EQ(123, opts.get_or<DefaultedOption>().value);
+  EXPECT_EQ(42, opts.get_or<DefaultedOption>(42).value);
 }
 
 TEST(Options, MutateOption) {


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5738

Note: Let's feel free to discuss alternative naming for the interface methods on this class. Currently they are
* `.set<T>(...)`
* `.unset<T>()`
* `.get<T>()`
* `.get_or<T>(...)`

I'm open to better names, but they should likely all go together naturally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5843)
<!-- Reviewable:end -->
