### PR TITLE
refactor(spanner): instance admin uses new Options

### DIFF
--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -237,16 +237,34 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
-std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<InstanceAdminStub> base_stub,
-    spanner::ConnectionOptions const& options);
 
+/**
+ * Returns an InstanceAdminConnection object that can be used for interacting
+ * with Cloud Spanner's admin APIs.
+ *
+ * The returned connection object should not be used directly, rather it should
+ * be given to a `InstanceAdminClient` instance.
+ *
+ * The optional @p opts argument may be used to configure aspects of the
+ * returned `InstanceAdminConnection`. Expected options are any of the
+ * following:
+ *
+ * - `google::cloud::internal::CommonOptionList`
+ * - `google::cloud::internal::GrpcOptionList`
+ *
+ * @see `InstanceAdminConnection`
+ *
+ * @param opts (optional) configure the `InstanceAdminConnection` created by
+ *     this function.
+ */
 std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
-    std::shared_ptr<InstanceAdminStub> base_stub,
-    spanner::ConnectionOptions const& options,
-    std::unique_ptr<spanner::RetryPolicy> retry_policy,
-    std::unique_ptr<spanner::BackoffPolicy> backoff_policy,
-    std::unique_ptr<spanner::PollingPolicy> polling_policy);
+    internal::Options opts = {});
+
+/// Internal-only factory that allows us to inject mock stubs for testing.
+std::shared_ptr<spanner::InstanceAdminConnection>
+MakeInstanceAdminConnectionForTesting(
+    std::shared_ptr<InstanceAdminStub> base_stub, internal::Options opts);
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_internal
 


### PR DESCRIPTION
This PR defines an `MakeInstanceAdminConnection` that accepts the new
`Options` (within `spanner_internal`), and this will be the preferred
factory as soon as Options is public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6027)
<!-- Reviewable:end -->
