### PR TITLE
refactor(spanner): spanner::Timestamp/protobuf::Timestamp conversions…

### DIFF
--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/database_admin_client.h"
-#include "google/cloud/internal/time_utils.h"
+#include "google/cloud/spanner/timestamp.h"
 #include <algorithm>
 
 namespace google {
@@ -156,11 +156,12 @@ ListBackupsRange DatabaseAdminClient::ListBackups(Instance in,
 StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
     google::spanner::admin::database::v1::Backup const& backup,
     std::chrono::system_clock::time_point const& expire_time) {
-  auto proto_expire_time =
-      google::cloud::internal::ToProtoTimestamp(expire_time);
+  auto expire_timestamp = MakeTimestamp(expire_time);
+  if (!expire_timestamp) return expire_timestamp.status();
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   request.mutable_backup()->set_name(backup.name());
-  *request.mutable_backup()->mutable_expire_time() = proto_expire_time;
+  *request.mutable_backup()->mutable_expire_time() =
+      expire_timestamp->get<protobuf::Timestamp>().value();
   request.mutable_update_mask()->add_paths("expire_time");
   return conn_->UpdateBackup({request});
 }
@@ -168,11 +169,12 @@ StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
 StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
     Backup const& backup,
     std::chrono::system_clock::time_point const& expire_time) {
-  auto proto_expire_time =
-      google::cloud::internal::ToProtoTimestamp(expire_time);
+  auto expire_timestamp = MakeTimestamp(expire_time);
+  if (!expire_timestamp) return expire_timestamp.status();
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   request.mutable_backup()->set_name(backup.FullName());
-  *request.mutable_backup()->mutable_expire_time() = proto_expire_time;
+  *request.mutable_backup()->mutable_expire_time() =
+      expire_timestamp->get<protobuf::Timestamp>().value();
   request.mutable_update_mask()->add_paths("expire_time");
   return conn_->UpdateBackup({request});
 }

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -354,7 +354,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
     auto ts = MakeTimestamp(p.expire_time);
     if (!ts) {
       return google::cloud::make_ready_future(
-          StatusOr<gcsa::Backup>(ts.status()));
+          StatusOr<gcsa::Backup>(std::move(ts).status()));
     }
     *backup.mutable_expire_time() = ts->get<protobuf::Timestamp>().value();
     auto operation = RetryLoop(

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -26,6 +26,7 @@
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+#include <chrono>
 #include <string>
 #include <vector>
 

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -17,13 +17,13 @@
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/testing/cleanup_stale_instances.h"
 #include "google/cloud/spanner/testing/pick_instance_config.h"
+#include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/policies.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/spanner/testing/random_instance_name.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/internal/time_utils.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
@@ -124,7 +124,8 @@ TEST_F(BackupTest, BackupTest) {
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
   auto database = database_admin_client_.CreateDatabase(db).get();
   ASSERT_STATUS_OK(database);
-  auto create_time = internal::ToAbslTime(database->create_time());
+  auto create_time =
+      MakeTimestamp(database->create_time()).value().get<absl::Time>().value();
 
   auto expire_time = MakeTimestamp(create_time + absl::Hours(7)).value();
   auto backup_future = database_admin_client_.CreateBackup(
@@ -163,9 +164,7 @@ TEST_F(BackupTest, BackupTest) {
   auto backup = backup_future.get();
   EXPECT_STATUS_OK(backup);
   if (backup) {
-    EXPECT_EQ(
-        spanner_internal::TimestampFromProto(backup->expire_time()).value(),
-        expire_time);
+    EXPECT_EQ(MakeTimestamp(backup->expire_time()).value(), expire_time);
   }
 
   Backup backup_name(in, db.database_id());
@@ -213,8 +212,7 @@ TEST_F(BackupTest, BackupTest) {
       *backup,
       new_expire_time.get<std::chrono::system_clock::time_point>().value());
   EXPECT_STATUS_OK(updated_backup);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(updated_backup->expire_time())
-                .value(),
+  EXPECT_EQ(MakeTimestamp(updated_backup->expire_time()).value(),
             new_expire_time);
 
   EXPECT_STATUS_OK(database_admin_client_.DeleteBackup(*backup));

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/testing/cleanup_stale_instances.h"
 #include "google/cloud/spanner/testing/pick_instance_config.h"
-#include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/policies.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/spanner/testing/random_instance_name.h"

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -21,8 +21,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "absl/memory/memory.h"
+#include "absl/time/time.h"
 #include <gmock/gmock.h>
-#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -32,10 +32,8 @@ namespace {
 
 using ::testing::UnorderedElementsAreArray;
 
-std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
-MakeTimePoint(std::time_t sec, std::chrono::nanoseconds::rep nanos) {
-  return std::chrono::system_clock::from_time_t(sec) +
-         std::chrono::nanoseconds(nanos);
+absl::Time MakeTime(std::time_t sec, int nanos) {
+  return absl::FromTimeT(sec) + absl::Nanoseconds(nanos);
 }
 
 // A helper function used in the test fixtures below. This function writes the
@@ -189,11 +187,11 @@ TEST_F(DataTypeIntegrationTest, WriteReadTimestamp) {
 
   std::vector<Timestamp> const data = {
       *min,
-      MakeTimestamp(MakeTimePoint(-1, 0)).value(),
-      MakeTimestamp(MakeTimePoint(0, -1)).value(),
-      MakeTimestamp(MakeTimePoint(0, 0)).value(),
-      MakeTimestamp(MakeTimePoint(0, 1)).value(),
-      MakeTimestamp(MakeTimePoint(1, 0)).value(),
+      MakeTimestamp(MakeTime(-1, 0)).value(),
+      MakeTimestamp(MakeTime(0, -1)).value(),
+      MakeTimestamp(MakeTime(0, 0)).value(),
+      MakeTimestamp(MakeTime(0, 1)).value(),
+      MakeTimestamp(MakeTime(1, 0)).value(),
       *now,
       *max,
   };
@@ -299,11 +297,11 @@ TEST_F(DataTypeIntegrationTest, WriteReadArrayBytes) {
 TEST_F(DataTypeIntegrationTest, WriteReadArrayTimestamp) {
   std::vector<std::vector<Timestamp>> const data = {
       std::vector<Timestamp>{},
-      std::vector<Timestamp>{MakeTimestamp(MakeTimePoint(-1, 0)).value()},
+      std::vector<Timestamp>{MakeTimestamp(MakeTime(-1, 0)).value()},
       std::vector<Timestamp>{
-          MakeTimestamp(MakeTimePoint(-1, 0)).value(),
-          MakeTimestamp(MakeTimePoint(0, 0)).value(),
-          MakeTimestamp(MakeTimePoint(1, 0)).value(),
+          MakeTimestamp(MakeTime(-1, 0)).value(),
+          MakeTimestamp(MakeTime(0, 0)).value(),
+          MakeTimestamp(MakeTime(1, 0)).value(),
       },
   };
   auto result = WriteReadData(*client_, data, "ArrayTimestampValue");

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -173,7 +173,8 @@ spanner_proto::CommitResponse MakeCommitResponse(
     spanner::Timestamp commit_timestamp,
     absl::optional<spanner::CommitStats> commit_stats = absl::nullopt) {
   spanner_proto::CommitResponse response;
-  *response.mutable_commit_timestamp() = TimestampToProto(commit_timestamp);
+  *response.mutable_commit_timestamp() =
+      commit_timestamp.get<protobuf::Timestamp>().value();
   if (commit_stats.has_value()) {
     auto* proto_stats = response.mutable_commit_stats();
     proto_stats->set_mutation_count(commit_stats->mutation_count);

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -133,8 +133,7 @@ ResultSet Client::Read(SessionHolder& session,
     if (selector->begin().has_read_only() &&
         selector->begin().read_only().has_read_timestamp()) {
       auto const& proto = selector->begin().read_only().read_timestamp();
-      if (spanner_internal::TimestampFromProto(proto).value() ==
-              read_timestamp_ &&
+      if (spanner::MakeTimestamp(proto).value() == read_timestamp_ &&
           seqno > 0) {
         std::unique_lock<std::mutex> lock(mu_);
         switch (mode_) {

--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -31,8 +31,7 @@ absl::optional<Timestamp> GetReadTimestamp(
   absl::optional<Timestamp> timestamp;
   if (metadata.has_value() && metadata->has_transaction() &&
       metadata->transaction().has_read_timestamp()) {
-    auto ts = spanner_internal::TimestampFromProto(
-        metadata->transaction().read_timestamp());
+    auto ts = MakeTimestamp(metadata->transaction().read_timestamp());
     if (ts) timestamp = *std::move(ts);
   }
   return timestamp;

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -144,7 +144,7 @@ TEST(RowStream, TimestampPresent) {
   transaction_with_timestamp.mutable_transaction()->set_id("dummy2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
-      spanner_internal::TimestampToProto(timestamp);
+      timestamp.get<protobuf::Timestamp>().value();
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_with_timestamp));
 
@@ -158,7 +158,7 @@ TEST(ProfileQueryResult, TimestampPresent) {
   transaction_with_timestamp.mutable_transaction()->set_id("dummy2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
-      spanner_internal::TimestampToProto(timestamp);
+      timestamp.get<protobuf::Timestamp>().value();
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_with_timestamp));
 

--- a/google/cloud/spanner/timestamp.h
+++ b/google/cloud/spanner/timestamp.h
@@ -112,6 +112,9 @@ class Timestamp {
    */
   template <typename T>
   StatusOr<T> get() const {
+    // All `ConvertTo()` overloads return a `StatusOr<T>` even when they
+    // cannot actually fail (e.g., when the destination type can represent
+    // all `Timestamp` values). See individual comments below.
     return ConvertTo(T{});
   }
 

--- a/google/cloud/spanner/timestamp.h
+++ b/google/cloud/spanner/timestamp.h
@@ -94,11 +94,13 @@ class Timestamp {
    * `*this` cannot be represented as a `T`.
    *
    * Supported destination types are:
-   *   - `google::cloud::spanner::sys_time<Duration>` - `Duration::rep` may not
-   *      be wider than `std::int64_t`, and `Duration::period` may be no more
-   *      precise than `std::nano`.
    *   - `absl::Time` - Since `absl::Time` can represent all possible
    *     `Timestamp` values, `get<absl::Time>()` never returns an error.
+   *   - `google::protobuf::Timestamp` - Never returns an error, but any
+   *     sub-nanosecond precision will be lost.
+   *   - `google::cloud::spanner::sys_time<Duration>` - `Duration::rep` may
+   *     not be wider than `std::int64_t`, and `Duration::period` may be no
+   *     more precise than `std::nano`.
    *
    * @par Example
    *
@@ -140,6 +142,10 @@ class Timestamp {
   // Conversion to an `absl::Time`. Can never fail.
   StatusOr<absl::Time> ConvertTo(absl::Time) const { return t_; }
 
+  // Conversion to a `google::protobuf::Timestamp`. Can never fail, but
+  // any sub-nanosecond precision will be lost.
+  StatusOr<protobuf::Timestamp> ConvertTo(protobuf::Timestamp const&) const;
+
   explicit Timestamp(absl::Time t) : t_(t) {}
 
   absl::Time t_;
@@ -151,6 +157,13 @@ class Timestamp {
  * class comments above).
  */
 StatusOr<Timestamp> MakeTimestamp(absl::Time);
+
+/**
+ * Construct a `Timestamp` from a `google::protobuf::Timestamp`. May produce
+ * out-of-range errors if the given protobuf is beyond the range supported by
+ * `Timestamp` (which a valid protobuf never will).
+ */
+StatusOr<Timestamp> MakeTimestamp(protobuf::Timestamp const&);
 
 /**
  * Construct a `Timestamp` from a `std::chrono::time_point` on the system
@@ -188,8 +201,6 @@ namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 StatusOr<spanner::Timestamp> TimestampFromRFC3339(std::string const&);
 std::string TimestampToRFC3339(spanner::Timestamp);
-StatusOr<spanner::Timestamp> TimestampFromProto(protobuf::Timestamp const&);
-protobuf::Timestamp TimestampToProto(spanner::Timestamp);
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal
 

--- a/google/cloud/spanner/timestamp_test.cc
+++ b/google/cloud/spanner/timestamp_test.cc
@@ -48,9 +48,12 @@ google::protobuf::Timestamp MakeProtoTimestamp(std::int64_t seconds,
   return proto;
 }
 
+Timestamp MakeSpannerTimestamp(std::int64_t seconds, std::int32_t nanos) {
+  return MakeTimestamp(MakeProtoTimestamp(seconds, nanos)).value();
+}
+
 TEST(Timestamp, RegularSemantics) {
-  Timestamp const ts =
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(0, 0)).value();
+  Timestamp const ts = MakeSpannerTimestamp(0, 0);
 
   Timestamp const copy1(ts);
   EXPECT_EQ(copy1, ts);
@@ -64,198 +67,115 @@ TEST(Timestamp, RegularSemantics) {
 }
 
 TEST(Timestamp, RelationalOperators) {
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
-  EXPECT_LE(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
-  EXPECT_GE(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
+  EXPECT_EQ(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_LE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_GE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
 
-  EXPECT_NE(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422668))
-                .value());
-  EXPECT_LT(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422668))
-                .value());
-  EXPECT_NE(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030525, 611422667))
-                .value());
-  EXPECT_LT(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030525, 611422667))
-                .value());
+  EXPECT_NE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422668));
+  EXPECT_LT(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422668));
+  EXPECT_NE(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030525, 611422667));
+  EXPECT_LT(MakeSpannerTimestamp(1576030524, 611422667),
+            MakeSpannerTimestamp(1576030525, 611422667));
 
-  EXPECT_NE(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422668))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
-  EXPECT_GT(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422668))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
-  EXPECT_NE(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030525, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
-  EXPECT_GT(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030525, 611422667))
-                .value(),
-            spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1576030524, 611422667))
-                .value());
+  EXPECT_NE(MakeSpannerTimestamp(1576030524, 611422668),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_GT(MakeSpannerTimestamp(1576030524, 611422668),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_NE(MakeSpannerTimestamp(1576030525, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
+  EXPECT_GT(MakeSpannerTimestamp(1576030525, 611422667),
+            MakeSpannerTimestamp(1576030524, 611422667));
 }
 
 TEST(Timestamp, OutputStreaming) {
   std::ostringstream os;
-  os << spanner_internal::TimestampFromProto(
-            MakeProtoTimestamp(1561135942, 123456789))
-            .value();
+  os << MakeSpannerTimestamp(1561135942, 123456789);
   EXPECT_EQ("2019-06-21T16:52:22.123456789Z", os.str());
 }
 
 TEST(Timestamp, FromRFC3339) {
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 0))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 0),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22Z").value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 9))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 9),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000009Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 89))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 89),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000089Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000000789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1561135942, 6789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 6789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000006789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 56789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 56789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000056789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 456789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 456789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.000456789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 3456789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 3456789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.003456789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 23456789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 23456789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.023456789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 123456789))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 123456789),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456789Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 123456780))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 123456780),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345678Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 123456700))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 123456700),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234567Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 123456000))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 123456000),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.123456Z")
           .value());
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123450000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 123450000),
             spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.12345Z")
                 .value());
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123400000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 123400000),
             spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.1234Z")
                 .value());
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 123000000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 123000000),
             spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.123Z")
                 .value());
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1561135942, 120000000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(1561135942, 120000000),
             spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.12Z")
                 .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(1561135942, 100000000))
-          .value(),
+      MakeSpannerTimestamp(1561135942, 100000000),
       spanner_internal::TimestampFromRFC3339("2019-06-21T16:52:22.1Z").value());
 }
 
 TEST(Timestamp, FromRFC3339Offset) {
-  EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(1546398245, 0))
-          .value(),
-      spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05+00:00")
-          .value());
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1546398245 + 3600 + 120, 0))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(1546398245, 0),
+            spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05+00:00")
+                .value());
+  EXPECT_EQ(MakeSpannerTimestamp(1546398245 + 3600 + 120, 0),
             spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05-01:02")
                 .value());
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(1546398245 - 3600 - 120, 0))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(1546398245 - 3600 - 120, 0),
             spanner_internal::TimestampFromRFC3339("2019-01-02T03:04:05+01:02")
                 .value());
 }
@@ -286,14 +206,11 @@ TEST(Timestamp, FromRFC3339Failure) {
 TEST(Timestamp, FromRFC3339Limit) {
   // Verify Spanner range requirements.
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0))
-          .value(),
+      MakeSpannerTimestamp(-62135596800, 0),
       spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z")
           .value());
   EXPECT_EQ(
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(253402300799, 999999999))
-          .value(),
+      MakeSpannerTimestamp(253402300799, 999999999),
       spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
           .value());
 
@@ -307,129 +224,85 @@ TEST(Timestamp, FromRFC3339Limit) {
 
 TEST(Timestamp, ToRFC3339) {
   EXPECT_EQ("2019-06-21T16:52:22Z", spanner_internal::TimestampToRFC3339(
-                                        spanner_internal::TimestampFromProto(
-                                            MakeProtoTimestamp(1561135942, 0))
-                                            .value()));
+                                        MakeSpannerTimestamp(1561135942, 0)));
   EXPECT_EQ("2019-06-21T16:52:22.000000009Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 9))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 9)));
   EXPECT_EQ("2019-06-21T16:52:22.000000089Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 89))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 89)));
   EXPECT_EQ("2019-06-21T16:52:22.000000789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 789)));
   EXPECT_EQ("2019-06-21T16:52:22.000006789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 6789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 6789)));
   EXPECT_EQ("2019-06-21T16:52:22.000056789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 56789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 56789)));
   EXPECT_EQ("2019-06-21T16:52:22.000456789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 456789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 456789)));
   EXPECT_EQ("2019-06-21T16:52:22.003456789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 3456789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 3456789)));
   EXPECT_EQ("2019-06-21T16:52:22.023456789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 23456789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 23456789)));
   EXPECT_EQ("2019-06-21T16:52:22.123456789Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123456789))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123456789)));
   EXPECT_EQ("2019-06-21T16:52:22.12345678Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123456780))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123456780)));
   EXPECT_EQ("2019-06-21T16:52:22.1234567Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123456700))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123456700)));
   EXPECT_EQ("2019-06-21T16:52:22.123456Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123456000))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123456000)));
   EXPECT_EQ("2019-06-21T16:52:22.12345Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123450000))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123450000)));
   EXPECT_EQ("2019-06-21T16:52:22.1234Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123400000))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123400000)));
   EXPECT_EQ("2019-06-21T16:52:22.123Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 123000000))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 123000000)));
   EXPECT_EQ("2019-06-21T16:52:22.12Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 120000000))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 120000000)));
   EXPECT_EQ("2019-06-21T16:52:22.1Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(1561135942, 100000000))
-                    .value()));
+                MakeSpannerTimestamp(1561135942, 100000000)));
 }
 
 TEST(Timestamp, ToRFC3339Limit) {
   // Spanner range requirements.
   EXPECT_EQ("0001-01-01T00:00:00Z", spanner_internal::TimestampToRFC3339(
-                                        spanner_internal::TimestampFromProto(
-                                            MakeProtoTimestamp(-62135596800, 0))
-                                            .value()));
+                                        MakeSpannerTimestamp(-62135596800, 0)));
   EXPECT_EQ("9999-12-31T23:59:59.999999999Z",
             spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(
-                    MakeProtoTimestamp(253402300799, 999999999))
-                    .value()));
+                MakeSpannerTimestamp(253402300799, 999999999)));
 }
 
 TEST(Timestamp, FromProto) {
   auto proto = MakeProtoTimestamp(0, 0);
   EXPECT_EQ("1970-01-01T00:00:00Z",
-            spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 
   proto = MakeProtoTimestamp(1576030524, 611422667);
   EXPECT_EQ("2019-12-11T02:15:24.611422667Z",
-            spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 
   proto = MakeProtoTimestamp(-62135596800, 0);
   EXPECT_EQ("0001-01-01T00:00:00Z",
-            spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 
   proto = MakeProtoTimestamp(253402300799, 999999999);
   EXPECT_EQ("9999-12-31T23:59:59.999999999Z",
-            spanner_internal::TimestampToRFC3339(
-                spanner_internal::TimestampFromProto(proto).value()));
+            spanner_internal::TimestampToRFC3339(MakeTimestamp(proto).value()));
 }
 
 TEST(Timestamp, FromProtoLimit) {
@@ -438,38 +311,43 @@ TEST(Timestamp, FromProtoLimit) {
   // Note: These values can be computed with `date +%s --date="YYYY-MM-...Z"`
   EXPECT_EQ(
       spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00Z").value(),
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-62135596800, 0))
-          .value());
+      MakeSpannerTimestamp(-62135596800, 0));
   EXPECT_EQ(
       spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
           .value(),
-      spanner_internal::TimestampFromProto(
-          MakeProtoTimestamp(253402300799, 999999999))
-          .value());
+      MakeSpannerTimestamp(253402300799, 999999999));
 }
 
 TEST(Timestamp, ToProto) {
-  auto proto = spanner_internal::TimestampToProto(
+  auto proto =
       spanner_internal::TimestampFromRFC3339("1970-01-01T00:00:00.000000000Z")
-          .value());
+          .value()
+          .get<google::protobuf::Timestamp>()
+          .value();
   EXPECT_EQ(0, proto.seconds());
   EXPECT_EQ(0, proto.nanos());
 
-  proto = spanner_internal::TimestampToProto(
+  proto =
       spanner_internal::TimestampFromRFC3339("2019-12-11T02:15:24.611422667Z")
-          .value());
+          .value()
+          .get<google::protobuf::Timestamp>()
+          .value();
   EXPECT_EQ(1576030524, proto.seconds());
   EXPECT_EQ(611422667, proto.nanos());
 
-  proto = spanner_internal::TimestampToProto(
+  proto =
       spanner_internal::TimestampFromRFC3339("0001-01-01T00:00:00.000000000Z")
-          .value());
+          .value()
+          .get<google::protobuf::Timestamp>()
+          .value();
   EXPECT_EQ(-62135596800, proto.seconds());
   EXPECT_EQ(0, proto.nanos());
 
-  proto = spanner_internal::TimestampToProto(
+  proto =
       spanner_internal::TimestampFromRFC3339("9999-12-31T23:59:59.999999999Z")
-          .value());
+          .value()
+          .get<google::protobuf::Timestamp>()
+          .value();
   EXPECT_EQ(253402300799, proto.seconds());
   EXPECT_EQ(999999999, proto.nanos());
 }
@@ -477,50 +355,36 @@ TEST(Timestamp, ToProto) {
 TEST(Timestamp, FromChrono) {  // i.e., MakeTimestamp(sys_time<Duration>)
   auto const tp1 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(2123456789, 123456789))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789, 123456789),
             MakeTimestamp(tp1).value());
 
   auto const tp2 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::microseconds(123456);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(2123456789, 123456000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789, 123456000),
             MakeTimestamp(tp2).value());
 
   auto const tp3 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::milliseconds(123);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(2123456789, 123000000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789, 123000000),
             MakeTimestamp(tp3).value());
 
   auto const tp4 = kUnixEpoch + std::chrono::minutes(2123456789);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(2123456789LL * 60, 0))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(2123456789LL * 60, 0),
             MakeTimestamp(tp4).value());
 
   auto const tp5 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(-2123456789, 123456789))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(-2123456789, 123456789),
             MakeTimestamp(tp5).value());
 
   auto const tp6 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::microseconds(123456);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(-2123456789, 123456000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(-2123456789, 123456000),
             MakeTimestamp(tp6).value());
 
   auto const tp7 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::milliseconds(123);
-  EXPECT_EQ(spanner_internal::TimestampFromProto(
-                MakeProtoTimestamp(-2123456789, 123000000))
-                .value(),
+  EXPECT_EQ(MakeSpannerTimestamp(-2123456789, 123000000),
             MakeTimestamp(tp7).value());
 }
 
@@ -540,9 +404,7 @@ TEST(Timestamp, FromChronoOverflow) {
 }
 
 TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
-  auto const ts_pos = spanner_internal::TimestampFromProto(
-                          MakeProtoTimestamp(2123456789, 123456789))
-                          .value();
+  auto const ts_pos = MakeSpannerTimestamp(2123456789, 123456789);
 
   auto const tp1 = kUnixEpoch + std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
@@ -562,9 +424,7 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
   auto const tp5 = kUnixEpoch + std::chrono::hours(2123456789 / 60 / 60);
   EXPECT_EQ(tp5, ts_pos.get<sys_time<std::chrono::hours>>().value());
 
-  auto const ts_neg = spanner_internal::TimestampFromProto(
-                          MakeProtoTimestamp(-2123456789, 123456789))
-                          .value();
+  auto const ts_neg = MakeSpannerTimestamp(-2123456789, 123456789);
 
   auto const tp6 = kUnixEpoch - std::chrono::seconds(2123456789) +
                    std::chrono::nanoseconds(123456789);
@@ -589,25 +449,19 @@ TEST(Timestamp, ToChrono) {  // i.e., Timestamp::get<sys_time<Duration>>()
 
   // The limit of a 64-bit count of nanoseconds (assuming the system_clock
   // epoch is the Unix epoch).
-  auto const ts11 = spanner_internal::TimestampFromProto(
-                        MakeProtoTimestamp(9223372036, 854775807))
-                        .value();
+  auto const ts11 = MakeSpannerTimestamp(9223372036, 854775807);
   auto const tp11 = kUnixEpoch + std::chrono::seconds(9223372036) +
                     std::chrono::nanoseconds(854775807);
   EXPECT_EQ(tp11, ts11.get<sys_time<std::chrono::nanoseconds>>().value());
 }
 
 TEST(Timestamp, ToChronoOverflow) {
-  auto const ts1 =
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(20000000000, 0))
-          .value();
+  auto const ts1 = MakeSpannerTimestamp(20000000000, 0);
   auto const tp1 = ts1.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp1,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
 
-  auto const ts2 =
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-20000000000, 0))
-          .value();
+  auto const ts2 = MakeSpannerTimestamp(-20000000000, 0);
   auto const tp2 = ts2.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp2,
               StatusIs(Not(StatusCode::kOk), HasSubstr("negative overflow")));
@@ -615,9 +469,7 @@ TEST(Timestamp, ToChronoOverflow) {
   // One beyond the limit of a 64-bit count of nanoseconds (assuming the
   // system_clock epoch is the Unix epoch). This overflow is detected in a
   // different code path to the "positive overflow" above.
-  auto const ts3 = spanner_internal::TimestampFromProto(
-                       MakeProtoTimestamp(9223372036, 854775808))
-                       .value();
+  auto const ts3 = MakeSpannerTimestamp(9223372036, 854775808);
   auto const tp3 = ts3.get<sys_time<std::chrono::nanoseconds>>();
   EXPECT_THAT(tp3,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
@@ -625,21 +477,18 @@ TEST(Timestamp, ToChronoOverflow) {
   // Uses a small duration (8-bits of seconds) to clearly demonstrate that we
   // detect potential overflow into the Duration's rep.
   using Sec8Bit = std::chrono::duration<std::int8_t, std::ratio<1>>;
-  auto const ts4 =
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(127, 0)).value();
+  auto const ts4 = MakeSpannerTimestamp(127, 0);
   auto const tp4 = ts4.get<sys_time<Sec8Bit>>();
   EXPECT_TRUE(tp4);  // An in-range value succeeds.
 
   // One beyond the capacity for (signed) 8-bits of seconds would overflow.
-  auto const ts5 =
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(128, 0)).value();
+  auto const ts5 = MakeSpannerTimestamp(128, 0);
   auto const tp5 = ts5.get<sys_time<Sec8Bit>>();
   EXPECT_THAT(tp5,
               StatusIs(Not(StatusCode::kOk), HasSubstr("positive overflow")));
 
   // One less than the capacity for (signed) 8-bits of seconds would overflow.
-  auto const ts6 =
-      spanner_internal::TimestampFromProto(MakeProtoTimestamp(-129, 0)).value();
+  auto const ts6 = MakeSpannerTimestamp(-129, 0);
   auto const tp6 = ts6.get<sys_time<Sec8Bit>>();
   EXPECT_THAT(tp6,
               StatusIs(Not(StatusCode::kOk), HasSubstr("negative overflow")));
@@ -673,7 +522,7 @@ TEST(Timestamp, AbslTimeRoundTrip) {  // i.e., `MakeTimestamp(absl::Time)`
   for (auto const& tc : round_trip_cases) {
     SCOPED_TRACE("Time: " + absl::FormatTime(tc.t));
     auto const ts = MakeTimestamp(tc.t).value();
-    EXPECT_EQ(ts, spanner_internal::TimestampFromProto(tc.proto).value());
+    EXPECT_EQ(ts, MakeTimestamp(tc.proto).value());
     auto const t = ts.get<absl::Time>().value();
     EXPECT_EQ(t, tc.t);
   }

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -57,7 +57,7 @@ Transaction::ReadOnlyOptions::ReadOnlyOptions() {
 
 Transaction::ReadOnlyOptions::ReadOnlyOptions(Timestamp read_timestamp) {
   *ro_opts_.mutable_read_timestamp() =
-      spanner_internal::TimestampToProto(read_timestamp);
+      read_timestamp.get<protobuf::Timestamp>().value();
   ro_opts_.set_return_read_timestamp(true);
 }
 
@@ -75,7 +75,7 @@ Transaction::SingleUseOptions::SingleUseOptions(ReadOnlyOptions opts) {
 
 Transaction::SingleUseOptions::SingleUseOptions(Timestamp min_read_timestamp) {
   *ro_opts_.mutable_min_read_timestamp() =
-      spanner_internal::TimestampToProto(min_read_timestamp);
+      min_read_timestamp.get<protobuf::Timestamp>().value();
   ro_opts_.set_return_read_timestamp(true);
 }
 

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -33,6 +33,7 @@ struct TransactionInternals;
 
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 /**
  * The representation of a Cloud Spanner transaction.
  *

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -16,10 +16,10 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/time/time.h"
 #include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
-#include <chrono>
 #include <cmath>
 #include <ios>
 #include <limits>
@@ -39,10 +39,8 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
 using ::testing::Not;
 
-std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
-MakeTimePoint(std::time_t sec, std::chrono::nanoseconds::rep nanos) {
-  return std::chrono::system_clock::from_time_t(sec) +
-         std::chrono::nanoseconds(nanos);
+absl::Time MakeTime(std::time_t sec, int nanos) {
+  return absl::FromTimeT(sec) + absl::Nanoseconds(nanos);
 }
 
 template <typename T>
@@ -170,7 +168,7 @@ TEST(Value, BasicSemantics) {
            9223372036LL     // near the limit of 64-bit/ns system_clock
        }) {
     for (auto nanos : {-1, 0, 1}) {
-      auto ts = MakeTimestamp(MakeTimePoint(t, nanos)).value();
+      auto ts = MakeTimestamp(MakeTime(t, nanos)).value();
       SCOPED_TRACE("Testing: google::cloud::spanner::Timestamp " +
                    spanner_internal::TimestampToRFC3339(ts));
       TestBasicSemantics(ts);
@@ -697,7 +695,7 @@ TEST(Value, ProtoConversionTimestamp) {
            9223372036LL     // near the limit of 64-bit/ns system_clock
        }) {
     for (auto nanos : {-1, 0, 1}) {
-      auto ts = MakeTimestamp(MakeTimePoint(t, nanos)).value();
+      auto ts = MakeTimestamp(MakeTime(t, nanos)).value();
       Value const v(ts);
       auto const p = spanner_internal::ToProto(v);
       EXPECT_EQ(v, spanner_internal::FromProto(p.first, p.second));
@@ -1229,7 +1227,7 @@ TEST(Value, OutputStreamMatchesT) {
 
   // Timestamp
   StreamMatchesValueStream(Timestamp());
-  StreamMatchesValueStream(MakeTimestamp(MakeTimePoint(1, 1)).value());
+  StreamMatchesValueStream(MakeTimestamp(MakeTime(1, 1)).value());
 
   // std::vector<T>
   // Not included, because a raw vector cannot be streamed.


### PR DESCRIPTION
… (#5851)

`spanner::Timestamp` and `protobuf::Timestamp` are fundamental parts
of the Spanner admin API (and will be even more so with the introduction
of PITR), but there was no mechanism provided to the user for converting
between them.

So, `internal::TimestampFromProto()` and `internal::TimestampToProto()`
are here refactored as `spanner::MakeTimestamp(protobuf::Timestamp)`
and `spanner::Timestamp::get<protobuf::Timestamp>()` respectively.

This means Spanner no longer depends on the "internal/time_utils.h"
grab bag. Time arithmetic is done using `absl::Time`, and expectations
in tests are checked using `spanner::Timestamp`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5876)
<!-- Reviewable:end -->
