### PR TITLE
ci(gcb): write newline to stderr to match time

### DIFF
--- a/ci/cloudbuild/builds/lib/bazel.sh
+++ b/ci/cloudbuild/builds/lib/bazel.sh
@@ -40,7 +40,7 @@ time {
     @go_sdk//... \
     @remotejdk11_linux//:jdk
 }
-echo
+echo >&2
 
 # Outputs a list of args that should be given to all bazel invocations. To read
 # this into an array use `mapfile -t my_array < <(bazel::common_args)`


### PR DESCRIPTION
Bash's `time` builtin writes to stderr, and GCB sometimes mixes up
output order between stdout and stderr. So this PR outputs the blank
line to stderr so that it will always follow the `time` output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6146)
<!-- Reviewable:end -->
