### PR TITLE
cleanup(bigtable): rename testing namespace

### DIFF
--- a/google/cloud/bigtable/async_list_app_profiles_test.cc
+++ b/google/cloud/bigtable/async_list_app_profiles_test.cc
@@ -37,12 +37,13 @@ namespace btadmin = google::bigtable::admin::v2;
 
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::_;
 using ::testing::ReturnRef;
 
 using MockAsyncListAppProfilesReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    google::cloud::bigtable_testing::MockAsyncResponseReader<
         btadmin::ListAppProfilesResponse>;
 using Functor = std::function<void(
     CompletionQueue&, std::vector<btadmin::AppProfile>&, grpc::Status&)>;
@@ -54,7 +55,7 @@ class AsyncListAppProfilesTest : public ::testing::Test {
   AsyncListAppProfilesTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new testing::MockInstanceAdminClient),
+        client_(new MockInstanceAdminClient),
         profiles_reader_1_(new MockAsyncListAppProfilesReader),
         profiles_reader_2_(new MockAsyncListAppProfilesReader),
         profiles_reader_3_(new MockAsyncListAppProfilesReader) {
@@ -69,7 +70,7 @@ class AsyncListAppProfilesTest : public ::testing::Test {
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
   CompletionQueue cq_;
-  std::shared_ptr<testing::MockInstanceAdminClient> client_;
+  std::shared_ptr<MockInstanceAdminClient> client_;
   future<StatusOr<std::vector<btadmin::AppProfile>>> user_future_;
   std::unique_ptr<MockAsyncListAppProfilesReader> profiles_reader_1_;
   std::unique_ptr<MockAsyncListAppProfilesReader> profiles_reader_2_;

--- a/google/cloud/bigtable/async_list_clusters_test.cc
+++ b/google/cloud/bigtable/async_list_clusters_test.cc
@@ -37,12 +37,13 @@ namespace btproto = google::bigtable::admin::v2;
 
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::_;
 using ::testing::ReturnRef;
 
 using MockAsyncListClustersReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    google::cloud::bigtable_testing::MockAsyncResponseReader<
         btproto::ListClustersResponse>;
 using Functor =
     std::function<void(CompletionQueue&, ClusterList&, grpc::Status&)>;
@@ -54,7 +55,7 @@ class AsyncListClustersTest : public ::testing::Test {
   AsyncListClustersTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new testing::MockInstanceAdminClient),
+        client_(new MockInstanceAdminClient),
         metadata_update_policy_("my_instance", MetadataParamTypes::NAME),
         clusters_reader_1_(new MockAsyncListClustersReader),
         clusters_reader_2_(new MockAsyncListClustersReader),
@@ -70,7 +71,7 @@ class AsyncListClustersTest : public ::testing::Test {
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
   CompletionQueue cq_;
-  std::shared_ptr<testing::MockInstanceAdminClient> client_;
+  std::shared_ptr<MockInstanceAdminClient> client_;
   future<StatusOr<ClusterList>> user_future_;
   MetadataUpdatePolicy metadata_update_policy_;
   std::unique_ptr<MockAsyncListClustersReader> clusters_reader_1_;

--- a/google/cloud/bigtable/async_list_instances_test.cc
+++ b/google/cloud/bigtable/async_list_instances_test.cc
@@ -36,10 +36,11 @@ namespace {
 namespace btproto = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using ::testing::_;
 using ::testing::ReturnRef;
 using MockAsyncListInstancesReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    google::cloud::bigtable_testing::MockAsyncResponseReader<
         btproto::ListInstancesResponse>;
 using google::cloud::testing_util::FakeCompletionQueueImpl;
 
@@ -53,7 +54,7 @@ class AsyncListInstancesTest : public ::testing::Test {
   AsyncListInstancesTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new testing::MockInstanceAdminClient),
+        client_(new MockInstanceAdminClient),
         instances_reader_1_(new MockAsyncListInstancesReader),
         instances_reader_2_(new MockAsyncListInstancesReader),
         instances_reader_3_(new MockAsyncListInstancesReader) {
@@ -68,7 +69,7 @@ class AsyncListInstancesTest : public ::testing::Test {
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
   CompletionQueue cq_;
-  std::shared_ptr<testing::MockInstanceAdminClient> client_;
+  std::shared_ptr<MockInstanceAdminClient> client_;
   future<StatusOr<InstanceList>> user_future_;
   std::unique_ptr<MockAsyncListInstancesReader> instances_reader_1_;
   std::unique_ptr<MockAsyncListInstancesReader> instances_reader_2_;

--- a/google/cloud/bigtable/async_row_reader_test.cc
+++ b/google/cloud/bigtable/async_row_reader_test.cc
@@ -34,7 +34,7 @@ namespace {
 
 namespace btproto = google::bigtable::v2;
 
-using ::google::cloud::bigtable::testing::MockClientAsyncReaderInterface;
+using ::google::cloud::bigtable_testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
@@ -48,7 +48,7 @@ bool Unsatisfied(future<T> const& fut) {
   return std::future_status::timeout == fut.wait_for(1_ms);
 }
 
-class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
+class TableAsyncReadRowsTest : public bigtable_testing::TableTestFixture {
  protected:
   TableAsyncReadRowsTest()
       : TableTestFixture(
@@ -160,7 +160,7 @@ TEST_F(TableAsyncReadRowsTest, SingleRow) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -211,7 +211,7 @@ TEST_F(TableAsyncReadRowsTest, SingleRowInstantFinish) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -259,7 +259,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunks) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -271,7 +271,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunks) {
                 })");
       })
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r2"
@@ -328,7 +328,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunksImmediatelySatisfied) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -340,7 +340,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunksImmediatelySatisfied) {
                 })");
       })
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r2"
@@ -394,7 +394,7 @@ TEST_F(TableAsyncReadRowsTest, ResponseInMultipleChunks) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -406,7 +406,7 @@ TEST_F(TableAsyncReadRowsTest, ResponseInMultipleChunks) {
                 })");
       })
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -454,7 +454,7 @@ TEST_F(TableAsyncReadRowsTest, ParserEofFailsOnUnfinishedRow) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             // missing final commit
             R"(
                 chunks {
@@ -494,7 +494,7 @@ TEST_F(TableAsyncReadRowsTest, ParserEofDoesntFailsOnUnfinishedRowIfRowLimit) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             // missing final commit
             R"(
                 chunks {
@@ -582,7 +582,7 @@ TEST_F(TableAsyncReadRowsTest, TransientErrorIsRetried) {
   // Make it a bit trickier by delivering the error while parsing second row.
   EXPECT_CALL(stream1, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -608,7 +608,7 @@ TEST_F(TableAsyncReadRowsTest, TransientErrorIsRetried) {
 
   EXPECT_CALL(stream2, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r2"
@@ -668,7 +668,7 @@ TEST_F(TableAsyncReadRowsTest, ParserFailure) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             // Row not in increasing order.
             R"(
                 chunks {
@@ -734,7 +734,7 @@ TEST_P(TableAsyncReadRowsCancelMidStreamTest, CancelMidStream) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -841,7 +841,7 @@ TEST_F(TableAsyncReadRowsTest, CancelAfterStreamFinish) {
   // while still keeping the two processed rows for the user.
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
                 chunks {
                   row_key: "r1"
@@ -910,7 +910,7 @@ TEST_F(TableAsyncReadRowsTest, CancelAfterStreamFinish) {
 TEST_F(TableAsyncReadRowsTest, DeepStack) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  auto large_response = bigtable::testing::ReadRowsResponseFromString(
+  auto large_response = bigtable_testing::ReadRowsResponseFromString(
       R"(
           chunks {
             row_key: "000"
@@ -979,7 +979,7 @@ TEST_F(TableAsyncReadRowsTest, ReadRowSuccess) {
 
   EXPECT_CALL(stream, Read(_, _))
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
-        *r = bigtable::testing::ReadRowsResponseFromString(
+        *r = bigtable_testing::ReadRowsResponseFromString(
             R"(
               chunks {
                 row_key: "000"

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -122,10 +122,10 @@ void RunAll(std::vector<std::string> const& argv) {
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),
       instance_id);
 
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
   auto schema = admin.CreateTable(
       table_id,
       cbt::TableConfig({{"fam", cbt::GcRule::MaxNumVersions(10)}}, {}));

--- a/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
@@ -183,9 +183,9 @@ void RunAll(std::vector<std::string> const& argv) {
       cbt::CreateDefaultInstanceAdminClient(project_id, cbt::ClientOptions{}));
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  google::cloud::bigtable::testing::CleanupStaleInstances(admin);
+  google::cloud::bigtable_testing::CleanupStaleInstances(admin);
   auto const instance_id =
-      google::cloud::bigtable::testing::RandomInstanceId(generator);
+      google::cloud::bigtable_testing::RandomInstanceId(generator);
   auto const cluster_id = instance_id + "-c1";
 
   std::cout << "\nRunning the BigtableHelloInstance() example" << std::endl;

--- a/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
@@ -138,10 +138,10 @@ void RunAll(std::vector<std::string> const& argv) {
       cbt::CreateDefaultAdminClient(project_id, cbt::ClientOptions{}),
       instance_id);
 
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
 
   std::cout << "\nRunning the HelloWorldTableAdmin() example" << std::endl;
   HelloWorldTableAdmin({project_id, instance_id, table_id});

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -154,7 +154,7 @@ void RunAll(std::vector<std::string> const& argv) {
       instance_id);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
 
   std::cout << "\nRunning the BigtableHelloWorld() example" << std::endl;
   BigtableHelloWorld({project_id, instance_id, table_id});

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -700,12 +700,12 @@ void RunAll(std::vector<std::string> const& argv) {
       cbt::CreateDefaultInstanceAdminClient(project_id, cbt::ClientOptions{}));
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
-  google::cloud::bigtable::testing::CleanupStaleInstances(admin);
+  google::cloud::bigtable_testing::CleanupStaleInstances(admin);
 
   // Create a different instance id to run the replicated instance example.
   {
     auto const id =
-        google::cloud::bigtable::testing::RandomInstanceId(generator);
+        google::cloud::bigtable_testing::RandomInstanceId(generator);
     std::cout << "\nRunning CreateReplicatedInstance() example" << std::endl;
     CreateReplicatedInstance(admin, {id, zone_a, zone_b});
     std::cout << "\nRunning GetInstance() example" << std::endl;
@@ -716,7 +716,7 @@ void RunAll(std::vector<std::string> const& argv) {
   // Create a different instance id to run the development instance example.
   {
     auto const id =
-        google::cloud::bigtable::testing::RandomInstanceId(generator);
+        google::cloud::bigtable_testing::RandomInstanceId(generator);
     std::cout << "\nRunning CreateDevInstance() example" << std::endl;
     CreateDevInstance(admin, {id, zone_a});
     std::cout << "\nRunning UpdateInstance() example" << std::endl;
@@ -728,15 +728,15 @@ void RunAll(std::vector<std::string> const& argv) {
   // id
   {
     auto const id =
-        google::cloud::bigtable::testing::RandomInstanceId(generator);
+        google::cloud::bigtable_testing::RandomInstanceId(generator);
     auto const cluster_id =
-        google::cloud::bigtable::testing::RandomClusterId(generator);
+        google::cloud::bigtable_testing::RandomClusterId(generator);
     std::cout << "\nRunning RunInstanceOperations() example" << std::endl;
     RunInstanceOperations(admin, {id, cluster_id, zone_a});
   }
 
   auto const instance_id =
-      google::cloud::bigtable::testing::RandomInstanceId(generator);
+      google::cloud::bigtable_testing::RandomInstanceId(generator);
 
   std::cout << "\nRunning CheckInstanceExists() example [1]" << std::endl;
   CheckInstanceExists(admin, {instance_id});

--- a/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
@@ -201,14 +201,14 @@ void RunAll(std::vector<std::string> const& argv) {
   // remove stale tables after 48 hours.
   std::cout << "\nCleaning up old tables" << std::endl;
   std::string const prefix = "table-admin-snippets-";
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
   std::string const backup_prefix = "table-admin-snippets-backup-";
-  google::cloud::bigtable::testing::CleanupStaleBackups(admin);
+  google::cloud::bigtable_testing::CleanupStaleBackups(admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   // This table is actually created and used to test the positive case (e.g.
   // GetTable() and "table does exist")
-  auto table_id_1 = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id_1 = google::cloud::bigtable_testing::RandomTableId(generator);
 
   auto table_1 = admin.CreateTable(
       table_id_1, cbt::TableConfig(
@@ -220,7 +220,7 @@ void RunAll(std::vector<std::string> const& argv) {
   if (!table_1) throw std::runtime_error(table_1.status().message());
 
   std::cout << "\nRunning CreateBackup() example" << std::endl;
-  auto backup_id_1 = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto backup_id_1 = google::cloud::bigtable_testing::RandomTableId(generator);
   CreateBackup(admin, {table_id_1, cluster_id, backup_id_1,
                        absl::FormatTime(absl::Now() + absl::Hours(12))});
 

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -308,12 +308,12 @@ void RunAll(std::vector<std::string> const& argv) {
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const table_id =
-      google::cloud::bigtable::testing::RandomTableId(generator);
+      google::cloud::bigtable_testing::RandomTableId(generator);
 
   std::cout << "\nCreating table to run the examples (" << table_id << ")"
             << std::endl;

--- a/google/cloud/bigtable/examples/data_filter_snippets.cc
+++ b/google/cloud/bigtable/examples/data_filter_snippets.cc
@@ -556,12 +556,12 @@ void RunAll(std::vector<std::string> const& argv) {
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
 
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
   auto schema = admin.CreateTable(
       table_id, cbt::TableConfig({{"fam-0", cbt::GcRule::MaxNumVersions(10)},
                                   {"fam-1", cbt::GcRule::MaxNumVersions(10)}},

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -729,7 +729,7 @@ void RunMutateExamples(google::cloud::bigtable::TableAdmin admin,
                        google::cloud::internal::DefaultPRNG& generator) {
   namespace cbt = google::cloud::bigtable;
 
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
   auto schema = admin.CreateTable(
       table_id,
       cbt::TableConfig({{"fam", cbt::GcRule::MaxNumVersions(10)}}, {}));
@@ -755,7 +755,7 @@ void RunWriteExamples(google::cloud::bigtable::TableAdmin admin,
                       google::cloud::internal::DefaultPRNG& generator) {
   namespace cbt = google::cloud::bigtable;
 
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
   auto schema = admin.CreateTable(
       table_id, cbt::TableConfig(
                     {{"stats_summary", cbt::GcRule::MaxNumVersions(11)}}, {}));
@@ -785,7 +785,7 @@ void RunDataExamples(google::cloud::bigtable::TableAdmin admin,
                      google::cloud::internal::DefaultPRNG& generator) {
   namespace cbt = google::cloud::bigtable;
 
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
   std::cout << "Creating table " << table_id << std::endl;
   auto schema = admin.CreateTable(
       table_id,
@@ -920,7 +920,7 @@ void RunAll(std::vector<std::string> const& argv) {
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());

--- a/google/cloud/bigtable/examples/read_snippets.cc
+++ b/google/cloud/bigtable/examples/read_snippets.cc
@@ -357,13 +357,13 @@ void RunAll(std::vector<std::string> const& argv) {
   // If a previous run of these samples crashes before cleaning up there may be
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   // Initialize a generator with some amount of entropy.
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
 
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
   std::cout << "Creating table " << table_id << std::endl;
   auto schema = admin.CreateTable(
       table_id, cbt::TableConfig(

--- a/google/cloud/bigtable/examples/table_admin_iam_policy_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_iam_policy_snippets.cc
@@ -142,12 +142,12 @@ void RunAll(std::vector<std::string> const& argv) {
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
   std::cout << "\nCleaning up old tables" << std::endl;
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   // This table is actually created and used to test the positive case (e.g.
   // GetTable() and "table does exist")
-  auto table_id = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id = google::cloud::bigtable_testing::RandomTableId(generator);
 
   auto table = admin.CreateTable(
       table_id, cbt::TableConfig(

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -542,15 +542,15 @@ void RunAll(std::vector<std::string> const& argv) {
   // old tables left over. As there are quotas on the total number of tables we
   // remove stale tables after 48 hours.
   std::cout << "\nCleaning up old tables" << std::endl;
-  google::cloud::bigtable::testing::CleanupStaleTables(admin);
+  google::cloud::bigtable_testing::CleanupStaleTables(admin);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   // This table is actually created and used to test the positive case (e.g.
   // GetTable() and "table does exist")
-  auto table_id_1 = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id_1 = google::cloud::bigtable_testing::RandomTableId(generator);
   // This table does not exist and used to test the negative case (e.g.
   // GetTable() but "table does not exist")
-  auto table_id_2 = google::cloud::bigtable::testing::RandomTableId(generator);
+  auto table_id_2 = google::cloud::bigtable_testing::RandomTableId(generator);
 
   auto table_1 = admin.CreateTable(
       table_id_1, cbt::TableConfig(

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -37,7 +37,7 @@ namespace {
 namespace btadmin = ::google::bigtable::admin::v2;
 
 using MockAdminClient =
-    ::google::cloud::bigtable::testing::MockInstanceAdminClient;
+    ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
@@ -668,7 +668,7 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
 }
 
 using MockAsyncIamPolicyReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::iam::v1::Policy>;
 
 class AsyncGetIamPolicyTest : public ::testing::Test {
@@ -1032,7 +1032,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
 }
 
 using MockAsyncDeleteClusterReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::protobuf::Empty>;
 
 class AsyncDeleteClusterTest : public ::testing::Test {
@@ -1117,7 +1117,7 @@ TEST_F(AsyncDeleteClusterTest, AsyncDeleteClusterUnrecoverableError) {
 }
 
 using MockAsyncSetIamPolicyReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::iam::v1::Policy>;
 
 class AsyncSetIamPolicyTest : public ::testing::Test {
@@ -1273,7 +1273,7 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicyUnrecoverableError) {
 }
 
 using MockAsyncTestIamPermissionsReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::iam::v1::TestIamPermissionsResponse>;
 
 class AsyncTestIamPermissionsTest : public ::testing::Test {
@@ -1394,7 +1394,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::CreateAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateAppProfile(_, _, _))
@@ -1411,7 +1411,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::DeleteAppProfileRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteAppProfile(_, _, _))
@@ -1432,7 +1432,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::DeleteInstanceRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteInstance(_, _, _))
@@ -1451,7 +1451,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::GetAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetAppProfile(_, _, _))
@@ -1466,7 +1466,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::GetClusterRequest, btadmin::Cluster>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetCluster(_, _, _))
@@ -1481,7 +1481,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::GetInstanceRequest, btadmin::Instance>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncGetInstance(_, _, _))
@@ -1495,7 +1495,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::CreateClusterRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateCluster(_, _, _))
@@ -1517,7 +1517,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::CreateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateInstance(_, _, _))
@@ -1534,7 +1534,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::UpdateAppProfileRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateAppProfile(_, _, _))
@@ -1551,7 +1551,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::Cluster, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateCluster(_, _, _))
@@ -1572,7 +1572,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateInstance) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::PartialUpdateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncUpdateInstance(_, _, _))

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -32,10 +32,10 @@ namespace {
 namespace btproto = google::bigtable::v2;
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::bigtable::testing::MockClientAsyncReaderInterface;
+using ::google::cloud::bigtable_testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 
-class AsyncBulkApplyTest : public bigtable::testing::TableTestFixture {
+class AsyncBulkApplyTest : public bigtable_testing::TableTestFixture {
  protected:
   AsyncBulkApplyTest()
       : TableTestFixture(

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -34,11 +34,12 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::bigtable::testing::MockAsyncResponseReader;
+using ::google::cloud::bigtable_testing::MockAdminClient;
+using ::google::cloud::bigtable_testing::MockAsyncResponseReader;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 
 using MockAsyncLongrunningOpReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         google::longrunning::Operation>;
 
 void OperationFinishedSuccessfully(google::longrunning::Operation& response,
@@ -53,7 +54,7 @@ void OperationFinishedSuccessfully(google::longrunning::Operation& response,
   response.set_allocated_response(any.release());
 }
 
-class AsyncPollOpTest : public bigtable::testing::TableTestFixture {
+class AsyncPollOpTest : public bigtable_testing::TableTestFixture {
  protected:
   AsyncPollOpTest()
       : TableTestFixture(
@@ -61,12 +62,12 @@ class AsyncPollOpTest : public bigtable::testing::TableTestFixture {
         polling_policy_(
             bigtable::DefaultPollingPolicy(internal::kBigtableLimits)),
         metadata_update_policy_("test_operation_id", MetadataParamTypes::NAME),
-        client_(new testing::MockAdminClient(
+        client_(new MockAdminClient(
             ClientOptions().DisableBackgroundThreads(cq_))) {}
 
   std::shared_ptr<PollingPolicy const> polling_policy_;
   MetadataUpdatePolicy metadata_update_policy_;
-  std::shared_ptr<testing::MockAdminClient> client_;
+  std::shared_ptr<MockAdminClient> client_;
 };
 
 TEST_F(AsyncPollOpTest, AsyncPollOpTestSuccess) {

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -34,6 +34,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace internal {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::_;
 using ::testing::Return;
@@ -102,7 +103,7 @@ class AsyncMultipageFutureTest : public ::testing::Test {
             absl::make_unique<SharedBackoffPolicyMock>()),
         cq_impl_(new google::cloud::testing_util::FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new testing::MockInstanceAdminClient),
+        client_(new MockInstanceAdminClient),
         metadata_update_policy_("my_instance", MetadataParamTypes::NAME) {}
 
   // Description of a single expected RPC exchange.
@@ -116,7 +117,7 @@ class AsyncMultipageFutureTest : public ::testing::Test {
   };
 
   using MockAsyncListClustersReader =
-      google::cloud::bigtable::testing::MockAsyncResponseReader<
+      google::cloud::bigtable_testing::MockAsyncResponseReader<
           ListClustersResponse>;
 
   void ExpectInteraction(std::vector<Exchange> const& interaction) {
@@ -188,7 +189,7 @@ class AsyncMultipageFutureTest : public ::testing::Test {
   std::shared_ptr<google::cloud::testing_util::FakeCompletionQueueImpl>
       cq_impl_;
   CompletionQueue cq_;
-  std::shared_ptr<testing::MockInstanceAdminClient> client_;
+  std::shared_ptr<MockInstanceAdminClient> client_;
   MetadataUpdatePolicy metadata_update_policy_;
   std::vector<std::unique_ptr<MockAsyncListClustersReader>> readers_to_delete_;
 };

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -37,12 +37,13 @@ namespace {
 namespace btproto = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using MockAsyncLongrunningOpReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    google::cloud::bigtable_testing::MockAsyncResponseReader<
         google::longrunning::Operation>;
 
 class AsyncStartPollAfterRetryUnaryRpcTest
-    : public bigtable::testing::TableTestFixture {
+    : public bigtable_testing::TableTestFixture {
  public:
   AsyncStartPollAfterRetryUnaryRpcTest()
       : TableTestFixture(CompletionQueue(
@@ -64,7 +65,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
         metadata_update_policy(
             "projects/" + k_project_id + "/instances/" + k_instance_id,
             MetadataParamTypes::PARENT),
-        client(std::make_shared<testing::MockInstanceAdminClient>(
+        client(std::make_shared<MockInstanceAdminClient>(
             ClientOptions().DisableBackgroundThreads(cq_))),
         create_cluster_reader(
             absl::make_unique<MockAsyncLongrunningOpReader>()),
@@ -172,7 +173,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
   std::unique_ptr<RPCRetryPolicy> rpc_retry_policy;
   std::unique_ptr<RPCBackoffPolicy> rpc_backoff_policy;
   MetadataUpdatePolicy metadata_update_policy;
-  std::shared_ptr<testing::MockInstanceAdminClient> client;
+  std::shared_ptr<MockInstanceAdminClient> client;
   std::unique_ptr<MockAsyncLongrunningOpReader> create_cluster_reader;
   std::unique_ptr<MockAsyncLongrunningOpReader> get_operation_reader;
 };

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -29,7 +29,7 @@ namespace {
 namespace btproto = google::bigtable::v2;
 using ::testing::Return;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::bigtable::testing::MockMutateRowsReader;
+using ::google::cloud::bigtable_testing::MockMutateRowsReader;
 
 std::unique_ptr<grpc::ClientContext> TestContext() {
   auto context = absl::make_unique<grpc::ClientContext>();
@@ -70,7 +70,7 @@ TEST(MultipleRowsMutatorTest, Simple) {
   EXPECT_CALL(*reader, Finish()).WillOnce(Return(grpc::Status::OK));
 
   // Now prepare the client for the one request.
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce(reader.release()->MakeMockReturner());
 
@@ -102,7 +102,7 @@ TEST(MultipleRowsMutatorTest, BulkApplyAppProfileId) {
 
   // Now prepare the client for the one request.
   std::string expected_id = "test-id";
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce([expected_id](grpc::ClientContext*,
                               btproto::MutateRowsRequest const& req) {
@@ -152,7 +152,7 @@ TEST(MultipleRowsMutatorTest, RetryPartialFailure) {
   // indicates a partial failure.
 
   // Setup the client to response with r1 first, and r2 next.
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce(
           [](grpc::ClientContext*, btproto::MutateRowsRequest const& req) {
@@ -254,7 +254,7 @@ TEST(MultipleRowsMutatorTest, PermanentFailure) {
       .WillOnce(Return(false));
   EXPECT_CALL(*r2, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce(r1.release()->MakeMockReturner())
       .WillOnce(r2.release()->MakeMockReturner());
@@ -318,7 +318,7 @@ TEST(MultipleRowsMutatorTest, PartialStream) {
       .WillOnce(Return(false));
   EXPECT_CALL(*r2, Finish()).WillOnce(Return(grpc::Status::OK));
 
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce(r1.release()->MakeMockReturner())
       .WillOnce(r2.release()->MakeMockReturner());
@@ -359,7 +359,7 @@ TEST(MultipleRowsMutatorTest, RetryOnlyIdempotent) {
     ASSERT_EQ(2, r.entries_size());
     EXPECT_EQ("bar", r.entries(0).row_key());
   };
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce([](grpc::ClientContext*, btproto::MutateRowsRequest const& r) {
         EXPECT_EQ(4, r.entries_size());
@@ -441,7 +441,7 @@ TEST(MultipleRowsMutatorTest, UnconfirmedAreFailed) {
   // The BulkMutator should not issue a second request because the error is
   // PERMISSION_DENIED (not retryable).
 
-  bigtable::testing::MockDataClient client;
+  bigtable_testing::MockDataClient client;
   EXPECT_CALL(client, MutateRows)
       .WillOnce([](grpc::ClientContext*, btproto::MutateRowsRequest const& r) {
         EXPECT_EQ(3, r.entries_size());

--- a/google/cloud/bigtable/internal/logging_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_admin_client_test.cc
@@ -24,6 +24,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::bigtable_testing::MockAdminClient;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -40,7 +41,7 @@ class LoggingAdminClientTest : public ::testing::Test {
 };
 
 TEST_F(LoggingAdminClientTest, CreateTable) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, CreateTable).WillOnce(Return(grpc::Status()));
 
@@ -58,7 +59,7 @@ TEST_F(LoggingAdminClientTest, CreateTable) {
 }
 
 TEST_F(LoggingAdminClientTest, ListTables) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, ListTables).WillOnce(Return(grpc::Status()));
 
@@ -76,7 +77,7 @@ TEST_F(LoggingAdminClientTest, ListTables) {
 }
 
 TEST_F(LoggingAdminClientTest, GetTable) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, GetTable).WillOnce(Return(grpc::Status()));
 
@@ -94,7 +95,7 @@ TEST_F(LoggingAdminClientTest, GetTable) {
 }
 
 TEST_F(LoggingAdminClientTest, DeleteTable) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, DeleteTable).WillOnce(Return(grpc::Status()));
 
@@ -112,7 +113,7 @@ TEST_F(LoggingAdminClientTest, DeleteTable) {
 }
 
 TEST_F(LoggingAdminClientTest, CreateBackup) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, CreateBackup).WillOnce(Return(grpc::Status()));
 
@@ -130,7 +131,7 @@ TEST_F(LoggingAdminClientTest, CreateBackup) {
 }
 
 TEST_F(LoggingAdminClientTest, GetBackup) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, GetBackup).WillOnce(Return(grpc::Status()));
 
@@ -148,7 +149,7 @@ TEST_F(LoggingAdminClientTest, GetBackup) {
 }
 
 TEST_F(LoggingAdminClientTest, UpdateBackup) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, UpdateBackup).WillOnce(Return(grpc::Status()));
 
@@ -166,7 +167,7 @@ TEST_F(LoggingAdminClientTest, UpdateBackup) {
 }
 
 TEST_F(LoggingAdminClientTest, DeleteBackup) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, DeleteBackup).WillOnce(Return(grpc::Status()));
 
@@ -184,7 +185,7 @@ TEST_F(LoggingAdminClientTest, DeleteBackup) {
 }
 
 TEST_F(LoggingAdminClientTest, ListBackups) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, ListBackups).WillOnce(Return(grpc::Status()));
 
@@ -202,7 +203,7 @@ TEST_F(LoggingAdminClientTest, ListBackups) {
 }
 
 TEST_F(LoggingAdminClientTest, RestoreTable) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, RestoreTable).WillOnce(Return(grpc::Status()));
 
@@ -220,7 +221,7 @@ TEST_F(LoggingAdminClientTest, RestoreTable) {
 }
 
 TEST_F(LoggingAdminClientTest, ModifyColumnFamilies) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, ModifyColumnFamilies).WillOnce(Return(grpc::Status()));
 
@@ -238,7 +239,7 @@ TEST_F(LoggingAdminClientTest, ModifyColumnFamilies) {
 }
 
 TEST_F(LoggingAdminClientTest, DropRowRange) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, DropRowRange).WillOnce(Return(grpc::Status()));
 
@@ -256,7 +257,7 @@ TEST_F(LoggingAdminClientTest, DropRowRange) {
 }
 
 TEST_F(LoggingAdminClientTest, GenerateConsistencyToken) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, GenerateConsistencyToken).WillOnce(Return(grpc::Status()));
 
@@ -275,7 +276,7 @@ TEST_F(LoggingAdminClientTest, GenerateConsistencyToken) {
 }
 
 TEST_F(LoggingAdminClientTest, CheckConsistency) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, CheckConsistency).WillOnce(Return(grpc::Status()));
 
@@ -293,7 +294,7 @@ TEST_F(LoggingAdminClientTest, CheckConsistency) {
 }
 
 TEST_F(LoggingAdminClientTest, GetOperation) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, GetOperation).WillOnce(Return(grpc::Status()));
 
@@ -311,7 +312,7 @@ TEST_F(LoggingAdminClientTest, GetOperation) {
 }
 
 TEST_F(LoggingAdminClientTest, GetIamPolicy) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, GetIamPolicy).WillOnce(Return(grpc::Status()));
 
@@ -329,7 +330,7 @@ TEST_F(LoggingAdminClientTest, GetIamPolicy) {
 }
 
 TEST_F(LoggingAdminClientTest, SetIamPolicy) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, SetIamPolicy).WillOnce(Return(grpc::Status()));
 
@@ -347,7 +348,7 @@ TEST_F(LoggingAdminClientTest, SetIamPolicy) {
 }
 
 TEST_F(LoggingAdminClientTest, TestIamPermissions) {
-  auto mock = std::make_shared<testing::MockAdminClient>();
+  auto mock = std::make_shared<MockAdminClient>();
 
   EXPECT_CALL(*mock, TestIamPermissions).WillOnce(Return(grpc::Status()));
 

--- a/google/cloud/bigtable/internal/logging_data_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_data_client_test.cc
@@ -24,6 +24,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::bigtable_testing::MockDataClient;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -40,7 +41,7 @@ class LoggingDataClientTest : public ::testing::Test {
 };
 
 TEST_F(LoggingDataClientTest, MutateRow) {
-  auto mock = std::make_shared<testing::MockDataClient>();
+  auto mock = std::make_shared<MockDataClient>();
 
   EXPECT_CALL(*mock, MutateRow).WillOnce(Return(grpc::Status()));
 
@@ -58,7 +59,7 @@ TEST_F(LoggingDataClientTest, MutateRow) {
 }
 
 TEST_F(LoggingDataClientTest, CheckAndMutateRow) {
-  auto mock = std::make_shared<testing::MockDataClient>();
+  auto mock = std::make_shared<MockDataClient>();
 
   EXPECT_CALL(*mock, CheckAndMutateRow).WillOnce(Return(grpc::Status()));
 
@@ -76,7 +77,7 @@ TEST_F(LoggingDataClientTest, CheckAndMutateRow) {
 }
 
 TEST_F(LoggingDataClientTest, ReadModifyWriteRow) {
-  auto mock = std::make_shared<testing::MockDataClient>();
+  auto mock = std::make_shared<MockDataClient>();
 
   EXPECT_CALL(*mock, ReadModifyWriteRow).WillOnce(Return(grpc::Status()));
 
@@ -94,7 +95,7 @@ TEST_F(LoggingDataClientTest, ReadModifyWriteRow) {
 }
 
 TEST_F(LoggingDataClientTest, ReadRows) {
-  auto mock = std::make_shared<testing::MockDataClient>();
+  auto mock = std::make_shared<MockDataClient>();
 
   EXPECT_CALL(*mock, ReadRows)
       .WillOnce([](grpc::ClientContext*, btproto::ReadRowsRequest const&) {
@@ -114,7 +115,7 @@ TEST_F(LoggingDataClientTest, ReadRows) {
 }
 
 TEST_F(LoggingDataClientTest, SampleRowKeys) {
-  auto mock = std::make_shared<testing::MockDataClient>();
+  auto mock = std::make_shared<MockDataClient>();
 
   EXPECT_CALL(*mock, SampleRowKeys)
       .WillOnce([](grpc::ClientContext*, btproto::SampleRowKeysRequest const&) {
@@ -134,7 +135,7 @@ TEST_F(LoggingDataClientTest, SampleRowKeys) {
 }
 
 TEST_F(LoggingDataClientTest, MutateRows) {
-  auto mock = std::make_shared<testing::MockDataClient>();
+  auto mock = std::make_shared<MockDataClient>();
 
   EXPECT_CALL(*mock, MutateRows)
       .WillOnce([](grpc::ClientContext*, btproto::MutateRowsRequest const&) {

--- a/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
+++ b/google/cloud/bigtable/internal/logging_instance_admin_client_test.cc
@@ -25,12 +25,13 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::bigtable_testing::MockInstanceAdminClient;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
 using MockAsyncLongrunningOpReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         google::longrunning::Operation>;
 
 namespace btadmin = google::bigtable::admin::v2;
@@ -45,7 +46,7 @@ class LoggingInstanceAdminClientTest : public ::testing::Test {
 };
 
 TEST_F(LoggingInstanceAdminClientTest, ListInstances) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, ListInstances).WillOnce(Return(grpc::Status()));
 
@@ -63,7 +64,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListInstances) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, CreateInstance) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, CreateInstance).WillOnce(Return(grpc::Status()));
 
@@ -81,7 +82,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateInstance) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, UpdateInstance) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, UpdateInstance).WillOnce(Return(grpc::Status()));
 
@@ -99,7 +100,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateInstance) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetOperation) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, GetOperation).WillOnce(Return(grpc::Status()));
 
@@ -117,7 +118,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetOperation) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetInstance) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, GetInstance).WillOnce(Return(grpc::Status()));
 
@@ -135,7 +136,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetInstance) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, DeleteInstance) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, DeleteInstance).WillOnce(Return(grpc::Status()));
 
@@ -153,7 +154,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteInstance) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, ListClusters) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, ListClusters).WillOnce(Return(grpc::Status()));
 
@@ -171,7 +172,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListClusters) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetCluster) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, GetCluster).WillOnce(Return(grpc::Status()));
 
@@ -189,7 +190,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetCluster) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, DeleteCluster) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, DeleteCluster).WillOnce(Return(grpc::Status()));
 
@@ -207,7 +208,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteCluster) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, CreateCluster) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, CreateCluster).WillOnce(Return(grpc::Status()));
 
@@ -225,7 +226,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateCluster) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, UpdateCluster) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, UpdateCluster).WillOnce(Return(grpc::Status()));
 
@@ -243,7 +244,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateCluster) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, CreateAppProfile) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, CreateAppProfile).WillOnce(Return(grpc::Status()));
 
@@ -261,7 +262,7 @@ TEST_F(LoggingInstanceAdminClientTest, CreateAppProfile) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetAppProfile) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, GetAppProfile).WillOnce(Return(grpc::Status()));
 
@@ -279,7 +280,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetAppProfile) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, ListAppProfiles) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, ListAppProfiles).WillOnce(Return(grpc::Status()));
 
@@ -297,7 +298,7 @@ TEST_F(LoggingInstanceAdminClientTest, ListAppProfiles) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, UpdateAppProfile) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, UpdateAppProfile).WillOnce(Return(grpc::Status()));
 
@@ -315,7 +316,7 @@ TEST_F(LoggingInstanceAdminClientTest, UpdateAppProfile) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, DeleteAppProfile) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, DeleteAppProfile).WillOnce(Return(grpc::Status()));
 
@@ -333,7 +334,7 @@ TEST_F(LoggingInstanceAdminClientTest, DeleteAppProfile) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, GetIamPolicy) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, GetIamPolicy).WillOnce(Return(grpc::Status()));
 
@@ -351,7 +352,7 @@ TEST_F(LoggingInstanceAdminClientTest, GetIamPolicy) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, SetIamPolicy) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, SetIamPolicy).WillOnce(Return(grpc::Status()));
 
@@ -369,7 +370,7 @@ TEST_F(LoggingInstanceAdminClientTest, SetIamPolicy) {
 }
 
 TEST_F(LoggingInstanceAdminClientTest, TestIamPermissions) {
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, TestIamPermissions).WillOnce(Return(grpc::Status()));
 
@@ -388,7 +389,7 @@ TEST_F(LoggingInstanceAdminClientTest, TestIamPermissions) {
 
 TEST_F(LoggingInstanceAdminClientTest, AsyncCreateInstance) {
   auto reader = absl::make_unique<MockAsyncLongrunningOpReader>();
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, AsyncCreateInstance)
       .WillOnce([&reader](grpc::ClientContext*,
@@ -412,7 +413,7 @@ TEST_F(LoggingInstanceAdminClientTest, AsyncCreateInstance) {
 
 TEST_F(LoggingInstanceAdminClientTest, AsyncUpdateInstance) {
   auto reader = absl::make_unique<MockAsyncLongrunningOpReader>();
-  auto mock = std::make_shared<testing::MockInstanceAdminClient>();
+  auto mock = std::make_shared<MockInstanceAdminClient>();
 
   EXPECT_CALL(*mock, AsyncUpdateInstance)
       .WillOnce([&reader](grpc::ClientContext*,

--- a/google/cloud/bigtable/metadata_update_policy_test.cc
+++ b/google/cloud/bigtable/metadata_update_policy_test.cc
@@ -27,7 +27,8 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
-class MetadataUpdatePolicyTest : public testing::EmbeddedServerTestFixture {};
+class MetadataUpdatePolicyTest
+    : public bigtable_testing::EmbeddedServerTestFixture {};
 
 using ::testing::HasSubstr;
 

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -36,7 +36,7 @@ namespace bt = ::google::cloud::bigtable;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using bigtable::testing::MockClientAsyncReaderInterface;
+using ::google::cloud::bigtable_testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::_;
 using ::testing::Not;
@@ -133,7 +133,7 @@ auto generate_response_generator = [](ResultPiece const& result_piece) {
   };
 };
 
-class MutationBatcherTest : public bigtable::testing::TableTestFixture {
+class MutationBatcherTest : public bigtable_testing::TableTestFixture {
  protected:
   MutationBatcherTest()
       : TableTestFixture(

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -35,7 +35,7 @@ namespace {
 using ::google::bigtable::v2::ReadRowsRequest;
 using ::google::bigtable::v2::ReadRowsResponse_CellChunk;
 using ::google::cloud::bigtable::Row;
-using ::google::cloud::bigtable::testing::MockReadRowsReader;
+using ::google::cloud::bigtable_testing::MockReadRowsReader;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::testing::_;
 using ::testing::Contains;
@@ -147,7 +147,7 @@ Matcher<const ReadRowsRequest&> RequestWithRowsLimit(std::int64_t n) {
   return Property(&ReadRowsRequest::rows_limit, Eq(n));
 }
 
-class RowReaderTest : public bigtable::testing::TableTestFixture {
+class RowReaderTest : public bigtable_testing::TableTestFixture {
  public:
   RowReaderTest()
       : TableTestFixture(CompletionQueue{}),
@@ -419,7 +419,7 @@ TEST_F(RowReaderTest, FailedParseIsRetried) {
   auto* stream = new MockReadRowsReader("google.bigtable.v2.Bigtable.ReadRows");
   auto parser = absl::make_unique<ReadRowsParserMock>();
   parser->SetRows({"r1"});
-  auto response = bigtable::testing::ReadRowsResponseFromString("chunks {}");
+  auto response = bigtable_testing::ReadRowsResponseFromString("chunks {}");
   {
     ::testing::InSequence s;
     EXPECT_CALL(*client_, ReadRows).WillOnce(stream->MakeMockReturner());

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -53,7 +53,7 @@ using ::testing::Not;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
-using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+using MockAdminClient = ::google::cloud::bigtable_testing::MockAdminClient;
 
 std::string const kProjectId = "the-project";
 std::string const kInstanceId = "the-instance";
@@ -1175,7 +1175,7 @@ TEST_F(TableAdminTest, TestIamPermissionsRecoverableError) {
 }
 
 using MockAsyncCheckConsistencyResponse =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         btadmin::CheckConsistencyResponse>;
 
 /**
@@ -1364,7 +1364,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 };
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateTable) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::CreateTableRequest, btadmin::Table>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateTable(_, _, _))
@@ -1379,7 +1379,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateTable) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteTable) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::DeleteTableRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDeleteTable(_, _, _))
@@ -1393,7 +1393,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteTable) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::CreateBackupRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCreateBackup(_, _, _))
@@ -1418,7 +1418,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateBackup) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncRestoreTable) {
   using ::testing::_;
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::RestoreTableRequest, google::longrunning::Operation>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncRestoreTable(_, _, _))
@@ -1435,7 +1435,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncRestoreTable) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncDropAllRows) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::DropRowRangeRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDropRowRange(_, _, _))
@@ -1449,7 +1449,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncDropAllRows) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncDropRowsByPrefix) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::DropRowRangeRequest, google::protobuf::Empty>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncDropRowRange(_, _, _))
@@ -1463,7 +1463,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncDropRowsByPrefix) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncGenerateConsistencyToken) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::GenerateConsistencyTokenRequest,
       btadmin::GenerateConsistencyTokenResponse>
       rpc_factory;
@@ -1478,7 +1478,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncGenerateConsistencyToken) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncListTables) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::ListTablesRequest, btadmin::ListTablesResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncListTables(_, _, _))
@@ -1492,7 +1492,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncListTables) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncModifyColumnFamilies) {
-  ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
+  ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory<
       btadmin::ModifyColumnFamiliesRequest, btadmin::Table>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncModifyColumnFamilies(_, _, _))
@@ -1505,7 +1505,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncModifyColumnFamilies) {
 }
 
 using MockAsyncIamPolicyReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::iam::v1::Policy>;
 
 class AsyncGetIamPolicyTest : public ::testing::Test {
@@ -1591,7 +1591,7 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
 }
 
 using MockAsyncSetIamPolicyReader =
-    google::cloud::bigtable::testing::MockAsyncResponseReader<
+    google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::iam::v1::Policy>;
 
 class AsyncSetIamPolicyTest : public ::testing::Test {
@@ -1685,7 +1685,7 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
 }
 
 using MockAsyncTestIamPermissionsReader =
-    ::google::cloud::bigtable::testing::MockAsyncResponseReader<
+    ::google::cloud::bigtable_testing::MockAsyncResponseReader<
         ::google::iam::v1::TestIamPermissionsResponse>;
 
 class AsyncTestIamPermissionsTest : public ::testing::Test {

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -41,7 +41,7 @@ auto mock_mutate_row = [](grpc::Status const& status) {
   };
 };
 
-class TableApplyTest : public bigtable::testing::TableTestFixture {
+class TableApplyTest : public bigtable_testing::TableTestFixture {
  public:
   TableApplyTest() : TableTestFixture(CompletionQueue{}) {}
 };

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -35,11 +35,11 @@ using ::testing::Return;
 
 /// Define types and functions used in the tests.
 class TableBulkApplyTest
-    : public ::google::cloud::bigtable::testing::TableTestFixture {
+    : public ::google::cloud::bigtable_testing::TableTestFixture {
  public:
   TableBulkApplyTest() : TableTestFixture(CompletionQueue{}) {}
 };
-using google::cloud::bigtable::testing::MockMutateRowsReader;
+using google::cloud::bigtable_testing::MockMutateRowsReader;
 
 /// @test Verify that Table::BulkApply() works in the easy case.
 TEST_F(TableBulkApplyTest, Simple) {

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -28,7 +28,7 @@ namespace {
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 
-class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
+class TableCheckAndMutateRowTest : public bigtable_testing::TableTestFixture {
  public:
   TableCheckAndMutateRowTest() : TableTestFixture(CompletionQueue{}) {}
 };

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -31,7 +31,7 @@ namespace btproto = ::google::bigtable::v2;
 using ::google::cloud::testing_util::IsContextMDValid;
 
 /// Define helper types and functions for this test.
-class TableReadModifyWriteTest : public bigtable::testing::TableTestFixture {
+class TableReadModifyWriteTest : public bigtable_testing::TableTestFixture {
  public:
   TableReadModifyWriteTest() : TableTestFixture(CompletionQueue{}) {}
 };

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -25,17 +25,17 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 namespace btproto = ::google::bigtable::v2;
-using ::google::cloud::bigtable::testing::MockReadRowsReader;
+using ::google::cloud::bigtable_testing::MockReadRowsReader;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::testing::Return;
 
-class TableReadRowTest : public bigtable::testing::TableTestFixture {
+class TableReadRowTest : public bigtable_testing::TableTestFixture {
  public:
   TableReadRowTest() : TableTestFixture(CompletionQueue{}) {}
 };
 
 TEST_F(TableReadRowTest, ReadRowSimple) {
-  auto const response = bigtable::testing::ReadRowsResponseFromString(R"(
+  auto const response = bigtable_testing::ReadRowsResponseFromString(R"(
       chunks {
         row_key: "r1"
         family_name { value: "fam" }

--- a/google/cloud/bigtable/table_readrows_test.cc
+++ b/google/cloud/bigtable/table_readrows_test.cc
@@ -24,19 +24,19 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
-using ::google::cloud::bigtable::testing::MockReadRowsReader;
+using ::google::cloud::bigtable_testing::MockReadRowsReader;
 using ::testing::DoAll;
 using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::WithoutArgs;
 
-class TableReadRowsTest : public bigtable::testing::TableTestFixture {
+class TableReadRowsTest : public bigtable_testing::TableTestFixture {
  public:
   TableReadRowsTest() : TableTestFixture(CompletionQueue{}) {}
 };
 
 TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
-  auto response = bigtable::testing::ReadRowsResponseFromString(R"(
+  auto response = bigtable_testing::ReadRowsResponseFromString(R"(
       chunks {
         row_key: "r1"
         family_name { value: "fam" }
@@ -66,7 +66,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadOneRow) {
 }
 
 TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
-  auto response = bigtable::testing::ReadRowsResponseFromString(R"(
+  auto response = bigtable_testing::ReadRowsResponseFromString(R"(
       chunks {
         row_key: "r1"
         family_name { value: "fam" }
@@ -77,7 +77,7 @@ TEST_F(TableReadRowsTest, ReadRowsCanReadWithRetries) {
       }
       )");
 
-  auto response_retry = bigtable::testing::ReadRowsResponseFromString(R"(
+  auto response_retry = bigtable_testing::ReadRowsResponseFromString(R"(
       chunks {
         row_key: "r2"
         family_name { value: "fam" }

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -26,12 +26,12 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;
-using ::google::cloud::bigtable::testing::MockSampleRowKeysReader;
+using ::google::cloud::bigtable_testing::MockSampleRowKeysReader;
 using ::testing::Return;
 using ::testing::Unused;
 
 class TableSampleRowKeysTest
-    : public ::google::cloud::bigtable::testing::TableTestFixture {
+    : public ::google::cloud::bigtable_testing::TableTestFixture {
  public:
   TableSampleRowKeysTest() : TableTestFixture(CompletionQueue{}) {}
 };

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -24,11 +24,12 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 namespace btproto = ::google::bigtable::v2;
-using google::cloud::testing_util::FakeCompletionQueueImpl;
+using ::google::cloud::bigtable_testing::MockAsyncFailingRpcFactory;
+using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 
 /// Define types and functions used in the tests.
 namespace {
-class TableTest : public ::google::cloud::bigtable::testing::TableTestFixture {
+class TableTest : public ::google::cloud::bigtable_testing::TableTestFixture {
  public:
   TableTest() : TableTestFixture(CompletionQueue{}) {}
 };
@@ -119,7 +120,7 @@ class ValidContextMdAsyncTest : public ::testing::Test {
   ValidContextMdAsyncTest()
       : cq_impl_(new FakeCompletionQueueImpl),
         cq_(cq_impl_),
-        client_(new ::google::cloud::bigtable::testing::MockDataClient(
+        client_(new ::google::cloud::bigtable_testing::MockDataClient(
             ClientOptions().DisableBackgroundThreads(cq_))) {
     EXPECT_CALL(*client_, project_id())
         .WillRepeatedly(::testing::ReturnRef(kProjectId));
@@ -151,14 +152,14 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 
   std::shared_ptr<FakeCompletionQueueImpl> cq_impl_;
   CompletionQueue cq_;
-  std::shared_ptr<testing::MockDataClient> client_;
+  std::shared_ptr<bigtable_testing::MockDataClient> client_;
   std::unique_ptr<Table> table_;
 };
 
 TEST_F(ValidContextMdAsyncTest, AsyncApply) {
   using ::testing::_;
-  testing::MockAsyncFailingRpcFactory<btproto::MutateRowRequest,
-                                      btproto::MutateRowResponse>
+  MockAsyncFailingRpcFactory<btproto::MutateRowRequest,
+                             btproto::MutateRowResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncMutateRow(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -173,8 +174,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncApply) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncCheckAndMutateRow) {
   using ::testing::_;
-  testing::MockAsyncFailingRpcFactory<btproto::CheckAndMutateRowRequest,
-                                      btproto::CheckAndMutateRowResponse>
+  MockAsyncFailingRpcFactory<btproto::CheckAndMutateRowRequest,
+                             btproto::CheckAndMutateRowResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncCheckAndMutateRow(_, _, _))
       .WillOnce(rpc_factory.Create(
@@ -191,8 +192,8 @@ TEST_F(ValidContextMdAsyncTest, AsyncCheckAndMutateRow) {
 
 TEST_F(ValidContextMdAsyncTest, AsyncReadModifyWriteRow) {
   using ::testing::_;
-  testing::MockAsyncFailingRpcFactory<btproto::ReadModifyWriteRowRequest,
-                                      btproto::ReadModifyWriteRowResponse>
+  MockAsyncFailingRpcFactory<btproto::ReadModifyWriteRowRequest,
+                             btproto::ReadModifyWriteRowResponse>
       rpc_factory;
   EXPECT_CALL(*client_, AsyncReadModifyWriteRow(_, _, _))
       .WillOnce(rpc_factory.Create(

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.cc
@@ -19,16 +19,14 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin) {
   auto const threshold =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   auto const max_table_id = RandomTableId(threshold);
   auto const re = std::regex(RandomTableIdRegex());
 
-  auto tables = admin.ListTables(TableAdmin::NAME_ONLY);
+  auto tables = admin.ListTables(bigtable::TableAdmin::NAME_ONLY);
   if (!tables) return std::move(tables).status();
   for (auto const& t : *tables) {
     std::vector<std::string> const components = absl::StrSplit(t.name(), '/');
@@ -85,7 +83,6 @@ Status CleanupStaleInstances(google::cloud::bigtable::InstanceAdmin admin) {
   return Status{};
 }
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.cc
@@ -20,6 +20,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 Status CleanupStaleTables(google::cloud::bigtable::TableAdmin admin) {
   auto const threshold =
       std::chrono::system_clock::now() - std::chrono::hours(48);

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.h
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.h
@@ -20,9 +20,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /**
  * Remove stale test tables.
  *
@@ -59,8 +57,7 @@ Status CleanupStaleBackups(google::cloud::bigtable::TableAdmin admin);
  */
 Status CleanupStaleInstances(google::cloud::bigtable::InstanceAdmin admin);
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/cleanup_stale_resources_test.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources_test.cc
@@ -21,8 +21,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
+namespace bigtable_testing {
 namespace {
 
 using ::google::cloud::internal::DefaultPRNG;
@@ -30,7 +29,7 @@ using ::testing::HasSubstr;
 using ::testing::ReturnRef;
 
 TEST(CleanupStaleResources, CleanupOldTables) {
-  using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+  using MockAdminClient = ::google::cloud::bigtable_testing::MockAdminClient;
   namespace btadmin = google::bigtable::admin::v2;
 
   auto const expired_tp =
@@ -82,7 +81,7 @@ TEST(CleanupStaleResources, CleanupOldTables) {
 }
 
 TEST(CleanupStaleResources, CleanupStaleBackups) {
-  using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+  using MockAdminClient = ::google::cloud::bigtable_testing::MockAdminClient;
   using google::protobuf::util::TimeUtil;
   namespace btadmin = google::bigtable::admin::v2;
 
@@ -150,7 +149,7 @@ TEST(CleanupStaleResources, CleanupStaleBackups) {
 
 TEST(CleanupStaleResources, CleanupOldInstances) {
   using MockAdminClient =
-      ::google::cloud::bigtable::testing::MockInstanceAdminClient;
+      ::google::cloud::bigtable_testing::MockInstanceAdminClient;
   namespace btadmin = google::bigtable::admin::v2;
 
   auto const expired_tp =
@@ -202,7 +201,6 @@ TEST(CleanupStaleResources, CleanupOldInstances) {
 }
 
 }  // namespace
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -20,6 +20,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 char const EmbeddedServerTestFixture::kProjectId[] = "foo-project";
 char const EmbeddedServerTestFixture::kInstanceId[] = "bar-instance";
 char const EmbeddedServerTestFixture::kTableId[] = "baz-table";

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.cc
@@ -19,9 +19,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 char const EmbeddedServerTestFixture::kProjectId[] = "foo-project";
 char const EmbeddedServerTestFixture::kInstanceId[] = "bar-instance";
 char const EmbeddedServerTestFixture::kTableId[] = "baz-table";
@@ -48,7 +46,8 @@ void EmbeddedServerTestFixture::SetUp() {
   StartServer();
 
   grpc::ChannelArguments channel_arguments;
-  channel_arguments.SetUserAgentPrefix(ClientOptions::UserAgentPrefix());
+  channel_arguments.SetUserAgentPrefix(
+      bigtable::ClientOptions::UserAgentPrefix());
   std::string project_id = kProjectId;
   std::string instance_id = kInstanceId;
   std::string table_id = kTableId;
@@ -72,7 +71,6 @@ void EmbeddedServerTestFixture::TearDown() {
   wait_thread_.join();
 }
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -27,6 +27,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 using ReceivedMetadata = std::multimap<std::string, std::string>;
 
 inline void GetClientMetadata(grpc::ServerContext* context,

--- a/google/cloud/bigtable/testing/embedded_server_test_fixture.h
+++ b/google/cloud/bigtable/testing/embedded_server_test_fixture.h
@@ -26,9 +26,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 using ReceivedMetadata = std::multimap<std::string, std::string>;
 
 inline void GetClientMetadata(grpc::ServerContext* context,
@@ -104,8 +102,8 @@ class EmbeddedServerTestFixture : public ::testing::Test {
 
   std::string project_id_ = kProjectId;
   std::string instance_id_ = kInstanceId;
-  std::shared_ptr<DataClient> data_client_;
-  std::shared_ptr<AdminClient> admin_client_;
+  std::shared_ptr<bigtable::DataClient> data_client_;
+  std::shared_ptr<bigtable::AdminClient> admin_client_;
   std::shared_ptr<bigtable::Table> table_;
   std::shared_ptr<bigtable::TableAdmin> admin_;
   std::thread wait_thread_;
@@ -115,8 +113,7 @@ class EmbeddedServerTestFixture : public ::testing::Test {
   std::unique_ptr<grpc::Server> server_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/inprocess_admin_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.cc
@@ -16,9 +16,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 namespace btadmin = google::bigtable::admin::v2;
 
 grpc::Status InProcessAdminClient::CreateTable(
@@ -302,7 +300,6 @@ InProcessAdminClient::AsyncGetOperation(
       stub->AsyncGetOperation(context, request, cq).release());
 }
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_admin_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.cc
@@ -17,6 +17,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 namespace btadmin = google::bigtable::admin::v2;
 
 grpc::Status InProcessAdminClient::CreateTable(

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -24,6 +24,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 /**
  * Connects to Cloud Bigtable's administration APIs.
  *

--- a/google/cloud/bigtable/testing/inprocess_admin_client.h
+++ b/google/cloud/bigtable/testing/inprocess_admin_client.h
@@ -23,9 +23,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /**
  * Connects to Cloud Bigtable's administration APIs.
  *
@@ -230,6 +228,7 @@ class InProcessAdminClient : public bigtable::AdminClient {
   //@}
 
  private:
+  using ClientOptions = bigtable::ClientOptions;
   ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
     return options_.background_threads_factory();
   }
@@ -239,8 +238,7 @@ class InProcessAdminClient : public bigtable::AdminClient {
   ClientOptions options_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/inprocess_data_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_data_client.cc
@@ -17,6 +17,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 namespace btproto = google::bigtable::v2;
 
 grpc::Status InProcessDataClient::MutateRow(

--- a/google/cloud/bigtable/testing/inprocess_data_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_data_client.cc
@@ -16,9 +16,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 namespace btproto = google::bigtable::v2;
 
 grpc::Status InProcessDataClient::MutateRow(
@@ -136,7 +134,6 @@ InProcessDataClient::AsyncSampleRowKeys(
   return Stub()->AsyncSampleRowKeys(context, request, cq, tag);
 }
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -23,6 +23,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 /**
  * Connect to an embedded Cloud Bigtable server implementing the data
  * manipulation APIs.

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -22,9 +22,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /**
  * Connect to an embedded Cloud Bigtable server implementing the data
  * manipulation APIs.
@@ -129,6 +127,7 @@ class InProcessDataClient : public bigtable::DataClient {
   //@}
 
  private:
+  using ClientOptions = bigtable::ClientOptions;
   ClientOptions::BackgroundThreadsFactory BackgroundThreadsFactory() override {
     return options_.background_threads_factory();
   }
@@ -139,8 +138,7 @@ class InProcessDataClient : public bigtable::DataClient {
   ClientOptions options_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -22,6 +22,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 class MockAdminClient : public bigtable::AdminClient {
  public:
   using ClientOptions = ::google::cloud::bigtable::ClientOptions;

--- a/google/cloud/bigtable/testing/mock_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_admin_client.h
@@ -21,11 +21,10 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 class MockAdminClient : public bigtable::AdminClient {
  public:
+  using ClientOptions = ::google::cloud::bigtable::ClientOptions;
   explicit MockAdminClient(ClientOptions options = {})
       : options_(std::move(options)) {}
 
@@ -264,8 +263,7 @@ class MockAdminClient : public bigtable::AdminClient {
   ClientOptions options_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -27,6 +27,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 /**
  * Helper class to create the expectations for a failing async RPC call.
  *

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -26,9 +26,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /**
  * Helper class to create the expectations for a failing async RPC call.
  *
@@ -46,7 +44,7 @@ struct MockAsyncFailingRpcFactory {
           grpc::CompletionQueue*);
 
   MockAsyncFailingRpcFactory()
-      : reader(new google::cloud::bigtable::testing::MockAsyncResponseReader<
+      : reader(new google::cloud::bigtable_testing::MockAsyncResponseReader<
                ResponseType>) {}
 
   /// Refactor the boilerplate common to most tests.
@@ -80,11 +78,10 @@ struct MockAsyncFailingRpcFactory {
   }
 
   std::unique_ptr<
-      google::cloud::bigtable::testing::MockAsyncResponseReader<ResponseType>>
+      google::cloud::bigtable_testing::MockAsyncResponseReader<ResponseType>>
       reader;
 };
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -21,11 +21,11 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 class MockDataClient : public bigtable::DataClient {
  public:
+  using ClientOptions = bigtable::ClientOptions;
+
   explicit MockDataClient(ClientOptions options = {})
       : options_(std::move(options)) {}
 
@@ -133,8 +133,7 @@ class MockDataClient : public bigtable::DataClient {
   ClientOptions options_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -22,6 +22,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 class MockDataClient : public bigtable::DataClient {
  public:
   using ClientOptions = bigtable::ClientOptions;

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -21,11 +21,10 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
  public:
+  using ClientOptions = ::google::cloud::bigtable::ClientOptions;
   explicit MockInstanceAdminClient(ClientOptions options = {})
       : options_(std::move(options)) {}
 
@@ -307,8 +306,7 @@ class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
   ClientOptions options_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_instance_admin_client.h
+++ b/google/cloud/bigtable/testing/mock_instance_admin_client.h
@@ -22,6 +22,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 class MockInstanceAdminClient : public bigtable::InstanceAdminClient {
  public:
   using ClientOptions = ::google::cloud::bigtable::ClientOptions;

--- a/google/cloud/bigtable/testing/mock_mutate_rows_reader.h
+++ b/google/cloud/bigtable/testing/mock_mutate_rows_reader.h
@@ -21,8 +21,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
+namespace bigtable_testing {
 using MockMutateRowsReader =
     MockResponseReader<google::bigtable::v2::MutateRowsResponse,
                        google::bigtable::v2::MutateRowsRequest>;
@@ -33,8 +32,7 @@ using MockMutateRowsReader =
 using MockAsyncApplyReader =
     MockAsyncResponseReader<google::bigtable::v2::MutateRowResponse>;
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_read_rows_reader.h
+++ b/google/cloud/bigtable/testing/mock_read_rows_reader.h
@@ -21,8 +21,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
+namespace bigtable_testing {
 using MockReadRowsReader =
     MockResponseReader<google::bigtable::v2::ReadRowsResponse,
                        google::bigtable::v2::ReadRowsRequest>;
@@ -30,8 +29,7 @@ using MockReadRowsReader =
 using MockAsyncReadRowsReader =
     MockAsyncResponseReader<google::bigtable::v2::ReadRowsResponse>;
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -27,8 +27,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
+namespace bigtable_testing {
 /**
  * Refactor code common to several mock objects.
  *
@@ -123,8 +122,7 @@ class MockClientAsyncReaderInterface
   MOCK_METHOD(void, Read, (Response*, void*), (override));
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_sample_row_keys_reader.h
+++ b/google/cloud/bigtable/testing/mock_sample_row_keys_reader.h
@@ -21,14 +21,12 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
+namespace bigtable_testing {
 using MockSampleRowKeysReader =
     MockResponseReader<google::bigtable::v2::SampleRowKeysResponse,
                        google::bigtable::v2::SampleRowKeysRequest>;
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/random_names.cc
+++ b/google/cloud/bigtable/testing/random_names.cc
@@ -17,9 +17,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 // Unless otherwise noted, the maximum ID lengths discovered by trial and error.
 auto constexpr kMaxTableIdLength = 50;
 char const kRandomTableIdRE[] = R"re(^tbl-\d{4}-\d{2}-\d{2}-.*$)re";
@@ -99,7 +97,6 @@ std::string RandomInstanceId(std::chrono::system_clock::time_point tp) {
 
 std::string RandomInstanceIdRegex() { return kRandomInstanceIdRE; }
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/random_names.cc
+++ b/google/cloud/bigtable/testing/random_names.cc
@@ -18,6 +18,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 // Unless otherwise noted, the maximum ID lengths discovered by trial and error.
 auto constexpr kMaxTableIdLength = 50;
 char const kRandomTableIdRE[] = R"re(^tbl-\d{4}-\d{2}-\d{2}-.*$)re";

--- a/google/cloud/bigtable/testing/random_names.h
+++ b/google/cloud/bigtable/testing/random_names.h
@@ -20,9 +20,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /// Create a random table ID given a PRNG generator.
 std::string RandomTableId(google::cloud::internal::DefaultPRNG& generator,
                           std::chrono::system_clock::time_point tp =
@@ -67,8 +65,7 @@ std::string RandomInstanceId(std::chrono::system_clock::time_point tp);
 /// Return a regular expression suitable to match the random instance IDs
 std::string RandomInstanceIdRegex();
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/random_names.h
+++ b/google/cloud/bigtable/testing/random_names.h
@@ -21,6 +21,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 /// Create a random table ID given a PRNG generator.
 std::string RandomTableId(google::cloud::internal::DefaultPRNG& generator,
                           std::chrono::system_clock::time_point tp =

--- a/google/cloud/bigtable/testing/random_names_test.cc
+++ b/google/cloud/bigtable/testing/random_names_test.cc
@@ -19,8 +19,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
+namespace bigtable_testing {
 namespace {
 
 using ::google::cloud::internal::DefaultPRNG;
@@ -90,7 +89,6 @@ TEST(BigtableRandomNames, RandomInstanceId) {
 }
 
 }  // namespace
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -24,6 +24,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 std::string TableTestEnvironment::project_id_;
 std::string TableTestEnvironment::instance_id_;
 std::string TableTestEnvironment::zone_a_;

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -28,9 +28,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /// Store the project and instance captured from the command-line arguments.
 class TableTestEnvironment : public ::testing::Environment {
  public:
@@ -169,8 +167,7 @@ class TableIntegrationTest
   std::shared_ptr<bigtable::DataClient> data_client_;
 };
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -29,6 +29,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 /// Store the project and instance captured from the command-line arguments.
 class TableTestEnvironment : public ::testing::Environment {
  public:

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -19,6 +19,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 char const TableTestFixture::kProjectId[] = "foo-project";
 char const TableTestFixture::kInstanceId[] = "bar-instance";
 char const TableTestFixture::kTableId[] = "baz-table";

--- a/google/cloud/bigtable/testing/table_test_fixture.cc
+++ b/google/cloud/bigtable/testing/table_test_fixture.cc
@@ -18,9 +18,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 char const TableTestFixture::kProjectId[] = "foo-project";
 char const TableTestFixture::kInstanceId[] = "bar-instance";
 char const TableTestFixture::kTableId[] = "baz-table";
@@ -43,7 +41,7 @@ google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
 
 std::shared_ptr<MockDataClient> TableTestFixture::SetupMockClient() {
   auto client = std::make_shared<MockDataClient>(
-      ClientOptions().DisableBackgroundThreads(cq_));
+      bigtable::ClientOptions().DisableBackgroundThreads(cq_));
   EXPECT_CALL(*client, project_id())
       .WillRepeatedly(::testing::ReturnRef(project_id_));
   EXPECT_CALL(*client, instance_id())
@@ -58,7 +56,6 @@ TableTestFixture::TableTestFixture(CompletionQueue cq)
       cq_(cq),
       client_(SetupMockClient()) {}
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -22,9 +22,7 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
-namespace testing {
-
+namespace bigtable_testing {
 /// Common fixture for the bigtable::Table tests.
 class TableTestFixture : public ::testing::Test {
  protected:
@@ -49,8 +47,7 @@ class TableTestFixture : public ::testing::Test {
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(
     std::string const& repr);
 
-}  // namespace testing
-}  // namespace bigtable
+}  // namespace bigtable_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -23,6 +23,7 @@
 namespace google {
 namespace cloud {
 namespace bigtable_testing {
+
 /// Common fixture for the bigtable::Table tests.
 class TableTestFixture : public ::testing::Test {
  protected:

--- a/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_async_future_integration_test.cc
@@ -35,7 +35,7 @@ namespace btadmin = google::bigtable::admin::v2;
 namespace bigtable = google::cloud::bigtable;
 
 class AdminAsyncFutureIntegrationTest
-    : public bigtable::testing::TableIntegrationTest {
+    : public bigtable_testing::TableIntegrationTest {
  protected:
   std::shared_ptr<AdminClient> admin_client_;
   std::unique_ptr<TableAdmin> table_admin_;
@@ -49,9 +49,9 @@ class AdminAsyncFutureIntegrationTest
 
     TableIntegrationTest::SetUp();
     admin_client_ = CreateDefaultAdminClient(
-        testing::TableTestEnvironment::project_id(), ClientOptions());
+        bigtable_testing::TableTestEnvironment::project_id(), ClientOptions());
     table_admin_ = absl::make_unique<TableAdmin>(
-        admin_client_, bigtable::testing::TableTestEnvironment::instance_id());
+        admin_client_, bigtable_testing::TableTestEnvironment::instance_id());
   }
 };
 
@@ -189,7 +189,7 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncDropRowsByPrefixTest) {
   future<void> chain =
       table_admin_
           ->AsyncDropRowsByPrefix(
-              cq, bigtable::testing::TableTestEnvironment::table_id(),
+              cq, bigtable_testing::TableTestEnvironment::table_id(),
               row_key1_prefix)
           .then([&](future<Status> fut) {
             Status delete_result = fut.get();
@@ -227,8 +227,8 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncDropAllRowsTest) {
 
   future<void> chain =
       table_admin_
-          ->AsyncDropAllRows(
-              cq, bigtable::testing::TableTestEnvironment::table_id())
+          ->AsyncDropAllRows(cq,
+                             bigtable_testing::TableTestEnvironment::table_id())
           .then([&](future<Status> fut) {
             Status delete_result = fut.get();
             EXPECT_STATUS_OK(delete_result);
@@ -246,10 +246,10 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncDropAllRowsTest) {
 /// @test Verify that `bigtable::TableAdmin` AsyncCheckConsistency works as
 /// expected.
 TEST_F(AdminAsyncFutureIntegrationTest, AsyncCheckConsistencyIntegrationTest) {
-  std::string id = bigtable::testing::TableTestEnvironment::RandomInstanceId();
+  std::string id = bigtable_testing::TableTestEnvironment::RandomInstanceId();
   std::string const table_id = RandomTableId();
 
-  auto project_id = bigtable::testing::TableTestEnvironment::project_id();
+  auto project_id = bigtable_testing::TableTestEnvironment::project_id();
 
   auto instance_admin_client = bigtable::CreateDefaultInstanceAdminClient(
       project_id, bigtable::ClientOptions());
@@ -270,10 +270,10 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncCheckConsistencyIntegrationTest) {
 
   // Replication needs at least two clusters
   auto cluster_config_1 =
-      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_a(),
+      bigtable::ClusterConfig(bigtable_testing::TableTestEnvironment::zone_a(),
                               3, bigtable::ClusterConfig::HDD);
   auto cluster_config_2 =
-      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_b(),
+      bigtable::ClusterConfig(bigtable_testing::TableTestEnvironment::zone_b(),
                               3, bigtable::ClusterConfig::HDD);
   bigtable::InstanceConfig config(
       id, display_name,
@@ -363,6 +363,6 @@ TEST_F(AdminAsyncFutureIntegrationTest, AsyncCheckConsistencyIntegrationTest) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable_testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/admin_backup_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_async_future_integration_test.cc
@@ -37,7 +37,7 @@ namespace btadmin = google::bigtable::admin::v2;
 namespace bigtable = google::cloud::bigtable;
 
 class AdminBackupAsyncFutureIntegrationTest
-    : public bigtable::testing::TableIntegrationTest {
+    : public bigtable_testing::TableIntegrationTest {
  protected:
   std::shared_ptr<AdminClient> admin_client_;
   std::unique_ptr<TableAdmin> table_admin_;
@@ -52,11 +52,11 @@ class AdminBackupAsyncFutureIntegrationTest
 
     TableIntegrationTest::SetUp();
     admin_client_ = CreateDefaultAdminClient(
-        testing::TableTestEnvironment::project_id(), ClientOptions());
+        bigtable_testing::TableTestEnvironment::project_id(), ClientOptions());
     table_admin_ = absl::make_unique<TableAdmin>(
-        admin_client_, bigtable::testing::TableTestEnvironment::instance_id());
+        admin_client_, bigtable_testing::TableTestEnvironment::instance_id());
     auto instance_admin_client = bigtable::CreateDefaultInstanceAdminClient(
-        bigtable::testing::TableTestEnvironment::project_id(),
+        bigtable_testing::TableTestEnvironment::project_id(),
         bigtable::ClientOptions());
     instance_admin_ =
         absl::make_unique<bigtable::InstanceAdmin>(instance_admin_client);
@@ -187,6 +187,6 @@ TEST_F(AdminBackupAsyncFutureIntegrationTest,
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable_testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_backup_integration_test.cc
@@ -39,7 +39,7 @@ namespace btadmin = google::bigtable::admin::v2;
 namespace bigtable = google::cloud::bigtable;
 
 class AdminBackupIntegrationTest
-    : public bigtable::testing::TableIntegrationTest {
+    : public bigtable_testing::TableIntegrationTest {
  protected:
   std::unique_ptr<bigtable::TableAdmin> table_admin_;
   std::unique_ptr<bigtable::InstanceAdmin> instance_admin_;
@@ -55,12 +55,12 @@ class AdminBackupIntegrationTest
 
     std::shared_ptr<bigtable::AdminClient> admin_client =
         bigtable::CreateDefaultAdminClient(
-            bigtable::testing::TableTestEnvironment::project_id(),
+            bigtable_testing::TableTestEnvironment::project_id(),
             bigtable::ClientOptions());
     table_admin_ = absl::make_unique<bigtable::TableAdmin>(
-        admin_client, bigtable::testing::TableTestEnvironment::instance_id());
+        admin_client, bigtable_testing::TableTestEnvironment::instance_id());
     auto instance_admin_client = bigtable::CreateDefaultInstanceAdminClient(
-        bigtable::testing::TableTestEnvironment::project_id(),
+        bigtable_testing::TableTestEnvironment::project_id(),
         bigtable::ClientOptions());
     instance_admin_ =
         absl::make_unique<bigtable::InstanceAdmin>(instance_admin_client);
@@ -183,6 +183,6 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable_testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_iam_policy_integration_test.cc
@@ -33,7 +33,7 @@ namespace btadmin = google::bigtable::admin::v2;
 namespace bigtable = google::cloud::bigtable;
 
 class AdminIAMPolicyIntegrationTest
-    : public bigtable::testing::TableIntegrationTest {
+    : public bigtable_testing::TableIntegrationTest {
  protected:
   std::shared_ptr<AdminClient> admin_client_;
   std::unique_ptr<TableAdmin> table_admin_;
@@ -47,9 +47,9 @@ class AdminIAMPolicyIntegrationTest
 
     TableIntegrationTest::SetUp();
     admin_client_ = CreateDefaultAdminClient(
-        testing::TableTestEnvironment::project_id(), ClientOptions());
+        bigtable_testing::TableTestEnvironment::project_id(), ClientOptions());
     table_admin_ = absl::make_unique<TableAdmin>(
-        admin_client_, bigtable::testing::TableTestEnvironment::instance_id());
+        admin_client_, bigtable_testing::TableTestEnvironment::instance_id());
   }
 };
 
@@ -179,6 +179,6 @@ TEST_F(AdminIAMPolicyIntegrationTest, SetGetTestIamAPIsTest) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable_testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -38,7 +38,7 @@ using ::testing::Not;
 
 namespace btadmin = google::bigtable::admin::v2;
 
-class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
+class AdminIntegrationTest : public bigtable_testing::TableIntegrationTest {
  protected:
   std::unique_ptr<bigtable::TableAdmin> table_admin_;
 
@@ -52,10 +52,10 @@ class AdminIntegrationTest : public bigtable::testing::TableIntegrationTest {
 
     std::shared_ptr<bigtable::AdminClient> admin_client =
         bigtable::CreateDefaultAdminClient(
-            bigtable::testing::TableTestEnvironment::project_id(),
+            bigtable_testing::TableTestEnvironment::project_id(),
             bigtable::ClientOptions());
     table_admin_ = absl::make_unique<bigtable::TableAdmin>(
-        admin_client, bigtable::testing::TableTestEnvironment::instance_id());
+        admin_client, bigtable_testing::TableTestEnvironment::instance_id());
   }
 };
 
@@ -127,7 +127,7 @@ TEST_F(AdminIntegrationTest, DropRowsByPrefix) {
   CreateCells(table, created_cells);
   // Delete all the records for a row
   EXPECT_STATUS_OK(table_admin_->DropRowsByPrefix(
-      bigtable::testing::TableTestEnvironment::table_id(), row_key1_prefix));
+      bigtable_testing::TableTestEnvironment::table_id(), row_key1_prefix));
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
 
   CheckEqualUnordered(expected_cells, actual_cells);
@@ -151,7 +151,7 @@ TEST_F(AdminIntegrationTest, DropAllRows) {
   CreateCells(table, created_cells);
   // Delete all the records from a table
   EXPECT_STATUS_OK(table_admin_->DropAllRows(
-      bigtable::testing::TableTestEnvironment::table_id()));
+      bigtable_testing::TableTestEnvironment::table_id()));
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
 
   ASSERT_TRUE(actual_cells.empty());
@@ -238,8 +238,8 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTable) {
 TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
   // WaitForConsistencyCheck() only makes sense on a replicated table, we need
   // to create an instance with at least 2 clusters to test it.
-  auto project_id = bigtable::testing::TableTestEnvironment::project_id();
-  std::string id = bigtable::testing::TableTestEnvironment::RandomInstanceId();
+  auto project_id = bigtable_testing::TableTestEnvironment::project_id();
+  std::string id = bigtable_testing::TableTestEnvironment::RandomInstanceId();
   std::string const random_table_id = RandomTableId();
 
   // Create a bigtable::InstanceAdmin and a bigtable::TableAdmin to create the
@@ -258,10 +258,10 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
   // than 30 characters.
   auto display_name = ("IT " + id).substr(0, 30);
   auto cluster_config_1 =
-      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_a(),
+      bigtable::ClusterConfig(bigtable_testing::TableTestEnvironment::zone_a(),
                               3, bigtable::ClusterConfig::HDD);
   auto cluster_config_2 =
-      bigtable::ClusterConfig(bigtable::testing::TableTestEnvironment::zone_b(),
+      bigtable::ClusterConfig(bigtable_testing::TableTestEnvironment::zone_b(),
                               3, bigtable::ClusterConfig::HDD);
   bigtable::InstanceConfig config(
       id, display_name,
@@ -325,10 +325,10 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
 
   std::shared_ptr<bigtable::AdminClient> admin_client =
       bigtable::CreateDefaultAdminClient(
-          bigtable::testing::TableTestEnvironment::project_id(),
+          bigtable_testing::TableTestEnvironment::project_id(),
           bigtable::ClientOptions().enable_tracing("rpc"));
   auto table_admin = absl::make_unique<bigtable::TableAdmin>(
-      admin_client, bigtable::testing::TableTestEnvironment::instance_id());
+      admin_client, bigtable_testing::TableTestEnvironment::instance_id());
 
   // verify new table id in current table list
   auto previous_table_list = table_admin->ListTables(btadmin::Table::NAME_ONLY);
@@ -415,6 +415,6 @@ TEST_F(AdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable_testing::TableTestEnvironment);
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -22,7 +22,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using DataAsyncFutureIntegrationTest = bigtable::testing::TableIntegrationTest;
+using DataAsyncFutureIntegrationTest = bigtable_testing::TableIntegrationTest;
 
 std::string const kFamily = "family1";
 
@@ -286,7 +286,7 @@ TEST_F(DataAsyncFutureIntegrationTest, TableReadRowTest) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::bigtable::testing::TableTestEnvironment);
+      new google::cloud::bigtable_testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -24,6 +24,7 @@ namespace bigtable {
 inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
+using ::google::cloud::bigtable_testing::TableTestEnvironment;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::std::chrono::duration_cast;
 using ::std::chrono::microseconds;
@@ -32,7 +33,7 @@ using ::testing::Contains;
 using ::testing::HasSubstr;
 
 using DataIntegrationTest =
-    ::google::cloud::bigtable::testing::TableIntegrationTest;
+    ::google::cloud::bigtable_testing::TableIntegrationTest;
 
 /// Use Table::Apply() to insert a single row.
 void Apply(Table& table, std::string const& row_key,
@@ -460,12 +461,11 @@ TEST_F(DataIntegrationTest, TableSampleRowKeysTest) {
 
   // Create kBatchSize * kBatchCount rows. Use a special client with tracing
   // disabled because it simply generates too much data.
-  auto bulk_table =
-      bigtable::Table(bigtable::CreateDefaultDataClient(
-                          testing::TableTestEnvironment::project_id(),
-                          testing::TableTestEnvironment::instance_id(),
-                          ClientOptions().disable_tracing("rpc")),
-                      testing::TableTestEnvironment::table_id());
+  auto bulk_table = bigtable::Table(
+      bigtable::CreateDefaultDataClient(TableTestEnvironment::project_id(),
+                                        TableTestEnvironment::instance_id(),
+                                        ClientOptions().disable_tracing("rpc")),
+      TableTestEnvironment::table_id());
   int constexpr kBatchCount = 10;
   int constexpr kBatchSize = 5000;
   int constexpr kColumnCount = 10;
@@ -608,8 +608,8 @@ TEST(ConnectionRefresh, Disabled) {
   auto client_options = bigtable::ClientOptions().set_max_conn_refresh_period(
       std::chrono::seconds(0));
   auto data_client = bigtable::CreateDefaultDataClient(
-      testing::TableTestEnvironment::project_id(),
-      testing::TableTestEnvironment::instance_id(), client_options);
+      TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
+      client_options);
   // In general, it is hard to show that something has *not* happened, at best
   // we can show that its side-effects have not happened. In this case we want
   // to show that the channels have not been refreshed. A side-effect of
@@ -628,7 +628,7 @@ TEST(ConnectionRefresh, Disabled) {
     EXPECT_EQ(GRPC_CHANNEL_IDLE, channel->GetState(false));
   }
   // Make sure things still work.
-  bigtable::Table table(data_client, testing::TableTestEnvironment::table_id());
+  bigtable::Table table(data_client, TableTestEnvironment::table_id());
   std::string const row_key = "row-key-1";
   std::vector<Cell> created{{row_key, kFamily4, "c0", 1000, "v1000"},
                             {row_key, kFamily4, "c1", 2000, "v2000"}};
@@ -648,8 +648,7 @@ TEST(ConnectionRefresh, Disabled) {
 
 TEST(ConnectionRefresh, Frequent) {
   auto data_client = bigtable::CreateDefaultDataClient(
-      testing::TableTestEnvironment::project_id(),
-      testing::TableTestEnvironment::instance_id(),
+      TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
       bigtable::ClientOptions().set_max_conn_refresh_period(
           std::chrono::milliseconds(100)));
 
@@ -663,7 +662,7 @@ TEST(ConnectionRefresh, Frequent) {
   }
 
   // Make sure things still work.
-  bigtable::Table table(data_client, testing::TableTestEnvironment::table_id());
+  bigtable::Table table(data_client, TableTestEnvironment::table_id());
   std::string const row_key = "row-key-1";
   std::vector<Cell> created{{row_key, kFamily4, "c0", 1000, "v1000"},
                             {row_key, kFamily4, "c1", 2000, "v2000"}};
@@ -679,7 +678,7 @@ TEST(ConnectionRefresh, Frequent) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new ::google::cloud::bigtable::testing::TableTestEnvironment);
+      new ::google::cloud::bigtable_testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -23,7 +23,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 using FilterIntegrationTest =
-    ::google::cloud::bigtable::testing::TableIntegrationTest;
+    ::google::cloud::bigtable_testing::TableIntegrationTest;
 
 /**
  * Create some complex rows in @p table.
@@ -610,7 +610,7 @@ TEST_F(FilterIntegrationTest, InterleaveFromRange) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new ::google::cloud::bigtable::testing::TableTestEnvironment);
+      new ::google::cloud::bigtable_testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -27,7 +27,8 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::testing::Not;
 
 using MutationIntegrationTest =
-    ::google::cloud::bigtable::testing::TableIntegrationTest;
+    ::google::cloud::bigtable_testing::TableIntegrationTest;
+
 /**
  * This function creates Cell by ignoring the timestamp.
  * In this case Cloud Bigtable will insert the default server
@@ -449,7 +450,7 @@ TEST_F(MutationIntegrationTest, DeleteFromRowTest) {
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
-      new ::google::cloud::bigtable::testing::TableTestEnvironment);
+      new ::google::cloud::bigtable_testing::TableTestEnvironment);
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Used to be called `google::cloud::bigtable::testing` which can clash
with `::testing`.

Part of the work for #732

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6078)
<!-- Reviewable:end -->
