### PR TITLE
ci(gcb): distro can now be looked up from trigger file

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -16,18 +16,18 @@
 #
 # ## Run builds using Google Cloud Build ##
 #
-# This script runs builds using Google Cloud Build. It expects a single
-# argument of the build name to run. Valid build names are the basenames of the
-# scripts in the `builds/` directory. An optional `--distro=<distro>` flag may
-# be specified to indicate which `<distro>.Dockerfile` to run the named build
-# in, and this build is submitted to Cloud Build to run. A distro of "local"
-# (the default) indicates to run the build locally, without docker, using the
-# invoking user's operating system and environment.
+# This script runs the builds defined in `ci/cloudbuild/builds/` on the local
+# machine (if `--local` is specified) or in the cloud using Google Cloud Build
+# (the default). A single argument indicating the build name is required. The
+# distro indicates the `<distro>.Dockerfile` to use for the build (ignored if
+# using `--local`). The distro is looked up from the specified build's trigger
+# file (`ci/cloudbuild/triggers/<build-name>.yaml`), but the distro can be
+# overridden with the optional `--distro=<arg>` flag.
 #
 # Usage: build.sh [options] <build-name>
 #
 #   Options:
-#     -d|--distro=<name>   The distro name to use
+#     --distro=<name>   The distro name to use
 #     -p|--project=<name>  The Cloud Project ID to use
 #     -l|--local           Run the build in the local environment
 #     -h|--help            Print this help message
@@ -48,7 +48,7 @@ function print_usage() {
 
 # Use getopt to parse and normalize all the args.
 PARSED="$(getopt -a \
-  --options="d:p:lh" \
+  --options="p:lh" \
   --longoptions="distro:,project:,local,help" \
   --name="${PROGRAM_NAME}" \
   -- "$@")"
@@ -59,7 +59,7 @@ PROJECT_ID=""
 LOCAL_BUILD="false"
 while true; do
   case "$1" in
-  -d | --distro)
+  --distro)
     DISTRO="$2"
     shift 2
     ;;
@@ -81,10 +81,10 @@ while true; do
     ;;
   esac
 done
-readonly DISTRO
 readonly PROJECT_ID
 
 if (($# == 0)); then
+  echo "Missing build name"
   print_usage
   exit 1
 fi
@@ -94,33 +94,43 @@ if [[ "${LOCAL_BUILD}" = "true" ]]; then
   io::log_h1 "Starting local build: ${BUILD_NAME}"
   readonly TIMEFORMAT="==> 🕑 ${BUILD_NAME} completed in %R seconds"
   time "${PROGRAM_DIR}/builds/${BUILD_NAME}.sh"
-elif [[ -n "${DISTRO}" ]]; then
-  # Quick checks to surface invalid arguments early
-  if [ ! -r "ci/cloudbuild/${DISTRO}.Dockerfile" ]; then
-    echo "Unknown distro: ${DISTRO}"
-    print_usage
-    exit 1
-  elif [ ! -x "ci/cloudbuild/builds/${BUILD_NAME}.sh" ]; then
-    echo "Unknown build name: ${BUILD_NAME}"
+  exit
+fi
+
+# If --distro wasn't specified, look it up from the build's trigger file.
+if [[ -z "${DISTRO}" ]]; then
+  trigger_file="ci/cloudbuild/triggers/${BUILD_NAME}.yaml"
+  DISTRO="$(grep _DISTRO "${trigger_file}" | awk '{print $2}' || true)"
+  if [[ -z "${DISTRO}" ]]; then
+    echo "Missing --distro=<arg>, and none found in ${trigger_file}"
     print_usage
     exit 1
   fi
-  account="$(gcloud config list account --format "value(core.account)")"
-  subs="_DISTRO=${DISTRO}"
-  subs+=",_BUILD_NAME=${BUILD_NAME}"
-  subs+=",_CACHE_TYPE=manual-${account}"
-  io::log_h1 "Starting cloud build: ${BUILD_NAME}"
-  io::log "Substitutions ${subs}"
-  args=(
-    "--config=ci/cloudbuild/cloudbuild.yaml"
-    "--substitutions=${subs}"
-  )
-  if [[ -n "${PROJECT_ID}" ]]; then
-    args+=("--project=${PROJECT_ID}")
-  fi
-  exec gcloud builds submit "${args[@]}" .
-else
-  echo "Invalid arguments"
+fi
+readonly DISTRO
+
+# Surface invalid arguments early rather than waiting for GCB to fail.
+if [ ! -r "${PROGRAM_DIR}/${DISTRO}.Dockerfile" ]; then
+  echo "Unknown distro: ${DISTRO}"
+  print_usage
+  exit 1
+elif [ ! -x "${PROGRAM_DIR}/builds/${BUILD_NAME}.sh" ]; then
+  echo "Unknown build name: ${BUILD_NAME}"
   print_usage
   exit 1
 fi
+
+account="$(gcloud config list account --format "value(core.account)")"
+subs="_DISTRO=${DISTRO}"
+subs+=",_BUILD_NAME=${BUILD_NAME}"
+subs+=",_CACHE_TYPE=manual-${account}"
+io::log_h1 "Starting cloud build: ${BUILD_NAME}"
+io::log "Substitutions ${subs}"
+args=(
+  "--config=ci/cloudbuild/cloudbuild.yaml"
+  "--substitutions=${subs}"
+)
+if [[ -n "${PROJECT_ID}" ]]; then
+  args+=("--project=${PROJECT_ID}")
+fi
+exec gcloud builds submit "${args[@]}" .


### PR DESCRIPTION
This makes it easier to run a build because `--distro` need not be
specified. Example:

```
build.sh asan  # Runs build in GCB using `fedora`
build.sh --local asan  # Runs build on local machine; distro unnecessary
```

I also removed the `-d` shorthand for distro since it will likely be
rarely used, and foresee wanting to use that short flag to mean
`--docker` (upcoming).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6121)
<!-- Reviewable:end -->
