### PR TITLE
ci(gcb): add elapsed time to Ninja builds

### DIFF
--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -24,6 +24,11 @@ fi # include guard
 
 source module ci/lib/io.sh
 
+# Adds an elapsed seconds counter at the beginning of the ninja output to help
+# us see where builds are taking the most time. See also
+# https://ninja-build.org/manual.html#_environment_variables
+export NINJA_STATUS="T+%es [%f/%t] "
+
 # This block is run the first (and only) time this script is sourced. It first
 # clears the ccache stats. Then it registers an exit handler that will display
 # the ccache stats when the calling script exits.


### PR DESCRIPTION
This should help us understand our build performance and possibly
diagnose timeouts like
https://github.com/googleapis/google-cloud-cpp/issues/6184

The output looks like:

```
T+10.458s [611/1832] Running gRPC C++ protocol buffer compiler on /wo...ogleapis/src/googleapis_download/google/cloud/bigquery/v2/model.proto
google/cloud/bigquery/v2/model.proto:28:1: warning: Import google/api/annotations.proto is unused.
T+10.701s [619/1832] Building CXX object external/googleapis/CMakeFil...protos.dir/google/cloud/bigquery/datatransfer/v1/datatransfer.pb.cc.o
external/googleapis/google/cloud/bigquery/datatransfer/v1/datatransfer.pb.cc:2271:13: warning: 'transfer_type' is deprecated [-Wdeprecated-declarations]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6186)
<!-- Reviewable:end -->
