### PR TITLE
ci(gcb): adds flags to generate yaml triggers

### DIFF
--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -1,18 +1,10 @@
----
-createTime: '2021-03-22T00:38:08.167137222Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
   push:
     branch: ^master$
-id: a803727d-8633-49ea-b545-bd7f9124bc3d
 name: asan-ci
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
-tags:
-- asan
-- bazel
-- fedora
-- ci

--- a/ci/cloudbuild/triggers/asan.yaml
+++ b/ci/cloudbuild/triggers/asan.yaml
@@ -1,5 +1,3 @@
----
-createTime: '2021-03-21T17:51:13.620749264Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -7,14 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-id: 502b5d9e-a6cf-415a-9121-317cfb45d37e
 name: asan
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
-tags:
-- asan
-- bazel
-- fedora
-- clang
-- pr

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -1,19 +1,10 @@
----
-createTime: '2021-03-22T00:36:44.386437504Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
   push:
     branch: ^master$
-id: 88b3547a-7d8b-4af2-998f-e2ed284ebaaa
 name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
   _DISTRO: fedora
-tags:
-- fedora
-- clang
-- clang-tidy
-- cmake
-- ci

--- a/ci/cloudbuild/triggers/cmake-clang-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang-ci.yaml
@@ -1,18 +1,10 @@
----
-createTime: '2021-03-22T02:46:10.927625019Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
   push:
     branch: ^master$
-id: 4eed46f7-2acb-405f-8734-826f1c887d19
 name: cmake-clang-ci
 substitutions:
   _BUILD_NAME: cmake-clang
   _DISTRO: fedora
-tags:
-- fedora
-- clang
-- cmake
-- ci

--- a/ci/cloudbuild/triggers/cmake-clang.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang.yaml
@@ -1,5 +1,3 @@
----
-createTime: '2021-03-21T21:02:18.738169993Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -7,13 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-id: 74b4ff4d-a52d-4f22-a92c-58e0971aa0a5
 name: cmake-clang
 substitutions:
   _BUILD_NAME: cmake-clang
   _DISTRO: fedora
-tags:
-- fedora
-- clang
-- pr
-- cmake

--- a/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
@@ -1,18 +1,10 @@
----
-createTime: '2021-03-22T02:46:38.977511021Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
   push:
     branch: ^master$
-id: 4b58f91e-a19c-4b18-99b9-0224507cf0e6
 name: cmake-gcc-ci
 substitutions:
   _BUILD_NAME: cmake-gcc
   _DISTRO: fedora
-tags:
-- fedora
-- cmake
-- gcc
-- ci

--- a/ci/cloudbuild/triggers/cmake-gcc.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc.yaml
@@ -1,5 +1,3 @@
----
-createTime: '2021-03-21T21:03:13.920618226Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -7,13 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-id: f5da0822-6bf4-40a3-b063-a194db1773ba
 name: cmake-gcc
 substitutions:
   _BUILD_NAME: cmake-gcc
   _DISTRO: fedora
-tags:
-- fedora
-- pr
-- cmake
-- gcc

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -1,18 +1,10 @@
----
-createTime: '2021-03-24T00:02:59.444857698Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
   push:
     branch: ^master$
-id: 49d3dff1-bee0-4a2b-9bd1-a696d54e48c9
 name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
-tags:
-- cmake
-- clang
-- fedora
-- ci

--- a/ci/cloudbuild/triggers/cmake-install.yaml
+++ b/ci/cloudbuild/triggers/cmake-install.yaml
@@ -1,5 +1,3 @@
----
-createTime: '2021-03-24T00:04:07.704267756Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -7,13 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-id: 1c4f30ca-29d9-456d-a858-70e53c079b6b
 name: cmake-install
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
-tags:
-- cmake
-- clang
-- fedora
-- pr

--- a/ci/cloudbuild/triggers/integration-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-ci.yaml
@@ -1,12 +1,10 @@
-disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  pullRequest:
+  push:
     branch: ^master$
-    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: clang-tidy
+name: integration-ci
 substitutions:
-  _BUILD_NAME: clang-tidy
+  _BUILD_NAME: integration
   _DISTRO: fedora

--- a/ci/cloudbuild/triggers/integration.yaml
+++ b/ci/cloudbuild/triggers/integration.yaml
@@ -1,4 +1,3 @@
-disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -6,7 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: clang-tidy
+name: integration
 substitutions:
-  _BUILD_NAME: clang-tidy
+  _BUILD_NAME: integration
   _DISTRO: fedora

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -1,12 +1,10 @@
-disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
-  pullRequest:
+  push:
     branch: ^master$
-    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: clang-tidy
+name: ubsan-ci
 substitutions:
-  _BUILD_NAME: clang-tidy
+  _BUILD_NAME: ubsan
   _DISTRO: fedora

--- a/ci/cloudbuild/triggers/ubsan.yaml
+++ b/ci/cloudbuild/triggers/ubsan.yaml
@@ -1,5 +1,3 @@
----
-createTime: '2021-03-21T21:03:51.588652971Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -7,13 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-id: 82ea0d45-6073-481d-a1bd-4daa329edd7a
 name: ubsan
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
-tags:
-- bazel
-- fedora
-- pr
-- ubsan

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -1,18 +1,10 @@
----
-createTime: '2021-03-23T16:27:32.983843488Z'
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
   owner: googleapis
   push:
     branch: ^master$
-id: 7af338de-c46d-41ff-a96b-f58e3b720fc5
 name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
-tags:
-- xsan
-- bazel
-- fedora
-- ci

--- a/ci/cloudbuild/triggers/xsan.yaml
+++ b/ci/cloudbuild/triggers/xsan.yaml
@@ -1,4 +1,3 @@
-disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -6,7 +5,7 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: clang-tidy
+name: xsan
 substitutions:
-  _BUILD_NAME: clang-tidy
+  _BUILD_NAME: xsan
   _DISTRO: fedora


### PR DESCRIPTION
Adds flags to output the YAML configs for a named build. The generated
YAML config can then be manually tweaked (if needed), and checked in.
Generating the config doesn't actually submit the file to GCB. To do
that, you must then use `trigger.sh --import <new-yaml-file>`.

I also used these flags to generate configs for a few builds that were
missing triggers and therefore weren't running (like integration and
xsan).

I also simplified the yaml configs:
- I removed the created time and trigger IDs, which are output-only
fields
- I removed the trigger tags, which don't really do anything useful, and
are difficult to generate automatically

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6125)
<!-- Reviewable:end -->
