### PR TITLE
cleanup: make CMake builds less verbose

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -146,7 +146,7 @@ time {
 printf "%-30s" "Running cspell:"
 time {
   if ! git ls-files -z | grep -zE '\.(cc|h)$' |
-    xargs -P "${NCPU}" -n 50 -0 cspell --no-summary -c ci/cspell.json; then
+    xargs -P "${NCPU}" -n 50 -0 cspell --no-summary --no-progress -c ci/cspell.json; then
     problems="${problems} cspell"
   fi
 }

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -50,7 +50,7 @@ io::log_yellow "Verify markdown"
   ./ci/check-markdown.sh
 )
 
-if command -v ccache; then
+if command -v ccache >/dev/null 2>&1; then
   echo "================================================================"
   io::log_yellow "ccache stats"
   ccache --show-stats
@@ -91,7 +91,9 @@ if [[ "${GOOGLE_CLOUD_CPP_CXX_STANDARD:-}" != "" ]]; then
 fi
 
 if [[ "${TEST_INSTALL:-}" == "yes" ]]; then
-  cmake_extra_flags+=("-DCMAKE_INSTALL_PREFIX=/var/tmp/staging")
+  cmake_extra_flags+=(
+    "-DCMAKE_INSTALL_PREFIX=/var/tmp/staging"
+    "-DCMAKE_INSTALL_MESSAGE=NEVER")
 fi
 
 if [[ "${USE_LIBCXX:-}" == "yes" ]]; then
@@ -120,11 +122,6 @@ ${CMAKE_COMMAND} \
   "-H${SOURCE_DIR}" \
   "-B${BINARY_DIR}"
 io::log_yellow "Finished CMake config"
-
-if [[ "${CLANG_TIDY:-}" == "yes" && "${RUNNING_CI}" == "yes" ]]; then
-  io::log_yellow "clang-tidy config:"
-  clang-tidy -dump-config
-fi
 
 if [[ "${CLANG_TIDY:-}" == "yes" && ("${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" || "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GIT_ON_BORG") ]]; then
   # For presubmit builds we only run clang-tidy on the files that have changed

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -302,9 +302,11 @@ echo "================================================================"
 io::log_yellow "change working directory to project root."
 cd "${PROJECT_ROOT}"
 
-echo "================================================================"
-io::log_yellow "Capture Docker version to troubleshoot."
-sudo docker version
+if [[ "${RUNNING_CI:-}" == "yes" ]]; then
+  echo "================================================================"
+  io::log_yellow "Capture Docker version to troubleshoot."
+  sudo docker version
+fi
 
 if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
   echo "================================================================"
@@ -318,9 +320,9 @@ source "${PROJECT_ROOT}/ci/define-dump-log.sh"
 echo "================================================================"
 io::log_yellow "Building with ${NCPU} cores on ${PWD}."
 
-echo "================================================================"
-io::log_yellow "Setup Google Container Registry access."
 if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
+  echo "================================================================"
+  io::log_yellow "Setup Google Container Registry access."
   gcloud auth activate-service-account --key-file \
     "${KOKORO_GFILE_DIR}/gcr-service-account.json"
 fi
@@ -329,10 +331,10 @@ if [[ "${RUNNING_CI:-}" == "yes" ]]; then
   gcloud auth configure-docker
 fi
 
-echo "================================================================"
-io::log_yellow "Download existing image (if available) for ${DISTRO}."
 has_cache="false"
 if [[ -n "${PROJECT_ID:-}" ]] && docker pull "${IMAGE}:latest"; then
+  echo "================================================================"
+  io::log_yellow "Download existing image (if available) for ${DISTRO}."
   echo "Existing image successfully downloaded."
   has_cache="true"
 fi


### PR DESCRIPTION
I made a number of changes to quiet up the builds, including:

- stop cspell from listing all the files in the repository
- stop `cmake --install` from listing all the installed files
- do not dump the clang-tidy configuration
- avoid logging actions that will not happen

I tried enabling `ctest --quiet`, but it does not print failures in that
case, we need something more involved, like logging to a file and
printing the file if there is an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5891)
<!-- Reviewable:end -->
