### PR TITLE
feat(internal): add internal::MergeOptions()

### DIFF
--- a/google/cloud/internal/options.cc
+++ b/google/cloud/internal/options.cc
@@ -34,9 +34,10 @@ void CheckExpectedOptionsImpl(std::set<std::type_index> const& expected,
   }
 }
 
-void MergeOptions(Options& a, Options b) {
+Options MergeOptions(Options a, Options b) {
   a.m_.insert(std::make_move_iterator(b.m_.begin()),
               std::make_move_iterator(b.m_.end()));
+  return a;
 }
 
 }  // namespace internal

--- a/google/cloud/internal/options.cc
+++ b/google/cloud/internal/options.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/internal/options.h"
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/log.h"
+#include <iterator>
 #include <set>
 #include <unordered_map>
 
@@ -31,6 +32,11 @@ void CheckExpectedOptionsImpl(std::set<std::type_index> const& expected,
                        << p.first.name();
     }
   }
+}
+
+void MergeOptions(Options& a, Options b) {
+  a.m_.insert(std::make_move_iterator(b.m_.begin()),
+              std::make_move_iterator(b.m_.end()));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -28,7 +28,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 
 class Options;
 namespace internal {
-void MergeOptions(Options&, Options);
+Options MergeOptions(Options, Options);
 void CheckExpectedOptionsImpl(std::set<std::type_index> const&, Options const&,
                               char const*);
 }  // namespace internal
@@ -190,7 +190,7 @@ class Options {
   }
 
  private:
-  friend void MergeOptions(Options&, Options);
+  friend Options MergeOptions(Options, Options);
   friend void CheckExpectedOptionsImpl(std::set<std::type_index> const&,
                                        Options const&, char const*);
 
@@ -260,10 +260,10 @@ void CheckExpectedOptions(Options const& opts, char const* caller) {
 }
 
 /**
- * Moves the options from @p b into @p a, unless the option already exists in
- * @p a.
+ * Moves the options from @p b into @p a and returns the result, unless the
+ * option already exists in @p a.
  */
-void MergeOptions(Options& a, Options b);
+Options MergeOptions(Options a, Options b);
 
 }  // namespace internal
 

--- a/google/cloud/internal/options.h
+++ b/google/cloud/internal/options.h
@@ -28,6 +28,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 
 class Options;
 namespace internal {
+void MergeOptions(Options&, Options);
 void CheckExpectedOptionsImpl(std::set<std::type_index> const&, Options const&,
                               char const*);
 }  // namespace internal
@@ -189,6 +190,7 @@ class Options {
   }
 
  private:
+  friend void MergeOptions(Options&, Options);
   friend void CheckExpectedOptionsImpl(std::set<std::type_index> const&,
                                        Options const&, char const*);
 
@@ -222,36 +224,46 @@ void CheckExpectedOptionsImpl(std::tuple<T...> const&, Options const& opts,
   CheckExpectedOptionsImpl({typeid(T)...}, opts, caller);
 }
 
-// Checks that `Options` only contains the given expected options or a subset
-// of them. Logs all unexpected options. Note that logging is not always shown
-// on the console. Set the environment variable
-// `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` to enable logging.
-//
-// Options may be specified directly or as a collection within a `std::tuple`.
-// For example,
-//
-// @code
-// struct FooOption { int value; };
-// struct BarOption { int value; };
-// using OptionTuple = std::tuple<FooOption, BarOption>;
-//
-// struct BazOption { int value; };
-//
-// // All valid ways to call this with varying expectations.
-// CheckExpectedOptions<FooOption>(opts, "test caller");
-// CheckExpectedOptions<FooOption, BarOption>(opts, "test caller");
-// CheckExpectedOptions<OptionTuple>(opts, "test caller");
-// CheckExpectedOptions<BazOption, OptionTuple>(opts, "test caller");
-// @endcode
-//
-// @param opts the `Options` to check.
-// @param caller some string indicating the callee function; logged IFF there's
-//        an unexpected option
+/**
+ * Checks that `Options` only contains the given expected options or a subset
+ * of them.
+ *
+ * Logs all unexpected options. Note that logging is not always shown
+ * on the console. Set the environment variable
+ * `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` to enable logging.
+ *
+ * Options may be specified directly or as a collection within a `std::tuple`.
+ * For example,
+ *
+ * @code
+ * struct FooOption { int value; };
+ * struct BarOption { int value; };
+ * using OptionTuple = std::tuple<FooOption, BarOption>;
+ *
+ * struct BazOption { int value; };
+ *
+ * // All valid ways to call this with varying expectations.
+ * CheckExpectedOptions<FooOption>(opts, "test caller");
+ * CheckExpectedOptions<FooOption, BarOption>(opts, "test caller");
+ * CheckExpectedOptions<OptionTuple>(opts, "test caller");
+ * CheckExpectedOptions<BazOption, OptionTuple>(opts, "test caller");
+ * @endcode
+ *
+ * @param opts the `Options` to check.
+ * @param caller some string indicating the callee function; logged IFF there's
+ *        an unexpected option
+ */
 template <typename... T>
 void CheckExpectedOptions(Options const& opts, char const* caller) {
   using Tuple = decltype(std::tuple_cat(typename FlatTuple<T>::Type{}...));
   CheckExpectedOptionsImpl(Tuple{}, opts, caller);
 }
+
+/**
+ * Moves the options from @p b into @p a, unless the option already exists in
+ * @p a.
+ */
+void MergeOptions(Options& a, Options b);
 
 }  // namespace internal
 

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -253,6 +253,15 @@ TEST(CheckUnexpectedOptions, OptionsListOneUnexpected) {
               Contains(ContainsRegex("caller: Unexpected option.+FooOption")));
 }
 
+TEST(MergeOptions, Basics) {
+  auto a = Options{}.set<StringOption>("from a").set<IntOption>(42);
+  auto b = Options{}.set<StringOption>("from b").set<BoolOption>(true);
+  MergeOptions(a, std::move(b));
+  EXPECT_EQ(a.get<StringOption>(), "from a");  // From a
+  EXPECT_EQ(a.get<BoolOption>(), true);        // From b
+  EXPECT_EQ(a.get<IntOption>(), 42);           // From a
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -256,7 +256,7 @@ TEST(CheckUnexpectedOptions, OptionsListOneUnexpected) {
 TEST(MergeOptions, Basics) {
   auto a = Options{}.set<StringOption>("from a").set<IntOption>(42);
   auto b = Options{}.set<StringOption>("from b").set<BoolOption>(true);
-  MergeOptions(a, std::move(b));
+  a = MergeOptions(std::move(a), std::move(b));
   EXPECT_EQ(a.get<StringOption>(), "from a");  // From a
   EXPECT_EQ(a.get<BoolOption>(), true);        // From b
   EXPECT_EQ(a.get<IntOption>(), 42);           // From a


### PR DESCRIPTION
Also changed `CheckExpectedOptions` to use doxygen-style `/** */` comments since it was wrong and looked funny next to `MergeOptions()` w/ the doxygen-style comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5991)
<!-- Reviewable:end -->
