### PR TITLE
ci: improve Windows+CMake logs

### DIFF
--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -45,6 +45,7 @@ Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Configuring CMake wi
 cmake $cmake_flags
 if ($LastExitCode) {
     Write-Host -ForegroundColor Red "cmake config failed with exit code $LastExitCode"
+    Get-Content -Path "${binary_dir}/vcpkg-manifest-install.log"
     Exit ${LastExitCode}
 }
 


### PR DESCRIPTION
Part of the work for #6192. Manually triggering the build works with this PR:

https://source.cloud.google.com/results/invocations/f2bb1b2e-d029-4a7f-a416-fe66f6686bfd

I do not believe this PR "fixes" anything, but at least improves the logs in a failure. That should
make troubleshooting easier. I know believe #6192 was a flake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6193)
<!-- Reviewable:end -->
