### PR TITLE
ci: add --local flag to GCB build.sh

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -57,7 +57,7 @@ steps:
   # Runs the specified build in the image that was created in the first step.
 - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
-  args: [ '${_BUILD_NAME}' ]
+  args: [ '--local', '${_BUILD_NAME}' ]
   env: [
     'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}'
   ]


### PR DESCRIPTION
This flag is better than looking for a special string of "local" in
`DISTRO`. This also sets up the script for the next flag, which will be
`--docker` to run the build in docker on the current machine instead of
submitting to cloud build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6119)
<!-- Reviewable:end -->
