### PR TITLE
ci(gcb): enable GCS tests that require json and p12 keyfiles

### DIFF
--- a/ci/cloudbuild/fedora.Dockerfile
+++ b/ci/cloudbuild/fedora.Dockerfile
@@ -137,6 +137,7 @@ COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 ENV CLOUDSDK_PYTHON=python3.8
 RUN /var/tmp/ci/install-cloud-sdk.sh
+ENV PATH=/usr/local/google-cloud-sdk/bin/:${PATH}
 # The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
 # Bazel needs the '-devel' version with javac.
 RUN dnf makecache && dnf install -y java-latest-openjdk-devel


### PR DESCRIPTION
The keyfiles will be stored in a special GCS bucket that the cloudbuild
account has access to read. The keyfiles are named `key-YYYY-MM.ext` to
make it easier to rotate the keys. The idea is that GCB jobs should
always look for the key w/ the current month. Rotating the keys will be
done separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6150)
<!-- Reviewable:end -->
