### PR TITLE
ci: add yaml files for current triggers

### DIFF
--- a/ci/cloudbuild/trigger.sh
+++ b/ci/cloudbuild/trigger.sh
@@ -65,27 +65,20 @@ PARSED="$(getopt -a \
   -- "$@")"
 eval set -- "${PARSED}"
 
-while true; do
-  case "$1" in
-  -d | --describe)
-    describe_trigger "$2"
-    exit
-    ;;
-  -i | --import)
-    import_trigger "$2"
-    exit
-    ;;
-  -l | --list)
-    list_triggers
-    exit
-    ;;
-  -h | --help)
-    print_usage
-    exit
-    ;;
-  *)
-    print_usage
-    exit
-    ;;
-  esac
-done
+case "$1" in
+-d | --describe)
+  describe_trigger "$2"
+  ;;
+-i | --import)
+  import_trigger "$2"
+  ;;
+-l | --list)
+  list_triggers
+  ;;
+-h | --help)
+  print_usage
+  ;;
+*)
+  print_usage
+  ;;
+esac

--- a/ci/cloudbuild/trigger.sh
+++ b/ci/cloudbuild/trigger.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script manages Google Cloud Build triggers. The triggers are defined by
+# yaml files that live in the `triggers/` directory.
+#
+# Usage: ./trigger.sh [options]
+#
+#   Options:
+#     -l|--list           List all triggers for this repo on the server
+#     -d|--describe=name  Describe the named trigger
+#     -i|--import=file    Uploads the local yaml file to create/update a trigger
+#     -h|--help           Print this help message
+
+set -euo pipefail
+
+source "$(dirname "$0")/../lib/init.sh"
+source module ci/lib/io.sh
+
+function print_usage() {
+  # Extracts the usage from the file comment starting at line 17.
+  sed -n '17,/^$/s/^# \?//p' "${PROGRAM_PATH}"
+}
+
+readonly CLOUD_PROJECT="cloud-cpp-testing-resources"
+readonly GITHUB_NAME="google-cloud-cpp"
+
+function list_triggers() {
+  gcloud beta builds triggers list \
+    --project "${CLOUD_PROJECT}" \
+    --filter "github.name = ${GITHUB_NAME}"
+}
+
+function describe_trigger() {
+  local name="$1"
+  gcloud beta builds triggers describe "${name}" \
+    --project "${CLOUD_PROJECT}"
+}
+
+function import_trigger() {
+  local file="$1"
+  gcloud beta builds triggers import \
+    --source "${file}" --project "${CLOUD_PROJECT}" | tee "${file}.IMPORTED"
+  mv "${file}.IMPORTED" "${file}"
+}
+
+# Use getopt to parse and normalize all the args.
+PARSED="$(getopt -a \
+  --options="d:i:lh" \
+  --longoptions="describe:,import:,list,help" \
+  --name="${PROGRAM_NAME}" \
+  -- "$@")"
+eval set -- "${PARSED}"
+
+while true; do
+  case "$1" in
+  -d | --describe)
+    describe_trigger "$2"
+    exit
+    ;;
+  -i | --import)
+    import_trigger "$2"
+    exit
+    ;;
+  -l | --list)
+    list_triggers
+    exit
+    ;;
+  -h | --help)
+    print_usage
+    exit
+    ;;
+  *)
+    print_usage
+    exit
+    ;;
+  esac
+done

--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -1,0 +1,18 @@
+---
+createTime: '2021-03-22T00:38:08.167137222Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+id: a803727d-8633-49ea-b545-bd7f9124bc3d
+name: asan-ci
+substitutions:
+  _BUILD_NAME: asan
+  _DISTRO: fedora
+tags:
+- asan
+- bazel
+- fedora
+- ci

--- a/ci/cloudbuild/triggers/asan.yaml
+++ b/ci/cloudbuild/triggers/asan.yaml
@@ -1,0 +1,20 @@
+---
+createTime: '2021-03-21T17:51:13.620749264Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+id: 502b5d9e-a6cf-415a-9121-317cfb45d37e
+name: asan
+substitutions:
+  _BUILD_NAME: asan
+  _DISTRO: fedora
+tags:
+- asan
+- bazel
+- fedora
+- clang
+- pr

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -1,0 +1,19 @@
+---
+createTime: '2021-03-22T00:36:44.386437504Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+id: 88b3547a-7d8b-4af2-998f-e2ed284ebaaa
+name: clang-tidy-ci
+substitutions:
+  _BUILD_NAME: clang-tidy
+  _DISTRO: fedora
+tags:
+- fedora
+- clang
+- clang-tidy
+- cmake
+- ci

--- a/ci/cloudbuild/triggers/clang-tidy.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy.yaml
@@ -1,0 +1,20 @@
+---
+createTime: '2021-03-20T22:56:56.896890729Z'
+disabled: true
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+id: eb9be3d8-db81-4fb1-95eb-e86afb6de32a
+name: clang-tidy
+substitutions:
+  _BUILD_NAME: clang-tidy
+  _DISTRO: fedora
+tags:
+- fedora
+- clang
+- clang-tidy
+- pr

--- a/ci/cloudbuild/triggers/cmake-clang-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang-ci.yaml
@@ -1,0 +1,18 @@
+---
+createTime: '2021-03-22T02:46:10.927625019Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+id: 4eed46f7-2acb-405f-8734-826f1c887d19
+name: cmake-clang-ci
+substitutions:
+  _BUILD_NAME: cmake+clang
+  _DISTRO: fedora
+tags:
+- fedora
+- clang
+- cmake
+- ci

--- a/ci/cloudbuild/triggers/cmake-clang.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang.yaml
@@ -1,0 +1,19 @@
+---
+createTime: '2021-03-21T21:02:18.738169993Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+id: 74b4ff4d-a52d-4f22-a92c-58e0971aa0a5
+name: cmake-clang
+substitutions:
+  _BUILD_NAME: cmake+clang
+  _DISTRO: fedora
+tags:
+- fedora
+- clang
+- pr
+- cmake

--- a/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
@@ -1,0 +1,18 @@
+---
+createTime: '2021-03-22T02:46:38.977511021Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+id: 4b58f91e-a19c-4b18-99b9-0224507cf0e6
+name: cmake-gcc-ci
+substitutions:
+  _BUILD_NAME: cmake+gcc
+  _DISTRO: fedora
+tags:
+- fedora
+- cmake
+- gcc
+- ci

--- a/ci/cloudbuild/triggers/cmake-gcc.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc.yaml
@@ -1,0 +1,19 @@
+---
+createTime: '2021-03-21T21:03:13.920618226Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+id: f5da0822-6bf4-40a3-b063-a194db1773ba
+name: cmake-gcc
+substitutions:
+  _BUILD_NAME: cmake+gcc
+  _DISTRO: fedora
+tags:
+- fedora
+- pr
+- cmake
+- gcc

--- a/ci/cloudbuild/triggers/ubsan.yaml
+++ b/ci/cloudbuild/triggers/ubsan.yaml
@@ -1,0 +1,19 @@
+---
+createTime: '2021-03-21T21:03:51.588652971Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+id: 82ea0d45-6073-481d-a1bd-4daa329edd7a
+name: ubsan
+substitutions:
+  _BUILD_NAME: ubsan
+  _DISTRO: fedora
+tags:
+- bazel
+- fedora
+- pr
+- ubsan

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -1,0 +1,18 @@
+---
+createTime: '2021-03-23T16:27:32.983843488Z'
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+id: 7af338de-c46d-41ff-a96b-f58e3b720fc5
+name: xsan-ci
+substitutions:
+  _BUILD_NAME: xsan
+  _DISTRO: fedora
+tags:
+- xsan
+- bazel
+- fedora
+- ci


### PR DESCRIPTION
The list of triggers and yaml files will grow, but for now, I'm just
copying what currently exists in the UI.

This PR also adds a script, `trigger.sh`, to make it easier for us to
manipulate these trigger yaml files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6092)
<!-- Reviewable:end -->
