### PR TITLE
chore: add/remove common c++ includes in our headers

### DIFF
--- a/google/cloud/bigtable/app_profile_config.h
+++ b/google/cloud/bigtable/app_profile_config.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -32,7 +32,9 @@
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <chrono>
 #include <queue>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -22,6 +22,7 @@
 #include "google/cloud/status_or.h"
 #include <chrono>
 #include <deque>
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/bigtable/benchmarks/random_mutation.h
+++ b/google/cloud/bigtable/benchmarks/random_mutation.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/internal/random.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/benchmarks/setup.h
+++ b/google/cloud/bigtable/benchmarks/setup.h
@@ -19,7 +19,6 @@
 #include "google/cloud/status_or.h"
 #include <chrono>
 #include <string>
-#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/cell.h
+++ b/google/cloud/bigtable/cell.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/status_or.h"
 #include <chrono>
+#include <string>
 #include <type_traits>
 #include <vector>
 

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -20,6 +20,7 @@
 #include "google/cloud/tracing_options.h"
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/resource_quota.h>
+#include <chrono>
 #include <set>
 #include <string>
 

--- a/google/cloud/bigtable/cluster_config.h
+++ b/google/cloud/bigtable/cluster_config.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/cluster_list_responses.h
+++ b/google/cloud/bigtable/cluster_list_responses.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -21,6 +21,7 @@
 #include <google/bigtable/admin/v2/table.pb.h>
 #include <chrono>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/row.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/examples/bigtable_examples_common.h
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.h
@@ -20,6 +20,9 @@
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/expr.h
+++ b/google/cloud/bigtable/expr.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/type/expr.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -19,6 +19,7 @@
 #include "absl/meta/type_traits.h"
 #include <google/bigtable/v2/data.pb.h>
 #include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/iam_binding.h
+++ b/google/cloud/bigtable/iam_binding.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/iam_policy.h
+++ b/google/cloud/bigtable/iam_policy.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/iam_binding.h"
 #include "google/cloud/bigtable/version.h"
 #include <list>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -32,6 +32,8 @@
 #include "google/cloud/status_or.h"
 #include <future>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_config.h
+++ b/google/cloud/bigtable/instance_config.h
@@ -20,7 +20,7 @@
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
 #include <google/bigtable/admin/v2/common.pb.h>
 #include <map>
-#include <vector>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_list_responses.h
+++ b/google/cloud/bigtable/instance_list_responses.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -21,7 +21,7 @@
 #include <google/bigtable/admin/v2/bigtable_instance_admin.pb.h>
 #include <google/bigtable/admin/v2/common.pb.h>
 #include <map>
-#include <vector>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -23,6 +23,8 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "absl/memory/memory.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/async_poll_op.h
+++ b/google/cloud/bigtable/internal/async_poll_op.h
@@ -21,6 +21,8 @@
 #include "google/cloud/bigtable/version.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
+#include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/async_retry_multi_page.h
+++ b/google/cloud/bigtable/internal/async_retry_multi_page.h
@@ -21,6 +21,8 @@
 #include "google/cloud/bigtable/polling_policy.h"
 #include "google/cloud/bigtable/version.h"
 #include "absl/memory/memory.h"
+#include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll.h
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/async_retry_unary_rpc.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <sstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -22,6 +22,8 @@
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "absl/memory/memory.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -23,7 +23,9 @@
 #include "google/cloud/log.h"
 #include "google/cloud/status_or.h"
 #include <grpcpp/grpcpp.h>
+#include <chrono>
 #include <list>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/google_bytes_traits.h
+++ b/google/cloud/bigtable/internal/google_bytes_traits.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/port_platform.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/internal/readrowsparser.h
+++ b/google/cloud/bigtable/internal/readrowsparser.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "absl/memory/memory.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/bigtable/internal/unary_client_utils.h
+++ b/google/cloud/bigtable/internal/unary_client_utils.h
@@ -21,6 +21,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/retry_policy.h"
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/bigtable/metadata_update_policy.h
+++ b/google/cloud/bigtable/metadata_update_policy.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/version.h"
 #include <grpcpp/grpcpp.h>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -27,6 +27,7 @@
 #include <functional>
 #include <memory>
 #include <queue>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -27,7 +27,9 @@
 #include <google/bigtable/v2/data.pb.h>
 #include <grpcpp/grpcpp.h>
 #include <chrono>
+#include <string>
 #include <type_traits>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/polling_policy.h
+++ b/google/cloud/bigtable/polling_policy.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include <grpcpp/grpcpp.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/read_modify_write_rule.h
+++ b/google/cloud/bigtable/read_modify_write_rule.h
@@ -17,7 +17,7 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/v2/data.pb.h>
-#include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/row_key.h
+++ b/google/cloud/bigtable/row_key.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/internal/google_bytes_traits.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/v2/data.pb.h>
+#include <string>
 #include <type_traits>
 #include <utility>
 

--- a/google/cloud/bigtable/row_key.h
+++ b/google/cloud/bigtable/row_key.h
@@ -18,7 +18,6 @@
 #include "google/cloud/bigtable/internal/google_bytes_traits.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/v2/data.pb.h>
-#include <string>
 #include <type_traits>
 #include <utility>
 

--- a/google/cloud/bigtable/row_key_sample.h
+++ b/google/cloud/bigtable/row_key_sample.h
@@ -18,7 +18,6 @@
 #include "google/cloud/bigtable/row_key.h"
 #include "google/cloud/bigtable/version.h"
 #include <cstdint>
-#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/row_range.h
+++ b/google/cloud/bigtable/row_range.h
@@ -19,7 +19,7 @@
 #include "google/cloud/bigtable/row_key.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/v2/data.pb.h>
-#include <chrono>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -31,6 +31,7 @@
 #include <grpcpp/grpcpp.h>
 #include <cinttypes>
 #include <iterator>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -20,7 +20,6 @@
 #include "google/cloud/internal/retry_policy.h"
 #include "google/cloud/status.h"
 #include <grpcpp/grpcpp.h>
-#include <chrono>
 #include <memory>
 
 namespace google {

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -33,6 +33,8 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "absl/meta/type_traits.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -30,8 +30,11 @@
 #include "google/cloud/internal/attributes.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
+#include <chrono>
 #include <future>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/table_config.h
+++ b/google/cloud/bigtable/table_config.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.pb.h>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -21,6 +21,7 @@
 #include "google/cloud/bigtable/testing/inprocess_data_client.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <gtest/gtest.h>
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/client_options.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/client_options.h"
 #include "google/cloud/bigtable/data_client.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/admin_client.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/table.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/instance_admin_client.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -23,6 +23,7 @@
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/sync_stream.h>
 #include <grpcpp/support/async_unary_call.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -22,6 +22,8 @@
 #include "google/cloud/bigtable/table_admin.h"
 #include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/mock_data_client.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/completion_queue.h
+++ b/google/cloud/completion_queue.h
@@ -23,6 +23,7 @@
 #include "google/cloud/version.h"
 #include "absl/memory/memory.h"
 #include "absl/meta/type_traits.h"
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/grpc_error_delegate.h
+++ b/google/cloud/grpc_error_delegate.h
@@ -19,6 +19,7 @@
 #include "google/cloud/version.h"
 #include <google/rpc/status.pb.h>
 #include <grpcpp/grpcpp.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/grpc_utils/version.h
+++ b/google/cloud/grpc_utils/version.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_GRPC_UTILS_VERSION_H
 
 #include "google/cloud/version.h"
-#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/iam/iam_credentials_client.gcpcxx.pb.h
+++ b/google/cloud/iam/iam_credentials_client.gcpcxx.pb.h
@@ -24,6 +24,8 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/iam/iam_credentials_connection.gcpcxx.pb.h
+++ b/google/cloud/iam/iam_credentials_connection.gcpcxx.pb.h
@@ -26,6 +26,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/iam_binding.h
+++ b/google/cloud/iam_binding.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include <set>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/iam_bindings.h
+++ b/google/cloud/iam_bindings.h
@@ -19,6 +19,7 @@
 #include "google/cloud/version.h"
 #include <map>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/google/cloud/iam_policy.h
+++ b/google/cloud/iam_policy.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/iam_bindings.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -24,6 +24,7 @@
 #include "google/cloud/version.h"
 #include "absl/meta/type_traits.h"
 #include <grpcpp/grpcpp.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/async_retry_unary_rpc.h
+++ b/google/cloud/internal/async_retry_unary_rpc.h
@@ -21,6 +21,8 @@
 #include "google/cloud/version.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/empty.pb.h>
+#include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/build_info.h
+++ b/google/cloud/internal/build_info.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_BUILD_INFO_H
 
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/compiler_info.h
+++ b/google/cloud/internal/compiler_info.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_COMPILER_INFO_H
 
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/completion_queue_impl.h
+++ b/google/cloud/internal/completion_queue_impl.h
@@ -22,6 +22,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include "absl/functional/function_ref.h"
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/default_completion_queue_impl.h
+++ b/google/cloud/internal/default_completion_queue_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/completion_queue_impl.h"
 #include "google/cloud/version.h"
 #include <atomic>
+#include <chrono>
 #include <cinttypes>
 #include <deque>
 #include <unordered_map>

--- a/google/cloud/internal/filesystem.h
+++ b/google/cloud/internal/filesystem.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include <cinttypes>
+#include <string>
 #include <system_error>
 
 namespace google {

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -22,6 +22,7 @@
 
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/version.h"
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/future_impl.h
+++ b/google/cloud/internal/future_impl.h
@@ -24,6 +24,7 @@
 #include "google/cloud/terminate_handler.h"
 #include "google/cloud/version.h"
 #include "absl/memory/memory.h"
+#include <chrono>
 #include <condition_variable>
 #include <exception>
 #include <future>

--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -24,6 +24,8 @@
 #include "google/cloud/version.h"
 #include <google/protobuf/message.h>
 #include <grpcpp/grpcpp.h>
+#include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/version.h"
 #include "absl/types/any.h"
 #include <set>
+#include <string>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -18,7 +18,6 @@
 #include "google/cloud/version.h"
 #include "absl/types/any.h"
 #include <set>
-#include <string>
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>

--- a/google/cloud/internal/polling_loop.h
+++ b/google/cloud/internal/polling_loop.h
@@ -22,6 +22,8 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.pb.h>
 #include <grpcpp/grpcpp.h>
+#include <chrono>
+#include <string>
 #include <thread>
 
 namespace google {

--- a/google/cloud/internal/random.h
+++ b/google/cloud/internal/random.h
@@ -17,6 +17,8 @@
 
 #include "google/cloud/version.h"
 #include <random>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/resumable_streaming_read_rpc.h
+++ b/google/cloud/internal/resumable_streaming_read_rpc.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/version.h"
+#include <chrono>
 #include <memory>
 #include <thread>
 

--- a/google/cloud/internal/retry_loop.h
+++ b/google/cloud/internal/retry_loop.h
@@ -22,6 +22,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>
+#include <chrono>
 #include <thread>
 
 namespace google {

--- a/google/cloud/internal/setenv.h
+++ b/google/cloud/internal/setenv.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/strerror.h
+++ b/google/cloud/internal/strerror.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STRERROR_H
 
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/throw_delegate.h
+++ b/google/cloud/internal/throw_delegate.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
+#include <string>
 #include <system_error>
 
 namespace google {

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -91,6 +91,7 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/logging/logging_service_v2_client.gcpcxx.pb.h
+++ b/google/cloud/logging/logging_service_v2_client.gcpcxx.pb.h
@@ -25,6 +25,8 @@
 #include "google/cloud/version.h"
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/logging/logging_service_v2_connection.gcpcxx.pb.h
+++ b/google/cloud/logging/logging_service_v2_connection.gcpcxx.pb.h
@@ -27,6 +27,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/logging/mocks/mock_logging_service_v2_connection.gcpcxx.pb.h
+++ b/google/cloud/logging/mocks/mock_logging_service_v2_connection.gcpcxx.pb.h
@@ -20,6 +20,7 @@
 
 #include "google/cloud/logging/logging_service_v2_connection.gcpcxx.pb.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/connection_options.h
+++ b/google/cloud/pubsub/connection_options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/connection_options.h"
 #include <grpcpp/grpcpp.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/experimental/schema_admin_client.h
+++ b/google/cloud/pubsub/experimental/schema_admin_client.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/experimental/schema_admin_connection.h"
 #include "google/cloud/pubsub/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/batch_sink.h
+++ b/google/cloud/pubsub/internal/batch_sink.h
@@ -20,6 +20,7 @@
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -18,8 +18,11 @@
 #include "google/cloud/pubsub/internal/batch_sink.h"
 #include "google/cloud/pubsub/publisher_connection.h"
 #include "google/cloud/pubsub/version.h"
+#include <chrono>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/default_batch_sink.h
+++ b/google/cloud/pubsub/internal/default_batch_sink.h
@@ -21,6 +21,7 @@
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
+++ b/google/cloud/pubsub/internal/ordering_key_publisher_connection.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/publisher_metadata.h
+++ b/google/cloud/pubsub/internal/publisher_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/tracing_options.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/rejects_with_ordering_key.h
+++ b/google/cloud/pubsub/internal/rejects_with_ordering_key.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/publisher_connection.h"
 #include "google/cloud/pubsub/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/schema_metadata.h
+++ b/google/cloud/pubsub/internal/schema_metadata.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/internal/schema_stub.h"
 #include "google/cloud/pubsub/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/sequential_batch_sink.h
+++ b/google/cloud/pubsub/internal/sequential_batch_sink.h
@@ -20,6 +20,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/session_shutdown_manager.h
+++ b/google/cloud/pubsub/internal/session_shutdown_manager.h
@@ -19,6 +19,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/status.h"
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 namespace google {

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -26,6 +26,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <iosfwd>

--- a/google/cloud/pubsub/internal/subscriber_logging.h
+++ b/google/cloud/pubsub/internal/subscriber_logging.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/tracing_options.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscriber_metadata.h
+++ b/google/cloud/pubsub/internal/subscriber_metadata.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/tracing_options.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/subscription_batch_source.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <chrono>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/google/cloud/pubsub/internal/subscription_concurrency_control.h
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control.h
@@ -20,8 +20,8 @@
 #include "google/cloud/pubsub/internal/subscription_message_source.h"
 #include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/version.h"
-#include <chrono>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscription_lease_management.h
+++ b/google/cloud/pubsub/internal/subscription_lease_management.h
@@ -22,6 +22,8 @@
 #include "google/cloud/internal/absl_flat_hash_map_quiet.h"
 #include <chrono>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscription_message_queue.h
+++ b/google/cloud/pubsub/internal/subscription_message_queue.h
@@ -25,6 +25,7 @@
 #include <deque>
 #include <functional>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscription_message_source.h
+++ b/google/cloud/pubsub/internal/subscription_message_source.h
@@ -20,6 +20,7 @@
 #include "google/cloud/status.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <functional>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/internal/subscription_session.h
+++ b/google/cloud/pubsub/internal/subscription_session.h
@@ -27,6 +27,7 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/message.h
+++ b/google/cloud/pubsub/message.h
@@ -17,8 +17,10 @@
 
 #include "google/cloud/pubsub/version.h"
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <chrono>
 #include <iosfwd>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/pubsub/mocks/mock_ack_handler.h
+++ b/google/cloud/pubsub/mocks/mock_ack_handler.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/ack_handler.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/mocks/mock_publisher_connection.h
+++ b/google/cloud/pubsub/mocks/mock_publisher_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/publisher_connection.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/publisher.h
+++ b/google/cloud/pubsub/publisher.h
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/publisher_connection.h"
 #include "google/cloud/pubsub/publisher_options.h"
 #include "google/cloud/pubsub/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -25,6 +25,8 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/samples/pubsub_samples_common.h
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.h
@@ -21,6 +21,8 @@
 #include "google/cloud/pubsub/subscription_admin_client.h"
 #include "google/cloud/pubsub/topic_admin_client.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/snapshot_builder.h
+++ b/google/cloud/pubsub/snapshot_builder.h
@@ -22,6 +22,7 @@
 #include <google/protobuf/util/field_mask_util.h>
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <set>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -27,6 +27,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/status_or.h"
 #include <functional>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/subscription.h
+++ b/google/cloud/pubsub/subscription.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/version.h"
 #include <grpcpp/grpcpp.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -19,7 +19,9 @@
 #include "google/cloud/pubsub/subscription_admin_connection.h"
 #include "google/cloud/pubsub/subscription_builder.h"
 #include "google/cloud/pubsub/version.h"
+#include <chrono>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -26,6 +26,7 @@
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/subscription_builder.h
+++ b/google/cloud/pubsub/subscription_builder.h
@@ -20,7 +20,10 @@
 #include "google/cloud/pubsub/version.h"
 #include <google/protobuf/util/field_mask_util.h>
 #include <google/pubsub/v1/pubsub.pb.h>
+#include <chrono>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/testing/mock_batch_sink.h
+++ b/google/cloud/pubsub/testing/mock_batch_sink.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/internal/batch_sink.h"
 #include "google/cloud/pubsub/version.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/testing/mock_subscription_batch_source.h
+++ b/google/cloud/pubsub/testing/mock_subscription_batch_source.h
@@ -18,6 +18,9 @@
 #include "google/cloud/pubsub/internal/subscription_batch_source.h"
 #include "google/cloud/pubsub/version.h"
 #include <gmock/gmock.h>
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/testing/mock_subscription_message_source.h
+++ b/google/cloud/pubsub/testing/mock_subscription_message_source.h
@@ -18,6 +18,7 @@
 #include "google/cloud/pubsub/internal/subscription_message_source.h"
 #include "google/cloud/pubsub/version.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/testing/random_names.h
+++ b/google/cloud/pubsub/testing/random_names.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/internal/random.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/topic.h
+++ b/google/cloud/pubsub/topic.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/pubsub/version.h"
 #include <grpcpp/grpcpp.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/topic_admin_client.h
+++ b/google/cloud/pubsub/topic_admin_client.h
@@ -20,6 +20,7 @@
 #include "google/cloud/pubsub/topic_builder.h"
 #include "google/cloud/pubsub/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -26,6 +26,7 @@
 #include "google/cloud/status_or.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/topic_builder.h
+++ b/google/cloud/pubsub/topic_builder.h
@@ -20,6 +20,7 @@
 #include "google/cloud/pubsub/version.h"
 #include <google/pubsub/v1/pubsub.pb.h>
 #include <set>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/pubsub/version_info.h"
 #include "google/cloud/version.h"
-#include <string>
 
 #define GOOGLE_CLOUD_CPP_PUBSUB_NS                                     \
   GOOGLE_CLOUD_CPP_VEVAL(GOOGLE_CLOUD_CPP_PUBSUB_CLIENT_VERSION_MAJOR, \

--- a/google/cloud/spanner/client_options.h
+++ b/google/cloud/spanner/client_options.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/spanner/query_options.h"
 #include "google/cloud/spanner/version.h"
-#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/version.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
 #include <map>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -27,6 +27,8 @@
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <chrono>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -20,6 +20,8 @@
 #include "google/cloud/spanner/instance_admin_connection.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -24,6 +24,8 @@
 #include "google/cloud/internal/pagination_range.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -32,7 +32,6 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/spanner/internal/database_admin_metadata.h
+++ b/google/cloud/spanner/internal/database_admin_metadata.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -24,6 +24,7 @@
 #include "absl/types/optional.h"
 #include <functional>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -27,6 +27,8 @@
 #include <grpcpp/grpcpp.h>
 #include <deque>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -19,7 +19,6 @@
 #include "google/cloud/spanner/internal/clock.h"
 #include "google/cloud/spanner/version.h"
 #include <atomic>
-#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -16,8 +16,10 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TUPLE_UTILS_H
 
 #include "google/cloud/spanner/version.h"
+#include <string>
 #include <tuple>
 #include <type_traits>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -16,10 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TUPLE_UTILS_H
 
 #include "google/cloud/spanner/version.h"
-#include <string>
 #include <tuple>
 #include <type_traits>
-#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -18,7 +18,6 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/spanner/version.h"
 #include <google/spanner/v1/keys.pb.h>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -21,6 +21,7 @@
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/spanner/version.h"
 #include <google/spanner/v1/mutation.pb.h>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/spanner/sql_statement.h
+++ b/google/cloud/spanner/sql_statement.h
@@ -21,6 +21,7 @@
 #include <google/spanner/v1/spanner.pb.h>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/fake_clock.h
+++ b/google/cloud/spanner/testing/fake_clock.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/spanner/internal/clock.h"
 #include "google/cloud/spanner/version.h"
-#include <chrono>
 #include <mutex>
 
 namespace google {

--- a/google/cloud/spanner/testing/pick_instance_config.h
+++ b/google/cloud/spanner/testing/pick_instance_config.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/random.h"
 #include <regex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/policies.h
+++ b/google/cloud/spanner/testing/policies.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/update_instance_request_builder.h
+++ b/google/cloud/spanner/update_instance_request_builder.h
@@ -20,6 +20,7 @@
 #include <google/protobuf/util/field_mask_util.h>
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
 #include <map>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -34,6 +34,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/status.h
+++ b/google/cloud/status.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include <iostream>
+#include <string>
 #include <tuple>
 
 namespace google {

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -21,7 +21,6 @@
 #include "google/cloud/testing_util/command_line_parsing.h"
 #include "google/cloud/testing_util/timer.h"
 #include "absl/types/optional.h"
-#include <chrono>
 #include <functional>
 #include <sstream>
 #include <string>

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/benchmarks/throughput_options.h"
 #include "google/cloud/storage/benchmarks/throughput_result.h"
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_OPTIONS_H
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include <chrono>
 #include <string>
 #include <vector>
 

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/patch_builder.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -23,9 +23,12 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/optional.h"
 #include "absl/types/optional.h"
+#include <chrono>
 #include <map>
+#include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -38,7 +38,9 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "absl/meta/type_traits.h"
+#include <string>
 #include <type_traits>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/version.h"
+#include <chrono>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/download_options.h
+++ b/google/cloud/storage/download_options.h
@@ -19,7 +19,6 @@
 #include "google/cloud/storage/version.h"
 #include <cstdint>
 #include <iostream>
-#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -19,6 +19,8 @@
 #include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
 #include "absl/types/optional.h"
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/internal/bucket_access_control_parser.h
+++ b/google/cloud/storage/internal/bucket_access_control_parser.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/bucket_access_control.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -21,6 +21,8 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_metadata_parser.h
+++ b/google/cloud/storage/internal/bucket_metadata_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/status_or.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -23,6 +23,8 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include "google/cloud/iam_policy.h"
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -20,8 +20,8 @@
 #include "absl/types/optional.h"
 #include <chrono>
 #include <map>
+#include <string>
 #include <utility>
-#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/common_metadata_parser.h
+++ b/google/cloud/storage/internal/common_metadata_parser.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/status.h"
 #include <nlohmann/json.hpp>
+#include <string>
 namespace google {
 namespace cloud {
 namespace storage {

--- a/google/cloud/storage/internal/compute_engine_util.h
+++ b/google/cloud/storage/internal/compute_engine_util.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_COMPUTE_ENGINE_UTIL_H
 
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -22,6 +22,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/random.h"
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -19,6 +19,9 @@
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/internal/object_read_source.h"
 #include "google/cloud/storage/version.h"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 #include <curl/curl.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/curl_wrappers.h"
 #include "google/cloud/storage/version.h"
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -20,7 +20,7 @@
 #include "google/cloud/storage/internal/curl_handle_factory.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
-#include <vector>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -21,6 +21,8 @@
 #include "google/cloud/storage/internal/curl_request.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_headers.h"
+#include <chrono>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_wrappers.h
+++ b/google/cloud/storage/internal/curl_wrappers.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -22,6 +22,8 @@
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/generic_object_request.h
+++ b/google/cloud/storage/internal/generic_object_request.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iostream>
+#include <string>
 #include <utility>
 
 namespace google {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
 #include <google/storage/v1/storage.grpc.pb.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include <google/storage/v1/storage.grpc.pb.h>
 #include <functional>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/grpc_resumable_upload_session_url.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_url.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_url.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hash_validator_impl.h
+++ b/google/cloud/storage/internal/hash_validator_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/hash_validator.h"
 #include "google/cloud/storage/version.h"
 #include <openssl/md5.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hmac_key_metadata_parser.h
+++ b/google/cloud/storage/internal/hmac_key_metadata_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/hmac_key_metadata.h"
 #include "google/cloud/status_or.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -21,6 +21,8 @@
 #include "google/cloud/storage/override_default_project.h"
 #include "google/cloud/storage/version.h"
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/lifecycle_rule_parser.h
+++ b/google/cloud/storage/internal/lifecycle_rule_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/status_or.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/logging_resumable_upload_session.h
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/notification_metadata_parser.h
+++ b/google/cloud/storage/internal/notification_metadata_parser.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/notification_metadata.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -21,6 +21,8 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_access_control_parser.h
+++ b/google/cloud/storage/internal/object_access_control_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/object_acl_requests.h"
 #include "google/cloud/status_or.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -22,6 +22,8 @@
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_metadata_parser.h
+++ b/google/cloud/storage/internal/object_metadata_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/status.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -18,7 +18,6 @@
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
-#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -26,6 +26,7 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include "absl/types/span.h"
 #include <numeric>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/object_streambuf.h
+++ b/google/cloud/storage/internal/object_streambuf.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/openssl_util.h
+++ b/google/cloud/storage/internal/openssl_util.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 #include <algorithm>
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -18,7 +18,6 @@
 #include "google/cloud/storage/version.h"
 #include <memory>
 #include <string>
-#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -21,6 +21,9 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -37,6 +37,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/version.h"
 #include "absl/types/optional.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/service_account_parser.h
+++ b/google/cloud/storage/internal/service_account_parser.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/service_account.h"
 #include "google/cloud/status_or.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/service_account_requests.h
+++ b/google/cloud/storage/internal/service_account_requests.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
 #include <iosfwd>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -22,8 +22,11 @@
 #include "google/cloud/storage/well_known_parameters.h"
 #include "google/cloud/status.h"
 #include "absl/types/optional.h"
+#include <chrono>
 #include <iosfwd>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -22,8 +22,8 @@
 #include "google/cloud/status_or.h"
 #include "absl/time/civil_time.h"
 #include "absl/types/optional.h"
-#include <chrono>
 #include <iosfwd>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/google/cloud/storage/list_objects_and_prefixes_reader.h
+++ b/google/cloud/storage/list_objects_and_prefixes_reader.h
@@ -20,6 +20,7 @@
 #include "absl/types/variant.h"
 #include <iterator>
 #include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -22,8 +22,10 @@
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
+#include <chrono>
 #include <iostream>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/compute_engine_credentials.h
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.h
@@ -24,9 +24,11 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/status.h"
+#include <chrono>
 #include <ctime>
 #include <mutex>
 #include <set>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/credentials.h
+++ b/google/cloud/storage/oauth2/credentials.h
@@ -19,7 +19,8 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
-#include <chrono>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/google_credentials.h
+++ b/google/cloud/storage/oauth2/google_credentials.h
@@ -22,6 +22,7 @@
 #include "absl/types/optional.h"
 #include <memory>
 #include <set>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -25,11 +25,14 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
+#include <chrono>
 #include <condition_variable>
 #include <ctime>
 #include <iostream>
 #include <mutex>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/internal/patch_builder.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -22,7 +22,10 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
+#include <chrono>
 #include <map>
+#include <string>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/invoke_result.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -24,14 +24,15 @@
 #include "google/cloud/status_or.h"
 #include "absl/memory/memory.h"
 #include "absl/types/optional.h"
-#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <fstream>
 #include <functional>
 #include <mutex>
+#include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/service_account.h
+++ b/google/cloud/storage/service_account.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/canonical_errors.h
+++ b/google/cloud/storage/testing/canonical_errors.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/status.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/internal/resumable_upload_session.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/mock_http_request.h
+++ b/google/cloud/storage/testing/mock_http_request.h
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/internal/curl_request.h"
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/testing/storage_integration_test.h
+++ b/google/cloud/storage/testing/storage_integration_test.h
@@ -20,7 +20,6 @@
 #include "google/cloud/internal/random.h"
 #include <gmock/gmock.h>
 #include <algorithm>
-#include <chrono>
 #include <string>
 #include <thread>
 #include <vector>

--- a/google/cloud/testing_util/async_sequencer.h
+++ b/google/cloud/testing_util/async_sequencer.h
@@ -20,6 +20,7 @@
 #include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/contains_once.h
+++ b/google/cloud/testing_util/contains_once.h
@@ -18,8 +18,10 @@
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
 #include <cstddef>
+#include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/contains_once.h
+++ b/google/cloud/testing_util/contains_once.h
@@ -18,10 +18,8 @@
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
 #include <cstddef>
-#include <string>
 #include <type_traits>
 #include <utility>
-#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/expect_future_error.h
+++ b/google/cloud/testing_util/expect_future_error.h
@@ -18,6 +18,7 @@
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
 #include <future>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/is_proto_equal.h
+++ b/google/cloud/testing_util/is_proto_equal.h
@@ -19,6 +19,7 @@
 #include "absl/types/optional.h"
 #include <google/protobuf/message.h>
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/mock_completion_queue_impl.h
+++ b/google/cloud/testing_util/mock_completion_queue_impl.h
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/completion_queue_impl.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/scoped_log.h
+++ b/google/cloud/testing_util/scoped_log.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/log.h"
 #include "google/cloud/version.h"
+#include <string>
 #include <vector>
 
 namespace google {

--- a/google/cloud/testing_util/status_matchers.h
+++ b/google/cloud/testing_util/status_matchers.h
@@ -19,6 +19,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <gmock/gmock.h>
+#include <string>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/testing_types.h
+++ b/google/cloud/testing_util/testing_types.h
@@ -28,8 +28,8 @@
 
 #include "google/cloud/log.h"
 #include "google/cloud/version.h"
+#include <string>
 #include <utility>
-#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/testing_util/timer.h
+++ b/google/cloud/testing_util/timer.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include <chrono>
+#include <string>
 #if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 #include <sys/resource.h>
 #endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE


### PR DESCRIPTION
Adds/removes includes as necessary _in our header files_ for `<vector>`,
`<string>`, and `<chrono>` only. We could expand this to do more, but
these are the most common headers. Trying to keep this a bit smaller.

Related to #5922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5960)
<!-- Reviewable:end -->
