### PR TITLE
refactor(storage): use g::c::Options in CurlClient

### DIFF
--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -29,12 +29,13 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 class ClientOptions;
 namespace internal {
-std::string JsonEndpoint(ClientOptions const&);
-std::string JsonUploadEndpoint(ClientOptions const&);
-std::string XmlEndpoint(ClientOptions const&);
-std::string IamEndpoint(ClientOptions const&);
+std::string JsonEndpoint(Options const&);
+std::string JsonUploadEndpoint(Options const&);
+std::string XmlEndpoint(Options const&);
+std::string IamEndpoint(Options const&);
 
 Options MakeOptions(ClientOptions);
+ClientOptions MakeBackwardsCompatibleClientOptions(Options);
 Options FillWithDefaults(std::shared_ptr<oauth2::Credentials> credentials,
                          Options = {});
 
@@ -309,11 +310,10 @@ class ClientOptions {
   //@}
 
  private:
-  friend std::string internal::JsonEndpoint(ClientOptions const&);
-  friend std::string internal::JsonUploadEndpoint(ClientOptions const&);
-  friend std::string internal::XmlEndpoint(ClientOptions const&);
-  friend std::string internal::IamEndpoint(ClientOptions const&);
   friend Options internal::MakeOptions(ClientOptions);
+  friend ClientOptions internal::MakeBackwardsCompatibleClientOptions(Options);
+
+  explicit ClientOptions(Options o);
 
   Options opts_;
 

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -135,12 +135,13 @@ TEST_F(ClientOptionsTest, EndpointsDefault) {
                                            {});
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   EXPECT_EQ("https://storage.googleapis.com", options.endpoint());
+  auto o = internal::MakeOptions(std::move(options));
   EXPECT_EQ("https://storage.googleapis.com/storage/v1",
-            internal::JsonEndpoint(options));
+            internal::JsonEndpoint(o));
   EXPECT_EQ("https://storage.googleapis.com/upload/storage/v1",
-            internal::JsonUploadEndpoint(options));
+            internal::JsonUploadEndpoint(o));
   EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
-            internal::IamEndpoint(options));
+            internal::IamEndpoint(o));
 }
 
 TEST_F(ClientOptionsTest, EndpointsOverride) {
@@ -149,13 +150,14 @@ TEST_F(ClientOptionsTest, EndpointsOverride) {
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   options.set_endpoint("http://127.0.0.1.nip.io:1234");
   EXPECT_EQ("http://127.0.0.1.nip.io:1234", options.endpoint());
+  auto o = internal::MakeOptions(std::move(options));
   EXPECT_EQ("http://127.0.0.1.nip.io:1234/storage/v1",
-            internal::JsonEndpoint(options));
+            internal::JsonEndpoint(o));
   EXPECT_EQ("http://127.0.0.1.nip.io:1234/upload/storage/v1",
-            internal::JsonUploadEndpoint(options));
-  EXPECT_EQ("http://127.0.0.1.nip.io:1234", internal::XmlEndpoint(options));
+            internal::JsonUploadEndpoint(o));
+  EXPECT_EQ("http://127.0.0.1.nip.io:1234", internal::XmlEndpoint(o));
   EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
-            internal::IamEndpoint(options));
+            internal::IamEndpoint(o));
 }
 
 TEST_F(ClientOptionsTest, EndpointsEmulator) {
@@ -163,12 +165,12 @@ TEST_F(ClientOptionsTest, EndpointsEmulator) {
                                            "http://localhost:1234");
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   EXPECT_EQ("http://localhost:1234", options.endpoint());
-  EXPECT_EQ("http://localhost:1234/storage/v1",
-            internal::JsonEndpoint(options));
+  auto o = internal::MakeOptions(std::move(options));
+  EXPECT_EQ("http://localhost:1234/storage/v1", internal::JsonEndpoint(o));
   EXPECT_EQ("http://localhost:1234/upload/storage/v1",
-            internal::JsonUploadEndpoint(options));
-  EXPECT_EQ("http://localhost:1234", internal::XmlEndpoint(options));
-  EXPECT_EQ("http://localhost:1234/iamapi", internal::IamEndpoint(options));
+            internal::JsonUploadEndpoint(o));
+  EXPECT_EQ("http://localhost:1234", internal::XmlEndpoint(o));
+  EXPECT_EQ("http://localhost:1234/iamapi", internal::IamEndpoint(o));
 }
 
 TEST_F(ClientOptionsTest, OldEndpointsEmulator) {
@@ -177,22 +179,23 @@ TEST_F(ClientOptionsTest, OldEndpointsEmulator) {
                                            "http://localhost:1234");
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   EXPECT_EQ("http://localhost:1234", options.endpoint());
-  EXPECT_EQ("http://localhost:1234/storage/v1",
-            internal::JsonEndpoint(options));
+  auto o = internal::MakeOptions(std::move(options));
+  EXPECT_EQ("http://localhost:1234/storage/v1", internal::JsonEndpoint(o));
   EXPECT_EQ("http://localhost:1234/upload/storage/v1",
-            internal::JsonUploadEndpoint(options));
-  EXPECT_EQ("http://localhost:1234", internal::XmlEndpoint(options));
-  EXPECT_EQ("http://localhost:1234/iamapi", internal::IamEndpoint(options));
+            internal::JsonUploadEndpoint(o));
+  EXPECT_EQ("http://localhost:1234", internal::XmlEndpoint(o));
+  EXPECT_EQ("http://localhost:1234/iamapi", internal::IamEndpoint(o));
 }
 
 TEST_F(ClientOptionsTest, SetVersion) {
   ClientOptions options(oauth2::CreateAnonymousCredentials());
   options.set_version("vTest");
   EXPECT_EQ("vTest", options.version());
+  auto o = internal::MakeOptions(std::move(options));
   EXPECT_EQ("https://storage.googleapis.com/storage/vTest",
-            internal::JsonEndpoint(options));
+            internal::JsonEndpoint(o));
   EXPECT_EQ("https://storage.googleapis.com/upload/storage/vTest",
-            internal::JsonUploadEndpoint(options));
+            internal::JsonUploadEndpoint(o));
 }
 
 TEST_F(ClientOptionsTest, SetIamEndpoint) {

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -39,7 +39,8 @@ class CurlClient : public RawClient,
  public:
   static std::shared_ptr<CurlClient> Create(ClientOptions options) {
     // Cannot use std::make_shared because the constructor is private.
-    return std::shared_ptr<CurlClient>(new CurlClient(std::move(options)));
+    return std::shared_ptr<CurlClient>(
+        new CurlClient(internal::MakeOptions(std::move(options))));
   }
   static std::shared_ptr<CurlClient> Create(
       std::shared_ptr<oauth2::Credentials> credentials) {
@@ -68,7 +69,9 @@ class CurlClient : public RawClient,
       QueryResumableUploadRequest const&);
   //@}
 
-  ClientOptions const& client_options() const override { return options_; }
+  ClientOptions const& client_options() const override {
+    return backwards_compatibility_options_;
+  }
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;
@@ -183,7 +186,7 @@ class CurlClient : public RawClient,
  protected:
   // The constructor is private because the class must always be created
   // as a shared_ptr<>.
-  explicit CurlClient(ClientOptions options);
+  explicit CurlClient(Options options);
 
  private:
   /// Setup the configuration parameters that do not depend on the request.
@@ -212,7 +215,8 @@ class CurlClient : public RawClient,
   StatusOr<std::unique_ptr<ResumableUploadSession>>
   CreateResumableSessionGeneric(RequestType const& request);
 
-  ClientOptions options_;
+  google::cloud::Options opts_;
+  ClientOptions backwards_compatibility_options_;
   std::string const x_goog_api_client_header_;
   std::string const storage_endpoint_;
   std::string const storage_host_;

--- a/google/cloud/storage/internal/curl_handle_factory.h
+++ b/google/cloud/storage/internal/curl_handle_factory.h
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/internal/curl_handle.h"
 #include "google/cloud/storage/internal/curl_wrappers.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/options.h"
 #include <deque>
 #include <mutex>
 #include <string>
@@ -46,7 +47,7 @@ class CurlHandleFactory {
   // Only virtual for testing purposes.
   virtual void SetCurlStringOption(CURL* handle, CURLoption option_tag,
                                    char const* value);
-  void SetCurlOptions(CURL* handle, ChannelOptions const& options);
+  void SetCurlOptions(CURL* handle, std::string const& ssl_root_path);
 
   static CURL* GetHandle(CurlHandle& h) { return h.handle_.get(); }
   static void ResetHandle(CurlHandle& h) { h.handle_.reset(); }
@@ -54,7 +55,7 @@ class CurlHandleFactory {
 };
 
 std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory(
-    ChannelOptions const& options);
+    Options const& options);
 std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory();
 
 /**
@@ -67,8 +68,8 @@ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory();
 class DefaultCurlHandleFactory : public CurlHandleFactory {
  public:
   DefaultCurlHandleFactory() = default;
-  explicit DefaultCurlHandleFactory(ChannelOptions options)
-      : options_(std::move(options)) {}
+  explicit DefaultCurlHandleFactory(Options const& o)
+      : ssl_root_path_(o.get<SslRootPathOption>()) {}
 
   CurlPtr CreateHandle() override;
   void CleanupHandle(CurlHandle&&) override;
@@ -84,7 +85,7 @@ class DefaultCurlHandleFactory : public CurlHandleFactory {
  private:
   mutable std::mutex mu_;
   std::string last_client_ip_address_;
-  ChannelOptions options_;
+  std::string ssl_root_path_;
 };
 
 /**
@@ -95,7 +96,7 @@ class DefaultCurlHandleFactory : public CurlHandleFactory {
  */
 class PooledCurlHandleFactory : public CurlHandleFactory {
  public:
-  PooledCurlHandleFactory(std::size_t maximum_size, ChannelOptions options);
+  PooledCurlHandleFactory(std::size_t maximum_size, Options const& o);
   explicit PooledCurlHandleFactory(std::size_t maximum_size)
       : PooledCurlHandleFactory(maximum_size, {}) {}
   ~PooledCurlHandleFactory() override;
@@ -117,7 +118,7 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
   std::deque<CURL*> handles_;
   std::deque<CURLM*> multi_handles_;
   std::string last_client_ip_address_;
-  ChannelOptions options_;
+  std::string ssl_root_path_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/curl_handle_factory_test.cc
+++ b/google/cloud/storage/internal/curl_handle_factory_test.cc
@@ -30,7 +30,7 @@ using ::testing::IsEmpty;
 class OverriddenDefaultCurlHandleFactory : public DefaultCurlHandleFactory {
  public:
   OverriddenDefaultCurlHandleFactory() = default;
-  explicit OverriddenDefaultCurlHandleFactory(ChannelOptions const& options)
+  explicit OverriddenDefaultCurlHandleFactory(Options const& options)
       : DefaultCurlHandleFactory(options) {}
 
  protected:
@@ -51,7 +51,7 @@ class OverriddenPooledCurlHandleFactory : public PooledCurlHandleFactory {
   explicit OverriddenPooledCurlHandleFactory(std::size_t maximum_size)
       : PooledCurlHandleFactory(maximum_size) {}
   OverriddenPooledCurlHandleFactory(std::size_t maximum_size,
-                                    ChannelOptions const& options)
+                                    Options const& options)
       : PooledCurlHandleFactory(maximum_size, options) {}
 
  protected:
@@ -74,8 +74,7 @@ TEST(CurlHandleFactoryTest,
 }
 
 TEST(CurlHandleFactoryTest, DefaultFactoryChannelOptionsCallsSetOptions) {
-  ChannelOptions options;
-  options.set_ssl_root_path("foo");
+  auto options = Options{}.set<SslRootPathOption>("foo");
   OverriddenDefaultCurlHandleFactory object_under_test(options);
 
   auto const expected = std::make_pair(CURLOPT_CAINFO, std::string("foo"));
@@ -92,8 +91,7 @@ TEST(CurlHandleFactoryTest, PooledFactoryNoChannelOptionsDoesntCallSetOptions) {
 }
 
 TEST(CurlHandleFactoryTest, PooledFactoryChannelOptionsCallsSetOptions) {
-  ChannelOptions options;
-  options.set_ssl_root_path("foo");
+  auto options = Options{}.set<SslRootPathOption>("foo");
   OverriddenPooledCurlHandleFactory object_under_test(2, options);
 
   auto const expected = std::make_pair(CURLOPT_CAINFO, std::string("foo"));

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -163,7 +163,7 @@ class CurlRequestBuilder {
   CurlRequestBuilder& SetMethod(std::string const& method);
 
   /// Copy interesting configuration parameters from the client options.
-  CurlRequestBuilder& ApplyClientOptions(ClientOptions const& options);
+  CurlRequestBuilder& ApplyClientOptions(Options const& options);
 
   /// Sets the CURLSH* handle to share resources.
   CurlRequestBuilder& SetCurlShare(CURLSH* share);

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -36,7 +36,8 @@ class MockCurlClient : public CurlClient {
   }
 
   MockCurlClient()
-      : CurlClient(ClientOptions(oauth2::CreateAnonymousCredentials())) {}
+      : CurlClient(
+            internal::FillWithDefaults(oauth2::CreateAnonymousCredentials())) {}
 
   MOCK_METHOD(StatusOr<ResumableUploadResponse>, UploadChunk,
               (UploadChunkRequest const&), (override));

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_wrappers.h"
+#include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
 #include "google/cloud/log.h"
 #include <openssl/crypto.h>
@@ -236,12 +237,12 @@ std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,
   return size;
 }
 
-void CurlInitializeOnce(ClientOptions const& options) {
+void CurlInitializeOnce(Options const& options) {
   static CurlInitializer curl_initializer;
   std::call_once(ssl_locking_initialized, InitializeSslLocking,
-                 options.enable_ssl_locking_callbacks());
+                 options.get<EnableCurlSslLockingOption>());
   std::call_once(sigpipe_handler_initialized, InitializeSigPipeHandler,
-                 options.enable_sigpipe_handler());
+                 options.get<EnableCurlSigpipeHandlerOption>());
 }
 
 std::string ExtractUrlHostpart(std::string url) {

--- a/google/cloud/storage/internal/curl_wrappers.h
+++ b/google/cloud/storage/internal/curl_wrappers.h
@@ -15,10 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_WRAPPERS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_CURL_WRAPPERS_H
 
-#include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/options.h"
 #include <curl/curl.h>
 #include <functional>
 #include <map>
@@ -57,7 +57,7 @@ using CurlShare = std::unique_ptr<CURLSH, decltype(&curl_share_cleanup)>;
 bool SslLockingCallbacksInstalled();
 
 /// Initializes (if needed) the SSL locking callbacks.
-void CurlInitializeOnce(ClientOptions const& options);
+void CurlInitializeOnce(Options const& options);
 
 /// Returns the id of the SSL library used by libcurl.
 std::string CurlSslLibraryId();

--- a/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_disable_sigpipe_handler_test.cc
@@ -44,8 +44,7 @@ TEST(CurlWrappers, SigpipeHandlerDisabledTest) {
   // curl_global_init(). Unfortunately 7.29.0 is the default on CentOS-7, and
   // the tests here fails. We simply skip the test with this ancient library.
   auto initial_handler = std::signal(SIGPIPE, &test_handler);
-  CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
-                         .set_enable_sigpipe_handler(false));
+  CurlInitializeOnce(Options{}.set<EnableCurlSigpipeHandlerOption>(false));
   auto actual = std::signal(SIGPIPE, initial_handler);
   EXPECT_EQ(actual, &test_handler);
 #endif  // defined(SIGPIPE)

--- a/google/cloud/storage/internal/curl_wrappers_enable_sigpipe_handler_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_enable_sigpipe_handler_test.cc
@@ -33,14 +33,12 @@ TEST(CurlWrappers, SigpipeHandlerEnabledTest) {
   GTEST_SKIP();  // nothing to do
 #else
   auto initial_handler = std::signal(SIGPIPE, &test_handler);
-  CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
-                         .set_enable_sigpipe_handler(true));
+  CurlInitializeOnce(Options{}.set<EnableCurlSigpipeHandlerOption>(true));
   auto actual = std::signal(SIGPIPE, initial_handler);
   EXPECT_EQ(actual, SIG_IGN);
 
   // Also verify a second call has no effect.
-  CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
-                         .set_enable_sigpipe_handler(true));
+  CurlInitializeOnce(Options{}.set<EnableCurlSigpipeHandlerOption>(true));
   actual = std::signal(SIGPIPE, initial_handler);
   EXPECT_EQ(actual, initial_handler);
 #endif  // defined(SIGPIPE)

--- a/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_already_present_test.cc
@@ -34,8 +34,7 @@ TEST(CurlWrappers, LockingDisabledTest) {
   // Install a trivial callback, this should disable the installation of the
   // normal callbacks in the the curl wrappers.
   CRYPTO_set_locking_callback(test_cb);
-  CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
-                         .set_enable_ssl_locking_callbacks(true));
+  CurlInitializeOnce(Options{}.set<EnableCurlSslLockingOption>(true));
   EXPECT_FALSE(SslLockingCallbacksInstalled());
 }
 }  // namespace

--- a/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_disabled_test.cc
@@ -26,8 +26,7 @@ namespace {
 TEST(CurlWrappers, LockingDisabledTest) {
   // The test cannot execute in this case.
   if (!SslLibraryNeedsLocking(CurlSslLibraryId())) GTEST_SKIP();
-  CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
-                         .set_enable_ssl_locking_callbacks(false));
+  CurlInitializeOnce(Options{}.set<EnableCurlSslLockingOption>(false));
   EXPECT_FALSE(SslLockingCallbacksInstalled());
 }
 }  // namespace

--- a/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
+++ b/google/cloud/storage/internal/curl_wrappers_locking_enabled_test.cc
@@ -26,8 +26,7 @@ namespace {
 TEST(CurlWrappers, LockingEnabledTest) {
   // The test cannot execute in this case.
   if (!SslLibraryNeedsLocking(CurlSslLibraryId())) GTEST_SKIP();
-  CurlInitializeOnce(ClientOptions(oauth2::CreateAnonymousCredentials())
-                         .set_enable_ssl_locking_callbacks(true));
+  CurlInitializeOnce(Options{}.set<EnableCurlSslLockingOption>(true));
   EXPECT_TRUE(SslLockingCallbacksInstalled());
 }
 }  // namespace

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -83,8 +83,9 @@ class AuthorizedUserCredentials : public Credentials {
                                      ChannelOptions const& channel_options = {})
       : clock_() {
     HttpRequestBuilderType request_builder(
-        info.token_uri,
-        storage::internal::GetDefaultCurlHandleFactory(channel_options));
+        info.token_uri, storage::internal::GetDefaultCurlHandleFactory(
+                            Options{}.set<internal::SslRootPathOption>(
+                                channel_options.ssl_root_path())));
     std::string payload("grant_type=refresh_token");
     payload += "&client_id=";
     payload += request_builder.MakeEscapedString(info.client_id).get();

--- a/google/cloud/storage/oauth2/service_account_credentials.h
+++ b/google/cloud/storage/oauth2/service_account_credentials.h
@@ -143,8 +143,9 @@ class ServiceAccountCredentials : public Credentials {
                             ChannelOptions const& options)
       : info_(std::move(info)), clock_() {
     HttpRequestBuilderType request_builder(
-        info_.token_uri,
-        storage::internal::GetDefaultCurlHandleFactory(options));
+        info_.token_uri, storage::internal::GetDefaultCurlHandleFactory(
+                             Options{}.set<internal::SslRootPathOption>(
+                                 options.ssl_root_path())));
     request_builder.AddHeader(
         "Content-Type: application/x-www-form-urlencoded");
     // This is the value of grant_type for JSON-formatted service account

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -301,9 +301,8 @@ TEST(CurlRequestTest, UserAgent) {
   // Also verifying the telemetry header is present.
   CurlRequestBuilder builder(HttpBinEndpoint() + "/headers",
                              storage::internal::GetDefaultCurlHandleFactory());
-  auto options =
-      ClientOptions(std::make_shared<storage::oauth2::AnonymousCredentials>())
-          .add_user_agent_prefix("test-user-agent-prefix");
+  auto options = google::cloud::Options{}.set<UserAgentProductsOption>(
+      {"test-user-agent-prefix"});
   builder.ApplyClientOptions(options);
   builder.AddHeader("Accept: application/json");
   builder.AddHeader("charsets: utf-8");
@@ -504,8 +503,7 @@ TEST(CurlRequestTest, Logging) {
         HttpBinEndpoint() + "/post?foo=bar",
         storage::internal::GetDefaultCurlHandleFactory());
     auto options =
-        ClientOptions(std::make_shared<storage::oauth2::AnonymousCredentials>())
-            .set_enable_http_tracing(true);
+        google::cloud::Options{}.set<TracingComponentsOption>({"http"});
     builder.ApplyClientOptions(options);
     builder.AddHeader("Accept: application/json");
     builder.AddHeader("charsets: utf-8");


### PR DESCRIPTION
Change `google::cloud::internal::CurlClient` to receive a
`google::cloud::Options` for its configuration. Several related classes
and functions in `internal::` needed adjusting to their interfaces too.

Part of the work for #6161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6203)
<!-- Reviewable:end -->
