### PR TITLE
chore(spanner): fully qualify google::protobuf::util names

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -943,7 +943,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
     // successful so we cannot indicate an error. This should not happen,
     // but if it does we set r.commit_timestamp to its maximal value.
     protobuf::Timestamp proto;
-    proto.set_seconds(protobuf::util::TimeUtil::kTimestampMaxSeconds);
+    proto.set_seconds(google::protobuf::util::TimeUtil::kTimestampMaxSeconds);
     proto.set_nanos(999999999);
     timestamp = spanner::MakeTimestamp(proto);
   }

--- a/google/cloud/spanner/timestamp.cc
+++ b/google/cloud/spanner/timestamp.cc
@@ -42,9 +42,9 @@ StatusOr<protobuf::Timestamp> Timestamp::ConvertTo(
     protobuf::Timestamp const&) const {
   auto constexpr kDestType = "google::protobuf::Timestamp";
   auto const s = absl::ToUnixSeconds(t_);
-  if (s > protobuf::util::TimeUtil::kTimestampMaxSeconds)
+  if (s > google::protobuf::util::TimeUtil::kTimestampMaxSeconds)
     return PositiveOverflow(kDestType);
-  if (s < protobuf::util::TimeUtil::kTimestampMinSeconds)
+  if (s < google::protobuf::util::TimeUtil::kTimestampMinSeconds)
     return NegativeOverflow(kDestType);
   auto const ns = absl::ToInt64Nanoseconds(t_ - absl::FromUnixSeconds(s));
   google::protobuf::Timestamp proto;
@@ -66,10 +66,10 @@ StatusOr<std::int64_t> Timestamp::ToRatio(std::int64_t min, std::int64_t max,
 
 StatusOr<Timestamp> MakeTimestamp(absl::Time t) {
   auto constexpr kDestType = "google::cloud::spanner::Timestamp";
-  auto constexpr kMinTime =
-      absl::FromUnixSeconds(protobuf::util::TimeUtil::kTimestampMinSeconds);
-  auto constexpr kMaxTime =
-      absl::FromUnixSeconds(protobuf::util::TimeUtil::kTimestampMaxSeconds + 1);
+  auto constexpr kMinTime = absl::FromUnixSeconds(
+      google::protobuf::util::TimeUtil::kTimestampMinSeconds);
+  auto constexpr kMaxTime = absl::FromUnixSeconds(
+      google::protobuf::util::TimeUtil::kTimestampMaxSeconds + 1);
   if (t >= kMaxTime) return PositiveOverflow(kDestType);
   if (t < kMinTime) return NegativeOverflow(kDestType);
   return Timestamp(t);


### PR DESCRIPTION
The `protobuf::util::TimeUtil` names introduced in #5876 need
to be qualified with `google` to satisfy the requirements of
some existing, downstream name mangling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5880)
<!-- Reviewable:end -->
