### PR TITLE
doc(pubsub): fix region tags for two examples

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -1018,7 +1018,7 @@ google::cloud::future<google::cloud::Status> SubscribeAvroRecords(
 
 void PublishProtobufRecords(google::cloud::pubsub::Publisher publisher,
                             std::vector<std::string> const&) {
-  //! [START pubsub_publish_proto_records]
+  //! [START pubsub_publish_proto_messages]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
   using google::cloud::StatusOr;
@@ -1045,14 +1045,14 @@ void PublishProtobufRecords(google::cloud::pubsub::Publisher publisher,
     // Block until all messages are published.
     for (auto& d : done) d.get();
   }
-  //! [END pubsub_publish_proto_records]
+  //! [END pubsub_publish_proto_messages]
   (std::move(publisher));
 }
 
 google::cloud::future<google::cloud::Status> SubscribeProtobufRecords(
     google::cloud::pubsub::Subscriber subscriber,
     std::vector<std::string> const&) {
-  //! [START pubsub_subscribe_protobuf_records]
+  //! [START pubsub_subscribe_proto_messages]
   namespace pubsub = google::cloud::pubsub;
   using google::cloud::future;
   using google::cloud::StatusOr;
@@ -1066,7 +1066,7 @@ google::cloud::future<google::cloud::Status> SubscribeProtobufRecords(
         });
     return session;
   }
-  //! [END pubsub_subscribe_protobuf_records]
+  //! [END pubsub_subscribe_proto_messages]
   (std::move(subscriber));
 }
 


### PR DESCRIPTION
I did not pay enough attention to the difference between the AVRO and
protocol buffer samples.

Part of the work for #5706 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5944)
<!-- Reviewable:end -->
