### PR TITLE
feat: adds internal::CheckExpectedOptions<T>(...)

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(
     internal/getenv.h
     internal/invoke_result.h
     internal/ios_flags_saver.h
+    internal/options.cc
     internal/options.h
     internal/pagination_range.h
     internal/parse_rfc3339.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -85,6 +85,7 @@ google_cloud_cpp_common_srcs = [
     "internal/format_time_point.cc",
     "internal/future_impl.cc",
     "internal/getenv.cc",
+    "internal/options.cc",
     "internal/parse_rfc3339.cc",
     "internal/random.cc",
     "internal/setenv.cc",

--- a/google/cloud/internal/common_options.h
+++ b/google/cloud/internal/common_options.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_COMMON_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_COMMON_OPTIONS_H
 
-#include "google/cloud/internal/options.h"
 #include "google/cloud/version.h"
 #include <set>
 #include <string>
+#include <tuple>
 
 namespace google {
 namespace cloud {
@@ -63,6 +63,26 @@ struct TracingComponentsOption {
 };
 
 }  // namespace internal
+
+namespace internal {
+
+/**
+ * A list of all the options in this file.
+ *
+ * This is intended to be used with `internal::CheckExpectedOptions<T>()` to
+ * make it easy to specify groups of options as allowed/expected.
+ *
+ * @code
+ * Options opts;
+ * opts.set<EndpointOption>("...");
+ * internal::CheckExpectedOptions<internal::CommonOptions>(
+ *     opts, "some factory function");
+ * @endcode
+ */
+using CommonOptions =
+    std::tuple<EndpointOption, UserAgentPrefixOption, TracingComponentsOption>;
+}  // namespace internal
+
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -26,6 +26,9 @@ namespace internal {
 
 namespace {
 
+using ::testing::Contains;
+using ::testing::ContainsRegex;
+
 // Tests a generic option by setting it, then getting it.
 template <typename T, typename ValueType = decltype(std::declval<T>().value)>
 void TestOption(ValueType const& expected) {
@@ -58,7 +61,7 @@ TEST(CommonOptions, Unexpected) {
   internal::CheckExpectedOptions<CommonOptions>(opts, "caller");
   EXPECT_THAT(
       log.ExtractLines(),
-            Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption"));
+      Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption")));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/options.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
 #include <string>
 #include <utility>
@@ -38,6 +40,25 @@ TEST(CommonOptions, RegularOptions) {
   TestOption<EndpointOption>("foo.googleapis.com");
   TestOption<UserAgentPrefixOption>({"foo", "bar"});
   TestOption<TracingComponentsOption>({"foo", "bar", "baz"});
+}
+
+TEST(CommonOptions, Expected) {
+  testing_util::ScopedLog log;
+  Options opts;
+  opts.set<EndpointOption>("foo.googleapis.com");
+  internal::CheckExpectedOptions<CommonOptions>(opts, "caller");
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
+TEST(CommonOptions, Unexpected) {
+  struct UnexpectedOption {};
+  testing_util::ScopedLog log;
+  Options opts;
+  opts.set<UnexpectedOption>();
+  internal::CheckExpectedOptions<CommonOptions>(opts, "caller");
+  EXPECT_THAT(
+      log.ExtractLines(),
+            Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption"));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_options.h
+++ b/google/cloud/internal/grpc_options.h
@@ -22,6 +22,7 @@
 #include <grpcpp/grpcpp.h>
 #include <map>
 #include <string>
+#include <tuple>
 
 namespace google {
 namespace cloud {
@@ -90,6 +91,24 @@ namespace internal {
 
 /// Creates a new `grpc::ChannelArguments` configured with @p opts.
 grpc::ChannelArguments MakeChannelArguments(Options const& opts);
+
+/**
+ * A list of all the options in this file.
+ *
+ * This is intended to be used with `internal::CheckExpectedOptions<T>()` to
+ * make it easy to specify groups of options as allowed/expected.
+ *
+ * @code
+ * Options opts;
+ * opts.set<GrpcCredentialOption>(...);
+ * internal::CheckExpectedOptions<internal::GrpcOptions>(
+ *     opts, "some factory function");
+ * @endcode
+ */
+using GrpcOptions =
+    std::tuple<GrpcCredentialOption, GrpcNumChannelsOption,
+               GrpcChannelArgumentsOption, GrpcTracingOptionsOption,
+               GrpcBackgroundThreadsOption>;
 
 }  // namespace internal
 

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
 #include <string>
@@ -24,6 +25,9 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
 namespace {
+
+using ::testing::Contains;
+using ::testing::ContainsRegex;
 
 // Tests a generic option by setting it, then getting it.
 template <typename T, typename ValueType = decltype(std::declval<T>().value)>
@@ -60,7 +64,7 @@ TEST(GrpcOptions, GrpcBackgroundThreadsOption) {
 TEST(GrpcOptions, Expected) {
   testing_util::ScopedLog log;
   Options opts;
-  opts.set<GrpcNumchannelsOption>(42);
+  opts.set<GrpcNumChannelsOption>(42);
   internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
   EXPECT_TRUE(log.ExtractLines().empty());
 }
@@ -73,7 +77,7 @@ TEST(GrpcOptions, Unexpected) {
   internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
   EXPECT_THAT(
       log.ExtractLines(),
-            Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption"));
+      Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption")));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -57,6 +57,25 @@ TEST(GrpcOptions, GrpcBackgroundThreadsOption) {
   EXPECT_TRUE(invoked);
 }
 
+TEST(GrpcOptions, Expected) {
+  testing_util::ScopedLog log;
+  Options opts;
+  opts.set<GrpcNumchannelsOption>(42);
+  internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
+  EXPECT_TRUE(log.ExtractLines().empty());
+}
+
+TEST(GrpcOptions, Unexpected) {
+  struct UnexpectedOption {};
+  testing_util::ScopedLog log;
+  Options opts;
+  opts.set<UnexpectedOption>();
+  internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
+  EXPECT_THAT(
+      log.ExtractLines(),
+            Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption"));
+}
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/options.cc
+++ b/google/cloud/internal/options.cc
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/options.h"
+#include "google/cloud/internal/algorithm.h"
+#include "google/cloud/log.h"
+#include <set>
+#include <unordered_map>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+void WarnUnexpectedOptionsImpl(std::set<std::type_index> const& expected,
+                               Options const& opts) {
+  for (auto const& p : opts.m_) {
+    if (!Contains(expected, p.first)) {
+      GCP_LOG(WARNING) << "Unexpected option (mangled name): " << p.first.name();
+    }
+  }
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/options.cc
+++ b/google/cloud/internal/options.cc
@@ -23,11 +23,12 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 
-void WarnUnexpectedOptionsImpl(std::set<std::type_index> const& expected,
-                               Options const& opts) {
+void CheckExpectedOptionsImpl(std::set<std::type_index> const& expected,
+                              Options const& opts, char const* const caller) {
   for (auto const& p : opts.m_) {
     if (!Contains(expected, p.first)) {
-      GCP_LOG(WARNING) << "Unexpected option (mangled name): " << p.first.name();
+      GCP_LOG(WARNING) << caller << ": Unexpected option (mangled name): "
+                       << p.first.name();
     }
   }
 }

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -146,7 +146,7 @@ struct FlatTuple {
 };
 template <typename... T>
 struct FlatTuple<std::tuple<T...>> {
-  using Type = std::tuple<T...>;
+  using Type = std::tuple<T...>;  // Note: Doesn't work w/ nested tuples.
 };
 
 template <typename... T>

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -151,7 +151,7 @@ struct FlatTuple<std::tuple<T...>> {
 
 template <typename... T>
 void CheckExpectedOptionsImpl(std::tuple<T...> const&, Options const& opts,
-                              char const* const caller) {
+                              char const* caller) {
   CheckExpectedOptionsImpl({typeid(T)...}, opts, caller);
 }
 
@@ -181,7 +181,7 @@ void CheckExpectedOptionsImpl(std::tuple<T...> const&, Options const& opts,
 // @param caller some string indicating the callee function; logged IFF there's
 //        an unexpected option
 template <typename... T>
-void CheckExpectedOptions(Options const& opts, char const* const caller) {
+void CheckExpectedOptions(Options const& opts, char const* caller) {
   using Tuple = decltype(std::tuple_cat(typename FlatTuple<T>::Type{}...));
   CheckExpectedOptionsImpl(Tuple{}, opts, caller);
 }

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/version.h"
 #include "absl/types/any.h"
 #include "absl/types/optional.h"
+#include <set>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
@@ -25,6 +26,13 @@
 namespace google {
 namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
+
+class Options;
+namespace internal {
+void WarnUnexpectedOptionsImpl(std::set<std::type_index> const& expected,
+                               Options const& opts);
+}  // namespace internal
+
 namespace internal {
 
 /**
@@ -121,10 +129,25 @@ class Options {
   }
 
  private:
+  friend void WarnUnexpectedOptionsImpl(std::set<std::type_index> const&,
+                                        Options const&);
+
   std::unordered_map<std::type_index, absl::any> m_;
 };
 
 }  // namespace internal
+
+namespace internal {
+
+// Checks that `Options` only contains the given expected options or a subset
+// of them. If any unexpected options exist, LOGS them
+template <typename... Expected>
+void WarnUnexpectedOptions(Options const& opts) {
+  WarnUnexpectedOptionsImpl({typeid(Expected)...}, opts);
+}
+
+}  // namespace internal
+
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -173,6 +173,18 @@ TEST(CheckUnexpectedOptions, TwoExpected) {
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
+TEST(CheckUnexpectedOptions, FullishLogLine) {
+  testing_util::ScopedLog log;
+  Options opts;
+  opts.set<IntOption>();
+  internal::CheckExpectedOptions<BoolOption>(opts, "caller");
+  // This tests exists just to show us what a full log line may look like.
+  // The regex hides the nastiness of the actual mangled name.
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(ContainsRegex(
+                  "caller: Unexpected option (mangled name): .+IntOption")));
+}
+
 TEST(CheckUnexpectedOptions, OneUnexpected) {
   testing_util::ScopedLog log;
   Options opts;

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -180,9 +180,10 @@ TEST(CheckUnexpectedOptions, FullishLogLine) {
   internal::CheckExpectedOptions<BoolOption>(opts, "caller");
   // This tests exists just to show us what a full log line may look like.
   // The regex hides the nastiness of the actual mangled name.
-  EXPECT_THAT(log.ExtractLines(),
-              Contains(ContainsRegex(
-                  "caller: Unexpected option (mangled name): .+IntOption")));
+  EXPECT_THAT(
+      log.ExtractLines(),
+      Contains(ContainsRegex(
+          R"(caller: Unexpected option \(mangled name\): .+IntOption)")));
 }
 
 TEST(CheckUnexpectedOptions, OneUnexpected) {


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5738

This PR adds the strict options checking function described in https://github.com/googleapis/google-cloud-cpp/issues/5738#issuecomment-779897018

Callers (i.e., our factory functions) will be able to check that a user-provided `Options` object contains only the set of expected options. Any unexpected options will be `GCP_LOG(WARNING)`'d. The log message will include the _mangled name_ of each unexpected option. See https://github.com/googleapis/google-cloud-cpp/issues/5738#issuecomment-786960263 for more discussion of this point.

Our factory functions will call this like:

```cc
spanner::MakeConnection(..., Options const& opts) {
  internal::CheckExpectedOptions<internal::CommonOptions, internal::GrpcOptions>(options, "spanner::MakeConnection");
  ...
}
```

*NOTE:* Sometimes I close the `internal` namespace then re-open it again to declare stuff. I'm doing this in cases where the code should *remain* internal, even after the rest of the `Options` code moves out of `internal. I don't want to remove the `internal` namespaces then accidentally expose something that should have remained internal. So I'm creating separate `internal` blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5938)
<!-- Reviewable:end -->
