### PR TITLE
feat: bind `CompletionQueue` with `TableAdmin`

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -437,6 +437,10 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
   }
 
  private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return impl_.Options().background_threads_factory();
+  }
+
   std::string project_;
   Impl impl_;
 };

--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -289,6 +289,12 @@ class AdminClient {
                     const google::longrunning::GetOperationRequest& request,
                     grpc::CompletionQueue* cq) = 0;
   //@}
+
+ private:
+  /// The thread factory from `ClientOptions` this client was created with.
+  virtual ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() {
+    return {};
+  }
 };
 
 /// Create a new admin client configured via @p options.

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -254,6 +254,10 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
                     grpc::CompletionQueue* cq) override;
 
  private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return child_->BackgroundThreadsFactory();
+  }
+
   std::shared_ptr<google::cloud::bigtable::AdminClient> child_;
   google::cloud::TracingOptions tracing_options_;
 };

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -255,16 +255,8 @@ TableAdmin::CreateBackupParams::AsProto(std::string instance_name) const {
 
 StatusOr<google::bigtable::admin::v2::Backup> TableAdmin::CreateBackup(
     CreateBackupParams const& params) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-  return AsyncCreateBackup(cq, params)
-      .then(
-          [cq](
-              future<StatusOr<google::bigtable::admin::v2::Backup>> f) mutable {
-            cq.Shutdown();
-            return f.get();
-          })
-      .get();
+  auto cq = background_threads_->cq();
+  return AsyncCreateBackup(cq, params).get();
 }
 
 future<StatusOr<google::bigtable::admin::v2::Backup>>
@@ -558,15 +550,8 @@ TableAdmin::RestoreTableParams::AsProto(
 
 StatusOr<google::bigtable::admin::v2::Table> TableAdmin::RestoreTable(
     RestoreTableParams const& params) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-  return AsyncRestoreTable(cq, params)
-      .then(
-          [cq](future<StatusOr<google::bigtable::admin::v2::Table>> f) mutable {
-            cq.Shutdown();
-            return f.get();
-          })
-      .get();
+  auto cq = background_threads_->cq();
+  return AsyncRestoreTable(cq, params).get();
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
@@ -590,15 +575,8 @@ google::bigtable::admin::v2::RestoreTableRequest AsProto(
 
 StatusOr<google::bigtable::admin::v2::Table> TableAdmin::RestoreTable(
     RestoreTableFromInstanceParams params) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-  return AsyncRestoreTable(cq, std::move(params))
-      .then(
-          [cq](future<StatusOr<google::bigtable::admin::v2::Table>> f) mutable {
-            cq.Shutdown();
-            return f.get();
-          })
-      .get();
+  auto cq = background_threads_->cq();
+  return AsyncRestoreTable(cq, std::move(params)).get();
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
@@ -709,14 +687,8 @@ future<Status> TableAdmin::AsyncDropRowsByPrefix(CompletionQueue& cq,
 
 google::cloud::future<StatusOr<Consistency>> TableAdmin::WaitForConsistency(
     std::string const& table_id, std::string const& consistency_token) {
-  CompletionQueue cq;
-  std::thread([](CompletionQueue cq) { cq.Run(); }, cq).detach();
-
-  return AsyncWaitForConsistency(cq, table_id, consistency_token)
-      .then([cq](future<StatusOr<Consistency>> f) mutable {
-        cq.Shutdown();
-        return f.get();
-      });
+  auto cq = background_threads_->cq();
+  return AsyncWaitForConsistency(cq, table_id, consistency_token);
 }
 
 google::cloud::future<StatusOr<Consistency>>

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -150,7 +150,8 @@ class TableAdmin {
             DefaultRPCBackoffPolicy(internal::kBigtableTableAdminLimits)),
         metadata_update_policy_(instance_name(), MetadataParamTypes::PARENT),
         polling_policy_prototype_(
-            DefaultPollingPolicy(internal::kBigtableTableAdminLimits)) {}
+            DefaultPollingPolicy(internal::kBigtableTableAdminLimits)),
+        background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**
    * Create a new TableAdmin using explicit policies to handle RPC errors.
@@ -1756,6 +1757,7 @@ class TableAdmin {
   std::shared_ptr<RPCBackoffPolicy const> rpc_backoff_policy_prototype_;
   bigtable::MetadataUpdatePolicy metadata_update_policy_;
   std::shared_ptr<PollingPolicy const> polling_policy_prototype_;
+  std::shared_ptr<BackgroundThreads> background_threads_;
 };
 
 }  // namespace BIGTABLE_CLIENT_NS

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -230,8 +230,13 @@ class InProcessAdminClient : public bigtable::AdminClient {
   //@}
 
  private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return options_.background_threads_factory();
+  }
+
   std::string project_;
   std::shared_ptr<grpc::Channel> channel_;
+  ClientOptions options_;
 };
 
 }  // namespace testing

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -26,6 +26,9 @@ namespace testing {
 
 class MockAdminClient : public bigtable::AdminClient {
  public:
+  explicit MockAdminClient(ClientOptions options = {})
+      : options_(std::move(options)) {}
+
   MOCK_METHOD(std::string const&, project, (), (const, override));
   MOCK_METHOD(std::shared_ptr<grpc::Channel>, Channel, (), (override));
   MOCK_METHOD(void, reset, (), (override));
@@ -252,6 +255,13 @@ class MockAdminClient : public bigtable::AdminClient {
                const google::longrunning::GetOperationRequest&,
                grpc::CompletionQueue*),
               (override));
+
+ private:
+  ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
+    return options_.background_threads_factory();
+  }
+
+  ClientOptions options_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
This is a part of #2567 and a continuation of #5967.

This MR makes all synchronous operations on `TableAdmin`
execute on a `CompletionQueue` bound with that `TableAdmin`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6004)
<!-- Reviewable:end -->
