### PR TITLE
Revert "feat: add support for get_pointer"

### DIFF
--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -119,26 +119,6 @@ class Options {
     return T{std::forward<U>(u)...};
   }
 
-  /**
-   * Gets a const pointer to the option specified by `T`, else nullptr.
-   */
-  template <typename T>
-  T const* get_pointer() const {
-    auto it = m_.find(typeid(T));
-    if (it == m_.end()) return nullptr;
-    return absl::any_cast<T>(&it->second);
-  }
-
-  /**
-   * Gets a non-const pointer to the option specified by `T`, else nullptr.
-   */
-  template <typename T>
-  T* get_pointer() {
-    auto it = m_.find(typeid(T));
-    if (it == m_.end()) return nullptr;
-    return absl::any_cast<T>(&it->second);
-  }
-
  private:
   std::unordered_map<std::type_index, absl::any> m_;
 };

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -140,35 +140,6 @@ TEST(Options, BasicOperations) {
   EXPECT_EQ(opts.get<StringOption>()->value, "foo");
 }
 
-TEST(Options, GetPointerConst) {
-  auto const opts = Options{}.set<IntOption>(42);
-
-  auto const* p1 = opts.get_pointer<IntOption>();
-  EXPECT_EQ(p1->value, 42);
-
-  auto const* p2 = opts.get_pointer<IntOption>();
-  EXPECT_EQ(p2->value, 42);
-
-  EXPECT_EQ(p1, p2);
-}
-
-TEST(Options, GetPointerMutable) {
-  auto opts = Options{}.set<IntOption>(42);
-
-  auto* p1 = opts.get_pointer<IntOption>();
-  EXPECT_EQ(p1->value, 42);
-
-  auto* p2 = opts.get_pointer<IntOption>();
-  EXPECT_EQ(p2->value, 42);
-
-  EXPECT_EQ(p1, p2);
-
-  p1->value = 123;
-  EXPECT_EQ(p1->value, 123);
-  EXPECT_EQ(p2->value, 123);
-  EXPECT_EQ(p1, p2);
-}
-
 }  // namespace
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud


### PR DESCRIPTION
Reverts googleapis/google-cloud-cpp#5860

Per the reasons in https://github.com/googleapis/google-cloud-cpp/pull/5860#issuecomment-780593237

We can add these functions (or similar ones) later if/when they are actually needed again. At the moment, I no longer need these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5863)
<!-- Reviewable:end -->
