### PR TITLE
feat(spanner): connection factories now prefer `Options`

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -341,9 +341,8 @@ std::shared_ptr<Connection> MakeConnection(
   auto opts = internal::MergeOptions(
       internal::MakeOptions(connection_options),
       spanner_internal::MakeOptions(std::move(session_pool_options)));
-  opts.set<spanner_internal::SpannerRetryPolicyOption>(retry_policy->clone());
-  opts.set<spanner_internal::SpannerBackoffPolicyOption>(
-      backoff_policy->clone());
+  opts.set<SpannerRetryPolicyOption>(retry_policy->clone());
+  opts.set<SpannerBackoffPolicyOption>(backoff_policy->clone());
   return spanner_internal::MakeConnection(db, std::move(opts));
 }
 
@@ -356,9 +355,9 @@ inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 spanner_internal::SessionPoolOptionList,
-                                 spanner_internal::SpannerPolicyOptionList>(
-      opts, __func__);
+                                 spanner::SessionPoolOptionList,
+                                 spanner::SpannerPolicyOptionList>(opts,
+                                                                   __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
   int num_channels = opts.get<GrpcNumChannelsOption>();

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -324,40 +324,11 @@ QueryOptions Client::OverlayQueryOptions(QueryOptions const& preferred) {
   return opts;
 }
 
-std::shared_ptr<Connection> MakeConnection(
-    Database const& db, ConnectionOptions const& connection_options,
-    SessionPoolOptions session_pool_options) {
-  auto opts = internal::MergeOptions(
-      internal::MakeOptions(connection_options),
-      spanner_internal::MakeOptions(std::move(session_pool_options)));
-  return spanner_internal::MakeConnection(db, std::move(opts));
-}
-
-std::shared_ptr<Connection> MakeConnection(
-    Database const& db, ConnectionOptions const& connection_options,
-    SessionPoolOptions session_pool_options,
-    std::unique_ptr<RetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy) {
-  auto opts = internal::MergeOptions(
-      internal::MakeOptions(connection_options),
-      spanner_internal::MakeOptions(std::move(session_pool_options)));
-  opts.set<SpannerRetryPolicyOption>(retry_policy->clone());
-  opts.set<SpannerBackoffPolicyOption>(backoff_policy->clone());
-  return spanner_internal::MakeConnection(db, std::move(opts));
-}
-
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner
-
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 spanner::SessionPoolOptionList,
-                                 spanner::SpannerPolicyOptionList>(opts,
-                                                                   __func__);
+                                 SessionPoolOptionList,
+                                 SpannerPolicyOptionList>(opts, __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));
   std::vector<std::shared_ptr<spanner_internal::SpannerStub>> stubs;
   int num_channels = opts.get<GrpcNumChannelsOption>();
@@ -370,7 +341,29 @@ std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
       std::move(db), std::move(stubs), opts);
 }
 
+std::shared_ptr<Connection> MakeConnection(
+    Database const& db, ConnectionOptions const& connection_options,
+    SessionPoolOptions session_pool_options) {
+  auto opts = internal::MergeOptions(
+      internal::MakeOptions(connection_options),
+      spanner_internal::MakeOptions(std::move(session_pool_options)));
+  return MakeConnection(db, std::move(opts));
+}
+
+std::shared_ptr<Connection> MakeConnection(
+    Database const& db, ConnectionOptions const& connection_options,
+    SessionPoolOptions session_pool_options,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy) {
+  auto opts = internal::MergeOptions(
+      internal::MakeOptions(connection_options),
+      spanner_internal::MakeOptions(std::move(session_pool_options)));
+  opts.set<SpannerRetryPolicyOption>(retry_policy->clone());
+  opts.set<SpannerBackoffPolicyOption>(backoff_policy->clone());
+  return MakeConnection(db, std::move(opts));
+}
+
 }  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
+}  // namespace spanner
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -640,49 +640,6 @@ class Client {
 /**
  * Returns a Connection object that can be used for interacting with Spanner.
  *
- * The returned connection object should not be used directly, rather it should
- * be given to a `Client` instance, and methods should be invoked on `Client`.
- *
- * @see `Connection`
- *
- * @param db See `Database`.
- * @param connection_options (optional) configure the `Connection` created by
- *     this function.
- * @param session_pool_options (optional) configure the `SessionPool` created
- *     by the `Connection`.
- */
-std::shared_ptr<Connection> MakeConnection(
-    Database const& db,
-    ConnectionOptions const& connection_options = ConnectionOptions(),
-    SessionPoolOptions session_pool_options = SessionPoolOptions());
-
-/**
- * @copydoc MakeConnection(Database const&, ConnectionOptions const&, SessionPoolOptions)
- *
- * @param retry_policy override the default `RetryPolicy`, controls how long
- *     the returned `Connection` object retries requests on transient
- *     failures.
- * @param backoff_policy override the default `BackoffPolicy`, controls how
- *     long the `Connection` object waits before retrying a failed request.
- *
- * @par Example
- * @snippet samples.cc custom-retry-policy
- */
-std::shared_ptr<Connection> MakeConnection(
-    Database const& db, ConnectionOptions const& connection_options,
-    SessionPoolOptions session_pool_options,
-    std::unique_ptr<RetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy);
-
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner
-
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-
-/**
- * Returns a Connection object that can be used for interacting with Spanner.
- *
  * The returned connection object should not be used directly; instead it
  * should be given to a `Client` instance, and methods should be invoked on
  * `Client`.
@@ -709,8 +666,50 @@ inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     Options opts = {});
 
+/**
+ * Returns a Connection object that can be used for interacting with Spanner.
+ *
+ * The returned connection object should not be used directly, rather it should
+ * be given to a `Client` instance, and methods should be invoked on `Client`.
+ *
+ * @note Prefer using the `MakeConnection()` overload that accepts
+ *     `google::cloud::Options`.
+ *
+ * @see `Connection`
+ *
+ * @param db See `Database`.
+ * @param connection_options (optional) configure the `Connection` created by
+ *     this function.
+ * @param session_pool_options (optional) configure the `SessionPool` created
+ *     by the `Connection`.
+ */
+std::shared_ptr<Connection> MakeConnection(
+    Database const& db, ConnectionOptions const& connection_options,
+    SessionPoolOptions session_pool_options = SessionPoolOptions());
+
+/**
+ * @copydoc MakeConnection(Database const&, ConnectionOptions const&, SessionPoolOptions)
+ *
+ * @note Prefer using the `MakeConnection()` overload that accepts
+ *     `google::cloud::Options`.
+ *
+ * @param retry_policy override the default `RetryPolicy`, controls how long
+ *     the returned `Connection` object retries requests on transient
+ *     failures.
+ * @param backoff_policy override the default `BackoffPolicy`, controls how
+ *     long the `Connection` object waits before retrying a failed request.
+ *
+ * @par Example
+ * @snippet samples.cc custom-retry-policy
+ */
+std::shared_ptr<Connection> MakeConnection(
+    Database const& db, ConnectionOptions const& connection_options,
+    SessionPoolOptions session_pool_options,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy);
+
 }  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
+}  // namespace spanner
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -693,7 +693,8 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
- * - `google::cloud::spanner_internal::SessionPoolOptionList`
+ * - `google::cloud::spanner::SpannerPolicyOptionList`
+ * - `google::cloud::spanner::SessionPoolOptionList`
  *
  * @note Unrecognized options will be ignored. To debug issues with options set
  *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -391,10 +391,10 @@ TEST(ClientTest, MakeConnectionOptionalArguments) {
   conn = MakeConnection(db, ConnectionOptions(), SessionPoolOptions());
   EXPECT_NE(conn, nullptr);
 
-  conn = spanner_internal::MakeConnection(db);
+  conn = MakeConnection(db);
   EXPECT_NE(conn, nullptr);
 
-  conn = spanner_internal::MakeConnection(db, Options{});
+  conn = MakeConnection(db, Options{});
   EXPECT_NE(conn, nullptr);
 }
 

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -121,12 +121,11 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       std::shared_ptr<spanner_internal::DatabaseAdminStub> stub,
       Options const& opts)
       : stub_(std::move(stub)),
-        retry_policy_prototype_(
-            opts.get<spanner_internal::SpannerRetryPolicyOption>()->clone()),
+        retry_policy_prototype_(opts.get<SpannerRetryPolicyOption>()->clone()),
         backoff_policy_prototype_(
-            opts.get<spanner_internal::SpannerBackoffPolicyOption>()->clone()),
+            opts.get<SpannerBackoffPolicyOption>()->clone()),
         polling_policy_prototype_(
-            opts.get<spanner_internal::SpannerPollingPolicyOption>()->clone()),
+            opts.get<SpannerPollingPolicyOption>()->clone()),
         background_threads_(opts.get<GrpcBackgroundThreadsFactoryOption>()()) {}
 
   ~DatabaseAdminConnectionImpl() override = default;
@@ -638,11 +637,9 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   auto opts = internal::MakeOptions(options);
-  opts.set<spanner_internal::SpannerRetryPolicyOption>(std::move(retry_policy));
-  opts.set<spanner_internal::SpannerBackoffPolicyOption>(
-      std::move(backoff_policy));
-  opts.set<spanner_internal::SpannerPollingPolicyOption>(
-      std::move(polling_policy));
+  opts.set<SpannerRetryPolicyOption>(std::move(retry_policy));
+  opts.set<SpannerBackoffPolicyOption>(std::move(backoff_policy));
+  opts.set<SpannerPollingPolicyOption>(std::move(polling_policy));
   return spanner_internal::MakeDatabaseAdminConnection(std::move(opts));
 }
 
@@ -655,8 +652,8 @@ inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 spanner_internal::SpannerPolicyOptionList>(
-      opts, __func__);
+                                 spanner::SpannerPolicyOptionList>(opts,
+                                                                   __func__);
   opts = spanner_internal::DefaultAdminOptions(std::move(opts));
   auto stub = spanner_internal::CreateDefaultDatabaseAdminStub(opts);
   return std::make_shared<spanner::DatabaseAdminConnectionImpl>(

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -626,29 +626,6 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
 DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 
-std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    ConnectionOptions const& options) {
-  return spanner_internal::MakeDatabaseAdminConnection(
-      internal::MakeOptions(options));
-}
-
-std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy,
-    std::unique_ptr<PollingPolicy> polling_policy) {
-  auto opts = internal::MakeOptions(options);
-  opts.set<SpannerRetryPolicyOption>(std::move(retry_policy));
-  opts.set<SpannerBackoffPolicyOption>(std::move(backoff_policy));
-  opts.set<SpannerPollingPolicyOption>(std::move(polling_policy));
-  return spanner_internal::MakeDatabaseAdminConnection(std::move(opts));
-}
-
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner
-
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
-
 std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
@@ -659,6 +636,28 @@ std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
   return std::make_shared<spanner::DatabaseAdminConnectionImpl>(
       std::move(stub), std::move(opts));
 }
+
+std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    ConnectionOptions const& options) {
+  return MakeDatabaseAdminConnection(internal::MakeOptions(options));
+}
+
+std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<PollingPolicy> polling_policy) {
+  auto opts = internal::MakeOptions(options);
+  opts.set<SpannerRetryPolicyOption>(std::move(retry_policy));
+  opts.set<SpannerBackoffPolicyOption>(std::move(backoff_policy));
+  opts.set<SpannerPollingPolicyOption>(std::move(polling_policy));
+  return MakeDatabaseAdminConnection(std::move(opts));
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+
+namespace spanner_internal {
+inline namespace SPANNER_CLIENT_NS {
 
 std::shared_ptr<spanner::DatabaseAdminConnection>
 MakeDatabaseAdminConnectionForTesting(std::shared_ptr<DatabaseAdminStub> stub,

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -629,8 +629,7 @@ DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 spanner::SpannerPolicyOptionList>(opts,
-                                                                   __func__);
+                                 SpannerPolicyOptionList>(opts, __func__);
   opts = spanner_internal::DefaultAdminOptions(std::move(opts));
   auto stub = spanner_internal::CreateDefaultDatabaseAdminStub(opts);
   return std::make_shared<spanner::DatabaseAdminConnectionImpl>(

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -318,8 +318,33 @@ class DatabaseAdminConnection {
  * Returns an DatabaseAdminConnection object that can be used for interacting
  * with Cloud Spanner's admin APIs.
  *
+ * The returned connection object should not be used directly; instead it
+ * should be given to a `DatabaseAdminClient` instance.
+ *
+ * The optional @p opts argument may be used to configure aspects of the
+ * returned `DatabaseAdminConnection`. Expected options are any of types in the
+ * following option lists.
+ *
+ * - `google::cloud::CommonOptionList`
+ * - `google::cloud::GrpcOptionList`
+ *
+ * @see `DatabaseAdminConnection`
+ *
+ * @param opts (optional) configure the `DatabaseAdminConnection` created by
+ *     this function.
+ */
+std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
+    Options opts = {});
+
+/**
+ * Returns an DatabaseAdminConnection object that can be used for interacting
+ * with Cloud Spanner's admin APIs.
+ *
  * The returned connection object should not be used directly, rather it should
  * be given to a `DatabaseAdminClient` instance.
+ *
+ * @note Prefer using the `MakeDatabaseAdminConnection()` overload that accepts
+ *     `google::cloud::Options`.
  *
  * @see `DatabaseAdminConnection`
  *
@@ -327,10 +352,13 @@ class DatabaseAdminConnection {
  *     this function.
  */
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    ConnectionOptions const& options = ConnectionOptions());
+    ConnectionOptions const& options);
 
 /**
  * @copydoc MakeDatabaseAdminConnection
+ *
+ * @note Prefer using the `MakeDatabaseAdminConnection()` overload that accepts
+ *     `google::cloud::Options`.
  *
  * @param retry_policy control for how long (or how many times) are retryable
  *     RPCs attempted
@@ -352,28 +380,6 @@ std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
 
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
-
-/**
- * Returns an DatabaseAdminConnection object that can be used for interacting
- * with Cloud Spanner's admin APIs.
- *
- * The returned connection object should not be used directly; instead it
- * should be given to a `DatabaseAdminClient` instance.
- *
- * The optional @p opts argument may be used to configure aspects of the
- * returned `DatabaseAdminConnection`. Expected options are any of types in the
- * following option lists.
- *
- * - `google::cloud::CommonOptionList`
- * - `google::cloud::GrpcOptionList`
- *
- * @see `DatabaseAdminConnection`
- *
- * @param opts (optional) configure the `DatabaseAdminConnection` created by
- *     this function.
- */
-std::shared_ptr<spanner::DatabaseAdminConnection> MakeDatabaseAdminConnection(
-    Options opts = {});
 
 /// Internal-only factory that allows us to inject mock stubs for testing.
 std::shared_ptr<spanner::DatabaseAdminConnection>

--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -327,6 +327,7 @@ class DatabaseAdminConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::SpannerPolicyOptionList`
  *
  * @see `DatabaseAdminConnection`
  *

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -52,9 +52,9 @@ std::shared_ptr<DatabaseAdminConnection> CreateTestingConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   Options opts;
-  opts.set<spanner_internal::SpannerRetryPolicyOption>(retry.clone());
-  opts.set<spanner_internal::SpannerBackoffPolicyOption>(backoff.clone());
-  opts.set<spanner_internal::SpannerPollingPolicyOption>(polling.clone());
+  opts.set<SpannerRetryPolicyOption>(retry.clone());
+  opts.set<SpannerBackoffPolicyOption>(backoff.clone());
+  opts.set<SpannerPollingPolicyOption>(polling.clone());
   return spanner_internal::MakeDatabaseAdminConnectionForTesting(
       std::move(mock), std::move(opts));
 }

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -38,12 +38,11 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
       std::shared_ptr<spanner_internal::InstanceAdminStub> stub,
       Options const& opts)
       : stub_(std::move(stub)),
-        retry_policy_prototype_(
-            opts.get<spanner_internal::SpannerRetryPolicyOption>()->clone()),
+        retry_policy_prototype_(opts.get<SpannerRetryPolicyOption>()->clone()),
         backoff_policy_prototype_(
-            opts.get<spanner_internal::SpannerBackoffPolicyOption>()->clone()),
+            opts.get<SpannerBackoffPolicyOption>()->clone()),
         polling_policy_prototype_(
-            opts.get<spanner_internal::SpannerPollingPolicyOption>()->clone()),
+            opts.get<SpannerPollingPolicyOption>()->clone()),
         background_threads_(opts.get<GrpcBackgroundThreadsFactoryOption>()()) {}
 
   ~InstanceAdminConnectionImpl() override = default;
@@ -300,11 +299,9 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::unique_ptr<PollingPolicy> polling_policy) {
   auto opts = internal::MakeOptions(options);
-  opts.set<spanner_internal::SpannerRetryPolicyOption>(std::move(retry_policy));
-  opts.set<spanner_internal::SpannerBackoffPolicyOption>(
-      std::move(backoff_policy));
-  opts.set<spanner_internal::SpannerPollingPolicyOption>(
-      std::move(polling_policy));
+  opts.set<SpannerRetryPolicyOption>(std::move(retry_policy));
+  opts.set<SpannerBackoffPolicyOption>(std::move(backoff_policy));
+  opts.set<SpannerPollingPolicyOption>(std::move(polling_policy));
   return spanner_internal::MakeInstanceAdminConnection(std::move(opts));
 }
 
@@ -317,8 +314,8 @@ inline namespace SPANNER_CLIENT_NS {
 std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 spanner_internal::SpannerPolicyOptionList>(
-      opts, __func__);
+                                 spanner::SpannerPolicyOptionList>(opts,
+                                                                   __func__);
   opts = spanner_internal::DefaultAdminOptions(std::move(opts));
   auto stub = spanner_internal::CreateDefaultInstanceAdminStub(opts);
   return std::make_shared<spanner::InstanceAdminConnectionImpl>(

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -288,10 +288,19 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
 InstanceAdminConnection::~InstanceAdminConnection() = default;
 
+std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
+    Options opts) {
+  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 SpannerPolicyOptionList>(opts, __func__);
+  opts = spanner_internal::DefaultAdminOptions(std::move(opts));
+  auto stub = spanner_internal::CreateDefaultInstanceAdminStub(opts);
+  return std::make_shared<spanner::InstanceAdminConnectionImpl>(
+      std::move(stub), std::move(opts));
+}
+
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     ConnectionOptions const& options) {
-  return spanner_internal::MakeInstanceAdminConnection(
-      internal::MakeOptions(options));
+  return MakeInstanceAdminConnection(internal::MakeOptions(options));
 }
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
@@ -302,7 +311,7 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
   opts.set<SpannerRetryPolicyOption>(std::move(retry_policy));
   opts.set<SpannerBackoffPolicyOption>(std::move(backoff_policy));
   opts.set<SpannerPollingPolicyOption>(std::move(polling_policy));
-  return spanner_internal::MakeInstanceAdminConnection(std::move(opts));
+  return MakeInstanceAdminConnection(std::move(opts));
 }
 
 }  // namespace SPANNER_CLIENT_NS
@@ -310,17 +319,6 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
-
-std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
-    Options opts) {
-  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 spanner::SpannerPolicyOptionList>(opts,
-                                                                   __func__);
-  opts = spanner_internal::DefaultAdminOptions(std::move(opts));
-  auto stub = spanner_internal::CreateDefaultInstanceAdminStub(opts);
-  return std::make_shared<spanner::InstanceAdminConnectionImpl>(
-      std::move(stub), std::move(opts));
-}
 
 std::shared_ptr<spanner::InstanceAdminConnection>
 MakeInstanceAdminConnectionForTesting(std::shared_ptr<InstanceAdminStub> stub,

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -203,8 +203,34 @@ class InstanceAdminConnection {
  * Returns an InstanceAdminConnection object that can be used for interacting
  * with Cloud Spanner's admin APIs.
  *
+ * The returned connection object should not be used directly; instead it
+ * should be given to a `InstanceAdminClient` instance.
+ *
+ * The optional @p opts argument may be used to configure aspects of the
+ * returned `InstanceAdminConnection`. Expected options are any of the types in
+ * the following option lists.
+ *
+ * - `google::cloud::CommonOptionList`
+ * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::SpannerPolicyOptionList`
+ *
+ * @see `InstanceAdminConnection`
+ *
+ * @param opts (optional) configure the `InstanceAdminConnection` created by
+ *     this function.
+ */
+std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
+    Options opts = {});
+
+/**
+ * Returns an InstanceAdminConnection object that can be used for interacting
+ * with Cloud Spanner's admin APIs.
+ *
  * The returned connection object should not be used directly, rather it should
  * be given to a `InstanceAdminClient` instance.
+ *
+ * @note Prefer using the `MakeInstanceAdminConnection()` overload that accepts
+ *     `google::cloud::Options`.
  *
  * @see `InstanceAdminConnection`
  *
@@ -212,10 +238,13 @@ class InstanceAdminConnection {
  *     this function.
  */
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
-    ConnectionOptions const& options = ConnectionOptions());
+    ConnectionOptions const& options);
 
 /**
  * @copydoc MakeInstanceAdminConnection
+ *
+ * @note Prefer using the `MakeInstanceAdminConnection()` overload that accepts
+ *     `google::cloud::Options`.
  *
  * @param retry_policy control for how long (or how many times) are retryable
  *     RPCs attempted
@@ -237,28 +266,6 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 
 namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
-
-/**
- * Returns an InstanceAdminConnection object that can be used for interacting
- * with Cloud Spanner's admin APIs.
- *
- * The returned connection object should not be used directly; instead it
- * should be given to a `InstanceAdminClient` instance.
- *
- * The optional @p opts argument may be used to configure aspects of the
- * returned `InstanceAdminConnection`. Expected options are any of the types in
- * the following option lists.
- *
- * - `google::cloud::CommonOptionList`
- * - `google::cloud::GrpcOptionList`
- *
- * @see `InstanceAdminConnection`
- *
- * @param opts (optional) configure the `InstanceAdminConnection` created by
- *     this function.
- */
-std::shared_ptr<spanner::InstanceAdminConnection> MakeInstanceAdminConnection(
-    Options opts = {});
 
 /// Internal-only factory that allows us to inject mock stubs for testing.
 std::shared_ptr<spanner::InstanceAdminConnection>

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -53,9 +53,9 @@ std::shared_ptr<InstanceAdminConnection> MakeLimitedRetryConnection(
       /*scaling=*/2.0);
   GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   Options opts;
-  opts.set<spanner_internal::SpannerRetryPolicyOption>(retry.clone());
-  opts.set<spanner_internal::SpannerBackoffPolicyOption>(backoff.clone());
-  opts.set<spanner_internal::SpannerPollingPolicyOption>(polling.clone());
+  opts.set<SpannerRetryPolicyOption>(retry.clone());
+  opts.set<SpannerBackoffPolicyOption>(backoff.clone());
+  opts.set<SpannerPollingPolicyOption>(polling.clone());
   return spanner_internal::MakeInstanceAdminConnectionForTesting(
       std::move(mock), std::move(opts));
 }

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -59,10 +59,10 @@ TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   std::thread t([&cq] { cq.Run(); });
   auto const db = GetDatabase();
   auto opts = spanner_internal::DefaultOptions();
-  opts.set<SpannerRetryPolicyOption>(
+  opts.set<spanner::SpannerRetryPolicyOption>(
       std::make_shared<spanner::LimitedTimeRetryPolicy>(
           std::chrono::minutes(5)));
-  opts.set<SpannerBackoffPolicyOption>(
+  opts.set<spanner::SpannerBackoffPolicyOption>(
       std::make_shared<spanner::ExponentialBackoffPolicy>(
           std::chrono::seconds(10), std::chrono::minutes(1), 2.0));
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -90,9 +90,10 @@ ConnectionImpl::ConnectionImpl(spanner::Database db,
                                std::vector<std::shared_ptr<SpannerStub>> stubs,
                                Options const& opts)
     : db_(std::move(db)),
-      retry_policy_prototype_(opts.get<SpannerRetryPolicyOption>()->clone()),
+      retry_policy_prototype_(
+          opts.get<spanner::SpannerRetryPolicyOption>()->clone()),
       backoff_policy_prototype_(
-          opts.get<SpannerBackoffPolicyOption>()->clone()),
+          opts.get<spanner::SpannerBackoffPolicyOption>()->clone()),
       background_threads_(opts.get<GrpcBackgroundThreadsFactoryOption>()()),
       session_pool_(MakeSessionPool(db_, std::move(stubs),
                                     background_threads_->cq(), opts)),

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -205,10 +205,10 @@ std::shared_ptr<spanner::Connection> MakeLimitedRetryConnection(
     spanner::Database const& db,
     std::shared_ptr<spanner_testing::MockSpannerStub> mock) {
   Options opts;
-  opts.set<SpannerRetryPolicyOption>(
+  opts.set<spanner::SpannerRetryPolicyOption>(
       std::make_shared<spanner::LimitedErrorCountRetryPolicy>(
           /*maximum_failures=*/2));
-  opts.set<SpannerBackoffPolicyOption>(
+  opts.set<spanner::SpannerBackoffPolicyOption>(
       std::make_shared<spanner::ExponentialBackoffPolicy>(
           /*initial_delay=*/std::chrono::microseconds(1),
           /*maximum_delay=*/std::chrono::microseconds(1),

--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -61,43 +61,41 @@ void SetBasicDefaults(Options& opts) {
 Options DefaultOptions(Options opts) {
   SetBasicDefaults(opts);
 
-  if (!opts.has<spanner_internal::SpannerRetryPolicyOption>()) {
-    opts.set<spanner_internal::SpannerRetryPolicyOption>(
+  if (!opts.has<spanner::SpannerRetryPolicyOption>()) {
+    opts.set<spanner::SpannerRetryPolicyOption>(
         std::make_shared<google::cloud::spanner::LimitedTimeRetryPolicy>(
             std::chrono::minutes(10)));
   }
-  if (!opts.has<spanner_internal::SpannerBackoffPolicyOption>()) {
+  if (!opts.has<spanner::SpannerBackoffPolicyOption>()) {
     auto constexpr kBackoffScaling = 2.0;
-    opts.set<spanner_internal::SpannerBackoffPolicyOption>(
+    opts.set<spanner::SpannerBackoffPolicyOption>(
         std::make_shared<google::cloud::spanner::ExponentialBackoffPolicy>(
             std::chrono::milliseconds(100), std::chrono::minutes(1),
             kBackoffScaling));
   }
 
   // Sets Spanner-specific options from session_pool_options.h
-  if (!opts.has<spanner_internal::SessionPoolMaxSessionsPerChannelOption>()) {
-    opts.set<spanner_internal::SessionPoolMaxSessionsPerChannelOption>(100);
+  if (!opts.has<spanner::SessionPoolMaxSessionsPerChannelOption>()) {
+    opts.set<spanner::SessionPoolMaxSessionsPerChannelOption>(100);
   }
-  if (!opts.has<spanner_internal::SessionPoolActionOnExhaustionOption>()) {
-    opts.set<spanner_internal::SessionPoolActionOnExhaustionOption>(
+  if (!opts.has<spanner::SessionPoolActionOnExhaustionOption>()) {
+    opts.set<spanner::SessionPoolActionOnExhaustionOption>(
         spanner::ActionOnExhaustion::kBlock);
   }
-  if (!opts.has<spanner_internal::SessionPoolKeepAliveIntervalOption>()) {
-    opts.set<spanner_internal::SessionPoolKeepAliveIntervalOption>(
+  if (!opts.has<spanner::SessionPoolKeepAliveIntervalOption>()) {
+    opts.set<spanner::SessionPoolKeepAliveIntervalOption>(
         std::chrono::minutes(55));
   }
   if (!opts.has<SessionPoolClockOption>()) {
     opts.set<SessionPoolClockOption>(std::make_shared<Session::Clock>());
   }
   // Enforces some SessionPool constraints.
-  auto& max_idle =
-      opts.lookup<spanner_internal::SessionPoolMaxIdleSessionsOption>();
+  auto& max_idle = opts.lookup<spanner::SessionPoolMaxIdleSessionsOption>();
   max_idle = (std::max)(max_idle, 0);
   auto& max_sessions_per_channel =
-      opts.lookup<spanner_internal::SessionPoolMaxSessionsPerChannelOption>();
+      opts.lookup<spanner::SessionPoolMaxSessionsPerChannelOption>();
   max_sessions_per_channel = (std::max)(max_sessions_per_channel, 1);
-  auto& min_sessions =
-      opts.lookup<spanner_internal::SessionPoolMinSessionsOption>();
+  auto& min_sessions = opts.lookup<spanner::SessionPoolMinSessionsOption>();
   min_sessions = (std::max)(min_sessions, 0);
   min_sessions =
       (std::min)(min_sessions,
@@ -111,20 +109,20 @@ Options DefaultOptions(Options opts) {
 Options DefaultAdminOptions(Options opts) {
   SetBasicDefaults(opts);
 
-  if (!opts.has<spanner_internal::SpannerRetryPolicyOption>()) {
-    opts.set<spanner_internal::SpannerRetryPolicyOption>(
+  if (!opts.has<spanner::SpannerRetryPolicyOption>()) {
+    opts.set<spanner::SpannerRetryPolicyOption>(
         std::make_shared<google::cloud::spanner::LimitedTimeRetryPolicy>(
             std::chrono::minutes(30)));
   }
-  if (!opts.has<spanner_internal::SpannerBackoffPolicyOption>()) {
+  if (!opts.has<spanner::SpannerBackoffPolicyOption>()) {
     auto constexpr kBackoffScaling = 2.0;
-    opts.set<spanner_internal::SpannerBackoffPolicyOption>(
+    opts.set<spanner::SpannerBackoffPolicyOption>(
         std::make_shared<google::cloud::spanner::ExponentialBackoffPolicy>(
             std::chrono::seconds(1), std::chrono::minutes(5), kBackoffScaling));
   }
-  if (!opts.has<spanner_internal::SpannerPollingPolicyOption>()) {
+  if (!opts.has<spanner::SpannerPollingPolicyOption>()) {
     auto constexpr kBackoffScaling = 2.0;
-    opts.set<spanner_internal::SpannerPollingPolicyOption>(
+    opts.set<spanner::SpannerPollingPolicyOption>(
         std::make_shared<google::cloud::spanner::GenericPollingPolicy<>>(
             google::cloud::spanner::LimitedTimeRetryPolicy(
                 std::chrono::minutes(30)),

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -54,18 +54,16 @@ TEST(Options, Defaults) {
   EXPECT_THAT(opts.get<UserAgentProductsOption>(),
               ElementsAre(gcloud_user_agent_matcher()));
 
-  EXPECT_EQ(0, opts.get<spanner_internal::SessionPoolMinSessionsOption>());
-  EXPECT_EQ(
-      100,
-      opts.get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
-  EXPECT_EQ(0, opts.get<spanner_internal::SessionPoolMaxIdleSessionsOption>());
+  EXPECT_EQ(0, opts.get<SessionPoolMinSessionsOption>());
+  EXPECT_EQ(100, opts.get<SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_EQ(0, opts.get<SessionPoolMaxIdleSessionsOption>());
   EXPECT_EQ(ActionOnExhaustion::kBlock,
-            opts.get<spanner_internal::SessionPoolActionOnExhaustionOption>());
+            opts.get<SessionPoolActionOnExhaustionOption>());
   EXPECT_EQ(std::chrono::minutes(55),
-            opts.get<spanner_internal::SessionPoolKeepAliveIntervalOption>());
+            opts.get<SessionPoolKeepAliveIntervalOption>());
 
-  EXPECT_TRUE(opts.has<spanner_internal::SpannerRetryPolicyOption>());
-  EXPECT_TRUE(opts.has<spanner_internal::SpannerBackoffPolicyOption>());
+  EXPECT_TRUE(opts.has<SpannerRetryPolicyOption>());
+  EXPECT_TRUE(opts.has<SpannerBackoffPolicyOption>());
   EXPECT_TRUE(opts.has<spanner_internal::SessionPoolClockOption>());
 }
 
@@ -81,19 +79,16 @@ TEST(Options, AdminDefaults) {
   EXPECT_THAT(opts.get<UserAgentProductsOption>(),
               ElementsAre(gcloud_user_agent_matcher()));
 
-  EXPECT_TRUE(opts.has<spanner_internal::SpannerRetryPolicyOption>());
-  EXPECT_TRUE(opts.has<spanner_internal::SpannerBackoffPolicyOption>());
-  EXPECT_TRUE(opts.has<spanner_internal::SpannerPollingPolicyOption>());
+  EXPECT_TRUE(opts.has<SpannerRetryPolicyOption>());
+  EXPECT_TRUE(opts.has<SpannerBackoffPolicyOption>());
+  EXPECT_TRUE(opts.has<SpannerPollingPolicyOption>());
 
   // Admin connections don't use a session pool, so these should not be set.
-  EXPECT_FALSE(opts.has<spanner_internal::SessionPoolMinSessionsOption>());
-  EXPECT_FALSE(
-      opts.has<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
-  EXPECT_FALSE(opts.has<spanner_internal::SessionPoolMaxIdleSessionsOption>());
-  EXPECT_FALSE(
-      opts.has<spanner_internal::SessionPoolActionOnExhaustionOption>());
-  EXPECT_FALSE(
-      opts.has<spanner_internal::SessionPoolKeepAliveIntervalOption>());
+  EXPECT_FALSE(opts.has<SessionPoolMinSessionsOption>());
+  EXPECT_FALSE(opts.has<SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_FALSE(opts.has<SessionPoolMaxIdleSessionsOption>());
+  EXPECT_FALSE(opts.has<SessionPoolActionOnExhaustionOption>());
+  EXPECT_FALSE(opts.has<SessionPoolKeepAliveIntervalOption>());
   EXPECT_FALSE(opts.has<spanner_internal::SessionPoolClockOption>());
 }
 

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -52,15 +52,6 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-// TODO(#5738): Move this closer to the option that uses it once those are
-// moved to the "spanner" namespace.
-// What action to take if the session pool is exhausted.
-enum class ActionOnExhaustion { kBlock, kFail };
-}  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner
-
-namespace spanner_internal {
-inline namespace SPANNER_CLIENT_NS {
 
 /**
  * Option for `google::cloud::Options` to set a `spanner::RetryPolicy`.
@@ -87,11 +78,13 @@ struct SpannerPollingPolicyOption {
  * List of all "policy" options.
  */
 using SpannerPolicyOptionList =
-    OptionList<SpannerRetryPolicyOption, SpannerBackoffPolicyOption,
+    OptionList<spanner::SpannerRetryPolicyOption, SpannerBackoffPolicyOption,
                SpannerPollingPolicyOption>;
 
 /**
- * The minimum number of sessions to keep in the pool.
+ * Option for `google::cloud::Options` to set the minimum number of sessions to
+ * keep in the pool.
+ *
  * Values <= 0 are treated as 0.
  * This value will effectively be reduced if it exceeds the overall limit on
  * the number of sessions (`max_sessions_per_channel` * number of channels).
@@ -101,7 +94,9 @@ struct SessionPoolMinSessionsOption {
 };
 
 /**
- * The maximum number of sessions to create on each channel.
+ * Option for `google::cloud::Options` to set the maximum number of sessions to
+ * create on each channel.
+ *
  * Values <= 1 are treated as 1.
  */
 struct SessionPoolMaxSessionsPerChannelOption {
@@ -109,24 +104,30 @@ struct SessionPoolMaxSessionsPerChannelOption {
 };
 
 /**
- * The maximum number of sessions to keep in the pool in an idle state.
+ * Option for `google::cloud::Options` to set the maximum number of sessions to
+ * keep in the pool in an idle state.
+ *
  * Values <= 0 are treated as 0.
  */
 struct SessionPoolMaxIdleSessionsOption {
   using Type = int;
 };
 
+/// Action to take when the session pool is exhausted.
+enum class ActionOnExhaustion { kBlock, kFail };
 /**
- * The action to take (kBlock or kFail) when attempting to allocate a session
- * when the pool is exhausted.
+ * Option for `google::cloud::Options` to set the action to take when
+ * attempting to allocate a session when the pool is exhausted.
  */
 struct SessionPoolActionOnExhaustionOption {
   using Type = spanner::ActionOnExhaustion;
 };
 
 /*
- * The interval at which we refresh sessions so they don't get collected by the
- * backend GC. The GC collects objects older than 60 minutes, so any duration
+ * Option for `google::cloud::Options` to set the interval at which we refresh
+ * sessions so they don't get collected by the backend GC.
+ *
+ * The GC collects objects older than 60 minutes, so any duration
  * below that (less some slack to allow the calls to be made to refresh the
  * sessions) should suffice.
  */
@@ -135,7 +136,9 @@ struct SessionPoolKeepAliveIntervalOption {
 };
 
 /**
- * The labels used when creating sessions within the pool.
+ * Option for `google::cloud::Options` to set the labels used when creating
+ * sessions within the pool.
+ *
  *  * Label keys must match `[a-z]([-a-z0-9]{0,61}[a-z0-9])?`.
  *  * Label values must match `([a-z]([-a-z0-9]{0,61}[a-z0-9])?)?`.
  *  * The maximum number of labels is 64.
@@ -153,7 +156,7 @@ using SessionPoolOptionList = OptionList<
     SessionPoolKeepAliveIntervalOption, SessionPoolLabelsOption>;
 
 }  // namespace SPANNER_CLIENT_NS
-}  // namespace spanner_internal
+}  // namespace spanner
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -82,28 +82,25 @@ class SessionPoolOptions {
    * the number of sessions (`max_sessions_per_channel` * number of channels).
    */
   SessionPoolOptions& set_min_sessions(int count) {
-    opts_.set<spanner_internal::SessionPoolMinSessionsOption>(count);
+    opts_.set<SessionPoolMinSessionsOption>(count);
     return *this;
   }
 
   /// Return the minimum number of sessions to keep in the pool.
-  int min_sessions() const {
-    return opts_.get<spanner_internal::SessionPoolMinSessionsOption>();
-  }
+  int min_sessions() const { return opts_.get<SessionPoolMinSessionsOption>(); }
 
   /**
    * Set the maximum number of sessions to create on each channel.
    * Values <= 1 are treated as 1.
    */
   SessionPoolOptions& set_max_sessions_per_channel(int count) {
-    opts_.set<spanner_internal::SessionPoolMaxSessionsPerChannelOption>(count);
+    opts_.set<SessionPoolMaxSessionsPerChannelOption>(count);
     return *this;
   }
 
   /// Return the minimum number of sessions to keep in the pool.
   int max_sessions_per_channel() const {
-    return opts_
-        .get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>();
+    return opts_.get<SessionPoolMaxSessionsPerChannelOption>();
   }
 
   /**
@@ -111,19 +108,18 @@ class SessionPoolOptions {
    * Values <= 0 are treated as 0.
    */
   SessionPoolOptions& set_max_idle_sessions(int count) {
-    opts_.set<spanner_internal::SessionPoolMaxIdleSessionsOption>(count);
+    opts_.set<SessionPoolMaxIdleSessionsOption>(count);
     return *this;
   }
 
   /// Return the maximum number of idle sessions to keep in the pool.
   int max_idle_sessions() const {
-    return opts_.get<spanner_internal::SessionPoolMaxIdleSessionsOption>();
+    return opts_.get<SessionPoolMaxIdleSessionsOption>();
   }
 
   /// Set whether to block or fail on pool exhaustion.
   SessionPoolOptions& set_action_on_exhaustion(ActionOnExhaustion action) {
-    opts_.set<spanner_internal::SessionPoolActionOnExhaustionOption>(
-        std::move(action));
+    opts_.set<SessionPoolActionOnExhaustionOption>(std::move(action));
     return *this;
   }
 
@@ -132,7 +128,7 @@ class SessionPoolOptions {
    * session when the pool is exhausted.
    */
   ActionOnExhaustion action_on_exhaustion() const {
-    return opts_.get<spanner_internal::SessionPoolActionOnExhaustionOption>();
+    return opts_.get<SessionPoolActionOnExhaustionOption>();
   }
 
   /*
@@ -142,14 +138,13 @@ class SessionPoolOptions {
    * to be made to refresh the sessions) should suffice.
    */
   SessionPoolOptions& set_keep_alive_interval(std::chrono::seconds interval) {
-    opts_.set<spanner_internal::SessionPoolKeepAliveIntervalOption>(
-        std::move(interval));
+    opts_.set<SessionPoolKeepAliveIntervalOption>(std::move(interval));
     return *this;
   }
 
   /// Return the interval at which we refresh sessions to prevent GC.
   std::chrono::seconds keep_alive_interval() const {
-    return opts_.get<spanner_internal::SessionPoolKeepAliveIntervalOption>();
+    return opts_.get<SessionPoolKeepAliveIntervalOption>();
   }
 
   /**
@@ -159,13 +154,13 @@ class SessionPoolOptions {
    *  * The maximum number of labels is 64.
    */
   SessionPoolOptions& set_labels(std::map<std::string, std::string> labels) {
-    opts_.set<spanner_internal::SessionPoolLabelsOption>(std::move(labels));
+    opts_.set<SessionPoolLabelsOption>(std::move(labels));
     return *this;
   }
 
   /// Return the labels used when creating sessions within the pool.
   std::map<std::string, std::string> const& labels() const {
-    return opts_.get<spanner_internal::SessionPoolLabelsOption>();
+    return opts_.get<SessionPoolLabelsOption>();
   }
 
  private:

--- a/google/cloud/spanner/session_pool_options_test.cc
+++ b/google/cloud/spanner/session_pool_options_test.cc
@@ -65,19 +65,16 @@ TEST(SessionPoolOptionsTest, MakeOptions) {
   auto const expected = SessionPoolOptions{};
   auto const opts = spanner_internal::MakeOptions(SessionPoolOptions{});
 
-  EXPECT_EQ(expected.min_sessions(),
-            opts.get<spanner_internal::SessionPoolMinSessionsOption>());
-  EXPECT_EQ(
-      expected.max_sessions_per_channel(),
-      opts.get<spanner_internal::SessionPoolMaxSessionsPerChannelOption>());
+  EXPECT_EQ(expected.min_sessions(), opts.get<SessionPoolMinSessionsOption>());
+  EXPECT_EQ(expected.max_sessions_per_channel(),
+            opts.get<SessionPoolMaxSessionsPerChannelOption>());
   EXPECT_EQ(expected.max_idle_sessions(),
-            opts.get<spanner_internal::SessionPoolMaxIdleSessionsOption>());
+            opts.get<SessionPoolMaxIdleSessionsOption>());
   EXPECT_EQ(expected.action_on_exhaustion(),
-            opts.get<spanner_internal::SessionPoolActionOnExhaustionOption>());
+            opts.get<SessionPoolActionOnExhaustionOption>());
   EXPECT_EQ(expected.keep_alive_interval(),
-            opts.get<spanner_internal::SessionPoolKeepAliveIntervalOption>());
-  EXPECT_EQ(expected.labels(),
-            opts.get<spanner_internal::SessionPoolLabelsOption>());
+            opts.get<SessionPoolKeepAliveIntervalOption>());
+  EXPECT_EQ(expected.labels(), opts.get<SessionPoolLabelsOption>());
 }
 
 }  // namespace


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/5738

This is a mechanical rename PR, where some existing types and functions are moving from `spanner_internal::` -> `spanner::` to become public. In a few places I manually tweaked the resulting comments.

* All the types in `google/cloud/spanner/options.h` are now "public" in the `spanner::` namespace
* `spanner::MakeConnection()` now recommends use of the `Options` overload
* `spanner::MakeDatabaseAdminConnection()` now recommends use of the `Options` overload
* `spanner::MakeInstanceAdminConnection()` now recommends use of the `Options` overload

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6046)
<!-- Reviewable:end -->
