### PR TITLE
cleanup(bigtable): remove ill-conceived static checks

### DIFF
--- a/google/cloud/bigtable/testing/random_names.cc
+++ b/google/cloud/bigtable/testing/random_names.cc
@@ -23,20 +23,14 @@ namespace testing {
 // Unless otherwise noted, the maximum ID lengths discovered by trial and error.
 auto constexpr kMaxTableIdLength = 50;
 char const kRandomTableIdRE[] = R"re(^tbl-\d{4}-\d{2}-\d{2}-.*$)re";
-static_assert(sizeof(kRandomTableIdRE) < kMaxTableIdLength,
-              "TableId prefix is too long");
 
 // Per google/bigtable/admin/v2/bigtable_table_admin.proto, backup names must
 // be between 1 and 50 characters such, [_a-zA-Z0-9][-_.a-zA-Z0-9]*.
 auto constexpr kMaxBackupIdLength = 50;
 char const kRandomBackupIdRE[] = R"re(^bck-\d{4}-\d{2}-\d{2}-.*$)re";
-static_assert(sizeof(kRandomBackupIdRE) < kMaxBackupIdLength,
-              "InstanceId prefix is too long");
 
 auto constexpr kMaxClusterIdLength = 30;
 char const kRandomClusterIdRE[] = R"re(^cl-\d{4}-\d{2}-\d{2}-.*$)re";
-static_assert(sizeof(kRandomClusterIdRE) < kMaxClusterIdLength,
-              "ClusterId prefix is too long");
 
 // Cloud Bigtable instance ids must have at least 6 characters, and can have
 // up to 33 characters. But many of the examples append `-c1` or `-c2` to
@@ -44,8 +38,6 @@ static_assert(sizeof(kRandomClusterIdRE) < kMaxClusterIdLength,
 // even shorter.
 auto constexpr kMaxInstanceIdLength = kMaxClusterIdLength - 3;
 char const kRandomInstanceIdRE[] = R"re(^it-\d{4}-\d{2}-\d{2}-.*$)re";
-static_assert(sizeof(kRandomInstanceIdRE) < kMaxInstanceIdLength,
-              "InstanceId prefix is too long");
 
 std::string RandomTableId(google::cloud::internal::DefaultPRNG& generator,
                           std::chrono::system_clock::time_point tp) {
@@ -65,7 +57,7 @@ std::string RandomTableIdRegex() { return kRandomTableIdRE; }
 std::string RandomBackupId(google::cloud::internal::DefaultPRNG& generator,
                            std::chrono::system_clock::time_point tp) {
   auto const prefix = RandomBackupId(tp);
-  auto size = static_cast<int>(kMaxTableIdLength - 1 - prefix.size());
+  auto size = static_cast<int>(kMaxBackupIdLength - 1 - prefix.size());
   return prefix + google::cloud::internal::Sample(
                       generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }

--- a/google/cloud/bigtable/testing/random_names_test.cc
+++ b/google/cloud/bigtable/testing/random_names_test.cc
@@ -32,6 +32,9 @@ TEST(BigtableRandomNames, RandomTableId) {
   auto const current = RandomTableId(generator, now);
   auto const older = RandomTableId(generator, now - hours(48));
   EXPECT_LT(older, current);
+  auto constexpr kMaxLength = 50;
+  EXPECT_LT(older.size(), kMaxLength);
+  EXPECT_LT(current.size(), kMaxLength);
 
   auto re = std::regex(RandomTableIdRegex());
   EXPECT_TRUE(std::regex_match(current, re));
@@ -45,6 +48,9 @@ TEST(BigtableRandomNames, RandomBackupId) {
   auto const current = RandomBackupId(generator, now);
   auto const older = RandomBackupId(generator, now - hours(48));
   EXPECT_LT(older, current);
+  auto constexpr kMaxLength = 50;
+  EXPECT_LT(older.size(), kMaxLength);
+  EXPECT_LT(current.size(), kMaxLength);
 
   auto re = std::regex(RandomBackupIdRegex());
   EXPECT_TRUE(std::regex_match(current, re));
@@ -58,6 +64,9 @@ TEST(BigtableRandomNames, RandomClusterId) {
   auto const current = RandomClusterId(generator, now);
   auto const older = RandomClusterId(generator, now - hours(48));
   EXPECT_LT(older, current);
+  auto constexpr kMaxLength = 30;
+  EXPECT_LT(older.size(), kMaxLength);
+  EXPECT_LT(current.size(), kMaxLength);
 
   auto re = std::regex(RandomClusterIdRegex());
   EXPECT_TRUE(std::regex_match(current, re));
@@ -71,6 +80,9 @@ TEST(BigtableRandomNames, RandomInstanceId) {
   auto const current = RandomInstanceId(generator, now);
   auto const older = RandomInstanceId(generator, now - hours(48));
   EXPECT_LT(older, current);
+  auto constexpr kMaxLength = 27;
+  EXPECT_LT(older.size(), kMaxLength);
+  EXPECT_LT(current.size(), kMaxLength);
 
   auto re = std::regex(RandomInstanceIdRegex());
   EXPECT_TRUE(std::regex_match(current, re));


### PR DESCRIPTION
Thanks to @devbww for noticing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6002)
<!-- Reviewable:end -->
