### PR TITLE
ci: add an xsan GCB build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -72,7 +72,8 @@ build:xsan --linkopt=-stdlib=libc++
 build:xsan --linkopt=-lc++
 build:xsan --linkopt=-lc++abi
 build:xsan --linkopt=-fsanitize-link-c++-runtime
-build:xsan --linkcopt=-fsanitize=undefined
+build:xsan --linkopt=-fsanitize=float-divide-by-zero
+build:xsan --linkopt=-fsanitize=nullability
 build:xsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
 # --config msan: Memory Sanitizer

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,6 +31,8 @@ build:asan --strip=never
 build:asan --copt=-Og
 build:asan --copt=-g
 build:asan --copt=-fsanitize=address
+build:asan --copt=-fsanitize=float-divide-by-zero
+build:asan --copt=-fsanitize=nullability
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,12 +31,20 @@ build:asan --strip=never
 build:asan --copt=-Og
 build:asan --copt=-g
 build:asan --copt=-fsanitize=address
-build:asan --copt=-fsanitize=float-divide-by-zero
-build:asan --copt=-fsanitize=nullability
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 build:asan --action_env=LSAN_OPTIONS=report_objects=1
+
+# --config xsan: Runs misc. sanitizers that aren't covered elsewhere.
+build:xsan --strip=never
+build:xsan --copt=-Og
+build:xsan --copt=-g
+build:xsan --copt=-fsanitize=float-divide-by-zero
+build:xsan --copt=-fsanitize=nullability
+build:xsan --copt=-fno-omit-frame-pointer
+build:xsan --linkopt=-fsanitize=nullability
+build:xsan --action_env=UBSAN_OPTIONS=print_stacktrace=1
 
 # --config tsan: Thread Sanitizer
 build:tsan --strip=never

--- a/.bazelrc
+++ b/.bazelrc
@@ -36,16 +36,6 @@ build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 build:asan --action_env=LSAN_OPTIONS=report_objects=1
 
-# --config xsan: Runs misc. sanitizers that aren't covered elsewhere.
-build:xsan --strip=never
-build:xsan --copt=-Og
-build:xsan --copt=-g
-build:xsan --copt=-fsanitize=float-divide-by-zero
-build:xsan --copt=-fsanitize=nullability
-build:xsan --copt=-fno-omit-frame-pointer
-build:xsan --linkopt=-fsanitize=undefined
-build:xsan --action_env=UBSAN_OPTIONS=print_stacktrace=1
-
 # --config tsan: Thread Sanitizer
 build:tsan --strip=never
 build:tsan --copt=-Og
@@ -69,6 +59,21 @@ build:ubsan --cxxopt=-stdlib=libc++
 build:ubsan --linkopt=-stdlib=libc++
 build:ubsan --linkopt=-lc++
 build:ubsan --linkopt=-lc++abi
+
+# --config xsan: Runs misc. sanitizers that aren't covered elsewhere.
+build:xsan --strip=never
+build:xsan --copt=-Og
+build:xsan --copt=-g
+build:xsan --copt=-fsanitize=float-divide-by-zero
+build:xsan --copt=-fsanitize=nullability
+build:xsan --copt=-fno-omit-frame-pointer
+build:xsan --cxxopt=-stdlib=libc++
+build:xsan --linkopt=-stdlib=libc++
+build:xsan --linkopt=-lc++
+build:xsan --linkopt=-lc++abi
+build:xsan --linkopt=-fsanitize-link-c++-runtime
+build:xsan --linkcopt=-fsanitize=undefined
+build:xsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
 # --config msan: Memory Sanitizer
 build:msan --strip=never

--- a/.bazelrc
+++ b/.bazelrc
@@ -43,7 +43,7 @@ build:xsan --copt=-g
 build:xsan --copt=-fsanitize=float-divide-by-zero
 build:xsan --copt=-fsanitize=nullability
 build:xsan --copt=-fno-omit-frame-pointer
-build:xsan --linkopt=-fsanitize=nullability
+build:xsan --linkopt=-fsanitize=undefined
 build:xsan --action_env=UBSAN_OPTIONS=print_stacktrace=1
 
 # --config tsan: Thread Sanitizer

--- a/ci/cloudbuild/builds/xsan.sh
+++ b/ci/cloudbuild/builds/xsan.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
+export CC=clang
+export CXX=clang++
+
+mapfile -t args < <(bazel::common_args)
+args+=("--config=xsan")
+args+=("--test_tag_filters=-integration-test")
+bazel test "${args[@]}" ...


### PR DESCRIPTION
Adds an `xsan` GCB build. This runs several sanitizers that are not already run elsewhere, such as 
`-fsanitize=float-divide-by-zero` and `-fsanitize=nullability`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6090)
<!-- Reviewable:end -->
