### PR TITLE
ci(gcb): time the bazel prefetching

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -25,18 +25,22 @@ fi # include guard
 
 source module ci/lib/io.sh
 
-io::log_h2 "Prefetching bazel deps"
+io::log "Prefetching bazel deps..."
 # Bazel downloads all the dependencies of a project, as well as a number of
 # development tools during startup. In automated builds these downloads fail
 # from time to time due to transient network problems. Running `bazel fetch` at
 # the beginning of the build prevents such transient failures from flaking the
 # build.
-"./ci/retry-command.sh" 3 120 bazel fetch ... \
-  @local_config_platform//... \
-  @local_config_cc_toolchains//... \
-  @local_config_sh//... \
-  @go_sdk//... \
-  @remotejdk11_linux//:jdk
+TIMEFORMAT="==> 🕑 prefetching done in %R seconds"
+time {
+  "./ci/retry-command.sh" 3 120 bazel fetch ... \
+    @local_config_platform//... \
+    @local_config_cc_toolchains//... \
+    @local_config_sh//... \
+    @go_sdk//... \
+    @remotejdk11_linux//:jdk
+}
+echo
 
 # Outputs a list of args that should be given to all bazel invocations. To read
 # this into an array use `mapfile -t my_array < <(bazel::common_args)`


### PR DESCRIPTION
This also changes the H2 log to a regular log because the h2 banner made
it look like all the following bazel build output was part of the
prefetching. Output now looks like:

```

==================================
|   Starting local build: asan   |
==================================
2021-03-30T21:16:12Z: Prefetching bazel deps...
Starting local Bazel server and connecting to it...
INFO: All external dependencies fetched successfully.
Loading: 125 packages loaded
==> 🕑 prefetching done in 5.045 seconds

INFO: Analyzed 532 targets (1 packages loaded, 5924 targets configured).
INFO: Found 182 targets and 350 test targets...
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6143)
<!-- Reviewable:end -->
