### PR TITLE
fix(storage): do not update upload session ids

### DIFF
--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -68,7 +68,7 @@ void CurlResumableUploadSession::Update(
     // Nothing has been committed on the server side yet, keep resending.
     next_expected_ = 0;
   }
-  if (!result->upload_session_url.empty()) {
+  if (session_id_.empty() && !result->upload_session_url.empty()) {
     session_id_ = result->upload_session_url;
   }
 }

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -128,7 +128,9 @@ TEST(CurlResumableUploadSessionTest, Reset) {
 
   session.ResetSession();
   EXPECT_EQ(2 * size, session.next_expected_byte());
-  EXPECT_EQ(url2, session.session_id());
+  // Changes to the session id are ignored, they do not happen in production
+  // anyway
+  EXPECT_EQ(url1, session.session_id());
   StatusOr<ResumableUploadResponse> const& last_response =
       session.last_response();
   ASSERT_STATUS_OK(last_response);
@@ -160,7 +162,9 @@ TEST(CurlResumableUploadSessionTest, SessionUpdatedInChunkUpload) {
   upload = session.UploadChunk({{payload}});
   EXPECT_STATUS_OK(upload);
   EXPECT_EQ(2 * size, session.next_expected_byte());
-  EXPECT_EQ(url2, session.session_id());
+  // Changes to the session id are ignored, they do not happen in production
+  // anyway
+  EXPECT_EQ(url1, session.session_id());
 }
 
 TEST(CurlResumableUploadSessionTest, Empty) {

--- a/google/cloud/storage/object_stream.h
+++ b/google/cloud/storage/object_stream.h
@@ -315,8 +315,6 @@ class ObjectWriteStream : public std::basic_ostream<char> {
    * Note that this is an empty string for uploads that do not use resumable
    * upload session ids. `Client::WriteObject()` enables resumable uploads based
    * on the options set by the application.
-   *
-   * Furthermore, this value might change during an upload.
    */
   std::string const& resumable_session_id() const {
     return buf_->resumable_session_id();


### PR DESCRIPTION
Our documentation said the upload session id could change. This does not
seem to happen in production, and the APIs are harder to use if we
accept changes.  I modified to the doxygen documentation, and prevented
changes from having any effect (even if the changes are not supposed to
happen).

Fixes #5975

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5979)
<!-- Reviewable:end -->
