### PR TITLE
ci: use Cloud ID rather than unix ID

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -97,9 +97,10 @@ if [ "${DISTRO}" != "local" ]; then
     print_usage
     exit 1
   fi
+  account="$(gcloud config list account --format "value(core.account)")"
   subs="_DISTRO=${DISTRO}"
   subs+=",_BUILD_NAME=${BUILD_NAME}"
-  subs+=",_CACHE_TYPE=manual-$(id -un)"
+  subs+=",_CACHE_TYPE=manual-${account})"
   io::log "====> Submitting cloud build job for ${subs}"
   args=(
     "--config=ci/cloudbuild/cloudbuild.yaml"


### PR DESCRIPTION
Manual build caches show up named like `manual-<user>`. The username
part should use the gcloud account rather than the `id -un`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6109)
<!-- Reviewable:end -->
