### PR TITLE
cleanup: internal/*_options.h were not in the internal namespace

### DIFF
--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -48,26 +48,27 @@ TEST(ConnectionOptionsTest, Credentials) {
   auto expected = grpc::InsecureChannelCredentials();
   TestConnectionOptions options(expected);
   EXPECT_EQ(expected.get(), options.credentials().get());
-  EXPECT_EQ(expected, ToOptions(options).get<GrpcCredentialOption>()->value);
+  EXPECT_EQ(expected,
+            ToOptions(options).get<internal::GrpcCredentialOption>()->value);
 
   auto other_credentials = grpc::InsecureChannelCredentials();
   EXPECT_NE(expected, other_credentials);
   options.set_credentials(other_credentials);
   EXPECT_EQ(other_credentials, options.credentials());
   EXPECT_EQ(other_credentials,
-            ToOptions(options).get<GrpcCredentialOption>()->value);
+            ToOptions(options).get<internal::GrpcCredentialOption>()->value);
 }
 
 TEST(ConnectionOptionsTest, AdminEndpoint) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::default_endpoint(), options.endpoint());
   EXPECT_EQ(options.endpoint(),
-            ToOptions(options).get<EndpointOption>()->value);
+            ToOptions(options).get<internal::EndpointOption>()->value);
 
   options.set_endpoint("invalid-endpoint");
   EXPECT_EQ("invalid-endpoint", options.endpoint());
   EXPECT_EQ(options.endpoint(),
-            ToOptions(options).get<EndpointOption>()->value);
+            ToOptions(options).get<internal::EndpointOption>()->value);
 }
 
 TEST(ConnectionOptionsTest, NumChannels) {
@@ -75,13 +76,13 @@ TEST(ConnectionOptionsTest, NumChannels) {
   int num_channels = options.num_channels();
   EXPECT_EQ(TestTraits::default_num_channels(), num_channels);
   EXPECT_EQ(options.num_channels(),
-            ToOptions(options).get<GrpcNumChannelsOption>()->value);
+            ToOptions(options).get<internal::GrpcNumChannelsOption>()->value);
 
   num_channels *= 2;  // ensure we change it from the default value.
   options.set_num_channels(num_channels);
   EXPECT_EQ(num_channels, options.num_channels());
   EXPECT_EQ(options.num_channels(),
-            ToOptions(options).get<GrpcNumChannelsOption>()->value);
+            ToOptions(options).get<internal::GrpcNumChannelsOption>()->value);
 }
 
 TEST(ConnectionOptionsTest, Tracing) {
@@ -89,18 +90,18 @@ TEST(ConnectionOptionsTest, Tracing) {
   options.enable_tracing("fake-component");
   EXPECT_TRUE(options.tracing_enabled("fake-component"));
   EXPECT_EQ(options.components(),
-            ToOptions(options).get<TracingComponentsOption>()->value);
+            ToOptions(options).get<internal::TracingComponentsOption>()->value);
 
   options.disable_tracing("fake-component");
   EXPECT_FALSE(options.tracing_enabled("fake-component"));
-  EXPECT_FALSE(ToOptions(options).get<TracingComponentsOption>());
+  EXPECT_FALSE(ToOptions(options).get<internal::TracingComponentsOption>());
 }
 
 TEST(ConnectionOptionsTest, DefaultTracingUnset) {
   testing_util::ScopedEnvironment env("GOOGLE_CLOUD_CPP_ENABLE_TRACING", {});
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_FALSE(options.tracing_enabled("rpc"));
-  EXPECT_FALSE(ToOptions(options).get<TracingComponentsOption>());
+  EXPECT_FALSE(ToOptions(options).get<internal::TracingComponentsOption>());
 }
 
 TEST(ConnectionOptionsTest, DefaultTracingSet) {
@@ -111,8 +112,9 @@ TEST(ConnectionOptionsTest, DefaultTracingSet) {
   EXPECT_TRUE(options.tracing_enabled("foo"));
   EXPECT_TRUE(options.tracing_enabled("bar"));
   EXPECT_TRUE(options.tracing_enabled("baz"));
-  EXPECT_THAT(ToOptions(options).get<TracingComponentsOption>()->value,
-              testing::UnorderedElementsAre("foo", "bar", "baz"));
+  EXPECT_THAT(
+      ToOptions(options).get<internal::TracingComponentsOption>()->value,
+      testing::UnorderedElementsAre("foo", "bar", "baz"));
 }
 
 TEST(ConnectionOptionsTest, TracingOptions) {
@@ -125,18 +127,19 @@ TEST(ConnectionOptionsTest, TracingOptions) {
   EXPECT_FALSE(tracing_options.single_line_mode());
   EXPECT_FALSE(tracing_options.use_short_repeated_primitives());
   EXPECT_EQ(32, tracing_options.truncate_string_field_longer_than());
-  EXPECT_EQ(options.tracing_options(),
-            ToOptions(options).get<GrpcTracingOptionsOption>()->value);
+  EXPECT_EQ(
+      options.tracing_options(),
+      ToOptions(options).get<internal::GrpcTracingOptionsOption>()->value);
 }
 
 TEST(ConnectionOptionsTest, ChannelPoolName) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_TRUE(options.channel_pool_domain().empty());
-  EXPECT_FALSE(ToOptions(options).get<GrpcChannelArgumentsOption>());
+  EXPECT_FALSE(ToOptions(options).get<internal::GrpcChannelArgumentsOption>());
 
   options.set_channel_pool_domain("test-channel-pool");
   EXPECT_EQ("test-channel-pool", options.channel_pool_domain());
-  auto opts = ToOptions(options).get<GrpcChannelArgumentsOption>();
+  auto opts = ToOptions(options).get<internal::GrpcChannelArgumentsOption>();
   EXPECT_TRUE(opts);
   EXPECT_EQ(opts->value["grpc.channel_pooling_domain"], "test-channel-pool");
 }
@@ -144,13 +147,13 @@ TEST(ConnectionOptionsTest, ChannelPoolName) {
 TEST(ConnectionOptionsTest, UserAgentPrefix) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::user_agent_prefix(), options.user_agent_prefix());
-  EXPECT_THAT(ToOptions(options).get<UserAgentPrefixOption>()->value,
+  EXPECT_THAT(ToOptions(options).get<internal::UserAgentPrefixOption>()->value,
               testing::ElementsAre(options.user_agent_prefix()));
 
   options.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + TestTraits::user_agent_prefix(),
             options.user_agent_prefix());
-  EXPECT_THAT(ToOptions(options).get<UserAgentPrefixOption>()->value,
+  EXPECT_THAT(ToOptions(options).get<internal::UserAgentPrefixOption>()->value,
               testing::ElementsAre(options.user_agent_prefix()));
 }
 

--- a/google/cloud/internal/common_options.h
+++ b/google/cloud/internal/common_options.h
@@ -23,7 +23,6 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
-
 namespace internal {
 
 /**
@@ -64,7 +63,6 @@ struct TracingComponentsOption {
 };
 
 }  // namespace internal
-
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/internal/common_options.h
+++ b/google/cloud/internal/common_options.h
@@ -24,6 +24,8 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
+namespace internal {
+
 /**
  * Change the endpoint.
  *
@@ -60,6 +62,8 @@ struct UserAgentPrefixOption {
 struct TracingComponentsOption {
   std::set<std::string> value;
 };
+
+}  // namespace internal
 
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/grpc_options.h
+++ b/google/cloud/internal/grpc_options.h
@@ -27,6 +27,8 @@ namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 
+namespace internal {
+
 /**
  * The gRPC credentials used by clients configured with this object.
  */
@@ -81,6 +83,8 @@ using BackgroundThreadsFactory =
 struct GrpcBackgroundThreadsOption {
   BackgroundThreadsFactory value;
 };
+
+}  // namespace internal
 
 namespace internal {
 


### PR DESCRIPTION
These options were in the `google/cloud/internal/` directory, but they were accidentally not in the `google::cloud::internal` namespace. Fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5900)
<!-- Reviewable:end -->
