### PR TITLE
cleanup(bigtable): remove DirectPath specific endpoint

### DIFF
--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -67,13 +67,6 @@ namespace internal {
 std::string DefaultDataEndpoint() {
   auto emulator = google::cloud::internal::GetEnv("BIGTABLE_EMULATOR_HOST");
   if (emulator.has_value()) return *std::move(emulator);
-  auto direct_path =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH");
-  if (direct_path.has_value()) {
-    for (auto const& token : absl::StrSplit(*std::move(direct_path), ',')) {
-      if (token == "bigtable") return "directpath-bigtable.googleapis.com";
-    }
-  }
   return "bigtable.googleapis.com";
 }
 

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -81,9 +81,7 @@ class ClientOptionsDefaultEndpointTest : public ::testing::Test {
       : bigtable_emulator_host_("BIGTABLE_EMULATOR_HOST",
                                 "testendpoint.googleapis.com"),
         bigtable_instance_admin_emulator_host_(
-            "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST", {}),
-        google_cloud_enable_direct_path_("GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
-                                         {}) {}
+            "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST", {}) {}
 
  protected:
   static std::string GetInstanceAdminEndpoint(ClientOptions const& options) {
@@ -93,8 +91,6 @@ class ClientOptionsDefaultEndpointTest : public ::testing::Test {
   google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host_;
   google::cloud::testing_util::ScopedEnvironment
       bigtable_instance_admin_emulator_host_;
-  google::cloud::testing_util::ScopedEnvironment
-      google_cloud_enable_direct_path_;
 };
 
 TEST_F(ClientOptionsDefaultEndpointTest, Default) {
@@ -146,51 +142,9 @@ TEST_F(ClientOptionsDefaultEndpointTest, DataNoEnv) {
   EXPECT_EQ("bigtable.googleapis.com", internal::DefaultDataEndpoint());
 }
 
-TEST_F(ClientOptionsDefaultEndpointTest, DataDirectPathMismatched) {
-  google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
-      "BIGTABLE_EMULATOR_HOST", {});
-  google::cloud::testing_util::ScopedEnvironment
-      google_cloud_enable_direct_path(
-          "GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
-          "bad-name-for-bigtable,bigtable-no-no,bar");
-
-  EXPECT_EQ("bigtable.googleapis.com", internal::DefaultDataEndpoint());
-}
-
-TEST_F(ClientOptionsDefaultEndpointTest, DataDirectPath) {
-  google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
-      "BIGTABLE_EMULATOR_HOST", {});
-  google::cloud::testing_util::ScopedEnvironment
-      google_cloud_enable_direct_path("GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
-                                      "bigtable-mismatch,bigtable");
-
-  EXPECT_EQ("directpath-bigtable.googleapis.com",
-            internal::DefaultDataEndpoint());
-}
-
-TEST_F(ClientOptionsDefaultEndpointTest, DataEmulatorOverridesDirectPath) {
-  google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
-      "BIGTABLE_EMULATOR_HOST", "127.0.0.1:1234");
-  google::cloud::testing_util::ScopedEnvironment
-      google_cloud_enable_direct_path("GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
-                                      "bigtable");
-
-  EXPECT_EQ("127.0.0.1:1234", internal::DefaultDataEndpoint());
-}
-
 TEST_F(ClientOptionsDefaultEndpointTest, AdminNoEnv) {
   google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
       "BIGTABLE_EMULATOR_HOST", {});
-
-  EXPECT_EQ("bigtableadmin.googleapis.com", internal::DefaultAdminEndpoint());
-}
-
-TEST_F(ClientOptionsDefaultEndpointTest, AdminDirectPathNoEffect) {
-  google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
-      "BIGTABLE_EMULATOR_HOST", {});
-  google::cloud::testing_util::ScopedEnvironment
-      google_cloud_enable_direct_path("GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
-                                      "bigtable");
 
   EXPECT_EQ("bigtableadmin.googleapis.com", internal::DefaultAdminEndpoint());
 }
@@ -215,17 +169,6 @@ TEST_F(ClientOptionsDefaultEndpointTest, AdminInstanceAdminNoEffect) {
 TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminNoEnv) {
   google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
       "BIGTABLE_EMULATOR_HOST", {});
-
-  EXPECT_EQ("bigtableadmin.googleapis.com",
-            internal::DefaultInstanceAdminEndpoint());
-}
-
-TEST_F(ClientOptionsDefaultEndpointTest, InstanceAdminDirectPathNoEffect) {
-  google::cloud::testing_util::ScopedEnvironment bigtable_emulator_host(
-      "BIGTABLE_EMULATOR_HOST", {});
-  google::cloud::testing_util::ScopedEnvironment
-      google_cloud_enable_direct_path("GOOGLE_CLOUD_ENABLE_DIRECT_PATH",
-                                      "bigtable");
 
   EXPECT_EQ("bigtableadmin.googleapis.com",
             internal::DefaultInstanceAdminEndpoint());


### PR DESCRIPTION
Since the bigtable main endpoint `bigtable.googleapis.com` has rollout to DirectPath, we no longer need the DirectPath specific endpoing `directpath-bigtable.googleapis.com`, and we should move all the tests to use the main endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6175)
<!-- Reviewable:end -->
