### PR TITLE
ci(gcb): add tsan build

### DIFF
--- a/ci/cloudbuild/builds/tsan.sh
+++ b/ci/cloudbuild/builds/tsan.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+
+# Compile with the ThreadSanitizer enabled.
+# We need to use clang-9 for the TSAN build because:
+#   https://github.com/google/sanitizers/issues/1259
+# Using Fedora >= 32 will push us to clang-10, and Fedora < 32 is EOL.
+# Fortunately, Ubuntu:18.04 is a LTS release with clang-9 as an alternative.
+export CC=clang-9
+export CXX=clang++-9
+
+mapfile -t args < <(bazel::common_args)
+args+=("--config=tsan")
+args+=("--test_tag_filters=-integration-test")
+bazel test "${args[@]}" ...

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -1,0 +1,10 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+name: tsan-ci
+substitutions:
+  _BUILD_NAME: tsan
+  _DISTRO: ubuntu-bionic

--- a/ci/cloudbuild/triggers/tsan.yaml
+++ b/ci/cloudbuild/triggers/tsan.yaml
@@ -1,0 +1,11 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: tsan
+substitutions:
+  _BUILD_NAME: tsan
+  _DISTRO: ubuntu-bionic


### PR DESCRIPTION
Will make all the *san builds run integration tests in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6134)
<!-- Reviewable:end -->
