### PR TITLE
refactor(spanner): changes the "stub" layer to use `Options`

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -15,11 +15,13 @@
 #include "google/cloud/spanner/benchmarks/benchmarks_config.h"
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/timer.h"
 #include "absl/memory/memory.h"
@@ -482,7 +484,8 @@ class ExperimentImpl {
       clients.emplace_back(
           spanner::Client(spanner::MakeConnection(database, options)));
       stubs.emplace_back(spanner_internal::CreateDefaultSpannerStub(
-          database, options, /*channel_id=*/0));
+          database, google::cloud::internal::MakeOptions(options),
+          /*channel_id=*/0));
       std::cout << '.' << std::flush;
     }
     std::cout << " DONE\n";

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -483,9 +483,11 @@ class ExperimentImpl {
           "task:" + std::to_string(i));
       clients.emplace_back(
           spanner::Client(spanner::MakeConnection(database, options)));
-      stubs.emplace_back(spanner_internal::CreateDefaultSpannerStub(
-          database, google::cloud::internal::MakeOptions(options),
-          /*channel_id=*/0));
+      auto opts = google::cloud::internal::MakeOptions(options);
+      opts = spanner_internal::DefaultOptions(std::move(opts));
+      stubs.emplace_back(
+          spanner_internal::CreateDefaultSpannerStub(database, opts,
+                                                     /*channel_id=*/0));
       std::cout << '.' << std::flush;
     }
     std::cout << " DONE\n";

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -340,12 +340,12 @@ std::shared_ptr<Connection> MakeConnection(
   internal::CheckExpectedOptions<internal::CommonOptions,
                                  internal::GrpcOptions>(opts, __func__);
 
-  // Sets spanner defaults, and merges in the session pool options.
-  opts = spanner_internal::DefaultOptions(std::move(opts));
   // TODO(#5738): Move session_pool_options once it's no longer passed to
   // ConnectionImpl.
   opts = internal::MergeOptions(
       std::move(opts), spanner_internal::MakeOptions(session_pool_options));
+  // Sets spanner defaults.
+  opts = spanner_internal::DefaultOptions(std::move(opts));
 
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
   int num_channels = opts.get<internal::GrpcNumChannelsOption>();

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -50,24 +50,5 @@ int ConnectionOptionsTraits::default_num_channels() {
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
-
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-// Override connection endpoint and credentials with values appropriate for
-// an emulated backend. This should be done after any user code that could
-// also override the default values (i.e., immediately before establishing
-// the connection).
-spanner::ConnectionOptions EmulatorOverrides(
-    spanner::ConnectionOptions options) {
-  auto emulator_addr = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
-  if (emulator_addr.has_value()) {
-    options.set_endpoint(*emulator_addr)
-        .set_credentials(grpc::InsecureChannelCredentials());
-  }
-  return options;
-}
-
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -48,13 +48,6 @@ using ConnectionOptions =
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-spanner::ConnectionOptions EmulatorOverrides(
-    spanner::ConnectionOptions options);
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
-
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -63,17 +63,6 @@ TEST(DefaultEndpoint, EnvironmentWorks) {
   EXPECT_EQ("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
 }
 
-TEST(EmulatorOverrides, EnvironmentWorks) {
-  // When SPANNER_EMULATOR_HOST is set, the original endpoint is reset to
-  // ${SPANNER_EMULATOR_HOST}, and the original credentials are reset to
-  // grpc::InsecureChannelCredentials().
-  ScopedEnvironment env("SPANNER_EMULATOR_HOST", "localhost:9010");
-  ConnectionOptions options(std::shared_ptr<grpc::ChannelCredentials>{});
-  options = spanner_internal::EmulatorOverrides(options);
-  EXPECT_NE(std::shared_ptr<grpc::ChannelCredentials>{}, options.credentials());
-  EXPECT_EQ("localhost:9010", options.endpoint());
-}
-
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -650,7 +650,9 @@ DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     ConnectionOptions const& options) {
   return spanner_internal::MakeDatabaseAdminConnection(
-      spanner_internal::CreateDefaultDatabaseAdminStub(options), options);
+      spanner_internal::CreateDefaultDatabaseAdminStub(
+          internal::MakeOptions(options)),
+      options);
 }
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
@@ -658,8 +660,9 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   return spanner_internal::MakeDatabaseAdminConnection(
-      spanner_internal::CreateDefaultDatabaseAdminStub(options), options,
-      std::move(retry_policy), std::move(backoff_policy),
+      spanner_internal::CreateDefaultDatabaseAdminStub(
+          internal::MakeOptions(options)),
+      options, std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
 

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/database_admin_connection.h"
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
@@ -649,20 +650,21 @@ DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     ConnectionOptions const& options) {
+  auto opts = internal::MakeOptions(options);
+  opts = spanner_internal::DefaultOptions(opts);
   return spanner_internal::MakeDatabaseAdminConnection(
-      spanner_internal::CreateDefaultDatabaseAdminStub(
-          internal::MakeOptions(options)),
-      options);
+      spanner_internal::CreateDefaultDatabaseAdminStub(opts), options);
 }
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
+  auto opts = internal::MakeOptions(options);
+  opts = spanner_internal::DefaultOptions(opts);
   return spanner_internal::MakeDatabaseAdminConnection(
-      spanner_internal::CreateDefaultDatabaseAdminStub(
-          internal::MakeOptions(options)),
-      options, std::move(retry_policy), std::move(backoff_policy),
+      spanner_internal::CreateDefaultDatabaseAdminStub(opts), options,
+      std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
 

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -320,7 +320,9 @@ InstanceAdminConnection::~InstanceAdminConnection() = default;
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     ConnectionOptions const& options) {
   return spanner_internal::MakeInstanceAdminConnection(
-      spanner_internal::CreateDefaultInstanceAdminStub(options), options);
+      spanner_internal::CreateDefaultInstanceAdminStub(
+          internal::MakeOptions(options)),
+      options);
 }
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
@@ -328,8 +330,9 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   return spanner_internal::MakeInstanceAdminConnection(
-      spanner_internal::CreateDefaultInstanceAdminStub(options), options,
-      std::move(retry_policy), std::move(backoff_policy),
+      spanner_internal::CreateDefaultInstanceAdminStub(
+          internal::MakeOptions(options)),
+      options, std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
 

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/instance_admin_connection.h"
 #include "google/cloud/spanner/instance.h"
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
 #include <grpcpp/grpcpp.h>
@@ -319,20 +320,21 @@ InstanceAdminConnection::~InstanceAdminConnection() = default;
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     ConnectionOptions const& options) {
+  auto opts = internal::MakeOptions(options);
+  opts = spanner_internal::DefaultOptions(opts);
   return spanner_internal::MakeInstanceAdminConnection(
-      spanner_internal::CreateDefaultInstanceAdminStub(
-          internal::MakeOptions(options)),
-      options);
+      spanner_internal::CreateDefaultInstanceAdminStub(opts), options);
 }
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
+  auto opts = internal::MakeOptions(options);
+  opts = spanner_internal::DefaultOptions(opts);
   return spanner_internal::MakeInstanceAdminConnection(
-      spanner_internal::CreateDefaultInstanceAdminStub(
-          internal::MakeOptions(options)),
-      options, std::move(retry_policy), std::move(backoff_policy),
+      spanner_internal::CreateDefaultInstanceAdminStub(opts), options,
+      std::move(retry_policy), std::move(backoff_policy),
       std::move(polling_policy));
 }
 

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -55,7 +56,7 @@ TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
   auto const db = GetDatabase();
-  auto stub = CreateDefaultSpannerStub(db, spanner::ConnectionOptions{},
+  auto stub = CreateDefaultSpannerStub(db, spanner_internal::DefaultOptions(),
                                        /*channel_id=*/0);
   auto session_pool = MakeSessionPool(
       db, {stub}, spanner::SessionPoolOptions{}, cq,

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.pb.h>
 #include <grpcpp/grpcpp.h>
@@ -148,7 +149,7 @@ class DatabaseAdminStub {
  * This stub does not create a channel pool, or retry operations.
  */
 std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
-    spanner::ConnectionOptions options);
+    internal::Options const& opts);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -16,6 +16,9 @@
 #include "google/cloud/spanner/internal/instance_admin_logging.h"
 #include "google/cloud/spanner/internal/instance_admin_metadata.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/algorithm.h"
+#include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/log.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
@@ -174,11 +177,11 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
 };
 
 std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
-    spanner::ConnectionOptions options) {
-  options = EmulatorOverrides(std::move(options));
-  auto channel =
-      grpc::CreateCustomChannel(options.endpoint(), options.credentials(),
-                                options.CreateChannelArguments());
+    internal::Options const& opts) {
+  auto channel_args = internal::MakeChannelArguments(opts);
+  auto channel = grpc::CreateCustomChannel(
+      opts.get<internal::EndpointOption>(),
+      opts.get<internal::GrpcCredentialOption>(), channel_args);
   auto spanner_grpc_stub = gcsa::InstanceAdmin::NewStub(channel);
   auto longrunning_grpc_stub =
       google::longrunning::Operations::NewStub(channel);
@@ -189,10 +192,11 @@ std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
 
   stub = std::make_shared<InstanceAdminMetadata>(std::move(stub));
 
-  if (options.tracing_enabled("rpc")) {
+  if (internal::Contains(opts.get<internal::TracingComponentsOption>(),
+                         "rpc")) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    stub = std::make_shared<InstanceAdminLogging>(std::move(stub),
-                                                  options.tracing_options());
+    stub = std::make_shared<InstanceAdminLogging>(
+        std::move(stub), opts.get<internal::GrpcTracingOptionsOption>());
   }
   return stub;
 }

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
 #include <grpcpp/grpcpp.h>
@@ -86,7 +87,7 @@ class InstanceAdminStub {
  * This stub does not create a channel pool, or retry operations.
  */
 std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
-    spanner::ConnectionOptions options);
+    internal::Options const& opts);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -123,8 +123,7 @@ class SpannerStub {
  * to ensure they use different underlying connections.
  */
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
-    spanner::Database const& db, spanner::ConnectionOptions options,
-    int channel_id);
+    spanner::Database const& db, internal::Options const& opts, int channel_id);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
+#include "google/cloud/spanner/internal/options.h"
+#include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -31,21 +34,23 @@ using ::testing::Contains;
 using ::testing::HasSubstr;
 
 TEST(SpannerStub, CreateDefaultStub) {
-  auto stub =
-      CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"),
-                               spanner::ConnectionOptions(), /*channel_id=*/0);
+  auto stub = CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"),
+                                       spanner_internal::DefaultOptions(),
+                                       /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 }
 
 TEST(SpannerStub, CreateDefaultStubWithLogging) {
   testing_util::ScopedLog log;
 
-  auto stub = CreateDefaultSpannerStub(
-      spanner::Database("foo", "bar", "baz"),
-      spanner::ConnectionOptions(grpc::InsecureChannelCredentials())
-          .set_endpoint("localhost:1")
-          .enable_tracing("rpc"),
-      /*channel_id=*/0);
+  auto opts = internal::Options{}
+                  .set<internal::GrpcCredentialOption>(
+                      grpc::InsecureChannelCredentials())
+                  .set<internal::EndpointOption>("localhost:1")
+                  .set<internal::TracingComponentsOption>({"rpc"});
+  auto stub =
+      CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"), opts,
+                               /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 
   grpc::ClientContext context;


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5738

There's no user-facing change in this PR. This just changes the lowest-layer of the Spanner stack to start accepting the new `Options`, so we can make these changes in bite-sized PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5998)
<!-- Reviewable:end -->
