### PR TITLE
cleanup(bigtable): cleanup static analyzer nit

### DIFF
--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -557,7 +557,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
         new_binding.set_role("writer");
         new_binding.add_members("abc@gmail.com");
         new_binding.add_members("xyz@gmail.com");
-        new_binding.set_allocated_condition(new google::type::Expr);
+        *new_binding.mutable_condition() = google::type::Expr{};
 
         return grpc::Status::OK;
       });


### PR DESCRIPTION
Clang's static analyzer sees the raw call to `new` as potentially
leaking. It is not, but it is also not consistent with how we assign
proto message fields elsewhere in the code, so I changed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6067)
<!-- Reviewable:end -->
