### PR TITLE
cleanup: add testing_util::ScopedLog

### DIFF
--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.gcpcxx.pb.h"
 #include <gmock/gmock.h>
 #include <grpcpp/impl/codegen/status_code_enum.h>

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_factory_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_factory_test.cc
@@ -27,31 +27,16 @@ using ::testing::HasSubstr;
 
 class GoldenKitchenSinkStubFactoryTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
-
- private:
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-  long logger_id_ = 0;  // NOLINT
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(GoldenKitchenSinkStubFactoryTest, DefaultStubWithoutLogging) {
   auto default_stub = CreateDefaultGoldenKitchenSinkStub({});
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_EQ(log_lines.size(), 0);
 }
 
@@ -59,7 +44,7 @@ TEST_F(GoldenKitchenSinkStubFactoryTest, DefaultStubWithLogging) {
   golden::GoldenKitchenSinkConnectionOptions options;
   options.enable_tracing("rpc");
   auto default_stub = CreateDefaultGoldenKitchenSinkStub(options);
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("Enabled logging for gRPC calls")));
 }
 

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_factory_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_factory_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.gcpcxx.pb.h"
 #include <gmock/gmock.h>
 #include <memory>

--- a/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.gcpcxx.pb.h"
 #include <gmock/gmock.h>
 #include <memory>
@@ -161,9 +161,7 @@ class MockGoldenStub
 
 class LoggingDecoratorTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    mock_ = std::make_shared<MockGoldenStub>();
-  }
+  void SetUp() override { mock_ = std::make_shared<MockGoldenStub>(); }
 
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");

--- a/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
@@ -162,28 +162,15 @@ class MockGoldenStub
 class LoggingDecoratorTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
     mock_ = std::make_shared<MockGoldenStub>();
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
   }
 
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
-
   std::shared_ptr<MockGoldenStub> mock_;
-
- private:
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-  long logger_id_ = 0;  // NOLINT
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(LoggingDecoratorTest, GetDatabaseSuccess) {
@@ -197,7 +184,7 @@ TEST_F(LoggingDecoratorTest, GetDatabaseSuccess) {
       context, google::test::admin::database::v1::GetDatabaseRequest());
   EXPECT_STATUS_OK(status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("my_database")));
 }
@@ -211,7 +198,7 @@ TEST_F(LoggingDecoratorTest, GetDatabase) {
       context, google::test::admin::database::v1::GetDatabaseRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -225,7 +212,7 @@ TEST_F(LoggingDecoratorTest, ListDatabases) {
       context, google::test::admin::database::v1::ListDatabasesRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListDatabases")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -239,7 +226,7 @@ TEST_F(LoggingDecoratorTest, CreateDatabase) {
       context, google::test::admin::database::v1::CreateDatabaseRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -254,7 +241,7 @@ TEST_F(LoggingDecoratorTest, UpdateDatabaseDdl) {
       context, google::test::admin::database::v1::UpdateDatabaseDdlRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateDatabaseDdl")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -268,7 +255,7 @@ TEST_F(LoggingDecoratorTest, DropDatabase) {
       context, google::test::admin::database::v1::DropDatabaseRequest());
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("DropDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -282,7 +269,7 @@ TEST_F(LoggingDecoratorTest, GetDatabaseDdl) {
       context, google::test::admin::database::v1::GetDatabaseDdlRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabaseDdl")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -296,7 +283,7 @@ TEST_F(LoggingDecoratorTest, SetIamPolicy) {
       stub.SetIamPolicy(context, google::iam::v1::SetIamPolicyRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("SetIamPolicy")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -310,7 +297,7 @@ TEST_F(LoggingDecoratorTest, GetIamPolicy) {
       stub.GetIamPolicy(context, google::iam::v1::GetIamPolicyRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetIamPolicy")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -325,7 +312,7 @@ TEST_F(LoggingDecoratorTest, TestIamPermissions) {
       context, google::iam::v1::TestIamPermissionsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("TestIamPermissions")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -339,7 +326,7 @@ TEST_F(LoggingDecoratorTest, CreateBackup) {
       context, google::test::admin::database::v1::CreateBackupRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -353,7 +340,7 @@ TEST_F(LoggingDecoratorTest, GetBackup) {
       context, google::test::admin::database::v1::GetBackupRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -367,7 +354,7 @@ TEST_F(LoggingDecoratorTest, UpdateBackup) {
       context, google::test::admin::database::v1::UpdateBackupRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -381,7 +368,7 @@ TEST_F(LoggingDecoratorTest, DeleteBackup) {
       context, google::test::admin::database::v1::DeleteBackupRequest());
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -395,7 +382,7 @@ TEST_F(LoggingDecoratorTest, ListBackups) {
       context, google::test::admin::database::v1::ListBackupsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListBackups")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -409,7 +396,7 @@ TEST_F(LoggingDecoratorTest, RestoreDatabase) {
       context, google::test::admin::database::v1::RestoreDatabaseRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("RestoreDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -425,7 +412,7 @@ TEST_F(LoggingDecoratorTest, ListDatabaseOperations) {
       google::test::admin::database::v1::ListDatabaseOperationsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListDatabaseOperations")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -441,7 +428,7 @@ TEST_F(LoggingDecoratorTest, ListBackupOperations) {
       google::test::admin::database::v1::ListBackupOperationsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListBackupOperations")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -455,7 +442,7 @@ TEST_F(LoggingDecoratorTest, GetOperation) {
       stub.GetOperation(context, google::longrunning::GetOperationRequest());
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetOperation")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -469,7 +456,7 @@ TEST_F(LoggingDecoratorTest, CancelOperation) {
       context, google::longrunning::CancelOperationRequest());
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CancelOperation")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }

--- a/generator/integration_tests/golden/tests/golden_thing_admin_stub_factory_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_stub_factory_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.gcpcxx.pb.h"
 #include <gmock/gmock.h>
 #include <memory>

--- a/google/cloud/bigtable/internal/logging_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_admin_client_test.cc
@@ -33,25 +33,11 @@ namespace btadmin = google::bigtable::admin::v2;
 
 class LoggingAdminClientTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-
- private:
-  long logger_id_ = 0;  // NOLINT(google-runtime-int)
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(LoggingAdminClientTest, CreateTable) {
@@ -69,7 +55,7 @@ TEST_F(LoggingAdminClientTest, CreateTable) {
   auto status = stub.CreateTable(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateTable")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateTable")));
 }
 
 TEST_F(LoggingAdminClientTest, ListTables) {
@@ -87,7 +73,7 @@ TEST_F(LoggingAdminClientTest, ListTables) {
   auto status = stub.ListTables(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ListTable")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ListTable")));
 }
 
 TEST_F(LoggingAdminClientTest, GetTable) {
@@ -105,7 +91,7 @@ TEST_F(LoggingAdminClientTest, GetTable) {
   auto status = stub.GetTable(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetTable")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetTable")));
 }
 
 TEST_F(LoggingAdminClientTest, DeleteTable) {
@@ -123,7 +109,7 @@ TEST_F(LoggingAdminClientTest, DeleteTable) {
   auto status = stub.DeleteTable(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DeleteTable")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DeleteTable")));
 }
 
 TEST_F(LoggingAdminClientTest, CreateBackup) {
@@ -141,7 +127,7 @@ TEST_F(LoggingAdminClientTest, CreateBackup) {
   auto status = stub.CreateBackup(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateBackup")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateBackup")));
 }
 
 TEST_F(LoggingAdminClientTest, GetBackup) {
@@ -159,7 +145,7 @@ TEST_F(LoggingAdminClientTest, GetBackup) {
   auto status = stub.GetBackup(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetBackup")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetBackup")));
 }
 
 TEST_F(LoggingAdminClientTest, UpdateBackup) {
@@ -177,7 +163,7 @@ TEST_F(LoggingAdminClientTest, UpdateBackup) {
   auto status = stub.UpdateBackup(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("UpdateBackup")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("UpdateBackup")));
 }
 
 TEST_F(LoggingAdminClientTest, DeleteBackup) {
@@ -195,7 +181,7 @@ TEST_F(LoggingAdminClientTest, DeleteBackup) {
   auto status = stub.DeleteBackup(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DeleteBackup")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DeleteBackup")));
 }
 
 TEST_F(LoggingAdminClientTest, ListBackups) {
@@ -213,7 +199,7 @@ TEST_F(LoggingAdminClientTest, ListBackups) {
   auto status = stub.ListBackups(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ListBackups")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ListBackups")));
 }
 
 TEST_F(LoggingAdminClientTest, RestoreTable) {
@@ -231,7 +217,7 @@ TEST_F(LoggingAdminClientTest, RestoreTable) {
   auto status = stub.RestoreTable(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("RestoreTable")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("RestoreTable")));
 }
 
 TEST_F(LoggingAdminClientTest, ModifyColumnFamilies) {
@@ -249,7 +235,7 @@ TEST_F(LoggingAdminClientTest, ModifyColumnFamilies) {
   auto status = stub.ModifyColumnFamilies(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("ModifyColumnFamilies")));
 }
 
@@ -268,7 +254,7 @@ TEST_F(LoggingAdminClientTest, DropRowRange) {
   auto status = stub.DropRowRange(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DropRowRange")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DropRowRange")));
 }
 
 TEST_F(LoggingAdminClientTest, GenerateConsistencyToken) {
@@ -286,7 +272,7 @@ TEST_F(LoggingAdminClientTest, GenerateConsistencyToken) {
   auto status = stub.GenerateConsistencyToken(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("GenerateConsistencyToken")));
 }
 
@@ -305,7 +291,7 @@ TEST_F(LoggingAdminClientTest, CheckConsistency) {
   auto status = stub.CheckConsistency(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("CheckConsistency")));
 }
 
@@ -324,7 +310,7 @@ TEST_F(LoggingAdminClientTest, GetOperation) {
   auto status = stub.GetOperation(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetOperation")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetOperation")));
 }
 
 TEST_F(LoggingAdminClientTest, GetIamPolicy) {
@@ -342,7 +328,7 @@ TEST_F(LoggingAdminClientTest, GetIamPolicy) {
   auto status = stub.GetIamPolicy(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetIamPolicy")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetIamPolicy")));
 }
 
 TEST_F(LoggingAdminClientTest, SetIamPolicy) {
@@ -360,7 +346,7 @@ TEST_F(LoggingAdminClientTest, SetIamPolicy) {
   auto status = stub.SetIamPolicy(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("SetIamPolicy")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("SetIamPolicy")));
 }
 
 TEST_F(LoggingAdminClientTest, TestIamPermissions) {
@@ -378,7 +364,7 @@ TEST_F(LoggingAdminClientTest, TestIamPermissions) {
   auto status = stub.TestIamPermissions(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("TestIamPermissions")));
 }
 

--- a/google/cloud/bigtable/internal/logging_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_admin_client_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/bigtable/admin_client.h"
 #include "google/cloud/bigtable/testing/mock_admin_client.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -235,8 +235,7 @@ TEST_F(LoggingAdminClientTest, ModifyColumnFamilies) {
   auto status = stub.ModifyColumnFamilies(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("ModifyColumnFamilies")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ModifyColumnFamilies")));
 }
 
 TEST_F(LoggingAdminClientTest, DropRowRange) {
@@ -291,8 +290,7 @@ TEST_F(LoggingAdminClientTest, CheckConsistency) {
   auto status = stub.CheckConsistency(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("CheckConsistency")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CheckConsistency")));
 }
 
 TEST_F(LoggingAdminClientTest, GetOperation) {
@@ -364,8 +362,7 @@ TEST_F(LoggingAdminClientTest, TestIamPermissions) {
   auto status = stub.TestIamPermissions(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("TestIamPermissions")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("TestIamPermissions")));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/logging_data_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_data_client_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/bigtable/data_client.h"
 #include "google/cloud/bigtable/testing/mock_data_client.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -73,8 +73,7 @@ TEST_F(LoggingDataClientTest, CheckAndMutateRow) {
   auto status = stub.CheckAndMutateRow(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("CheckAndMutateRow")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CheckAndMutateRow")));
 }
 
 TEST_F(LoggingDataClientTest, ReadModifyWriteRow) {
@@ -92,8 +91,7 @@ TEST_F(LoggingDataClientTest, ReadModifyWriteRow) {
   auto status = stub.ReadModifyWriteRow(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("ReadModifyWriteRow")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ReadModifyWriteRow")));
 }
 
 TEST_F(LoggingDataClientTest, ReadRows) {

--- a/google/cloud/bigtable/internal/logging_data_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_data_client_test.cc
@@ -33,25 +33,11 @@ namespace btproto = google::bigtable::v2;
 
 class LoggingDataClientTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-
- private:
-  long logger_id_ = 0;  // NOLINT(google-runtime-int)
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(LoggingDataClientTest, MutateRow) {
@@ -69,7 +55,7 @@ TEST_F(LoggingDataClientTest, MutateRow) {
   auto status = stub.MutateRow(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("MutateRow")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("MutateRow")));
 }
 
 TEST_F(LoggingDataClientTest, CheckAndMutateRow) {
@@ -87,7 +73,7 @@ TEST_F(LoggingDataClientTest, CheckAndMutateRow) {
   auto status = stub.CheckAndMutateRow(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("CheckAndMutateRow")));
 }
 
@@ -106,7 +92,7 @@ TEST_F(LoggingDataClientTest, ReadModifyWriteRow) {
   auto status = stub.ReadModifyWriteRow(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("ReadModifyWriteRow")));
 }
 
@@ -127,7 +113,7 @@ TEST_F(LoggingDataClientTest, ReadRows) {
 
   stub.ReadRows(&context, request);
 
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ReadRows")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ReadRows")));
 }
 
 TEST_F(LoggingDataClientTest, SampleRowKeys) {
@@ -147,7 +133,7 @@ TEST_F(LoggingDataClientTest, SampleRowKeys) {
 
   stub.SampleRowKeys(&context, request);
 
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("SampleRowKeys")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("SampleRowKeys")));
 }
 
 TEST_F(LoggingDataClientTest, MutateRows) {
@@ -167,7 +153,7 @@ TEST_F(LoggingDataClientTest, MutateRows) {
 
   stub.MutateRows(&context, request);
 
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("MutateRows")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("MutateRows")));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/bigtable/testing/mock_instance_admin_client.h"
 #include "google/cloud/bigtable/testing/mock_response_reader.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -258,8 +258,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateAppProfile) {
   auto status = stub.CreateAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("CreateAppProfile")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateAppProfile")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetAppProfile) {
@@ -295,8 +294,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListAppProfiles) {
   auto status = stub.ListAppProfiles(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("ListAppProfiles")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ListAppProfiles")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, UpdateAppProfile) {
@@ -314,8 +312,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateAppProfile) {
   auto status = stub.UpdateAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("UpdateAppProfile")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("UpdateAppProfile")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, DeleteAppProfile) {
@@ -333,8 +330,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteAppProfile) {
   auto status = stub.DeleteAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("DeleteAppProfile")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DeleteAppProfile")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetIamPolicy) {
@@ -388,8 +384,7 @@ TEST_F(LoggingInstanceAdminClientTest, TestIamPermissions) {
   auto status = stub.TestIamPermissions(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("TestIamPermissions")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("TestIamPermissions")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, AsyncCreateInstance) {
@@ -413,8 +408,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncCreateInstance) {
 
   stub.AsyncCreateInstance(&context, request, &cq);
 
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("AsyncCreateInstance")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("AsyncCreateInstance")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, AsyncUpdateInstance) {
@@ -438,8 +432,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncUpdateInstance) {
 
   stub.AsyncUpdateInstance(&context, request, &cq);
 
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("AsyncUpdateInstance")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("AsyncUpdateInstance")));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
@@ -38,25 +38,11 @@ namespace btadmin = google::bigtable::admin::v2;
 
 class LoggingInstanceAdminClientTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-
- private:
-  long logger_id_ = 0;  // NOLINT(google-runtime-int)
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(LoggingInstanceAdminClientTest, ListInstances) {
@@ -74,7 +60,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListInstances) {
   auto status = stub.ListInstances(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ListInstances")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ListInstances")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, CreateInstance) {
@@ -92,7 +78,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateInstance) {
   auto status = stub.CreateInstance(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateInstance")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateInstance")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, UpdateInstance) {
@@ -110,7 +96,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateInstance) {
   auto status = stub.UpdateInstance(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("UpdateInstance")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("UpdateInstance")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetOperation) {
@@ -128,7 +114,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetOperation) {
   auto status = stub.GetOperation(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetOperation")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetOperation")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetInstance) {
@@ -146,7 +132,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetInstance) {
   auto status = stub.GetInstance(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetInstance")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetInstance")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, DeleteInstance) {
@@ -164,7 +150,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteInstance) {
   auto status = stub.DeleteInstance(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DeleteInstance")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DeleteInstance")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, ListClusters) {
@@ -182,7 +168,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListClusters) {
   auto status = stub.ListClusters(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ListClusters")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ListClusters")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetCluster) {
@@ -200,7 +186,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetCluster) {
   auto status = stub.GetCluster(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetCluster")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetCluster")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, DeleteCluster) {
@@ -218,7 +204,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteCluster) {
   auto status = stub.DeleteCluster(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DeleteCluster")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DeleteCluster")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, CreateCluster) {
@@ -236,7 +222,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateCluster) {
   auto status = stub.CreateCluster(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateCluster")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateCluster")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, UpdateCluster) {
@@ -254,7 +240,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateCluster) {
   auto status = stub.UpdateCluster(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("UpdateCluster")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("UpdateCluster")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, CreateAppProfile) {
@@ -272,7 +258,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateAppProfile) {
   auto status = stub.CreateAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("CreateAppProfile")));
 }
 
@@ -291,7 +277,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetAppProfile) {
   auto status = stub.GetAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetAppProfile")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetAppProfile")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, ListAppProfiles) {
@@ -309,7 +295,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListAppProfiles) {
   auto status = stub.ListAppProfiles(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("ListAppProfiles")));
 }
 
@@ -328,7 +314,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateAppProfile) {
   auto status = stub.UpdateAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("UpdateAppProfile")));
 }
 
@@ -347,7 +333,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteAppProfile) {
   auto status = stub.DeleteAppProfile(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("DeleteAppProfile")));
 }
 
@@ -366,7 +352,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetIamPolicy) {
   auto status = stub.GetIamPolicy(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetIamPolicy")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetIamPolicy")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, SetIamPolicy) {
@@ -384,7 +370,7 @@ TEST_F(LoggingInstanceAdminClientTest, SetIamPolicy) {
   auto status = stub.SetIamPolicy(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("SetIamPolicy")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("SetIamPolicy")));
 }
 
 TEST_F(LoggingInstanceAdminClientTest, TestIamPermissions) {
@@ -402,7 +388,7 @@ TEST_F(LoggingInstanceAdminClientTest, TestIamPermissions) {
   auto status = stub.TestIamPermissions(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("TestIamPermissions")));
 }
 
@@ -427,7 +413,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncCreateInstance) {
 
   stub.AsyncCreateInstance(&context, request, &cq);
 
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("AsyncCreateInstance")));
 }
 
@@ -452,7 +438,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncUpdateInstance) {
 
   stub.AsyncUpdateInstance(&context, request, &cq);
 
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("AsyncUpdateInstance")));
 }
 

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -19,7 +19,7 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -702,9 +702,7 @@ TEST_F(RowReaderTest, BeginThrowsAfterCancelClosesStreamNoExcept) {
 }
 
 TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   std::unique_ptr<bigtable::RowReader> reader(new bigtable::RowReader(
       client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
@@ -723,10 +721,8 @@ TEST_F(RowReaderTest, BeginThrowsAfterImmediateCancelNoExcept) {
   // error.
   reader.reset();
 
-  google::cloud::LogSink::Instance().RemoveBackend(id);
-
   EXPECT_THAT(
-      backend->ClearLogLines(),
+      log.ExtractLines(),
       Not(Contains(HasSubstr(
           "RowReader has an error, and the error status was not retrieved"))));
 }

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -17,9 +17,9 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/contains_once.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <string>

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -319,9 +319,7 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 /// @test Verify rpc logging for `bigtable::TableAdmin`
 TEST_F(AdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
   using GC = bigtable::GcRule;
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   std::string const table_id = RandomTableId();
 
@@ -401,13 +399,12 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
       TableNames(*current_table_list),
       Not(Contains(table_admin->instance_name() + "/tables/" + table_id)));
 
-  auto const log_lines = backend->ClearLogLines();
+  auto const log_lines = log.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListTables")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateTable")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetTable")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("ModifyColumnFamilies")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteTable")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 }  // namespace
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -15,8 +15,8 @@
 #include "google/cloud/bigtable/testing/table_integration_test.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/chrono_literals.h"
+#include "google/cloud/testing_util/scoped_log.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -562,10 +562,7 @@ TEST_F(DataIntegrationTest, TableReadMultipleCellsBigValue) {
 }
 
 TEST_F(DataIntegrationTest, TableApplyWithLogging) {
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
-
+  testing_util::ScopedLog log;
   std::string const table_id = RandomTableId();
 
   auto constexpr kTestMaxVersions = 10;
@@ -595,9 +592,7 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
 
   auto actual = ReadRows(table, Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
-  EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("MutateRow")));
-
-  google::cloud::LogSink::Instance().RemoveBackend(id);
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("MutateRow")));
 }
 
 TEST(ConnectionRefresh, Disabled) {

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -430,10 +430,7 @@ TEST_F(InstanceAdminIntegrationTest, SetGetTestIamNativeAPIsTest) {
 /// @test Verify that Instance CRUD operations with logging work as expected.
 TEST_F(InstanceAdminIntegrationTest,
        CreateListGetDeleteInstanceTestWithLogging) {
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
-
+  testing_util::ScopedLog log;
   std::string instance_id =
       "it-" + google::cloud::internal::Sample(
                   generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
@@ -492,13 +489,12 @@ TEST_F(InstanceAdminIntegrationTest,
   EXPECT_FALSE(
       IsInstancePresent(instances_after_delete->instances, instance->name()));
 
-  auto const log_lines = backend->ClearLogLines();
+  auto const log_lines = log.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstances")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncCreateInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncUpdateInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteInstance")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 }  // namespace
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -18,8 +18,8 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/contains_once.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>

--- a/google/cloud/iam/integration_tests/iam_credentials_integration_test.cc
+++ b/google/cloud/iam/integration_tests/iam_credentials_integration_test.cc
@@ -32,9 +32,6 @@ using ::testing::HasSubstr;
 class IamCredentialsIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
     rpc_tracing_options_.enable_tracing("rpc");
 
     iam_service_account_ = google::cloud::internal::GetEnv(
@@ -48,18 +45,13 @@ class IamCredentialsIntegrationTest : public ::testing::Test {
     ASSERT_FALSE(iam_service_account_.empty());
     ASSERT_FALSE(invalid_iam_service_account_.empty());
   }
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
+  std::vector<std::string> ClearLogLines() { return log_.ExtractLines(); }
   IAMCredentialsConnectionOptions rpc_tracing_options_;
   std::string iam_service_account_;
   std::string invalid_iam_service_account_;
 
  private:
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-  long logger_id_ = 0;  // NOLINT
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(IamCredentialsIntegrationTest, GenerateAccessTokenSuccess) {

--- a/google/cloud/iam/integration_tests/iam_credentials_integration_test.cc
+++ b/google/cloud/iam/integration_tests/iam_credentials_integration_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/log_wrapper.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/tracing_options.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <google/protobuf/text_format.h>

--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/internal/resumable_streaming_read_rpc.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>

--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/internal/resumable_streaming_read_rpc.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/retry_policy.h"
-#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>

--- a/google/cloud/internal/streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_logging_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/tracing_options.h"
 #include "absl/memory/memory.h"
 #include "absl/types/variant.h"

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/streaming_read_rpc.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -153,9 +153,7 @@ TEST(StreamingReadRpcImpl, HandleUnfinished) {
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
 
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   {
     StreamingReadRpcImpl<FakeResponse> impl(
@@ -165,11 +163,9 @@ TEST(StreamingReadRpcImpl, HandleUnfinished) {
     values.push_back(absl::get<FakeResponse>(impl.Read()).value);
     EXPECT_THAT(values, ElementsAre("value-0", "value-1"));
   }
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr("unhandled error"), HasSubstr("status="),
                              HasSubstr("uh-oh"))));
-
-  google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 
 }  // namespace

--- a/google/cloud/logging/integration_tests/logging_integration_test.cc
+++ b/google/cloud/logging/integration_tests/logging_integration_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/pubsub/experimental/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/experimental/schema_admin_connection_test.cc
@@ -16,8 +16,8 @@
 #include "google/cloud/pubsub/testing/mock_schema_stub.h"
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/internal/api_client_header.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <google/protobuf/text_format.h>

--- a/google/cloud/pubsub/experimental/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/experimental/schema_admin_connection_test.cc
@@ -145,9 +145,7 @@ TEST(SchemaAdminConnectionTest, List) {
  */
 TEST(SchemaAdminConnectionTest, DeleteWithLogging) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   std::string const text = R"pb(
     name: "projects/test-project/schemas/test-schema"
@@ -165,8 +163,7 @@ TEST(SchemaAdminConnectionTest, DeleteWithLogging) {
   auto response = schema_admin->DeleteSchema(request);
   ASSERT_THAT(response, IsOk());
 
-  EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("DeleteSchema")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("DeleteSchema")));
 }
 
 TEST(SchemaAdminConnectionTest, ValidateSchema) {

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/pubsub/internal/publisher_logging.h"
 #include "google/cloud/pubsub/testing/mock_publisher_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -32,25 +32,11 @@ using ::testing::Return;
 
 class PublisherLoggingTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-
- private:
-  long logger_id_ = 0;  // NOLINT(google-runtime-int)
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(PublisherLoggingTest, CreateTopic) {
@@ -63,7 +49,7 @@ TEST_F(PublisherLoggingTest, CreateTopic) {
   topic.set_name("test-topic-name");
   auto status = stub.CreateTopic(context, topic);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateTopic")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateTopic")));
 }
 
 TEST_F(PublisherLoggingTest, GetTopic) {
@@ -76,7 +62,7 @@ TEST_F(PublisherLoggingTest, GetTopic) {
   request.set_topic("test-topic-name");
   auto status = stub.GetTopic(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetTopic")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetTopic")));
 }
 
 TEST_F(PublisherLoggingTest, UpdateTopic) {
@@ -89,7 +75,7 @@ TEST_F(PublisherLoggingTest, UpdateTopic) {
   request.mutable_topic()->set_name("test-topic-name");
   auto status = stub.UpdateTopic(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("UpdateTopic")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("UpdateTopic")));
 }
 
 TEST_F(PublisherLoggingTest, ListTopics) {
@@ -104,7 +90,7 @@ TEST_F(PublisherLoggingTest, ListTopics) {
   auto status = stub.ListTopics(context, request);
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->ClearLogLines(),
+      log_.ExtractLines(),
       Contains(AllOf(HasSubstr("ListTopics"), HasSubstr("test-project-name"))));
 }
 
@@ -118,7 +104,7 @@ TEST_F(PublisherLoggingTest, DeleteTopic) {
   auto status = stub.DeleteTopic(context, request);
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->ClearLogLines(),
+      log_.ExtractLines(),
       Contains(AllOf(HasSubstr("DeleteTopic"), HasSubstr("test-topic-name"))));
 }
 
@@ -133,7 +119,7 @@ TEST_F(PublisherLoggingTest, DetachSubscription) {
   request.set_subscription("test-subscription-name");
   auto status = stub.DetachSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(AllOf(HasSubstr("DetachSubscription"),
                              HasSubstr("test-subscription-name"))));
 }
@@ -149,7 +135,7 @@ TEST_F(PublisherLoggingTest, ListTopicSubscriptions) {
   request.set_topic("test-topic-name");
   auto status = stub.ListTopicSubscriptions(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(AllOf(HasSubstr("ListTopicSubscriptions"),
                              HasSubstr("test-topic-name"))));
 }
@@ -165,7 +151,7 @@ TEST_F(PublisherLoggingTest, ListTopicSnapshots) {
   request.set_topic("test-topic-name");
   auto status = stub.ListTopicSnapshots(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(AllOf(HasSubstr("ListTopicSnapshots"),
                              HasSubstr("test-topic-name"))));
 }
@@ -188,7 +174,7 @@ TEST_F(PublisherLoggingTest, AsyncPublish) {
           .get();
   EXPECT_STATUS_OK(status);
   EXPECT_THAT(
-      backend_->ClearLogLines(),
+      log_.ExtractLines(),
       Contains(AllOf(HasSubstr("AsyncPublish"), HasSubstr("test-topic-name"))));
 }
 

--- a/google/cloud/pubsub/internal/schema_logging_test.cc
+++ b/google/cloud/pubsub/internal/schema_logging_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/pubsub/internal/schema_logging.h"
 #include "google/cloud/pubsub/testing/mock_schema_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 
@@ -109,8 +109,7 @@ TEST_F(SchemaLoggingTest, ValidateMessage) {
   google::pubsub::v1::ValidateMessageRequest request;
   auto status = stub.ValidateMessage(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("ValidateMessage")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ValidateMessage")));
 }
 
 }  // namespace

--- a/google/cloud/pubsub/internal/schema_logging_test.cc
+++ b/google/cloud/pubsub/internal/schema_logging_test.cc
@@ -31,25 +31,11 @@ using ::testing::Return;
 
 class SchemaLoggingTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
-  }
-
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-
- private:
-  long logger_id_ = 0;  // NOLINT(google-runtime-int)
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(SchemaLoggingTest, CreateSchema) {
@@ -61,7 +47,7 @@ TEST_F(SchemaLoggingTest, CreateSchema) {
   google::pubsub::v1::CreateSchemaRequest request;
   auto status = stub.CreateSchema(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("CreateSchema")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateSchema")));
 }
 
 TEST_F(SchemaLoggingTest, GetSchema) {
@@ -73,7 +59,7 @@ TEST_F(SchemaLoggingTest, GetSchema) {
   google::pubsub::v1::GetSchemaRequest request;
   auto status = stub.GetSchema(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("GetSchema")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetSchema")));
 }
 
 TEST_F(SchemaLoggingTest, ListSchemas) {
@@ -86,7 +72,7 @@ TEST_F(SchemaLoggingTest, ListSchemas) {
   google::pubsub::v1::ListSchemasRequest request;
   auto status = stub.ListSchemas(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ListSchemas")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ListSchemas")));
 }
 
 TEST_F(SchemaLoggingTest, DeleteSchema) {
@@ -97,7 +83,7 @@ TEST_F(SchemaLoggingTest, DeleteSchema) {
   google::pubsub::v1::DeleteSchemaRequest request;
   auto status = stub.DeleteSchema(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("DeleteSchema")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("DeleteSchema")));
 }
 
 TEST_F(SchemaLoggingTest, ValidateSchema) {
@@ -110,7 +96,7 @@ TEST_F(SchemaLoggingTest, ValidateSchema) {
   google::pubsub::v1::ValidateSchemaRequest request;
   auto status = stub.ValidateSchema(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(), Contains(HasSubstr("ValidateSchema")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("ValidateSchema")));
 }
 
 TEST_F(SchemaLoggingTest, ValidateMessage) {
@@ -123,7 +109,7 @@ TEST_F(SchemaLoggingTest, ValidateMessage) {
   google::pubsub::v1::ValidateMessageRequest request;
   auto status = stub.ValidateMessage(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(backend_->ClearLogLines(),
+  EXPECT_THAT(log_.ExtractLines(),
               Contains(HasSubstr("ValidateMessage")));
 }
 

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -19,8 +19,8 @@
 #include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/async_sequencer.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <deque>

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -20,7 +20,6 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/async_sequencer.h"
 #include "google/cloud/testing_util/mock_completion_queue_impl.h"
-#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <deque>

--- a/google/cloud/pubsub/internal/subscriber_logging_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging_test.cc
@@ -15,7 +15,7 @@
 #include "google/cloud/pubsub/internal/subscriber_logging.h"
 #include "google/cloud/pubsub/testing/mock_subscriber_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 
@@ -49,8 +49,7 @@ TEST_F(SubscriberLoggingTest, CreateSubscription) {
   google::pubsub::v1::Subscription subscription;
   auto status = stub.CreateSubscription(context, subscription);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("CreateSubscription")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("CreateSubscription")));
 }
 
 TEST_F(SubscriberLoggingTest, GetSubscription) {
@@ -63,8 +62,7 @@ TEST_F(SubscriberLoggingTest, GetSubscription) {
   google::pubsub::v1::GetSubscriptionRequest request;
   auto status = stub.GetSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("GetSubscription")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("GetSubscription")));
 }
 
 TEST_F(SubscriberLoggingTest, UpdateSubscription) {
@@ -77,8 +75,7 @@ TEST_F(SubscriberLoggingTest, UpdateSubscription) {
   google::pubsub::v1::UpdateSubscriptionRequest request;
   auto status = stub.UpdateSubscription(context, request);
   EXPECT_STATUS_OK(status);
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("UpdateSubscription")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("UpdateSubscription")));
 }
 
 TEST_F(SubscriberLoggingTest, ListSubscriptions) {
@@ -169,8 +166,7 @@ TEST_F(SubscriberLoggingTest, AsyncStreamingPull) {
   request.set_subscription("test-subscription-name");
   auto stream = stub.AsyncStreamingPull(
       cq, absl::make_unique<grpc::ClientContext>(), request);
-  EXPECT_THAT(log_.ExtractLines(),
-              Contains(HasSubstr("AsyncStreamingPull")));
+  EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("AsyncStreamingPull")));
 
   EXPECT_TRUE(stream->Start().get());
   EXPECT_THAT(log_.ExtractLines(), Contains(HasSubstr("Start")));

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -90,9 +90,7 @@ TEST(PublisherConnectionTest, Metadata) {
 TEST(PublisherConnectionTest, Logging) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   Topic const topic("test-project", "test-topic");
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   EXPECT_CALL(*mock, AsyncPublish)
       .Times(AtLeast(1))
@@ -114,8 +112,7 @@ TEST(PublisherConnectionTest, Logging) {
           .get();
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("AsyncPublish")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("AsyncPublish")));
 }
 
 TEST(PublisherConnectionTest, OrderingKey) {

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -18,7 +18,7 @@
 #include "google/cloud/pubsub/testing/test_retry_policies.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -122,9 +122,7 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
       .Times(AtLeast(1))
       .WillRepeatedly(FakeAsyncStreamingPull);
 
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   CompletionQueue cq;
   auto subscriber = pubsub_internal::MakeSubscriberConnection(
@@ -153,13 +151,12 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsLogging) {
   cq.Shutdown();
   t.join();
 
-  auto const log_lines = backend->ClearLogLines();
+  auto const log_lines = log.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("AsyncStreamingPull")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("Start")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("Write")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("Read")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("Finish")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 
 /// @test Verify the metadata decorator is configured

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -177,9 +177,7 @@ TEST(SubscriptionAdminConnectionTest, Update) {
 TEST(SubscriptionAdminConnectionTest, DeleteWithLogging) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   Subscription const subscription("test-project", "test-subscription");
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   EXPECT_CALL(*mock, DeleteSubscription)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
@@ -196,17 +194,13 @@ TEST(SubscriptionAdminConnectionTest, DeleteWithLogging) {
   auto response = subscription_admin->DeleteSubscription({subscription});
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->ClearLogLines(),
-              Contains(HasSubstr("DeleteSubscription")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("DeleteSubscription")));
 }
 
 TEST(SubscriptionAdminConnectionTest, ModifyPushConfig) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   Subscription const subscription("test-project", "test-subscription");
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   EXPECT_CALL(*mock, ModifyPushConfig)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
@@ -225,9 +219,7 @@ TEST(SubscriptionAdminConnectionTest, ModifyPushConfig) {
   auto response = subscription_admin->ModifyPushConfig({request});
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->ClearLogLines(),
-              Contains(HasSubstr("ModifyPushConfig")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("ModifyPushConfig")));
 }
 
 TEST(SubscriptionAdminConnectionTest, CreateSnapshot) {

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -19,8 +19,8 @@
 #include "google/cloud/pubsub/topic.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -18,8 +18,8 @@
 #include "google/cloud/pubsub/topic_builder.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -160,9 +160,7 @@ TEST(TopicAdminConnectionTest, List) {
 TEST(TopicAdminConnectionTest, DeleteWithLogging) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   Topic const topic("test-project", "test-topic");
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   EXPECT_CALL(*mock, DeleteTopic)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
@@ -178,8 +176,7 @@ TEST(TopicAdminConnectionTest, DeleteWithLogging) {
   auto response = topic_admin->DeleteTopic({topic});
   ASSERT_STATUS_OK(response);
 
-  EXPECT_THAT(backend->ClearLogLines(), Contains(HasSubstr("DeleteTopic")));
-  google::cloud::LogSink::Instance().RemoveBackend(id);
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("DeleteTopic")));
 }
 
 TEST(TopicAdminConnectionTest, DetachSubscription) {

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -35,28 +35,15 @@ namespace gcsa = ::google::spanner::admin::database::v1;
 class DatabaseAdminLoggingTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
     mock_ = std::make_shared<spanner_testing::MockDatabaseAdminStub>();
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
   }
 
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
-
   std::shared_ptr<spanner_testing::MockDatabaseAdminStub> mock_;
-
- private:
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-  long logger_id_ = 0;  // NOLINT
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
@@ -68,7 +55,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   auto status = stub.CreateDatabase(context, gcsa::CreateDatabaseRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -82,7 +69,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabase) {
   auto response = stub.GetDatabase(context, gcsa::GetDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -96,7 +83,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
   auto response = stub.GetDatabaseDdl(context, gcsa::GetDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetDatabaseDdl")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -110,7 +97,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   auto status = stub.UpdateDatabase(context, gcsa::UpdateDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -124,7 +111,7 @@ TEST_F(DatabaseAdminLoggingTest, DropDatabase) {
   auto status = stub.DropDatabase(context, gcsa::DropDatabaseRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("DropDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -138,7 +125,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
   auto response = stub.ListDatabases(context, gcsa::ListDatabasesRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListDatabases")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -152,7 +139,7 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   auto status = stub.RestoreDatabase(context, gcsa::RestoreDatabaseRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("RestoreDatabase")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -167,7 +154,7 @@ TEST_F(DatabaseAdminLoggingTest, GetIamPolicy) {
       stub.GetIamPolicy(context, google::iam::v1::GetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetIamPolicy")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -182,7 +169,7 @@ TEST_F(DatabaseAdminLoggingTest, SetIamPolicy) {
       stub.SetIamPolicy(context, google::iam::v1::SetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("SetIamPolicy")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -198,7 +185,7 @@ TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
       context, google::iam::v1::TestIamPermissionsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("TestIamPermissions")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -212,7 +199,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   auto status = stub.CreateBackup(context, gcsa::CreateBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -226,7 +213,7 @@ TEST_F(DatabaseAdminLoggingTest, GetBackup) {
   auto status = stub.GetBackup(context, gcsa::GetBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -240,7 +227,7 @@ TEST_F(DatabaseAdminLoggingTest, DeleteBackup) {
   auto status = stub.DeleteBackup(context, gcsa::DeleteBackupRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -254,7 +241,7 @@ TEST_F(DatabaseAdminLoggingTest, ListBackups) {
   auto response = stub.ListBackups(context, gcsa::ListBackupsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListBackups")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -268,7 +255,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateBackup) {
   auto status = stub.UpdateBackup(context, gcsa::UpdateBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateBackup")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -284,7 +271,7 @@ TEST_F(DatabaseAdminLoggingTest, ListBackupOperations) {
       stub.ListBackupOperations(context, gcsa::ListBackupOperationsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListBackupOperations")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -300,7 +287,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
       context, gcsa::ListDatabaseOperationsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListDatabaseOperations")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -315,7 +302,7 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
       stub.GetOperation(context, google::longrunning::GetOperationRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetOperation")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -330,7 +317,7 @@ TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
       context, google::longrunning::CancelOperationRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CancelOperation")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -35,28 +35,15 @@ namespace gcsa = ::google::spanner::admin::instance::v1;
 class InstanceAdminLoggingTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    backend_ =
-        std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-    logger_id_ = google::cloud::LogSink::Instance().AddBackend(backend_);
     mock_ = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  }
-
-  void TearDown() override {
-    google::cloud::LogSink::Instance().RemoveBackend(logger_id_);
-    logger_id_ = 0;
   }
 
   static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  std::vector<std::string> ClearLogLines() { return backend_->ClearLogLines(); }
-
   std::shared_ptr<spanner_testing::MockInstanceAdminStub> mock_;
-
- private:
-  std::shared_ptr<google::cloud::testing_util::CaptureLogLinesBackend> backend_;
-  long logger_id_ = 0;  // NOLINT
+  testing_util::ScopedLog log_;
 };
 
 TEST_F(InstanceAdminLoggingTest, GetInstance) {
@@ -68,7 +55,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
   auto response = stub.GetInstance(context, gcsa::GetInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -82,7 +69,7 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   auto response = stub.CreateInstance(context, gcsa::CreateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("CreateInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -96,7 +83,7 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   auto response = stub.UpdateInstance(context, gcsa::UpdateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("UpdateInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -110,7 +97,7 @@ TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
   auto status = stub.DeleteInstance(context, gcsa::DeleteInstanceRequest{});
   EXPECT_EQ(TransientError(), status);
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteInstance")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -126,7 +113,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
       stub.GetInstanceConfig(context, gcsa::GetInstanceConfigRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetInstanceConfig")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -142,7 +129,7 @@ TEST_F(InstanceAdminLoggingTest, ListInstanceConfigs) {
       stub.ListInstanceConfigs(context, gcsa::ListInstanceConfigsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstanceConfigs")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -156,7 +143,7 @@ TEST_F(InstanceAdminLoggingTest, ListInstances) {
   auto response = stub.ListInstances(context, gcsa::ListInstancesRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ListInstances")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -171,7 +158,7 @@ TEST_F(InstanceAdminLoggingTest, GetIamPolicy) {
       stub.GetIamPolicy(context, google::iam::v1::GetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("GetIamPolicy")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -186,7 +173,7 @@ TEST_F(InstanceAdminLoggingTest, SetIamPolicy) {
       stub.SetIamPolicy(context, google::iam::v1::SetIamPolicyRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("SetIamPolicy")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }
@@ -202,7 +189,7 @@ TEST_F(InstanceAdminLoggingTest, TestIamPermissions) {
       context, google::iam::v1::TestIamPermissionsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
-  auto const log_lines = ClearLogLines();
+  auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("TestIamPermissions")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(TransientError().message())));
 }

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/log.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -37,9 +37,7 @@ TEST(SpannerStub, CreateDefaultStub) {
 }
 
 TEST(SpannerStub, CreateDefaultStubWithLogging) {
-  auto backend =
-      std::make_shared<google::cloud::testing_util::CaptureLogLinesBackend>();
-  auto id = google::cloud::LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
 
   auto stub = CreateDefaultSpannerStub(
       spanner::Database("foo", "bar", "baz"),
@@ -58,10 +56,8 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
                                       StatusCode::kInvalidArgument,
                                       StatusCode::kDeadlineExceeded)));
 
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Contains(HasSubstr(session.status().message())));
-
-  google::cloud::LogSink::Instance().RemoveBackend(id);
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -16,8 +16,8 @@
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/contains_once.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/storage/tests/object_checksum_integration_test.cc
+++ b/google/cloud/storage/tests/object_checksum_integration_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <regex>

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -17,7 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <cstdio>
 #include <fstream>

--- a/google/cloud/storage/tests/object_file_integration_test.cc
+++ b/google/cloud/storage/tests/object_file_integration_test.cc
@@ -347,17 +347,12 @@ TEST_F(ObjectFileIntegrationTest, UploadFileNonRegularWarning) {
     os << expected;
     os.close();
   });
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
-
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> meta =
       client->UploadFile(file_name, bucket_name_, object_name,
                          IfGenerationMatch(0), DisableMD5Hash(true));
-  ASSERT_STATUS_OK(meta);
-  LogSink::Instance().RemoveBackend(id);
 
-  EXPECT_THAT(backend->ClearLogLines(),
-              Contains(HasSubstr("not a regular file")));
+  EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("not a regular file")));
 
   t.join();
   auto status = client->DeleteObject(bucket_name_, object_name);

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -18,8 +18,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <regex>
 

--- a/google/cloud/storage/tests/object_hash_integration_test.cc
+++ b/google/cloud/storage/tests/object_hash_integration_test.cc
@@ -54,16 +54,13 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashXML) {
                     .set_enable_http_tracing(true));
   auto object_name = MakeRandomObjectName();
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), Fields(""));
   ASSERT_STATUS_OK(insert_meta);
 
-  LogSink::Instance().RemoveBackend(id);
-
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
@@ -79,20 +76,17 @@ TEST_F(ObjectHashIntegrationTest, DefaultMD5HashJSON) {
                     .set_enable_http_tracing(true));
   auto object_name = MakeRandomObjectName();
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0));
   ASSERT_STATUS_OK(insert_meta);
-
-  LogSink::Instance().RemoveBackend(id);
 
   // This is a big indirect, we detect if the upload changed to
   // multipart/related, and if so, we assume the hash value is being used.
   // Unfortunately I (@coryan) cannot think of a way to examine the upload
   // contents.
   EXPECT_THAT(
-      backend->ClearLogLines(),
+      log.ExtractLines(),
       Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_emulator_upload")) {
@@ -115,16 +109,13 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashXML) {
                     .set_enable_http_tracing(true));
   auto object_name = MakeRandomObjectName();
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta = client.InsertObject(
       bucket_name_, object_name, LoremIpsum(), IfGenerationMatch(0),
       DisableMD5Hash(true), Fields(""));
   ASSERT_STATUS_OK(insert_meta);
 
-  LogSink::Instance().RemoveBackend(id);
-
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Not(Contains(StartsWith("x-goog-hash: md5="))));
 
   auto status = client.DeleteObject(bucket_name_, object_name);
@@ -140,21 +131,18 @@ TEST_F(ObjectHashIntegrationTest, DisableMD5HashJSON) {
                     .set_enable_http_tracing(true));
   auto object_name = MakeRandomObjectName();
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), DisableMD5Hash(true));
   ASSERT_STATUS_OK(insert_meta);
-
-  LogSink::Instance().RemoveBackend(id);
 
   // This is a big indirect, we detect if the upload changed to
   // multipart/related, and if so, we assume the hash value is being used.
   // Unfortunately I (@coryan) cannot think of a way to examine the upload
   // contents.
   EXPECT_THAT(
-      backend->ClearLogLines(),
+      log.ExtractLines(),
       Contains(StartsWith("content-type: multipart/related; boundary=")));
 
   if (insert_meta->has_metadata("x_emulator_upload")) {

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -554,16 +554,13 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithQuotaUser) {
                     .set_enable_http_tracing(true));
   auto object_name = MakeRandomObjectName();
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), QuotaUser("test-quota-user"));
   ASSERT_STATUS_OK(insert_meta);
 
-  LogSink::Instance().RemoveBackend(id);
-
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("quotaUser=test-quota-user"))));
@@ -589,16 +586,13 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIp) {
                     .set_enable_http_tracing(true));
   auto object_name = MakeRandomObjectName();
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), UserIp("127.0.0.1"));
   ASSERT_STATUS_OK(insert_meta);
 
-  LogSink::Instance().RemoveBackend(id);
-
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("userIp=127.0.0.1"))));
@@ -636,16 +630,13 @@ TEST_P(ObjectInsertIntegrationTest, InsertWithUserIpBlank) {
     ASSERT_STATUS_OK(status);
   }
 
-  auto backend = std::make_shared<testing_util::CaptureLogLinesBackend>();
-  auto id = LogSink::Instance().AddBackend(backend);
+  testing_util::ScopedLog log;
   StatusOr<ObjectMetadata> insert_meta =
       client.InsertObject(bucket_name_, object_name, LoremIpsum(),
                           IfGenerationMatch(0), UserIp(""));
   ASSERT_STATUS_OK(insert_meta);
 
-  LogSink::Instance().RemoveBackend(id);
-
-  EXPECT_THAT(backend->ClearLogLines(),
+  EXPECT_THAT(log.ExtractLines(),
               Contains(AllOf(HasSubstr(" POST "),
                              HasSubstr("/b/" + bucket_name_ + "/o"),
                              HasSubstr("userIp="))));

--- a/google/cloud/storage/tests/object_insert_integration_test.cc
+++ b/google/cloud/storage/tests/object_insert_integration_test.cc
@@ -19,8 +19,8 @@
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <regex>
 

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -17,8 +17,8 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
 #include "google/cloud/testing_util/expect_exception.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <regex>
 

--- a/google/cloud/storage/tests/object_rewrite_integration_test.cc
+++ b/google/cloud/storage/tests/object_rewrite_integration_test.cc
@@ -18,7 +18,6 @@
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/expect_exception.h"
-#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <regex>
 

--- a/google/cloud/testing_util/CMakeLists.txt
+++ b/google/cloud/testing_util/CMakeLists.txt
@@ -21,8 +21,6 @@ if (BUILD_TESTING)
         assert_ok.cc
         assert_ok.h
         async_sequencer.h
-        capture_log_lines_backend.cc
-        capture_log_lines_backend.h
         check_predicate_becomes_false.h
         chrono_literals.h
         command_line_parsing.cc
@@ -36,6 +34,8 @@ if (BUILD_TESTING)
         expect_future_error.h
         scoped_environment.cc
         scoped_environment.h
+        scoped_log.cc
+        scoped_log.h
         scoped_thread.h
         status_matchers.h
         testing_types.cc

--- a/google/cloud/testing_util/capture_log_lines_backend.cc
+++ b/google/cloud/testing_util/capture_log_lines_backend.cc
@@ -20,7 +20,7 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace testing_util {
 
-std::vector<std::string> CaptureLogLinesBackend::ClearLogLines() {
+std::vector<std::string> ScopedLog::Backend::ExtractLines() {
   std::vector<std::string> result;
   {
     std::lock_guard<std::mutex> lk(mu_);
@@ -29,14 +29,14 @@ std::vector<std::string> CaptureLogLinesBackend::ClearLogLines() {
   return result;
 }
 
-void CaptureLogLinesBackend::Process(LogRecord const& lr) {
+void ScopedLog::Backend::Process(LogRecord const& lr) {
   // Break the records in lines, it is easier to analyze them as such.
   std::lock_guard<std::mutex> lk(mu_);
   std::vector<std::string> result = absl::StrSplit(lr.message, '\n');
   log_lines_.insert(log_lines_.end(), result.begin(), result.end());
 }
 
-void CaptureLogLinesBackend::ProcessWithOwnership(LogRecord lr) { Process(lr); }
+void ScopedLog::Backend::ProcessWithOwnership(LogRecord lr) { Process(lr); }
 
 }  // namespace testing_util
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/testing_util/google_cloud_cpp_testing.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing.bzl
@@ -19,7 +19,7 @@
 google_cloud_cpp_testing_hdrs = [
     "assert_ok.h",
     "async_sequencer.h",
-    "capture_log_lines_backend.h",
+    "scoped_log.h",
     "check_predicate_becomes_false.h",
     "chrono_literals.h",
     "command_line_parsing.h",
@@ -37,7 +37,7 @@ google_cloud_cpp_testing_hdrs = [
 
 google_cloud_cpp_testing_srcs = [
     "assert_ok.cc",
-    "capture_log_lines_backend.cc",
+    "scoped_log.cc",
     "command_line_parsing.cc",
     "crash_handler.cc",
     "example_driver.cc",

--- a/google/cloud/testing_util/google_cloud_cpp_testing.bzl
+++ b/google/cloud/testing_util/google_cloud_cpp_testing.bzl
@@ -19,7 +19,6 @@
 google_cloud_cpp_testing_hdrs = [
     "assert_ok.h",
     "async_sequencer.h",
-    "scoped_log.h",
     "check_predicate_becomes_false.h",
     "chrono_literals.h",
     "command_line_parsing.h",
@@ -29,6 +28,7 @@ google_cloud_cpp_testing_hdrs = [
     "expect_exception.h",
     "expect_future_error.h",
     "scoped_environment.h",
+    "scoped_log.h",
     "scoped_thread.h",
     "status_matchers.h",
     "testing_types.h",
@@ -37,11 +37,11 @@ google_cloud_cpp_testing_hdrs = [
 
 google_cloud_cpp_testing_srcs = [
     "assert_ok.cc",
-    "scoped_log.cc",
     "command_line_parsing.cc",
     "crash_handler.cc",
     "example_driver.cc",
     "scoped_environment.cc",
+    "scoped_log.cc",
     "testing_types.cc",
     "timer.cc",
 ]

--- a/google/cloud/testing_util/scoped_log.cc
+++ b/google/cloud/testing_util/scoped_log.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/testing_util/capture_log_lines_backend.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/strings/str_split.h"
 
 namespace google {

--- a/google/cloud/testing_util/scoped_log.h
+++ b/google/cloud/testing_util/scoped_log.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_CAPTURE_LOG_LINES_BACKEND_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_CAPTURE_LOG_LINES_BACKEND_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_LOG_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_LOG_H
 
 #include "google/cloud/log.h"
 #include "google/cloud/version.h"
@@ -30,7 +30,6 @@ namespace testing_util {
  * Captured lines are exposed via the `ScopedLog::ExtractLines` method.
  *
  * @par Example
- * 
  * @code
  * TEST(Foo, Bar) {
  *   ScopedLog log;
@@ -69,4 +68,4 @@ class ScopedLog {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_CAPTURE_LOG_LINES_BACKEND_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_TESTING_UTIL_SCOPED_LOG_H


### PR DESCRIPTION
This is basically a replacement for the old `testing_util::CaptureLogLinesBackend` class that's a bit easier to use because it's an RAII object. I also updated all call sites to use this new class, and then renamed the header and impl file because now all call sites only used the new `ScopedLog` form.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5936)
<!-- Reviewable:end -->
