### PR TITLE
refactor(spanner): remove unnecessary MakeConnection factory

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -343,9 +343,10 @@ std::shared_ptr<Connection> MakeConnection(
     stubs.push_back(spanner_internal::CreateDefaultSpannerStub(
         db, connection_options, channel_id));
   }
-  return spanner_internal::MakeConnection(
-      db, std::move(stubs), connection_options, std::move(session_pool_options),
-      std::move(retry_policy), std::move(backoff_policy));
+  return std::make_shared<spanner_internal::ConnectionImpl>(
+      std::move(db), std::move(stubs), connection_options,
+      std::move(session_pool_options), std::move(retry_policy),
+      std::move(backoff_policy));
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -80,17 +80,6 @@ std::unique_ptr<spanner::BackoffPolicy> DefaultConnectionBackoffPolicy() {
       .clone();
 }
 
-std::shared_ptr<ConnectionImpl> MakeConnection(
-    spanner::Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
-    spanner::ConnectionOptions const& options,
-    spanner::SessionPoolOptions session_pool_options,
-    std::unique_ptr<spanner::RetryPolicy> retry_policy,
-    std::unique_ptr<spanner::BackoffPolicy> backoff_policy) {
-  return std::shared_ptr<ConnectionImpl>(new ConnectionImpl(
-      std::move(db), std::move(stubs), options, std::move(session_pool_options),
-      std::move(retry_policy), std::move(backoff_policy)));
-}
-
 spanner_proto::TransactionOptions PartitionedDmlTransactionOptions() {
   spanner_proto::TransactionOptions options;
   *options.mutable_partitioned_dml() =


### PR DESCRIPTION
There's no need for a factory to construct
`spanner_internal::ConnectionImpl`. We can just construct it directly
from `client.cc`. I don't think the factory was adding any value, but it
was adding an extra layer of things to plumb parameters through.
This also makes the code easier to follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5995)
<!-- Reviewable:end -->
