### PR TITLE
doc(storage): always use signing account in examples

### DIFF
--- a/ci/cloudbuild/builds/integration.sh
+++ b/ci/cloudbuild/builds/integration.sh
@@ -93,11 +93,6 @@ storage_args=(
   # "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12=${TEST_KEY_FILE_P12}"
   "-//google/cloud/storage/tests:key_file_integration_test"
 
-  # Skip these tests until we can figure out how to get them to work. These run
-  # against production, not the emulator.
-  "-//google/cloud/storage/examples:storage_policy_doc_samples"
-  "-//google/cloud/storage/examples:storage_signed_url_v2_samples"
-  "-//google/cloud/storage/examples:storage_signed_url_v4_samples"
 )
 "./google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
   bazel test "${args[@]}" "${storage_args[@]}"

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -25,10 +25,11 @@ void CreateGetSignedUrlV4(google::cloud::storage::Client client,
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
-     std::string const& object_name) {
+     std::string const& object_name, std::string const& signing_account) {
     StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
         "GET", std::move(bucket_name), std::move(object_name),
-        gcs::SignedUrlDuration(std::chrono::minutes(15)));
+        gcs::SignedUrlDuration(std::chrono::minutes(15)),
+        gcs::SigningAccount(signing_account));
 
     if (!signed_url) throw std::runtime_error(signed_url.status().message());
     std::cout << "The signed url is: " << *signed_url << "\n\n"
@@ -36,7 +37,7 @@ void CreateGetSignedUrlV4(google::cloud::storage::Client client,
               << "curl '" << *signed_url << "'\n";
   }
   //! [sign url v4] [END storage_generate_signed_url_v4]
-  (std::move(client), argv.at(0), argv.at(1));
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void CreatePutSignedUrlV4(google::cloud::storage::Client client,
@@ -45,11 +46,12 @@ void CreatePutSignedUrlV4(google::cloud::storage::Client client,
   namespace gcs = google::cloud::storage;
   using ::google::cloud::StatusOr;
   [](gcs::Client client, std::string const& bucket_name,
-     std::string const& object_name) {
+     std::string const& object_name, std::string const& signing_account) {
     StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
         "PUT", std::move(bucket_name), std::move(object_name),
         gcs::SignedUrlDuration(std::chrono::minutes(15)),
-        gcs::AddExtensionHeader("content-type", "application/octet-stream"));
+        gcs::AddExtensionHeader("content-type", "application/octet-stream"),
+        gcs::SigningAccount(signing_account));
 
     if (!signed_url) throw std::runtime_error(signed_url.status().message());
     std::cout << "The signed url is: " << *signed_url << "\n\n"
@@ -58,7 +60,7 @@ void CreatePutSignedUrlV4(google::cloud::storage::Client client,
               << " --upload-file my-file '" << *signed_url << "'\n";
   }
   //! [create put signed url v4] [END storage_generate_upload_signed_url_v4]
-  (std::move(client), argv.at(0), argv.at(1));
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2));
 }
 
 void RunAll(std::vector<std::string> const& argv) {
@@ -69,12 +71,17 @@ void RunAll(std::vector<std::string> const& argv) {
   examples::CheckEnvironmentVariablesAreSet({
       "GOOGLE_CLOUD_PROJECT",
       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME",
+      "GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT",
   });
   auto const project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
   auto const bucket_name = google::cloud::internal::GetEnv(
                                "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
                                .value();
+  auto const signing_account =
+      google::cloud::internal::GetEnv(
+          "GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT")
+          .value();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const object_name =
       examples::MakeRandomObjectName(generator, "cloud-cpp-test-examples-");
@@ -87,10 +94,10 @@ void RunAll(std::vector<std::string> const& argv) {
   }
 
   std::cout << "\nRunning CreatePutSignedUrlV4() example" << std::endl;
-  CreatePutSignedUrlV4(client, {bucket_name, object_name});
+  CreatePutSignedUrlV4(client, {bucket_name, object_name, signing_account});
 
   std::cout << "\nRunning CreateGetSignedUrlV4() example" << std::endl;
-  CreateGetSignedUrlV4(client, {bucket_name, object_name});
+  CreateGetSignedUrlV4(client, {bucket_name, object_name, signing_account});
 }
 
 }  // namespace
@@ -100,7 +107,7 @@ int main(int argc, char* argv[]) {
   auto make_entry = [](std::string const& name,
                        examples::ClientCommand const& cmd) {
     return examples::CreateCommandEntry(
-        name, {"<bucket-name>", "<object-name>"}, cmd);
+        name, {"<bucket-name>", "<object-name>", "<signing-account>"}, cmd);
   };
   examples::Example example({
       make_entry("create-get-signed-url-v4", CreateGetSignedUrlV4),


### PR DESCRIPTION
The storage client library defaults to the account used in the
credentials as the signing account for signed URLs. This does not work
for users running the examples in the command-line, as only service
accounts can sign urls. It also does not work for the cloud builds,
where the account used for authentication cannot sign blobs as itself,
but can sign blobs as "other" accounts.

This PR changes the examples to require a signing account parameter.
Fortunately, we already had a convenient environment variable with such
an account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6149)
<!-- Reviewable:end -->
