### PR TITLE
refactor(storage): use g::c::Options for GrpcClient

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -248,7 +248,7 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
 
 std::shared_ptr<grpc::ChannelInterface> CreateGcsChannel(int thread_id) {
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
-  return gcs::internal::CreateGrpcChannel(gcs::internal::FillWithDefaultsGrpc(),
+  return gcs::internal::CreateGrpcChannel(gcs::internal::DefaultOptionsGrpc(),
                                           thread_id);
 #else
   grpc::ChannelArguments args;

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -248,8 +248,8 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
 
 std::shared_ptr<grpc::ChannelInterface> CreateGcsChannel(int thread_id) {
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
-  gcs::ClientOptions options{gcs::oauth2::GoogleDefaultCredentials().value()};
-  return gcs::internal::CreateGrpcChannel(options, thread_id);
+  return gcs::internal::CreateGrpcChannel(gcs::internal::FillWithDefaultsGrpc(),
+                                          thread_id);
 #else
   grpc::ChannelArguments args;
   args.SetInt("grpc.channel_id", thread_id);

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -134,7 +134,7 @@ Options FillWithDefaults(std::shared_ptr<oauth2::Credentials> credentials,
           .set<DownloadStallTimeoutOption>(std::chrono::seconds(
               GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_STALL_TIMEOUT));
 
-  o = google::cloud::internal::MergeOptions(std::move(o), std::move(opts));
+  o = google::cloud::internal::MergeOptions(std::move(opts), std::move(o));
   auto emulator = GetEmulator();
   if (emulator.has_value()) {
     o.set<GcsRestEndpointOption>(*emulator).set<GcsIamEndpointOption>(

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -112,8 +112,8 @@ ClientOptions MakeBackwardsCompatibleClientOptions(Options opts) {
   return ClientOptions(std::move(opts));
 }
 
-Options FillWithDefaults(std::shared_ptr<oauth2::Credentials> credentials,
-                         Options opts) {
+Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
+                       Options opts) {
   auto o =
       Options{}
           .set<Oauth2CredentialsOption>(std::move(credentials))
@@ -178,7 +178,7 @@ StatusOr<ClientOptions> ClientOptions::CreateDefaultClientOptions(
 
 ClientOptions::ClientOptions(std::shared_ptr<oauth2::Credentials> credentials,
                              ChannelOptions channel_options)
-    : opts_(internal::FillWithDefaults(std::move(credentials))),
+    : opts_(internal::DefaultOptions(std::move(credentials))),
       channel_options_(std::move(channel_options)) {}
 
 ClientOptions::ClientOptions(Options o)

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -36,8 +36,8 @@ std::string IamEndpoint(Options const&);
 
 Options MakeOptions(ClientOptions);
 ClientOptions MakeBackwardsCompatibleClientOptions(Options);
-Options FillWithDefaults(std::shared_ptr<oauth2::Credentials> credentials,
-                         Options = {});
+Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
+                       Options opts = {});
 
 /// Configure the IAM endpoint for the GCS client library.
 struct GcsRestEndpointOption {

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -327,6 +327,19 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_THAT(opts.get<internal::SslRootPathOption>(), IsEmpty());
 }
 
+TEST_F(ClientOptionsTest, FillWithDefaults) {
+  auto o = internal::FillWithDefaults(oauth2::CreateAnonymousCredentials(), {});
+  EXPECT_EQ("https://storage.googleapis.com",
+            o.get<internal::GcsRestEndpointOption>());
+
+  // Verify any set values are respected overriden.
+  o = internal::FillWithDefaults(oauth2::CreateAnonymousCredentials(),
+                                 Options{}.set<internal::GcsRestEndpointOption>(
+                                     "https://private.googleapis.com"));
+  EXPECT_EQ("https://private.googleapis.com",
+            o.get<internal::GcsRestEndpointOption>());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -327,15 +327,15 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_THAT(opts.get<internal::SslRootPathOption>(), IsEmpty());
 }
 
-TEST_F(ClientOptionsTest, FillWithDefaults) {
-  auto o = internal::FillWithDefaults(oauth2::CreateAnonymousCredentials(), {});
+TEST_F(ClientOptionsTest, DefaultOptions) {
+  auto o = internal::DefaultOptions(oauth2::CreateAnonymousCredentials(), {});
   EXPECT_EQ("https://storage.googleapis.com",
             o.get<internal::GcsRestEndpointOption>());
 
   // Verify any set values are respected overriden.
-  o = internal::FillWithDefaults(oauth2::CreateAnonymousCredentials(),
-                                 Options{}.set<internal::GcsRestEndpointOption>(
-                                     "https://private.googleapis.com"));
+  o = internal::DefaultOptions(oauth2::CreateAnonymousCredentials(),
+                               Options{}.set<internal::GcsRestEndpointOption>(
+                                   "https://private.googleapis.com"));
   EXPECT_EQ("https://private.googleapis.com",
             o.get<internal::GcsRestEndpointOption>());
 }

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -41,11 +41,15 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient() {
 google::cloud::storage::Client DefaultGrpcClient(
     google::cloud::storage::ClientOptions options, int channel_id) {
   if (UseGrpcForMetadata()) {
-    return storage::Client(std::make_shared<storage::internal::GrpcClient>(
-        std::move(options), channel_id));
+    return storage::Client(storage::internal::GrpcClient::Create(
+        google::cloud::storage::internal::MakeOptions(std::move(options)),
+        channel_id));
   }
-  return storage::Client(std::make_shared<storage::internal::HybridClient>(
-      std::move(options), channel_id));
+  auto credentials = options.credentials();
+  return storage::Client(storage::internal::HybridClient::Create(
+      std::move(credentials),
+      google::cloud::storage::internal::MakeOptions(std::move(options)),
+      channel_id));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -41,7 +41,7 @@ class CurlClient : public RawClient,
       std::shared_ptr<oauth2::Credentials> credentials, Options options) {
     // Cannot use std::make_shared because the constructor is private.
     return std::shared_ptr<CurlClient>(new CurlClient(
-        FillWithDefaults(std::move(credentials), std::move(options))));
+        DefaultOptions(std::move(credentials), std::move(options))));
   }
   static std::shared_ptr<CurlClient> Create(ClientOptions options) {
     auto credentials = options.credentials();

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -37,14 +37,19 @@ class CurlRequestBuilder;
 class CurlClient : public RawClient,
                    public std::enable_shared_from_this<CurlClient> {
  public:
-  static std::shared_ptr<CurlClient> Create(ClientOptions options) {
+  static std::shared_ptr<CurlClient> Create(
+      std::shared_ptr<oauth2::Credentials> credentials, Options options) {
     // Cannot use std::make_shared because the constructor is private.
-    return std::shared_ptr<CurlClient>(
-        new CurlClient(internal::MakeOptions(std::move(options))));
+    return std::shared_ptr<CurlClient>(new CurlClient(
+        FillWithDefaults(std::move(credentials), std::move(options))));
+  }
+  static std::shared_ptr<CurlClient> Create(ClientOptions options) {
+    auto credentials = options.credentials();
+    return Create(std::move(credentials), MakeOptions(std::move(options)));
   }
   static std::shared_ptr<CurlClient> Create(
       std::shared_ptr<oauth2::Credentials> credentials) {
-    return Create(ClientOptions(std::move(credentials)));
+    return Create(std::move(credentials), Options{});
   }
 
   CurlClient(CurlClient const& rhs) = delete;

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -37,7 +37,7 @@ class MockCurlClient : public CurlClient {
 
   MockCurlClient()
       : CurlClient(
-            internal::FillWithDefaults(oauth2::CreateAnonymousCredentials())) {}
+            internal::DefaultOptions(oauth2::CreateAnonymousCredentials())) {}
 
   MOCK_METHOD(StatusOr<ResumableUploadResponse>, UploadChunk,
               (UploadChunkRequest const&), (override));

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -59,9 +59,9 @@ bool DirectPathEnabled() {
                         [](absl::string_view v) { return v == "storage"; });
 }
 
-Options FillWithDefaultsGrpc(Options options) {
-  options = FillWithDefaults(std::make_shared<oauth2::AnonymousCredentials>(),
-                             std::move(options));
+Options DefaultOptionsGrpc(Options options) {
+  options = DefaultOptions(std::make_shared<oauth2::AnonymousCredentials>(),
+                           std::move(options));
   auto env = google::cloud::internal::GetEnv("CLOUD_STORAGE_GRPC_ENDPOINT");
   if (env.has_value()) {
     options.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
@@ -99,7 +99,7 @@ std::shared_ptr<GrpcClient> GrpcClient::Create(Options options,
                                                int channel_id) {
   // Cannot use std::make_shared<> as the constructor is private.
   return std::shared_ptr<GrpcClient>(
-      new GrpcClient(FillWithDefaultsGrpc(std::move(options)), channel_id));
+      new GrpcClient(DefaultOptionsGrpc(std::move(options)), channel_id));
 }
 
 GrpcClient::GrpcClient(Options const& options, int channel_id)

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/internal/sha256_hash.h"
 #include "google/cloud/storage/oauth2/anonymous_credentials.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/big_endian.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
@@ -40,6 +41,16 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
+auto constexpr kDirectPathConfig = R"json({
+    "loadBalancingConfig": [{
+      "grpclb": {
+        "childPolicy": [{
+          "pick_first": {}
+        }]
+      }
+    }]
+  })json";
+
 bool DirectPathEnabled() {
   auto const direct_path_settings =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH")
@@ -48,60 +59,54 @@ bool DirectPathEnabled() {
                         [](absl::string_view v) { return v == "storage"; });
 }
 
-std::string GrpcEndpoint() {
+Options FillWithDefaultsGrpc(Options options) {
+  options = FillWithDefaults(std::make_shared<oauth2::AnonymousCredentials>(),
+                             std::move(options));
   auto env = google::cloud::internal::GetEnv("CLOUD_STORAGE_GRPC_ENDPOINT");
   if (env.has_value()) {
-    return env.value();
+    options.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
+    options.set<EndpointOption>(*env);
   }
-  return "storage.googleapis.com";
-}
+  if (!options.has<GrpcCredentialOption>()) {
+    // Try to avoid calling grpc::GoogleDefaultCredentials() because it tries to
+    // open files and generates warnings in the CI system as they do not exist.
+    options.set<GrpcCredentialOption>(grpc::GoogleDefaultCredentials());
+  }
+  if (!options.has<EndpointOption>()) {
+    options.set<EndpointOption>("storage.googleapis.com");
+  }
 
-std::shared_ptr<grpc::ChannelCredentials> GrpcCredentials(
-    ClientOptions const& options) {
-  auto env = google::cloud::internal::GetEnv("CLOUD_STORAGE_GRPC_ENDPOINT");
-  if (env.has_value()) {
-    return grpc::InsecureChannelCredentials();
-  }
-  if (dynamic_cast<oauth2::AnonymousCredentials*>(
-          options.credentials().get()) != nullptr) {
-    return grpc::InsecureChannelCredentials();
-  }
-  return grpc::GoogleDefaultCredentials();
+  return options;
 }
 
 std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
-    ClientOptions const& options) {
-  return CreateGrpcChannel(options, 0);
-}
-
-std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
-    ClientOptions const& options, int channel_id) {
+    Options const& options, int channel_id) {
   grpc::ChannelArguments args;
   args.SetInt("grpc.channel_id", channel_id);
   if (DirectPathEnabled()) {
-    args.SetServiceConfigJSON(R"json({
-      "loadBalancingConfig": [{
-        "grpclb": {
-          "childPolicy": [{
-            "pick_first": {}
-          }]
-        }
-      }]
-    })json");
+    args.SetServiceConfigJSON(kDirectPathConfig);
   }
-  return grpc::CreateCustomChannel(GrpcEndpoint(), GrpcCredentials(options),
+  return grpc::CreateCustomChannel(options.get<EndpointOption>(),
+                                   options.get<GrpcCredentialOption>(),
                                    std::move(args));
 }
 
-GrpcClient::GrpcClient(ClientOptions options)
-    : options_(std::move(options)),
-      stub_(
-          google::storage::v1::Storage::NewStub(CreateGrpcChannel(options_))) {}
+std::shared_ptr<GrpcClient> GrpcClient::Create(Options options) {
+  return Create(std::move(options), /*channel_id=*/0);
+}
 
-GrpcClient::GrpcClient(ClientOptions options, int channel_id)
-    : options_(std::move(options)),
+std::shared_ptr<GrpcClient> GrpcClient::Create(Options options,
+                                               int channel_id) {
+  // Cannot use std::make_shared<> as the constructor is private.
+  return std::shared_ptr<GrpcClient>(
+      new GrpcClient(FillWithDefaultsGrpc(std::move(options)), channel_id));
+}
+
+GrpcClient::GrpcClient(Options const& options, int channel_id)
+    : backwards_compatibility_options_(
+          MakeBackwardsCompatibleClientOptions(options)),
       stub_(google::storage::v1::Storage::NewStub(
-          CreateGrpcChannel(options_, channel_id))) {}
+          CreateGrpcChannel(options, channel_id))) {}
 
 std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
     grpc::ClientContext& context, google::storage::v1::Object& result) {
@@ -127,7 +132,9 @@ StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
       {}};
 }
 
-ClientOptions const& GrpcClient::client_options() const { return options_; }
+ClientOptions const& GrpcClient::client_options() const {
+  return backwards_compatibility_options_;
+}
 
 StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
     ListBucketsRequest const& request) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -29,16 +29,15 @@ namespace internal {
 /// Determine if using DirectPath for GCS has been enabled through
 /// GOOGLE_CLOUD_DIRECT_PATH.
 bool DirectPathEnabled();
-
-std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(ClientOptions const&);
-std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(ClientOptions const&,
+Options FillWithDefaultsGrpc(Options = {});
+std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(Options const&,
                                                           int channel_id);
 
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
-  explicit GrpcClient(ClientOptions options);
-  explicit GrpcClient(ClientOptions options, int channel_id);
+  static std::shared_ptr<GrpcClient> Create(Options options);
+  static std::shared_ptr<GrpcClient> Create(Options options, int channel_id);
   ~GrpcClient() override = default;
 
   //@{
@@ -318,8 +317,11 @@ class GrpcClient : public RawClient,
   static std::string MD5FromProto(std::string const&);
   static std::string MD5ToProto(std::string const&);
 
+ protected:
+  explicit GrpcClient(Options const& options, int channel_id);
+
  private:
-  ClientOptions options_;
+  ClientOptions backwards_compatibility_options_;
   std::shared_ptr<google::storage::v1::Storage::Stub> stub_;
 };
 

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -29,7 +29,7 @@ namespace internal {
 /// Determine if using DirectPath for GCS has been enabled through
 /// GOOGLE_CLOUD_DIRECT_PATH.
 bool DirectPathEnabled();
-Options FillWithDefaultsGrpc(Options = {});
+Options DefaultOptionsGrpc(Options = {});
 std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(Options const&,
                                                           int channel_id);
 

--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/internal/grpc_resumable_upload_session_url.h"
 #include "google/cloud/storage/internal/hybrid_client.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -49,11 +50,10 @@ class GrpcClientFailuresTest
     std::string const grpc_config = GetParam();
     google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                     grpc_config);
-    ClientOptions client_options(oauth2::CreateAnonymousCredentials());
     if (grpc_config == "metadata") {
-      client_.reset(new GrpcClient(std::move(client_options)));
+      client_ = GrpcClient::Create({});
     } else {
-      client_.reset(new HybridClient(std::move(client_options)));
+      client_ = HybridClient::Create(oauth2::CreateAnonymousCredentials(), {});
     }
   }
 

--- a/google/cloud/storage/internal/grpc_client_object_request_test.cc
+++ b/google/cloud/storage/internal/grpc_client_object_request_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -434,8 +435,9 @@ TEST(GrpcClientObjectRequest, ReadObjectRangeRequestReadLastZero) {
 
   testing_util::ScopedEnvironment grpc_endpoint{
       "GOOGLE_CLOUD_CPP_STORAGE_GRPC_ENDPOINT", "locahost:1"};
-  GrpcClient client{ClientOptions{oauth2::CreateAnonymousCredentials()}};
-  StatusOr<std::unique_ptr<ObjectReadSource>> reader = client.ReadObject(req);
+  auto client = GrpcClient::Create(
+      Options{}.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials()));
+  StatusOr<std::unique_ptr<ObjectReadSource>> reader = client->ReadObject(req);
   EXPECT_THAT(reader, StatusIs(StatusCode::kOutOfRange));
 }
 

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/grpc_resumable_upload_session.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
 #include "google/cloud/storage/testing/random_names.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
@@ -49,7 +50,9 @@ class MockGrpcClient : public GrpcClient {
   }
 
   MockGrpcClient()
-      : GrpcClient(ClientOptions(oauth2::CreateAnonymousCredentials())) {}
+      : GrpcClient(Options{}.set<GrpcCredentialOption>(
+                       grpc::InsecureChannelCredentials()),
+                   /*channel_id=*/0) {}
 
   MOCK_METHOD(std::unique_ptr<GrpcClient::UploadWriter>, CreateUploadWriter,
               (grpc::ClientContext&, google::storage::v1::Object&), (override));

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -21,13 +21,17 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-HybridClient::HybridClient(ClientOptions options)
-    : grpc_(std::make_shared<GrpcClient>(options)),
-      curl_(CurlClient::Create(std::move(options))) {}
+std::shared_ptr<RawClient> HybridClient::Create(
+    std::shared_ptr<oauth2::Credentials> credentials, Options options,
+    int channel_id) {
+  return std::shared_ptr<RawClient>(
+      new HybridClient(std::move(credentials), std::move(options), channel_id));
+}
 
-HybridClient::HybridClient(ClientOptions options, int channel_id)
-    : grpc_(std::make_shared<GrpcClient>(options, channel_id)),
-      curl_(CurlClient::Create(std::move(options))) {}
+HybridClient::HybridClient(std::shared_ptr<oauth2::Credentials> credentials,
+                           Options options, int channel_id)
+    : grpc_(GrpcClient::Create(options, channel_id)),
+      curl_(CurlClient::Create(std::move(credentials), std::move(options))) {}
 
 ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -29,8 +29,13 @@ namespace internal {
 
 class HybridClient : public RawClient {
  public:
-  explicit HybridClient(ClientOptions options);
-  explicit HybridClient(ClientOptions options, int channel_id);
+  static std::shared_ptr<RawClient> Create(
+      std::shared_ptr<oauth2::Credentials> credentials, Options options) {
+    return Create(std::move(credentials), std::move(options), /*channel_id=*/0);
+  }
+  static std::shared_ptr<RawClient> Create(
+      std::shared_ptr<oauth2::Credentials> credentials, Options options,
+      int channel_id);
   ~HybridClient() override = default;
 
   ClientOptions const& client_options() const override;
@@ -146,6 +151,9 @@ class HybridClient : public RawClient {
       DeleteNotificationRequest const&) override;
 
  private:
+  explicit HybridClient(std::shared_ptr<oauth2::Credentials> credentials,
+                        Options options, int channel_id);
+
   std::shared_ptr<GrpcClient> grpc_;
   std::shared_ptr<CurlClient> curl_;
 };

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -73,18 +73,17 @@ StorageIntegrationTest::MakeIntegrationTestClient(
     std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   auto options = ClientOptions::CreateDefaultClientOptions();
-  if (!options) {
-    return std::move(options).status();
-  }
+  if (!options) return std::move(options).status();
 
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   if (UseGrpcForMetadata()) {
-    return Client(std::make_shared<internal::GrpcClient>(*options),
+    return Client(internal::GrpcClient::Create(Options{}), *retry_policy,
                   *backoff_policy);
   }
   if (UseGrpcForMedia()) {
-    return Client(std::make_shared<internal::HybridClient>(*options),
-                  *backoff_policy);
+    return Client(
+        internal::HybridClient::Create(options->credentials(), Options{}),
+        *retry_policy, *backoff_policy);
   }
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -460,7 +460,7 @@ TEST_P(GrpcIntegrationTest, GetObjectMediaNotFound) {
   auto object_name = MakeRandomObjectName();
 
   auto channel = google::cloud::storage::internal::CreateGrpcChannel(
-      FillWithDefaultsGrpc(), /*channel_id=*/0);
+      DefaultOptionsGrpc(), /*channel_id=*/0);
   auto stub = google::storage::v1::Storage::NewStub(channel);
 
   grpc::ClientContext context;

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -459,9 +459,8 @@ TEST_P(GrpcIntegrationTest, GetObjectMediaNotFound) {
 
   auto object_name = MakeRandomObjectName();
 
-  auto options = ClientOptions::CreateDefaultClientOptions();
-  ASSERT_STATUS_OK(options);
-  auto channel = google::cloud::storage::internal::CreateGrpcChannel(*options);
+  auto channel = google::cloud::storage::internal::CreateGrpcChannel(
+      FillWithDefaultsGrpc(), /*channel_id=*/0);
   auto stub = google::storage::v1::Storage::NewStub(channel);
 
   grpc::ClientContext context;


### PR DESCRIPTION
Change `storage::internal::GrpcClient` and
`storage::internal::HybridClient` to use `google::cloud::Options`. I had
to define exactly where the defaults are applied to an `Options` object,
for now this is in the `*Client::Create()` factory functions, it may get
refined later.

Some additional refactoring in `storage::ClientOptions` and
`storage::internal::CurlClient` to share the initialization of default
options.

Part of the work for #6161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6209)
<!-- Reviewable:end -->
