### PR TITLE
ci: use x86_64 bazel package on macOS M1

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -25,8 +25,15 @@ if [[ -z "${PROJECT_ROOT+x}" ]]; then
 fi
 source "${PROJECT_ROOT}/ci/etc/install-config.sh"
 
-readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" |
-  tr '[:upper:]' '[:lower:]')
+readonly KERNEL="$(uname -s | tr '[:upper:]' '[:lower:]')"
+MACHINE="$(uname -m)"
+if [[ "${KERNEL}" = "darwin" ]]; then
+  # Bazel currently doesn't offer a darwin + arm package, but the x86_64
+  # package works.
+  MACHINE="x86_64"
+fi
+readonly MACHINE
+readonly PLATFORM="${KERNEL}-${MACHINE}"
 
 readonly BAZEL_VERSION="${GOOGLE_CLOUD_CPP_BAZEL_VERSION}"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"


### PR DESCRIPTION
Bazel doesn't (yet?) offer a darwin + arm64 package, but the x86_64
package works fine emulated.

Fixes https://github.com/googleapis/google-cloud-cpp/issues/5878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5884)
<!-- Reviewable:end -->
