### PR TITLE
refactor: simplify the Options API, easier to use, improved efficiency

### DIFF
--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -262,8 +262,7 @@ Options MakeOptions(ConnectionOptions<ConnectionTraits>&& old) {
   opts.set<GrpcCredentialOption>(std::move(old.credentials_));
   opts.set<EndpointOption>(std::move(old.endpoint_));
   opts.set<GrpcNumChannelsOption>(old.num_channels_);
-  opts.set<UserAgentPrefixOption>(
-      std::set<std::string>{std::move(old.user_agent_prefix_)});
+  opts.set<UserAgentPrefixOption>({std::move(old.user_agent_prefix_)});
   opts.set<GrpcTracingOptionsOption>(std::move(old.tracing_options_));
   opts.set<GrpcBackgroundThreadsOption>(old.background_threads_factory());
   if (!old.tracing_components_.empty()) {
@@ -274,8 +273,8 @@ Options MakeOptions(ConnectionOptions<ConnectionTraits>&& old) {
     // parameter to a different value. Newer versions of gRPC include a macro
     // for this purpose (GRPC_ARG_CHANNEL_POOL_DOMAIN). As we are compiling
     // against older versions in some cases, we use the actual value.
-    opts.set<GrpcChannelArgumentsOption>(std::map<std::string, std::string>{
-        {"grpc.channel_pooling_domain", std::move(old.channel_pool_domain_)}});
+    opts.set<GrpcChannelArgumentsOption>(
+        {{"grpc.channel_pooling_domain", std::move(old.channel_pool_domain_)}});
   }
   return opts;
 }

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -49,26 +49,26 @@ TEST(ConnectionOptionsTest, Credentials) {
   TestConnectionOptions options(expected);
   EXPECT_EQ(expected.get(), options.credentials().get());
   EXPECT_EQ(expected,
-            ToOptions(options).get_or<internal::GrpcCredentialOption>());
+            ToOptions(options).get_or<internal::GrpcCredentialOption>({}));
 
   auto other_credentials = grpc::InsecureChannelCredentials();
   EXPECT_NE(expected, other_credentials);
   options.set_credentials(other_credentials);
   EXPECT_EQ(other_credentials, options.credentials());
   EXPECT_EQ(other_credentials,
-            ToOptions(options).get_or<internal::GrpcCredentialOption>());
+            ToOptions(options).get_or<internal::GrpcCredentialOption>({}));
 }
 
 TEST(ConnectionOptionsTest, AdminEndpoint) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::default_endpoint(), options.endpoint());
   EXPECT_EQ(options.endpoint(),
-            ToOptions(options).get_or<internal::EndpointOption>());
+            ToOptions(options).get_or<internal::EndpointOption>({}));
 
   options.set_endpoint("invalid-endpoint");
   EXPECT_EQ("invalid-endpoint", options.endpoint());
   EXPECT_EQ(options.endpoint(),
-            ToOptions(options).get_or<internal::EndpointOption>());
+            ToOptions(options).get_or<internal::EndpointOption>({}));
 }
 
 TEST(ConnectionOptionsTest, NumChannels) {
@@ -76,13 +76,13 @@ TEST(ConnectionOptionsTest, NumChannels) {
   int num_channels = options.num_channels();
   EXPECT_EQ(TestTraits::default_num_channels(), num_channels);
   EXPECT_EQ(options.num_channels(),
-            ToOptions(options).get_or<internal::GrpcNumChannelsOption>());
+            ToOptions(options).get_or<internal::GrpcNumChannelsOption>({}));
 
   num_channels *= 2;  // ensure we change it from the default value.
   options.set_num_channels(num_channels);
   EXPECT_EQ(num_channels, options.num_channels());
   EXPECT_EQ(options.num_channels(),
-            ToOptions(options).get_or<internal::GrpcNumChannelsOption>());
+            ToOptions(options).get_or<internal::GrpcNumChannelsOption>({}));
 }
 
 TEST(ConnectionOptionsTest, Tracing) {
@@ -90,7 +90,7 @@ TEST(ConnectionOptionsTest, Tracing) {
   options.enable_tracing("fake-component");
   EXPECT_TRUE(options.tracing_enabled("fake-component"));
   EXPECT_EQ(options.components(),
-            ToOptions(options).get_or<internal::TracingComponentsOption>());
+            ToOptions(options).get_or<internal::TracingComponentsOption>({}));
 
   options.disable_tracing("fake-component");
   EXPECT_FALSE(options.tracing_enabled("fake-component"));
@@ -112,7 +112,7 @@ TEST(ConnectionOptionsTest, DefaultTracingSet) {
   EXPECT_TRUE(options.tracing_enabled("foo"));
   EXPECT_TRUE(options.tracing_enabled("bar"));
   EXPECT_TRUE(options.tracing_enabled("baz"));
-  EXPECT_THAT(ToOptions(options).get_or<internal::TracingComponentsOption>(),
+  EXPECT_THAT(ToOptions(options).get_or<internal::TracingComponentsOption>({}),
               testing::UnorderedElementsAre("foo", "bar", "baz"));
 }
 
@@ -127,7 +127,7 @@ TEST(ConnectionOptionsTest, TracingOptions) {
   EXPECT_FALSE(tracing_options.use_short_repeated_primitives());
   EXPECT_EQ(32, tracing_options.truncate_string_field_longer_than());
   EXPECT_EQ(options.tracing_options(),
-            ToOptions(options).get_or<internal::GrpcTracingOptionsOption>());
+            ToOptions(options).get_or<internal::GrpcTracingOptionsOption>({}));
 }
 
 TEST(ConnectionOptionsTest, ChannelPoolName) {
@@ -137,20 +137,21 @@ TEST(ConnectionOptionsTest, ChannelPoolName) {
 
   options.set_channel_pool_domain("test-channel-pool");
   EXPECT_EQ("test-channel-pool", options.channel_pool_domain());
-  auto opts = ToOptions(options).get_or<internal::GrpcChannelArgumentsOption>();
+  auto opts =
+      ToOptions(options).get_or<internal::GrpcChannelArgumentsOption>({});
   EXPECT_EQ(opts["grpc.channel_pooling_domain"], "test-channel-pool");
 }
 
 TEST(ConnectionOptionsTest, UserAgentPrefix) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::user_agent_prefix(), options.user_agent_prefix());
-  EXPECT_THAT(ToOptions(options).get_or<internal::UserAgentPrefixOption>(),
+  EXPECT_THAT(ToOptions(options).get_or<internal::UserAgentPrefixOption>({}),
               testing::ElementsAre(options.user_agent_prefix()));
 
   options.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + TestTraits::user_agent_prefix(),
             options.user_agent_prefix());
-  EXPECT_THAT(ToOptions(options).get_or<internal::UserAgentPrefixOption>(),
+  EXPECT_THAT(ToOptions(options).get_or<internal::UserAgentPrefixOption>({}),
               testing::ElementsAre(options.user_agent_prefix()));
 }
 

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -49,26 +49,26 @@ TEST(ConnectionOptionsTest, Credentials) {
   TestConnectionOptions options(expected);
   EXPECT_EQ(expected.get(), options.credentials().get());
   EXPECT_EQ(expected,
-            ToOptions(options).get<internal::GrpcCredentialOption>()->value);
+            ToOptions(options).get_or<internal::GrpcCredentialOption>());
 
   auto other_credentials = grpc::InsecureChannelCredentials();
   EXPECT_NE(expected, other_credentials);
   options.set_credentials(other_credentials);
   EXPECT_EQ(other_credentials, options.credentials());
   EXPECT_EQ(other_credentials,
-            ToOptions(options).get<internal::GrpcCredentialOption>()->value);
+            ToOptions(options).get_or<internal::GrpcCredentialOption>());
 }
 
 TEST(ConnectionOptionsTest, AdminEndpoint) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::default_endpoint(), options.endpoint());
   EXPECT_EQ(options.endpoint(),
-            ToOptions(options).get<internal::EndpointOption>()->value);
+            ToOptions(options).get_or<internal::EndpointOption>());
 
   options.set_endpoint("invalid-endpoint");
   EXPECT_EQ("invalid-endpoint", options.endpoint());
   EXPECT_EQ(options.endpoint(),
-            ToOptions(options).get<internal::EndpointOption>()->value);
+            ToOptions(options).get_or<internal::EndpointOption>());
 }
 
 TEST(ConnectionOptionsTest, NumChannels) {
@@ -76,13 +76,13 @@ TEST(ConnectionOptionsTest, NumChannels) {
   int num_channels = options.num_channels();
   EXPECT_EQ(TestTraits::default_num_channels(), num_channels);
   EXPECT_EQ(options.num_channels(),
-            ToOptions(options).get<internal::GrpcNumChannelsOption>()->value);
+            ToOptions(options).get_or<internal::GrpcNumChannelsOption>());
 
   num_channels *= 2;  // ensure we change it from the default value.
   options.set_num_channels(num_channels);
   EXPECT_EQ(num_channels, options.num_channels());
   EXPECT_EQ(options.num_channels(),
-            ToOptions(options).get<internal::GrpcNumChannelsOption>()->value);
+            ToOptions(options).get_or<internal::GrpcNumChannelsOption>());
 }
 
 TEST(ConnectionOptionsTest, Tracing) {
@@ -90,18 +90,18 @@ TEST(ConnectionOptionsTest, Tracing) {
   options.enable_tracing("fake-component");
   EXPECT_TRUE(options.tracing_enabled("fake-component"));
   EXPECT_EQ(options.components(),
-            ToOptions(options).get<internal::TracingComponentsOption>()->value);
+            ToOptions(options).get_or<internal::TracingComponentsOption>());
 
   options.disable_tracing("fake-component");
   EXPECT_FALSE(options.tracing_enabled("fake-component"));
-  EXPECT_FALSE(ToOptions(options).get<internal::TracingComponentsOption>());
+  EXPECT_FALSE(ToOptions(options).has<internal::TracingComponentsOption>());
 }
 
 TEST(ConnectionOptionsTest, DefaultTracingUnset) {
   testing_util::ScopedEnvironment env("GOOGLE_CLOUD_CPP_ENABLE_TRACING", {});
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_FALSE(options.tracing_enabled("rpc"));
-  EXPECT_FALSE(ToOptions(options).get<internal::TracingComponentsOption>());
+  EXPECT_FALSE(ToOptions(options).has<internal::TracingComponentsOption>());
 }
 
 TEST(ConnectionOptionsTest, DefaultTracingSet) {
@@ -112,9 +112,8 @@ TEST(ConnectionOptionsTest, DefaultTracingSet) {
   EXPECT_TRUE(options.tracing_enabled("foo"));
   EXPECT_TRUE(options.tracing_enabled("bar"));
   EXPECT_TRUE(options.tracing_enabled("baz"));
-  EXPECT_THAT(
-      ToOptions(options).get<internal::TracingComponentsOption>()->value,
-      testing::UnorderedElementsAre("foo", "bar", "baz"));
+  EXPECT_THAT(ToOptions(options).get_or<internal::TracingComponentsOption>(),
+              testing::UnorderedElementsAre("foo", "bar", "baz"));
 }
 
 TEST(ConnectionOptionsTest, TracingOptions) {
@@ -127,33 +126,31 @@ TEST(ConnectionOptionsTest, TracingOptions) {
   EXPECT_FALSE(tracing_options.single_line_mode());
   EXPECT_FALSE(tracing_options.use_short_repeated_primitives());
   EXPECT_EQ(32, tracing_options.truncate_string_field_longer_than());
-  EXPECT_EQ(
-      options.tracing_options(),
-      ToOptions(options).get<internal::GrpcTracingOptionsOption>()->value);
+  EXPECT_EQ(options.tracing_options(),
+            ToOptions(options).get_or<internal::GrpcTracingOptionsOption>());
 }
 
 TEST(ConnectionOptionsTest, ChannelPoolName) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_TRUE(options.channel_pool_domain().empty());
-  EXPECT_FALSE(ToOptions(options).get<internal::GrpcChannelArgumentsOption>());
+  EXPECT_FALSE(ToOptions(options).has<internal::GrpcChannelArgumentsOption>());
 
   options.set_channel_pool_domain("test-channel-pool");
   EXPECT_EQ("test-channel-pool", options.channel_pool_domain());
-  auto opts = ToOptions(options).get<internal::GrpcChannelArgumentsOption>();
-  EXPECT_TRUE(opts);
-  EXPECT_EQ(opts->value["grpc.channel_pooling_domain"], "test-channel-pool");
+  auto opts = ToOptions(options).get_or<internal::GrpcChannelArgumentsOption>();
+  EXPECT_EQ(opts["grpc.channel_pooling_domain"], "test-channel-pool");
 }
 
 TEST(ConnectionOptionsTest, UserAgentPrefix) {
   TestConnectionOptions options(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::user_agent_prefix(), options.user_agent_prefix());
-  EXPECT_THAT(ToOptions(options).get<internal::UserAgentPrefixOption>()->value,
+  EXPECT_THAT(ToOptions(options).get_or<internal::UserAgentPrefixOption>(),
               testing::ElementsAre(options.user_agent_prefix()));
 
   options.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + TestTraits::user_agent_prefix(),
             options.user_agent_prefix());
-  EXPECT_THAT(ToOptions(options).get<internal::UserAgentPrefixOption>()->value,
+  EXPECT_THAT(ToOptions(options).get_or<internal::UserAgentPrefixOption>(),
               testing::ElementsAre(options.user_agent_prefix()));
 }
 

--- a/google/cloud/internal/common_options.h
+++ b/google/cloud/internal/common_options.h
@@ -33,7 +33,7 @@ namespace internal {
  * or (2) use a beta or EAP version of the service.
  */
 struct EndpointOption {
-  std::string value;
+  using Type = std::string;
 };
 
 /**
@@ -44,7 +44,7 @@ struct EndpointOption {
  * number of users running particular versions of their system or library.
  */
 struct UserAgentPrefixOption {
-  std::set<std::string> value;
+  using Type = std::set<std::string>;
 };
 
 /**
@@ -59,7 +59,7 @@ struct UserAgentPrefixOption {
  * - rpc-streams
  */
 struct TracingComponentsOption {
-  std::set<std::string> value;
+  using Type = std::set<std::string>;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -33,7 +33,7 @@ using ::testing::ContainsRegex;
 template <typename T, typename ValueType = decltype(std::declval<T>().value)>
 void TestOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
-  EXPECT_EQ(expected, opts.template get<T>()->value)
+  EXPECT_EQ(expected, opts.template get_or<T>())
       << "Failed with type: " << typeid(T).name();
 }
 
@@ -54,7 +54,9 @@ TEST(CommonOptions, Expected) {
 }
 
 TEST(CommonOptions, Unexpected) {
-  struct UnexpectedOption {};
+  struct UnexpectedOption {
+    int value;
+  };
   testing_util::ScopedLog log;
   Options opts;
   opts.set<UnexpectedOption>();

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -30,7 +30,7 @@ using ::testing::Contains;
 using ::testing::ContainsRegex;
 
 // Tests a generic option by setting it, then getting it.
-template <typename T, typename ValueType = decltype(std::declval<T>().value)>
+template <typename T, typename ValueType = typename T::Type>
 void TestOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
   EXPECT_EQ(expected, opts.template get_or<T>({}))
@@ -55,7 +55,7 @@ TEST(CommonOptions, Expected) {
 
 TEST(CommonOptions, Unexpected) {
   struct UnexpectedOption {
-    int value;
+    using Type = int;
   };
   testing_util::ScopedLog log;
   Options opts;

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -33,7 +33,7 @@ using ::testing::ContainsRegex;
 template <typename T, typename ValueType = decltype(std::declval<T>().value)>
 void TestOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
-  EXPECT_EQ(expected, opts.template get_or<T>())
+  EXPECT_EQ(expected, opts.template get_or<T>({}))
       << "Failed with type: " << typeid(T).name();
 }
 
@@ -59,7 +59,7 @@ TEST(CommonOptions, Unexpected) {
   };
   testing_util::ScopedLog log;
   Options opts;
-  opts.set<UnexpectedOption>();
+  opts.set<UnexpectedOption>({});
   internal::CheckExpectedOptions<CommonOptions>(opts, "caller");
   EXPECT_THAT(
       log.ExtractLines(),

--- a/google/cloud/internal/grpc_options.cc
+++ b/google/cloud/internal/grpc_options.cc
@@ -30,8 +30,7 @@ grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   }
   auto const user_agent_prefix = opts.get_or<UserAgentPrefixOption>();
   if (!user_agent_prefix.empty()) {
-    channel_arguments.SetUserAgentPrefix(
-        absl::StrJoin(user_agent_prefix, " "));
+    channel_arguments.SetUserAgentPrefix(absl::StrJoin(user_agent_prefix, " "));
   }
   return channel_arguments;
 }

--- a/google/cloud/internal/grpc_options.cc
+++ b/google/cloud/internal/grpc_options.cc
@@ -24,11 +24,10 @@ namespace internal {
 
 grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   grpc::ChannelArguments channel_arguments;
-  auto const channel_args = opts.get_or<GrpcChannelArgumentsOption>();
-  for (auto const& p : channel_args) {
+  for (auto const& p : opts.get_or<GrpcChannelArgumentsOption>({})) {
     channel_arguments.SetString(p.first, p.second);
   }
-  auto const user_agent_prefix = opts.get_or<UserAgentPrefixOption>();
+  auto const user_agent_prefix = opts.get_or<UserAgentPrefixOption>({});
   if (!user_agent_prefix.empty()) {
     channel_arguments.SetUserAgentPrefix(absl::StrJoin(user_agent_prefix, " "));
   }

--- a/google/cloud/internal/grpc_options.cc
+++ b/google/cloud/internal/grpc_options.cc
@@ -24,16 +24,14 @@ namespace internal {
 
 grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   grpc::ChannelArguments channel_arguments;
-  auto const channel_args = opts.get<GrpcChannelArgumentsOption>();
-  if (channel_args) {
-    for (auto const& p : channel_args->value) {
-      channel_arguments.SetString(p.first, p.second);
-    }
+  auto const channel_args = opts.get_or<GrpcChannelArgumentsOption>();
+  for (auto const& p : channel_args) {
+    channel_arguments.SetString(p.first, p.second);
   }
-  auto const user_agent_prefix = opts.get<UserAgentPrefixOption>();
-  if (user_agent_prefix) {
+  auto const user_agent_prefix = opts.get_or<UserAgentPrefixOption>();
+  if (!user_agent_prefix.empty()) {
     channel_arguments.SetUserAgentPrefix(
-        absl::StrJoin(user_agent_prefix->value, " "));
+        absl::StrJoin(user_agent_prefix, " "));
   }
   return channel_arguments;
 }

--- a/google/cloud/internal/grpc_options.h
+++ b/google/cloud/internal/grpc_options.h
@@ -34,7 +34,7 @@ namespace internal {
  * The gRPC credentials used by clients configured with this object.
  */
 struct GrpcCredentialOption {
-  std::shared_ptr<grpc::ChannelCredentials> value;
+  using Type = std::shared_ptr<grpc::ChannelCredentials>;
 };
 
 /**
@@ -45,7 +45,7 @@ struct GrpcCredentialOption {
  * operations that can be in progress in parallel.
  */
 struct GrpcNumChannelsOption {
-  int value;
+  using Type = int;
 };
 
 /**
@@ -59,14 +59,14 @@ struct GrpcNumChannelsOption {
  * @see https://grpc.github.io/grpc/core/group__grpc__arg__keys.html
  */
 struct GrpcChannelArgumentsOption {
-  std::map<std::string, std::string> value;
+  using Type = std::map<std::string, std::string>;
 };
 
 /**
  * The `TracingOptions` to use when printing grpc protocol buffer messages.
  */
 struct GrpcTracingOptionsOption {
-  TracingOptions value;
+  using Type = TracingOptions;
 };
 
 /**
@@ -82,7 +82,7 @@ struct GrpcTracingOptionsOption {
 using BackgroundThreadsFactory =
     std::function<std::unique_ptr<BackgroundThreads>()>;
 struct GrpcBackgroundThreadsOption {
-  BackgroundThreadsFactory value;
+  using Type = BackgroundThreadsFactory;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -33,7 +33,7 @@ using ::testing::ContainsRegex;
 template <typename T, typename ValueType = decltype(std::declval<T>().value)>
 void TestGrpcOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
-  EXPECT_EQ(expected, opts.template get<T>()->value)
+  EXPECT_EQ(expected, opts.template get_or<T>())
       << "Failed with type: " << typeid(T).name();
 }
 
@@ -57,7 +57,7 @@ TEST(GrpcOptions, GrpcBackgroundThreadsOption) {
   };
   auto opts = Options{}.set<GrpcBackgroundThreadsOption>(factory);
   EXPECT_FALSE(invoked);
-  opts.get<GrpcBackgroundThreadsOption>()->value();
+  opts.get_or<GrpcBackgroundThreadsOption>()();
   EXPECT_TRUE(invoked);
 }
 
@@ -70,7 +70,9 @@ TEST(GrpcOptions, Expected) {
 }
 
 TEST(GrpcOptions, Unexpected) {
-  struct UnexpectedOption {};
+  struct UnexpectedOption {
+    int value;
+  };
   testing_util::ScopedLog log;
   Options opts;
   opts.set<UnexpectedOption>();

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -30,7 +30,7 @@ using ::testing::Contains;
 using ::testing::ContainsRegex;
 
 // Tests a generic option by setting it, then getting it.
-template <typename T, typename ValueType = decltype(std::declval<T>().value)>
+template <typename T, typename ValueType = typename T::Type>
 void TestGrpcOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
   EXPECT_EQ(expected, opts.template get_or<T>({}))
@@ -71,7 +71,7 @@ TEST(GrpcOptions, Expected) {
 
 TEST(GrpcOptions, Unexpected) {
   struct UnexpectedOption {
-    int value;
+    using Type = int;
   };
   testing_util::ScopedLog log;
   Options opts;

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -33,7 +33,7 @@ using ::testing::ContainsRegex;
 template <typename T, typename ValueType = decltype(std::declval<T>().value)>
 void TestGrpcOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
-  EXPECT_EQ(expected, opts.template get_or<T>())
+  EXPECT_EQ(expected, opts.template get_or<T>({}))
       << "Failed with type: " << typeid(T).name();
 }
 
@@ -57,7 +57,7 @@ TEST(GrpcOptions, GrpcBackgroundThreadsOption) {
   };
   auto opts = Options{}.set<GrpcBackgroundThreadsOption>(factory);
   EXPECT_FALSE(invoked);
-  opts.get_or<GrpcBackgroundThreadsOption>()();
+  opts.get_or<GrpcBackgroundThreadsOption>({})();
   EXPECT_TRUE(invoked);
 }
 
@@ -75,7 +75,7 @@ TEST(GrpcOptions, Unexpected) {
   };
   testing_util::ScopedLog log;
   Options opts;
-  opts.set<UnexpectedOption>();
+  opts.set<UnexpectedOption>({});
   internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
   EXPECT_THAT(
       log.ExtractLines(),

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -29,6 +29,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 
 class Options;
 namespace internal {
+
 // See https://en.cppreference.com/w/cpp/types/type_identity
 template <typename T>
 struct type_identity {
@@ -37,7 +38,7 @@ struct type_identity {
 template <typename T>
 using type_identity_t = typename type_identity<T>::type;
 
-
+// Extracts the type of `T`'s `.value` data member.
 template <typename T>
 struct value_type {
   using type = decltype(std::declval<T>().value);

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -18,7 +18,6 @@
 #include "google/cloud/version.h"
 #include "absl/types/any.h"
 #include <set>
-#include <type_traits>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -55,14 +55,15 @@ namespace internal {
 /**
  * A class that holds option structs indexed by their type.
  *
- * An "Option" struct is any struct that has a public `.value` data member, and
- * by convention they are named like "FooOption". Each library (e.g., spanner,
- * storage) may define their own set of options. Additionally, various common
- * classes may define options. All these options may be set in a single
- * `Options` instance, and each library will look at the options that it needs.
+ * An "Option" struct is any struct that has a public `.value` data member. By
+ * convention they are named like "FooOption". Each library (e.g., spanner,
+ * storage) may define their own set of options. Additionally, there may be
+ * common options defined that many libraries may use. All these options may be
+ * set in a single `Options` instance, and each library will look at the
+ * options that it needs.
  *
  * Here's an overview of this class's interface, but see the method
- * documentation below for more details.
+ * documentation below for details.
  *
  * - `.set<T>(x)`    -- Sets the option `T` to value `x`
  * - `.has<T>()`     -- Returns true iff option `T` is set

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -40,10 +40,10 @@ namespace internal {
  *
  * An "Option" is any struct that has a public `Type` member typedef. By
  * convention they are named like "FooOption". Each library (e.g., spanner,
- * storage) may define their own set of options. Additionally, there may be
- * common options defined that many libraries may use. All these options may be
- * set in a single `Options` instance, and each library will look at the
- * options that it needs.
+ * storage) may define their own set of options. Additionally, there are common
+ * options defined that many libraries may use. All these options may be set in
+ * a single `Options` instance, and each library will look at the options that
+ * it needs.
  *
  * Here's an overview of this class's interface, but see the method
  * documentation below for details.

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -116,7 +116,7 @@ class Options {
    * @param v the value to set the option T
    */
   template <typename T>
-  Options& set(ValueTypeT<T> v = T{}.value) {
+  Options& set(ValueTypeT<T> v) {
     T t;
     t.value = std::move(v);
     m_[typeid(T)] = std::move(t);
@@ -164,7 +164,7 @@ class Options {
    * @param default_value the value to return if `T` is not set
    */
   template <typename T>
-  ValueTypeT<T> get_or(ValueTypeT<T> default_value = T{}.value) const {
+  ValueTypeT<T> get_or(ValueTypeT<T> default_value) const {
     auto it = m_.find(typeid(T));
     if (it != m_.end()) return absl::any_cast<T>(it->second).value;
     return default_value;
@@ -191,7 +191,7 @@ class Options {
    * @param init_value the value to return if `T` is not set
    */
   template <typename T>
-  ValueTypeT<T>& lookup(ValueTypeT<T> init_value = T{}.value) {
+  ValueTypeT<T>& lookup(ValueTypeT<T> init_value = {}) {
     auto it = m_.find(typeid(T));
     if (it != m_.end()) return absl::any_cast<T>(&it->second)->value;
     set<T>(std::move(init_value));

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -196,7 +196,7 @@ class Options {
   value_type_t<T> get_or(value_type_t<T> default_value) const {
     auto it = m_.find(typeid(T));
     if (it != m_.end()) return absl::any_cast<T>(it->second).value;
-    return std::move(default_value);
+    return default_value;
   }
 
   /**

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -253,7 +253,9 @@ TEST(CheckUnexpectedOptions, BasicOptionsList) {
 }
 
 TEST(CheckUnexpectedOptions, OptionsListPlusOne) {
-  struct FooOption {};
+  struct FooOption {
+    int value;
+  };
   testing_util::ScopedLog log;
   Options opts;
   opts.set<IntOption>();
@@ -264,7 +266,9 @@ TEST(CheckUnexpectedOptions, OptionsListPlusOne) {
 }
 
 TEST(CheckUnexpectedOptions, OptionsListOneUnexpected) {
-  struct FooOption {};
+  struct FooOption {
+    int value;
+  };
   testing_util::ScopedLog log;
   Options opts;
   opts.set<IntOption>();

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -31,15 +31,15 @@ using ::testing::ContainsRegex;
 using ::testing::UnorderedElementsAre;
 
 struct IntOption {
-  int value;
+  using Type = int;
 };
 
 struct BoolOption {
-  bool value;
+  using Type = bool;
 };
 
 struct StringOption {
-  std::string value;
+  using Type = std::string;
 };
 
 using TestOptionsTuple = std::tuple<IntOption, BoolOption, StringOption>;
@@ -55,7 +55,7 @@ TEST(OptionsUseCase, CustomerSettingSimpleOptions) {
 // This is how customers should append to an option.
 TEST(OptionsUseCase, CustomerSettingComplexOption) {
   struct ComplexOption {
-    std::set<std::string> value;
+    using Type = std::set<std::string>;
   };
 
   Options opts;
@@ -237,7 +237,7 @@ TEST(CheckUnexpectedOptions, BasicOptionsList) {
 
 TEST(CheckUnexpectedOptions, OptionsListPlusOne) {
   struct FooOption {
-    int value;
+    using Type = int;
   };
   testing_util::ScopedLog log;
   Options opts;
@@ -250,7 +250,7 @@ TEST(CheckUnexpectedOptions, OptionsListPlusOne) {
 
 TEST(CheckUnexpectedOptions, OptionsListOneUnexpected) {
   struct FooOption {
-    int value;
+    using Type = int;
   };
   testing_util::ScopedLog log;
   Options opts;

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -98,18 +98,12 @@ TEST(Options, Set) {
   EXPECT_EQ(0, opts.get_or<IntOption>(-1));
   opts.set<IntOption>(123);
   EXPECT_EQ(123, opts.get_or<IntOption>(-1));
-  const IntOption default_int{42};
-  opts.set<IntOption>(default_int);
-  EXPECT_EQ(42, opts.get_or<IntOption>(-1));
 
   opts = Options{};
   opts.set<BoolOption>();
   EXPECT_TRUE(opts.has<BoolOption>());
   EXPECT_EQ(false, opts.get_or<BoolOption>(true));
   opts.set<BoolOption>(true);
-  EXPECT_EQ(true, opts.get_or<BoolOption>(false));
-  const BoolOption default_bool{true};
-  opts.set<BoolOption>(default_bool);
   EXPECT_EQ(true, opts.get_or<BoolOption>(false));
 
   opts = Options{};
@@ -118,9 +112,6 @@ TEST(Options, Set) {
   EXPECT_EQ("", opts.get_or<StringOption>("default"));
   opts.set<StringOption>("foo");
   EXPECT_EQ("foo", opts.get_or<StringOption>("default"));
-  const StringOption default_string{"foo"};
-  opts.set<StringOption>(default_string);
-  EXPECT_EQ("foo", opts.get_or<StringOption>("default"));
 
   opts = Options{};
   opts.set<DefaultedOption>();
@@ -128,35 +119,21 @@ TEST(Options, Set) {
   EXPECT_EQ(123, opts.get_or<DefaultedOption>(-1));
   opts.set<DefaultedOption>(42);
   EXPECT_EQ(42, opts.get_or<DefaultedOption>(-1));
-  DefaultedOption default_default;
-  default_default.value = 42;
-  opts.set<DefaultedOption>(default_default);
-  EXPECT_EQ(42, opts.get_or<DefaultedOption>(-1));
 }
 
 TEST(Options, GetOr) {
-  const IntOption default_int{42};
-  const BoolOption default_bool{true};
-  const StringOption default_string{"foo"};
-  DefaultedOption default_default;
-  default_default.value = 42;
-
   Options opts;
   EXPECT_EQ(opts.get_or<IntOption>(), 0);
   EXPECT_EQ(opts.get_or<IntOption>(42), 42);
-  EXPECT_EQ(opts.get_or<IntOption>(default_int), 42);
 
   EXPECT_EQ(opts.get_or<BoolOption>(), false);
   EXPECT_EQ(opts.get_or<BoolOption>(true), true);
-  EXPECT_EQ(opts.get_or<BoolOption>(default_bool), true);
 
   EXPECT_EQ(opts.get_or<StringOption>(), "");
   EXPECT_EQ(opts.get_or<StringOption>("foo"), "foo");
-  EXPECT_EQ(opts.get_or<StringOption>(default_string), "foo");
 
   EXPECT_EQ(opts.get_or<DefaultedOption>(), 123);
   EXPECT_EQ(opts.get_or<DefaultedOption>(42), 42);
-  EXPECT_EQ(opts.get_or<DefaultedOption>(default_default), 42);
 }
 
 TEST(Options, Lookup) {
@@ -174,13 +151,6 @@ TEST(Options, Lookup) {
   opts.unset<IntOption>();
   EXPECT_FALSE(opts.has<IntOption>());
   EXPECT_EQ(42, opts.lookup<IntOption>(42));
-  EXPECT_TRUE(opts.has<IntOption>());
-
-  // Lookup with user-supplied default IntOption
-  const IntOption default_int{42};
-  opts.unset<IntOption>();
-  EXPECT_FALSE(opts.has<IntOption>());
-  EXPECT_EQ(42, opts.lookup<IntOption>(default_int));
   EXPECT_TRUE(opts.has<IntOption>());
 }
 


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5738
Fixes my concerns described in https://github.com/googleapis/google-cloud-cpp/pull/5864

The API changes in this PR

* "Option" structs now must contain a public `Type` member typedef indicating the type of the option's value. It no longer needs to have a public `.value` data member, and we no longer care how to construct one -- indeed, we never construct an "option" class at all.
* All uses of `absl::optional` are gone, as any "getter" method that might have to indicate that the value was not there. Instead, the only pure "getter" is `.get_or<T>(default_value)`, which returns by value, and can never fail because the caller must provide a default value to return if the option was not set (note: the default can simply be `{}`, but it's good that this is explicit at the call site).
* Since `absl::optional` is gone, I added `.has<T>()` to allow users to check if an option was set.
* Since `absl::optional` is gone, callers no longer have to dereference the value through something like `->value`. Instead, all accessors directly return the *value* (by copy or reference, depending on the method) that the user wanted, making call sites clearer and more succinct.
* Added a `.lookup<T>(init_value)` method that **returns a reference to the contained value**, inserting one if it was not already present. This behavior is similar to `std::map::insert`. This method makes it easy for users to do things like appending something to a potentially already present option. No pointers, or unnecessary copies are required here.

Note: It's possible that we might still want reference/pointer access to an option's value via a `const` accessor. If we end up wanting this for performance reasons, we could add this later similar to what was done in https://github.com/googleapis/google-cloud-cpp/pull/5860. We could even add it as a non-member friend that's `internal` so only we can use it if we want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5939)
<!-- Reviewable:end -->
