### PR TITLE
feat(bigtable): enable keepalive pings by default

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -148,7 +148,7 @@ ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
       return std::numeric_limits<int>::max();
     }
     if (count <= (std::numeric_limits<int>::min)()) {
-      return std::numeric_limits<int>::max();
+      return std::numeric_limits<int>::min();
     }
     return static_cast<int>(ms.count());
   };

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -38,7 +38,7 @@ using ::testing::HasSubstr;
 absl::optional<int> GetInt(grpc::ChannelArguments const& args,
                            std::string const& key) {
   auto c_args = args.c_channel_args();
-  // Just do a linear search for the key, the data structure is not organized
+  // Just do a linear search for the key; the data structure is not organized
   // in any other useful way.
   for (auto const* a = c_args.args; a != c_args.args + c_args.num_args; ++a) {
     if (key != a->key) continue;
@@ -51,7 +51,7 @@ absl::optional<int> GetInt(grpc::ChannelArguments const& args,
 absl::optional<std::string> GetString(grpc::ChannelArguments const& args,
                                       std::string const& key) {
   auto c_args = args.c_channel_args();
-  // Just do a linear search for the key, the data structure is not organized
+  // Just do a linear search for the key; the data structure is not organized
   // in any other useful way.
   for (auto const* a = c_args.args; a != c_args.args + c_args.num_args; ++a) {
     if (key != a->key) continue;


### PR DESCRIPTION
This ensures dropped connections are detected promptly.

Fixes #5662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5969)
<!-- Reviewable:end -->
