### PR TITLE
fix: support for static builds with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,11 @@ cmake_minimum_required(VERSION 3.5)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
+
 # Enable support for SelectMSVCRuntime
-cmake_policy(SET CMP0091 NEW)
+if (NOT (CMAKE_VERSION VERSION_LESS 3.15))
+    cmake_policy(SET CMP0091 NEW)
+endif ()
 project(
     google-cloud-cpp
     VERSION 1.25.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ cmake_minimum_required(VERSION 3.5)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
+# Enable support for SelectMSVCRuntime
+cmake_policy(SET CMP0091 NEW)
 project(
     google-cloud-cpp
     VERSION 1.25.0
@@ -39,6 +41,9 @@ if (NOT ("${GOOGLE_CLOUD_CPP_CXX_STANDARD}" STREQUAL ""))
         WARNING
             "GOOGLE_CLOUD_CPP_CXX_STANDARD is retired, use CMAKE_CXX_STANDARD")
 endif ()
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+include(SelectMSVCRuntime)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
@@ -125,7 +130,6 @@ option(GOOGLE_CLOUD_CPP_USE_MASTER_FOR_REFDOC_LINKS
 mark_as_advanced(GOOGLE_CLOUD_CPP_USE_MASTER_FOR_REFDOC_LINKS)
 
 set(PROJECT_THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/third_party")
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(CMakeDependentOption)
 

--- a/cmake/SelectMSVCRuntime.cmake
+++ b/cmake/SelectMSVCRuntime.cmake
@@ -31,8 +31,7 @@
 if (MSVC)
     # TODO(#5852) - if we require CMake >= 3.15 we can remove this conditional
     # and the hacks below.
-    if ((${CMAKE_VERSION} VERSION_GREATER 3.15) OR (${CMAKE_VERSION}
-                                                    VERSION_EQUAL 3.14))
+    if (NOT (CMAKE_VERSION VERSION_LESS 3.15))
         if (VCPKG_TARGET_TRIPLET MATCHES "-static$")
             set(CMAKE_MSVC_RUNTIME_LIBRARY
                 "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
My previous cleanup was incorrect. CMake protects usage of
CMAKE_MSVC_RUNTIME_LIBRARY with a policy, the variable (or rather the
MSVC_RUNTIME_LIBRARY property set by this variable) has no effect if the
CMP0091 policy is set to OLD, as would be in our builds because we say
that version 3.5 is the behavior we want in cmake_minimum_required().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5856)
<!-- Reviewable:end -->
