### PR TITLE
cleanup: get roots.pem from https://pki.google.com

### DIFF
--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -55,7 +55,7 @@ bazel_args=(
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly CREDENTIALS_FILE="${CONFIG_DIR}/kokoro-run-key.json"
-readonly ROOTS_PEM_SOURCE="https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem"
+readonly ROOTS_PEM_SOURCE="https://pki.google.com/roots.pem"
 readonly BAZEL_CACHE="https://storage.googleapis.com/cloud-cpp-bazel-cache"
 
 if [[ -r "${CREDENTIALS_FILE}" ]]; then

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -52,7 +52,7 @@ fi
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly CREDENTIALS_FILE="${CONFIG_DIR}/kokoro-run-key.json"
-readonly ROOTS_PEM_SOURCE="https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem"
+readonly ROOTS_PEM_SOURCE="https://pki.google.com/roots.pem"
 if [[ -r "${CREDENTIALS_FILE}" ]]; then
   if [[ -r "${CONFIG_DIR}/roots.pem" ]]; then
     run_quickstart="true"

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -105,7 +105,7 @@ io::log_yellow "getting roots.pem for gRPC."
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${KOKORO_GFILE_DIR}/roots.pem"
 rm -f "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
 curl -sSL --retry 10 -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
-  https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+  https://pki.google.com/roots.pem
 
 BRANCH="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
 readonly BRANCH

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -157,7 +157,7 @@ if (Integration-Tests-Enabled) {
             "Downloading roots.pem [$_]"
         try {
             (New-Object System.Net.WebClient).Downloadfile(
-                    'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                    'https://pki.google.com/roots.pem',
                     "${env:KOKORO_GFILE_DIR}/roots.pem")
             break
         } catch {

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -123,7 +123,7 @@ if (Integration-Tests-Enabled) {
             "Downloading roots.pem [$_]"
         try {
             (New-Object System.Net.WebClient).Downloadfile(
-                    'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                    'https://pki.google.com/roots.pem',
                     "${env:KOKORO_GFILE_DIR}/roots.pem")
             break
         } catch {

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -93,7 +93,7 @@ if (-not (Test-Path env:KOKORO_GFILE_DIR)) {
             "Downloading roots.pem [$_]"
             try {
                 (New-Object System.Net.WebClient).Downloadfile(
-                        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                        'https://pki.google.com/roots.pem',
                         "${env:KOKORO_GFILE_DIR}/roots.pem")
                 break
             } catch {

--- a/ci/kokoro/windows/build-quickstart-cmake.ps1
+++ b/ci/kokoro/windows/build-quickstart-cmake.ps1
@@ -53,7 +53,7 @@ if (-not (Test-Path env:KOKORO_GFILE_DIR)) {
             "Downloading roots.pem [$_]"
             try {
                 (New-Object System.Net.WebClient).Downloadfile(
-                        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+                        'https://pki.google.com/roots.pem',
                         "${env:KOKORO_GFILE_DIR}/roots.pem")
                 break
             } catch {

--- a/google/cloud/bigtable/examples/README.md
+++ b/google/cloud/bigtable/examples/README.md
@@ -47,7 +47,7 @@ file.
 This file is included with the gRPC source. You can download it using:
 
 ```console
-$ wget https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+$ wget https://pki.google.com/roots.pem
 $ GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=$PWD/roots.pem
 $ export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH
 ```

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -124,7 +124,7 @@ gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 
 ```bash
-curl -Lo roots.pem https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+curl -Lo roots.pem https://pki.google.com/roots.pem
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 ```
 
@@ -156,8 +156,7 @@ trust store for SSL certificates, you can download and configure this using:
 ```console
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
     (new-object System.Net.WebClient).Downloadfile( ^
-        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem', ^
-        'roots.pem')
+        'https://pki.google.com/roots.pem', 'roots.pem')
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -122,7 +122,7 @@ gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 
 ```bash
-curl -Lo roots.pem https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+curl -Lo roots.pem https://pki.google.com/roots.pem
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 ```
 
@@ -154,8 +154,7 @@ trust store for SSL certificates, you can download and configure this using:
 ```console
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
     (new-object System.Net.WebClient).Downloadfile( ^
-        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem', ^
-        'roots.pem')
+        'https://pki.google.com/roots.pem', 'roots.pem')
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -122,7 +122,7 @@ gRPC [requires][grpc-roots-pem-bug] an environment variable to configure the
 trust store for SSL certificates, you can download and configure this using:
 
 ```bash
-curl -Lo roots.pem https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+curl -Lo roots.pem https://pki.google.com/roots.pem
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 ```
 
@@ -154,8 +154,7 @@ trust store for SSL certificates, you can download and configure this using:
 ```console
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
     (new-object System.Net.WebClient).Downloadfile( ^
-        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem', ^
-        'roots.pem')
+        'https://pki.google.com/roots.pem', 'roots.pem')
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 

--- a/google/cloud/spanner/samples/README.md
+++ b/google/cloud/spanner/samples/README.md
@@ -28,7 +28,7 @@ On Windows and macOS gRPC [requires][grpc-roots-pem-bug] an environment variable
 to find the root of trust for SSL. On macOS use:
 
 ```console
-curl -Lo roots.pem https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem
+curl -Lo roots.pem https://pki.google.com/roots.pem
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$PWD/roots.pem"
 ```
 
@@ -37,8 +37,7 @@ While on Windows use:
 ```console
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command ^
     (new-object System.Net.WebClient).Downloadfile( ^
-        'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem', ^
-        'roots.pem')
+        'https://pki.google.com/roots.pem', 'roots.pem')
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%cd%\roots.pem
 ```
 


### PR DESCRIPTION
That is a shorter URL, and seems better to use a google.com address to
get it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/5999)
<!-- Reviewable:end -->
