### PR TITLE
Arch build support: ca-certificates.crt location

### DIFF
--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -67,6 +67,8 @@ genrule(
         echo '#define CURL_CA_BUNDLE "/etc/pki/tls/certs/ca-bundle.crt"'
       elif [ -f /etc/debian_version ]; then
         echo '#define CURL_CA_BUNDLE "/etc/ssl/certs/ca-certificates.crt"'
+      elif [ -f /etc/arch-release ]; then
+        echo '#define CURL_CA_BUNDLE "/etc/ssl/certs/ca-certificates.crt"'
       else
         >&2 echo "Unknown platform, cannot guess location of CA bundle"
         exit 1


### PR DESCRIPTION
```
➜  google-cloud-cpp git:(master) ✗ ls /etc/arch-release                    
/etc/arch-release
➜  google-cloud-cpp git:(master) ✗ ls -l /etc/ssl/certs/ca-certificates.crt
lrwxrwxrwx 1 root root 49 Jul 28  2020 /etc/ssl/certs/ca-certificates.crt -> ../../ca-certificates/extracted/tls-ca-bundle.pem
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6011)
<!-- Reviewable:end -->
