### PR TITLE
cleanup: add internal-only Contains() and ContainsIf() helpers

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(
     internal/absl_str_cat_quiet.h
     internal/absl_str_join_quiet.h
     internal/absl_str_replace_quiet.h
+    internal/algorithm.h
     internal/api_client_header.cc
     internal/api_client_header.h
     internal/backoff_policy.cc
@@ -242,6 +243,7 @@ if (BUILD_TESTING)
         future_void_test.cc
         future_void_then_test.cc
         iam_bindings_test.cc
+        internal/algorithm_test.cc
         internal/api_client_header_test.cc
         internal/backoff_policy_test.cc
         internal/big_endian_test.cc

--- a/google/cloud/bigtable/app_profile_config.cc
+++ b/google/cloud/bigtable/app_profile_config.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/app_profile_config.h"
+#include "google/cloud/internal/algorithm.h"
 
 namespace google {
 namespace cloud {
@@ -40,10 +41,8 @@ AppProfileConfig AppProfileConfig::SingleClusterRouting(
 }
 
 void AppProfileUpdateConfig::AddPathIfNotPresent(std::string field_name) {
-  auto const& paths = proto_.update_mask().paths();
-  auto is_present =
-      paths.end() != std::find(paths.begin(), paths.end(), field_name);
-  if (!is_present) {
+  if (!google::cloud::internal::Contains(proto_.update_mask().paths(),
+                                         field_name)) {
     proto_.mutable_update_mask()->add_paths(std::move(field_name));
   }
 }

--- a/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/instance_admin.h"
 //! [bigtable includes]
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
+#include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/crash_handler.h"
@@ -65,12 +66,11 @@ void BigtableHelloInstance(std::vector<std::string> const& argv) {
   }
   auto instance_name =
       instance_admin.project_name() + "/instances/" + instance_id;
-  auto instance_name_it = std::find_if(
-      instances->instances.begin(), instances->instances.end(),
+  bool instance_exists = google::cloud::internal::ContainsIf(
+      instances->instances,
       [&instance_name](google::bigtable::admin::v2::Instance const& i) {
         return i.name() == instance_name;
       });
-  bool instance_exists = instance_name_it != instances->instances.end();
   std::cout << "The instance " << instance_id
             << (instance_exists ? " already exists" : " does not exist")
             << "\n";

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/cluster_config.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/internal/algorithm.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
 #include <google/bigtable/admin/v2/common.pb.h>
 #include <map>
@@ -117,10 +118,8 @@ class InstanceUpdateConfig {
 
  private:
   void AddPathIfNotPresent(std::string const& field_name) {
-    auto is_present = proto_.update_mask().paths().end() !=
-                      std::find(proto_.update_mask().paths().begin(),
-                                proto_.update_mask().paths().end(), field_name);
-    if (!is_present) {
+    if (!google::cloud::internal::Contains(proto_.update_mask().paths(),
+                                           field_name)) {
       proto_.mutable_update_mask()->add_paths(field_name);
     }
   }

--- a/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_async_future_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/instance_admin.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/status_or.h"
@@ -77,30 +78,27 @@ class InstanceAdminAsyncFutureIntegrationTest : public ::testing::Test {
 
 bool IsInstancePresent(std::vector<btadmin::Instance> const& instances,
                        std::string const& instance_name) {
-  return instances.end() !=
-         std::find_if(instances.begin(), instances.end(),
-                      [&instance_name](btadmin::Instance const& i) {
-                        return i.name() == instance_name;
-                      });
+  return google::cloud::internal::ContainsIf(
+      instances, [&instance_name](btadmin::Instance const& i) {
+        return i.name() == instance_name;
+      });
 }
 
 bool IsClusterPresent(std::vector<btadmin::Cluster> const& clusters,
                       std::string const& cluster_name) {
-  return clusters.end() !=
-         std::find_if(clusters.begin(), clusters.end(),
-                      [&cluster_name](btadmin::Cluster const& i) {
-                        return i.name() == cluster_name;
-                      });
+  return google::cloud::internal::ContainsIf(
+      clusters, [&cluster_name](btadmin::Cluster const& i) {
+        return i.name() == cluster_name;
+      });
 }
 
 bool IsIdOrNamePresentInClusterList(
     std::vector<btadmin::Cluster> const& clusters,
     std::string const& cluster_id) {
-  return clusters.end() !=
-         std::find_if(clusters.begin(), clusters.end(),
-                      [&cluster_id](btadmin::Cluster const& i) {
-                        return i.name().find(cluster_id) != std::string::npos;
-                      });
+  return google::cloud::internal::ContainsIf(
+      clusters, [&cluster_id](btadmin::Cluster const& i) {
+        return i.name().find(cluster_id) != std::string::npos;
+      });
 }
 
 bigtable::InstanceConfig IntegrationTestConfig(

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/instance_admin.h"
+#include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/status_or.h"
@@ -77,20 +78,18 @@ class InstanceAdminIntegrationTest : public ::testing::Test {
 
 bool IsInstancePresent(std::vector<btadmin::Instance> const& instances,
                        std::string const& instance_name) {
-  return instances.end() !=
-         std::find_if(instances.begin(), instances.end(),
-                      [&instance_name](btadmin::Instance const& i) {
-                        return i.name() == instance_name;
-                      });
+  return google::cloud::internal::ContainsIf(
+      instances, [&instance_name](btadmin::Instance const& i) {
+        return i.name() == instance_name;
+      });
 }
 
 bool IsClusterPresent(std::vector<btadmin::Cluster> const& clusters,
                       std::string const& cluster_name) {
-  return clusters.end() !=
-         std::find_if(clusters.begin(), clusters.end(),
-                      [&cluster_name](btadmin::Cluster const& i) {
-                        return i.name() == cluster_name;
-                      });
+  return google::cloud::internal::ContainsIf(
+      clusters, [&cluster_name](btadmin::Cluster const& i) {
+        return i.name() == cluster_name;
+      });
 }
 
 bigtable::InstanceConfig IntegrationTestConfig(

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -28,6 +28,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/absl_str_cat_quiet.h",
     "internal/absl_str_join_quiet.h",
     "internal/absl_str_replace_quiet.h",
+    "internal/algorithm.h",
     "internal/api_client_header.h",
     "internal/backoff_policy.h",
     "internal/big_endian.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -22,6 +22,7 @@ google_cloud_cpp_common_unit_tests = [
     "future_void_test.cc",
     "future_void_then_test.cc",
     "iam_bindings_test.cc",
+    "internal/algorithm_test.cc",
     "internal/api_client_header_test.cc",
     "internal/backoff_policy_test.cc",
     "internal/big_endian_test.cc",

--- a/google/cloud/internal/algorithm.h
+++ b/google/cloud/internal/algorithm.h
@@ -34,6 +34,17 @@ bool Contains(C&& c, V&& v) {
   return it != end;
 }
 
+/**
+ * Returns true if the container @p c contains a value for which @p p is true.
+ */
+template <typename C, typename UnaryPredicate>
+bool ContainsIf(C&& c, UnaryPredicate&& p) {
+  auto end = std::end(std::forward<C>(c));
+  auto it = std::find_if(std::begin(std::forward<C>(c)), end,
+                         std::forward<UnaryPredicate>(p));
+  return it != end;
+}
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/algorithm.h
+++ b/google/cloud/internal/algorithm.h
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ALGORITHM_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ALGORITHM_H
+
+#include "google/cloud/version.h"
+#include <algorithm>
+#include <iterator>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/**
+ * Returns true if the container @p c contains the value @p v.
+ */
+template <typename C, typename V>
+bool Contains(C&& c, V&& v) {
+  auto end = std::end(std::forward<C>(c));
+  auto it = std::find(std::begin(std::forward<C>(c)), end, std::forward<V>(v));
+  return it != end;
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ALGORITHM_H

--- a/google/cloud/internal/algorithm.h
+++ b/google/cloud/internal/algorithm.h
@@ -29,9 +29,8 @@ namespace internal {
  */
 template <typename C, typename V>
 bool Contains(C&& c, V&& v) {
-  auto end = std::end(std::forward<C>(c));
-  auto it = std::find(std::begin(std::forward<C>(c)), end, std::forward<V>(v));
-  return it != end;
+  auto const e = std::end(std::forward<C>(c));
+  return e != std::find(std::begin(std::forward<C>(c)), e, std::forward<V>(v));
 }
 
 /**
@@ -39,10 +38,9 @@ bool Contains(C&& c, V&& v) {
  */
 template <typename C, typename UnaryPredicate>
 bool ContainsIf(C&& c, UnaryPredicate&& p) {
-  auto end = std::end(std::forward<C>(c));
-  auto it = std::find_if(std::begin(std::forward<C>(c)), end,
-                         std::forward<UnaryPredicate>(p));
-  return it != end;
+  auto const e = std::end(std::forward<C>(c));
+  return e != std::find_if(std::begin(std::forward<C>(c)), e,
+                           std::forward<UnaryPredicate>(p));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/algorithm_test.cc
+++ b/google/cloud/internal/algorithm_test.cc
@@ -42,8 +42,10 @@ TEST(Algorithm, ContainsIf) {
   EXPECT_FALSE(ContainsIf(s, [](char c) { return c == 'z'; }));
 
   char const* a[] = {"foo", "bar", "baz"};
-  EXPECT_TRUE(ContainsIf(a, [](std::string s) { return s == "foo"; }));
-  EXPECT_FALSE(ContainsIf(a, [](std::string s) { return s == "OOPS"; }));
+  EXPECT_TRUE(
+      ContainsIf(a, [](char const* s) { return std::string(s) == "foo"; }));
+  EXPECT_FALSE(
+      ContainsIf(a, [](char const* s) { return std::string(s) == "OOPS"; }));
 
   std::vector<std::string> v = {"foo", "bar", "baz"};
   EXPECT_TRUE(ContainsIf(v, [](std::string s) { return s == "foo"; }));

--- a/google/cloud/internal/algorithm_test.cc
+++ b/google/cloud/internal/algorithm_test.cc
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/algorithm.h"
+#include <gmock/gmock.h>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+TEST(Algorithm, StringContains) {
+  std::string v = "abcde";
+  EXPECT_TRUE(Contains(v, 'c'));
+  EXPECT_FALSE(Contains(v, 'z'));
+}
+
+TEST(Algorithm, ArrayContains) {
+  std::string v[] = {"foo", "bar", "baz"};
+  EXPECT_TRUE(Contains(v, "foo"));
+  EXPECT_FALSE(Contains(v, "OOPS"));
+}
+
+TEST(Algorithm, VectorContains) {
+  std::vector<std::string> v = {"foo", "bar", "baz"};
+  EXPECT_TRUE(Contains(v, "foo"));
+  EXPECT_FALSE(Contains(v, "OOPS"));
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/algorithm_test.cc
+++ b/google/cloud/internal/algorithm_test.cc
@@ -22,22 +22,32 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-TEST(Algorithm, StringContains) {
-  std::string v = "abcde";
-  EXPECT_TRUE(Contains(v, 'c'));
-  EXPECT_FALSE(Contains(v, 'z'));
-}
+TEST(Algorithm, Contains) {
+  std::string s = "abcde";
+  EXPECT_TRUE(Contains(s, 'c'));
+  EXPECT_FALSE(Contains(s, 'z'));
 
-TEST(Algorithm, ArrayContains) {
-  std::string v[] = {"foo", "bar", "baz"};
-  EXPECT_TRUE(Contains(v, "foo"));
-  EXPECT_FALSE(Contains(v, "OOPS"));
-}
+  std::string a[] = {"foo", "bar", "baz"};
+  EXPECT_TRUE(Contains(a, "foo"));
+  EXPECT_FALSE(Contains(a, "OOPS"));
 
-TEST(Algorithm, VectorContains) {
   std::vector<std::string> v = {"foo", "bar", "baz"};
   EXPECT_TRUE(Contains(v, "foo"));
   EXPECT_FALSE(Contains(v, "OOPS"));
+}
+
+TEST(Algorithm, ContainsIf) {
+  std::string s = "abcde";
+  EXPECT_TRUE(ContainsIf(s, [](char c) { return c == 'a'; }));
+  EXPECT_FALSE(ContainsIf(s, [](char c) { return c == 'z'; }));
+
+  char const* a[] = {"foo", "bar", "baz"};
+  EXPECT_TRUE(ContainsIf(a, [](std::string s) { return s == "foo"; }));
+  EXPECT_FALSE(ContainsIf(a, [](std::string s) { return s == "OOPS"; }));
+
+  std::vector<std::string> v = {"foo", "bar", "baz"};
+  EXPECT_TRUE(ContainsIf(v, [](std::string s) { return s == "foo"; }));
+  EXPECT_FALSE(ContainsIf(v, [](std::string s) { return s == "OOPS"; }));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/algorithm_test.cc
+++ b/google/cloud/internal/algorithm_test.cc
@@ -48,8 +48,8 @@ TEST(Algorithm, ContainsIf) {
       ContainsIf(a, [](char const* s) { return std::string(s) == "OOPS"; }));
 
   std::vector<std::string> v = {"foo", "bar", "baz"};
-  EXPECT_TRUE(ContainsIf(v, [](std::string s) { return s == "foo"; }));
-  EXPECT_FALSE(ContainsIf(v, [](std::string s) { return s == "OOPS"; }));
+  EXPECT_TRUE(ContainsIf(v, [](std::string const& s) { return s == "foo"; }));
+  EXPECT_FALSE(ContainsIf(v, [](std::string const& s) { return s == "OOPS"; }));
 }
 
 }  // namespace internal

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/list_objects_reader.h"
 #include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/contains_once.h"
@@ -778,8 +779,7 @@ TEST_F(BucketIntegrationTest, NativeIamCRUD) {
     }
     role_updated = true;
     auto& members = binding.members();
-    if (std::find(members.begin(), members.end(), "allAuthenticatedUsers") ==
-        members.end()) {
+    if (!google::cloud::internal::Contains(members, "allAuthenticatedUsers")) {
       members.emplace_back("allAuthenticatedUsers");
     }
   }
@@ -1128,8 +1128,7 @@ TEST_F(BucketIntegrationTest, NativeIamWithRequestedPolicyVersion) {
     role_updated = true;
 
     auto& members = binding.members();
-    if (std::find(members.begin(), members.end(), "allAuthenticatedUsers") ==
-        members.end()) {
+    if (!google::cloud::internal::Contains(members, "allAuthenticatedUsers")) {
       members.emplace_back("serviceAccount:" + service_account_);
     }
   }

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -742,11 +742,10 @@ TEST_F(BucketIntegrationTest, NativeIamCRUD) {
   ASSERT_STATUS_OK(policy);
   auto const& bindings = policy->bindings();
   // There must always be at least an OWNER for the Bucket.
-  auto owner_it = std::find_if(
-      bindings.begin(), bindings.end(), [](NativeIamBinding const& binding) {
+  ASSERT_TRUE(google::cloud::internal::ContainsIf(
+      bindings, [](NativeIamBinding const& binding) {
         return binding.role() == "roles/storage.legacyBucketOwner";
-      });
-  ASSERT_NE(bindings.end(), owner_it);
+      }));
 
   StatusOr<std::vector<BucketAccessControl>> acl =
       client->ListBucketAcl(bucket_name);
@@ -1113,11 +1112,10 @@ TEST_F(BucketIntegrationTest, NativeIamWithRequestedPolicyVersion) {
 
   auto const& bindings = policy->bindings();
   // There must always be at least an OWNER for the Bucket.
-  auto owner_it = std::find_if(
-      bindings.begin(), bindings.end(), [](NativeIamBinding const& binding) {
+  ASSERT_TRUE(google::cloud::internal::ContainsIf(
+      bindings, [](NativeIamBinding const& binding) {
         return binding.role() == "roles/storage.legacyBucketOwner";
-      });
-  ASSERT_NE(bindings.end(), owner_it);
+      }));
 
   NativeIamPolicy update = *policy;
   bool role_updated = false;


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5738

I also looked around for uses of `std::find` and `std::find_if` that were logically performing a "contains", and changed those to call this helper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5898)
<!-- Reviewable:end -->
