### PR TITLE
refactor: rename user-agent option and change type

### DIFF
--- a/google/cloud/connection_options.h
+++ b/google/cloud/connection_options.h
@@ -268,7 +268,7 @@ namespace internal {
 template <typename ConnectionTraits>
 Options MakeOptions(ConnectionOptions<ConnectionTraits> old) {
   Options opts = std::move(old.opts_);
-  opts.set<UserAgentPrefixOption>({std::move(old.user_agent_prefix_)});
+  opts.set<UserAgentProductsOption>({std::move(old.user_agent_prefix_)});
   opts.set<GrpcBackgroundThreadsFactoryOption>(
       old.background_threads_factory());
   if (!old.channel_pool_domain_.empty()) {

--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -154,18 +154,18 @@ TEST(ConnectionOptionsTest, ChannelPoolName) {
   EXPECT_EQ(opts["grpc.channel_pooling_domain"], "test-channel-pool");
 }
 
-TEST(ConnectionOptionsTest, UserAgentPrefix) {
+TEST(ConnectionOptionsTest, UserAgentProducts) {
   TestConnectionOptions conn_opts(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::user_agent_prefix(), conn_opts.user_agent_prefix());
   EXPECT_THAT(
-      internal::MakeOptions(conn_opts).get<internal::UserAgentPrefixOption>(),
+      internal::MakeOptions(conn_opts).get<internal::UserAgentProductsOption>(),
       testing::ElementsAre(conn_opts.user_agent_prefix()));
 
   conn_opts.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + TestTraits::user_agent_prefix(),
             conn_opts.user_agent_prefix());
   EXPECT_THAT(
-      internal::MakeOptions(conn_opts).get<internal::UserAgentPrefixOption>(),
+      internal::MakeOptions(conn_opts).get<internal::UserAgentProductsOption>(),
       testing::ElementsAre(conn_opts.user_agent_prefix()));
 }
 

--- a/google/cloud/internal/common_options.h
+++ b/google/cloud/internal/common_options.h
@@ -19,6 +19,7 @@
 #include <set>
 #include <string>
 #include <tuple>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -37,14 +38,17 @@ struct EndpointOption {
 };
 
 /**
- * User-agent strings to include with each request.
+ * User-agent products to include with each request.
  *
  * Libraries or services that use Cloud C++ clients may want to set their own
- * user-agent prefix. This can help them develop telemetry information about
- * number of users running particular versions of their system or library.
+ * user-agent product information. This can help them develop telemetry
+ * information about number of users running particular versions of their
+ * system or library.
+ *
+ * @see https://tools.ietf.org/html/rfc7231#section-5.5.3
  */
-struct UserAgentPrefixOption {
-  using Type = std::set<std::string>;
+struct UserAgentProductsOption {
+  using Type = std::vector<std::string>;
 };
 
 /**
@@ -79,8 +83,8 @@ namespace internal {
  *     opts, "some factory function");
  * @endcode
  */
-using CommonOptions =
-    std::tuple<EndpointOption, UserAgentPrefixOption, TracingComponentsOption>;
+using CommonOptions = std::tuple<EndpointOption, UserAgentProductsOption,
+                                 TracingComponentsOption>;
 }  // namespace internal
 
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -41,7 +41,7 @@ void TestOption(ValueType const& expected) {
 
 TEST(CommonOptions, RegularOptions) {
   TestOption<EndpointOption>("foo.googleapis.com");
-  TestOption<UserAgentPrefixOption>({"foo", "bar"});
+  TestOption<UserAgentProductsOption>({"foo", "bar"});
   TestOption<TracingComponentsOption>({"foo", "bar", "baz"});
 }
 

--- a/google/cloud/internal/grpc_options.cc
+++ b/google/cloud/internal/grpc_options.cc
@@ -28,7 +28,7 @@ grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   for (auto const& p : opts.get_or<GrpcChannelArgumentsOption>({})) {
     channel_arguments.SetString(p.first, p.second);
   }
-  auto const user_agent_prefix = opts.get_or<UserAgentPrefixOption>({});
+  auto const user_agent_prefix = opts.get_or<UserAgentProductsOption>({});
   if (!user_agent_prefix.empty()) {
     channel_arguments.SetUserAgentPrefix(absl::StrJoin(user_agent_prefix, " "));
   }


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/5952

Per the reasons in #5952, the type is changing form `std::set` ->
`std::vector` to convey that multiple can be set and the order matters.

This also renames the option from `UserAgentPrefixOption` ->
`UserAgentProductsOption` to better reflect the terminology used in
https://tools.ietf.org/html/rfc7231#section-5.5.3. It's also plural to
indicate that multiple can be set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5953)
<!-- Reviewable:end -->
