### PR TITLE
refactor(spanner): DefaultAdminOptions don't need SessionPool options

### DIFF
--- a/google/cloud/spanner/internal/options_test.cc
+++ b/google/cloud/spanner/internal/options_test.cc
@@ -80,20 +80,20 @@ TEST(Options, AdminDefaults) {
   EXPECT_THAT(opts.get<internal::UserAgentProductsOption>(),
               ElementsAre(gcloud_user_agent_matcher()));
 
-  EXPECT_EQ(0, opts.get<spanner_internal::SessionPoolMinSessionsOption>());
-  EXPECT_EQ(
-      100,
-      opts.get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
-  EXPECT_EQ(0, opts.get<spanner_internal::SessionPoolMaxIdleSessionsOption>());
-  EXPECT_EQ(ActionOnExhaustion::kBlock,
-            opts.get<spanner_internal::SessionPoolActionOnExhaustionOption>());
-  EXPECT_EQ(std::chrono::minutes(55),
-            opts.get<spanner_internal::SessionPoolKeepAliveIntervalOption>());
-
   EXPECT_TRUE(opts.has<spanner_internal::SpannerRetryPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SpannerBackoffPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SpannerPollingPolicyOption>());
-  EXPECT_TRUE(opts.has<spanner_internal::SessionPoolClockOption>());
+
+  // Admin connections don't use a session pool, so these should not be set.
+  EXPECT_FALSE(opts.has<spanner_internal::SessionPoolMinSessionsOption>());
+  EXPECT_FALSE(
+      opts.has<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_FALSE(opts.has<spanner_internal::SessionPoolMaxIdleSessionsOption>());
+  EXPECT_FALSE(
+      opts.has<spanner_internal::SessionPoolActionOnExhaustionOption>());
+  EXPECT_FALSE(
+      opts.has<spanner_internal::SessionPoolKeepAliveIntervalOption>());
+  EXPECT_FALSE(opts.has<spanner_internal::SessionPoolClockOption>());
 }
 
 TEST(Options, EndpointFromEnv) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6035)
<!-- Reviewable:end -->
