### PR TITLE
fix(bigtable): set timeouts for asynchronous operations

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -399,6 +399,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/retry_loop.h
         internal/retry_loop_helpers.cc
         internal/retry_loop_helpers.h
+        internal/setup_context.h
         internal/streaming_read_rpc.cc
         internal/streaming_read_rpc.h
         internal/streaming_read_rpc_logging.h

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -41,6 +41,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/resumable_streaming_read_rpc.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",
+    "internal/setup_context.h",
     "internal/streaming_read_rpc.h",
     "internal/streaming_read_rpc_logging.h",
     "internal/time_utils.h",

--- a/google/cloud/internal/async_retry_loop_test.cc
+++ b/google/cloud/internal/async_retry_loop_test.cc
@@ -161,7 +161,6 @@ TEST(AsyncRetryLoopTest, UsesBackoffPolicy) {
   EXPECT_CALL(*mock, OnCompletion()).Times(3).WillRepeatedly(Return(ms(1)));
 
   int counter = 0;
-  std::vector<ms> sleep_for;
   AutomaticallyCreatedBackgroundThreads background;
   StatusOr<int> actual =
       AsyncRetryLoop(
@@ -280,8 +279,6 @@ class MockRetryPolicy : public RetryPolicyWithSetup {
 };
 
 TEST(AsyncRetryLoopTest, SetsTimeout) {
-  using ms = std::chrono::milliseconds;
-
   auto mock = absl::make_unique<MockRetryPolicy>();
   EXPECT_CALL(*mock, OnFailure)
       .WillOnce(Return(true))
@@ -295,7 +292,6 @@ TEST(AsyncRetryLoopTest, SetsTimeout) {
   EXPECT_CALL(*mock, IsPermanentFailure).WillRepeatedly(Return(false));
   EXPECT_CALL(*mock, Setup).Times(3);
 
-  std::vector<ms> sleep_for;
   AutomaticallyCreatedBackgroundThreads background;
 
   StatusOr<int> actual =

--- a/google/cloud/internal/async_retry_unary_rpc.h
+++ b/google/cloud/internal/async_retry_unary_rpc.h
@@ -18,6 +18,7 @@
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/internal/completion_queue_impl.h"
 #include "google/cloud/internal/retry_policy.h"
+#include "google/cloud/internal/setup_context.h"
 #include "google/cloud/version.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/empty.pb.h>
@@ -147,7 +148,7 @@ class RetryAsyncUnaryRpc {
   static void StartIteration(std::shared_ptr<RetryAsyncUnaryRpc> self,
                              CompletionQueue cq) {
     auto context = absl::make_unique<grpc::ClientContext>();
-
+    SetupContext<RPCRetryPolicy>::Setup(*self->rpc_retry_policy_, *context);
     cq.MakeUnaryRpc(self->async_call_, self->request_, std::move(context))
         .then([self, cq](future<StatusOr<Response>> fut) {
           self->OnCompletion(self, cq, fut.get());

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -407,7 +407,8 @@ TEST(AsyncRetryUnaryRpcTest, SetsTimeout) {
         };
         auto r = absl::make_unique<ReaderType>();
         EXPECT_CALL(*r, Finish).WillOnce(finish_failure);
-        // gRPC defines a trivial deleter for these, and gmock complains if
+        // gRPC defines a trivial deleter for these, and google mock complains
+        // if they are not deleted.
         auto* tmp = r.get();
         cleanup_readers.push_back(std::move(r));
         return std::unique_ptr<

--- a/google/cloud/internal/setup_context.h
+++ b/google/cloud/internal/setup_context.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/internal/setup_context.h
+++ b/google/cloud/internal/setup_context.h
@@ -1,0 +1,46 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETUP_CONTEXT_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETUP_CONTEXT_H
+
+#include "google/cloud/internal/invoke_result.h"
+#include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/// Uses SFINAE to call Policy.Setup(context) when possible.
+template <typename Policy, typename = void>
+struct SetupContext {
+  static void Setup(Policy&, grpc::ClientContext&) {}
+};
+
+template <typename Policy>
+struct SetupContext<Policy, void_t<decltype(std::declval<Policy>().Setup(
+                                std::declval<grpc::ClientContext&>()))>> {
+  static void Setup(Policy& p, grpc::ClientContext& context) {
+    p.Setup(context);
+  }
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_SETUP_CONTEXT_H


### PR DESCRIPTION
Part of the work for #4926.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6014)
<!-- Reviewable:end -->
