### PR TITLE
ci(gcb): add bigquery notifier

### DIFF
--- a/ci/cloudbuild/notifiers/bigquery.yaml
+++ b/ci/cloudbuild/notifiers/bigquery.yaml
@@ -4,7 +4,6 @@ metadata:
   name: google-cloud-cpp-bigquery-notifier
 spec:
   notification:
-    filter: >
-      build.build_trigger_id in ["39670f28-2623-4300-b427-91a0b627a074"]
+    filter: has(build.build_trigger_id)
     delivery:
       table: projects/936212892354/datasets/cloudbuild/tables/google_cloud_cpp

--- a/ci/cloudbuild/notifiers/bigquery.yaml
+++ b/ci/cloudbuild/notifiers/bigquery.yaml
@@ -1,0 +1,10 @@
+apiVersion: cloud-build-notifiers/v1
+kind: BigQueryNotifier
+metadata:
+  name: google-cloud-cpp-bigquery-notifier
+spec:
+  notification:
+    filter: >
+      build.build_trigger_id in ["39670f28-2623-4300-b427-91a0b627a074"]
+    delivery:
+      table: projects/936212892354/datasets/cloudbuild/tables/google_cloud_cpp

--- a/ci/cloudbuild/notifiers/bigquery/README.md
+++ b/ci/cloudbuild/notifiers/bigquery/README.md
@@ -1,0 +1,20 @@
+This directory contains the config and `deploy.sh` script for use of the Cloud
+Build BigQuery notifier. The high-level description of how this works (as I
+understand it), is the following:
+
+* We use Google Cloud Build (GCB) to run many of our builds. See
+  https://pantheon.corp.google.com/cloud-build/dashboard?project=cloud-cpp-testing-resources
+* GCB sends build status notifications to the Pub/Sub
+  `projects/cloud-cpp-testing-resources/topics/cloud-builds` topic. See
+  https://pantheon.corp.google.com/cloudpubsub/topic/detail/cloud-builds?project=cloud-cpp-testing-resources 
+* We run the GCB BigQuery Notifier as a Cloud Run service, which subscribes to
+  the build notifications and writes them to a BigQuery table.
+
+The `bigquery.yaml` file is the config that we give to the GCB BigQuery
+Notifier service. It is read from a GCS bucket, so we first copy the file there
+before deploying the service. The steps to deploy are captured in the
+`deploy.sh` script.
+
+Links:
+* https://cloud.google.com/build/docs/configuring-notifications/configure-bigquery
+* https://github.com/GoogleCloudPlatform/cloud-build-notifiers/tree/master/bigquery

--- a/ci/cloudbuild/notifiers/bigquery/README.md
+++ b/ci/cloudbuild/notifiers/bigquery/README.md
@@ -1,12 +1,12 @@
-This directory contains the config and `deploy.sh` script for use of the Cloud
-Build BigQuery notifier. The high-level description of how this works (as I
-understand it), is the following:
+This directory contains files needed to use the Cloud Build BigQuery notifier.
+The high-level description of how this works (as I understand it) is the
+following:
 
 * We use Google Cloud Build (GCB) to run many of our builds. See
-  https://pantheon.corp.google.com/cloud-build/dashboard?project=cloud-cpp-testing-resources
+  https://console.cloud.google.com/cloud-build/dashboard?project=cloud-cpp-testing-resources
 * GCB sends build status notifications to the Pub/Sub
   `projects/cloud-cpp-testing-resources/topics/cloud-builds` topic. See
-  https://pantheon.corp.google.com/cloudpubsub/topic/detail/cloud-builds?project=cloud-cpp-testing-resources 
+  https://console.cloud.google.com/cloudpubsub/topic/detail/cloud-builds?project=cloud-cpp-testing-resources
 * We run the GCB BigQuery Notifier as a Cloud Run service, which subscribes to
   the build notifications and writes them to a BigQuery table.
 

--- a/ci/cloudbuild/notifiers/bigquery/README.md
+++ b/ci/cloudbuild/notifiers/bigquery/README.md
@@ -1,10 +1,18 @@
+# Configuration files for Cloud Build BigQuery notifier
+
+Sometimes we need to analyze our build results, looking for patterns of build
+latency, flakiness, etc. These analyses often require looking at the results
+over long periods of time, so the usual dashboards and squinting may not work.
+Putting the results in some sort of database works better for that purpose.
+The Cloud Build BigQuery notifier allows us to store build results in BigQuery.
+
 This directory contains files needed to use the Cloud Build BigQuery notifier.
 The high-level description of how this works (as I understand it) is the
 following:
 
 * We use Google Cloud Build (GCB) to run many of our builds. See
   https://console.cloud.google.com/cloud-build/dashboard?project=cloud-cpp-testing-resources
-* GCB sends build status notifications to the Pub/Sub
+* GCB sends build status notifications to the Cloud Pub/Sub
   `projects/cloud-cpp-testing-resources/topics/cloud-builds` topic. See
   https://console.cloud.google.com/cloudpubsub/topic/detail/cloud-builds?project=cloud-cpp-testing-resources
 * We run the GCB BigQuery Notifier as a Cloud Run service, which subscribes to

--- a/ci/cloudbuild/notifiers/bigquery/bigquery.yaml
+++ b/ci/cloudbuild/notifiers/bigquery/bigquery.yaml
@@ -4,6 +4,6 @@ metadata:
   name: google-cloud-cpp-bigquery-notifier
 spec:
   notification:
-    filter: has(build.build_trigger_id)
+    filter: build.substitutions["REPO_NAME"] == "google-cloud-cpp"
     delivery:
       table: projects/936212892354/datasets/cloudbuild/tables/google_cloud_cpp

--- a/ci/cloudbuild/notifiers/bigquery/deploy.sh
+++ b/ci/cloudbuild/notifiers/bigquery/deploy.sh
@@ -33,11 +33,11 @@ run_args=(
   "--image=us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers/bigquery:latest"
   "--no-allow-unauthenticated"
   "--update-env-vars=CONFIG_PATH=${BUCKET}/bigquery.yaml,PROJECT_ID=936212892354"
-  "--project cloud-cpp-testing-resources"
-  "--platform managed"
-  "--region us-central1"
+  "--project=cloud-cpp-testing-resources"
+  "--platform=managed"
+  "--region=us-central1"
 )
 gcloud run deploy "${SERVICE}" "${run_args[@]}"
 
-io::log_yellow "You can view the status at: " \
-  "https://pantheon.corp.google.com/run?project=cloud-cpp-testing-resources"
+io::log_yellow "You can view the status at:" \
+  "https://console.cloud.google.com/run?project=cloud-cpp-testing-resources"

--- a/ci/cloudbuild/notifiers/bigquery/deploy.sh
+++ b/ci/cloudbuild/notifiers/bigquery/deploy.sh
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# There are a few commmands that need to be run in order to deploy a change to
-# the bigquery.yaml file, and this script runs those commands.
+# There are a few commmands that need to be run in order to re-deploy a change
+# to the bigquery.yaml file, and this script runs those commands. These
+# commands are enough to RE-deploy the service, but there are about 10
+# additional commands needed to set up the service in the first place. See
+# https://cloud.google.com/build/docs/configuring-notifications/configure-bigquery
+# for more details about the first-time setup that's needed if we ever move
+# this to a new cloud project.
 
 set -euo pipefail
 
@@ -32,7 +37,7 @@ io::log_h1 "Deploying Cloud Run service ${SERVICE}"
 run_args=(
   "--image=us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers/bigquery:latest"
   "--no-allow-unauthenticated"
-  "--update-env-vars=CONFIG_PATH=${BUCKET}/bigquery.yaml,PROJECT_ID=936212892354"
+  "--update-env-vars=CONFIG_PATH=${BUCKET}/bigquery.yaml,PROJECT_ID=cloud-cpp-testing-resources"
   "--project=cloud-cpp-testing-resources"
   "--platform=managed"
   "--region=us-central1"

--- a/ci/cloudbuild/notifiers/bigquery/deploy.sh
+++ b/ci/cloudbuild/notifiers/bigquery/deploy.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# There are a few commmands that need to be run in order to deploy a change to
+# the bigquery.yaml file, and this script runs those commands.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../../lib/init.sh"
+source module ci/lib/io.sh
+cd "${PROGRAM_DIR}"
+
+readonly BUCKET="gs://cloud-cpp-testing-resources-configs/google-cloud-cpp"
+io::log_h1 "Copying bigquery.yaml to ${BUCKET}"
+gsutil cp bigquery.yaml gs://cloud-cpp-testing-resources-configs/google-cloud-cpp
+
+readonly SERVICE="google-cloud-cpp-gcb-bigquery-notifier"
+io::log_h1 "Deploying Cloud Run service ${SERVICE}"
+run_args=(
+  "--image=us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers/bigquery:latest"
+  "--no-allow-unauthenticated"
+  "--update-env-vars=CONFIG_PATH=${BUCKET}/bigquery.yaml,PROJECT_ID=936212892354"
+  "--project cloud-cpp-testing-resources"
+  "--platform managed"
+  "--region us-central1"
+)
+gcloud run deploy "${SERVICE}" "${run_args[@]}"
+
+io::log_yellow "You can view the status at: " \
+  "https://pantheon.corp.google.com/run?project=cloud-cpp-testing-resources"


### PR DESCRIPTION
This PR adds adds a GCB notifier that runs as a Cloud Run service, consumes GCB pub/sub notifications, and writes them to a BigQuery table.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6211)
<!-- Reviewable:end -->
