### PR TITLE
fix(storage): use after move problems

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -95,13 +95,13 @@ std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
 
 GrpcClient::GrpcClient(ClientOptions options)
     : options_(std::move(options)),
-      stub_(google::storage::v1::Storage::NewStub(CreateGrpcChannel(options))) {
-}
+      stub_(
+          google::storage::v1::Storage::NewStub(CreateGrpcChannel(options_))) {}
 
 GrpcClient::GrpcClient(ClientOptions options, int channel_id)
     : options_(std::move(options)),
       stub_(google::storage::v1::Storage::NewStub(
-          CreateGrpcChannel(options, channel_id))) {}
+          CreateGrpcChannel(options_, channel_id))) {}
 
 std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
     grpc::ClientContext& context, google::storage::v1::Object& result) {

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -104,7 +104,6 @@ std::ostream& operator<<(std::ostream& os, LifecycleRuleCondition const& rhs) {
   }
   if (rhs.custom_time_before.has_value()) {
     os << sep << "custom_time_before=" << *rhs.custom_time_before;
-    sep = ", ";
   }
   return os << "}";
 }
@@ -141,11 +140,12 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
   }
   if (rhs.matches_storage_class.has_value()) {
     if (result.matches_storage_class.has_value()) {
-      std::vector<std::string> tmp;
-      std::vector<std::string> a = *std::move(result.matches_storage_class);
+      std::vector<std::string> a;
+      a.swap(*result.matches_storage_class);
       std::sort(a.begin(), a.end());
       std::vector<std::string> b = *rhs.matches_storage_class;
       std::sort(b.begin(), b.end());
+      std::vector<std::string> tmp;
       std::set_intersection(a.begin(), a.end(), b.begin(), b.end(),
                             std::back_inserter(tmp));
       result.matches_storage_class.emplace(std::move(tmp));


### PR DESCRIPTION
We were using objects after move-assigning from them. Found using
Clang's static analyzer.

Also cleaned up a (mostly harmless) unused assignment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6066)
<!-- Reviewable:end -->
