### PR TITLE
ci: prefer curl which is avail by default more often

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -31,13 +31,14 @@ readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" |
 readonly BAZEL_VERSION="${GOOGLE_CLOUD_CPP_BAZEL_VERSION}"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
-wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
-wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
+readonly SCRIPT_HASH="${SCRIPT_NAME}.sha256"
+curl -L "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}" -o "${SCRIPT_NAME}"
+curl -L "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_HASH}" -o "${SCRIPT_HASH}"
 
 # We want to protect against accidents (i.e., we don't want to download and
 # execute a 404 page), not malice, so downloading the checksum and the file
 # from the same source is Okay.
-sha256sum --check "${SCRIPT_NAME}.sha256"
+sha256sum --check "${SCRIPT_HASH}"
 
 chmod +x "${SCRIPT_NAME}"
 if [[ "${USER:-}" = "root" ]] || [[ "${USER+x}" = "" ]]; then

--- a/ci/install-cloud-sdk.sh
+++ b/ci/install-cloud-sdk.sh
@@ -20,7 +20,7 @@ source "$(dirname "$0")/etc/install-config.sh"
 
 readonly SITE="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads"
 readonly TARBALL="google-cloud-sdk-${GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"
-wget -q "${SITE}/${TARBALL}"
+curl -L "${SITE}/${TARBALL}" -o "${TARBALL}"
 
 echo "${GOOGLE_CLOUD_CPP_SDK_SHA256} ${TARBALL}" | sha256sum --check -
 tar x -C /usr/local -f "${TARBALL}"


### PR DESCRIPTION
Curl seems to be more commonly available on default installs of
operating systems, including macOS, so it's nice to prefer curl rather
than wget so we can avoid the user having to install wget when we could
have used curl.

Note: most of our CI scripts were already depending on curl, so this
shouldn't introduce a new dep, rather I think it should remove a dep.

Also, I'm not using the "--silent" option because I think the download progress info may be useful. But if others disagree and think this should be silent, I can change to that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5882)
<!-- Reviewable:end -->
