### PR TITLE
fix(storage): correctly set customTime on inserts

### DIFF
--- a/google/cloud/storage/internal/object_metadata_parser.cc
+++ b/google/cloud/storage/internal/object_metadata_parser.cc
@@ -139,7 +139,7 @@ nlohmann::json ObjectMetadataJsonForCompose(ObjectMetadata const& meta) {
     metadata_as_json["metadata"] = std::move(meta_as_json);
   }
 
-  if (meta.custom_time() != std::chrono::system_clock::time_point{}) {
+  if (meta.has_custom_time()) {
     metadata_as_json["customTime"] =
         google::cloud::internal::FormatRfc3339(meta.custom_time());
   }

--- a/google/cloud/storage/internal/object_metadata_parser.cc
+++ b/google/cloud/storage/internal/object_metadata_parser.cc
@@ -139,6 +139,11 @@ nlohmann::json ObjectMetadataJsonForCompose(ObjectMetadata const& meta) {
     metadata_as_json["metadata"] = std::move(meta_as_json);
   }
 
+  if (meta.custom_time() != std::chrono::system_clock::time_point{}) {
+    metadata_as_json["customTime"] =
+        google::cloud::internal::FormatRfc3339(meta.custom_time());
+  }
+
   return metadata_as_json;
 }
 

--- a/google/cloud/storage/object_metadata_test.cc
+++ b/google/cloud/storage/object_metadata_test.cc
@@ -217,6 +217,7 @@ TEST(ObjectMetadataTest, JsonForCompose) {
        }},
       {"name", "baz"},
       {"storageClass", "STANDARD"},
+      {"customTime", "2020-08-10T12:34:56Z"},
   };
   EXPECT_EQ(expected, actual)
       << "diff=" << nlohmann::json::diff(expected, actual);
@@ -252,6 +253,7 @@ TEST(ObjectMetadataTest, JsonForCopy) {
        }},
       {"name", "baz"},
       {"storageClass", "STANDARD"},
+      {"customTime", "2020-08-10T12:34:56Z"},
   };
   EXPECT_EQ(expected, actual)
       << "diff=" << nlohmann::json::diff(expected, actual);
@@ -289,6 +291,7 @@ TEST(ObjectMetadataTest, JsonForInsert) {
        }},
       {"name", "baz"},
       {"storageClass", "STANDARD"},
+      {"customTime", "2020-08-10T12:34:56Z"},
   };
   EXPECT_EQ(expected, actual)
       << "diff=" << nlohmann::json::diff(expected, actual);
@@ -324,6 +327,7 @@ TEST(ObjectMetadataTest, JsonForRewrite) {
        }},
       {"name", "baz"},
       {"storageClass", "STANDARD"},
+      {"customTime", "2020-08-10T12:34:56Z"},
   };
   EXPECT_EQ(expected, actual)
       << "diff=" << nlohmann::json::diff(expected, actual);

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -926,6 +926,7 @@ TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
 }
 
 TEST_F(ObjectIntegrationTest, InsertWithCustomTime) {
+  if (UsingGrpc()) GTEST_SKIP();  // TODO(#4893) - no support in GCS+gRPC
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -949,6 +950,7 @@ TEST_F(ObjectIntegrationTest, InsertWithCustomTime) {
 }
 
 TEST_F(ObjectIntegrationTest, WriteWithCustomTime) {
+  if (UsingGrpc()) GTEST_SKIP();  // TODO(#4893) - no support in GCS+gRPC
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
The library was ignoring any `custom_time()` attributes set in the
object metadata for inserts or writes.

Fixes #5977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5980)
<!-- Reviewable:end -->
