### PR TITLE
cleanup: do not duplicate the Status code within its message

### DIFF
--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -23,7 +23,7 @@ namespace internal {
 Status RetryLoopError(char const* loop_message, char const* location,
                       Status const& last_status) {
   std::ostringstream os;
-  os << loop_message << " " << location << ": " << last_status;
+  os << loop_message << " " << location << ": " << last_status.message();
   return Status(last_status.code(), std::move(os).str());
 }
 

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -86,7 +86,7 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
     if (idempotency == Idempotency::kNonIdempotent) {
       std::ostringstream os;
       os << "Error in non-idempotent operation " << error_message << ": "
-         << last_status;
+         << last_status.message();
       return error(std::move(os).str());
     }
     if (!retry_policy.OnFailure(last_status)) {
@@ -95,7 +95,8 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
         // policy is exhausted, we call these "permanent errors", and they
         // get a special message.
         std::ostringstream os;
-        os << "Permanent error in " << error_message << ": " << last_status;
+        os << "Permanent error in " << error_message << ": "
+           << last_status.message();
         return error(std::move(os).str());
       }
       // Exit the loop immediately instead of sleeping before trying again.
@@ -105,7 +106,8 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
     std::this_thread::sleep_for(delay);
   }
   std::ostringstream os;
-  os << "Retry policy exhausted in " << error_message << ": " << last_status;
+  os << "Retry policy exhausted in " << error_message << ": "
+     << last_status.message();
   return error(std::move(os).str());
 }
 }  // namespace

--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -122,11 +122,11 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
   auto status = std::move(result).status();
   std::stringstream os;
   if (internal::StatusTraits::IsPermanentFailure(status)) {
-    os << "Permanent error in Read(): " << status;
+    os << "Permanent error in Read(): " << status.message();
   } else {
-    os << "Retry policy exhausted in Read(): " << status;
+    os << "Retry policy exhausted in Read(): " << status.message();
   }
-  return Status(status.code(), os.str());
+  return Status(status.code(), std::move(os).str());
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -28,11 +28,13 @@ StatusOr<ResumableUploadResponse> ReturnError(Status&& last_status,
                                               char const* error_message) {
   std::ostringstream os;
   if (retry_policy.IsExhausted()) {
-    os << "Retry policy exhausted in " << error_message << ": " << last_status;
+    os << "Retry policy exhausted in " << error_message << ": "
+       << last_status.message();
   } else {
-    os << "Permanent error in " << error_message << ": " << last_status;
+    os << "Permanent error in " << error_message << ": "
+       << last_status.message();
   }
-  return Status(last_status.code(), os.str());
+  return Status(last_status.code(), std::move(os).str());
 }
 }  // namespace
 
@@ -130,8 +132,8 @@ RetryResumableUploadSession::UploadGenericChunk(
     last_status = Status();
   }
   std::ostringstream os;
-  os << "Retry policy exhausted in " << func << ": " << last_status;
-  return Status(last_status.code(), os.str());
+  os << "Retry policy exhausted in " << func << ": " << last_status.message();
+  return Status(last_status.code(), std::move(os).str());
 }
 
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession(
@@ -150,8 +152,9 @@ StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession(
     std::this_thread::sleep_for(delay);
   }
   std::ostringstream os;
-  os << "Retry policy exhausted in " << __func__ << ": " << last_status;
-  return Status(last_status.code(), os.str());
+  os << "Retry policy exhausted in " << __func__ << ": "
+     << last_status.message();
+  return Status(last_status.code(), std::move(os).str());
 }
 
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {


### PR DESCRIPTION
When adding detail to a `Status` message, but keeping the same
code, use `status.message()` to obtain the previous text, rather
than streaming `status`, as the latter will contain " [CODE]",
which will then be duplicated when the new value is streamed.

For example, when prefixing "func: " to an existing `Status` of
"file [NOT_FOUND]", we want to produce "func: file [NOT_FOUND]"
and not "func: file [NOT_FOUND] [NOT_FOUND]".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6162)
<!-- Reviewable:end -->
