### PR TITLE
feat(storage): reduce overhead in pooled handle factory

### DIFF
--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -86,7 +86,6 @@ PooledCurlHandleFactory::~PooledCurlHandleFactory() {
 }
 
 CurlPtr PooledCurlHandleFactory::CreateHandle() {
-  std::cerr << __func__ << "()" << std::endl;
   std::unique_lock<std::mutex> lk(mu_);
   if (!handles_.empty()) {
     auto* handle = handles_.back();
@@ -103,7 +102,6 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
 }
 
 void PooledCurlHandleFactory::CleanupHandle(CurlHandle&& h) {
-  std::cerr << __func__ << "()" << std::endl;
   std::unique_lock<std::mutex> lk(mu_);
   char* ip;
   auto res = curl_easy_getinfo(GetHandle(h), CURLINFO_LOCAL_IP, &ip);

--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -18,9 +18,9 @@
 #include "google/cloud/storage/internal/curl_handle.h"
 #include "google/cloud/storage/internal/curl_wrappers.h"
 #include "google/cloud/storage/version.h"
+#include <deque>
 #include <mutex>
 #include <string>
-#include <vector>
 
 namespace google {
 namespace cloud {
@@ -114,8 +114,8 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
  private:
   std::size_t maximum_size_;
   mutable std::mutex mu_;
-  std::vector<CURL*> handles_;
-  std::vector<CURLM*> multi_handles_;
+  std::deque<CURL*> handles_;
+  std::deque<CURLM*> multi_handles_;
   std::string last_client_ip_address_;
   ChannelOptions options_;
 };


### PR DESCRIPTION
Replace `std::vector<>` with `std::deque<>` because when the pool grows
too large we want to remove the *oldest* handles (fron the front). Also,
use a while loop during cleanup because it makes the intent clearer. I
expect that while loop to run at most once, but why force humans to
think this through?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6169)
<!-- Reviewable:end -->
