### PR TITLE
feat: add support for get_pointer

### DIFF
--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -107,6 +107,16 @@ class Options {
   }
 
   /**
+   * Gets a pointer to the option specified by `T`, else nullptr.
+   */
+  template <typename T>
+  T* get_pointer() {
+    auto it = m_.find(typeid(T));
+    if (it == m_.end()) return nullptr;
+    return absl::any_cast<T>(&it->second);
+  }
+
+  /**
    * Gets the option of type `T` if set, else a newly constructed default `T`.
    *
    * If the specified option `T` is not set, a new `T` will be constructed with

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -120,7 +120,17 @@ class Options {
   }
 
   /**
-   * Gets a pointer to the option specified by `T`, else nullptr.
+   * Gets a const pointer to the option specified by `T`, else nullptr.
+   */
+  template <typename T>
+  T const* get_pointer() const {
+    auto it = m_.find(typeid(T));
+    if (it == m_.end()) return nullptr;
+    return absl::any_cast<T>(&it->second);
+  }
+
+  /**
+   * Gets a non-const pointer to the option specified by `T`, else nullptr.
    */
   template <typename T>
   T* get_pointer() {

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -107,16 +107,6 @@ class Options {
   }
 
   /**
-   * Gets a pointer to the option specified by `T`, else nullptr.
-   */
-  template <typename T>
-  T* get_pointer() {
-    auto it = m_.find(typeid(T));
-    if (it == m_.end()) return nullptr;
-    return absl::any_cast<T>(&it->second);
-  }
-
-  /**
    * Gets the option of type `T` if set, else a newly constructed default `T`.
    *
    * If the specified option `T` is not set, a new `T` will be constructed with
@@ -127,6 +117,16 @@ class Options {
     auto v = get<T>();
     if (v) return *v;
     return T{std::forward<U>(u)...};
+  }
+
+  /**
+   * Gets a pointer to the option specified by `T`, else nullptr.
+   */
+  template <typename T>
+  T* get_pointer() {
+    auto it = m_.find(typeid(T));
+    if (it == m_.end()) return nullptr;
+    return absl::any_cast<T>(&it->second);
   }
 
  private:

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -140,6 +140,24 @@ TEST(Options, BasicOperations) {
   EXPECT_EQ(opts.get<StringOption>()->value, "foo");
 }
 
+TEST(Options, GetPointer) {
+  Options opts{};
+  opts.set<IntOption>(42);
+
+  auto* p1 = opts.get_pointer<IntOption>();
+  EXPECT_EQ(p1->value, 42);
+
+  auto* p2 = opts.get_pointer<IntOption>();
+  EXPECT_EQ(p2->value, 42);
+
+  EXPECT_EQ(p1, p2);
+
+  p1->value = 123;
+  EXPECT_EQ(p1->value, 123);
+  EXPECT_EQ(p2->value, 123);
+  EXPECT_EQ(p1, p2);
+}
+
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -143,10 +143,10 @@ TEST(Options, BasicOperations) {
 TEST(Options, GetPointerConst) {
   auto const opts = Options{}.set<IntOption>(42);
 
-  auto* p1 = opts.get_pointer<IntOption>();
+  auto const* p1 = opts.get_pointer<IntOption>();
   EXPECT_EQ(p1->value, 42);
 
-  auto* p2 = opts.get_pointer<IntOption>();
+  auto const* p2 = opts.get_pointer<IntOption>();
   EXPECT_EQ(p2->value, 42);
 
   EXPECT_EQ(p1, p2);

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -140,9 +140,20 @@ TEST(Options, BasicOperations) {
   EXPECT_EQ(opts.get<StringOption>()->value, "foo");
 }
 
-TEST(Options, GetPointer) {
-  Options opts{};
-  opts.set<IntOption>(42);
+TEST(Options, GetPointerConst) {
+  auto const opts = Options{}.set<IntOption>(42);
+
+  auto* p1 = opts.get_pointer<IntOption>();
+  EXPECT_EQ(p1->value, 42);
+
+  auto* p2 = opts.get_pointer<IntOption>();
+  EXPECT_EQ(p2->value, 42);
+
+  EXPECT_EQ(p1, p2);
+}
+
+TEST(Options, GetPointerMutable) {
+  auto opts = Options{}.set<IntOption>(42);
 
   auto* p1 = opts.get_pointer<IntOption>();
   EXPECT_EQ(p1->value, 42);


### PR DESCRIPTION
This gives us the ability to mutate options directly within `Options`
class. This also gives us the ability to get options that will not move
so that we can return references to them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5860)
<!-- Reviewable:end -->
