### PR TITLE
cleanup(spanner): cleanup instance_admin_integration_test

### DIFF
--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -23,10 +23,10 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
-#include <chrono>
-#include <ctime>
+#include <algorithm>
 #include <regex>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -39,88 +39,100 @@ using ::testing::AnyOf;
 using ::testing::HasSubstr;
 using ::testing::UnorderedElementsAre;
 
-class InstanceAdminClientTest : public testing::Test {
+std::string const& ProjectId() {
+  static std::string project_id =
+      internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  return project_id;
+}
+
+std::string const& InstanceId() {
+  static std::string instance_id =
+      internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID")
+          .value_or("");
+  return instance_id;
+}
+
+bool RunSlowInstanceTests() {
+  static bool run_slow_instance_tests =
+      internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
+          .value_or("")
+          .find("instance") != std::string::npos;
+  return run_slow_instance_tests;
+}
+
+bool Emulator() {
+  static bool emulator = internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
+  return emulator;
+}
+
+class CleanupStaleInstances : public ::testing::Environment {
  public:
-  InstanceAdminClientTest() : client_(MakeInstanceAdminConnection()) {}
-
- protected:
   void SetUp() override {
-    emulator_ =
-        google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
-    project_id_ =
-        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-    instance_id_ = google::cloud::internal::GetEnv(
-                       "GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID")
-                       .value_or("");
-    test_iam_service_account_ =
-        google::cloud::internal::GetEnv(
-            "GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT")
-            .value_or("");
-    auto const run_slow_integration_tests =
-        google::cloud::internal::GetEnv(
-            "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-            .value_or("");
-    run_slow_instance_tests_ =
-        run_slow_integration_tests.find("instance") != std::string::npos;
+    std::regex instance_name_regex(
+        R"(projects/.+/instances/)"
+        R"((temporary-instance-(\d{4}-\d{2}-\d{2})-.+))");
 
-    if (emulator_) {
-      // When running against the emulator the instance might not exist, in that
-      // case we create the instance to run as much of the test as possible:
-      Instance in(project_id_, instance_id_);
-      auto create_instance_request =
-          spanner::CreateInstanceRequestBuilder(
-              in, "projects/" + in.project_id() +
-                      "/instanceConfigs/emulator-config")
-              .Build();
-      StatusOr<google::spanner::admin::instance::v1::Instance> instance =
-          client_.CreateInstance(create_instance_request).get();
-      ASSERT_TRUE(instance ||
-                  instance.status().code() == StatusCode::kAlreadyExists)
-          << " status=" << instance.status();
-    }
+    // Make sure we're using a correct regex.
+    EXPECT_EQ(2, instance_name_regex.mark_count());
+    auto generator = internal::MakeDefaultPRNG();
+    Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator));
+    auto fq_instance_name = in.FullName();
+    std::smatch m;
+    EXPECT_TRUE(std::regex_match(fq_instance_name, m, instance_name_regex));
+    EXPECT_EQ(3, m.size());
+
+    EXPECT_STATUS_OK(spanner_testing::CleanupStaleInstances(
+        in.project_id(), instance_name_regex));
   }
-  InstanceAdminClient client_;
-  bool emulator_;
-  std::string project_id_;
-  std::string instance_id_;
-  std::string test_iam_service_account_;
-  bool run_slow_instance_tests_;
 };
 
-class InstanceAdminClientTestWithCleanup : public InstanceAdminClientTest {
+::testing::Environment* const kCleanupEnv =
+    ::testing::AddGlobalTestEnvironment(new CleanupStaleInstances);
+
+class InstanceAdminClientTest : public testing::Test {
+ public:
+  InstanceAdminClientTest()
+      : generator_(internal::MakeDefaultPRNG()),
+        client_(MakeInstanceAdminConnection()) {
+    static_cast<void>(kCleanupEnv);
+  }
+
  protected:
   void SetUp() override {
-    InstanceAdminClientTest::SetUp();
-    instance_name_regex_ = std::regex(
-        R"(projects/.+/instances/(temporary-instance-(\d{4}-\d{2}-\d{2})-.+))");
-    instance_config_regex_ = std::regex(".*us-west.*");
-    if (!run_slow_instance_tests_) {
-      return;
+    if (Emulator()) {
+      // We expect test instances to exist when running against real services,
+      // but if we are running against the emulator we're happy to create one.
+      Instance in(ProjectId(), InstanceId());
+      auto create_instance_request =
+          CreateInstanceRequestBuilder(in,
+                                       "projects/" + in.project_id() +
+                                           "/instanceConfigs/emulator-config")
+              .Build();
+      auto instance = client_.CreateInstance(create_instance_request).get();
+      if (!instance) {
+        ASSERT_THAT(instance, StatusIs(StatusCode::kAlreadyExists));
+      }
     }
-    auto s = spanner_testing::CleanupStaleInstances(project_id_,
-                                                    instance_name_regex_);
-    EXPECT_STATUS_OK(s) << s.message();
   }
-  std::regex instance_config_regex_;
-  std::regex instance_name_regex_;
+
+  internal::DefaultPRNG generator_;
+  InstanceAdminClient client_;
 };
 
 /// @test Verify the basic read operations for instances work.
 TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
-  ASSERT_FALSE(project_id_.empty());
-  ASSERT_FALSE(instance_id_.empty());
-
-  Instance in(project_id_, instance_id_);
+  Instance in(ProjectId(), InstanceId());
+  ASSERT_FALSE(in.project_id().empty());
+  ASSERT_FALSE(in.instance_id().empty());
 
   auto instance = client_.GetInstance(in);
-  EXPECT_STATUS_OK(instance);
-  EXPECT_THAT(instance->name(), HasSubstr(project_id_));
-  EXPECT_THAT(instance->name(), HasSubstr(instance_id_));
-  EXPECT_NE(0, instance->node_count());
+  ASSERT_STATUS_OK(instance);
+  EXPECT_EQ(instance->name(), in.FullName());
+  EXPECT_NE(instance->node_count(), 0);
 
-  std::vector<std::string> instance_names = [this]() mutable {
+  auto instance_names = [&in, this]() mutable {
     std::vector<std::string> names;
-    for (auto const& instance : client_.ListInstances(project_id_, "")) {
+    for (auto const& instance : client_.ListInstances(in.project_id(), "")) {
       EXPECT_STATUS_OK(instance);
       if (!instance) break;
       names.push_back(instance->name());
@@ -132,68 +144,65 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 }
 
 /// @test Verify the basic CRUD operations for instances work.
-TEST_F(InstanceAdminClientTestWithCleanup, InstanceCRUDOperations) {
-  if (!run_slow_instance_tests_) GTEST_SKIP();
+TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
+  if (!RunSlowInstanceTests()) GTEST_SKIP();
 
-  auto generator = google::cloud::internal::MakeDefaultPRNG();
-  std::string instance_id =
-      google::cloud::spanner_testing::RandomInstanceName(generator);
-  ASSERT_FALSE(project_id_.empty());
-  ASSERT_FALSE(instance_id.empty());
-  Instance in(project_id_, instance_id);
+  std::string instance_id = spanner_testing::RandomInstanceName(generator_);
+  Instance in(ProjectId(), instance_id);
+  ASSERT_FALSE(in.project_id().empty());
+  ASSERT_FALSE(in.instance_id().empty());
 
-  // Make sure we're using correct regex.
-  std::smatch m;
-  auto full_name = in.FullName();
-  EXPECT_TRUE(std::regex_match(full_name, m, instance_name_regex_));
-
-  std::string instance_config = spanner_testing::PickInstanceConfig(
-      project_id_, instance_config_regex_, generator);
+  auto instance_config = spanner_testing::PickInstanceConfig(
+      in.project_id(), std::regex(".*us-west.*"), generator_);
   ASSERT_FALSE(instance_config.empty()) << "could not get an instance config";
 
-  future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
-      client_.CreateInstance(CreateInstanceRequestBuilder(in, instance_config)
-                                 .SetDisplayName("test-display-name")
-                                 .SetNodeCount(1)
-                                 .SetLabels({{"label-key", "label-value"}})
-                                 .Build());
-  StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();
+  auto instance =
+      client_
+          .CreateInstance(CreateInstanceRequestBuilder(in, instance_config)
+                              .SetDisplayName("test-display-name")
+                              .SetNodeCount(1)
+                              .SetLabels({{"label-key", "label-value"}})
+                              .Build())
+          .get();
 
-  EXPECT_STATUS_OK(instance);
-  EXPECT_THAT(instance->name(), HasSubstr(project_id_));
-  EXPECT_THAT(instance->name(), HasSubstr(instance_id));
-  EXPECT_EQ("test-display-name", instance->display_name());
-  EXPECT_NE(0, instance->node_count());
-  EXPECT_EQ(instance_config, instance->config());
-  if (!emulator_ || instance->labels_size() != 0) {
-    EXPECT_EQ("label-value", instance->labels().at("label-key"));
+  ASSERT_STATUS_OK(instance);
+  EXPECT_EQ(instance->name(), in.FullName());
+  EXPECT_EQ(instance->display_name(), "test-display-name");
+  EXPECT_NE(instance->node_count(), 0);
+  EXPECT_EQ(instance->config(), instance_config);
+  if (!Emulator() || instance->labels_size() != 0) {
+    EXPECT_EQ(instance->labels().at("label-key"), "label-value");
   }
 
   // Then update the instance
-  f = client_.UpdateInstance(UpdateInstanceRequestBuilder(*instance)
-                                 .SetDisplayName("New display name")
-                                 .AddLabels({{"new-key", "new-value"}})
-                                 .SetNodeCount(2)
-                                 .Build());
-  instance = f.get();
-  if (!emulator_ || instance) {
+  instance = client_
+                 .UpdateInstance(UpdateInstanceRequestBuilder(*instance)
+                                     .SetDisplayName("New display name")
+                                     .AddLabels({{"new-key", "new-value"}})
+                                     .SetNodeCount(2)
+                                     .Build())
+                 .get();
+  if (!Emulator() || instance) {
     EXPECT_STATUS_OK(instance);
-    EXPECT_EQ("New display name", instance->display_name());
-    EXPECT_EQ(2, instance->labels_size());
-    EXPECT_EQ("new-value", instance->labels().at("new-key"));
-    EXPECT_EQ(2, instance->node_count());
+    if (instance) {
+      EXPECT_EQ(instance->display_name(), "New display name");
+      EXPECT_EQ(instance->labels_size(), 2);
+      EXPECT_EQ(instance->labels().at("new-key"), "new-value");
+      EXPECT_EQ(instance->node_count(), 2);
+    }
   }
-  auto status = client_.DeleteInstance(in);
-  EXPECT_STATUS_OK(status);
+
+  EXPECT_STATUS_OK(client_.DeleteInstance(in));
 }
 
 TEST_F(InstanceAdminClientTest, InstanceConfig) {
-  ASSERT_FALSE(project_id_.empty());
+  auto project_id = ProjectId();
+  ASSERT_FALSE(project_id.empty());
 
-  std::vector<std::string> instance_config_names = [this]() mutable {
+  auto instance_config_names = [&project_id, this]() mutable {
     std::vector<std::string> names;
     for (auto const& instance_config :
-         client_.ListInstanceConfigs(project_id_)) {
+         client_.ListInstanceConfigs(project_id)) {
       EXPECT_STATUS_OK(instance_config);
       if (!instance_config) break;
       names.push_back(instance_config->name());
@@ -201,31 +210,33 @@ TEST_F(InstanceAdminClientTest, InstanceConfig) {
     return names;
   }();
   ASSERT_FALSE(instance_config_names.empty());
+
   // Use the name of the first element from the list of instance configs.
   auto instance_config = client_.GetInstanceConfig(instance_config_names[0]);
-  EXPECT_STATUS_OK(instance_config);
-  EXPECT_THAT(instance_config->name(), HasSubstr(project_id_));
+  EXPECT_THAT(instance_config->name(), HasSubstr(project_id));
   EXPECT_EQ(
       1, std::count(instance_config_names.begin(), instance_config_names.end(),
                     instance_config->name()));
 }
 
 TEST_F(InstanceAdminClientTest, InstanceIam) {
-  if (emulator_) GTEST_SKIP();
+  if (Emulator()) GTEST_SKIP();
 
-  ASSERT_FALSE(project_id_.empty());
-  ASSERT_FALSE(instance_id_.empty());
-  ASSERT_TRUE(emulator_ || !test_iam_service_account_.empty());
+  Instance in(ProjectId(), InstanceId());
+  ASSERT_FALSE(in.project_id().empty());
+  ASSERT_FALSE(in.instance_id().empty());
 
-  Instance in(project_id_, instance_id_);
+  ASSERT_FALSE(internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT")
+                   .value_or("")
+                   .empty());
 
   auto actual_policy = client_.GetIamPolicy(in);
   ASSERT_STATUS_OK(actual_policy);
   EXPECT_FALSE(actual_policy->etag().empty());
 
-  if (run_slow_instance_tests_) {
-    // Set the policy to the existing value of the policy. While this changes
-    // nothing it tests all the code in the client library.
+  if (RunSlowInstanceTests()) {
+    // Set the policy to the existing value of the policy. While this
+    // changes nothing, it tests all the code in the client library.
     auto updated_policy = client_.SetIamPolicy(in, *actual_policy);
     ASSERT_THAT(updated_policy, AnyOf(StatusIs(StatusCode::kOk),
                                       StatusIs(StatusCode::kAborted)));


### PR DESCRIPTION
Carry over similar changes from backup_integration_test.  In
particular, only run `CleanupStaleInstances()` once, when the
test starts, rather than before every test case.  But follow
a previous suggestion to do so unconditionally, instead of
only when "slow" tests are enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5895)
<!-- Reviewable:end -->
