### PR TITLE
ci: windows update vcpkg version

### DIFF
--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -49,8 +49,8 @@ if ($args.count -ge 1) {
 }
 $vcpkg_dir = "cmake-out\${vcpkg_base}"
 
-$vcpkg_version = "5214a247018b3bf2d793cea188ea2f2c150daddd"
-$vcpkg_tool_version = "2021-01-13-768d8f95c9e752603d2c5901c7a7c7fbdb08af35"
+$vcpkg_version = "2afee4c5aad8f936ea2bbe58dcdff96d2eadc258"
+$vcpkg_tool_version = "2021-02-24-d67989bce1043b98092ac45996a8230a059a2d7e"
 
 New-Item -ItemType Directory -Path "cmake-out" -ErrorAction SilentlyContinue
 # Download the right version of `vcpkg`


### PR DESCRIPTION
Use a more recent version of vcpkg and the vcpkg-tool. These include
support for cross-compilation, and our manifest file describe such
dependencies.

Part of the work for #6192

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6194)
<!-- Reviewable:end -->
