### PR TITLE
refactor(ci): simplified gcb build.sh to accept --project

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -15,6 +15,7 @@
 options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'
+  dynamic_substitutions: true
   env: [ 'HOME=/h' ]
   volumes:
     - name: 'home'
@@ -25,8 +26,8 @@ options:
 substitutions:
   _DISTRO: 'unknown'
   _BUILD_NAME: 'unknown'
-  _CACHE_BUCKET: 'cloud-cpp-cloudbuild-cache'
-  _CACHE_TYPE: '${_PR_NUMBER:-base}'
+  _CACHE_BUCKET: '${PROJECT_ID}_cloudbuild'
+  _CACHE_TYPE: '${_PR_NUMBER:-main}'
 
 timeout: 3600s
 
@@ -47,9 +48,9 @@ steps:
   dir: '/h'
   args: [
     'restore',
-    '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp',
+    '--bucket_url=gs://${_CACHE_BUCKET}/build-cache/google-cloud-cpp',
     '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
-    '--fallback_key=base/${_DISTRO}-${_BUILD_NAME}/h'
+    '--fallback_key=main/${_DISTRO}-${_BUILD_NAME}/h'
   ]
 
   # Runs the specified build in the image that was created in the first step.
@@ -66,7 +67,7 @@ steps:
   dir: '/h'
   args: [
     'save',
-    '--bucket_url=gs://${_CACHE_BUCKET}/google-cloud-cpp',
+    '--bucket_url=gs://${_CACHE_BUCKET}/build-cache/google-cloud-cpp',
     '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
     '--path=.ccache',
     '--path=.cache/ccache',


### PR DESCRIPTION
This PR simplifies the `ci/cloudbuild/build.sh` script so that it now
takes an (optional) `--project` flag (the same as `gcloud`), and it no
longer requires/supports the `--cache_bucket` flag. The cache bucket is
now computed from the specified (or defaulted) project ID, and it's the
same cache bucket that Google Cloud Build uses for its source upload.
The bucket is: `${PROJECT_ID}_cloudbuild`. The nice thing is that GCB
creates this bucket if necessary automatically, and we re-use this same
bucket for our build cache and bazel cache. So we only have a single
"cloudbuild" bucket now, instead of two.

I also changed the "base" branch cache key to be named "main", since
this will eventually match our `main` branch, and that's the build that
it corresponds to. I did this now since changing the cache bucket will
have to rebuild all the caches anyway, so better to do that only once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6108)
<!-- Reviewable:end -->
