### PR TITLE
feat: added equality to TracingOptions

### DIFF
--- a/google/cloud/tracing_options.cc
+++ b/google/cloud/tracing_options.cc
@@ -42,6 +42,13 @@ absl::optional<std::int64_t> ParseInteger(std::string const& str) {
 
 }  // namespace
 
+bool operator==(TracingOptions const& a, TracingOptions const& b) {
+  return a.single_line_mode_ == b.single_line_mode_ &&
+         a.use_short_repeated_primitives_ == b.use_short_repeated_primitives_ &&
+         a.truncate_string_field_longer_than_ ==
+             b.truncate_string_field_longer_than_;
+}
+
 TracingOptions& TracingOptions::SetOptions(std::string const& str) {
   auto const beg = str.begin();
   auto const end = str.end();

--- a/google/cloud/tracing_options.h
+++ b/google/cloud/tracing_options.h
@@ -32,6 +32,17 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
  */
 class TracingOptions {
  public:
+  TracingOptions() = default;
+  TracingOptions(TracingOptions const&) = default;
+  TracingOptions& operator=(TracingOptions const&) = default;
+  TracingOptions(TracingOptions&&) = default;
+  TracingOptions& operator=(TracingOptions&&) = default;
+
+  friend bool operator==(TracingOptions const& a, TracingOptions const& b);
+  friend bool operator!=(TracingOptions const& a, TracingOptions const& b) {
+    return !(a == b);
+  }
+
   /// Override the default options with values from @p `str`.
   TracingOptions& SetOptions(std::string const& str);
 

--- a/google/cloud/tracing_options_test.cc
+++ b/google/cloud/tracing_options_test.cc
@@ -20,17 +20,54 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 
+TEST(TracingOptionsTest, Equality) {
+  auto const empty = TracingOptions{};
+  auto const expected_defaults = TracingOptions{}.SetOptions(
+      ",single_line_mode=T"
+      ",use_short_repeated_primitives=Y"
+      ",truncate_string_field_longer_than=128");
+  EXPECT_EQ(empty, expected_defaults);
+
+  auto const overridden = TracingOptions{}.SetOptions(
+      ",single_line_mode=F"
+      ",use_short_repeated_primitives=n"
+      ",truncate_string_field_longer_than=256");
+  EXPECT_NE(overridden, empty);
+
+  TracingOptions opts;
+  EXPECT_EQ(opts, empty);
+
+  opts.SetOptions("single_line_mode=F");
+  EXPECT_NE(opts, empty);
+  EXPECT_NE(opts, overridden);
+
+  opts.SetOptions("use_short_repeated_primitives=n");
+  EXPECT_NE(opts, empty);
+  EXPECT_NE(opts, overridden);
+
+  opts.SetOptions("truncate_string_field_longer_than=256");
+  EXPECT_NE(opts, empty);
+  EXPECT_EQ(opts, overridden);
+}
+
 TEST(TracingOptionsTest, Defaults) {
+  auto const expected_defaults = TracingOptions{}.SetOptions(
+      ",single_line_mode=T"
+      ",use_short_repeated_primitives=Y"
+      ",truncate_string_field_longer_than=128");
+
   TracingOptions tracing_options;
   EXPECT_TRUE(tracing_options.single_line_mode());
   EXPECT_TRUE(tracing_options.use_short_repeated_primitives());
   EXPECT_EQ(128, tracing_options.truncate_string_field_longer_than());
+  EXPECT_EQ(tracing_options, expected_defaults);
 
   // Unknown/unparseable options are ignored.
   tracing_options.SetOptions("foo=1,bar=T,baz=no");
   EXPECT_TRUE(tracing_options.single_line_mode());
   EXPECT_TRUE(tracing_options.use_short_repeated_primitives());
   EXPECT_EQ(128, tracing_options.truncate_string_field_longer_than());
+  EXPECT_EQ(tracing_options, expected_defaults);
 }
 
 TEST(TracingOptionsTest, Override) {


### PR DESCRIPTION
This makes the class a little easier to use as a regular value type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5858)
<!-- Reviewable:end -->
