### PR TITLE
ci: retry "vcpkg install google-cloud-cpp" once

### DIFF
--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -64,7 +64,7 @@ fi
 
 "${vcpkg_bin}" remove --outdated --recurse
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
-    "${vcpkg_bin}" install google-cloud-cpp
+  "${vcpkg_bin}" install google-cloud-cpp
 
 run_quickstart="false"
 readonly CONFIG_DIR="/c"

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -63,7 +63,12 @@ else
 fi
 
 "${vcpkg_bin}" remove --outdated --recurse
-"${vcpkg_bin}" install google-cloud-cpp
+if ! "${vcpkg_bin}" install google-cloud-cpp; then
+  # We have seen download errors here, so make a single retry after a
+  # short pause. See https://github.com/microsoft/vcpkg/issues/11073.
+  sleep 5
+  "${vcpkg_bin}" install google-cloud-cpp
+fi
 
 run_quickstart="false"
 readonly CONFIG_DIR="/c"

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -63,12 +63,8 @@ else
 fi
 
 "${vcpkg_bin}" remove --outdated --recurse
-if ! "${vcpkg_bin}" install google-cloud-cpp; then
-  # We have seen download errors here, so make a single retry after a
-  # short pause. See https://github.com/microsoft/vcpkg/issues/11073.
-  sleep 5
-  "${vcpkg_bin}" install google-cloud-cpp
-fi
+"${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
+    "${vcpkg_bin}" install google-cloud-cpp
 
 run_quickstart="false"
 readonly CONFIG_DIR="/c"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -46,7 +46,12 @@ else
 fi
 
 "${vcpkg_bin}" remove --outdated --recurse
-"${vcpkg_bin}" install google-cloud-cpp
+if ! "${vcpkg_bin}" install google-cloud-cpp; then
+  # We have seen download errors here, so make a single retry after a
+  # short pause. See https://github.com/microsoft/vcpkg/issues/11073.
+  sleep 5
+  "${vcpkg_bin}" install google-cloud-cpp
+fi
 
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -47,7 +47,7 @@ fi
 
 "${vcpkg_bin}" remove --outdated --recurse
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
-    "${vcpkg_bin}" install google-cloud-cpp
+  "${vcpkg_bin}" install google-cloud-cpp
 
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -46,12 +46,8 @@ else
 fi
 
 "${vcpkg_bin}" remove --outdated --recurse
-if ! "${vcpkg_bin}" install google-cloud-cpp; then
-  # We have seen download errors here, so make a single retry after a
-  # short pause. See https://github.com/microsoft/vcpkg/issues/11073.
-  sleep 5
-  "${vcpkg_bin}" install google-cloud-cpp
-fi
+"${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
+    "${vcpkg_bin}" install google-cloud-cpp
 
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"

--- a/ci/retry-command.sh
+++ b/ci/retry-command.sh
@@ -34,6 +34,7 @@ readonly PROGRAM=${1}
 shift
 
 "${PROGRAM}" "$@" && exit 0
+status=${?}
 
 while (((retries--) > 0)); do
   # apply +/- 50% jitter to min_wait
@@ -42,6 +43,7 @@ while (((retries--) > 0)); do
   sleep ${period}s
   min_wait=$((min_wait * 2))
   "${PROGRAM}" "$@" && exit 0
+  status=${?}
 done
 
-exit 1
+exit "${status}"

--- a/ci/retry-command.sh
+++ b/ci/retry-command.sh
@@ -16,17 +16,13 @@
 
 set -eu
 
-# Make three attempts to install the dependencies. It is rare, but from time to
-# time the downloading the packages, building the Docker images, or an installer
-# Bazel, or the Google Cloud SDK fails. To make the CI build more robust, try
-# again when that happens.
-
 if (($# < 3)); then
   cat <<EOM
-Usage: $(basename "$0") attempts initial-interval program [arguments]
+Usage: $(basename "$0") retries initial-interval program [arguments]
 
-  Retries <program> up to <attempts> times, with exponential backoff.
-  The initial retry interval is <initial-interval> seconds.
+  Runs <program> [arguments], and then retries up to <retries> times,
+  with jittered exponential backoff between failures. The initial backoff
+  interval is <initial-interval> seconds.
 EOM
   exit 1
 fi
@@ -37,18 +33,15 @@ shift
 readonly PROGRAM=${1}
 shift
 
-# Do not exit on failures for this loop.
-set +e
-while (((--retries) > 0)); do
-  "${PROGRAM}" "$@"
-  if [[ $? -eq 0 ]]; then
-    exit 0
-  fi
+"${PROGRAM}" "$@" && exit 0
+
+while (((retries--) > 0)); do
   # apply +/- 50% jitter to min_wait
   period=$((min_wait * (50 + (RANDOM % 100)) / 100))
   echo "${PROGRAM} failed; trying again in ${period} seconds."
   sleep ${period}s
   min_wait=$((min_wait * 2))
+  "${PROGRAM}" "$@" && exit 0
 done
 
 exit 1


### PR DESCRIPTION
We have seen download errors here, so make a single retry after a
short pause. (See microsoft/vcpkg#11073 for a request to have
vcpkg do this itself.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5873)
<!-- Reviewable:end -->
