### PR TITLE
refactor(spanner): implement SessionPoolOptions in terms of Options

### DIFF
--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -56,24 +56,26 @@ internal::Options DefaultOptions(internal::Options opts) {
                       google::cloud::internal::CompilerFeatures() + ")");
 
   // Sets Spanner-specific options from session_pool_options.h
-  if (!opts.has<spanner::SessionPoolMaxSessionsPerChannelOption>()) {
-    opts.set<spanner::SessionPoolMaxSessionsPerChannelOption>(100);
+  if (!opts.has<spanner_internal::SessionPoolMaxSessionsPerChannelOption>()) {
+    opts.set<spanner_internal::SessionPoolMaxSessionsPerChannelOption>(100);
   }
-  if (!opts.has<spanner::SessionPoolActionOnExhaustionOption>()) {
-    opts.set<spanner::SessionPoolActionOnExhaustionOption>(
+  if (!opts.has<spanner_internal::SessionPoolActionOnExhaustionOption>()) {
+    opts.set<spanner_internal::SessionPoolActionOnExhaustionOption>(
         spanner::ActionOnExhaustion::kBlock);
   }
-  if (!opts.has<spanner::SessionPoolKeepAliveIntervalOption>()) {
-    opts.set<spanner::SessionPoolKeepAliveIntervalOption>(
+  if (!opts.has<spanner_internal::SessionPoolKeepAliveIntervalOption>()) {
+    opts.set<spanner_internal::SessionPoolKeepAliveIntervalOption>(
         std::chrono::minutes(55));
   }
   // Enforces some SessionPool constraints.
-  auto& max_idle = opts.lookup<spanner::SessionPoolMaxIdleSessionsOption>();
+  auto& max_idle =
+      opts.lookup<spanner_internal::SessionPoolMaxIdleSessionsOption>();
   max_idle = (std::max)(max_idle, 0);
   auto& max_sessions_per_channel =
-      opts.lookup<spanner::SessionPoolMaxSessionsPerChannelOption>();
+      opts.lookup<spanner_internal::SessionPoolMaxSessionsPerChannelOption>();
   max_sessions_per_channel = (std::max)(max_sessions_per_channel, 1);
-  auto& min_sessions = opts.lookup<spanner::SessionPoolMinSessionsOption>();
+  auto& min_sessions =
+      opts.lookup<spanner_internal::SessionPoolMinSessionsOption>();
   min_sessions = (std::max)(min_sessions, 0);
   min_sessions =
       (std::min)(min_sessions, max_sessions_per_channel *

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/options.h"
+#include "google/cloud/spanner/session_pool_options.h"
 #include "google/cloud/internal/common_options.h"
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/internal/options.h"
+#include <chrono>
 #include <string>
 
 namespace google {
@@ -52,6 +54,30 @@ internal::Options DefaultOptions(internal::Options opts) {
                       " (" + google::cloud::internal::CompilerId() + "-" +
                       google::cloud::internal::CompilerVersion() + "; " +
                       google::cloud::internal::CompilerFeatures() + ")");
+
+  // Sets Spanner-specific options from session_pool_options.h
+  if (!opts.has<spanner::SessionPoolMaxSessionsPerChannelOption>()) {
+    opts.set<spanner::SessionPoolMaxSessionsPerChannelOption>(100);
+  }
+  if (!opts.has<spanner::SessionPoolActionOnExhaustionOption>()) {
+    opts.set<spanner::SessionPoolActionOnExhaustionOption>(
+        spanner::ActionOnExhaustion::kBlock);
+  }
+  if (!opts.has<spanner::SessionPoolKeepAliveIntervalOption>()) {
+    opts.set<spanner::SessionPoolKeepAliveIntervalOption>(
+        std::chrono::minutes(55));
+  }
+  // Enforces some SessionPool constraints.
+  auto& max_idle = opts.lookup<spanner::SessionPoolMaxIdleSessionsOption>();
+  max_idle = (std::max)(max_idle, 0);
+  auto& max_sessions_per_channel =
+      opts.lookup<spanner::SessionPoolMaxSessionsPerChannelOption>();
+  max_sessions_per_channel = (std::max)(max_sessions_per_channel, 1);
+  auto& min_sessions = opts.lookup<spanner::SessionPoolMinSessionsOption>();
+  min_sessions = (std::max)(min_sessions, 0);
+  min_sessions =
+      (std::min)(min_sessions, max_sessions_per_channel *
+                                   opts.get<internal::GrpcNumChannelsOption>());
   return opts;
 }
 

--- a/google/cloud/spanner/internal/options_test.cc
+++ b/google/cloud/spanner/internal/options_test.cc
@@ -49,13 +49,15 @@ TEST(Options, Defaults) {
   EXPECT_THAT(opts.get<internal::UserAgentProductsOption>(),
               ElementsAre(gcloud_user_agent_matcher()));
 
-  EXPECT_EQ(0, opts.get<SessionPoolMinSessionsOption>());
-  EXPECT_EQ(100, opts.get<SessionPoolMaxSessionsPerChannelOption>());
-  EXPECT_EQ(0, opts.get<SessionPoolMaxIdleSessionsOption>());
+  EXPECT_EQ(0, opts.get<spanner_internal::SessionPoolMinSessionsOption>());
+  EXPECT_EQ(
+      100,
+      opts.get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_EQ(0, opts.get<spanner_internal::SessionPoolMaxIdleSessionsOption>());
   EXPECT_EQ(ActionOnExhaustion::kBlock,
-            opts.get<SessionPoolActionOnExhaustionOption>());
+            opts.get<spanner_internal::SessionPoolActionOnExhaustionOption>());
   EXPECT_EQ(std::chrono::minutes(55),
-            opts.get<SessionPoolKeepAliveIntervalOption>());
+            opts.get<spanner_internal::SessionPoolKeepAliveIntervalOption>());
 }
 
 TEST(Options, EndpointFromEnv) {

--- a/google/cloud/spanner/internal/options_test.cc
+++ b/google/cloud/spanner/internal/options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/options.h"
+#include "google/cloud/spanner/session_pool_options.h"
 #include "google/cloud/internal/common_options.h"
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/internal/grpc_options.h"
@@ -47,6 +48,14 @@ TEST(Options, Defaults) {
   EXPECT_EQ(opts.get<internal::GrpcNumChannelsOption>(), 4);
   EXPECT_THAT(opts.get<internal::UserAgentProductsOption>(),
               ElementsAre(gcloud_user_agent_matcher()));
+
+  EXPECT_EQ(0, opts.get<SessionPoolMinSessionsOption>());
+  EXPECT_EQ(100, opts.get<SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_EQ(0, opts.get<SessionPoolMaxIdleSessionsOption>());
+  EXPECT_EQ(ActionOnExhaustion::kBlock,
+            opts.get<SessionPoolActionOnExhaustionOption>());
+  EXPECT_EQ(std::chrono::minutes(55),
+            opts.get<SessionPoolKeepAliveIntervalOption>());
 }
 
 TEST(Options, EndpointFromEnv) {

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -27,21 +27,18 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
+// What action to take if the session pool is exhausted.
+enum class ActionOnExhaustion { kBlock, kFail };
+
 class SessionPoolOptions;
-}
+
+}  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 internal::Options MakeOptions(spanner::SessionPoolOptions);
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
-
-namespace spanner {
-inline namespace SPANNER_CLIENT_NS {
-
-// What action to take if the session pool is exhausted.
-enum class ActionOnExhaustion { kBlock, kFail };
 
 /**
  * The minimum number of sessions to keep in the pool.
@@ -82,7 +79,7 @@ struct SessionPoolMaxIdleSessionsOption {
  * @note This option is to be used with the `google/cloud/internal/options.h`
  */
 struct SessionPoolActionOnExhaustionOption {
-  using Type = ActionOnExhaustion;
+  using Type = spanner::ActionOnExhaustion;
 };
 
 /*
@@ -109,12 +106,14 @@ struct SessionPoolLabelsOption {
   using Type = std::map<std::string, std::string>;
 };
 
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_internal
+
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
 /**
  * Controls the session pool maintained by a `spanner::Client`.
- *
- * @note Prefer using the above "*Option" classes with
- *     `google/cloud/internal/options.h` instead of this `SessionPoolOptions`
- *     class.
  *
  * Creating Cloud Spanner sessions is an expensive operation. The
  * [recommended practice][spanner-sessions-doc] is to maintain a cache (or pool)
@@ -152,60 +151,50 @@ class SessionPoolOptions {
    * Values <= 0 are treated as 0.
    * This value will effectively be reduced if it exceeds the overall limit on
    * the number of sessions (`max_sessions_per_channel` * number of channels).
-   *
-   * @note Prefer using `SessionPoolMinSessionsOption` with
-   *     `google/cloud/internal/options.h` instead.
    */
   SessionPoolOptions& set_min_sessions(int count) {
-    opts_.set<SessionPoolMinSessionsOption>(count);
+    opts_.set<spanner_internal::SessionPoolMinSessionsOption>(count);
     return *this;
   }
 
   /// Return the minimum number of sessions to keep in the pool.
-  int min_sessions() const { return opts_.get<SessionPoolMinSessionsOption>(); }
+  int min_sessions() const {
+    return opts_.get<spanner_internal::SessionPoolMinSessionsOption>();
+  }
 
   /**
    * Set the maximum number of sessions to create on each channel.
    * Values <= 1 are treated as 1.
-   *
-   * @note Prefer using `SessionPoolMaxSessionsPerChannelOption` with
-   *     `google/cloud/internal/options.h` instead.
    */
   SessionPoolOptions& set_max_sessions_per_channel(int count) {
-    opts_.set<SessionPoolMaxSessionsPerChannelOption>(count);
+    opts_.set<spanner_internal::SessionPoolMaxSessionsPerChannelOption>(count);
     return *this;
   }
 
   /// Return the minimum number of sessions to keep in the pool.
   int max_sessions_per_channel() const {
-    return opts_.get<SessionPoolMaxSessionsPerChannelOption>();
+    return opts_
+        .get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>();
   }
 
   /**
    * Set the maximum number of sessions to keep in the pool in an idle state.
    * Values <= 0 are treated as 0.
-   *
-   * @note Prefer using `SessionPoolMaxIdleSessionsOption` with
-   *     `google/cloud/internal/options.h` instead.
    */
   SessionPoolOptions& set_max_idle_sessions(int count) {
-    opts_.set<SessionPoolMaxIdleSessionsOption>(count);
+    opts_.set<spanner_internal::SessionPoolMaxIdleSessionsOption>(count);
     return *this;
   }
 
   /// Return the maximum number of idle sessions to keep in the pool.
   int max_idle_sessions() const {
-    return opts_.get<SessionPoolMaxIdleSessionsOption>();
+    return opts_.get<spanner_internal::SessionPoolMaxIdleSessionsOption>();
   }
 
-  /**
-   * Set whether to block or fail on pool exhaustion.
-   *
-   * @note Prefer using `SessionPoolActionOnExhaustionOption` with
-   *     `google/cloud/internal/options.h` instead.
-   */
+  /// Set whether to block or fail on pool exhaustion.
   SessionPoolOptions& set_action_on_exhaustion(ActionOnExhaustion action) {
-    opts_.set<SessionPoolActionOnExhaustionOption>(std::move(action));
+    opts_.set<spanner_internal::SessionPoolActionOnExhaustionOption>(
+        std::move(action));
     return *this;
   }
 
@@ -214,7 +203,7 @@ class SessionPoolOptions {
    * session when the pool is exhausted.
    */
   ActionOnExhaustion action_on_exhaustion() const {
-    return opts_.get<SessionPoolActionOnExhaustionOption>();
+    return opts_.get<spanner_internal::SessionPoolActionOnExhaustionOption>();
   }
 
   /*
@@ -222,18 +211,16 @@ class SessionPoolOptions {
    * collected by the backend GC. The GC collects objects older than 60
    * minutes, so any duration below that (less some slack to allow the calls
    * to be made to refresh the sessions) should suffice.
-   *
-   * @note Prefer using `SessionPoolKeepAliveIntervalOption` with
-   *     `google/cloud/internal/options.h` instead.
    */
   SessionPoolOptions& set_keep_alive_interval(std::chrono::seconds interval) {
-    opts_.set<SessionPoolKeepAliveIntervalOption>(std::move(interval));
+    opts_.set<spanner_internal::SessionPoolKeepAliveIntervalOption>(
+        std::move(interval));
     return *this;
   }
 
   /// Return the interval at which we refresh sessions to prevent GC.
   std::chrono::seconds keep_alive_interval() const {
-    return opts_.get<SessionPoolKeepAliveIntervalOption>();
+    return opts_.get<spanner_internal::SessionPoolKeepAliveIntervalOption>();
   }
 
   /**
@@ -241,18 +228,15 @@ class SessionPoolOptions {
    *  * Label keys must match `[a-z]([-a-z0-9]{0,61}[a-z0-9])?`.
    *  * Label values must match `([a-z]([-a-z0-9]{0,61}[a-z0-9])?)?`.
    *  * The maximum number of labels is 64.
-   *
-   * @note Prefer using `SessionPoolLabelsOption` with
-   *     `google/cloud/internal/options.h` instead.
    */
   SessionPoolOptions& set_labels(std::map<std::string, std::string> labels) {
-    opts_.set<SessionPoolLabelsOption>(std::move(labels));
+    opts_.set<spanner_internal::SessionPoolLabelsOption>(std::move(labels));
     return *this;
   }
 
   /// Return the labels used when creating sessions within the pool.
   std::map<std::string, std::string> const& labels() const {
-    return opts_.get<SessionPoolLabelsOption>();
+    return opts_.get<spanner_internal::SessionPoolLabelsOption>();
   }
 
  private:

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -46,7 +46,7 @@ internal::Options MakeOptions(spanner::SessionPoolOptions);
  * This value will effectively be reduced if it exceeds the overall limit on
  * the number of sessions (`max_sessions_per_channel` * number of channels).
  *
- * @note This option is to be used with the `google/cloud/internal/options.h`
+ * @note This option is to be used with the `google::cloud::internal::Options`
  */
 struct SessionPoolMinSessionsOption {
   using Type = int;
@@ -56,7 +56,7 @@ struct SessionPoolMinSessionsOption {
  * The maximum number of sessions to create on each channel.
  * Values <= 1 are treated as 1.
  *
- * @note This option is to be used with the `google/cloud/internal/options.h`
+ * @note This option is to be used with the `google::cloud::internal::Options`
  */
 struct SessionPoolMaxSessionsPerChannelOption {
   using Type = int;
@@ -66,7 +66,7 @@ struct SessionPoolMaxSessionsPerChannelOption {
  * The maximum number of sessions to keep in the pool in an idle state.
  * Values <= 0 are treated as 0.
  *
- * @note This option is to be used with the `google/cloud/internal/options.h`
+ * @note This option is to be used with the `google::cloud::internal::Options`
  */
 struct SessionPoolMaxIdleSessionsOption {
   using Type = int;
@@ -76,7 +76,7 @@ struct SessionPoolMaxIdleSessionsOption {
  * The action to take (kBlock or kFail) when attempting to allocate a session
  * when the pool is exhausted.
  *
- * @note This option is to be used with the `google/cloud/internal/options.h`
+ * @note This option is to be used with the `google::cloud::internal::Options`
  */
 struct SessionPoolActionOnExhaustionOption {
   using Type = spanner::ActionOnExhaustion;
@@ -88,7 +88,7 @@ struct SessionPoolActionOnExhaustionOption {
  * below that (less some slack to allow the calls to be made to refresh the
  * sessions) should suffice.
  *
- * @note This option is to be used with the `google/cloud/internal/options.h`
+ * @note This option is to be used with the `google::cloud::internal::Options`
  */
 struct SessionPoolKeepAliveIntervalOption {
   using Type = std::chrono::seconds;
@@ -100,7 +100,7 @@ struct SessionPoolKeepAliveIntervalOption {
  *  * Label values must match `([a-z]([-a-z0-9]{0,61}[a-z0-9])?)?`.
  *  * The maximum number of labels is 64.
  *
- * @note This option is to be used with the `google/cloud/internal/options.h`
+ * @note This option is to be used with the `google::cloud::internal::Options`
  */
 struct SessionPoolLabelsOption {
   using Type = std::map<std::string, std::string>;

--- a/google/cloud/spanner/session_pool_options_test.cc
+++ b/google/cloud/spanner/session_pool_options_test.cc
@@ -51,6 +51,32 @@ TEST(SessionPoolOptionsTest, MaxMinSessionsConflict) {
   EXPECT_EQ(2, options.max_sessions_per_channel());
 }
 
+TEST(SessionPoolOptionsTest, DefaultOptions) {
+  auto const opts = SessionPoolOptions{};
+  EXPECT_EQ(0, opts.min_sessions());
+  EXPECT_EQ(100, opts.max_sessions_per_channel());
+  EXPECT_EQ(0, opts.max_idle_sessions());
+  EXPECT_EQ(ActionOnExhaustion::kBlock, opts.action_on_exhaustion());
+  EXPECT_EQ(std::chrono::minutes(55), opts.keep_alive_interval());
+  EXPECT_TRUE(opts.labels().empty());
+}
+
+TEST(SessionPoolOptionsTest, MakeOptions) {
+  auto const expected = SessionPoolOptions{};
+  auto const opts = spanner_internal::MakeOptions(SessionPoolOptions{});
+
+  EXPECT_EQ(expected.min_sessions(), opts.get<SessionPoolMinSessionsOption>());
+  EXPECT_EQ(expected.max_sessions_per_channel(),
+            opts.get<SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_EQ(expected.max_idle_sessions(),
+            opts.get<SessionPoolMaxIdleSessionsOption>());
+  EXPECT_EQ(expected.action_on_exhaustion(),
+            opts.get<SessionPoolActionOnExhaustionOption>());
+  EXPECT_EQ(expected.keep_alive_interval(),
+            opts.get<SessionPoolKeepAliveIntervalOption>());
+  EXPECT_EQ(expected.labels(), opts.get<SessionPoolLabelsOption>());
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/session_pool_options_test.cc
+++ b/google/cloud/spanner/session_pool_options_test.cc
@@ -65,16 +65,19 @@ TEST(SessionPoolOptionsTest, MakeOptions) {
   auto const expected = SessionPoolOptions{};
   auto const opts = spanner_internal::MakeOptions(SessionPoolOptions{});
 
-  EXPECT_EQ(expected.min_sessions(), opts.get<SessionPoolMinSessionsOption>());
-  EXPECT_EQ(expected.max_sessions_per_channel(),
-            opts.get<SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_EQ(expected.min_sessions(),
+            opts.get<spanner_internal::SessionPoolMinSessionsOption>());
+  EXPECT_EQ(
+      expected.max_sessions_per_channel(),
+      opts.get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
   EXPECT_EQ(expected.max_idle_sessions(),
-            opts.get<SessionPoolMaxIdleSessionsOption>());
+            opts.get<spanner_internal::SessionPoolMaxIdleSessionsOption>());
   EXPECT_EQ(expected.action_on_exhaustion(),
-            opts.get<SessionPoolActionOnExhaustionOption>());
+            opts.get<spanner_internal::SessionPoolActionOnExhaustionOption>());
   EXPECT_EQ(expected.keep_alive_interval(),
-            opts.get<SessionPoolKeepAliveIntervalOption>());
-  EXPECT_EQ(expected.labels(), opts.get<SessionPoolLabelsOption>());
+            opts.get<spanner_internal::SessionPoolKeepAliveIntervalOption>());
+  EXPECT_EQ(expected.labels(),
+            opts.get<spanner_internal::SessionPoolLabelsOption>());
 }
 
 }  // namespace


### PR DESCRIPTION
This will allow us to remove `SessionPoolOptions` in factory functions that take the new `Options` class. The new options are in `spanner_internal` for now. They'll be made public as soon as we decide to make `Options` public.

There should be no API or semantic change in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5992)
<!-- Reviewable:end -->
