### PR TITLE
ci: deflake some macOS builds

### DIFF
--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -87,6 +87,20 @@ else
   exit 1
 fi
 
+# Sadly, the Kokoro machines seem to be out of sync
+if command ntpdate >/dev/null 2>&1; then
+  echo "================================================================"
+  io::log_yellow "using ntpdate to synchronize clock from time.google.com."
+  sudo ntpdate time.google.com
+elif command sntp >/dev/null 2>&1; then
+  echo "================================================================"
+  io::log_yellow "using sntp to synchronize clock from time.google.com."
+  sudo sntp -sS time.google.com
+else
+  echo "================================================================"
+  io::log_red "no command available to sync clock"
+fi
+
 # We need this environment variable because on macOS gRPC crashes if it cannot
 # find the credentials, even if you do not use them. Some of the unit tests do
 # exactly that.


### PR DESCRIPTION
Forcefully synchronize the build machine clock at the beginning of the
build. This avoids flakiness due to machines with clock skews big enough
to invalidate authentication tokens generated on the machine.