### PR TITLE
ci: disable GCS+gRPC integration tests on production

### DIFF
--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -158,12 +158,19 @@ if should_run_integration_tests; then
     "--test_env=GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT}"
   )
 
+  excluded_rules=(
+    "-//google/cloud/bigtable/examples:bigtable_grpc_credentials"
+    "-//google/cloud/storage/examples:storage_service_account_samples"
+    "-//google/cloud/storage/tests:service_account_integration_test"
+
+    # TODO(#6062) - enable gRPC integration tests again
+    "-//google/cloud/storage/examples:storage_grpc_samples"
+    "-//google/cloud/storage/tests:grpc_integration_test"
+  )
+
   "${BAZEL_BIN}" test \
     "${bazel_args[@]}" \
     "--test_tag_filters=integration-test" \
-    -- ... \
-    -//google/cloud/bigtable/examples:bigtable_grpc_credentials \
-    -//google/cloud/storage/examples:storage_service_account_samples \
-    -//google/cloud/storage/tests:service_account_integration_test
+    -- ... "${excluded_rules[@]}"
 
 fi

--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -108,9 +108,10 @@ if should_run_integration_tests; then
     else
       cd "${BINARY_DIR}"
     fi
+    # TODO(6062) - restore the GCS+gRPC tests (i.e. remove storage_grpc_ from the -E option)
     ctest \
       -L 'integration-test-production' \
-      -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test)' \
+      -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test|storage_grpc_)' \
       --output-on-failure -j "${NCPU}"
   )
 fi

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -208,12 +208,18 @@ if (Integration-Tests-Enabled) {
         "--test_env=GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT=${env:GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT}",
         "--test_env=GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT=${env:GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT}"
     )
+    $excluded_rules=@(
+        "-//google/cloud/bigtable/examples:bigtable_grpc_credentials",
+        "-//google/cloud/storage/examples:storage_service_account_samples",
+        "-//google/cloud/storage/tests:service_account_integration_test",
+
+        # TODO(#6062) - enable gRPC integration tests again
+        "-//google/cloud/storage/examples:storage_grpc_samples",
+        "-//google/cloud/storage/tests:grpc_integration_test"
+    )
     bazel $common_flags test $test_flags $integration_flags `
         "--test_tag_filters=integration-test" `
-        -- ... `
-        -//google/cloud/bigtable/examples:bigtable_grpc_credentials `
-        -//google/cloud/storage/examples:storage_service_account_samples `
-        -//google/cloud/storage/tests:service_account_integration_test
+        -- ... $excluded_rules
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "Integration tests failed with exit code ${LastExitCode}."
         Exit ${LastExitCode}

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -140,9 +140,10 @@ if (Integration-Tests-Enabled) {
 
     Set-Location "${project_root}"
     Set-Location "${binary_dir}"
+    # TODO(6062) - restore the GCS+gRPC tests (i.e. remove storage_grpc_ from the -E option)
     ctest $ctest_flags `
         -L 'integration-test-production' `
-        -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test)'
+        -E '(bigtable_grpc_credentials|storage_service_account_samples|service_account_integration_test|storage_grpc_)'
     if ($LastExitCode) {
         Write-Host -ForegroundColor Red "Integration tests failed with exit code ${LastExitCode}."
         Exit ${LastExitCode}

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -115,18 +115,19 @@ INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestJson,
 INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestXml,
                          ThroughputExperimentIntegrationTest,
                          ::testing::Values(ApiName::kApiXml));
-INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestGrpc,
-                         ThroughputExperimentIntegrationTest,
-                         ::testing::Values(ApiName::kApiGrpc));
 INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawJson,
                          ThroughputExperimentIntegrationTest,
                          ::testing::Values(ApiName::kApiRawJson));
 INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawXml,
                          ThroughputExperimentIntegrationTest,
                          ::testing::Values(ApiName::kApiRawXml));
-INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawGrpc,
-                         ThroughputExperimentIntegrationTest,
-                         ::testing::Values(ApiName::kApiRawGrpc));
+// TODO(#6062) - enable gRPC integration tests again
+// INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestGrpc,
+//                         ThroughputExperimentIntegrationTest,
+//                         ::testing::Values(ApiName::kApiGrpc));
+// INSTANTIATE_TEST_SUITE_P(ThroughputExperimentIntegrationTestRawGrpc,
+//                         ThroughputExperimentIntegrationTest,
+//                         ::testing::Values(ApiName::kApiRawGrpc));
 
 }  // namespace
 }  // namespace storage_benchmarks


### PR DESCRIPTION
To be restored as part of #6062 
