### PR TITLE
feat: bind `CompletionQueue` with InstanceAdmin

### DIFF
--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -134,14 +134,8 @@ future<StatusOr<InstanceList>> InstanceAdmin::AsyncListInstances(
 
 future<StatusOr<btadmin::Instance>> InstanceAdmin::CreateInstance(
     InstanceConfig instance_config) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-
-  return AsyncCreateInstance(cq, std::move(instance_config))
-      .then([cq](future<StatusOr<btadmin::Instance>> f) mutable {
-        cq.Shutdown();
-        return f.get();
-      });
+  auto cq = background_threads_->cq();
+  return AsyncCreateInstance(cq, std::move(instance_config));
 }
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
@@ -172,15 +166,9 @@ InstanceAdmin::AsyncCreateInstance(CompletionQueue& cq,
 future<StatusOr<btadmin::Cluster>> InstanceAdmin::CreateCluster(
     ClusterConfig cluster_config, std::string const& instance_id,
     std::string const& cluster_id) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-
+  auto cq = background_threads_->cq();
   return AsyncCreateCluster(cq, std::move(cluster_config), instance_id,
-                            cluster_id)
-      .then([cq](future<StatusOr<btadmin::Cluster>> f) mutable {
-        cq.Shutdown();
-        return f.get();
-      });
+                            cluster_id);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
@@ -213,14 +201,8 @@ InstanceAdmin::AsyncCreateCluster(CompletionQueue& cq,
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 InstanceAdmin::UpdateInstance(InstanceUpdateConfig instance_update_config) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-
-  return AsyncUpdateInstance(cq, std::move(instance_update_config))
-      .then([cq](future<StatusOr<btadmin::Instance>> f) mutable {
-        cq.Shutdown();
-        return f.get();
-      });
+  auto cq = background_threads_->cq();
+  return AsyncUpdateInstance(cq, std::move(instance_update_config));
 }
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
@@ -501,14 +483,8 @@ future<StatusOr<ClusterList>> InstanceAdmin::AsyncListClusters(
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 InstanceAdmin::UpdateCluster(ClusterConfig cluster_config) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-
-  return AsyncUpdateCluster(cq, std::move(cluster_config))
-      .then([cq](future<StatusOr<btadmin::Cluster>> f) mutable {
-        cq.Shutdown();
-        return f.get();
-      });
+  auto cq = background_threads_->cq();
+  return AsyncUpdateCluster(cq, std::move(cluster_config));
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
@@ -636,14 +612,8 @@ InstanceAdmin::AsyncGetAppProfile(CompletionQueue& cq,
 future<StatusOr<btadmin::AppProfile>> InstanceAdmin::UpdateAppProfile(
     std::string const& instance_id, std::string const& profile_id,
     AppProfileUpdateConfig config) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-
-  return AsyncUpdateAppProfile(cq, instance_id, profile_id, std::move(config))
-      .then([cq](future<StatusOr<btadmin::AppProfile>> f) mutable {
-        cq.Shutdown();
-        return f.get();
-      });
+  auto cq = background_threads_->cq();
+  return AsyncUpdateAppProfile(cq, instance_id, profile_id, std::move(config));
 }
 
 future<StatusOr<google::bigtable::admin::v2::AppProfile>>

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -134,7 +134,8 @@ class InstanceAdmin {
         rpc_backoff_policy_prototype_(
             DefaultRPCBackoffPolicy(internal::kBigtableInstanceAdminLimits)),
         polling_policy_prototype_(
-            DefaultPollingPolicy(internal::kBigtableInstanceAdminLimits)) {}
+            DefaultPollingPolicy(internal::kBigtableInstanceAdminLimits)),
+        background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**
    * Create a new InstanceAdmin using explicit policies to handle RPC errors.
@@ -1419,6 +1420,7 @@ class InstanceAdmin {
   std::shared_ptr<RPCRetryPolicy const> rpc_retry_policy_prototype_;
   std::shared_ptr<RPCBackoffPolicy const> rpc_backoff_policy_prototype_;
   std::shared_ptr<PollingPolicy const> polling_policy_prototype_;
+  std::shared_ptr<BackgroundThreads> background_threads_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -368,6 +368,10 @@ class DefaultInstanceAdminClient : public InstanceAdminClient {
       delete;
 
  private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return impl_.Options().background_threads_factory();
+  }
+
   std::string project_;
   Impl impl_;
 };

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -332,6 +332,12 @@ class InstanceAdminClient {
                     const google::longrunning::GetOperationRequest& request,
                     grpc::CompletionQueue* cq) = 0;
   //@}
+
+ private:
+  /// The `ClientOptions` this client was created with.
+  virtual ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() {
+    return {};
+  }
 };
 
 /// Create a new admin client configured via @p options.

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -126,9 +126,10 @@ class CommonClient {
         current_index_(0),
         background_threads_(
             google::cloud::internal::DefaultBackgroundThreads(1)),
-        cq_(std::make_shared<CompletionQueue>(background_threads_->cq())),
+        refresh_cq_(
+            std::make_shared<CompletionQueue>(background_threads_->cq())),
         refresh_state_(std::make_shared<ConnectionRefreshState>(
-            cq_, options_.min_conn_refresh_period(),
+            refresh_cq_, options_.min_conn_refresh_period(),
             options_.max_conn_refresh_period())) {}
 
   ~CommonClient() {
@@ -219,7 +220,7 @@ class CommonClient {
     if (options_.max_conn_refresh_period().count() == 0) {
       return res;
     }
-    ScheduleChannelRefresh(cq_, refresh_state_, res);
+    ScheduleChannelRefresh(refresh_cq_, refresh_state_, res);
     return res;
   }
 
@@ -254,7 +255,7 @@ class CommonClient {
   // deadlock). We solve both problems by holding only weak pointers to the
   // completion queue in the operations scheduled on it. In order to do it, we
   // need to hold one instance by a shared pointer.
-  std::shared_ptr<CompletionQueue> cq_;
+  std::shared_ptr<CompletionQueue> refresh_cq_;
   std::shared_ptr<ConnectionRefreshState> refresh_state_;
 };
 

--- a/google/cloud/bigtable/internal/logging_instance_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client.h
@@ -283,6 +283,10 @@ class LoggingInstanceAdminClient
                     grpc::CompletionQueue* cq) override;
 
  private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return child_->BackgroundThreadsFactory();
+  }
+
   std::shared_ptr<google::cloud::bigtable::InstanceAdminClient> child_;
   google::cloud::TracingOptions tracing_options_;
 };

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -26,6 +26,9 @@ namespace testing {
 
 class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
  public:
+  explicit MockInstanceAdminClient(ClientOptions options = {})
+      : options_(std::move(options)) {}
+
   MOCK_METHOD(std::string const&, project, (), (const, override));
   MOCK_METHOD(std::shared_ptr<grpc::Channel>, Channel, (), (override));
   MOCK_METHOD(void, reset, (), (override));
@@ -295,6 +298,13 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
                const google::longrunning::GetOperationRequest&,
                grpc::CompletionQueue*),
               (override));
+
+ private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return options_.background_threads_factory();
+  }
+
+  ClientOptions options_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
This is a part of #2567.

Eventually, most `Async*` calls will be removed from the Bigtable API
but those which will remain (in `Table`) will have the `CompletionQueue`
argument removed. Instead, the `CompletionQueue` will be bound with
the `Table` object. In the same spirit, we're binding it with
`InstanceAdmin` in this PR. This allows to eliminate creating threads on
all calls which return `future<>`s but do not take a `CompletionQueue`
argument.

A decision was made to store the background threads in `InstanceAdmin`
rather than `CommonClient` even though `CommonClient` seems to resemble
other clients better. This is because `CommonClient` must not be the
owner of the background threads executing the completion queue
associated with itself because at some point the completion queue may hold
the last reference to the `CommonClient`. This is problematic because it
could potentially lead to a situation where `CompletionQueue` would
trigger `CommonClient`'s destructor, which in turn would trigger the
same `CompletionQueue`'s destructor, which would be really hard to
handle.

This is a reiteration of #5665.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5967)
<!-- Reviewable:end -->
