### PR TITLE
cleanup: add/remove a few spanner headers

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -25,6 +25,7 @@
 #include "absl/memory/memory.h"
 #include "absl/time/civil_time.h"
 #include <google/spanner/v1/result_set.pb.h>
+#include <grpcpp/grpcpp.h>
 #include <algorithm>
 #include <chrono>
 #include <future>

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -18,7 +18,6 @@
 #include "google/cloud/spanner/batch_dml_result.h"
 #include "google/cloud/spanner/commit_options.h"
 #include "google/cloud/spanner/commit_result.h"
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/partition_options.h"

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 
 namespace google {

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -22,6 +22,7 @@
 #include "absl/time/time.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 
 namespace google {

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/testing_util/status_matchers.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/retry_policy.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/util/time_util.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -25,6 +25,7 @@
 #include "absl/types/optional.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 #include <array>
 #include <atomic>
 #include <chrono>

--- a/google/cloud/spanner/internal/database_admin_logging.cc
+++ b/google/cloud/spanner/internal/database_admin_logging.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/internal/database_admin_logging.h"
 #include "google/cloud/internal/log_wrapper.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/database_admin_logging.h
+++ b/google/cloud/spanner/internal/database_admin_logging.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/spanner/version.h"
+#include <grpcpp/grpcpp.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/database_admin_metadata.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/internal/database_admin_metadata.h"
 #include "google/cloud/internal/api_client_header.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/database_admin_metadata.h
+++ b/google/cloud/spanner/internal/database_admin_metadata.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <grpcpp/grpcpp.h>
 #include <string>
 
 namespace google {

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/log.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -20,6 +20,7 @@
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.pb.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_logging.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/internal/instance_admin_logging.h"
 #include "google/cloud/internal/log_wrapper.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/spanner/version.h"
+#include <grpcpp/grpcpp.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/internal/instance_admin_metadata.h"
 #include "google/cloud/internal/api_client_header.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <grpcpp/grpcpp.h>
 #include <string>
 
 namespace google {

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/log.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -20,6 +20,7 @@
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/logging_spanner_stub.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/internal/logging_spanner_stub.h"
 #include "google/cloud/internal/log_wrapper.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/logging_spanner_stub.h
+++ b/google/cloud/spanner/internal/logging_spanner_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/tracing_options.h"
 #include "google/cloud/spanner/version.h"
+#include <grpcpp/grpcpp.h>
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/log.h"
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/metadata_spanner_stub.h
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <grpcpp/grpcpp.h>
 #include <string>
 
 namespace google {

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/testing_util/assert_ok.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -22,6 +22,7 @@
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 #include <array>
 #include <cstdint>
 #include <string>

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/status.h"
 #include "absl/memory/memory.h"
+#include <grpcpp/grpcpp.h>
 #include <algorithm>
 #include <chrono>
 #include <random>

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -26,6 +26,7 @@
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <memory>
 #include <string>

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/log.h"
 #include <google/spanner/v1/spanner.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/mock_database_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_database_admin_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/mock_spanner_stub.h
+++ b/google/cloud/spanner/testing/mock_spanner_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
 #include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/testing/pick_instance_config.cc
+++ b/google/cloud/spanner/testing/pick_instance_config.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/pick_instance_config.h"
-#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/instance_admin_client.h"
 #include <regex>
 


### PR DESCRIPTION
This cleanup adds `<grpcpp/grpcpp.h>` anywhere `grpc::ClientContext` is
used. It also removes a couple includes of `connection_options.h` in
files where `ConnectionOptions` was not used. This is preparation for
spanner using the new `internal::Options` class.

Related to this sketch PR: https://github.com/googleapis/google-cloud-cpp/pull/5984

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5987)
<!-- Reviewable:end -->
