### PR TITLE
test(spanner): extend samples and integration-test timeouts

### DIFF
--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -20,7 +20,7 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
-    timeout = "long",
+    timeout = "eternal",
     srcs = [test],
     tags = [
         "integration-test",

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -23,7 +23,7 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 
 [cc_test(
     name = test.replace("/", "_").replace(".cc", ""),
-    timeout = "long",
+    timeout = "eternal",
     srcs = [test],
     tags = [
         "integration-test",


### PR DESCRIPTION
We now run the GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS
overnight, with a couple of new ones either recently submitted
or in the works, so extend the timeout.

The change from 15m to 60m could cause a failure delay if you
hit a hang without even running the slow tests, but so be it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5926)
<!-- Reviewable:end -->
