### PR TITLE
refactor: renamed option to GrpcBackgroundThreadsFactoryOption

### DIFF
--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -263,7 +263,8 @@ Options MakeOptions(ConnectionOptions<ConnectionTraits> old) {
   opts.set<GrpcNumChannelsOption>(old.num_channels_);
   opts.set<UserAgentPrefixOption>({std::move(old.user_agent_prefix_)});
   opts.set<GrpcTracingOptionsOption>(std::move(old.tracing_options_));
-  opts.set<GrpcBackgroundThreadsOption>(old.background_threads_factory());
+  opts.set<GrpcBackgroundThreadsFactoryOption>(
+      old.background_threads_factory());
   if (!old.tracing_components_.empty()) {
     opts.set<TracingComponentsOption>(std::move(old.tracing_components_));
   }

--- a/google/cloud/internal/grpc_options.cc
+++ b/google/cloud/internal/grpc_options.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/internal/common_options.h"
 
 namespace google {
@@ -32,6 +33,10 @@ grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
     channel_arguments.SetUserAgentPrefix(absl::StrJoin(user_agent_prefix, " "));
   }
   return channel_arguments;
+}
+
+std::unique_ptr<BackgroundThreads> DefaultBackgroundThreadsFactory() {
+  return absl::make_unique<AutomaticallyCreatedBackgroundThreads>();
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_options.h
+++ b/google/cloud/internal/grpc_options.h
@@ -92,6 +92,9 @@ namespace internal {
 /// Creates a new `grpc::ChannelArguments` configured with @p opts.
 grpc::ChannelArguments MakeChannelArguments(Options const& opts);
 
+/// Returns a factory to use if `GrpcBackgroundThreadsOption` is unset.
+std::unique_ptr<BackgroundThreads> DefaultBackgroundThreadsFactory();
+
 /**
  * A list of all the options in this file.
  *

--- a/google/cloud/internal/grpc_options.h
+++ b/google/cloud/internal/grpc_options.h
@@ -81,7 +81,7 @@ struct GrpcTracingOptionsOption {
  */
 using BackgroundThreadsFactory =
     std::function<std::unique_ptr<BackgroundThreads>()>;
-struct GrpcBackgroundThreadsOption {
+struct GrpcBackgroundThreadsFactoryOption {
   using Type = BackgroundThreadsFactory;
 };
 
@@ -92,7 +92,7 @@ namespace internal {
 /// Creates a new `grpc::ChannelArguments` configured with @p opts.
 grpc::ChannelArguments MakeChannelArguments(Options const& opts);
 
-/// Returns a factory to use if `GrpcBackgroundThreadsOption` is unset.
+/// Returns a factory to use if `GrpcBackgroundThreadsFactoryOption` is unset.
 std::unique_ptr<BackgroundThreads> DefaultBackgroundThreadsFactory();
 
 /**
@@ -111,7 +111,7 @@ std::unique_ptr<BackgroundThreads> DefaultBackgroundThreadsFactory();
 using GrpcOptions =
     std::tuple<GrpcCredentialOption, GrpcNumChannelsOption,
                GrpcChannelArgumentsOption, GrpcTracingOptionsOption,
-               GrpcBackgroundThreadsOption>;
+               GrpcBackgroundThreadsFactoryOption>;
 
 }  // namespace internal
 

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/background_threads_impl.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
@@ -59,6 +60,14 @@ TEST(GrpcOptions, GrpcBackgroundThreadsFactoryOption) {
   EXPECT_FALSE(invoked);
   opts.get_or<GrpcBackgroundThreadsFactoryOption>({})();
   EXPECT_TRUE(invoked);
+}
+
+TEST(GrpcOptions, DefaultBackgroundThreadsFactory) {
+  auto f = DefaultBackgroundThreadsFactory();
+  auto* tp =
+      dynamic_cast<internal::AutomaticallyCreatedBackgroundThreads*>(f.get());
+  ASSERT_NE(nullptr, tp);
+  EXPECT_EQ(1, tp->pool_size());
 }
 
 TEST(GrpcOptions, Expected) {

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -46,7 +46,7 @@ TEST(GrpcOptions, RegularOptions) {
   TestGrpcOption<GrpcTracingOptionsOption>(TracingOptions{});
 }
 
-TEST(GrpcOptions, GrpcBackgroundThreadsOption) {
+TEST(GrpcOptions, GrpcBackgroundThreadsFactoryOption) {
   struct Fake : BackgroundThreads {
     CompletionQueue cq() const override { return {}; }
   };
@@ -55,9 +55,9 @@ TEST(GrpcOptions, GrpcBackgroundThreadsOption) {
     invoked = true;
     return absl::make_unique<Fake>();
   };
-  auto opts = Options{}.set<GrpcBackgroundThreadsOption>(factory);
+  auto opts = Options{}.set<GrpcBackgroundThreadsFactoryOption>(factory);
   EXPECT_FALSE(invoked);
-  opts.get_or<GrpcBackgroundThreadsOption>({})();
+  opts.get_or<GrpcBackgroundThreadsFactoryOption>({})();
   EXPECT_TRUE(invoked);
 }
 


### PR DESCRIPTION
This PR also adds a `internal::DefaultBackgroundThreadsFactory()` function. This function will be convenient to use as a default value when our factories inspect an option like:

```
auto f = opts.get_or<GrpcBackgroundThreadsFactoryOption>(internal::DefaultBackgroundThreadsFactory);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5942)
<!-- Reviewable:end -->
