### PR TITLE
ci(gcb): add quickstart-cmake and quickstart-bazel builds

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -25,7 +25,12 @@ fi # include guard
 # Outputs a list of args that should be given to all bazel invocations. To read
 # this into an array use `mapfile -t my_array < <(bazel::common_args)`
 function bazel::common_args() {
-  local args=("--test_output=errors" "--verbose_failures=true" "--keep_going")
+  local args=(
+    "--test_output=errors"
+    "--verbose_failures=true"
+    "--keep_going"
+    "--experimental_convenience_symlinks=ignore"
+  )
   if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
     args+=("--remote_cache=${BAZEL_REMOTE_CACHE}")
     args+=("--google_default_credentials")

--- a/ci/cloudbuild/builds/quickstart-bazel.sh
+++ b/ci/cloudbuild/builds/quickstart-bazel.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/etc/quickstart-config.sh
+source module ci/lib/io.sh
+
+export CC=gcc
+export CXX=g++
+
+mapfile -t args < <(bazel::common_args)
+for lib in $(quickstart::libraries); do
+  io::log_h2 "Running Bazel quickstart for ${lib}"
+  env -C "${PROJECT_ROOT}/google/cloud/${lib}/quickstart" \
+    bazel run "${args[@]}" :quickstart -- $(quickstart::arguments "${lib}")
+done

--- a/ci/cloudbuild/builds/quickstart-bazel.sh
+++ b/ci/cloudbuild/builds/quickstart-bazel.sh
@@ -27,6 +27,7 @@ export CXX=g++
 mapfile -t args < <(bazel::common_args)
 for lib in $(quickstart::libraries); do
   io::log_h2 "Running Bazel quickstart for ${lib}"
+  mapfile -t run_args < <(quickstart::arguments "${lib}")
   env -C "${PROJECT_ROOT}/google/cloud/${lib}/quickstart" \
-    bazel run "${args[@]}" :quickstart -- $(quickstart::arguments "${lib}")
+    bazel run "${args[@]}" :quickstart -- "${run_args[@]}"
 done

--- a/ci/cloudbuild/builds/quickstart-cmake.sh
+++ b/ci/cloudbuild/builds/quickstart-cmake.sh
@@ -46,5 +46,6 @@ for lib in $(quickstart::libraries); do
   flag="-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
   cmake -H"${src_dir}" -B"${bin_dir}" "${flag}"
   cmake --build "${bin_dir}"
-  "${bin_dir}/quickstart" $(quickstart::arguments "${lib}")
+  mapfile -t run_args < <(quickstart::arguments "${lib}")
+  "${bin_dir}/quickstart" "${run_args[@]}"
 done

--- a/ci/cloudbuild/builds/quickstart-cmake.sh
+++ b/ci/cloudbuild/builds/quickstart-cmake.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/etc/quickstart-config.sh
+source module ci/lib/io.sh
+
+export CC=gcc
+export CXX=g++
+
+io::log_h2 "Installing vcpkg"
+vcpkg_dir="${HOME}/vcpkg-quickstart"
+vcpkg_sha="105456798402aa5f494ffeb3b19dd0d870656d39"
+vcpkg_bin="${vcpkg_dir}/vcpkg"
+mkdir -p "${vcpkg_dir}"
+io::log "Downloading vcpkg@${vcpkg_sha} into ${vcpkg_dir}..."
+curl -sSL "https://github.com/microsoft/vcpkg/archive/${vcpkg_sha}.tar.gz" |
+  tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
+env CC="ccache ${CC}" CXX="ccache ${CXX}" "${vcpkg_dir}"/bootstrap-vcpkg.sh
+
+io::log_h2 "Installing google-cloud-cpp with vcpkg"
+"${vcpkg_bin}" remove --outdated --recurse
+"${vcpkg_bin}" install google-cloud-cpp
+
+# Compiles and runs all the quickstart CMake builds.
+for lib in $(quickstart::libraries); do
+  io::log_h2 "Running CMake quickstart for ${lib}"
+  src_dir="${PROJECT_ROOT}/google/cloud/${lib}/quickstart"
+  bin_dir="${PROJECT_ROOT}/cmake-out/quickstart-${lib}"
+  flag="-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
+  cmake -H"${src_dir}" -B"${bin_dir}" "${flag}"
+  cmake --build "${bin_dir}"
+  "${bin_dir}/quickstart" $(quickstart::arguments "${lib}")
+done

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -59,7 +59,8 @@ steps:
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '--local', '${_BUILD_NAME}' ]
   env: [
-    'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}'
+    'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}',
+    'VCPKG_BINARY_SOURCES=x-gcs,gs://${_CACHE_BUCKET}/vcpkg-cache/${_DISTRO}-${_BUILD_NAME},readwrite'
   ]
 
   # Caches some directories in the homedir, in the specified GCS bucket.

--- a/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
@@ -1,0 +1,10 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+name: quickstart-bazel-ci
+substitutions:
+  _BUILD_NAME: quickstart-bazel
+  _DISTRO: ubuntu-bionic

--- a/ci/cloudbuild/triggers/quickstart-bazel.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel.yaml
@@ -1,0 +1,11 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: quickstart-bazel
+substitutions:
+  _BUILD_NAME: quickstart-bazel
+  _DISTRO: ubuntu-bionic

--- a/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
@@ -1,0 +1,10 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+name: quickstart-cmake-ci
+substitutions:
+  _BUILD_NAME: quickstart-cmake
+  _DISTRO: ubuntu-bionic

--- a/ci/cloudbuild/triggers/quickstart-cmake.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake.yaml
@@ -1,0 +1,11 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: quickstart-cmake
+substitutions:
+  _BUILD_NAME: quickstart-cmake
+  _DISTRO: ubuntu-bionic

--- a/ci/cloudbuild/ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/ubuntu-bionic.Dockerfile
@@ -63,6 +63,7 @@ RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
+ENV PATH=/usr/local/google-cloud-sdk/bin/:${PATH}
 # The Cloud Pub/Sub emulator needs Java :shrug:
 RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
 

--- a/ci/etc/quickstart-config.sh
+++ b/ci/etc/quickstart-config.sh
@@ -19,6 +19,8 @@ if ((CI_ETC_QUICKSTART_CONFIG_SH__++ != 0)); then
   return 0
 fi # include guard
 
+source module ci/etc/integration-tests-config.sh
+
 function quickstart::libraries() {
   echo "bigtable"
   echo "spanner"


### PR DESCRIPTION
The `quickstart-cmake` builds use ccache to speed up the building of the `vcpkg` binary itself. And it uses `VCPKG_BINARY_SOURCES` to speed up vcpkg's installation of `google-cloud-cpp`. 

I'll enable these triggers after this PR merges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6132)
<!-- Reviewable:end -->
