### PR TITLE
refactor(spanner): adds internal-only spanner-specific Retry and Backoff options

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -66,18 +66,20 @@ class DefaultPartialResultSetReader : public PartialResultSetReader {
 
 namespace spanner_proto = ::google::spanner::v1;
 
+// TODO(#5738): Delete this function once `google::cloud::internal::Options`
+// are directly used in this class.
 std::unique_ptr<spanner::RetryPolicy> DefaultConnectionRetryPolicy() {
-  return google::cloud::spanner::LimitedTimeRetryPolicy(
-             std::chrono::minutes(10))
-      .clone();
+  return spanner_internal::DefaultOptions()
+      .get<spanner_internal::SpannerRetryPolicyOption>()
+      ->clone();
 }
 
+// TODO(#5738): Delete this function once `google::cloud::internal::Options`
+// are directly used in this class.
 std::unique_ptr<spanner::BackoffPolicy> DefaultConnectionBackoffPolicy() {
-  auto constexpr kBackoffScaling = 2.0;
-  return google::cloud::spanner::ExponentialBackoffPolicy(
-             std::chrono::milliseconds(100), std::chrono::minutes(1),
-             kBackoffScaling)
-      .clone();
+  return spanner_internal::DefaultOptions()
+      .get<spanner_internal::SpannerBackoffPolicyOption>()
+      ->clone();
 }
 
 std::shared_ptr<ConnectionImpl> MakeConnection(

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -83,16 +83,15 @@ internal::Options DefaultOptions(internal::Options opts) {
 
   if (!opts.has<spanner_internal::SpannerRetryPolicyOption>()) {
     opts.set<spanner_internal::SpannerRetryPolicyOption>(
-        google::cloud::spanner::LimitedTimeRetryPolicy(std::chrono::minutes(10))
-            .clone());
+        std::make_shared<google::cloud::spanner::LimitedTimeRetryPolicy>(
+            std::chrono::minutes(10)));
   }
   if (!opts.has<spanner_internal::SpannerBackoffPolicyOption>()) {
     auto constexpr kBackoffScaling = 2.0;
     opts.set<spanner_internal::SpannerBackoffPolicyOption>(
-        google::cloud::spanner::ExponentialBackoffPolicy(
+        std::make_shared<google::cloud::spanner::ExponentialBackoffPolicy>(
             std::chrono::milliseconds(100), std::chrono::minutes(1),
-            kBackoffScaling)
-            .clone());
+            kBackoffScaling));
   }
 
   return opts;

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -80,6 +80,21 @@ internal::Options DefaultOptions(internal::Options opts) {
   min_sessions =
       (std::min)(min_sessions, max_sessions_per_channel *
                                    opts.get<internal::GrpcNumChannelsOption>());
+
+  if (!opts.has<spanner_internal::SpannerRetryPolicyOption>()) {
+    opts.set<spanner_internal::SpannerRetryPolicyOption>(
+        google::cloud::spanner::LimitedTimeRetryPolicy(std::chrono::minutes(10))
+            .clone());
+  }
+  if (!opts.has<spanner_internal::SpannerBackoffPolicyOption>()) {
+    auto constexpr kBackoffScaling = 2.0;
+    opts.set<spanner_internal::SpannerBackoffPolicyOption>(
+        google::cloud::spanner::ExponentialBackoffPolicy(
+            std::chrono::milliseconds(100), std::chrono::minutes(1),
+            kBackoffScaling)
+            .clone());
+  }
+
   return opts;
 }
 

--- a/google/cloud/spanner/internal/options.h
+++ b/google/cloud/spanner/internal/options.h
@@ -15,13 +15,36 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_OPTIONS_H
 
+#include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/options.h"
+#include <memory>
 
 namespace google {
 namespace cloud {
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * *Internal-only* options for `google::cloud::internal::Options` to allow
+ * passing a `spanner::RetryPolicy`. Customers will not use these, but they
+ * will allow us internally to stop passing this policy separately from the
+ * other `Options.`
+ */
+struct SpannerRetryPolicyOption {
+  using Type = std::shared_ptr<spanner::RetryPolicy>;
+};
+
+/**
+ * *Internal-only* options for `google::cloud::internal::Options` to allow
+ * passing a `spanner::BackoffPolicy`. Customers will not use these, but they
+ * will allow us internally to stop passing this policy separately from the
+ * other `Options.`
+ */
+struct SpannerBackoffPolicyOption {
+  using Type = std::shared_ptr<spanner::BackoffPolicy>;
+};
 
 /**
  * Returns an `Options` with the appropriate defaults for Spanner.

--- a/google/cloud/spanner/internal/options_test.cc
+++ b/google/cloud/spanner/internal/options_test.cc
@@ -58,6 +58,9 @@ TEST(Options, Defaults) {
             opts.get<spanner_internal::SessionPoolActionOnExhaustionOption>());
   EXPECT_EQ(std::chrono::minutes(55),
             opts.get<spanner_internal::SessionPoolKeepAliveIntervalOption>());
+
+  EXPECT_TRUE(opts.has<spanner_internal::SpannerRetryPolicyOption>());
+  EXPECT_TRUE(opts.has<spanner_internal::SpannerBackoffPolicyOption>());
 }
 
 TEST(Options, EndpointFromEnv) {


### PR DESCRIPTION
These options are internal-only and spanner specific. They will not be
used by customers and we can change them if/when we have other
user-facing options that we want our customers to use. In the mean time,
our implementation can use these options to pass around RetryPolicy and
BackoffPolicy objects inside an `Options`, without having to pass them
as separate arguments.

Note: these options hold the policies in `std::shared_ptr<T>` rather
than unique_ptr. This is because `Options` uses `absl::any`, which
doesn't work with move-only types. However, I think shared_ptr should be
fine for these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5994)
<!-- Reviewable:end -->
