### PR TITLE
refactor: add Options::get<T>()

### DIFF
--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -72,7 +72,7 @@ TEST(OptionsUseCase, CustomerSettingComplexOption) {
 TEST(OptionsUseCase, FactoriesGettingOptions) {
   auto factory = [](Options const& opts) {
     EXPECT_EQ(123, opts.get_or<IntOption>(123));
-    EXPECT_EQ("set-by-customer", opts.get_or<StringOption>({}));
+    EXPECT_EQ("set-by-customer", opts.get<StringOption>());
   };
 
   auto opts = Options{}.set<StringOption>("set-by-customer");
@@ -162,9 +162,9 @@ TEST(Options, Copy) {
   EXPECT_TRUE(copy.has<BoolOption>());
   EXPECT_TRUE(copy.has<StringOption>());
 
-  EXPECT_EQ(42, copy.get_or<IntOption>({}));
-  EXPECT_EQ(true, copy.get_or<BoolOption>({}));
-  EXPECT_EQ("foo", copy.get_or<StringOption>({}));
+  EXPECT_EQ(42, copy.get<IntOption>());
+  EXPECT_EQ(true, copy.get<BoolOption>());
+  EXPECT_EQ("foo", copy.get<StringOption>());
 }
 
 TEST(Options, Move) {
@@ -176,9 +176,9 @@ TEST(Options, Move) {
   EXPECT_TRUE(moved.has<BoolOption>());
   EXPECT_TRUE(moved.has<StringOption>());
 
-  EXPECT_EQ(42, moved.get_or<IntOption>({}));
-  EXPECT_EQ(true, moved.get_or<BoolOption>({}));
-  EXPECT_EQ("foo", moved.get_or<StringOption>({}));
+  EXPECT_EQ(42, moved.get<IntOption>());
+  EXPECT_EQ(true, moved.get<BoolOption>());
+  EXPECT_EQ("foo", moved.get<StringOption>());
 }
 
 TEST(CheckUnexpectedOptions, Empty) {

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -109,6 +109,20 @@ TEST(Options, Set) {
   EXPECT_EQ("foo", opts.get_or<StringOption>("default"));
 }
 
+TEST(Options, Get) {
+  Options opts;
+
+  int const& i = opts.get<IntOption>();
+  EXPECT_EQ(0, i);
+  opts.set<IntOption>(42);
+  EXPECT_EQ(42, opts.get<IntOption>());
+
+  std::string const& s = opts.get<StringOption>();
+  EXPECT_TRUE(s.empty());
+  opts.set<StringOption>("test");
+  EXPECT_EQ("test", opts.get<StringOption>());
+}
+
 TEST(Options, GetOr) {
   Options opts;
   EXPECT_EQ(opts.get_or<IntOption>({}), 0);


### PR DESCRIPTION
It turns out that we actually can provide a const `get<T>()` method that
returns a const-ref by defining that it returns a reference to a static
value-initialzied default value. I think this will be very useful for
cases where we want to query an option with changing or setting it. For
example, in a number of places we inspect the `TracingComponentsOption`
which is a `std::set<std::string>` to see if it contains an element.
Using `.get<T>()` would let us do this without copying the `set` every
time. I believe this will also allow us to re-implement
`ConnectionOptions` in terms of `Options`, since it can now return
const-refs, even to unset options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5947)
<!-- Reviewable:end -->
