### PR TITLE
ci: add h1 and h2 heads to ci/lib/io.sh

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -101,7 +101,7 @@ if [ "${DISTRO}" != "local" ]; then
   subs="_DISTRO=${DISTRO}"
   subs+=",_BUILD_NAME=${BUILD_NAME}"
   subs+=",_CACHE_TYPE=manual-${account}"
-  io::log "====> Submitting cloud build job for ${subs}"
+  io::log_h1 "Submitting cloud build job for ${subs}"
   args=(
     "--config=ci/cloudbuild/cloudbuild.yaml"
     "--substitutions=${subs}"
@@ -112,7 +112,7 @@ if [ "${DISTRO}" != "local" ]; then
   exec gcloud builds submit "${args[@]}" .
 fi
 
-io::log "====> STARTING BUILD: ${BUILD_NAME}"
+io::log_h1 "STARTING BUILD: ${BUILD_NAME}"
 readonly TIMEFORMAT="==> 🕑 ${BUILD_NAME} completed in %R seconds"
 time {
   "${PROGRAM_DIR}/builds/${BUILD_NAME}.sh"

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -112,7 +112,7 @@ if [ "${DISTRO}" != "local" ]; then
   exec gcloud builds submit "${args[@]}" .
 fi
 
-io::log_h1 "STARTING BUILD: ${BUILD_NAME}"
+io::log_h1 "Starting build: ${BUILD_NAME}"
 readonly TIMEFORMAT="==> 🕑 ${BUILD_NAME} completed in %R seconds"
 time {
   "${PROGRAM_DIR}/builds/${BUILD_NAME}.sh"

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -32,7 +32,7 @@ cmake -GNinja \
   -S . -B cmake-out
 cmake --build cmake-out --target install
 
-io::log "Verifying installed directories"
+io::log_h2 "Verifying installed directories"
 # Finds all the installed leaf directories (i.e., directories with exactly two
 # links: . and ..). We only look at leaf directories, because obviously all
 # parent directories must also exist.
@@ -115,7 +115,7 @@ if [[ -n "${discrepancies}" ]]; then
   exit_code=1
 fi
 
-io::log "Validating installed pkg-config files"
+io::log_h2 "Validating installed pkg-config files"
 export PKG_CONFIG_PATH="${INSTALL_PREFIX}/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
 while IFS= read -r -d '' pc; do
   # Ignores the warning noise from system .pc files, but we redo the validation
@@ -130,7 +130,7 @@ while IFS= read -r -d '' pc; do
   fi
 done < <(find "${INSTALL_PREFIX}" -name '*.pc' -print0)
 
-io::log "Validating installed file extensions"
+io::log_h2 "Validating installed file extensions"
 # All installed libraries have the same version, so pick one.
 version=$(pkg-config google_cloud_cpp_common --modversion)
 version_major=$(cut -d. -f1 <<<"${version}")

--- a/ci/lib/io.sh
+++ b/ci/lib/io.sh
@@ -72,3 +72,28 @@ function io::log_yellow() {
 function io::log_red() {
   io::internal::log_impl "${IO_COLOR_RED}" "$@"
 }
+
+# Logs an "H1" heading. This looks like a blank line, followed by the message
+# in a double-lined box.
+#
+# ========================================
+# |   This is an example of io::log_h1   |
+# ========================================
+function io::log_h1() {
+  local msg="|   $*   |"
+  local line
+  line="$(printf -- "=%.0s" $(seq 1 ${#msg}))"
+  printf "\n%s\n%s\n%s\n" "${line}" "${msg}" "${line}"
+}
+
+# Logs an "H2" heading. Same as H1, but uses a single-lined box.
+#
+# ----------------------------------------
+# |   This is an example of io::log_h2   |
+# ----------------------------------------
+function io::log_h2() {
+  local msg="|   $*   |"
+  local line
+  line="$(printf -- "-%.0s" $(seq 1 ${#msg}))"
+  printf "\n%s\n%s\n%s\n" "${line}" "${msg}" "${line}"
+}


### PR DESCRIPTION
In GCB, our builds run without a TTY so the colors in our logs don't
show up. To make log sections easier to spot visually in a sea of
black-n-white, I'm adding `io::log_h1` and `io::log_h2` to make it easy
to output H1 and H2 (think of html heading tags) headings in boxes to
make them visually distinct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6114)
<!-- Reviewable:end -->
