### PR TITLE
DO NOT SUBMIT -- Change spanner to use Options

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -15,11 +15,14 @@
 #include "google/cloud/spanner/benchmarks/benchmarks_config.h"
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/timer.h"
 #include "absl/memory/memory.h"
@@ -477,8 +480,9 @@ class ExperimentImpl {
     std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
     std::cout << "# Creating clients and stubs " << std::flush;
     for (int i = 0; i != config.maximum_clients; ++i) {
-      auto options = spanner::ConnectionOptions().set_channel_pool_domain(
-          "task:" + std::to_string(i));
+      auto options = spanner_internal::DefaultOptions();
+      options.set<google::cloud::internal::GrpcChannelArgumentsOption>(
+          {{"grpc.channel_pooling_domain", "task:" + std::to_string(i)}});
       clients.emplace_back(
           spanner::Client(spanner::MakeConnection(database, options)));
       stubs.emplace_back(spanner_internal::CreateDefaultSpannerStub(

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/random.h"
 #include <algorithm>
 #include <future>
@@ -241,8 +243,11 @@ spanner::Client MakeClient(Config const& config, int num_channels,
             << num_channels << " channels\n"
             << std::flush;
 
+  auto options =
+      google::cloud::internal::Options{}
+          .set<google::cloud::internal::GrpcNumChannelsOption>(num_channels);
   auto connection = spanner::MakeConnection(
-      database, spanner::ConnectionOptions().set_num_channels(num_channels),
+      database, std::move(options),
       // This pre-creates all the Sessions we will need (one per thread).
       spanner::SessionPoolOptions().set_min_sessions(config.maximum_threads));
   return spanner::Client(std::move(connection));

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -36,6 +36,7 @@
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/optional.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
@@ -652,9 +653,12 @@ class Client {
  *     by the `Connection`.
  */
 std::shared_ptr<Connection> MakeConnection(
-    Database const& db,
-    ConnectionOptions const& connection_options = ConnectionOptions(),
-    SessionPoolOptions session_pool_options = SessionPoolOptions());
+    Database const& db, internal::Options options = {},
+    SessionPoolOptions session_pool_options = {});
+// DEPRECATED
+std::shared_ptr<Connection> MakeConnection(
+    Database const& db, ConnectionOptions const& connection_options,
+    SessionPoolOptions session_pool_options);
 
 /**
  * @copydoc MakeConnection(Database const&, ConnectionOptions const&, SessionPoolOptions)
@@ -668,6 +672,12 @@ std::shared_ptr<Connection> MakeConnection(
  * @par Example
  * @snippet samples.cc custom-retry-policy
  */
+std::shared_ptr<Connection> MakeConnection(
+    Database const& db, internal::Options options,
+    SessionPoolOptions session_pool_options,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy);
+// DEPRECATED
 std::shared_ptr<Connection> MakeConnection(
     Database const& db, ConnectionOptions const& connection_options,
     SessionPoolOptions session_pool_options,

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/results.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/value.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
@@ -386,10 +387,10 @@ TEST(ClientTest, MakeConnectionOptionalArguments) {
   auto conn = MakeConnection(db);
   EXPECT_NE(conn, nullptr);
 
-  conn = MakeConnection(db, ConnectionOptions());
+  conn = MakeConnection(db, internal::Options{});
   EXPECT_NE(conn, nullptr);
 
-  conn = MakeConnection(db, ConnectionOptions(), SessionPoolOptions());
+  conn = MakeConnection(db, internal::Options{}, SessionPoolOptions{});
   EXPECT_NE(conn, nullptr);
 }
 

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/grpc_options.h"
 
 namespace google {
@@ -46,5 +47,24 @@ int ConnectionOptionsTraits::default_num_channels() {
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
+
+namespace spanner_internal {
+inline namespace SPANNER_CLIENT_NS {
+// Override connection endpoint and credentials with values appropriate for
+// an emulated backend. This should be done after any user code that could
+// also override the default values (i.e., immediately before establishing
+// the connection).
+spanner::ConnectionOptions EmulatorOverrides(
+    spanner::ConnectionOptions options) {
+  auto emulator_addr = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
+  if (emulator_addr.has_value()) {
+    options.set_endpoint(*emulator_addr)
+        .set_credentials(grpc::InsecureChannelCredentials());
+  }
+  return options;
+}
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_internal
+
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -63,8 +63,8 @@ spanner::ConnectionOptions EmulatorOverrides(
   }
   return options;
 }
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal
-
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -25,9 +25,12 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 std::string ConnectionOptionsTraits::default_endpoint() {
-  static auto const* const kEndpoint = new auto(
-      spanner_internal::DefaultOptions().get<internal::EndpointOption>());
-  return *kEndpoint;
+  // TODO(5738): cache the default endpoint in a function-local static after we
+  // add support for users using the new `Options` class. We don't want to
+  // cache the value currently because users might expect that changing the env
+  // var between calls to `MakeConnection()` actually changes the endpoint, and
+  // we want to give them an alternative way to accomplish that.
+  return spanner_internal::DefaultOptions().get<internal::EndpointOption>();
 }
 
 std::string ConnectionOptionsTraits::user_agent_prefix() {

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/common_options.h"
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/grpc_options.h"
 
 namespace google {
@@ -50,24 +49,5 @@ int ConnectionOptionsTraits::default_num_channels() {
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
-
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-// Override connection endpoint and credentials with values appropriate for
-// an emulated backend. This should be done after any user code that could
-// also override the default values (i.e., immediately before establishing
-// the connection).
-spanner::ConnectionOptions EmulatorOverrides(
-    spanner::ConnectionOptions options) {
-  auto emulator_addr = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
-  if (emulator_addr.has_value()) {
-    options.set_endpoint(*emulator_addr)
-        .set_credentials(grpc::InsecureChannelCredentials());
-  }
-  return options;
-}
-
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -48,6 +48,14 @@ using ConnectionOptions =
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 
+
+namespace spanner_internal {
+inline namespace SPANNER_CLIENT_NS {
+spanner::ConnectionOptions EmulatorOverrides(
+    spanner::ConnectionOptions options);
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_internal
+
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -48,13 +48,6 @@ using ConnectionOptions =
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-spanner::ConnectionOptions EmulatorOverrides(
-    spanner::ConnectionOptions options);
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
-
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -48,7 +48,6 @@ using ConnectionOptions =
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 
-
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 spanner::ConnectionOptions EmulatorOverrides(

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -23,6 +23,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
+using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::HasSubstr;
 using ::testing::StartsWith;
 
@@ -53,6 +54,17 @@ TEST(ConnectionOptionsTraits, UserAgentPrefix) {
   EXPECT_EQ(actual, options.user_agent_prefix());
   options.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + actual, options.user_agent_prefix());
+}
+
+TEST(EmulatorOverrides, EnvironmentWorks) {
+  // When SPANNER_EMULATOR_HOST is set, the original endpoint is reset to
+  // ${SPANNER_EMULATOR_HOST}, and the original credentials are reset to
+  // grpc::InsecureChannelCredentials().
+  ScopedEnvironment env("SPANNER_EMULATOR_HOST", "localhost:9010");
+  ConnectionOptions options(std::shared_ptr<grpc::ChannelCredentials>{});
+  options = spanner_internal::EmulatorOverrides(options);
+  EXPECT_NE(std::shared_ptr<grpc::ChannelCredentials>{}, options.credentials());
+  EXPECT_EQ("localhost:9010", options.endpoint());
 }
 
 }  // namespace

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -23,7 +23,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::HasSubstr;
 using ::testing::StartsWith;
 
@@ -54,24 +53,6 @@ TEST(ConnectionOptionsTraits, UserAgentPrefix) {
   EXPECT_EQ(actual, options.user_agent_prefix());
   options.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + actual, options.user_agent_prefix());
-}
-
-TEST(DefaultEndpoint, EnvironmentWorks) {
-  EXPECT_NE("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
-  ScopedEnvironment env("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT",
-                        "invalid-endpoint");
-  EXPECT_EQ("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
-}
-
-TEST(EmulatorOverrides, EnvironmentWorks) {
-  // When SPANNER_EMULATOR_HOST is set, the original endpoint is reset to
-  // ${SPANNER_EMULATOR_HOST}, and the original credentials are reset to
-  // grpc::InsecureChannelCredentials().
-  ScopedEnvironment env("SPANNER_EMULATOR_HOST", "localhost:9010");
-  ConnectionOptions options(std::shared_ptr<grpc::ChannelCredentials>{});
-  options = spanner_internal::EmulatorOverrides(options);
-  EXPECT_NE(std::shared_ptr<grpc::ChannelCredentials>{}, options.credentials());
-  EXPECT_EQ("localhost:9010", options.endpoint());
 }
 
 }  // namespace

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -56,6 +56,13 @@ TEST(ConnectionOptionsTraits, UserAgentPrefix) {
   EXPECT_EQ("test-prefix/1.2.3 " + actual, options.user_agent_prefix());
 }
 
+TEST(DefaultEndpoint, EnvironmentWorks) {
+  EXPECT_NE("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
+  ScopedEnvironment env("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT",
+                        "invalid-endpoint");
+  EXPECT_EQ("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
+}
+
 TEST(EmulatorOverrides, EnvironmentWorks) {
   // When SPANNER_EMULATOR_HOST is set, the original endpoint is reset to
   // ${SPANNER_EMULATOR_HOST}, and the original credentials are reset to

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/timestamp.h"
+#include "google/cloud/internal/options.h"
 #include <algorithm>
 
 namespace google {
@@ -23,7 +24,7 @@ inline namespace SPANNER_CLIENT_NS {
 
 namespace gcsa = ::google::spanner::admin::database::v1;
 
-DatabaseAdminClient::DatabaseAdminClient(ConnectionOptions const& options)
+DatabaseAdminClient::DatabaseAdminClient(internal::Options const& options)
     : conn_(MakeDatabaseAdminConnection(options)) {}
 
 future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -24,6 +24,7 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
 #include <chrono>
@@ -115,8 +116,10 @@ inline namespace SPANNER_CLIENT_NS {
  */
 class DatabaseAdminClient {
  public:
-  explicit DatabaseAdminClient(
-      ConnectionOptions const& options = ConnectionOptions());
+  explicit DatabaseAdminClient(internal::Options const& options = {});
+  // DEPRECATED
+  explicit DatabaseAdminClient(ConnectionOptions const& options)
+      : DatabaseAdminClient(internal::MakeOptions(options)) {}
 
   /**
    * Creates a new Cloud Spanner database in the given project and instance.

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/backup.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/internal/database_admin_stub.h"
@@ -25,6 +26,7 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include "absl/types/optional.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.pb.h>
@@ -327,7 +329,12 @@ class DatabaseAdminConnection {
  *     this function.
  */
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    ConnectionOptions const& options = ConnectionOptions());
+    internal::Options options = {});
+// DEPRECATED
+inline std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    ConnectionOptions const& options) {
+  return MakeDatabaseAdminConnection(internal::MakeOptions(options));
+}
 
 /**
  * @copydoc MakeDatabaseAdminConnection
@@ -343,9 +350,18 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
  * @snippet samples.cc custom-database-admin-policies
  */
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
+    internal::Options options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
+// DEPRECATED
+inline std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<PollingPolicy> polling_policy) {
+  return MakeDatabaseAdminConnection(
+      internal::MakeOptions(options), std::move(retry_policy),
+      std::move(backoff_policy), std::move(polling_policy));
+}
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
@@ -353,12 +369,7 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<DatabaseAdminStub> stub,
-    spanner::ConnectionOptions const& options);
-
-std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<DatabaseAdminStub> stub,
-    spanner::ConnectionOptions const& options,
+    std::shared_ptr<DatabaseAdminStub> stub, internal::Options options,
     std::unique_ptr<spanner::RetryPolicy> retry_policy,
     std::unique_ptr<spanner::BackoffPolicy> backoff_policy,
     std::unique_ptr<spanner::PollingPolicy> polling_policy);

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/database_admin_connection.h"
 #include "google/cloud/spanner/testing/mock_database_admin_stub.h"
 #include "google/cloud/spanner/timestamp.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -50,7 +51,7 @@ std::shared_ptr<DatabaseAdminConnection> CreateTestingConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   return spanner_internal::MakeDatabaseAdminConnection(
-      std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
+      std::move(mock), internal::Options{}, retry.clone(), backoff.clone(),
       polling.clone());
 }
 

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -16,11 +16,13 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INSTANCE_ADMIN_CONNECTION_H
 
 #include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
 #include <map>
@@ -212,7 +214,12 @@ class InstanceAdminConnection {
  *     this function.
  */
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    ConnectionOptions const& options = ConnectionOptions());
+    internal::Options options = {});
+// DEPRECATED
+inline std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
+    ConnectionOptions const& options) {
+  return MakeInstanceAdminConnection(internal::MakeOptions(options));
+}
 
 /**
  * @copydoc MakeInstanceAdminConnection
@@ -228,9 +235,18 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
  * @snippet samples.cc custom-instance-admin-policies
  */
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
+    internal::Options options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy);
+// DEPRECATED
+inline std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<PollingPolicy> polling_policy) {
+  return MakeInstanceAdminConnection(
+      internal::MakeOptions(options), std::move(retry_policy),
+      std::move(backoff_policy), std::move(polling_policy));
+}
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
@@ -238,12 +254,7 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<InstanceAdminStub> base_stub,
-    spanner::ConnectionOptions const& options);
-
-std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<InstanceAdminStub> base_stub,
-    spanner::ConnectionOptions const& options,
+    std::shared_ptr<InstanceAdminStub> base_stub, internal::Options options,
     std::unique_ptr<spanner::RetryPolicy> retry_policy,
     std::unique_ptr<spanner::BackoffPolicy> backoff_policy,
     std::unique_ptr<spanner::PollingPolicy> polling_policy);

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/instance_admin_connection.h"
 #include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/testing/mock_instance_admin_stub.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -52,7 +53,7 @@ std::shared_ptr<InstanceAdminConnection> MakeLimitedRetryConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   return spanner_internal::MakeInstanceAdminConnection(
-      std::move(mock), ConnectionOptions{}, retry.clone(), backoff.clone(),
+      std::move(mock), internal::Options{}, retry.clone(), backoff.clone(),
       polling.clone());
 }
 

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -67,7 +68,7 @@ class BackupTest : public ::testing::Test {
   BackupTest()
       : generator_(google::cloud::internal::MakeDefaultPRNG()),
         database_admin_client_(MakeDatabaseAdminConnection(
-            ConnectionOptions{}, spanner_testing::TestRetryPolicy(),
+            internal::Options{}, spanner_testing::TestRetryPolicy(),
             spanner_testing::TestBackoffPolicy(),
             spanner_testing::TestPollingPolicy())) {}
 

--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -15,10 +15,13 @@
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include "absl/memory/memory.h"
@@ -104,8 +107,11 @@ Result RunExperiment(Database const& db, int iterations) {
     return std::move(os).str();
   }();
 
-  Client client(
-      MakeConnection(db, ConnectionOptions().set_channel_pool_domain(pool)));
+  auto options = spanner_internal::DefaultOptions();
+  options.set<internal::GrpcChannelArgumentsOption>(
+      {{"grpc.channel_pooling_domain", pool}});
+
+  Client client(MakeConnection(db, std::move(options)));
 
   int number_of_successes = 0;
   int number_of_failures = 0;

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -55,7 +56,7 @@ TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
   auto const db = GetDatabase();
-  auto stub = CreateDefaultSpannerStub(db, spanner::ConnectionOptions{},
+  auto stub = CreateDefaultSpannerStub(db, spanner_internal::DefaultOptions(),
                                        /*channel_id=*/0);
   auto session_pool = MakeSessionPool(
       db, {stub}, spanner::SessionPoolOptions{}, cq,

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -26,6 +26,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/v1/spanner.pb.h>
@@ -53,9 +54,8 @@ std::unique_ptr<spanner::BackoffPolicy> DefaultConnectionBackoffPolicy();
 class ConnectionImpl;
 std::shared_ptr<ConnectionImpl> MakeConnection(
     spanner::Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
-    spanner::ConnectionOptions const& options = spanner::ConnectionOptions{},
-    spanner::SessionPoolOptions session_pool_options =
-        spanner::SessionPoolOptions{},
+    internal::Options const& options = {},
+    spanner::SessionPoolOptions session_pool_options = {},
     std::unique_ptr<spanner::RetryPolicy> retry_policy =
         DefaultConnectionRetryPolicy(),
     std::unique_ptr<spanner::BackoffPolicy> backoff_policy =
@@ -89,11 +89,11 @@ class ConnectionImpl : public spanner::Connection {
   // Only the factory method can construct instances of this class.
   friend std::shared_ptr<ConnectionImpl> MakeConnection(
       spanner::Database, std::vector<std::shared_ptr<SpannerStub>>,
-      spanner::ConnectionOptions const&, spanner::SessionPoolOptions,
+      internal::Options const&, spanner::SessionPoolOptions,
       std::unique_ptr<spanner::RetryPolicy>, std::unique_ptr<BackoffPolicy>);
   ConnectionImpl(spanner::Database db,
                  std::vector<std::shared_ptr<SpannerStub>> stubs,
-                 spanner::ConnectionOptions const& options,
+                 internal::Options const& options,
                  spanner::SessionPoolOptions session_pool_options,
                  std::unique_ptr<spanner::RetryPolicy> retry_policy,
                  std::unique_ptr<spanner::BackoffPolicy> backoff_policy);

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H
 
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.pb.h>
 #include <grpcpp/grpcpp.h>
@@ -148,7 +148,7 @@ class DatabaseAdminStub {
  * This stub does not create a channel pool, or retry operations.
  */
 std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
-    spanner::ConnectionOptions options);
+    internal::Options const& options);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_INSTANCE_ADMIN_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_INSTANCE_ADMIN_STUB_H
 
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
 #include <grpcpp/grpcpp.h>
@@ -86,7 +86,7 @@ class InstanceAdminStub {
  * This stub does not create a channel pool, or retry operations.
  */
 std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
-    spanner::ConnectionOptions options);
+    internal::Options const& options);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -16,6 +16,10 @@
 #include "google/cloud/spanner/internal/logging_spanner_stub.h"
 #include "google/cloud/spanner/internal/metadata_spanner_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/log.h"
 #include <google/spanner/v1/spanner.grpc.pb.h>
 #include <grpcpp/grpcpp.h>
@@ -285,27 +289,28 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
 }  // namespace
 
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
-    spanner::Database const& db, spanner::ConnectionOptions options,
+    spanner::Database const& db, internal::Options const& options,
     int channel_id) {
-  options = EmulatorOverrides(std::move(options));
-
-  grpc::ChannelArguments channel_arguments = options.CreateChannelArguments();
+  grpc::ChannelArguments channel_arguments =
+      internal::MakeChannelArguments(options);
   // Newer versions of gRPC include a macro (`GRPC_ARG_CHANNEL_ID`) but use
   // its value here to allow compiling against older versions.
   channel_arguments.SetInt("grpc.channel_id", channel_id);
 
   auto spanner_grpc_stub =
       spanner_proto::Spanner::NewStub(grpc::CreateCustomChannel(
-          options.endpoint(), options.credentials(), channel_arguments));
+          options.get<internal::EndpointOption>(),
+          options.get<internal::GrpcCredentialOption>(), channel_arguments));
 
   std::shared_ptr<SpannerStub> stub =
       std::make_shared<DefaultSpannerStub>(std::move(spanner_grpc_stub));
   stub = std::make_shared<MetadataSpannerStub>(std::move(stub), db.FullName());
 
-  if (options.tracing_enabled("rpc")) {
+  if (internal::Contains(options.get<internal::TracingComponentsOption>(),
+                         "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    return std::make_shared<LoggingSpannerStub>(std::move(stub),
-                                                options.tracing_options());
+    return std::make_shared<LoggingSpannerStub>(
+        std::move(stub), options.get<internal::GrpcTracingOptionsOption>());
   }
   return stub;
 }

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_SPANNER_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_SPANNER_STUB_H
 
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/v1/spanner.grpc.pb.h>
@@ -123,7 +123,7 @@ class SpannerStub {
  * to ensure they use different underlying connections.
  */
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
-    spanner::Database const& db, spanner::ConnectionOptions options,
+    spanner::Database const& db, internal::Options const& options,
     int channel_id);
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
+#include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -31,9 +34,8 @@ using ::testing::Contains;
 using ::testing::HasSubstr;
 
 TEST(SpannerStub, CreateDefaultStub) {
-  auto stub =
-      CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"),
-                               spanner::ConnectionOptions(), /*channel_id=*/0);
+  auto stub = CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"),
+                                       internal::Options{}, /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 }
 
@@ -42,9 +44,11 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
 
   auto stub = CreateDefaultSpannerStub(
       spanner::Database("foo", "bar", "baz"),
-      spanner::ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1")
-          .enable_tracing("rpc"),
+      internal::Options{}
+          .set<internal::GrpcCredentialOption>(
+              grpc::InsecureChannelCredentials())
+          .set<internal::EndpointOption>("localhost:1")
+          .set<internal::TracingComponentsOption>({"rpc"}),
       /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -17,7 +17,6 @@
 //! [END spanner_quickstart]
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/backup.h"
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/instance_admin_client.h"
@@ -29,6 +28,7 @@
 #include "google/cloud/spanner/testing/random_instance_name.h"
 #include "google/cloud/spanner/update_instance_request_builder.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/random.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
@@ -2597,7 +2597,7 @@ void CustomRetryPolicy(std::vector<std::string> argv) {
      std::string const& database_id) {
     auto client = spanner::Client(spanner::MakeConnection(
         spanner::Database(project_id, instance_id, database_id),
-        spanner::ConnectionOptions{}, spanner::SessionPoolOptions{},
+        google::cloud::internal::Options{}, spanner::SessionPoolOptions{},
         // Retry for at most 25 minutes.
         spanner::LimitedTimeRetryPolicy(
             /*maximum_duration=*/std::chrono::minutes(25))
@@ -2663,7 +2663,7 @@ void CustomInstanceAdminPolicies(std::vector<std::string> argv) {
             .clone();
     auto client =
         spanner::InstanceAdminClient(spanner::MakeInstanceAdminConnection(
-            spanner::ConnectionOptions{}, std::move(retry_policy),
+            google::cloud::internal::Options{}, std::move(retry_policy),
             std::move(backoff_policy), std::move(polling_policy)));
 
     // Use the client as usual.
@@ -2718,7 +2718,7 @@ void CustomDatabaseAdminPolicies(std::vector<std::string> argv) {
             .clone();
     auto client =
         spanner::DatabaseAdminClient(spanner::MakeDatabaseAdminConnection(
-            spanner::ConnectionOptions{}, std::move(retry_policy),
+            google::cloud::internal::Options{}, std::move(retry_policy),
             std::move(backoff_policy), std::move(polling_policy)));
 
     // Use the client as usual.
@@ -3155,7 +3155,7 @@ void RunAll(bool emulator) {
 
   google::cloud::spanner::InstanceAdminClient instance_admin_client(
       google::cloud::spanner::MakeInstanceAdminConnection(
-          google::cloud::spanner::ConnectionOptions{},
+          google::cloud::internal::Options{},
           google::cloud::spanner_testing::TestRetryPolicy(),
           google::cloud::spanner_testing::TestBackoffPolicy(),
           google::cloud::spanner_testing::TestPollingPolicy()));
@@ -3182,8 +3182,8 @@ void RunAll(bool emulator) {
       google::cloud::spanner_testing::RandomDatabaseName(generator);
 
   google::cloud::spanner::DatabaseAdminClient database_admin_client(
-      MakeDatabaseAdminConnection(
-          google::cloud::spanner::ConnectionOptions{},
+      google::cloud::spanner::MakeDatabaseAdminConnection(
+          google::cloud::internal::Options{},
           google::cloud::spanner_testing::TestRetryPolicy(),
           google::cloud::spanner_testing::TestBackoffPolicy(),
           google::cloud::spanner_testing::TestPollingPolicy()));


### PR DESCRIPTION
Related to https://github.com/googleapis/google-cloud-cpp/issues/5738

This PR changes all the Spanner code use the new `internal::Options` class. Functions accepting the old `spanner::ConnectionOptions` would still work, but they would quickly call the preferred `Options` overload.

**The intent of this PR is to show the design of how a product would use the new `Options`. This PR is still sloppy and would not be submitted as-is.** 

## The main design points are

* The `Options` class is still in `internal::` so please try to imagine all the code with `internal::` removed.
* All factory functions will accept -- and prefer -- an `internal::Options` object. An empty, default-constructed `Options` will be fine.
* Once a factory function gets an `options` argument (which is likely empty), it will call `spanner_internal::DefaultOptions()` to set and possibly override options as is appropriate for the service. See `MakeConnection` in client.cc as an example.
* End-users will never need to call `spanner_internal::DefaultOptions()`. _We_ make calls to `DefaultOptions()` internally in our tests some places, but that should not affect users, and it's never used in user-facing samples.
* The `spanner_internal::DefaultOptions()` function (see `.../spanner/internal/options.cc`) is the *one* place where have all the logic for setting and overriding options. This allows us to have logic that, say, overrides an explicitly specified option with an environment variable, which is something we actually need to do with `SPANNER_EMULATOR_HOST`. Today we cannot do this within the "options" framework, instead we needed a separate `EmulatorOverrides()` function for this special case.
* Each user-facing factory function that accepts an `Options` will also call `internal::CheckExpectedOptions<...>()` to log and warn the user to help with debugging if the user specified unexpected options.
* All the functions logically below the user-facing factory functions can assume that any `Options` they get are fully populated with any relevant defaults, and they can simply access options via the `Option::get<T>()` function. This function is `const`.
* If we have a service that needs/wants different defaults for different services, we need to provide a separate implementation of `spanner_internal::DefaultOptions()` for each. The name doesn't matter, it can be changed to be service-specific if we want.

## Open questions

1. Do we like this design? This is the test of the https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/internal/options.h API, and the ideas in https://github.com/googleapis/google-cloud-cpp/issues/5738
2. The user-facing factory functions accept `internal::Options` by value, because they may need to modify defaults and override things. This by-copy argument allows us to use move semantics. All other users of `Options` can be `const&` because they'll only use the `const` `.get<T>()` accessor. Do we like this? We could accept by const-ref everywhere and just make the copy internal to our factory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5984)
<!-- Reviewable:end -->
