### PR TITLE
cleanup: issue deprecation warnings for some IAM functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## FUTURE BREAKING CHANGES:
 
+<!-- Keep these sorted by estimated date -->
+
 <details>
 <summary>2021-06-01: retiring experimental Bigtable Admin Async APIs</summary>
 
@@ -12,8 +14,7 @@
   We do not think these functions are sufficiently useful to justify the
   additional maintenance and API clutter. Starting with the v1.25.0 release,
   and depending on your compiler settings, using these functions may issue a
-  deprecation warning at the call site. More information in
-  [#5923](https://github.com/googleapis/google-cloud-cpp/issues/5923).
+  deprecation warning at the call site. More information in [#5923].
 
 </details>
 
@@ -52,6 +53,19 @@
     [#5726](https://github.com/googleapis/google-cloud-cpp/issues/5726)
 </details>
 
+<details>
+<summary>2022-04-01: retiring legacy IAM functions</summary>
+<br>
+
+* On 2022-04-01 (or shortly after) we are planning to remove a number of
+  IAM functions designed before [IAM conditions][iam-conditions-link]. These
+  functions do not work with IAM policies that include IAM conditions, and
+  have been marked as deprecated since before 2019-08-01, albeit in Doxygen
+  comments only. Starting with the v1.25.0 release, and depending on your
+  compiler settings, using these functions may issue a deprecation warning at
+  the call site. See [#5929] for more details.
+</details>
+
 ## v1.25.0 - TBD
 
 ### Bigtable:
@@ -60,7 +74,21 @@
   deprecated. These functions were experimental and we do not think they add
   value to our customers. Removing them would simplify the code and free
   development time for further features and cleanups.  More information in
-  [#5923](https://github.com/googleapis/google-cloud-cpp/issues/5923).
+  [#5923].
+
+* The legacy IAM functions were marked as deprecated via doxygen comments.
+  Now they should generate warnings at the call site, depending on your
+  compiler settings. See [#5929] for more information.
+
+### Storage:
+
+* The legacy IAM functions were marked as deprecated via doxygen comments.
+  Now they should generate warnings at the call site, depending on your
+  compiler settings. See [#5929] for more information.
+
+[iam-conditions-link]: https://cloud.google.com/iam/docs/conditions-overview
+[#5923]: https://github.com/googleapis/google-cloud-cpp/issues/5923
+[#5929]: https://github.com/googleapis/google-cloud-cpp/issues/5929
 
 ## v1.24.0 - 2021-02
 

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -589,52 +589,6 @@ void DeleteAppProfile(std::vector<std::string> const& argv) {
   (std::move(instance), argv[1], argv[2], ignore_warnings);
 }
 
-void GetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
-                  std::vector<std::string> const& argv) {
-  //! [get iam policy]
-  namespace cbt = google::cloud::bigtable;
-  using google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id) {
-    StatusOr<google::cloud::IamPolicy> policy =
-        instance_admin.GetIamPolicy(instance_id);
-    if (!policy) throw std::runtime_error(policy.status().message());
-    std::cout << "The IAM Policy for " << instance_id << " is\n";
-    for (auto const& kv : policy->bindings) {
-      std::cout << "role " << kv.first << " includes [";
-      std::cout << absl::StrJoin(kv.second, ", ");
-      std::cout << "]\n";
-    }
-  }
-  //! [get iam policy]
-  (std::move(instance_admin), argv.at(0));
-}
-
-void SetIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
-                  std::vector<std::string> const& argv) {
-  //! [set iam policy]
-  namespace cbt = google::cloud::bigtable;
-  using google::cloud::StatusOr;
-  [](cbt::InstanceAdmin instance_admin, std::string const& instance_id,
-     std::string const& role, std::string const& member) {
-    StatusOr<google::cloud::IamPolicy> current =
-        instance_admin.GetIamPolicy(instance_id);
-    if (!current) throw std::runtime_error(current.status().message());
-    auto bindings = current->bindings;
-    bindings.AddMember(role, member);
-    StatusOr<google::cloud::IamPolicy> policy =
-        instance_admin.SetIamPolicy(instance_id, bindings, current->etag);
-    if (!policy) throw std::runtime_error(policy.status().message());
-    std::cout << "The IAM Policy for " << instance_id << " is\n";
-    for (auto const& kv : policy->bindings) {
-      std::cout << "role " << kv.first << " includes [";
-      std::cout << absl::StrJoin(kv.second, ", ");
-      std::cout << "]\n";
-    }
-  }
-  //! [set iam policy]
-  (std::move(instance_admin), argv.at(0), argv.at(1), argv.at(2));
-}
-
 void GetNativeIamPolicy(google::cloud::bigtable::InstanceAdmin instance_admin,
                         std::vector<std::string> const& argv) {
   //! [get native iam policy]
@@ -854,13 +808,6 @@ void RunAll(std::vector<std::string> const& argv) {
   std::cout << "\nRunning DeleteCluster() example" << std::endl;
   DeleteCluster(admin, {instance_id, instance_id + "-c2"});
 
-  std::cout << "\nRunning GetIamPolicy() example" << std::endl;
-  GetIamPolicy(admin, {instance_id});
-
-  std::cout << "\nRunning SetIamPolicy() example" << std::endl;
-  SetIamPolicy(admin, {instance_id, "roles/bigtable.user",
-                       "serviceAccount:" + service_account});
-
   std::cout << "\nRunning GetNativeIamPolicy() example" << std::endl;
   GetNativeIamPolicy(admin, {instance_id});
 
@@ -937,11 +884,6 @@ int main(int argc, char* argv[]) {
       examples::MakeCommandEntry("list-app-profiles", {"<instance-id>"},
                                  ListAppProfiles),
       {"delete-app-profile", DeleteAppProfile},
-      examples::MakeCommandEntry("get-iam-policy", {"<instance-id>"},
-                                 GetIamPolicy),
-      examples::MakeCommandEntry("set-iam-policy",
-                                 {"<instance-id>", "<role>", "<member>"},
-                                 SetIamPolicy),
       examples::MakeCommandEntry("get-native-iam-policy", {"<instance-id>"},
                                  GetNativeIamPolicy),
       examples::MakeCommandEntry("set-native-iam-policy",

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -1096,7 +1096,7 @@ class InstanceAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * @snippet bigtable_instance_admin_snippets.cc get iam policy
+   * Use #GetNativeIamPolicy() instead.
    */
   GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED("GetNativeIamPolicy")
   StatusOr<google::cloud::IamPolicy> GetIamPolicy(
@@ -1211,7 +1211,8 @@ class InstanceAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * @snippet bigtable_instance_admin_snippets.cc set iam policy
+   * Use #SetIamPolicy(std::string const&, google::iam::v1::Policy const&)
+   * instead.
    */
   GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED("SetNativeIamPolicy")
   StatusOr<google::cloud::IamPolicy> SetIamPolicy(

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -1214,7 +1214,8 @@ class InstanceAdmin {
    * Use #SetIamPolicy(std::string const&, google::iam::v1::Policy const&)
    * instead.
    */
-  GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED("SetNativeIamPolicy")
+  GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(
+      "SetIamPolicy(std::string const&, google::iam::v1::Policy const&)")
   StatusOr<google::cloud::IamPolicy> SetIamPolicy(
       std::string const& instance_id,
       google::cloud::IamBindings const& iam_bindings,

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -1086,7 +1086,6 @@ class InstanceAdmin {
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
    *     `GetNativeIamPolicy` instead.
-   *     TODO(#2857): Use proper deprecation attributes.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -1099,6 +1098,7 @@ class InstanceAdmin {
    * @par Example
    * @snippet bigtable_instance_admin_snippets.cc get iam policy
    */
+  GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED("GetNativeIamPolicy")
   StatusOr<google::cloud::IamPolicy> GetIamPolicy(
       std::string const& instance_id);
 
@@ -1139,7 +1139,6 @@ class InstanceAdmin {
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
    *     `AsyncGetNativeIamPolicy` instead.
-   *     TODO(#2857): Use proper deprecation attributes.
    *
    * @par Idempotency
    * This operation is read-only and therefore it is always idempotent.
@@ -1200,7 +1199,6 @@ class InstanceAdmin {
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
    *     the overload for `google::iam::v1::Policy` instead.
-   *     TODO(#2857): Use proper deprecation attributes.
    *
    * @warning ETags are currently not used by Cloud Bigtable.
    *
@@ -1215,6 +1213,7 @@ class InstanceAdmin {
    * @par Example
    * @snippet bigtable_instance_admin_snippets.cc set iam policy
    */
+  GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED("SetNativeIamPolicy")
   StatusOr<google::cloud::IamPolicy> SetIamPolicy(
       std::string const& instance_id,
       google::cloud::IamBindings const& iam_bindings,
@@ -1269,7 +1268,6 @@ class InstanceAdmin {
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
    *     the overload for `google::iam::v1::Policy` instead.
-   *     TODO(#2857): Use proper deprecation attributes.
    *
    * @warning ETags are currently not used by Cloud Bigtable.
    *

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -839,7 +839,7 @@ class TableAdmin {
     /**
      * Sets the cluster_id.
      *
-     * @param cluster_id the name of the cluster relative to the instance
+     * @param c the name of the cluster relative to the instance
      *     managed by the `TableAdmin` object. If no cluster_id is specified,
      *     the all backups in all clusters are listed. The full cluster name is
      *     `projects/<PROJECT_ID>/instances/<INSTANCE_ID>/clusters/<cluster_id>`
@@ -854,7 +854,7 @@ class TableAdmin {
     /**
      * Sets the filtering expression.
      *
-     * @param filter expression that filters backups listed in the response.
+     * @param f expression that filters backups listed in the response.
      *     The expression must specify the field name, a comparison operator,
      *     and the value that you want to use for filtering. The value must be a
      *     string, a number, or a boolean. The comparison operator must be
@@ -897,7 +897,7 @@ class TableAdmin {
     /**
      * Sets the ordering expression.
      *
-     * @param order_by expression for specifying the sort order of the results
+     * @param o expression for specifying the sort order of the results
      *     of the request. The string value should specify only one field in
      *     `google::bigtable::admin::v2::Backup`.
      *     The following field names are supported:
@@ -1493,7 +1493,8 @@ class TableAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * @snippet table_admin_iam_policy_snippets.cc get iam policy backup
+   * TODO(#5931) - example is missing:
+   *     snippet table_admin_iam_policy_snippets.cc get iam policy backup
    */
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& cluster_id,
                                                  std::string const& backup_id);
@@ -1575,7 +1576,8 @@ class TableAdmin {
    * and using different copies in each thread.
    *
    * @par Example
-   * @snippet table_admin_iam_policy_snippets.cc set iam policy backup
+   * TODO(#5931) - example is missing:
+   *     snippet table_admin_iam_policy_snippets.cc set iam policy backup
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& cluster_id, std::string const& backup_id,

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -23,6 +23,8 @@
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+// TODO(#5929) - remove once deprecated functions are removed
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -25,6 +25,12 @@
       "this experimental function will be removed on or shortly after " \
       "2021-06-01. See GitHub issue #5923 for more information.")
 
+#define GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(alternative)                  \
+  GOOGLE_CLOUD_CPP_DEPRECATED(                                                 \
+      "this function predates conditional bindings. It does not support such " \
+      "bindings and will not support newer IAM features. Please "              \
+      "use " alternative " instead")
+
 #define BIGTABLE_CLIENT_NS                              \
   GOOGLE_CLOUD_CPP_VEVAL(BIGTABLE_CLIENT_VERSION_MAJOR, \
                          BIGTABLE_CLIENT_VERSION_MINOR)

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -27,9 +27,10 @@
 
 #define GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(alternative)                  \
   GOOGLE_CLOUD_CPP_DEPRECATED(                                                 \
-      "this function predates conditional bindings. It does not support such " \
-      "bindings and will not support newer IAM features. Please "              \
-      "use " alternative " instead")
+      "this function predates IAM conditions and does not work with policies " \
+      "that include IAM conditions. Please use " alternative                   \
+      " instead. The function will be removed on 2022-04-01 or shortly "       \
+      "after. See GitHub issue #5929 for more information.")
 
 #define BIGTABLE_CLIENT_NS                              \
   GOOGLE_CLOUD_CPP_VEVAL(BIGTABLE_CLIENT_VERSION_MAJOR, \

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -21,6 +21,8 @@
 #include "google/cloud/storage/testing/retry_tests.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
+// TODO(#5929) - remove once deprecated functions are removed
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -599,7 +599,7 @@ class Client {
    * This is a read-only operation and is always idempotent.
    *
    * @par Example
-   * @snippet storage_bucket_iam_samples.cc get bucket iam policy
+   * Use #GetNativeBucketIamPolicy() instead.
    *
    * @see #google::cloud::v1::IamPolicy for details about the `IamPolicy` class.
    */
@@ -693,10 +693,7 @@ class Client {
    *     `SetNativeBucketIamPolicy` instead.
    *
    * @par Example: adding a new member
-   * @snippet storage_bucket_iam_samples.cc add bucket iam member
-   *
-   * @par Example: removing a IAM member
-   * @snippet storage_bucket_iam_samples.cc remove bucket iam member
+   * Use #GetNativeBucketIamPolicy() instead.
    *
    * @see #google::cloud::v1::IamPolicy for details about the `IamPolicy` class.
    */

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -594,7 +594,6 @@ class Client {
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
    *     `GetNativeBucketIamPolicy` instead.
-   *     TODO(#2857): Use proper deprecation attributes.
    *
    * @par Idempotency
    * This is a read-only operation and is always idempotent.
@@ -605,6 +604,7 @@ class Client {
    * @see #google::cloud::v1::IamPolicy for details about the `IamPolicy` class.
    */
   template <typename... Options>
+  GOOGLE_CLOUD_CPP_STORAGE_IAM_DEPRECATED("GetNativeBucketIamPolicy")
   StatusOr<IamPolicy> GetBucketIamPolicy(std::string const& bucket_name,
                                          Options&&... options) {
     internal::GetBucketIamPolicyRequest request(bucket_name);
@@ -691,7 +691,6 @@ class Client {
    * @deprecated this function is deprecated; it doesn't support conditional
    *     bindings and will not support any other features to come; please use
    *     `SetNativeBucketIamPolicy` instead.
-   *     TODO(#2857): Use proper deprecation attributes.
    *
    * @par Example: adding a new member
    * @snippet storage_bucket_iam_samples.cc add bucket iam member
@@ -702,6 +701,7 @@ class Client {
    * @see #google::cloud::v1::IamPolicy for details about the `IamPolicy` class.
    */
   template <typename... Options>
+  GOOGLE_CLOUD_CPP_STORAGE_IAM_DEPRECATED("SetNativeBucketIamPolicy")
   StatusOr<IamPolicy> SetBucketIamPolicy(std::string const& bucket_name,
                                          IamPolicy const& iam_policy,
                                          Options&&... options) {

--- a/google/cloud/storage/tests/bucket_integration_test.cc
+++ b/google/cloud/storage/tests/bucket_integration_test.cc
@@ -23,6 +23,8 @@
 #include <gmock/gmock.h>
 #include <chrono>
 #include <thread>
+// TODO(#5929) - remove once deprecated functions are removed
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/version.h
+++ b/google/cloud/storage/version.h
@@ -16,8 +16,15 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_VERSION_H
 
 #include "google/cloud/storage/version_info.h"
+#include "google/cloud/internal/attributes.h"
 #include "google/cloud/version.h"
 #include <string>
+
+#define GOOGLE_CLOUD_CPP_STORAGE_IAM_DEPRECATED(alternative)                   \
+  GOOGLE_CLOUD_CPP_DEPRECATED(                                                 \
+      "this function predates conditional bindings. It does not support such " \
+      "bindings and will not support newer IAM features. Please "              \
+      "use " alternative " instead")
 
 #define STORAGE_CLIENT_NS                              \
   GOOGLE_CLOUD_CPP_VEVAL(STORAGE_CLIENT_VERSION_MAJOR, \

--- a/google/cloud/storage/version.h
+++ b/google/cloud/storage/version.h
@@ -22,9 +22,10 @@
 
 #define GOOGLE_CLOUD_CPP_STORAGE_IAM_DEPRECATED(alternative)                   \
   GOOGLE_CLOUD_CPP_DEPRECATED(                                                 \
-      "this function predates conditional bindings. It does not support such " \
-      "bindings and will not support newer IAM features. Please "              \
-      "use " alternative " instead")
+      "this function predates IAM conditions and does not work with policies " \
+      "that include IAM conditions. Please use " alternative                   \
+      " instead. The function will be removed on 2022-04-01 or shortly "       \
+      "after. See GitHub issue #5929 for more information.")
 
 #define STORAGE_CLIENT_NS                              \
   GOOGLE_CLOUD_CPP_VEVAL(STORAGE_CLIENT_VERSION_MAJOR, \


### PR DESCRIPTION
These functions were already deprecated in the Doxygen documentation,
and have been since before 2019-08-01.

Thanks to @remyabel for pointing out that there were several TODO
entries for #2857 outstanding.

Part of the work for #5929 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5928)
<!-- Reviewable:end -->
