### PR TITLE
doc: workarounds for Bazel and path length problems

### DIFF
--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -142,6 +142,14 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
+Bazel tends to create very long file names and paths, you may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
 gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -142,7 +142,7 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
-Bazel tends to create very long file names and paths, you may need to use a
+Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:
 

--- a/google/cloud/bigtable/quickstart/WORKSPACE
+++ b/google/cloud/bigtable/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Bigtable C++
 # client library in Bazel-based projects.
-workspace(name = "google_cloud_cpp_bigtable_quickstart")
+workspace(name = "bigtable_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -140,6 +140,14 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
+Bazel tends to create very long file names and paths, you may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
 gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -140,7 +140,7 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
-Bazel tends to create very long file names and paths, you may need to use a
+Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:
 

--- a/google/cloud/pubsub/quickstart/WORKSPACE
+++ b/google/cloud/pubsub/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Pub/Sub C++
 # client library in Bazel-based projects.
-workspace(name = "google_cloud_cpp_pubsub_quickstart")
+workspace(name = "pubsub_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -140,7 +140,7 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
-Bazel tends to create very long file names and paths, you may need to use a
+Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:
 
@@ -158,7 +158,6 @@ trust store for SSL certificates, you can download and configure this using:
         'roots.pem')
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
-
 
 [bazel-install]: https://docs.bazel.build/versions/master/install.html
 [spanner-quickstart-link]: https://cloud.google.com/spanner/docs/quickstart-console

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -140,6 +140,14 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
+Bazel tends to create very long file names and paths, you may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
 gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 
@@ -150,6 +158,7 @@ trust store for SSL certificates, you can download and configure this using:
         'roots.pem')
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
+
 
 [bazel-install]: https://docs.bazel.build/versions/master/install.html
 [spanner-quickstart-link]: https://cloud.google.com/spanner/docs/quickstart-console

--- a/google/cloud/spanner/quickstart/WORKSPACE
+++ b/google/cloud/spanner/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Spanner C++
 # client library in Bazel-based projects.
-workspace(name = "google_cloud_cpp_spanner_quickstart")
+workspace(name = "spanner_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -128,7 +128,7 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
-Bazel tends to create very long file names and paths, you may need to use a
+Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:
 

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -128,6 +128,14 @@ To correctly configure the MSVC runtime you should change the CMake minimum
 required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
 CMake configuration step.
 
+Bazel tends to create very long file names and paths, you may need to use a
+short directory to store the build output, such as `c:\b`, and instruct Bazel
+to use it via:
+
+```shell
+bazel --output_user_root=c:\b build ...
+```
+
 [bazel-install]: https://docs.bazel.build/versions/master/install.html
 [choco-cmake-link]: https://chocolatey.org/packages/cmake
 [homebrew-cmake-link]: https://formulae.brew.sh/formula/cmake

--- a/google/cloud/storage/quickstart/WORKSPACE
+++ b/google/cloud/storage/quickstart/WORKSPACE
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Storage C++
 # client library in Bazel-based projects.
-workspace(name = "google_cloud_cpp_storage_quickstart")
+workspace(name = "storage_quickstart")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
Bazel on Windows can generate excessively long pathnames. Document how
to use the `--output_user_root=` option to shorten the paths, and try to
minimize the problem (again?) by shortening the workspace names.

Thanks to @rastogi-ayush for the suggestion in #5865

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5869)
<!-- Reviewable:end -->
