### PR TITLE
ci: print ccache stats at the end of cmake builds

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -16,6 +16,9 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+
 cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=clang-tidy -S . -B cmake-out
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test"

--- a/ci/cloudbuild/builds/cmake+clang.sh
+++ b/ci/cloudbuild/builds/cmake+clang.sh
@@ -16,6 +16,9 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+
 export CC=clang
 export CXX=clang++
 

--- a/ci/cloudbuild/builds/cmake+gcc.sh
+++ b/ci/cloudbuild/builds/cmake+gcc.sh
@@ -16,6 +16,9 @@
 
 set -eu
 
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+
 export CC=gcc
 export CXX=g++
 

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This bash library has various helper functions for our cmake-based builds.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_CMAKE_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module ci/lib/io.sh
+
+# This block is run the first (and only) time this script is sourced. It first
+# clears the ccache stats. Then it registers an exit handler that will display
+# the ccache stats when the calling script exits.
+if command -v ccache >/dev/null 2>&1; then
+  io::log "Clearing ccache stats"
+  ccache --zero-stats
+  function show_stats_handler() {
+    io::log "===> ccache stats"
+    ccache --show-stats
+  }
+  trap show_stats_handler EXIT
+fi


### PR DESCRIPTION
This PR adds a `ci/cloudbuild/builds/lib/cmake.sh` module that
automatically prints ccache stats at the end of cmake-based builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6088)
<!-- Reviewable:end -->
