### PR TITLE
refactor(spanner): session_pool now uses Options

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -346,6 +346,9 @@ std::shared_ptr<Connection> MakeConnection(
       std::move(opts), spanner_internal::MakeOptions(session_pool_options));
   // Sets spanner defaults.
   opts = spanner_internal::DefaultOptions(std::move(opts));
+  opts.set<spanner_internal::SpannerRetryPolicyOption>(retry_policy->clone());
+  opts.set<spanner_internal::SpannerBackoffPolicyOption>(
+      backoff_policy->clone());
 
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
   int num_channels = opts.get<internal::GrpcNumChannelsOption>();

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -14,16 +14,17 @@
 
 #include "google/cloud/spanner/internal/connection_impl.h"
 #include "google/cloud/spanner/internal/logging_result_set_reader.h"
+#include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/internal/partial_result_set_resume.h"
 #include "google/cloud/spanner/internal/partial_result_set_source.h"
 #include "google/cloud/spanner/internal/status_utils.h"
 #include "google/cloud/spanner/query_partition.h"
 #include "google/cloud/spanner/read_partition.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "absl/memory/memory.h"
-#include "options.h"
 #include <google/protobuf/util/time_util.h>
 #include <grpcpp/grpcpp.h>
 

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/internal/options.h"
+#include "session_pool.h"
 #include <chrono>
 #include <string>
 
@@ -92,6 +93,9 @@ internal::Options DefaultOptions(internal::Options opts) {
         std::make_shared<google::cloud::spanner::ExponentialBackoffPolicy>(
             std::chrono::milliseconds(100), std::chrono::minutes(1),
             kBackoffScaling));
+  }
+  if (!opts.has<SessionPoolClockOption>()) {
+    opts.set<SessionPoolClockOption>(std::make_shared<Session::Clock>());
   }
 
   return opts;

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/options.h"
+#include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/session_pool_options.h"
 #include "google/cloud/internal/common_options.h"
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/internal/options.h"
-#include "session_pool.h"
 #include <chrono>
 #include <string>
 

--- a/google/cloud/spanner/internal/options_test.cc
+++ b/google/cloud/spanner/internal/options_test.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/testing_util/scoped_environment.h"
+#include "session_pool.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -64,6 +65,7 @@ TEST(Options, Defaults) {
 
   EXPECT_TRUE(opts.has<spanner_internal::SpannerRetryPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SpannerBackoffPolicyOption>());
+  EXPECT_TRUE(opts.has<spanner_internal::SessionPoolClockOption>());
 }
 
 TEST(Options, EndpointFromEnv) {

--- a/google/cloud/spanner/internal/options_test.cc
+++ b/google/cloud/spanner/internal/options_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/options.h"
+#include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/session_pool_options.h"
 #include "google/cloud/internal/common_options.h"
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/internal/grpc_options.h"
 #include "google/cloud/testing_util/scoped_environment.h"
-#include "session_pool.h"
 #include <gmock/gmock.h>
 
 namespace google {


### PR DESCRIPTION
There's a little crud in the code because some classes (e.g.
ConnectionImpl) are hybrid using the new and old Options. This naturally
be cleaned up when we move everything to Options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6006)
<!-- Reviewable:end -->
