### PR TITLE
chore: building blocks for patching googleapis after download

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -79,6 +79,9 @@ def google_cloud_cpp_deps():
             ],
             strip_prefix = "googleapis-6598bb829c9e9a534be674649ffd1b4671a821f9",
             sha256 = "117fda09e4ce0fc329393eb55914aaca564b81c6234e1e6c1e1588e5032bf45c",
+            patch_tool = "patch",
+            patch_args = ["-p1"],
+            patches = [],  # "googleapis.patch"
             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
         )
 

--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -79,10 +79,15 @@ def google_cloud_cpp_deps():
             ],
             strip_prefix = "googleapis-6598bb829c9e9a534be674649ffd1b4671a821f9",
             sha256 = "117fda09e4ce0fc329393eb55914aaca564b81c6234e1e6c1e1588e5032bf45c",
+            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
+            # Scaffolding for patching googleapis after download. For example:
+            #   patches = ["googleapis.patch"]
+            # NOTE: This should only be used while developing with a new
+            # protobuf message. No changes to `patches` should ever be
+            # committed to the main branch.
             patch_tool = "patch",
             patch_args = ["-p1"],
-            patches = [],  # "googleapis.patch"
-            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
+            patches = [],
         )
 
     # Load protobuf.

--- a/ci/kokoro/docker/Dockerfile.fedora
+++ b/ci/kokoro/docker/Dockerfile.fedora
@@ -20,7 +20,7 @@ ARG NCPU=4
 RUN dnf makecache && \
     dnf install -y ccache clang clang-tools-extra cmake diffutils findutils \
         gcc-c++ git libcxx-devel libcxxabi-devel libasan libubsan libtsan \
-        llvm make openssl-devel pkgconfig python python3.8 python3-devel \
+        llvm make openssl-devel patch pkgconfig python python3.8 python3-devel \
         python-pip tar unzip wget which zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell

--- a/ci/kokoro/docker/Dockerfile.fedora-install
+++ b/ci/kokoro/docker/Dockerfile.fedora-install
@@ -20,12 +20,12 @@ ARG NCPU=4
 # for `google-cloud-cpp`. Install these packages and additional development
 # tools to compile the dependencies:
 RUN dnf makecache && \
-    dnf install -y abi-compliance-checker abi-dumper ccache \
-        clang clang-analyzer clang-tools-extra \
-        cmake diffutils doxygen findutils gcc-c++ git \
-        grpc-devel grpc-plugins lcov libcxx-devel libcxxabi-devel libcurl-devel \
-        make ninja-build npm openssl-devel pkgconfig protobuf-compiler python \
-        python3.8 python-pip ShellCheck tar unzip w3m wget which zlib-devel
+    dnf install -y abi-compliance-checker abi-dumper ccache clang \
+        clang-analyzer clang-tools-extra cmake diffutils doxygen \
+        findutils gcc-c++ git grpc-devel grpc-plugins lcov libcxx-devel \
+        libcxxabi-devel libcurl-devel make ninja-build npm openssl-devel \
+        patch pkgconfig protobuf-compiler python python3.8 python-pip \
+        ShellCheck tar unzip w3m wget which zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -157,18 +157,22 @@ foreach (proto ${EXTERNAL_GOOGLEAPIS_PROTO_FILES})
 endforeach ()
 
 include(ExternalProject)
+
 ExternalProject_Add(
     googleapis_download
     EXCLUDE_FROM_ALL ON
     PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
     URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
     URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
-             # Scaffolding for patching googleapis after download. For example:
-             # PATCH_COMMAND patch -p1 --input=/v/external/googleapis.patch
-             # NOTE: This should only be used while developing with a new
-             # protobuf message. No changes to `PATCH_COMMAND` should ever be
-             # committed to the main branch.
-    PATCH_COMMAND ""
+    PATCH_COMMAND
+        ""
+        # ~~~
+        # Scaffolding for patching googleapis after download. For example:
+        #   PATCH_COMMAND patch -p1 --input=/v/external/googleapis.patch
+        # NOTE: This should only be used while developing with a new
+        # protobuf message. No changes to `PATCH_COMMAND` should ever be
+        # committed to the main branch.
+        # ~~~
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -163,6 +163,7 @@ ExternalProject_Add(
     PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
     URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
     URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
+    PATCH_COMMAND "" # patch -p1 --input=/v/external/googleapis.patch
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -163,7 +163,12 @@ ExternalProject_Add(
     PREFIX "${CMAKE_BINARY_DIR}/external/googleapis"
     URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
     URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
-    PATCH_COMMAND "" # patch -p1 --input=/v/external/googleapis.patch
+             # Scaffolding for patching googleapis after download. For example:
+             # PATCH_COMMAND patch -p1 --input=/v/external/googleapis.patch
+             # NOTE: This should only be used while developing with a new
+             # protobuf message. No changes to `PATCH_COMMAND` should ever be
+             # committed to the main branch.
+    PATCH_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
When developing a new feature based on simple changes to the
googleapis repo, it may well be easier to apply a patch to the
downloaded proto files rather than dealing with branches.

Those googleapis branches are often not kept up to date, so it
can be difficult to rebase branches in this repo, which hinders
developing at head. Patching also allows for the possibility of
layering changes from multiple googleapis branches.

This PR doesn't change any behavior, but it does leave indicators
for where patches can be applied in both the CMake and bazel
builds, as well as adding the "patch" binary to the docker images.

I recently used this mechanism to check whether a proposed proto
rearrangement would affect the build for the Cloud Spanner client.
An additional lesson from that effort was that any changes to the
shape of the proto tree made by the patch, which would require edits
to the list of proto files in external/googleapis/CMakeLists.txt,
would also necessitate patching the downloaded bazel BUILD files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6104)
<!-- Reviewable:end -->
