### PR TITLE
fix(generator): remove hardcoded method and response type in streaming rpc stub

### DIFF
--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -257,9 +257,9 @@ Status StubGenerator::GenerateCc() {
     "    grpc::ClientContext&,\n"
     "    $request_type$ const& request) {\n"
     "  auto context = absl::make_unique<grpc::ClientContext>();\n"
-    "  auto stream = grpc_stub_->TailLogEntries(context.get(), request);\n"
+    "  auto stream = grpc_stub_->$method_name$(context.get(), request);\n"
     "  return absl::make_unique<internal::StreamingReadRpcImpl<\n"
-    "      ::google::test::admin::database::v1::TailLogEntriesResponse>>(\n"
+    "      $response_type$>>(\n"
     "      std::move(context), std::move(stream));\n"
     "}\n\n"}},
              // clang-format on


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5972)
<!-- Reviewable:end -->
