### PR TITLE
fix(generator): properly escape delimiter character

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.gcpcxx.pb.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.gcpcxx.pb.h
@@ -140,11 +140,11 @@ class GoldenKitchenSinkClient {
    *  The permission `logging.logEntries.create` is needed on each project,
    *  organization, billing account, or folder that is receiving new log
    *  entries, whether the resource is specified in `logName` or in an
-   *  individual log entry.
+   *  individual log entry. $Test delimiter.
    * @param labels  Optional. Default labels that are added to the `labels` field of all log
    *  entries in `entries`. If a log entry already has a label with the same key
    *  as a label in this parameter, then the log entry's label is not changed.
-   *  See [LogEntry][google.logging.v2.LogEntry].
+   *  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
    * @return [::google::test::admin::database::v1::WriteLogEntriesResponse](https://github.com/googleapis/googleapis/blob/59f97e6044a1275f83427ab7962a154c00d915b5/generator/integration_tests/test.proto#L928)
    */
   StatusOr<::google::test::admin::database::v1::WriteLogEntriesResponse>

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -909,7 +909,7 @@ message WriteLogEntriesRequest {
   // The permission `logging.logEntries.create` is needed on each project,
   // organization, billing account, or folder that is receiving new log
   // entries, whether the resource is specified in `logName` or in an
-  // individual log entry.
+  // individual log entry. $Test delimiter.
   string log_name = 1 [
     (google.api.field_behavior) = OPTIONAL,
     (google.api.resource_reference) = {
@@ -920,7 +920,7 @@ message WriteLogEntriesRequest {
   // Optional. Default labels that are added to the `labels` field of all log
   // entries in `entries`. If a log entry already has a label with the same key
   // as a label in this parameter, then the log entry's label is not changed.
-  // See [LogEntry][google.logging.v2.LogEntry].
+  // See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   map<string, string> labels = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -149,7 +149,7 @@ Status ClientGenerator::GenerateHeader() {
         {MethodPattern(
              {
                  {FormatMethodCommentsFromRpcComments(
-                     method, MethodParameterStyle::kProtobufReqeust)},
+                     method, MethodParameterStyle::kProtobufRequest)},
                  {IsResponseTypeEmpty,
                   // clang-format off
     "  Status\n",
@@ -163,7 +163,7 @@ Status ClientGenerator::GenerateHeader() {
          MethodPattern(
              {
                  {FormatMethodCommentsFromRpcComments(
-                     method, MethodParameterStyle::kProtobufReqeust)},
+                     method, MethodParameterStyle::kProtobufRequest)},
                  {IsResponseTypeEmpty,
                   // clang-format off
     "  future<Status>\n",
@@ -177,7 +177,7 @@ Status ClientGenerator::GenerateHeader() {
              {
                  // clang-format off
                  {FormatMethodCommentsFromRpcComments(
-        method, MethodParameterStyle::kProtobufReqeust)},
+        method, MethodParameterStyle::kProtobufRequest)},
    {"  StreamRange<$range_output_type$>\n"
     "  $method_name$($request_type$ request);\n\n"},
                  // clang-format on
@@ -187,7 +187,7 @@ Status ClientGenerator::GenerateHeader() {
              {
                  // clang-format off
                  {FormatMethodCommentsFromRpcComments(
-        method, MethodParameterStyle::kProtobufReqeust)},
+        method, MethodParameterStyle::kProtobufRequest)},
    {"  StreamRange<$response_type$>\n"
     "  $method_name$($request_type$ request);\n\n"},
                  // clang-format on

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -70,7 +70,7 @@ Status PrintMethod(google::protobuf::MethodDescriptor const& method,
                    std::vector<MethodPattern> const& patterns, char const* file,
                    int line);
 
-enum class MethodParameterStyle { kApiMethodSignature, kProtobufReqeust };
+enum class MethodParameterStyle { kApiMethodSignature, kProtobufRequest };
 /**
  * Formats comments from the source .proto file into Doxygen compatible
  * function headers, including param and return lines as necessary.

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -119,6 +119,7 @@ const char* const kFrobberServiceProto =
     "// Leading comments about message Empty.\n"
     "message Empty {}\n"
     "// Leading comments about service FrobberService.\n"
+    "// $Delimiter escapes$ $\n"
     "service FrobberService {\n"
     "  // Leading comments about rpc Method0.\n"
     "  rpc Method0(Bar) returns (Empty) {\n"
@@ -181,6 +182,9 @@ TEST_P(CreateServiceVarsTest, KeySetCorrectly) {
 INSTANTIATE_TEST_SUITE_P(
     ServiceVars, CreateServiceVarsTest,
     testing::Values(
+        std::make_pair("class_comment_block",
+                       "/**\n * Leading comments about service "
+                       "FrobberService.\n * $Delimiter escapes$ $\n */"),
         std::make_pair("client_class_name", "FrobberServiceClient"),
         std::make_pair("client_cc_path",
                        "google/cloud/frobber/"
@@ -320,6 +324,7 @@ const char* const kServiceProto =
     "// Leading comments about message Foo.\n"
     "message Foo {\n"
     "  string baz = 1;\n"
+    "  // labels $field comment.\n"
     "  map<string, string> labels = 2;\n"
     "}\n"
     "// Leading comments about message Bar.\n"
@@ -344,7 +349,7 @@ const char* const kServiceProto =
     "}\n"
     "// Leading comments about service Service.\n"
     "service Service {\n"
-    "  // Leading comments about rpc Method0.\n"
+    "  // Leading comments about rpc Method0$.\n"
     "  rpc Method0(Bar) returns (Empty) {\n"
     "    option (google.api.http) = {\n"
     "       delete: \"/v1/{name=projects/*/instances/*/backups/*}\"\n"
@@ -394,7 +399,7 @@ const char* const kServiceProto =
     "    option (google.api.method_signature) = \"toggle\";\n"
     "    option (google.api.method_signature) = \"name,title\";\n"
     "  }\n"
-    "  // Leading comments about rpc Method6.\n"
+    "  // Leading comments about rpc $Method6.\n"
     "  rpc Method6(Foo) returns (Empty) {\n"
     "    option (google.api.http) = {\n"
     "       get: \"/v1/{name=projects/*/instances/*/databases/*}\"\n"
@@ -470,6 +475,31 @@ TEST_F(CreateMethodVarsTest, FilesParseSuccessfully) {
   EXPECT_NE(nullptr, pool_.FindFileByName("google/foo/v1/service.proto"));
 }
 
+TEST_F(CreateMethodVarsTest,
+       FormatMethodCommentsFromRpcCommentsProtobufRequest) {
+  const FileDescriptor* service_file_descriptor =
+      pool_.FindFileByName("google/foo/v1/service.proto");
+  EXPECT_EQ(
+      FormatMethodCommentsFromRpcComments(
+          *service_file_descriptor->service(0)->method(0),
+          MethodParameterStyle::kProtobufRequest),
+      "  /**\n   * Leading comments about rpc Method0$$.\n   *\n   * @param "
+      "request "
+      "[::google::protobuf::Bar](https://github.com/googleapis/googleapis/blob/"
+      "$googleapis_commit_hash$/google/foo/v1/service.proto#L14)\n   */\n");
+}
+
+TEST_F(CreateMethodVarsTest,
+       FormatMethodCommentsFromRpcCommentsApiMethodSignature) {
+  const FileDescriptor* service_file_descriptor =
+      pool_.FindFileByName("google/foo/v1/service.proto");
+  EXPECT_EQ(FormatMethodCommentsFromRpcComments(
+                *service_file_descriptor->service(0)->method(6),
+                MethodParameterStyle::kApiMethodSignature),
+            "  /**\n   * Leading comments about rpc $$Method6.\n   *\n   * "
+            "@param labels  labels $$field comment.\n   */\n");
+}
+
 TEST_P(CreateMethodVarsTest, KeySetCorrectly) {
   const FileDescriptor* service_file_descriptor =
       pool_.FindFileByName("google/foo/v1/service.proto");
@@ -499,7 +529,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues(
             "google.protobuf.Service.Method0", "method_return_doxygen_link",
             "[::google::protobuf::Empty](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L21)"),
+            "googleapis/blob/foo/google/foo/v1/service.proto#L22)"),
         // Method1
         MethodVarsTestValues("google.protobuf.Service.Method1", "method_name",
                              "Method1"),
@@ -512,7 +542,7 @@ INSTANTIATE_TEST_SUITE_P(
         MethodVarsTestValues(
             "google.protobuf.Service.Method1", "method_return_doxygen_link",
             "[::google::protobuf::Bar](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L13)"),
+            "googleapis/blob/foo/google/foo/v1/service.proto#L14)"),
         // Method2
         MethodVarsTestValues("google.protobuf.Service.Method2",
                              "longrunning_metadata_type",
@@ -542,7 +572,7 @@ INSTANTIATE_TEST_SUITE_P(
             "google.protobuf.Service.Method2",
             "method_longrunning_deduced_return_doxygen_link",
             "[::google::protobuf::Bar](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L13)"),
+            "googleapis/blob/foo/google/foo/v1/service.proto#L14)"),
         // Method3
         MethodVarsTestValues("google.protobuf.Service.Method3",
                              "longrunning_metadata_type",
@@ -654,7 +684,7 @@ INSTANTIATE_TEST_SUITE_P(
             "google.protobuf.Service.Method7",
             "method_longrunning_deduced_return_doxygen_link",
             "[::google::protobuf::Bar](https://github.com/googleapis/"
-            "googleapis/blob/foo/google/foo/v1/service.proto#L13)")),
+            "googleapis/blob/foo/google/foo/v1/service.proto#L14)")),
     [](const testing::TestParamInfo<CreateMethodVarsTest::ParamType>& info) {
       std::vector<std::string> pieces = absl::StrSplit(info.param.method, '.');
       return pieces.back() + "_" + info.param.vars_key;


### PR DESCRIPTION
When protobuf::io::Printer is provided text with single delimiters $, the text needs to be massaged to change all $ to $$ in order to avoid the Printer thinking that a substitution variable is incorrectly specified. Printer will replace all instances of $$ with a single $ in its emitted output, preserving the original text.

Occurrences of $ in the value of a substitution variable does not require escaping as Printer does not recursively attempt to substitute into the body of a substitution variable, even if some $label$ exists. Printer just emits $label$.

While unit tests exists for all various places $ can occur, the integration test build will fail with some placements of $ because the grpc plugin does not escape them properly. There is already an existing issue for this with grpc.

Also cspell didn't like my pre-existing typo of Reqeust, so that was fixed in all places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5889)
<!-- Reviewable:end -->
