### PR TITLE
fix: pkg-config requires typo

### DIFF
--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -726,7 +726,7 @@ string(
            " google_cloud_iam_protos"
            " google_cloud_pubsub_protos"
            " google_cloud_cpp_storage_protos"
-           " google_cloud_cpp_oo_protos"
+           " google_cloud_cpp_logging_protos"
            " google_cloud_cpp_iam_v1_iam_policy_protos"
            " google_cloud_cpp_iam_v1_options_protos"
            " google_cloud_cpp_iam_v1_policy_protos"


### PR DESCRIPTION
Looks like this typo slipped in during [this PR](https://github.com/googleapis/google-cloud-cpp/pull/5756/files#diff-a5ee3f8b8c970f368418195cd806ad21e60d9d50dddab1fa22a8a62474ff7d66L726)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6095)
<!-- Reviewable:end -->
