### PR TITLE
refactor(spanner): db admin connection uses new Options

### DIFF
--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -114,6 +114,8 @@ namespace {
 
 class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
  public:
+   // Note all the policies will be set to their default non-null values in the
+   // `MakeDatabaseAdminConnection()` function below.
   explicit DatabaseAdminConnectionImpl(
       std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
       internal::Options const& opts)

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -114,8 +114,8 @@ namespace {
 
 class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
  public:
-   // Note all the policies will be set to their default non-null values in the
-   // `MakeDatabaseAdminConnection()` function below.
+  // Note all the policies will be set to their default non-null values in the
+  // `MakeDatabaseAdminConnection()` function below.
   explicit DatabaseAdminConnectionImpl(
       std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
       internal::Options const& opts)

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -15,6 +15,9 @@
 #include "google/cloud/spanner/database_admin_connection.h"
 #include "google/cloud/spanner/internal/options.h"
 #include "google/cloud/spanner/timestamp.h"
+#include "google/cloud/internal/common_options.h"
+#include "google/cloud/internal/grpc_options.h"
+#include "google/cloud/internal/options.h"
 #include "google/cloud/internal/polling_loop.h"
 #include "google/cloud/internal/retry_loop.h"
 #include <grpcpp/grpcpp.h>
@@ -109,46 +112,20 @@ ListDatabaseOperationsRange DatabaseAdminConnection::ListDatabaseOperations(
 
 namespace {
 
-std::unique_ptr<RetryPolicy> DefaultAdminRetryPolicy() {
-  return LimitedTimeRetryPolicy(std::chrono::minutes(30)).clone();
-}
-
-std::unique_ptr<BackoffPolicy> DefaultAdminBackoffPolicy() {
-  auto constexpr kBackoffScaling = 2.0;
-  return ExponentialBackoffPolicy(std::chrono::seconds(1),
-                                  std::chrono::minutes(5), kBackoffScaling)
-      .clone();
-}
-
-std::unique_ptr<PollingPolicy> DefaultAdminPollingPolicy() {
-  auto constexpr kBackoffScaling = 2.0;
-  return GenericPollingPolicy<>(
-             LimitedTimeRetryPolicy(std::chrono::minutes(30)),
-             ExponentialBackoffPolicy(std::chrono::seconds(10),
-                                      std::chrono::minutes(5), kBackoffScaling))
-      .clone();
-}
-
 class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
  public:
   explicit DatabaseAdminConnectionImpl(
       std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
-      ConnectionOptions const& options,
-      std::unique_ptr<RetryPolicy> retry_policy,
-      std::unique_ptr<BackoffPolicy> backoff_policy,
-      std::unique_ptr<PollingPolicy> polling_policy)
+      internal::Options const& opts)
       : stub_(std::move(stub)),
-        retry_policy_prototype_(std::move(retry_policy)),
-        backoff_policy_prototype_(std::move(backoff_policy)),
-        polling_policy_prototype_(std::move(polling_policy)),
-        background_threads_(options.background_threads_factory()()) {}
-
-  explicit DatabaseAdminConnectionImpl(
-      std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
-      ConnectionOptions const& options)
-      : DatabaseAdminConnectionImpl(
-            std::move(stub), options, DefaultAdminRetryPolicy(),
-            DefaultAdminBackoffPolicy(), DefaultAdminPollingPolicy()) {}
+        retry_policy_prototype_(
+            opts.get<spanner_internal::SpannerRetryPolicyOption>()->clone()),
+        backoff_policy_prototype_(
+            opts.get<spanner_internal::SpannerBackoffPolicyOption>()->clone()),
+        polling_policy_prototype_(
+            opts.get<spanner_internal::SpannerPollingPolicyOption>()->clone()),
+        background_threads_(
+            opts.get<internal::GrpcBackgroundThreadsFactoryOption>()()) {}
 
   ~DatabaseAdminConnectionImpl() override = default;
 
@@ -650,10 +627,8 @@ DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     ConnectionOptions const& options) {
-  auto opts = internal::MakeOptions(options);
-  opts = spanner_internal::DefaultOptions(opts);
   return spanner_internal::MakeDatabaseAdminConnection(
-      spanner_internal::CreateDefaultDatabaseAdminStub(opts), options);
+      internal::MakeOptions(options));
 }
 
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
@@ -661,11 +636,12 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   auto opts = internal::MakeOptions(options);
-  opts = spanner_internal::DefaultOptions(opts);
-  return spanner_internal::MakeDatabaseAdminConnection(
-      spanner_internal::CreateDefaultDatabaseAdminStub(opts), options,
-      std::move(retry_policy), std::move(backoff_policy),
+  opts.set<spanner_internal::SpannerRetryPolicyOption>(std::move(retry_policy));
+  opts.set<spanner_internal::SpannerBackoffPolicyOption>(
+      std::move(backoff_policy));
+  opts.set<spanner_internal::SpannerPollingPolicyOption>(
       std::move(polling_policy));
+  return spanner_internal::MakeDatabaseAdminConnection(std::move(opts));
 }
 
 }  // namespace SPANNER_CLIENT_NS
@@ -675,21 +651,23 @@ namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 
 std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<DatabaseAdminStub> stub,
-    spanner::ConnectionOptions const& options) {
-  return std::make_shared<spanner::DatabaseAdminConnectionImpl>(std::move(stub),
-                                                                options);
+    internal::Options opts) {
+  internal::CheckExpectedOptions<internal::CommonOptionList,
+                                 internal::GrpcOptionList,
+                                 spanner_internal::SpannerInternalOptionList>(
+      opts, __func__);
+  opts = spanner_internal::DefaultAdminOptions(std::move(opts));
+  auto stub = spanner_internal::CreateDefaultDatabaseAdminStub(opts);
+  return std::make_shared<spanner::DatabaseAdminConnectionImpl>(
+      std::move(stub), std::move(opts));
 }
 
-std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<DatabaseAdminStub> stub,
-    spanner::ConnectionOptions const& options,
-    std::unique_ptr<spanner::RetryPolicy> retry_policy,
-    std::unique_ptr<spanner::BackoffPolicy> backoff_policy,
-    std::unique_ptr<spanner::PollingPolicy> polling_policy) {
+std::shared_ptr<spanner::DatabaseAdminConnection>
+MakeDatabaseAdminConnectionForTesting(std::shared_ptr<DatabaseAdminStub> stub,
+                                      internal::Options opts) {
+  opts = spanner_internal::DefaultAdminOptions(std::move(opts));
   return std::make_shared<spanner::DatabaseAdminConnectionImpl>(
-      std::move(stub), options, std::move(retry_policy),
-      std::move(backoff_policy), std::move(polling_policy));
+      std::move(stub), std::move(opts));
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -352,16 +352,34 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
 
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
-std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<DatabaseAdminStub> stub,
-    spanner::ConnectionOptions const& options);
 
+/**
+ * Returns an DatabaseAdminConnection object that can be used for interacting
+ * with Cloud Spanner's admin APIs.
+ *
+ * The returned connection object should not be used directly, rather it should
+ * be given to a `DatabaseAdminClient` instance.
+ *
+ * The optional @p opts argument may be used to configure aspects of the
+ * returned `DatabaseAdminConnection`. Expected options are any of the
+ * following:
+ *
+ * - `google::cloud::internal::CommonOptionList`
+ * - `google::cloud::internal::GrpcOptionList`
+ *
+ * @see `DatabaseAdminConnection`
+ *
+ * @param opts (optional) configure the `DatabaseAdminConnection` created by
+ *     this function.
+ */
 std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    std::shared_ptr<DatabaseAdminStub> stub,
-    spanner::ConnectionOptions const& options,
-    std::unique_ptr<spanner::RetryPolicy> retry_policy,
-    std::unique_ptr<spanner::BackoffPolicy> backoff_policy,
-    std::unique_ptr<spanner::PollingPolicy> polling_policy);
+    internal::Options opts = {});
+
+/// Internal-only factory that allows us to inject mock stubs for testing.
+std::shared_ptr<spanner::DatabaseAdminConnection>
+MakeDatabaseAdminConnectionForTesting(std::shared_ptr<DatabaseAdminStub> stub,
+                                      internal::Options opts);
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal
 

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -101,6 +101,33 @@ internal::Options DefaultOptions(internal::Options opts) {
   return opts;
 }
 
+// Sets the options that have differnt defaults for admin connections, then
+// uses `DefaultOptions()` to set all the remaining defaults.
+internal::Options DefaultAdminOptions(internal::Options opts) {
+  if (!opts.has<spanner_internal::SpannerRetryPolicyOption>()) {
+    opts.set<spanner_internal::SpannerRetryPolicyOption>(
+        std::make_shared<google::cloud::spanner::LimitedTimeRetryPolicy>(
+            std::chrono::minutes(30)));
+  }
+  if (!opts.has<spanner_internal::SpannerBackoffPolicyOption>()) {
+    auto constexpr kBackoffScaling = 2.0;
+    opts.set<spanner_internal::SpannerBackoffPolicyOption>(
+        std::make_shared<google::cloud::spanner::ExponentialBackoffPolicy>(
+            std::chrono::seconds(1), std::chrono::minutes(5), kBackoffScaling));
+  }
+  if (!opts.has<spanner_internal::SpannerPollingPolicyOption>()) {
+    auto constexpr kBackoffScaling = 2.0;
+    opts.set<spanner_internal::SpannerPollingPolicyOption>(
+        std::make_shared<google::cloud::spanner::GenericPollingPolicy<>>(
+            google::cloud::spanner::LimitedTimeRetryPolicy(
+                std::chrono::minutes(30)),
+            google::cloud::spanner::ExponentialBackoffPolicy(
+                std::chrono::seconds(10), std::chrono::minutes(5),
+                kBackoffScaling)));
+  }
+  return DefaultOptions(std::move(opts));
+}
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal
 }  // namespace cloud

--- a/google/cloud/spanner/internal/options.cc
+++ b/google/cloud/spanner/internal/options.cc
@@ -101,7 +101,7 @@ internal::Options DefaultOptions(internal::Options opts) {
   return opts;
 }
 
-// Sets the options that have differnt defaults for admin connections, then
+// Sets the options that have different defaults for admin connections, then
 // uses `DefaultOptions()` to set all the remaining defaults.
 internal::Options DefaultAdminOptions(internal::Options opts) {
   if (!opts.has<spanner_internal::SpannerRetryPolicyOption>()) {

--- a/google/cloud/spanner/internal/options.h
+++ b/google/cloud/spanner/internal/options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_OPTIONS_H
 
 #include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/options.h"
@@ -47,10 +48,19 @@ struct SpannerBackoffPolicyOption {
 };
 
 /**
+ * *Internal-only* option for `google::cloud::internal::Options` to allow
+ * passing a `spanner::PollingPolicy`.
+ */
+struct SpannerPollingPolicyOption {
+  using Type = std::shared_ptr<spanner::PollingPolicy>;
+};
+
+/**
  * List of internal-only options.
  */
 using SpannerInternalOptionList =
-    internal::OptionList<SpannerRetryPolicyOption, SpannerBackoffPolicyOption>;
+    internal::OptionList<SpannerRetryPolicyOption, SpannerBackoffPolicyOption,
+                         SpannerPollingPolicyOption>;
 
 /**
  * Returns an `Options` with the appropriate defaults for Spanner.
@@ -66,6 +76,22 @@ using SpannerInternalOptionList =
  * along unmodified.
  */
 internal::Options DefaultOptions(internal::Options opts = {});
+
+/**
+ * Returns an `Options` with the appropriate defaults for Spanner Admin
+ * connections.
+ *
+ * Environment variables and the optional @p opts argument may be consulted to
+ * determine the correct `Options` to set. It's up to the implementation as to
+ * what overrides what. For example, it may be that a user-provided value for
+ * `EndpointOption` via @p opts takes precedence, OR it may be that an
+ * environment variable overrides that, and these rules may differ for each
+ * setting.
+ *
+ * Option values that this implementation doesn't know about will be passed
+ * along unmodified.
+ */
+internal::Options DefaultAdminOptions(internal::Options opts = {});
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal


### PR DESCRIPTION
This PR changes adds a `MakeDatabaseAdminConnection` overload (currently
in `spanner_internal`) that accepts the new `Options`. This is the
overload that _will be_ the recommended user-facing factory once
`Options` become public. All other factories forward to this one (except
for the one overload that exists only for testing.)

This PR also adds `spanner_internal::DefaultAdminOptions`, which will create
the correct defaults for Spanner's admin operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6026)
<!-- Reviewable:end -->
