### PR TITLE
test(common): deflake tests for future<T>

### DIFF
--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -624,7 +624,7 @@ TEST(FutureTestInt, conform_30_6_6_21) {
   promise<int> p;
   future<int> const f = p.get_future();
 
-  // Just check that `.wait_for()` blocks for a few millis.
+  // Just check that `.wait_for()` blocks for at least one millisecond.
   auto const start = std::chrono::steady_clock::now();
   EXPECT_EQ(std::future_status::timeout, f.wait_for(10_ms));
   auto const elapsed = std::chrono::steady_clock::now() - start;

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -582,7 +582,7 @@ TEST(FutureTestVoid, conform_30_6_6_21) {
   promise<void> p;
   future<void> const f = p.get_future();
 
-  // Just check that `.wait_for()` blocks for a few millis.
+  // Just check that `.wait_for()` blocks for at least one millisecond.
   auto const start = std::chrono::steady_clock::now();
   EXPECT_EQ(std::future_status::timeout, f.wait_for(10_ms));
   auto const elapsed = std::chrono::steady_clock::now() - start;


### PR DESCRIPTION
The tests to verify `.wait_for()` actually blocks for a bit were flaky,
and overly complicated. The new version just measures the time spent in
the `.wait_for()` operation, if it is not-zero milliseconds we declare
success. A more sophisticated test would measure the wait time with
different sleep times, and run some statistics to convince ourselves the
implementation is "correct". We are relying on knowledge of how this is
implemented, and trusting the C++ library, maybe bad assumptions, but
reasonable tradeoffs for faster tests.

Fixes #5966

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6007)
<!-- Reviewable:end -->
