### PR TITLE
common: fix ambiguous match bazel error on macos 11 intel

### DIFF
--- a/google/cloud/testing_util/BUILD
+++ b/google/cloud/testing_util/BUILD
@@ -56,7 +56,7 @@ cc_library(
             "GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD",
         ],
         (
-            "@bazel_tools//src/conditions:darwin_x86_64",
+            "@bazel_tools//src/conditions:darwin",
             "@bazel_tools//src/conditions:freebsd",
             "@bazel_tools//src/conditions:openbsd",
         ): [

--- a/google/cloud/testing_util/BUILD
+++ b/google/cloud/testing_util/BUILD
@@ -57,7 +57,6 @@ cc_library(
         ],
         (
             "@bazel_tools//src/conditions:darwin_x86_64",
-            "@bazel_tools//src/conditions:darwin",
             "@bazel_tools//src/conditions:freebsd",
             "@bazel_tools//src/conditions:openbsd",
         ): [


### PR DESCRIPTION
On macos 11 intel, we will have the following compilation problem:
```
ERROR: Analysis of target '//google/cloud/pubsub/samples:samples' failed; build aborted: /Users/vovannghia/programming/google-cloud-cpp/google/cloud/testing_util/BUILD:43:11: Illegal ambiguous match on configurable attribute "defines" in //google/cloud/testing_util:google_cloud_cpp_testing:
@bazel_tools//src/conditions:darwin_x86_64
@bazel_tools//src/conditions:darwin
```
This PR removes `@bazel_tools//src/conditions:darwin` configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6044)
<!-- Reviewable:end -->
