### PR TITLE
fix: two more pkg-config requires typos

### DIFF
--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -723,8 +723,8 @@ string(
     CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
            "google_cloud_cpp_bigtable_protos"
            " google_cloud_cpp_cloud_bigquery_protos"
-           " google_cloud_iam_protos"
-           " google_cloud_pubsub_protos"
+           " google_cloud_cpp_iam_protos"
+           " google_cloud_cpp_pubsub_protos"
            " google_cloud_cpp_storage_protos"
            " google_cloud_cpp_logging_protos"
            " google_cloud_cpp_iam_v1_iam_policy_protos"


### PR DESCRIPTION
I think these slipped in during
https://github.com/googleapis/google-cloud-cpp/pull/5756 also.

FYI: I'm creating a CI build that will catch these in the future...
that's how I found these.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6097)
<!-- Reviewable:end -->
