### PR TITLE
refactor(internal): create OptionList<...> implemented with TypeList

### DIFF
--- a/google/cloud/internal/common_options.h
+++ b/google/cloud/internal/common_options.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_COMMON_OPTIONS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_COMMON_OPTIONS_H
 
+#include "google/cloud/internal/options.h"
 #include "google/cloud/version.h"
 #include <set>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace google {
@@ -79,12 +79,12 @@ namespace internal {
  * @code
  * Options opts;
  * opts.set<EndpointOption>("...");
- * internal::CheckExpectedOptions<internal::CommonOptions>(
+ * internal::CheckExpectedOptions<internal::CommonOptionList>(
  *     opts, "some factory function");
  * @endcode
  */
-using CommonOptions = std::tuple<EndpointOption, UserAgentProductsOption,
-                                 TracingComponentsOption>;
+using CommonOptionList = OptionList<EndpointOption, UserAgentProductsOption,
+                                    TracingComponentsOption>;
 }  // namespace internal
 
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/common_options_test.cc
+++ b/google/cloud/internal/common_options_test.cc
@@ -39,28 +39,28 @@ void TestOption(ValueType const& expected) {
 
 }  // namespace
 
-TEST(CommonOptions, RegularOptions) {
+TEST(CommonOptionList, RegularOptions) {
   TestOption<EndpointOption>("foo.googleapis.com");
   TestOption<UserAgentProductsOption>({"foo", "bar"});
   TestOption<TracingComponentsOption>({"foo", "bar", "baz"});
 }
 
-TEST(CommonOptions, Expected) {
+TEST(CommonOptionList, Expected) {
   testing_util::ScopedLog log;
   Options opts;
   opts.set<EndpointOption>("foo.googleapis.com");
-  internal::CheckExpectedOptions<CommonOptions>(opts, "caller");
+  internal::CheckExpectedOptions<CommonOptionList>(opts, "caller");
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
-TEST(CommonOptions, Unexpected) {
+TEST(CommonOptionList, Unexpected) {
   struct UnexpectedOption {
     using Type = int;
   };
   testing_util::ScopedLog log;
   Options opts;
   opts.set<UnexpectedOption>({});
-  internal::CheckExpectedOptions<CommonOptions>(opts, "caller");
+  internal::CheckExpectedOptions<CommonOptionList>(opts, "caller");
   EXPECT_THAT(
       log.ExtractLines(),
       Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption")));

--- a/google/cloud/internal/grpc_options.h
+++ b/google/cloud/internal/grpc_options.h
@@ -22,7 +22,6 @@
 #include <grpcpp/grpcpp.h>
 #include <map>
 #include <string>
-#include <tuple>
 
 namespace google {
 namespace cloud {
@@ -104,12 +103,12 @@ std::unique_ptr<BackgroundThreads> DefaultBackgroundThreadsFactory();
  * @code
  * Options opts;
  * opts.set<GrpcCredentialOption>(...);
- * internal::CheckExpectedOptions<internal::GrpcOptions>(
+ * internal::CheckExpectedOptions<internal::GrpcOptionList>(
  *     opts, "some factory function");
  * @endcode
  */
-using GrpcOptions =
-    std::tuple<GrpcCredentialOption, GrpcNumChannelsOption,
+using GrpcOptionList =
+    OptionList<GrpcCredentialOption, GrpcNumChannelsOption,
                GrpcChannelArgumentsOption, GrpcTracingOptionsOption,
                GrpcBackgroundThreadsFactoryOption>;
 

--- a/google/cloud/internal/grpc_options_test.cc
+++ b/google/cloud/internal/grpc_options_test.cc
@@ -40,14 +40,14 @@ void TestGrpcOption(ValueType const& expected) {
 
 }  // namespace
 
-TEST(GrpcOptions, RegularOptions) {
+TEST(GrpcOptionList, RegularOptions) {
   TestGrpcOption<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
   TestGrpcOption<GrpcNumChannelsOption>(42);
   TestGrpcOption<GrpcChannelArgumentsOption>({{"foo", "bar"}, {"baz", "quux"}});
   TestGrpcOption<GrpcTracingOptionsOption>(TracingOptions{});
 }
 
-TEST(GrpcOptions, GrpcBackgroundThreadsFactoryOption) {
+TEST(GrpcOptionList, GrpcBackgroundThreadsFactoryOption) {
   struct Fake : BackgroundThreads {
     CompletionQueue cq() const override { return {}; }
   };
@@ -62,7 +62,7 @@ TEST(GrpcOptions, GrpcBackgroundThreadsFactoryOption) {
   EXPECT_TRUE(invoked);
 }
 
-TEST(GrpcOptions, DefaultBackgroundThreadsFactory) {
+TEST(GrpcOptionList, DefaultBackgroundThreadsFactory) {
   auto f = DefaultBackgroundThreadsFactory();
   auto* tp =
       dynamic_cast<internal::AutomaticallyCreatedBackgroundThreads*>(f.get());
@@ -70,22 +70,22 @@ TEST(GrpcOptions, DefaultBackgroundThreadsFactory) {
   EXPECT_EQ(1, tp->pool_size());
 }
 
-TEST(GrpcOptions, Expected) {
+TEST(GrpcOptionList, Expected) {
   testing_util::ScopedLog log;
   Options opts;
   opts.set<GrpcNumChannelsOption>(42);
-  internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
+  internal::CheckExpectedOptions<GrpcOptionList>(opts, "caller");
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
-TEST(GrpcOptions, Unexpected) {
+TEST(GrpcOptionList, Unexpected) {
   struct UnexpectedOption {
     using Type = int;
   };
   testing_util::ScopedLog log;
   Options opts;
   opts.set<UnexpectedOption>({});
-  internal::CheckExpectedOptions<GrpcOptions>(opts, "caller");
+  internal::CheckExpectedOptions<GrpcOptionList>(opts, "caller");
   EXPECT_THAT(
       log.ExtractLines(),
       Contains(ContainsRegex("caller: Unexpected option.+UnexpectedOption")));

--- a/google/cloud/internal/options_test.cc
+++ b/google/cloud/internal/options_test.cc
@@ -17,7 +17,6 @@
 #include <gmock/gmock.h>
 #include <set>
 #include <string>
-#include <tuple>
 
 namespace google {
 namespace cloud {
@@ -42,7 +41,7 @@ struct StringOption {
   using Type = std::string;
 };
 
-using TestOptionsTuple = std::tuple<IntOption, BoolOption, StringOption>;
+using TestOptionList = OptionList<IntOption, BoolOption, StringOption>;
 
 // This is how customers should set a simple options.
 TEST(OptionsUseCase, CustomerSettingSimpleOptions) {
@@ -222,7 +221,7 @@ TEST(CheckUnexpectedOptions, BasicOptionsList) {
   Options opts;
   opts.set<IntOption>({});
   opts.set<StringOption>({});
-  internal::CheckExpectedOptions<TestOptionsTuple>(opts, "caller");
+  internal::CheckExpectedOptions<TestOptionList>(opts, "caller");
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
@@ -235,7 +234,7 @@ TEST(CheckUnexpectedOptions, OptionsListPlusOne) {
   opts.set<IntOption>({});
   opts.set<StringOption>({});
   opts.set<FooOption>({});
-  internal::CheckExpectedOptions<FooOption, TestOptionsTuple>(opts, "caller");
+  internal::CheckExpectedOptions<FooOption, TestOptionList>(opts, "caller");
   EXPECT_TRUE(log.ExtractLines().empty());
 }
 
@@ -248,7 +247,7 @@ TEST(CheckUnexpectedOptions, OptionsListOneUnexpected) {
   opts.set<IntOption>({});
   opts.set<StringOption>({});
   opts.set<FooOption>({});
-  internal::CheckExpectedOptions<TestOptionsTuple>(opts, "caller");
+  internal::CheckExpectedOptions<TestOptionList>(opts, "caller");
   EXPECT_THAT(log.ExtractLines(),
               Contains(ContainsRegex("caller: Unexpected option.+FooOption")));
 }

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -337,8 +337,8 @@ std::shared_ptr<Connection> MakeConnection(
     std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   auto opts = internal::MakeOptions(connection_options);
-  internal::CheckExpectedOptions<internal::CommonOptions,
-                                 internal::GrpcOptions>(opts, __func__);
+  internal::CheckExpectedOptions<internal::CommonOptionList,
+                                 internal::GrpcOptionList>(opts, __func__);
 
   opts = internal::MergeOptions(
       std::move(opts),

--- a/google/cloud/spanner/internal/options.h
+++ b/google/cloud/spanner/internal/options.h
@@ -47,6 +47,12 @@ struct SpannerBackoffPolicyOption {
 };
 
 /**
+ * List of internal-only options.
+ */
+using SpannerInternalOptionList =
+    internal::OptionList<SpannerRetryPolicyOption, SpannerBackoffPolicyOption>;
+
+/**
  * Returns an `Options` with the appropriate defaults for Spanner.
  *
  * Environment variables and the optional @p opts argument may be consulted to

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -106,6 +106,14 @@ struct SessionPoolLabelsOption {
   using Type = std::map<std::string, std::string>;
 };
 
+/**
+ * List of all SessionPool options.
+ */
+using SessionPoolOptionList = internal::OptionList<
+    SessionPoolMinSessionsOption, SessionPoolMaxSessionsPerChannelOption,
+    SessionPoolMaxIdleSessionsOption, SessionPoolActionOnExhaustionOption,
+    SessionPoolKeepAliveIntervalOption, SessionPoolLabelsOption>;
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal
 


### PR DESCRIPTION
This PR avoids `std::tuple` in favor of our own `TypeList` for creating
lists of options. This PR also introduces a `OptionList<...>`, which is
a template alias to allow us to define lists of related options. I also
add this list to two places in Spanner that were missing.

This will fix the error in https://source.cloud.google.com/results/invocations/f5efd65c-943c-4050-85d2-5ee41289e702/targets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6024)
<!-- Reviewable:end -->
