### PR TITLE
test(bigtable): fix ports for emulators with Bazel

### DIFF
--- a/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/bigtable/ci/run_integration_tests_emulator_bazel.sh
@@ -51,7 +51,7 @@ production_only_targets=(
 # (which is ${PROJECT_ROOT}) and we cannot use a subshell because we want the
 # environment variables that it sets.
 pushd "${HOME}" >/dev/null
-start_emulators
+start_emulators 8480 8490
 popd >/dev/null
 
 excluded_targets=(

--- a/google/cloud/bigtable/tools/run_emulator_utils.sh
+++ b/google/cloud/bigtable/tools/run_emulator_utils.sh
@@ -93,7 +93,7 @@ function wait_until_emulator_connects() {
   delay=1
   connected=no
   local -r attempts=$(seq 1 8)
-  for attempt in ${attempts}; do
+  for _ in ${attempts}; do
     if env BIGTABLE_EMULATOR_HOST="${address}" \
       "${CBT_CMD}" "${CBT_ARGS[@]}" "${subcmd}" >/dev/null 2>&1; then
       connected=yes
@@ -112,16 +112,19 @@ function wait_until_emulator_connects() {
 }
 
 function start_emulators() {
+  local -r initial_port="${1:-0}"
+  local -r initial_instance_admin_port="${2:-0}"
+
   echo "Launching Cloud Bigtable emulators in the background"
   trap kill_emulators EXIT
 
   # The tests typically run in a Docker container, where the ports are largely
   # free; when using in manual tests, you can set EMULATOR_PORT.
-  "${CBT_EMULATOR_CMD}" -port 0 >emulator.log 2>&1 </dev/null &
+  "${CBT_EMULATOR_CMD}" -port "${initial_port}" >emulator.log 2>&1 </dev/null &
   EMULATOR_PID=$!
   local -r emulator_port="$(wait_for_port emulator.log)"
 
-  "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" >instance-admin-emulator.log 2>&1 </dev/null &
+  "${CBT_INSTANCE_ADMIN_EMULATOR_CMD}" "${initial_instance_admin_port}" >instance-admin-emulator.log 2>&1 </dev/null &
   INSTANCE_ADMIN_EMULATOR_PID=$!
   local -r instance_admin_port="$(wait_for_port instance-admin-emulator.log)"
 


### PR DESCRIPTION
On Bazel builds it is worthwhile to use fixed ports for the emulators,
as Bazel invalidates the test results cache if the port changes. This
should save about 30 seconds in the PR builds.

Fixes #4125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6077)
<!-- Reviewable:end -->
