### PR TITLE
ci: garbage collect docker images in GCB

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -28,7 +28,7 @@ substitutions:
   _BUILD_NAME: 'unknown'
   _CACHE_BUCKET: '${PROJECT_ID}_cloudbuild'
   _CACHE_TYPE: '${_PR_NUMBER:-main}'
-  _IMAGE: '${PROJECT_ID}_cloudbuild/${_DISTRO}'
+  _IMAGE: 'cloudbuild/${_DISTRO}'
 
 timeout: 3600s
 

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -28,6 +28,7 @@ substitutions:
   _BUILD_NAME: 'unknown'
   _CACHE_BUCKET: '${PROJECT_ID}_cloudbuild'
   _CACHE_TYPE: '${_PR_NUMBER:-main}'
+  _IMAGE: '${PROJECT_ID}_cloudbuild/${_DISTRO}'
 
 timeout: 3600s
 
@@ -38,7 +39,7 @@ steps:
     '--context=dir:///workspace/ci',
     '--dockerfile=ci/cloudbuild/${_DISTRO}.Dockerfile',
     '--cache=true',
-    '--destination=gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}',
+    '--destination=gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}',
   ]
 
   # Restores the homedir cache into /h in parallel with the previous step.
@@ -54,7 +55,7 @@ steps:
   ]
 
   # Runs the specified build in the image that was created in the first step.
-- name: 'gcr.io/${PROJECT_ID}/google-cloud-cpp-cloudbuild-docker/${_DISTRO}-image:${BUILD_ID}'
+- name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '${_BUILD_NAME}' ]
   env: [
@@ -74,3 +75,32 @@ steps:
     '--path=.cache/vcpkg',
     '--path=.cache/google-cloud-cpp'
   ]
+
+  # Remove the images created by this build.
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      set +e
+      gcloud container images delete -q gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}
+      exit 0
+
+  # The previous step may not run if the build fails. Garbage collect any
+  # images created by this script, and/or similar scripts in this repository.
+  # The main idea is to remove images created over 4 weeks ago. Because the
+  # current builds create images with current timestamps, such images are not
+  # likely to be in use. This step should not break the build on error, and it
+  # can start running as soon as the build does.
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  waitFor: [ '-' ]
+  entrypoint: 'bash'
+  args:
+    - '-c'
+    - |
+      set +e
+      gcloud container images list-tags gcr.io/${PROJECT_ID}/${_IMAGE} \
+        --format='get(digest)' --filter='timestamp.datetime < -P4W' | \
+        xargs -r printf "gcr.io/${PROJECT_ID}/${_IMAGE}@%s\n" | \
+        xargs -r -P 4 -L 32 gcloud container images delete -q --force-delete-tags
+      exit 0


### PR DESCRIPTION
This will delete the BUILD_ID-specific docker image at the end of a
successful build. It will also clean up 4-week old images that were left
around from failed builds that didn't get to the cleanup step.

This PR also changes the image name to something nicer and shorter, and this will let us manually
clean up all the old images that are now lying around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6111)
<!-- Reviewable:end -->
