### PR TITLE
refactor(spanner): spanner::Timestamp/protobuf::Timestamp conversions

### DIFF
--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -179,7 +179,7 @@ StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   request.mutable_backup()->set_name(backup.name());
   *request.mutable_backup()->mutable_expire_time() =
-      internal::TimestampToProto(expire_time);
+      expire_time.get<protobuf::Timestamp>().value();
   request.mutable_update_mask()->add_paths("expire_time");
   return conn_->UpdateBackup({request});
 }
@@ -189,7 +189,7 @@ StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   request.mutable_backup()->set_name(backup.FullName());
   *request.mutable_backup()->mutable_expire_time() =
-      internal::TimestampToProto(expire_time);
+      expire_time.get<protobuf::Timestamp>().value();
   request.mutable_update_mask()->add_paths("expire_time");
   return conn_->UpdateBackup({request});
 }

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mocks/mock_database_admin_connection.h"
-#include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -559,8 +558,8 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
       .WillOnce([&backup, &expire_time](
                     DatabaseAdminConnection::UpdateBackupParams const& p) {
         EXPECT_EQ(backup.FullName(), p.request.backup().name());
-        EXPECT_THAT(expire_time, internal::TimestampFromProto(
-                                     p.request.backup().expire_time()));
+        EXPECT_THAT(expire_time,
+                    MakeTimestamp(p.request.backup().expire_time()).value());
         gcsa::Backup response;
         response.set_name(p.request.backup().name());
         *response.mutable_expire_time() = p.request.backup().expire_time();
@@ -570,12 +569,11 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
       .WillOnce([&backup, &expire_time](
                     DatabaseAdminConnection::UpdateBackupParams const& p) {
         EXPECT_EQ(backup.FullName(), p.request.backup().name());
-        EXPECT_THAT(
-            MakeTimestamp(
-                expire_time.get<std::chrono::system_clock::time_point>()
-                    .value())
-                .value(),  // loss of precision
-            internal::TimestampFromProto(p.request.backup().expire_time()));
+        EXPECT_THAT(MakeTimestamp(
+                        expire_time.get<std::chrono::system_clock::time_point>()
+                            .value())
+                        .value(),  // loss of precision
+                    MakeTimestamp(p.request.backup().expire_time()).value());
         gcsa::Backup response;
         response.set_name(p.request.backup().name());
         *response.mutable_expire_time() = p.request.backup().expire_time();
@@ -588,8 +586,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
   EXPECT_STATUS_OK(response);
   EXPECT_EQ(gcsa::Backup::READY, response->state());
   EXPECT_EQ(backup.FullName(), response->name());
-  EXPECT_THAT(expire_time,
-              internal::TimestampFromProto(response->expire_time()));
+  EXPECT_THAT(expire_time, MakeTimestamp(response->expire_time()).value());
 
   // Exercise the old interface with a `time_point` expiration parameter.
   response = client.UpdateBackupExpireTime(
@@ -601,7 +598,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
       MakeTimestamp(
           expire_time.get<std::chrono::system_clock::time_point>().value())
           .value(),  // loss of precision
-      internal::TimestampFromProto(response->expire_time()));
+      MakeTimestamp(response->expire_time()).value());
 }
 
 /// @test Verify DatabaseAdminClient uses GetBackup() correctly.
@@ -616,8 +613,8 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
       .WillOnce([&backup_name, &expire_time](
                     DatabaseAdminConnection::UpdateBackupParams const& p) {
         EXPECT_EQ(backup_name.FullName(), p.request.backup().name());
-        EXPECT_THAT(expire_time, internal::TimestampFromProto(
-                                     p.request.backup().expire_time()));
+        EXPECT_THAT(expire_time,
+                    MakeTimestamp(p.request.backup().expire_time()).value());
         gcsa::Backup response;
         response.set_name(p.request.backup().name());
         *response.mutable_expire_time() = p.request.backup().expire_time();
@@ -627,12 +624,11 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
       .WillOnce([&backup_name, &expire_time](
                     DatabaseAdminConnection::UpdateBackupParams const& p) {
         EXPECT_EQ(backup_name.FullName(), p.request.backup().name());
-        EXPECT_THAT(
-            MakeTimestamp(
-                expire_time.get<std::chrono::system_clock::time_point>()
-                    .value())
-                .value(),  // loss of precision
-            internal::TimestampFromProto(p.request.backup().expire_time()));
+        EXPECT_THAT(MakeTimestamp(
+                        expire_time.get<std::chrono::system_clock::time_point>()
+                            .value())
+                        .value(),  // loss of precision
+                    MakeTimestamp(p.request.backup().expire_time()).value());
         gcsa::Backup response;
         response.set_name(p.request.backup().name());
         *response.mutable_expire_time() = p.request.backup().expire_time();
@@ -645,8 +641,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
   EXPECT_STATUS_OK(response);
   EXPECT_EQ(gcsa::Backup::READY, response->state());
   EXPECT_EQ(backup_name.FullName(), response->name());
-  EXPECT_THAT(expire_time,
-              internal::TimestampFromProto(response->expire_time()));
+  EXPECT_THAT(expire_time, MakeTimestamp(response->expire_time()).value());
 
   // Exercise the old interface with a `time_point` expiration parameter.
   response = client.UpdateBackupExpireTime(
@@ -658,7 +653,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
       MakeTimestamp(
           expire_time.get<std::chrono::system_clock::time_point>().value())
           .value(),  // loss of precision
-      internal::TimestampFromProto(response->expire_time()));
+      MakeTimestamp(response->expire_time()).value());
 }
 
 TEST(DatabaseAdminClientTest, ListBackupOperations) {

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/spanner/database_admin_connection.h"
 #include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
-#include "google/cloud/internal/time_utils.h"
 #include <chrono>
 
 namespace google {
@@ -362,10 +361,10 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
     backup.set_database(p.database.FullName());
     // `p.expire_time` is deprecated and ignored here.
     *backup.mutable_expire_time() =
-        internal::TimestampToProto(p.expire_timestamp);
+        p.expire_timestamp.get<protobuf::Timestamp>().value();
     if (p.version_time) {
       *backup.mutable_version_time() =
-          internal::TimestampToProto(*p.version_time);
+          p.version_time->get<protobuf::Timestamp>().value();
     }
     if (p.encryption_key) {
       auto& encryption = *request.mutable_encryption_config();

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -272,8 +272,8 @@ TEST_F(DatabaseAdminClientTest, VersionRetentionPeriodCreate) {
   // Verify that earliest_version_time doesn't go past database create_time.
   EXPECT_TRUE(get->has_create_time());
   EXPECT_TRUE(get->has_earliest_version_time());
-  EXPECT_LE(internal::TimestampFromProto(get->create_time()),
-            internal::TimestampFromProto(get->earliest_version_time()));
+  EXPECT_LE(MakeTimestamp(get->create_time()).value(),
+            MakeTimestamp(get->earliest_version_time()).value());
 
   auto drop = client_.DropDatabase(database_);
   EXPECT_THAT(drop, IsOk());

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -168,7 +168,7 @@ spanner_proto::BatchCreateSessionsResponse MakeSessionsResponse(
 spanner_proto::CommitResponse MakeCommitResponse(Timestamp commit_timestamp) {
   spanner_proto::CommitResponse response;
   *response.mutable_commit_timestamp() =
-      internal::TimestampToProto(commit_timestamp);
+      commit_timestamp.get<protobuf::Timestamp>().value();
   return response;
 }
 

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -134,7 +134,7 @@ ResultSet Client::Read(SessionHolder& session,
     if (selector->begin().has_read_only() &&
         selector->begin().read_only().has_read_timestamp()) {
       auto const& proto = selector->begin().read_only().read_timestamp();
-      if (internal::TimestampFromProto(proto) == read_timestamp_ && seqno > 0) {
+      if (MakeTimestamp(proto).value() == read_timestamp_ && seqno > 0) {
         std::unique_lock<std::mutex> lock(mu_);
         switch (mode_) {
           case Mode::kReadSucceeds:  // first visit valid

--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -31,8 +31,8 @@ absl::optional<Timestamp> GetReadTimestamp(
   absl::optional<Timestamp> timestamp;
   if (metadata.has_value() && metadata->has_transaction() &&
       metadata->transaction().has_read_timestamp()) {
-    timestamp.emplace(
-        internal::TimestampFromProto(metadata->transaction().read_timestamp()));
+    auto ts = MakeTimestamp(metadata->transaction().read_timestamp());
+    if (ts) timestamp = *std::move(ts);
   }
   return timestamp;
 }

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -144,7 +144,7 @@ TEST(RowStream, TimestampPresent) {
   transaction_with_timestamp.mutable_transaction()->set_id("dummy2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
-      internal::TimestampToProto(timestamp);
+      timestamp.get<protobuf::Timestamp>().value();
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_with_timestamp));
 
@@ -158,7 +158,7 @@ TEST(ProfileQueryResult, TimestampPresent) {
   transaction_with_timestamp.mutable_transaction()->set_id("dummy2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
-      internal::TimestampToProto(timestamp);
+      timestamp.get<protobuf::Timestamp>().value();
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_with_timestamp));
 

--- a/google/cloud/spanner/timestamp_test.cc
+++ b/google/cloud/spanner/timestamp_test.cc
@@ -48,8 +48,12 @@ google::protobuf::Timestamp MakeProtoTimestamp(std::int64_t seconds,
   return proto;
 }
 
+Timestamp MakeSpannerTimestamp(std::int64_t seconds, std::int32_t nanos) {
+  return MakeTimestamp(MakeProtoTimestamp(seconds, nanos)).value();
+}
+
 TEST(Timestamp, RegularSemantics) {
-  Timestamp const ts = internal::TimestampFromProto(MakeProtoTimestamp(0, 0));
+  Timestamp const ts = MakeSpannerTimestamp(0, 0);
 
   Timestamp const copy1(ts);
   EXPECT_EQ(copy1, ts);
@@ -63,116 +67,100 @@ TEST(Timestamp, RegularSemantics) {
 }
 
 TEST(Timestamp, RelationalOperators) {
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
-  EXPECT_LE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
-  EXPECT_GE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
+  EXPECT_EQ(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_LE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_GE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
 
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668)));
-  EXPECT_LT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668)));
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667)));
-  EXPECT_LT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667)));
+  EXPECT_NE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422668));
+  EXPECT_LT(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422668));
+  EXPECT_NE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030525, 611422667));
+  EXPECT_LT(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030525, 611422667));
 
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
-  EXPECT_GT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422668)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
-  EXPECT_NE(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
-  EXPECT_GT(
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030525, 611422667)),
-      internal::TimestampFromProto(MakeProtoTimestamp(1576030524, 611422667)));
+  EXPECT_NE(MakeSpannerTimestamp(1576030524, 611422668),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_GT(MakeSpannerTimestamp(1576030524, 611422668),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_NE(MakeSpannerTimestamp(1576030525, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_GT(MakeSpannerTimestamp(1576030525, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
 }
 
 TEST(Timestamp, OutputStreaming) {
   std::ostringstream os;
-  os << internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456789));
+  os << MakeSpannerTimestamp(1561135942, 123456789);
   EXPECT_EQ("2019-06-21T16:52:22.123456789Z", os.str());
 }
 
 TEST(Timestamp, FromRFC3339) {
-  EXPECT_EQ(internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 0)),
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 0),
             internal::TimestampFromRFC3339("2019-06-21T16:52:22Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 9)),
+      MakeSpannerTimestamp(1561135942, 9),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000009Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 89)),
+      MakeSpannerTimestamp(1561135942, 89),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000089Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 789)),
+      MakeSpannerTimestamp(1561135942, 789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 6789)),
+      MakeSpannerTimestamp(1561135942, 6789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.000006789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 56789)),
+      MakeSpannerTimestamp(1561135942, 56789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.000056789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 456789)),
+      MakeSpannerTimestamp(1561135942, 456789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.000456789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 3456789)),
+      MakeSpannerTimestamp(1561135942, 3456789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.003456789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 23456789)),
+      MakeSpannerTimestamp(1561135942, 23456789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.023456789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456789)),
+      MakeSpannerTimestamp(1561135942, 123456789),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456789Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456780)),
+      MakeSpannerTimestamp(1561135942, 123456780),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345678Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456700)),
+      MakeSpannerTimestamp(1561135942, 123456700),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234567Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123456000)),
+      MakeSpannerTimestamp(1561135942, 123456000),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123450000)),
+      MakeSpannerTimestamp(1561135942, 123450000),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123400000)),
+      MakeSpannerTimestamp(1561135942, 123400000),
       internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 123000000)),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.123Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 120000000)),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.12Z").value());
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 100000000)),
-      internal::TimestampFromRFC3339("2019-06-21T16:52:22.1Z").value());
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 123000000),
+            internal::TimestampFromRFC3339("2019-06-21T16:52:22.123Z").value());
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 120000000),
+            internal::TimestampFromRFC3339("2019-06-21T16:52:22.12Z").value());
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 100000000),
+            internal::TimestampFromRFC3339("2019-06-21T16:52:22.1Z").value());
 }
 
 TEST(Timestamp, FromRFC3339Offset) {
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(1546398245, 0)),
+      MakeSpannerTimestamp(1546398245, 0),
       internal::TimestampFromRFC3339("2019-01-02T03:04:05+00:00").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(
-          MakeProtoTimestamp(1546398245 + 3600 + 120, 0)),
+      MakeSpannerTimestamp(1546398245 + 3600 + 120, 0),
       internal::TimestampFromRFC3339("2019-01-02T03:04:05-01:02").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(
-          MakeProtoTimestamp(1546398245 - 3600 - 120, 0)),
+      MakeSpannerTimestamp(1546398245 - 3600 - 120, 0),
       internal::TimestampFromRFC3339("2019-01-02T03:04:05+01:02").value());
 }
 
@@ -196,10 +184,10 @@ TEST(Timestamp, FromRFC3339Failure) {
 TEST(Timestamp, FromRFC3339Limit) {
   // Verify Spanner range requirements.
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0)),
+      MakeSpannerTimestamp(-62135596800, 0),
       internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z").value());
   EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(253402300799, 999999999)),
+      MakeSpannerTimestamp(253402300799, 999999999),
       internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value());
 
   // One nanosecond before the lower bound is invalid.
@@ -211,87 +199,83 @@ TEST(Timestamp, FromRFC3339Limit) {
 
 TEST(Timestamp, ToRFC3339) {
   EXPECT_EQ("2019-06-21T16:52:22Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 0))));
+            internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 0)));
   EXPECT_EQ("2019-06-21T16:52:22.000000009Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 9))));
+            internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 9)));
   EXPECT_EQ("2019-06-21T16:52:22.000000089Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 89))));
-  EXPECT_EQ("2019-06-21T16:52:22.000000789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 789))));
-  EXPECT_EQ("2019-06-21T16:52:22.000006789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 6789))));
-  EXPECT_EQ("2019-06-21T16:52:22.000056789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 56789))));
-  EXPECT_EQ("2019-06-21T16:52:22.000456789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 456789))));
-  EXPECT_EQ("2019-06-21T16:52:22.003456789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 3456789))));
-  EXPECT_EQ("2019-06-21T16:52:22.023456789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 23456789))));
+            internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 89)));
+  EXPECT_EQ(
+      "2019-06-21T16:52:22.000000789Z",
+      internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 789)));
+  EXPECT_EQ(
+      "2019-06-21T16:52:22.000006789Z",
+      internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 6789)));
+  EXPECT_EQ(
+      "2019-06-21T16:52:22.000056789Z",
+      internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 56789)));
+  EXPECT_EQ(
+      "2019-06-21T16:52:22.000456789Z",
+      internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 456789)));
+  EXPECT_EQ(
+      "2019-06-21T16:52:22.003456789Z",
+      internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 3456789)));
+  EXPECT_EQ(
+      "2019-06-21T16:52:22.023456789Z",
+      internal::TimestampToRFC3339(MakeSpannerTimestamp(1561135942, 23456789)));
   EXPECT_EQ("2019-06-21T16:52:22.123456789Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123456789))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123456789)));
   EXPECT_EQ("2019-06-21T16:52:22.12345678Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123456780))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123456780)));
   EXPECT_EQ("2019-06-21T16:52:22.1234567Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123456700))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123456700)));
   EXPECT_EQ("2019-06-21T16:52:22.123456Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123456000))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123456000)));
   EXPECT_EQ("2019-06-21T16:52:22.12345Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123450000))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123450000)));
   EXPECT_EQ("2019-06-21T16:52:22.1234Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123400000))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123400000)));
   EXPECT_EQ("2019-06-21T16:52:22.123Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123000000))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 123000000)));
   EXPECT_EQ("2019-06-21T16:52:22.12Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 120000000))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 120000000)));
   EXPECT_EQ("2019-06-21T16:52:22.1Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 100000000))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(1561135942, 100000000)));
 }
 
 TEST(Timestamp, ToRFC3339Limit) {
   // Spanner range requirements.
-  EXPECT_EQ("0001-01-01T00:00:00Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(-62135596800, 0))));
+  EXPECT_EQ("0001-01-01T00:00:00Z", internal::TimestampToRFC3339(
+                                        MakeSpannerTimestamp(-62135596800, 0)));
   EXPECT_EQ("9999-12-31T23:59:59.999999999Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(
-                MakeProtoTimestamp(253402300799, 999999999))));
+            internal::TimestampToRFC3339(
+                MakeSpannerTimestamp(253402300799, 999999999)));
 }
 
 TEST(Timestamp, FromProto) {
   auto proto = MakeProtoTimestamp(0, 0);
   EXPECT_EQ("1970-01-01T00:00:00Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(proto)));
+            internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 
   proto = MakeProtoTimestamp(1576030524, 611422667);
   EXPECT_EQ("2019-12-11T02:15:24.611422667Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(proto)));
+            internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 
   proto = MakeProtoTimestamp(-62135596800, 0);
   EXPECT_EQ("0001-01-01T00:00:00Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(proto)));
+            internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 
   proto = MakeProtoTimestamp(253402300799, 999999999);
   EXPECT_EQ("9999-12-31T23:59:59.999999999Z",
-            internal::TimestampToRFC3339(internal::TimestampFromProto(proto)));
+            internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 }
 
 TEST(Timestamp, FromProtoLimit) {
@@ -299,31 +283,38 @@ TEST(Timestamp, FromProtoLimit) {
   // ["0001-01-01T00:00:00Z", "9999-12-31T23:59:59.999999999Z"]
   // Note: These values can be computed with `date +%s --date="YYYY-MM-...Z"`
   EXPECT_EQ(internal::TimestampFromRFC3339("0001-01-01T00:00:00Z").value(),
-            internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0)));
+            MakeSpannerTimestamp(-62135596800, 0));
   EXPECT_EQ(
       internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value(),
-      internal::TimestampFromProto(
-          MakeProtoTimestamp(253402300799, 999999999)));
+      MakeSpannerTimestamp(253402300799, 999999999));
 }
 
 TEST(Timestamp, ToProto) {
-  auto proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("1970-01-01T00:00:00.000000000Z").value());
+  auto proto = internal::TimestampFromRFC3339("1970-01-01T00:00:00.000000000Z")
+                   .value()
+                   .get<google::protobuf::Timestamp>()
+                   .value();
   EXPECT_EQ(0, proto.seconds());
   EXPECT_EQ(0, proto.nanos());
 
-  proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("2019-12-11T02:15:24.611422667Z").value());
+  proto = internal::TimestampFromRFC3339("2019-12-11T02:15:24.611422667Z")
+              .value()
+              .get<google::protobuf::Timestamp>()
+              .value();
   EXPECT_EQ(1576030524, proto.seconds());
   EXPECT_EQ(611422667, proto.nanos());
 
-  proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z").value());
+  proto = internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z")
+              .value()
+              .get<google::protobuf::Timestamp>()
+              .value();
   EXPECT_EQ(-62135596800, proto.seconds());
   EXPECT_EQ(0, proto.nanos());
 
-  proto = internal::TimestampToProto(
-      internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z").value());
+  proto = internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
+              .value()
+              .get<google::protobuf::Timestamp>()
+              .value();
   EXPECT_EQ(253402300799, proto.seconds());
   EXPECT_EQ(999999999, proto.nanos());
 }
@@ -331,44 +322,37 @@ TEST(Timestamp, ToProto) {
 TEST(Timestamp, FromChrono) {  // i.e., MakeTimestamp(sys_time<Duration>)
   auto const tp1 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123456789)),
-      MakeTimestamp(tp1).value());
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789, 123456789),
+            MakeTimestamp(tp1).value());
 
   auto const tp2 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::microseconds(123456);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123456000)),
-      MakeTimestamp(tp2).value());
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789, 123456000),
+            MakeTimestamp(tp2).value());
 
   auto const tp3 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::milliseconds(123);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123000000)),
-      MakeTimestamp(tp3).value());
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789, 123000000),
+            MakeTimestamp(tp3).value());
 
   auto const tp4 = kUnixEpoch + std::chrono::minutes(2123456789);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789LL * 60, 0)),
-      MakeTimestamp(tp4).value());
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789LL * 60, 0),
+            MakeTimestamp(tp4).value());
 
   auto const tp5 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123456789)),
-      MakeTimestamp(tp5).value());
+  EXPECT_EQ(MakeSpannerTimestamp(-2123456789, 123456789),
+            MakeTimestamp(tp5).value());
 
   auto const tp6 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::microseconds(123456);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123456000)),
-      MakeTimestamp(tp6).value());
+  EXPECT_EQ(MakeSpannerTimestamp(-2123456789, 123456000),
+            MakeTimestamp(tp6).value());
 
   auto const tp7 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::milliseconds(123);
-  EXPECT_EQ(
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123000000)),
-      MakeTimestamp(tp7).value());
+  EXPECT_EQ(MakeSpannerTimestamp(-2123456789, 123000000),
+            MakeTimestamp(tp7).value());
 }
 
 TEST(Timestamp, FromChronoOverflow) {
@@ -387,8 +371,7 @@ TEST(Timestamp, FromChronoOverflow) {
 }
 
 TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
-  auto const ts_pos =
-      internal::TimestampFromProto(MakeProtoTimestamp(2123456789, 123456789));
+  auto const ts_pos = MakeSpannerTimestamp(2123456789, 123456789);
 
   auto const tp1 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
@@ -408,8 +391,7 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
   auto const tp5 = kUnixEpoch + std::chrono::hours(2123456789 / 60 / 60);
   EXPECT_EQ(tp5, ts_pos.get<sys_time<std::chrono::hours>>().value());
 
-  auto const ts_neg =
-      internal::TimestampFromProto(MakeProtoTimestamp(-2123456789, 123456789));
+  auto const ts_neg = MakeSpannerTimestamp(-2123456789, 123456789);
 
   auto const tp6 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
@@ -434,22 +416,19 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
 
   // The limit of a 64-bit count of nanoseconds (assuming the system_clock
   // epoch is the Unix epoch).
-  auto const ts11 =
-      internal::TimestampFromProto(MakeProtoTimestamp(9223372036, 854775807));
+  auto const ts11 = MakeSpannerTimestamp(9223372036, 854775807);
   auto const tp11 = kUnixEpoch + std::chrono::seconds(9223372036) +
                     std::chrono::nanoseconds(854775807);
   EXPECT_EQ(tp11, ts11.get<sys_time<std::chrono::nanoseconds>>().value());
 }
 
 TEST(Timestamp, ToChronoOverflow) {
-  auto const ts1 =
-      internal::TimestampFromProto(MakeProtoTimestamp(20000000000, 0));
+  auto const ts1 = MakeSpannerTimestamp(20000000000, 0);
   auto const tp1 = ts1.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp1,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
 
-  auto const ts2 =
-      internal::TimestampFromProto(MakeProtoTimestamp(-20000000000, 0));
+  auto const ts2 = MakeSpannerTimestamp(-20000000000, 0);
   auto const tp2 = ts2.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp2,
               StatusIs(Not(StatusCode::kOk), HasSubstr("negative overflow")));
@@ -457,8 +436,7 @@ TEST(Timestamp, ToChronoOverflow) {
   // One beyond the limit of a 64-bit count of nanoseconds (assuming the
   // system_clock epoch is the Unix epoch). This overflow is detected in a
   // different code path to the "positive overflow" above.
-  auto const ts3 =
-      internal::TimestampFromProto(MakeProtoTimestamp(9223372036, 854775808));
+  auto const ts3 = MakeSpannerTimestamp(9223372036, 854775808);
   auto const tp3 = ts3.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp3,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
@@ -466,18 +444,18 @@ TEST(Timestamp, ToChronoOverflow) {
   // Uses a small duration (8-bits of seconds) to clearly demonstrate that we
   // detect potential overflow into the Duration's rep.
   using Sec8Bit = std::chrono::duration<std::int8_t, std::ratio<1>>;
-  auto const ts4 = internal::TimestampFromProto(MakeProtoTimestamp(127, 0));
+  auto const ts4 = MakeSpannerTimestamp(127, 0);
   auto const tp4 = ts4.get<sys_time<Sec8Bit>>();
   EXPECT_TRUE(tp4);  // An in-range value succeeds.
 
   // One beyond the capacity for (signed) 8-bits of seconds would overflow.
-  auto const ts5 = internal::TimestampFromProto(MakeProtoTimestamp(128, 0));
+  auto const ts5 = MakeSpannerTimestamp(128, 0);
   auto const tp5 = ts5.get<sys_time<Sec8Bit>>();
   EXPECT_THAT(tp5,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
 
   // One less than the capacity for (signed) 8-bits of seconds would overflow.
-  auto const ts6 = internal::TimestampFromProto(MakeProtoTimestamp(-129, 0));
+  auto const ts6 = MakeSpannerTimestamp(-129, 0);
   auto const tp6 = ts6.get<sys_time<Sec8Bit>>();
   EXPECT_THAT(tp6,
               StatusIs(Not(StatusCode::kOk), HasSubstr("negative overflow")));
@@ -511,7 +489,7 @@ TEST(Timestamp, AbslTimeRoundTrip) {  // i.e., `MakeTimestamp(absl::Time)`
   for (auto const& tc : round_trip_cases) {
     SCOPED_TRACE("Time: " + absl::FormatTime(tc.t));
     auto const ts = MakeTimestamp(tc.t).value();
-    EXPECT_EQ(ts, internal::TimestampFromProto(tc.proto));
+    EXPECT_EQ(ts, MakeTimestamp(tc.proto).value());
     auto const t = ts.get<absl::Time>().value();
     EXPECT_EQ(t, tc.t);
   }

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -57,7 +57,7 @@ Transaction::ReadOnlyOptions::ReadOnlyOptions() {
 
 Transaction::ReadOnlyOptions::ReadOnlyOptions(Timestamp read_timestamp) {
   *ro_opts_.mutable_read_timestamp() =
-      internal::TimestampToProto(read_timestamp);
+      read_timestamp.get<protobuf::Timestamp>().value();
   ro_opts_.set_return_read_timestamp(true);
 }
 
@@ -75,7 +75,7 @@ Transaction::SingleUseOptions::SingleUseOptions(ReadOnlyOptions opts) {
 
 Transaction::SingleUseOptions::SingleUseOptions(Timestamp min_read_timestamp) {
   *ro_opts_.mutable_min_read_timestamp() =
-      internal::TimestampToProto(min_read_timestamp);
+      min_read_timestamp.get<protobuf::Timestamp>().value();
   ro_opts_.set_return_read_timestamp(true);
 }
 


### PR DESCRIPTION
`spanner::Timestamp` and `protobuf::Timestamp` are fundamental parts
of the Spanner admin API (and even more so with the introduction of
PITR), but there was no mechanism provided to the user for converting
between them.

So, `internal::TimestampFromProto()` and `internal::TimestampToProto()`
are here refactored as `spanner::MakeTimestamp(protobuf::Timestamp)`
and `spanner::Timestamp::get<protobuf::Timestamp>()` respectively.

This means Spanner no longer depends on the "internal/time_utils.h"
grab bag.

This also reverses a decision made in #5844 concerning the impossibility
of failure in `protobuf::Timestamp` to `spanner::Timestamp` conversions.
While failure is impossible for `protobuf::Timestamp` values that abide
by the "MUST" comments, in general we must be prepared to handle values
that are out of range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5851)
<!-- Reviewable:end -->
