### PR TITLE
ci(gcb): print info about machine doing local build

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -116,6 +116,21 @@ if [[ "${LOCAL_BUILD}" = "true" ]]; then
     print_usage
     exit 1
   fi
+  function mem_total() {
+    awk '$1 == "MemTotal:" {printf "%0.2f GiB", $2/1024/1024}' /proc/meminfo
+  }
+  io::log_h1 "Machine Info"
+  TZ=/etc/localtime printf "%10s %s (%s)\n" "local:" "$(date)" "$(date +%z)"
+  printf "%10s %s\n" "utc:" "$(date -u)"
+  printf "%10s %s\n" "kernel:" "$(uname -v)"
+  printf "%10s %s\n" "os:" "$(grep PRETTY_NAME /etc/os-release)"
+  printf "%10s %s\n" "nproc:" "$(nproc)"
+  printf "%10s %s\n" "mem:" "$(mem_total)"
+  printf "%10s %s\n" "gcc:" "$(gcc --version 2>&1 | head -1)"
+  printf "%10s %s\n" "clang:" "$(clang --version 2>&1 | head -1)"
+  printf "%10s %s\n" "cc:" "$(cc --version 2>&1 | head -1)"
+  printf "%10s %s\n" "cmake:" "$(cmake --version 2>&1 | head -1)"
+  printf "%10s %s\n" "bazel:" "$(bazel --version 2>&1 | head -1)"
   io::log_h1 "Starting local build: ${BUILD_NAME}"
   readonly TIMEFORMAT="==> 🕑 ${BUILD_NAME} completed in %R seconds"
   time "${PROGRAM_DIR}/builds/${BUILD_NAME}.sh"


### PR DESCRIPTION
These builds can run in a variety of environments, in Google Cloud
Build, a local docker, or on the local machine. It can be useful to
see some stats about the local machine runing the build.

Example output from a cloud build run:

```
Step #2: ====================
Step #2: |   Machine Info   |
Step #2: ====================
Step #2:     local: Sat Mar 27 17:32:03 UTC 2021 (+0000)
Step #2:       utc: Sat Mar 27 17:32:03 UTC 2021
Step #2:    kernel: #41~18.04.1-Ubuntu SMP Fri Feb 26 22:23:13 UTC 2021
Step #2:        os: PRETTY_NAME="Fedora 33 (Container Image)"
Step #2:     nproc: 32
Step #2:       mem: 28.21 GiB
Step #2:       gcc: gcc (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9)
Step #2:     clang: clang version 11.0.0 (Fedora 11.0.0-2.fc33)
Step #2:        cc: cc (GCC) 10.2.1 20201125 (Red Hat 10.2.1-9)
Step #2:     cmake: cmake version 3.19.7
Step #2:     bazel: bazel 3.5.0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6123)
<!-- Reviewable:end -->
