### PR TITLE
test(bigtable): plug one table leak

### DIFF
--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -593,6 +593,8 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
   auto actual = ReadRows(table, Filter::PassAllFilter());
   CheckEqualUnordered(expected, actual);
   EXPECT_THAT(log.ExtractLines(), Contains(HasSubstr("MutateRow")));
+
+  ASSERT_STATUS_OK(table_admin_->DeleteTable(table_id));
 }
 
 TEST(ConnectionRefresh, Disabled) {


### PR DESCRIPTION
This fixes a table leaked from the integration tests. Earlier today I
push changes to garbage collect all tables leaked for any reason, but
this is a little more tidy.

Looks like the title should be "last table leak".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6003)
<!-- Reviewable:end -->
