### PR TITLE
refactor(spanner): add spanner_internal::MakeConnection

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -354,9 +354,10 @@ inline namespace SPANNER_CLIENT_NS {
 
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     internal::Options opts) {
-  internal::CheckExpectedOptions<internal::CommonOptions, internal::GrpcOptions,
+  internal::CheckExpectedOptions<internal::CommonOptionList,
+                                 internal::GrpcOptionList,
                                  spanner_internal::SessionPoolOptionList,
-                                 spanner_internal::SpannerInternalOptions>(
+                                 spanner_internal::SpannerInternalOptionList>(
       opts, __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -355,7 +355,7 @@ inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     internal::Options opts) {
   internal::CheckExpectedOptions<internal::CommonOptions, internal::GrpcOptions,
-                                 spanner_internal::SessionPoolOptions,
+                                 spanner_internal::SessionPoolOptionList,
                                  spanner_internal::SpannerInternalOptions>(
       opts, __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -676,6 +676,38 @@ std::shared_ptr<Connection> MakeConnection(
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
+
+namespace spanner_internal {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * Returns a Connection object that can be used for interacting with Spanner.
+ *
+ * The returned connection object should not be used directly, rather it should
+ * be given to a `Client` instance, and methods should be invoked on `Client`.
+ *
+ * The optional @p opts argument may be used to configure aspects of the
+ * returned `Connection`. Expected options are any of the following:
+ *
+ * - `google::cloud::internal::CommonOptions`
+ * - `google::cloud::internal::GrpcOptions`
+ * - `google::cloud::spanner_internal::SessionPoolOptions`
+ *
+ * @note Unrecognized options will be ignored. To debug issues with options set
+ *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
+ *     options will be logged.
+ *
+ * @see `Connection`
+ *
+ * @param db See `Database`.
+ * @param opts (optional) configure the `Connection` created by
+ *     this function.
+ */
+std::shared_ptr<spanner::Connection> MakeConnection(
+    spanner::Database const& db, internal::Options opts = {});
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -691,7 +691,7 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * - `google::cloud::internal::CommonOptions`
  * - `google::cloud::internal::GrpcOptions`
- * - `google::cloud::spanner_internal::SessionPoolOptions`
+ * - `google::cloud::spanner_internal::SessionPoolOptionList`
  *
  * @note Unrecognized options will be ignored. To debug issues with options set
  *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -689,8 +689,8 @@ inline namespace SPANNER_CLIENT_NS {
  * The optional @p opts argument may be used to configure aspects of the
  * returned `Connection`. Expected options are any of the following:
  *
- * - `google::cloud::internal::CommonOptions`
- * - `google::cloud::internal::GrpcOptions`
+ * - `google::cloud::internal::CommonOptionList`
+ * - `google::cloud::internal::GrpcOptionList`
  * - `google::cloud::spanner_internal::SessionPoolOptionList`
  *
  * @note Unrecognized options will be ignored. To debug issues with options set

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -391,6 +391,12 @@ TEST(ClientTest, MakeConnectionOptionalArguments) {
 
   conn = MakeConnection(db, ConnectionOptions(), SessionPoolOptions());
   EXPECT_NE(conn, nullptr);
+
+  conn = spanner_internal::MakeConnection(db);
+  EXPECT_NE(conn, nullptr);
+
+  conn = spanner_internal::MakeConnection(db, internal::Options{});
+  EXPECT_NE(conn, nullptr);
 }
 
 TEST(ClientTest, CommitMutatorSuccess) {


### PR DESCRIPTION
This is the function that *will be* the preferred user-facing
"MakeConnection" function. It's requires a `spanner::Database` argument,
and nothing else. A single, optional `Options` argument may be specified
to configure aspects of the returned `Connection`. Appropriate defaults
will be used for any unspecified option, so `{}` is a valid (and the
default) argument.

The other `MakeConnection` overloads will continue to exist and they
will simply forward to this one new/preferred overload. The old
overloads will NOT be deprecated, so we will not break existing callers.
However, we will clearly document all the overloads to make it clear
that the new overload should be preferred, so that customers do not
struggle to decide which overload to choose.

Of course, this is all "internal" for now, but it will likely be moved
out of internal and made public soon (before the April release).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6022)
<!-- Reviewable:end -->
