### PR TITLE
ci: fix Ubuntu:16.04 images

### DIFF
--- a/ci/kokoro/docker/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/docker/Dockerfile.ubuntu-xenial
@@ -1,0 +1,50 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+ARG NCPU=4
+
+RUN apt-get update && \
+    apt-get install -y \
+        automake \
+        build-essential \
+        ccache \
+        clang \
+        cmake \
+        ctags \
+        curl \
+        gawk \
+        git \
+        gcc \
+        g++ \
+        cmake \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libtool \
+        llvm \
+        lsb-release \
+        make \
+        ninja-build \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-pip \
+        tar \
+        unzip \
+        zip \
+        wget \
+        zlib1g-dev \
+        apt-utils \
+        ca-certificates \
+        apt-transport-https

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -205,7 +205,7 @@ elif [[ "${BUILD_NAME}" = "gcc-5.4" ]]; then
   # against that version. The use of Ubuntu 16.04 for that build is not a
   # coincidence: the reason we support GCC 5.4 is to support this distribution.
   # See also https://github.com/googleapis/google-cloud-cpp/issues/4788
-  export DISTRO=ubuntu
+  export DISTRO=ubuntu-xenial
   export DISTRO_VERSION=16.04
   export CC=gcc
   export CXX=g++
@@ -218,7 +218,7 @@ elif [[ "${BUILD_NAME}" = "clang-3.8" ]]; then
   # particularly interesting about that version. It is simply the version
   # included with Ubuntu:16.04, and the oldest version tested by
   # google-cloud-cpp.
-  export DISTRO=ubuntu
+  export DISTRO=ubuntu-xenial
   export DISTRO_VERSION=16.04
   export CC=clang
   export CXX=clang++


### PR DESCRIPTION
The images were failing to build, as these images are only used in two
builds I took the opportunity to reduce the dependencies for the images.

Fixes #5963 