### PR TITLE
fix(pubsub): deadlocks for cancel during session startup

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -153,8 +153,8 @@ void StreamingSubscriptionBatchSource::OnInitialWrite(RetryLoopState const& rs,
                 s->OnInitialRead(std::move(rs), f.get());
             });
       });
-  // This is very rare, but if the session enters shutdown while the initial
-  // setup is in progress it can happen.
+  // This is very rare, but it can happen if the session enters shutdown while
+  // the initial setup is in progress.
   if (!scheduled) OnInitialError(std::move(rs));
 }
 


### PR DESCRIPTION
If an application canceled a session before the first `Write()` call
completes in the startup sequence.

Changed `pubsub/samples/samples.cc` to make it easier to troubleshoot
this problem, I am keeping the change because it feels generally useful.

Fixes #6053

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6055)
<!-- Reviewable:end -->
