### PR TITLE
refactor(storage): use g::c::Options in ClientOptions

### DIFF
--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -307,7 +307,7 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
       ClientOptions(oauth2::CreateAnonymousCredentials()));
   EXPECT_EQ("https://storage.googleapis.com",
             opts.get<internal::GcsRestEndpointOption>());
-  EXPECT_EQ("https://iam.googleapis.com",
+  EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
             opts.get<internal::GcsIamEndpointOption>());
   EXPECT_TRUE(opts.has<internal::Oauth2CredentialsOption>());
   EXPECT_EQ("v1", opts.get<internal::TargetApiVersionOption>());


### PR DESCRIPTION
This just changes the implementation of `storage::ClientOptions` to be
based on `google::cloud::Options`.

Part of the work for #6161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6183)
<!-- Reviewable:end -->
