### PR TITLE
ci(gcb): set TZ=:UTC; log google_time

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -124,7 +124,7 @@ if [[ "${LOCAL_BUILD}" = "true" ]]; then
     curl -sI google.com | grep "^Date:" | cut -f2- -d:
   }
   io::log_h1 "Machine Info"
-  printf "%10s %s\n" "utc:" "$(date -u --rfc-3339=seconds)"
+  printf "%10s %s\n" "host:" "$(date -u --rfc-3339=seconds)"
   printf "%10s %s\n" "google:" "$(date -ud "$(google_time)" --rfc-3339=seconds)"
   printf "%10s %s\n" "kernel:" "$(uname -v)"
   printf "%10s %s\n" "os:" "$(grep PRETTY_NAME /etc/os-release)"
@@ -172,7 +172,7 @@ if [[ "${DOCKER_BUILD}" = "true" ]]; then
     "--rm"
     "--user=$(id -u):$(id -g)"
     "--env=USER=$(id -un)"
-    "--env=TZ=:UTC"
+    "--env=TZ=UTC0"
     # Mounts an empty volume over "build-out" to isolate builds from each
     # other. Doesn't affect GCB builds, but it helps our local docker builds.
     "--volume=/workspace/build-out"

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -119,9 +119,13 @@ if [[ "${LOCAL_BUILD}" = "true" ]]; then
   function mem_total() {
     awk '$1 == "MemTotal:" {printf "%0.2f GiB", $2/1024/1024}' /proc/meminfo
   }
+  function google_time() {
+    # Extracts the time that Google thinks it is.
+    curl -sI google.com | grep "^Date:" | cut -f2- -d:
+  }
   io::log_h1 "Machine Info"
-  TZ=/etc/localtime printf "%10s %s (%s)\n" "local:" "$(date)" "$(date +%z)"
-  printf "%10s %s\n" "utc:" "$(date -u)"
+  printf "%10s %s\n" "utc:" "$(date -u --rfc-3339=seconds)"
+  printf "%10s %s\n" "google:" "$(date -ud "$(google_time)" --rfc-3339=seconds)"
   printf "%10s %s\n" "kernel:" "$(uname -v)"
   printf "%10s %s\n" "os:" "$(grep PRETTY_NAME /etc/os-release)"
   printf "%10s %s\n" "nproc:" "$(nproc)"
@@ -168,6 +172,7 @@ if [[ "${DOCKER_BUILD}" = "true" ]]; then
     "--rm"
     "--user=$(id -u):$(id -g)"
     "--env=USER=$(id -un)"
+    "--env=TZ=:UTC"
     # Mounts an empty volume over "build-out" to isolate builds from each
     # other. Doesn't affect GCB builds, but it helps our local docker builds.
     "--volume=/workspace/build-out"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -16,7 +16,7 @@ options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'
   dynamic_substitutions: true
-  env: [ 'HOME=/h', 'TZ=:UTC' ]
+  env: [ 'HOME=/h', 'TZ=UTC0' ]
   volumes:
     - name: 'home'
       path: '/h'

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -16,7 +16,7 @@ options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'
   dynamic_substitutions: true
-  env: [ 'HOME=/h' ]
+  env: [ 'HOME=/h', 'TZ=:UTC' ]
   volumes:
     - name: 'home'
       path: '/h'


### PR DESCRIPTION
Per @devbww's comments on
https://github.com/googleapis/google-cloud-cpp/pull/6123, we set
`TZ=:UTC` for docker and GCB builds so our logs -- and others' logs --
show up in UTC to make them easily comparable. This PR also logs the
time that google.com thinks it is, which would help us diagnose issues
caused by time synchronization issues (which we've seen on Kokoro).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6124)
<!-- Reviewable:end -->
