### PR TITLE
ci: require sourced modules to specify full path

### DIFF
--- a/ci/check-generated-code-hash.sh
+++ b/ci/check-generated-code-hash.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 source "${PROJECT_ROOT}/ci/etc/generator-googleapis-commit-hash.sh"
 

--- a/ci/check-golden-md5-hashes.sh
+++ b/ci/check-golden-md5-hashes.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ "${CHECK_GENERATED_CODE_HASH}" != "yes" ]]; then
   echo "Skipping the generated code hash check as it is disabled for this build."

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -17,7 +17,7 @@
 set -eu
 
 source "$(dirname "$0")/lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ "${CHECK_STYLE}" != "yes" ]]; then
   echo "Skipping code style check as it is disabled for this build."

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -16,8 +16,8 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <source-directory> <binary-directory>"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -17,8 +17,8 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <source-directory> <binary-directory>"

--- a/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-bazel.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module etc/quickstart-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/etc/quickstart-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   # The arguments are ignored, but required for compatibility with

--- a/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-quickstart-cmake.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module etc/quickstart-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/etc/quickstart-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   # The arguments are ignored, but required for compatibility with

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -17,8 +17,8 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/repo-config.sh
-source module lib/io.sh
+source module /ci/etc/repo-config.sh
+source module /ci/lib/io.sh
 
 export CC=gcc
 export CXX=g++

--- a/ci/kokoro/docker/check-abi.sh
+++ b/ci/kokoro/docker/check-abi.sh
@@ -17,7 +17,7 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <binary-directory> <library>"

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 3 ]]; then
   echo "Usage: $(basename "$0") <cache-folder> <cache-name> <home-directory>"

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 3 ]]; then
   echo "Usage: $(basename "$0") <cache-folder> <cache-name> <home-directory>"

--- a/ci/kokoro/docker/upload-docs.sh
+++ b/ci/kokoro/docker/upload-docs.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $(basename "$0") <branch-name> <build-output>"

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ $# -eq 1 ]]; then
   export DISTRO="${1}"

--- a/ci/kokoro/install/run-installed-programs.sh
+++ b/ci/kokoro/install/run-installed-programs.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source module etc/integration-tests-config.sh
-source module etc/quickstart-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/etc/quickstart-config.sh
+source module /ci/lib/io.sh
 
 run_all_installed_quickstart_programs() {
   CONFIG_DIRECTORY="${KOKORO_GFILE_DIR:-/dev/shm}"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -16,8 +16,8 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
 
 echo
 echo "================================================================"

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -16,8 +16,8 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# -ne 2 ]]; then
   echo "Usage: $(basename "$0")  <source-directory> <binary-directory>"

--- a/ci/kokoro/macos/build-quickstart-bazel.sh
+++ b/ci/kokoro/macos/build-quickstart-bazel.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module etc/quickstart-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/etc/quickstart-config.sh
+source module /ci/lib/io.sh
 
 echo
 echo "================================================================"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
-source module etc/integration-tests-config.sh
-source module etc/quickstart-config.sh
+source module /ci/lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/etc/quickstart-config.sh
 
 echo "================================================================"
 io::log_yellow "Update or install dependencies."

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -17,8 +17,8 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/repo-config.sh
-source module lib/io.sh
+source module /ci/etc/repo-config.sh
+source module /ci/lib/io.sh
 
 export BAZEL_CONFIG=""
 export RUN_INTEGRATION_TESTS="no"

--- a/ci/kokoro/macos/download-cache.sh
+++ b/ci/kokoro/macos/download-cache.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <cache-folder> <cache-name>"

--- a/ci/kokoro/macos/upload-cache.sh
+++ b/ci/kokoro/macos/upload-cache.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
-source module etc/integration-tests-config.sh
-source module etc/quickstart-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/etc/quickstart-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# != 2 ]]; then
   echo "Usage: $(basename "$0") <cache-folder> <cache-name>"

--- a/ci/lib/init.sh
+++ b/ci/lib/init.sh
@@ -20,11 +20,11 @@
 #
 #   set -eu  # We commonly do this, but it's optional
 #   source "$(dirname "$0")/../../lib/init.sh"  # The path to this library
-#   source module lib/io.sh
-#   source module lib/foo.sh
+#   source module /ci/lib/io.sh
+#   source module /ci/lib/foo.sh
 #
 # Further more, a bash library may source other bash libraries directly by
-# using a `source module lib/foo.sh` line. I.e., there's no need for a bash
+# using a `source module /ci/lib/foo.sh` line. I.e., there's no need for a bash
 # library to source init -- it may assume that the binary that called the
 # library has already called init.sh
 
@@ -59,10 +59,10 @@ if [[ ! "$PATH" =~ ${PROJECT_ROOT}/ci/lib ]]; then
   PATH="${PROJECT_ROOT}/ci/lib:${PATH}"
 fi
 
-# Sets a search path array for the "modules" that can be sourced. When a
-# caller writes `source module lib/foo.sh`, this path/array will be searched in
-# order for the caller-provided 'lib/foo.sh'. The first one found will be used.
+# Sets the module search path to only the PROJECT_ROOT to force sourced module
+# paths to be relative to the project root, thus making it easy to find the
+# actual file being sourced. This is similar to how C++ includes are all
+# relative to the project root.
 MODULE_SEARCH_PATH=(
-  "${PROGRAM_DIR}"
-  "${PROJECT_ROOT}/ci"
+  "${PROJECT_ROOT}"
 )

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -17,7 +17,7 @@
 #
 # Example:
 #
-#   source module lib/io.sh
+#   source module /ci/lib/io.sh
 #   io::log_yellow "Hello world"
 
 # Make our include guard clean against set -o nounset.

--- a/generator/ci/run_integration_tests_emulator_bazel.sh
+++ b/generator/ci/run_integration_tests_emulator_bazel.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
+source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"

--- a/generator/ci/run_integration_tests_emulator_cmake.sh
+++ b/generator/ci/run_integration_tests_emulator_cmake.sh
@@ -16,8 +16,8 @@
 set -eu
 
 source "$(dirname "$0")/../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/io.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"

--- a/generator/generate-libraries.sh
+++ b/generator/generate-libraries.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../ci/lib/init.sh"
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 if [[ "${GENERATE_LIBRARIES}" != "yes" ]]; then
   echo "Skipping the generated code hash check as it is disabled for this build."

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
+source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"

--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_cmake.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
+source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"

--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -19,7 +19,7 @@ if ((GOOGLE_CLOUD_PUBSUB_CI_LIB_PUBSUB_EMULATOR_SH__++ != 0)); then
   return 0
 fi # include guard
 
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 # Global variable that holds the PID of the Pubsub emulator. This will be set
 # when the emulator is started, and it will be used to kill the emulator.

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -16,8 +16,8 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/pubsub_emulator.sh
+source module /ci/etc/integration-tests-config.sh
+source module /google/cloud/pubsub/ci/lib/pubsub_emulator.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_cmake.sh
@@ -16,8 +16,8 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/pubsub_emulator.sh
+source module /ci/etc/integration-tests-config.sh
+source module /google/cloud/pubsub/ci/lib/pubsub_emulator.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -19,7 +19,7 @@ if ((GOOGLE_CLOUD_SPANNER_CI_LIB_SPANNER_EMULATOR_SH__++ != 0)); then
   return 0
 fi # include guard
 
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 # Global variable that holds the PID of the Spanner emulator. This will be set
 # when the emulator is started, and it will be used to kill the emulator.

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_cmake.sh
@@ -16,9 +16,9 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
-source module lib/io.sh
-source module lib/spanner_emulator.sh
+source module /ci/etc/integration-tests-config.sh
+source module /ci/lib/io.sh
+source module /google/cloud/spanner/ci/lib/spanner_emulator.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
+source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <bazel-program> [bazel-test-args]"

--- a/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_cmake.sh
@@ -16,7 +16,7 @@
 set -eu
 
 source "$(dirname "$0")/../../../../ci/lib/init.sh"
-source module etc/integration-tests-config.sh
+source module /ci/etc/integration-tests-config.sh
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $(basename "$0") <binary-dir> [ctest-args]"

--- a/google/cloud/storage/tools/run_emulator_utils.sh
+++ b/google/cloud/storage/tools/run_emulator_utils.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source module lib/io.sh
+source module /ci/lib/io.sh
 
 EMULATOR_PID=0
 


### PR DESCRIPTION
Part of https://github.com/googleapis/google-cloud-cpp/issues/3911

This change requires that shell libraries loaded with `source module
<file>` must specify the file via a full path starting from the project
root. This makes it easier for humans to see sourced files and know
which file on disk is actually loaded. This also more closely matches
the full paths we use in C++ includes.

Note the leading `/` in these sourced paths is optional. I'm including
it because I thought it made it look clear that the path was "absolute"
(well, relative to the project root).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6054)
<!-- Reviewable:end -->
