### PR TITLE
ci: fix quickstart+CMake builds on macOS

### DIFF
--- a/ci/kokoro/lib/cache.sh
+++ b/ci/kokoro/lib/cache.sh
@@ -62,6 +62,7 @@ cache_download_tarball() {
   echo "================================================================"
   io::log "gsutil configuration"
   gsutil version -l
+  echo "================================================================"
   io::log "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
     gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
@@ -92,6 +93,8 @@ cache_upload_tarball() {
   echo "================================================================"
   io::log "gsutil configuration"
   gsutil version -l
+
+  echo "================================================================"
   io::log "Uploading build cache ${FILENAME} to ${GCS_FOLDER}"
 
   trap cache_gcloud_cleanup RETURN

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -65,21 +65,26 @@ readonly run_quickstart
 echo "================================================================"
 cd "${PROJECT_ROOT}"
 cmake_flags=(
-  "-DCMAKE_TOOLCHAIN_FILE=${PROJECT_ROOT}/${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
+  "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"
 )
 
 build_quickstart() {
   local -r library="$1"
   local -r source_dir="google/cloud/${library}/quickstart"
   local -r binary_dir="cmake-out/quickstart-${library}"
+  local cmake
+  cmake="$("${vcpkg_dir}/vcpkg" fetch cmake)"
+  local ninja
+  ninja="$("${vcpkg_dir}/vcpkg" fetch ninja)"
 
   echo
   io::log_yellow "Configure CMake for ${library}'s quickstart."
-  cmake "-H${source_dir}" "-B${binary_dir}" "${cmake_flags[@]}"
+  "${cmake}" "-GNinja" "-DCMAKE_MAKE_PROGRAM=${ninja}" \
+      "-H${source_dir}" "-B${binary_dir}" "${cmake_flags[@]}"
 
   echo
   io::log_yellow "Compiling ${library}'s quickstart."
-  cmake --build "${binary_dir}"
+  "${cmake}" --build "${binary_dir}"
 
   if [[ "${run_quickstart}" == "true" ]]; then
     echo

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -25,7 +25,7 @@ io::log_yellow "Update or install dependencies."
 
 # Fetch vcpkg at the specified hash.
 vcpkg_dir="${HOME}/vcpkg-quickstart"
-vcpkg_sha="5214a247018b3bf2d793cea188ea2f2c150daddd"
+vcpkg_sha="2afee4c5aad8f936ea2bbe58dcdff96d2eadc258"
 vcpkg_bin="${vcpkg_dir}/vcpkg"
 mkdir -p "${vcpkg_dir}"
 echo "Downloading vcpkg@${vcpkg_sha} into ${vcpkg_dir}..."

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -47,7 +47,7 @@ fi
 
 "${vcpkg_bin}" remove --outdated --recurse
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
-  "${vcpkg_bin}" install crc32c grpc # google-cloud-cpp
+  "${vcpkg_bin}" install google-cloud-cpp
 
 # TODO(coryan) - DO NOT MERGE
 exit 0

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -47,9 +47,9 @@ fi
 
 "${vcpkg_bin}" remove --outdated --recurse
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
-  "${vcpkg_bin}" install google-cloud-cpp
+  "${vcpkg_bin}" install crc32c # google-cloud-cpp
 
-# TODO(coryan) - do not merge
+# TODO(coryan) - DO NOT MERGE
 exit 0
 
 run_quickstart="false"
@@ -76,9 +76,9 @@ build_quickstart() {
   local -r source_dir="google/cloud/${library}/quickstart"
   local -r binary_dir="cmake-out/quickstart-${library}"
   local cmake
-  cmake="$("${vcpkg_dir}/vcpkg" fetch cmake)"
+  cmake="$("${vcpkg_dir}/vcpkg" "--feature-flags=-manifests" fetch cmake)"
   local ninja
-  ninja="$("${vcpkg_dir}/vcpkg" fetch ninja)"
+  ninja="$("${vcpkg_dir}/vcpkg" "--feature-flags=-manifests" fetch ninja)"
 
   echo
   io::log_yellow "Configure CMake for ${library}'s quickstart."

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -49,6 +49,9 @@ fi
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
   "${vcpkg_bin}" install google-cloud-cpp
 
+# TODO(coryan) - do not merge
+exit 0
+
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly CREDENTIALS_FILE="${CONFIG_DIR}/kokoro-run-key.json"

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -47,7 +47,7 @@ fi
 
 "${vcpkg_bin}" remove --outdated --recurse
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
-  "${vcpkg_bin}" install crc32c # google-cloud-cpp
+  "${vcpkg_bin}" install crc32c grpc # google-cloud-cpp
 
 # TODO(coryan) - DO NOT MERGE
 exit 0

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -80,7 +80,7 @@ build_quickstart() {
   echo
   io::log_yellow "Configure CMake for ${library}'s quickstart."
   "${cmake}" "-GNinja" "-DCMAKE_MAKE_PROGRAM=${ninja}" \
-      "-H${source_dir}" "-B${binary_dir}" "${cmake_flags[@]}"
+    "-H${source_dir}" "-B${binary_dir}" "${cmake_flags[@]}"
 
   echo
   io::log_yellow "Compiling ${library}'s quickstart."

--- a/ci/kokoro/macos/build-quickstart-cmake.sh
+++ b/ci/kokoro/macos/build-quickstart-cmake.sh
@@ -49,9 +49,6 @@ fi
 "${PROJECT_ROOT}/ci/retry-command.sh" 2 5 \
   "${vcpkg_bin}" install google-cloud-cpp
 
-# TODO(coryan) - DO NOT MERGE
-exit 0
-
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly CREDENTIALS_FILE="${CONFIG_DIR}/kokoro-run-key.json"

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -60,13 +60,9 @@ fi
 # it is just partially installed. This gives us a more consistent environment.
 echo "================================================================"
 io::log_yellow "Update or reinstall 'google-cloud-sdk'."
-
-brew_env=()
-if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
-  brew_env+=("HOMEBREW_NO_AUTO_UPDATE=1")
-fi
-env ${brew_env[@]+"${brew_env[@]}"} brew reinstall google-cloud-sdk
-env ${brew_env[@]+"${brew_env[@]}"} brew doctor
+rm -fr "${HOME}/.pyenv"
+env "HOMEBREW_NO_AUTO_UPDATE=1" brew install google-cloud-sdk
+env "HOMEBREW_NO_AUTO_UPDATE=1" brew doctor
 
 echo "================================================================"
 io::log_yellow "change working directory to project root."

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -60,9 +60,9 @@ fi
 # it is just partially installed. This gives us a more consistent environment.
 echo "================================================================"
 io::log_yellow "Update or reinstall 'google-cloud-sdk'."
-rm -fr "${HOME}/.pyenv"
 env "HOMEBREW_NO_AUTO_UPDATE=1" brew install google-cloud-sdk
-env "HOMEBREW_NO_AUTO_UPDATE=1" brew doctor
+# Continue despite `brew doctor` errors and warnings.
+env "HOMEBREW_NO_AUTO_UPDATE=1" brew doctor || true
 
 echo "================================================================"
 io::log_yellow "change working directory to project root."

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -56,6 +56,18 @@ else
   exit 1
 fi
 
+# In some versions of Kokoro `google-cloud-sdk` is not installed by default, or
+# it is just partially installed. This gives us a more consistent environment.
+echo "================================================================"
+io::log_yellow "Update or reinstall 'google-cloud-sdk'."
+
+brew_env=()
+if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
+  brew_env+=("HOMEBREW_NO_AUTO_UPDATE=1")
+fi
+env ${brew_env[@]+"${brew_env[@]}"} brew reinstall google-cloud-sdk
+env ${brew_env[@]+"${brew_env[@]}"} brew doctor
+
 echo "================================================================"
 io::log_yellow "change working directory to project root."
 cd "${PROJECT_ROOT}"

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -60,7 +60,12 @@ fi
 # it is just partially installed. This gives us a more consistent environment.
 echo "================================================================"
 io::log_yellow "Update or reinstall 'google-cloud-sdk'."
-env "HOMEBREW_NO_AUTO_UPDATE=1" brew install google-cloud-sdk
+brew --version
+# Ignore errors, maybe the local version is functional.
+env "HOMEBREW_NO_AUTO_UPDATE=1" brew reinstall google-cloud-sdk ||
+  env "HOMEBREW_NO_AUTO_UPDATE=1" brew cask install google-cloud-sdk ||
+  true
+
 # Continue despite `brew doctor` errors and warnings.
 env "HOMEBREW_NO_AUTO_UPDATE=1" brew doctor || true
 
@@ -79,15 +84,15 @@ io::log_yellow "building with ${NCPU} cores on ${PWD}."
 
 script_flags=()
 
-if [[ "${BUILD_NAME}" = "bazel" ]]; then
+if [[ "${BUILD_NAME}" == "bazel" ]]; then
   export BUILD_TOOL="Bazel"
   driver_script="ci/kokoro/macos/build-bazel.sh"
-elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
+elif [[ "${BUILD_NAME}" == "cmake-super" ]]; then
   driver_script="ci/kokoro/macos/build-cmake.sh"
   script_flags+=("super" "cmake-out/macos")
-elif [[ "${BUILD_NAME}" = "quickstart-cmake" ]]; then
+elif [[ "${BUILD_NAME}" == "quickstart-cmake" ]]; then
   driver_script="ci/kokoro/macos/build-quickstart-cmake.sh"
-elif [[ "${BUILD_NAME}" = "quickstart-bazel" ]]; then
+elif [[ "${BUILD_NAME}" == "quickstart-bazel" ]]; then
   export BUILD_TOOL="Bazel"
   driver_script="ci/kokoro/macos/build-quickstart-bazel.sh"
 else


### PR DESCRIPTION
The build scripts had gone stales since they were disabled. I made a number
of changes:

- Update the vcpkg version to work well with manifests.
- The Kokoro pool we are using does not have CMake or Ninja pre-installed. Use the versions downloaded by vcpkg. Better to download them only once.
- Manually re-install `gcloud` and `gsutil` because the version pre-installed in this pool seems broken.

Part of the work for #3731 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6197)
<!-- Reviewable:end -->
