### PR TITLE
cleanup(spanner): remove some TODOs

### DIFF
--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -25,11 +25,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 std::string ConnectionOptionsTraits::default_endpoint() {
-  // TODO(5738): cache the default endpoint in a function-local static after we
-  // add support for users using the new `Options` class. We don't want to
-  // cache the value currently because users might expect that changing the env
-  // var between calls to `MakeConnection()` actually changes the endpoint, and
-  // we want to give them an alternative way to accomplish that.
   return spanner_internal::DefaultOptions().get<internal::EndpointOption>();
 }
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -70,22 +70,6 @@ class DefaultPartialResultSetReader : public PartialResultSetReader {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-// TODO(#5738): Delete this function once `google::cloud::internal::Options`
-// are directly used in this class.
-std::unique_ptr<spanner::RetryPolicy> DefaultConnectionRetryPolicy() {
-  return spanner_internal::DefaultOptions()
-      .get<spanner_internal::SpannerRetryPolicyOption>()
-      ->clone();
-}
-
-// TODO(#5738): Delete this function once `google::cloud::internal::Options`
-// are directly used in this class.
-std::unique_ptr<spanner::BackoffPolicy> DefaultConnectionBackoffPolicy() {
-  return spanner_internal::DefaultOptions()
-      .get<spanner_internal::SpannerBackoffPolicyOption>()
-      ->clone();
-}
-
 spanner_proto::TransactionOptions PartitionedDmlTransactionOptions() {
   spanner_proto::TransactionOptions options;
   *options.mutable_partitioned_dml() =

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -39,12 +39,6 @@ namespace cloud {
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 
-/// Return the default retry policy for `ConnectionImpl`
-std::unique_ptr<spanner::RetryPolicy> DefaultConnectionRetryPolicy();
-
-/// Return the default backoff policy for `ConnectionImpl`
-std::unique_ptr<spanner::BackoffPolicy> DefaultConnectionBackoffPolicy();
-
 /**
  * A concrete `Connection` subclass that uses gRPC to actually talk to a real
  * Spanner instance.


### PR DESCRIPTION
Cleans up some TODOs related to
https://github.com/googleapis/google-cloud-cpp/issues/5738.

Some of the TODOs are able to be completed now.

The TODO in connection_option.cc was not done, but I decided that it
doesn't actually need to be done. Caching the endpoint in a
function-local static is purely a performance optimization, which we
could do at any point if it's an _actual_ performance issue in practice.
Until then, it's safest to preserve backward compatible semantics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6043)
<!-- Reviewable:end -->
