### PR TITLE
refactor: remove Options::get_or

### DIFF
--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -33,7 +33,7 @@ using ::testing::ContainsRegex;
 template <typename T, typename ValueType = typename T::Type>
 void TestOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
-  EXPECT_EQ(expected, opts.template get_or<T>({}))
+  EXPECT_EQ(expected, opts.template get<T>())
       << "Failed with type: " << typeid(T).name();
 }
 

--- a/google/cloud/internal/grpc_options.cc
+++ b/google/cloud/internal/grpc_options.cc
@@ -25,10 +25,10 @@ namespace internal {
 
 grpc::ChannelArguments MakeChannelArguments(Options const& opts) {
   grpc::ChannelArguments channel_arguments;
-  for (auto const& p : opts.get_or<GrpcChannelArgumentsOption>({})) {
+  for (auto const& p : opts.get<GrpcChannelArgumentsOption>()) {
     channel_arguments.SetString(p.first, p.second);
   }
-  auto const user_agent_prefix = opts.get_or<UserAgentProductsOption>({});
+  auto const& user_agent_prefix = opts.get<UserAgentProductsOption>();
   if (!user_agent_prefix.empty()) {
     channel_arguments.SetUserAgentPrefix(absl::StrJoin(user_agent_prefix, " "));
   }

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -34,7 +34,7 @@ using ::testing::ContainsRegex;
 template <typename T, typename ValueType = typename T::Type>
 void TestGrpcOption(ValueType const& expected) {
   auto opts = Options{}.template set<T>(expected);
-  EXPECT_EQ(expected, opts.template get_or<T>({}))
+  EXPECT_EQ(expected, opts.template get<T>())
       << "Failed with type: " << typeid(T).name();
 }
 
@@ -58,7 +58,7 @@ TEST(GrpcOptions, GrpcBackgroundThreadsFactoryOption) {
   };
   auto opts = Options{}.set<GrpcBackgroundThreadsFactoryOption>(factory);
   EXPECT_FALSE(invoked);
-  opts.get_or<GrpcBackgroundThreadsFactoryOption>({})();
+  opts.get<GrpcBackgroundThreadsFactoryOption>()();
   EXPECT_TRUE(invoked);
 }
 

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -51,7 +51,6 @@ namespace internal {
  * - `.has<T>()`     -- Returns true iff option `T` is set
  * - `.unset<T>()`   -- Removes the option `T`
  * - `.get<T>()`     -- Gets a const-ref to the value of option `T`
- * - `.get_or<T>(x)` -- Gets the value of option `T`, or `x` if no value was set
  * - `.lookup<T>(x)` -- Gets a non-const-ref to option `T`'s value, initializing
  *                      it to `x` if it was no set (`x` is optional).
  *
@@ -68,12 +67,8 @@ namespace internal {
  * Options opts;
  *
  * assert(opts.get<FooOption>() == 0);
- * assert(opts.get_or<FooOption>(123) == 123);
- *
  * opts.set<FooOption>(42);
- *
  * assert(opts.get<FooOption>() == 42);
- * assert(opts.get_or<FooOption>(123) == 42);
  *
  * // Inserts two elements directly into the BarOption's std::set.
  * opts.lookup<BarOption>().insert("hello");
@@ -165,34 +160,6 @@ class Options {
     auto const it = m_.find(typeid(T));
     if (it != m_.end()) return absl::any_cast<Data<T>>(&it->second)->value;
     return *kDefaultValue;
-  }
-
-  /**
-   * Returns the value for the option `T`, else returns the @p default_value.
-   *
-   * @code
-   * struct FooOption {
-   *   using Type = int;
-   * };
-   * Options opts;
-   * int x = opts.get_or<FooOption>(123);
-   * assert(x == 123);
-   * assert(!x.has<FooOption>());
-   *
-   * opts.set<FooOption>(42);
-   * x = opts.get_or<FooOption>(123);
-   * assert(x == 42);
-   * assert(x.has<FooOption>());
-   * @endcode
-   *
-   * @tparam T the option type
-   * @param default_value the value to return if `T` is not set
-   */
-  template <typename T>
-  ValueTypeT<T> get_or(ValueTypeT<T> default_value) const {
-    auto const it = m_.find(typeid(T));
-    if (it != m_.end()) return absl::any_cast<Data<T>>(it->second).value;
-    return default_value;
   }
 
   /**

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -68,17 +68,6 @@ TEST(OptionsUseCase, CustomerSettingComplexOption) {
   EXPECT_THAT(opts.lookup<ComplexOption>(), UnorderedElementsAre("foo", "bar"));
 }
 
-// This is how our factory functions should get options.
-TEST(OptionsUseCase, FactoriesGettingOptions) {
-  auto factory = [](Options const& opts) {
-    EXPECT_EQ(123, opts.get_or<IntOption>(123));
-    EXPECT_EQ("set-by-customer", opts.get<StringOption>());
-  };
-
-  auto opts = Options{}.set<StringOption>("set-by-customer");
-  factory(opts);
-}
-
 TEST(Options, Has) {
   Options opts;
   EXPECT_FALSE(opts.has<IntOption>());
@@ -90,23 +79,23 @@ TEST(Options, Set) {
   Options opts;
   opts.set<IntOption>({});
   EXPECT_TRUE(opts.has<IntOption>());
-  EXPECT_EQ(0, opts.get_or<IntOption>(-1));
+  EXPECT_EQ(0, opts.get<IntOption>());
   opts.set<IntOption>(123);
-  EXPECT_EQ(123, opts.get_or<IntOption>(-1));
+  EXPECT_EQ(123, opts.get<IntOption>());
 
   opts = Options{};
   opts.set<BoolOption>({});
   EXPECT_TRUE(opts.has<BoolOption>());
-  EXPECT_EQ(false, opts.get_or<BoolOption>(true));
+  EXPECT_EQ(false, opts.get<BoolOption>());
   opts.set<BoolOption>(true);
-  EXPECT_EQ(true, opts.get_or<BoolOption>(false));
+  EXPECT_EQ(true, opts.get<BoolOption>());
 
   opts = Options{};
   opts.set<StringOption>({});
   EXPECT_TRUE(opts.has<StringOption>());
-  EXPECT_EQ("", opts.get_or<StringOption>("default"));
+  EXPECT_EQ("", opts.get<StringOption>());
   opts.set<StringOption>("foo");
-  EXPECT_EQ("foo", opts.get_or<StringOption>("default"));
+  EXPECT_EQ("foo", opts.get<StringOption>());
 }
 
 TEST(Options, Get) {
@@ -121,18 +110,6 @@ TEST(Options, Get) {
   EXPECT_TRUE(s.empty());
   opts.set<StringOption>("test");
   EXPECT_EQ("test", opts.get<StringOption>());
-}
-
-TEST(Options, GetOr) {
-  Options opts;
-  EXPECT_EQ(opts.get_or<IntOption>({}), 0);
-  EXPECT_EQ(opts.get_or<IntOption>(42), 42);
-
-  EXPECT_EQ(opts.get_or<BoolOption>({}), false);
-  EXPECT_EQ(opts.get_or<BoolOption>(true), true);
-
-  EXPECT_EQ(opts.get_or<StringOption>({}), "");
-  EXPECT_EQ(opts.get_or<StringOption>("foo"), "foo");
 }
 
 TEST(Options, Lookup) {


### PR DESCRIPTION
(sorry for all these `Options` API changes, but it's still internal and these should happen before it's public.)

After adding a const-ref-returning `Options::get<T>()`, I think there's
very little need for `get_or`. AFAICT, all uses of "get_or" are more
clearly written as "get", and they're more efficient. Additionally, the
functionality provided by "get_or" is "convenient" at best, and could be
completely implemented as a non-member helper function, thus improving
encapsulation.

It's always easier to add APIs than remove them, so we should err on the
side of removing this before the API is public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5955)
<!-- Reviewable:end -->
