### PR TITLE
feat(internal): add internal-only `TypeList`

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -164,6 +164,7 @@ add_library(
     internal/throw_delegate.cc
     internal/throw_delegate.h
     internal/tuple.h
+    internal/type_list.h
     internal/user_agent_prefix.cc
     internal/user_agent_prefix.h
     internal/utility.h
@@ -266,6 +267,7 @@ if (BUILD_TESTING)
         internal/strerror_test.cc
         internal/throw_delegate_test.cc
         internal/tuple_test.cc
+        internal/type_list_test.cc
         internal/user_agent_prefix_test.cc
         internal/utility_test.cc
         kms_key_name_test.cc

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -60,6 +60,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/strerror.h",
     "internal/throw_delegate.h",
     "internal/tuple.h",
+    "internal/type_list.h",
     "internal/user_agent_prefix.h",
     "internal/utility.h",
     "internal/version_info.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -41,6 +41,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/strerror_test.cc",
     "internal/throw_delegate_test.cc",
     "internal/tuple_test.cc",
+    "internal/type_list_test.cc",
     "internal/user_agent_prefix_test.cc",
     "internal/utility_test.cc",
     "kms_key_name_test.cc",

--- a/google/cloud/internal/type_list.h
+++ b/google/cloud/internal/type_list.h
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_LIST_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_LIST_H
+
+#include "google/cloud/version.h"
+#include <utility>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/**
+ * A list of types.
+ *
+ * This can be used instead of `std::tuple` when only the types are needed
+ * without any values.
+ */
+template <typename... T>
+struct TypeList {};
+
+/**
+ * A metafunction to concatenate `TypeList`s.
+ *
+ * @note Prefer to use the `TypeListCatT<...>` alias, which removes the need
+ *     for `typename` and `::Type`.
+ *
+ * @par Example:
+ *
+ * @code
+ * struct A {};
+ * struct B {};
+ * using Foo = TypeList<A, B>;
+ *
+ * struct C {};
+ * using Bar = TypeList<C>;
+ *
+ * using Both = TypeListCatT<Foo, Bar>;
+ * static_assert(std::is_same<TypeList<A, B, C>, Both>::value, "");
+ * @endcode
+ */
+template <typename... T>
+struct TypeListCat {};
+
+/**
+ * Convenience alias. Prefer this over directly using `TypeListCat`.
+ */
+template <typename... T>
+using TypeListCatT = typename TypeListCat<T...>::Type;
+
+// Full specialization for concatenating nothing.
+template <>
+struct TypeListCat<> {
+  using Type = TypeList<>;
+};
+
+// Partial specialization for exactly one `TypeList<...>`.
+template <typename T>
+struct TypeListCat<T> {
+  using Type = T;
+};
+
+// Partial specialization for two `TypeList<...>`s.
+template <typename... Ts, typename... Us>
+struct TypeListCat<TypeList<Ts...>, TypeList<Us...>> {
+  using Type = TypeList<Ts..., Us...>;
+};
+
+// Partial specialization for more than 2.
+template <typename T1, typename T2, typename... T>
+struct TypeListCat<T1, T2, T...> {
+  using Type = TypeListCatT<TypeListCatT<T1, T2>, T...>;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_LIST_H

--- a/google/cloud/internal/type_list_test.cc
+++ b/google/cloud/internal/type_list_test.cc
@@ -1,0 +1,81 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/type_list.h"
+#include <gmock/gmock.h>
+#include <type_traits>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+TEST(TypeList, Basic) {
+  using A = TypeList<int>;
+  using B = TypeList<char, double>;
+  static_assert(!std::is_same<A, B>::value, "");
+}
+
+TEST(TypeList, Cat) {
+  using A = TypeList<int>;
+  using B = TypeList<char, double>;
+  using C = TypeList<int, char, double>;
+  using E = TypeList<>;  // Empty
+
+  // Empty type lists work
+  static_assert(std::is_same<E, TypeListCatT<>>::value, "");
+  static_assert(std::is_same<E, TypeListCatT<E>>::value, "");
+  static_assert(std::is_same<E, TypeListCatT<E, E>>::value, "");
+
+  // A, B, C are not empty
+  static_assert(!std::is_same<A, E>::value, "");
+  static_assert(!std::is_same<B, E>::value, "");
+  static_assert(!std::is_same<C, E>::value, "");
+
+  // A = A + E
+  static_assert(std::is_same<A, TypeListCatT<A, E>>::value, "");
+  static_assert(std::is_same<A, TypeListCatT<E, A>>::value, "");
+
+  // C = A + B
+  static_assert(std::is_same<C, TypeListCatT<A, B>>::value, "");
+  static_assert(!std::is_same<C, TypeListCatT<B, A>>::value, "");
+
+  // A + A + A
+  using AAA = TypeList<int, int, int>;
+  static_assert(std::is_same<AAA, TypeListCatT<A, A, A>>::value, "");
+
+  using ABC = TypeList<int, char, double, int, char, double>;
+  static_assert(std::is_same<ABC, TypeListCatT<A, B, C>>::value, "");
+  static_assert(std::is_same<ABC, TypeListCatT<A, B, C, E>>::value, "");
+
+  // Empty doesn't mess up concatenations
+  static_assert(std::is_same<ABC, TypeListCatT<A, B, E, C>>::value, "");
+  static_assert(std::is_same<ABC, TypeListCatT<A, E, B, C>>::value, "");
+  static_assert(std::is_same<ABC, TypeListCatT<E, A, B, C>>::value, "");
+}
+
+TEST(TypeList, Big) {
+  // Verifies that we can concatenate lots of types, which breaks with
+  // `std::tuple` on clang 3.8
+  using BigList = TypeList<int, int, int, int, int, int, int, int, int, int>;
+  using BiggerList = TypeListCatT<BigList, BigList, BigList, BigList, BigList>;
+  static_assert(!std::is_same<BigList, BiggerList>::value, "");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Also adds the ability to concatenate type lists. This makes it so we
don't need to use `std::tuple` and `std::tuple_cat` when we only care
about the types and we don't care about values. This is important
because `std::tuple_cat` breaks with large type lists on clang-3.8.

I plan to use this in `google/cloud/internal/options.h` in a following
PR to avoid breakages like this: https://source.cloud.google.com/results/invocations/f5efd65c-943c-4050-85d2-5ee41289e702/targets/cloud-cpp%2Fgithub%2Fgoogle-cloud-cpp%2Fmaster%2Fdocker%2Fclang-3.8-presubmit/log

Note: If/when we get rid of clang-3.8, we could easily replace this with
calls to `<tuple>` stuff, if we think that's simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6023)
<!-- Reviewable:end -->
