### PR TITLE
test(spanner): support filtering of `PickRandomInstance()` candidates

### DIFF
--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -13,37 +13,56 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/pick_random_instance.h"
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/internal/getenv.h"
+#include <vector>
 
 namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
+
 StatusOr<std::string> PickRandomInstance(
     google::cloud::internal::DefaultPRNG& generator,
-    std::string const& project_id) {
+    std::string const& project_id, std::string const& filter,
+    std::function<bool(
+        google::spanner::admin::instance::v1::Instance const&,
+        google::spanner::admin::instance::v1::InstanceConfig const&)> const&
+        predicate) {
   spanner::InstanceAdminClient client(spanner::MakeInstanceAdminConnection());
 
-  /**
-   * We started to have integration tests for InstanceAdminClient which creates
-   * and deletes temporary instances. If we pick one of those instances here,
-   * the following tests will fail after the deletion.
-   * InstanceAdminClient's integration tests are using instances prefixed with
-   * "temporary-instances-", so we only pick instances prefixed with
-   * "test-instance-" here for isolation.
-   */
+  std::vector<google::spanner::admin::instance::v1::InstanceConfig> configs;
+  if (predicate) {
+    // Fetch the instance configurations for use in the callback.
+    for (auto& config : client.ListInstanceConfigs(project_id)) {
+      if (!config) return std::move(config).status();
+      configs.push_back(*std::move(config));
+    }
+  }
+
+  // We only pick instance IDs starting with "test-instance-" for isolation
+  // from tests that create/delete their own instances (in particular from
+  // tests calling `RandomInstanceName()`, which uses "temporary-instance-").
+  auto const instance_prefix = "projects/" + project_id + "/instances/";
+  auto const name_filter = " name:" + instance_prefix + "test-instance-";
+
   std::vector<std::string> instance_ids;
-  for (auto& instance : client.ListInstances(project_id, "")) {
+  for (auto& instance :
+       client.ListInstances(project_id, filter + name_filter)) {
     if (!instance) return std::move(instance).status();
-    auto name = instance->name();
-    std::string const sep = "/instances/";
-    std::string const valid_instance_name = sep + "test-instance-";
-    auto pos = name.rfind(valid_instance_name);
-    if (pos != std::string::npos) {
-      instance_ids.push_back(name.substr(pos + sep.size()));
+    auto instance_id = instance->name().substr(instance_prefix.size());
+    if (!predicate) {
+      instance_ids.push_back(instance_id);
+    } else {
+      for (auto const& config : configs) {
+        if (instance->config() == config.name()) {
+          if (predicate(*instance, config)) {
+            instance_ids.push_back(instance_id);
+          }
+          break;
+        }
+      }
     }
   }
 
@@ -65,8 +84,9 @@ StatusOr<std::string> PickRandomInstance(
       }
     }
   }
+
   if (instance_ids.empty()) {
-    return Status(StatusCode::kInternal, "No available instances for test");
+    return Status(StatusCode::kUnavailable, "No available instances");
   }
 
   auto random_index =

--- a/google/cloud/spanner/testing/pick_random_instance.h
+++ b/google/cloud/spanner/testing/pick_random_instance.h
@@ -27,6 +27,10 @@ namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
+using InstancePredicate = std::function<bool(
+    google::spanner::admin::instance::v1::Instance const&,
+    google::spanner::admin::instance::v1::InstanceConfig const&)>;
+
 /**
  * Select one of the instances in @p project_id to run tests on.
  *
@@ -36,10 +40,7 @@ inline namespace SPANNER_CLIENT_NS {
 StatusOr<std::string> PickRandomInstance(
     google::cloud::internal::DefaultPRNG& generator,
     std::string const& project_id, std::string const& filter = "",
-    std::function<bool(
-        google::spanner::admin::instance::v1::Instance const&,
-        google::spanner::admin::instance::v1::InstanceConfig const&)> const&
-        predicate = nullptr);
+    InstancePredicate predicate = nullptr);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_testing

--- a/google/cloud/spanner/testing/pick_random_instance.h
+++ b/google/cloud/spanner/testing/pick_random_instance.h
@@ -18,16 +18,28 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/status_or.h"
+#include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
+#include <functional>
 #include <string>
 
 namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
-/// Select one of the instances in @p project_id to run the tests on.
+
+/**
+ * Select one of the instances in @p project_id to run tests on.
+ *
+ * Only returns instances that match the @p filter and satisfy the
+ * @p predicate.
+ */
 StatusOr<std::string> PickRandomInstance(
     google::cloud::internal::DefaultPRNG& generator,
-    std::string const& project_id);
+    std::string const& project_id, std::string const& filter = "",
+    std::function<bool(
+        google::spanner::admin::instance::v1::Instance const&,
+        google::spanner::admin::instance::v1::InstanceConfig const&)> const&
+        predicate = nullptr);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_testing


### PR DESCRIPTION
Support filtering of `PickRandomInstance()` candidates (1) on the server
side, by exposing the `ListInstances` filter, and (2) on the client side,
via a predicate over `Instance` and `InstanceConfig`.

This will be needed to support the upcoming CMEK integration tests (at
least in their current configuration), where the selected instance must
be in the single location we use to store the encryption keys.

Also use server-side filtering to implement the restriction of instance
IDs to "test-instance-*".

Fixes #5588.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5885)
<!-- Reviewable:end -->
