### PR TITLE
cleanup: reenable DeleteResumableUpload test

### DIFF
--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -898,10 +898,6 @@ TEST_F(ObjectIntegrationTest, DeleteAccessControlFailure) {
 }
 
 TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
-  if (UsingGrpc()) {
-    // TODO(5030): DeleteResumableUpload doesn't work with gRPC yet.
-    GTEST_SKIP();
-  }
   StatusOr<Client> client = MakeIntegrationTestClient(
       absl::make_unique<LimitedErrorCountRetryPolicy>(1));
   ASSERT_STATUS_OK(client);


### PR DESCRIPTION
Per #5030 it's already been fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5908)
<!-- Reviewable:end -->
