### PR TITLE
cleanup: remove workarounds for absl package

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -18,10 +18,7 @@ set(DOXYGEN_EXCLUDE_SYMBOLS "generator_internal")
 set(DOXYGEN_EXAMPLE_PATH "")
 include(GoogleCloudCppCommon)
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 find_package(ProtobufWithTargets REQUIRED)
 

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -14,10 +14,7 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 # Generate the version information from the CMake values.
 configure_file(internal/version_info.h.in

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -26,10 +26,7 @@ set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v1")
 
 include(GoogleCloudCppCommon)
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 # configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -14,10 +14,7 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 set(DOXYGEN_PROJECT_NAME "Google Cloud Bigtable C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Bigtable")

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -25,10 +25,7 @@ set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v1")
 
 include(GoogleCloudCppCommon)
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 add_library(
     google_cloud_cpp_iam # cmake-format: sort

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -26,10 +26,7 @@ set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_NS=v1")
 
 include(GoogleCloudCppCommon)
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 # configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -26,10 +26,7 @@ set(DOXYGEN_PREDEFINED "GOOGLE_CLOUD_CPP_PUBSUB_NS=v1")
 
 include(GoogleCloudCppCommon)
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 add_library(
     google_cloud_cpp_pubsub # cmake-format: sort

--- a/google/cloud/pubsub/benchmarks/CMakeLists.txt
+++ b/google/cloud/pubsub/benchmarks/CMakeLists.txt
@@ -14,10 +14,7 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 function (pubsub_client_define_benchmarks)
     set(pubsub_client_benchmark_programs # cmake-format: sort

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -14,10 +14,7 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 set(DOXYGEN_PROJECT_NAME "Google Cloud Spanner C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Spanner")

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -14,10 +14,7 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl release
-set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
 find_package(absl CONFIG REQUIRED)
-unset(FPHSA_NAME_MISMATCHED)
 
 option(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC
        "Enable compilation for the GCS gRPC plugin (EXPERIMENTAL)" OFF)

--- a/google/cloud/storage/benchmarks/CMakeLists.txt
+++ b/google/cloud/storage/benchmarks/CMakeLists.txt
@@ -15,11 +15,7 @@
 # ~~~
 
 if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_ENABLE_GRPC)
-    # TODO(#4146) - remove FPHSA_NAME_MISMATCHED manipulation on next absl
-    # release
-    set(FPHSA_NAME_MISMATCHED Threads) # Quiet warning caused by Abseil
     find_package(absl CONFIG REQUIRED)
-    unset(FPHSA_NAME_MISMATCHED)
 
     add_library(
         storage_benchmarks # cmake-format: sort


### PR DESCRIPTION
With older versions of Abseil doing `find_package(absl)` generated some
ugly warnings. This got fixed with the update to the 2020-09 release.

Fixes #4146

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6076)
<!-- Reviewable:end -->
