### PR TITLE
feat(ci): add caching to GCB builds

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -99,6 +99,7 @@ if [ "${DISTRO}" != "local" ]; then
   fi
   subs="_DISTRO=${DISTRO}"
   subs+=",_BUILD_NAME=${BUILD_NAME}"
+  subs+=",_CACHE_TYPE=manual-$(id -un)"
   if [ -n "${CACHE_BUCKET}" ]; then
     subs+=",_CACHE_BUCKET=${CACHE_BUCKET}"
   fi

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script saves a cache tarball to GCS, and restores one from GCS. It is
+# intended to be called from a build step in the `cloudbuild.yaml` file. It
+# executes in the context of build. Typically the "restore cache" step will be
+# called in one step, followed by the actual build of the code, followed by the
+# "save cache" step.
+#
+# Usage: ./cache <save|restore>
+#
+#   Options:
+#     --bucket_url=<url>    URL to the GCS bucket where the cache should be saved
+#     --key=<key>           The primary key to use when caching
+#     --fallback_key=<key>  If the primary key isn't found when restoring, try this key
+#     --path=<path>         A path to be backed up. May be specified multiple times.
+#     -h|--help             Print this help message
+
+set -euo pipefail
+
+source "$(dirname "$0")/../lib/init.sh"
+source module ci/lib/io.sh
+cd "${PROJECT_ROOT}"
+
+function print_usage() {
+  # Extracts the usage from the file comment starting at line 17.
+  sed -n '17,/^$/s/^# \?//p' "${PROGRAM_PATH}"
+}
+
+# Use getopt to parse and normalize all the args.
+PARSED="$(getopt -a \
+  --options="h" \
+  --longoptions="bucket_url:,key:,fallback_key:,path:,help" \
+  --name="${PROGRAM_NAME}" \
+  -- "$@")"
+eval set -- "${PARSED}"
+
+BUCKET_URL=""
+KEY=""
+FALLBACK_KEY=""
+PATHS=()
+while true; do
+  case "$1" in
+  --bucket_url)
+    BUCKET_URL="$2"
+    shift 2
+    ;;
+  --key)
+    KEY="$2"
+    shift 2
+    ;;
+  --fallback_key)
+    FALLBACK_KEY="$2"
+    shift 2
+    ;;
+  --path)
+    PATHS+=("$2")
+    shift 2
+    ;;
+  -h | --help)
+    print_usage
+    exit 0
+    ;;
+  --)
+    shift
+    break
+    ;;
+  esac
+done
+readonly BUCKET_URL
+readonly KEY
+readonly FALLBACK_KEY
+readonly PATHS
+
+if [[ $# -eq 0 ]]; then
+  echo "Missing action: save|restore"
+  print_usage
+  exit 1
+elif [[ -z "${BUCKET_URL}" ]]; then
+  echo "Missing --bucket_url="
+  print_usage
+  exit 1
+elif [[ -z "${KEY}" ]]; then
+  echo "Missing --key="
+  print_usage
+  exit 1
+fi
+
+readonly PRIMARY_CACHE_URL="${BUCKET_URL}/${KEY}/cache.tar.gz"
+readonly FALLBACK_CACHE_URL="${BUCKET_URL}/${FALLBACK_KEY}/cache.tar.gz"
+
+function save_cache() {
+  paths=()
+  for p in "${PATHS[@]}"; do
+    if [[ -r "${p}" ]]; then paths+=("${p}"); fi
+  done
+  if ((${#paths[@]} == 0)); then
+    io::log "No paths to cache found."
+    return 0
+  fi
+  io::log "Saving ${PATHS[*]} to ${PRIMARY_CACHE_URL}"
+  tar -czf cache.tar.gz "${PATHS[@]}"
+  io::log "  Cache size: $(du -sh cache.tar.gz)"
+  gsutil -m cp cache.tar.gz "${url}"
+}
+
+function restore_cache() {
+  for url in "${PRIMARY_CACHE_URL}" "${FALLBACK_CACHE_URL}"; do
+    if gsutil stat "${url}"; then
+      io::log "Fetching cache url ${url}"
+      gsutil -m cp "${url}" cache.tar.gz || continue
+      io::log "  Cache size: $(du -sh cache.tar.gz)"
+      tar -zxf cache.tar.gz && break
+    fi
+  done
+}
+
+io::log "====> ${PROGRAM_NAME}"
+readonly TIMEFORMAT="==> 🕑 ${PROGRAM_NAME} completed in %R seconds"
+time {
+  case "$1" in
+    save)
+      save_cache
+      ;;
+    restore)
+      restore_cache
+      ;;
+    *)
+      print_usage
+      ;;
+  esac
+}

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -102,12 +102,15 @@ readonly PRIMARY_CACHE_URL="${BUCKET_URL}/${KEY}/cache.tar.gz"
 
 function save_cache() {
   # Filters PATHS to only those that exist.
-  paths=($(ls -d "${PATHS[@]}" 2>/dev/null))
+  paths=()
+  for p in "${PATHS[@]}"; do
+    test -r "${p}" && paths+=("${p}")
+  done
   if ((${#paths[@]} == 0)); then
     io::log "No paths to cache found."
     return 0
   fi
-  io::log "Saving ${paths[*]} to ${PRIMARY_CACHE_URL}"
+  io::log "Saving ( ${paths[*]} ) to ${PRIMARY_CACHE_URL}"
   tar -czf - "${paths[@]}" | gsutil cp - "${PRIMARY_CACHE_URL}"
 }
 

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -33,7 +33,6 @@ set -euo pipefail
 
 source "$(dirname "$0")/../lib/init.sh"
 source module ci/lib/io.sh
-cd "${PROJECT_ROOT}"
 
 function print_usage() {
   # Extracts the usage from the file comment starting at line 17.
@@ -132,14 +131,14 @@ io::log "====> ${PROGRAM_NAME}"
 readonly TIMEFORMAT="==> 🕑 ${PROGRAM_NAME} completed in %R seconds"
 time {
   case "$1" in
-    save)
-      save_cache
-      ;;
-    restore)
-      restore_cache
-      ;;
-    *)
-      print_usage
-      ;;
+  save)
+    save_cache
+    ;;
+  restore)
+    restore_cache
+    ;;
+  *)
+    print_usage
+    ;;
   esac
 }

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -112,6 +112,7 @@ function save_cache() {
   fi
   io::log "Saving ( ${paths[*]} ) to ${PRIMARY_CACHE_URL}"
   tar -czf - "${paths[@]}" | gsutil cp - "${PRIMARY_CACHE_URL}"
+  gsutil stat "${PRIMARY_CACHE_URL}"
 }
 
 function restore_cache() {

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -99,7 +99,6 @@ elif [[ -z "${KEY}" ]]; then
 fi
 
 readonly PRIMARY_CACHE_URL="${BUCKET_URL}/${KEY}/cache.tar.gz"
-readonly FALLBACK_CACHE_URL="${BUCKET_URL}/${FALLBACK_KEY}/cache.tar.gz"
 
 function save_cache() {
   # Filters PATHS to only those that exist.
@@ -113,16 +112,21 @@ function save_cache() {
 }
 
 function restore_cache() {
-  for url in "${PRIMARY_CACHE_URL}" "${FALLBACK_CACHE_URL}"; do
+  local urls=("${PRIMARY_CACHE_URL}")
+  if [[ -n "${FALLBACK_KEY}" ]]; then
+    urls+=("${BUCKET_URL}/${FALLBACK_KEY}/cache.tar.gz")
+  fi
+  for url in "${urls[@]}"; do
     if gsutil stat "${url}"; then
       io::log "Fetching cache url ${url}"
       gsutil cp "${url}" - | tar -zxf - || continue
+      break
     fi
   done
   return 0
 }
 
-io::log "====> ${PROGRAM_NAME}"
+io::log "====> ${PROGRAM_NAME}: $*"
 readonly TIMEFORMAT="==> 🕑 ${PROGRAM_NAME} completed in %R seconds"
 time {
   case "$1" in

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -15,21 +15,51 @@
 options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'
+  env: ['HOME=/h']
+  volumes:
+    - name: 'home'
+      path: '/h'
 
+# Variables that can be overridden from the `gcloud builds ...` command using
+# the `--substitutions=_FOO=bar` flag.
 substitutions:
   _DISTRO: "unknown"
   _BUILD_NAME: "unknown"
+  _CACHE_BUCKET: 'cloud-cpp-cloudbuild-cache'
 
 timeout: 3600s
 
 steps:
+  # Builds the docker image that will be used by the following steps. Uses
+  # kaniko to cache each layer to speed up building of the image.
 - name: 'gcr.io/kaniko-project/executor:edge'
   args: [
     '--context=dir:///workspace/ci',
     '--dockerfile=ci/cloudbuild/${_DISTRO}.Dockerfile',
     '--cache=true',
-    '--destination=gcr.io/$PROJECT_ID/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}',
+    '--destination=gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}',
   ]
-- name: 'gcr.io/$PROJECT_ID/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
+
+  # Restores the cached homedir into /h in parallel with the previous step.
+  # Failures are ignored.
+- name: 'gcr.io/cloud-builders/gsutil'
+  waitFor: '-'
+  entrypoint: 'bash'
+  args: [
+    '-c',
+    'gsutil -m rsync -r -c -e "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h" /h || exit 0'
+  ]
+
+  # Runs the specified build inside the docker image that was created in the
+  # first step.
+- name: 'gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '${_BUILD_NAME}' ]
+
+  # Caches the homedir, /h, in the specified GCS bucket.
+- name: 'gcr.io/cloud-builders/gsutil'
+  entrypoint: 'bash'
+  args: [
+    '-c',
+    'gsutil -m rsync -r -c -e /h "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h"'
+  ]

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -15,7 +15,7 @@
 options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'
-  env: ['HOME=/h']
+  env: [ 'HOME=/h' ]
   volumes:
     - name: 'home'
       path: '/h'
@@ -43,7 +43,7 @@ steps:
   # Restores the cached homedir into /h in parallel with the previous step.
   # Failures are ignored.
 - name: 'gcr.io/cloud-builders/gsutil'
-  waitFor: '-'
+  waitFor: [ '-' ]
   entrypoint: 'bash'
   args: [
     '-c',

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -67,6 +67,20 @@ steps:
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '${_BUILD_NAME}' ]
 
+  # Removes files in /h with non-UTF-8 filenames to prevent `gsutil rsync` from
+  # crashing: https://github.com/GoogleCloudPlatform/gsutil/issues/922
+- name: 'gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |-
+    for f in $(find /h); do
+      if ! iconv -f UTF-8 <<<"${f}" > /dev/null; then
+        printf "Removing non-UTF-8 filename: %s\n" "${f}"
+        rm -rf -- "${f}"
+      fi
+    done
+
   # Caches the homedir, /h, in the specified GCS bucket.
 - name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: 'bash'

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -48,6 +48,7 @@ steps:
 - name: 'gcr.io/cloud-builders/gsutil'
   waitFor: [ '-' ]
   entrypoint: 'bash'
+  dir: '/h'
   args:
   - '-c'
   - |-
@@ -57,7 +58,9 @@ steps:
     )
     for url in "${cache_urls[@]}"; do
       echo "Fetching cache url ${url}"
-      gsutil -q -m rsync -r -c -e "${url}/h" /h && break
+      gsutil -m cp "${url}/cache.tar.gz" . || continue
+      du -sh cache.tar.gz  # Prints helpful info in the logs
+      tar -zxf cache.tar.gz && break
     done
     exit 0
 
@@ -67,27 +70,15 @@ steps:
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '${_BUILD_NAME}' ]
 
-  # Removes files in /h with non-UTF-8 filenames to prevent `gsutil rsync` from
-  # crashing: https://github.com/GoogleCloudPlatform/gsutil/issues/922
-- name: 'gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  - |-
-    for f in $(find /h); do
-      if ! iconv -f UTF-8 <<<"${f}" > /dev/null; then
-        printf "Removing non-UTF-8 filename: %s\n" "${f}"
-        rm -rf -- "${f}"
-      fi
-    done
-
-  # Caches the homedir, /h, in the specified GCS bucket.
+  # Caches the homedir, /h, in the specified GCS bucket. Excludes the bazel
+  # cache because it's too big and GCB disks are too slow.
 - name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: 'bash'
+  dir: '/h'
   args:
   - '-c'
   - |-
-    du -sh /h
-    printf "Total files: %d\n" $(find /home/jgm | wc -l)
+    tar --exclude ".cache/bazel/*" -czf cache.tar.gz .*
+    du -sh cache.tar.gz  # Prints helpful info in the logs
     url='gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
-    gsutil -q -m rsync -r -c -e /h "${url}/h"
+    gsutil -m cp cache.tar.gz "${url}/cache.tar.gz"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -87,5 +87,7 @@ steps:
   args:
   - '-c'
   - |-
+    du -sh /h
+    printf "Total files: %d\n" $(find /home/jgm | wc -l)
     url='gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
     gsutil -q -m rsync -r -c -e /h "${url}/h"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -52,8 +52,8 @@ steps:
   - '-c'
   - |-
     cache_urls=(
-      "gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}"
-      "gs://${_CACHE_BUCKET}/google-cloud-cpp/base/${_DISTRO}-${_BUILD_NAME}"
+      'gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
+      'gs://${_CACHE_BUCKET}/google-cloud-cpp/base/${_DISTRO}-${_BUILD_NAME}'
     )
     for url in "${cache_urls[@]}"; do
       echo "Fetching cache url ${url}"
@@ -73,5 +73,5 @@ steps:
   args:
   - '-c'
   - |-
-    url="gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}"
+    url='gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
     gsutil -q -m rsync -r -c -e /h "${url}/h"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -49,11 +49,12 @@ steps:
   waitFor: [ '-' ]
   entrypoint: '/workspace/ci/cloudbuild/cache.sh'
   dir: '/h'
-  args:
-  - 'restore'
-  - '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp'
-  - '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
-  - '--fallback_key=base/${_DISTRO}-${_BUILD_NAME}'
+  args: [
+    'restore',
+    '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp',
+    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}',
+    '--fallback_key=base/${_DISTRO}-${_BUILD_NAME}'
+  ]
 
   # Runs the specified build inside the docker image that was created in the
   # first step.
@@ -66,10 +67,12 @@ steps:
 - name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: '/workspace/ci/cloudbuild/cache.sh'
   dir: '/h'
-  args:
-  - 'save'
-  - '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp'
-  - '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
-  - '--path=.ccache'
-  - '--path=.cache/vcpkg'
-  - '--path=.cache/google-cloud-cpp'
+  args: [
+    'save',
+    '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp',
+    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}',
+    '--path=.ccache',
+    '--path=.cache/ccache',
+    '--path=.cache/vcpkg',
+    '--path=.cache/google-cloud-cpp'
+  ]

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
   entrypoint: 'bash'
   args: [
     '-c',
-    'gsutil -m rsync -r -c -e "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h" /h || exit 0'
+    'gsutil -q -m rsync -r -c -e "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h" /h || exit 0'
   ]
 
   # Runs the specified build inside the docker image that was created in the
@@ -61,5 +61,5 @@ steps:
   entrypoint: 'bash'
   args: [
     '-c',
-    'gsutil -m rsync -r -c -e /h "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h"'
+    'gsutil -q -m rsync -r -c -e /h "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h"'
   ]

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -47,22 +47,13 @@ steps:
   # the specified build name. Failures are ignored.
 - name: 'gcr.io/cloud-builders/gsutil'
   waitFor: [ '-' ]
-  entrypoint: 'bash'
+  entrypoint: '/workspace/ci/cloudbuild/cache.sh'
   dir: '/h'
   args:
-  - '-c'
-  - |-
-    cache_urls=(
-      'gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
-      'gs://${_CACHE_BUCKET}/google-cloud-cpp/base/${_DISTRO}-${_BUILD_NAME}'
-    )
-    for url in "${cache_urls[@]}"; do
-      echo "Fetching cache url ${url}"
-      gsutil -m cp "${url}/cache.tar.gz" . || continue
-      du -sh cache.tar.gz  # Prints helpful info in the logs
-      tar -zxf cache.tar.gz && break
-    done
-    exit 0
+  - 'restore'
+  - '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp'
+  - '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
+  - '--fallback_key=base/${_DISTRO}-${_BUILD_NAME}'
 
   # Runs the specified build inside the docker image that was created in the
   # first step.
@@ -73,12 +64,12 @@ steps:
   # Caches the homedir, /h, in the specified GCS bucket. Excludes the bazel
   # cache because it's too big and GCB disks are too slow.
 - name: 'gcr.io/cloud-builders/gsutil'
-  entrypoint: 'bash'
+  entrypoint: '/workspace/ci/cloudbuild/cache.sh'
   dir: '/h'
   args:
-  - '-c'
-  - |-
-    tar --exclude ".cache/bazel/*" -czf cache.tar.gz .*
-    du -sh cache.tar.gz  # Prints helpful info in the logs
-    url='gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
-    gsutil -m cp cache.tar.gz "${url}/cache.tar.gz"
+  - 'save'
+  - '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp'
+  - '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}'
+  - '--path=.ccache'
+  - '--path=.cache/vcpkg'
+  - '--path=.cache/google-cloud-cpp'

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -31,8 +31,7 @@ substitutions:
 timeout: 3600s
 
 steps:
-  # Builds the docker image that will be used by the following steps. Uses
-  # kaniko to cache each layer to speed up building of the image.
+  # Builds the docker image that will be used by the main build step.
 - name: 'gcr.io/kaniko-project/executor:edge'
   args: [
     '--context=dir:///workspace/ci',
@@ -41,10 +40,7 @@ steps:
     '--destination=gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}',
   ]
 
-  # Restores the cached homedir into /h in parallel with the previous step.
-  # First tries to fetch cache-type-specific path (i.e., a cache specific to
-  # the current PR, if a PR triggered build), followed by the "base" cache for
-  # the specified build name. Failures are ignored.
+  # Restores the homedir cache into /h in parallel with the previous step.
 - name: 'gcr.io/cloud-builders/gsutil'
   waitFor: [ '-' ]
   entrypoint: '/workspace/ci/cloudbuild/cache.sh'
@@ -52,25 +48,23 @@ steps:
   args: [
     'restore',
     '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp',
-    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}',
-    '--fallback_key=base/${_DISTRO}-${_BUILD_NAME}'
+    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
+    '--fallback_key=base/${_DISTRO}-${_BUILD_NAME}/h'
   ]
 
-  # Runs the specified build inside the docker image that was created in the
-  # first step.
+  # Runs the specified build in the image that was created in the first step.
 - name: 'gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '${_BUILD_NAME}' ]
 
-  # Caches the homedir, /h, in the specified GCS bucket. Excludes the bazel
-  # cache because it's too big and GCB disks are too slow.
+  # Caches some directories in the homedir, in the specified GCS bucket.
 - name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: '/workspace/ci/cloudbuild/cache.sh'
   dir: '/h'
   args: [
     'save',
     '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp',
-    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}',
+    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
     '--path=.ccache',
     '--path=.cache/ccache',
     '--path=.cache/vcpkg',

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -23,9 +23,10 @@ options:
 # Variables that can be overridden from the `gcloud builds ...` command using
 # the `--substitutions=_FOO=bar` flag.
 substitutions:
-  _DISTRO: "unknown"
-  _BUILD_NAME: "unknown"
+  _DISTRO: 'unknown'
+  _BUILD_NAME: 'unknown'
   _CACHE_BUCKET: 'cloud-cpp-cloudbuild-cache'
+  _CACHE_TYPE: '${_PR_NUMBER:-base}'
 
 timeout: 3600s
 
@@ -41,14 +42,24 @@ steps:
   ]
 
   # Restores the cached homedir into /h in parallel with the previous step.
-  # Failures are ignored.
+  # First tries to fetch cache-type-specific path (i.e., a cache specific to
+  # the current PR, if a PR triggered build), followed by the "base" cache for
+  # the specified build name. Failures are ignored.
 - name: 'gcr.io/cloud-builders/gsutil'
   waitFor: [ '-' ]
   entrypoint: 'bash'
-  args: [
-    '-c',
-    'gsutil -q -m rsync -r -c -e "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h" /h || exit 0'
-  ]
+  args:
+  - '-c'
+  - |-
+    cache_urls=(
+      "gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}"
+      "gs://${_CACHE_BUCKET}/google-cloud-cpp/base/${_DISTRO}-${_BUILD_NAME}"
+    )
+    for url in "${cache_urls[@]}"; do
+      echo "Fetching cache url ${url}"
+      gsutil -q -m rsync -r -c -e "${url}/h" /h && break
+    done
+    exit 0
 
   # Runs the specified build inside the docker image that was created in the
   # first step.
@@ -59,7 +70,8 @@ steps:
   # Caches the homedir, /h, in the specified GCS bucket.
 - name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: 'bash'
-  args: [
-    '-c',
-    'gsutil -q -m rsync -r -c -e /h "gs://${_CACHE_BUCKET}/${PROJECT_ID}/${_DISTRO}-${_BUILD_NAME}/h"'
-  ]
+  args:
+  - '-c'
+  - |-
+    url="gs://${_CACHE_BUCKET}/google-cloud-cpp/${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}"
+    gsutil -q -m rsync -r -c -e /h "${url}/h"


### PR DESCRIPTION
Adds a `ci/cloudbuild/cache.sh` script that is responsible for `save`'ing and `restore`'ing our build caches to/from GCS.
There are also two new build steps in the `cloudbuild.yaml` file that call this script at the appropriate times.

NOTE: The `~/.cache/bazel` directory is not currently cached. It was huge and it wasn't clear if it was beneficial. I'll look into
fixing that later, or just using the normal remote build cache for bazel.

This PR also creates a home directory mount of `/h` that's visible to all build steps so they can all read/write to the homedir.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6084)
<!-- Reviewable:end -->
