### PR TITLE
ci: add bazel remote caching to GCB builds

### DIFF
--- a/ci/cloudbuild/builds/asan.sh
+++ b/ci/cloudbuild/builds/asan.sh
@@ -16,7 +16,13 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
 export CC=clang
 export CXX=clang++
 
-bazel test --config=asan --test_tag_filters=-integration-test ...
+args=($(bazel::common_args))
+args+=("--config=asan")
+args+=("--test_tag_filters=-integration-test")
+bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/asan.sh
+++ b/ci/cloudbuild/builds/asan.sh
@@ -22,7 +22,7 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 export CC=clang
 export CXX=clang++
 
-args=($(bazel::common_args))
+mapfile -t args < <(bazel::common_args)
 args+=("--config=asan")
 args+=("--test_tag_filters=-integration-test")
 bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/bazel+clang.sh
+++ b/ci/cloudbuild/builds/bazel+clang.sh
@@ -16,7 +16,12 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
 export CC=clang
 export CXX=clang++
 
-bazel test --test_tag_filters=-integration-test ...
+args=($(bazel::common_args))
+args+=("--test_tag_filters=-integration-test")
+bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/bazel+clang.sh
+++ b/ci/cloudbuild/builds/bazel+clang.sh
@@ -22,6 +22,6 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 export CC=clang
 export CXX=clang++
 
-args=($(bazel::common_args))
+mapfile -t args < <(bazel::common_args)
 args+=("--test_tag_filters=-integration-test")
 bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/bazel+gcc.sh
+++ b/ci/cloudbuild/builds/bazel+gcc.sh
@@ -16,7 +16,12 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
 export CC=gcc
 export CXX=g++
 
-bazel test --test_tag_filters=-integration-test ...
+args=($(bazel::common_args))
+args+=("--test_tag_filters=-integration-test")
+bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/bazel+gcc.sh
+++ b/ci/cloudbuild/builds/bazel+gcc.sh
@@ -22,6 +22,6 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 export CC=gcc
 export CXX=g++
 
-args=($(bazel::common_args))
+mapfile -t args < <(bazel::common_args)
 args+=("--test_tag_filters=-integration-test")
 bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,18 +19,19 @@
 # Make our include guard clean against set -o nounset.
 test -n "${CI_CLOUDBUILD_BUILDS_LIB_BAZEL_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_BAZEL_SH__=0
 if ((CI_CLOUDBUILD_BUILDS_LIB_BAZEL_SH__++ != 0)); then
-   return 0
+  return 0
 fi # include guard
 
-# Outputs a list of args that should be given to all bazel invocations.
+# Outputs a list of args that should be given to all bazel invocations. To read
+# this into an array use `mapfile -t my_array < <(bazel::common_args)`
 function bazel::common_args() {
-  local args=("--test_output=errors" "--verbose_failures=true" "--keep_going") 
-  if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
+  local args=("--test_output=errors" "--verbose_failures=true" "--keep_going")
+  if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
     args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
     args+=("--google_default_credentials")
     # See https://docs.bazel.build/versions/master/remote-caching.html#known-issues
     # and https://github.com/bazelbuild/bazel/issues/3360
     args+=("--experimental_guard_against_concurrent_changes")
   fi
-  echo "${args[@]}"
+  printf "%s\n" "${args[@]}"
 }

--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -1,0 +1,34 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This bash library has various helper functions for our bazel-based builds.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_BAZEL_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_BAZEL_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_BAZEL_SH__++ != 0)); then
+   return 0
+fi # include guard
+
+# Outputs a list of args that should be given to all bazel invocations.
+function bazel::common_args() {
+  local args=("--test_output=errors" "--verbose_failures=true" "--keep_going") 
+  if [[ -n "${BAZEL_REMOTE_CACHE}" ]]; then
+    args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
+    args+=("--google_default_credentials")
+    # See https://docs.bazel.build/versions/master/remote-caching.html#known-issues
+    # and https://github.com/bazelbuild/bazel/issues/3360
+    args+=("--experimental_guard_against_concurrent_changes")
+  fi
+  echo "${args[@]}"
+}

--- a/ci/cloudbuild/builds/ubsan.sh
+++ b/ci/cloudbuild/builds/ubsan.sh
@@ -16,7 +16,13 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
 export CC=clang
 export CXX=clang++
 
-bazel test --config=ubsan --test_tag_filters=-integration-test ...
+args=($(bazel::common_args))
+args+=("--config=ubsan")
+args+=("--test_tag_filters=-integration-test")
+bazel test "${args[@]}" ...

--- a/ci/cloudbuild/builds/ubsan.sh
+++ b/ci/cloudbuild/builds/ubsan.sh
@@ -22,7 +22,7 @@ source module ci/cloudbuild/builds/lib/bazel.sh
 export CC=clang
 export CXX=clang++
 
-args=($(bazel::common_args))
+mapfile -t args < <(bazel::common_args)
 args+=("--config=ubsan")
 args+=("--test_tag_filters=-integration-test")
 bazel test "${args[@]}" ...

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -56,6 +56,9 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '${_BUILD_NAME}' ]
+  env: [
+    'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}'
+  ]
 
   # Caches some directories in the homedir, in the specified GCS bucket.
 - name: 'gcr.io/cloud-builders/gsutil'


### PR DESCRIPTION
This PR also introduces the pattern of shell libraries that the builds
in `ci/cloudbuild/builds/` can use with `source module`. This PR adds
the `lib/bazel.sh` library which computes the common bazel flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6086)
<!-- Reviewable:end -->
