### PR TITLE
ci(gcb): tag builds as ci or pr

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -143,7 +143,7 @@ fi
 
 # If --distro wasn't specified, look it up from the build's trigger file.
 if [[ -z "${DISTRO}" ]]; then
-  trigger_file="ci/cloudbuild/triggers/${BUILD_NAME}.yaml"
+  trigger_file="ci/cloudbuild/triggers/${BUILD_NAME}-ci.yaml"
   DISTRO="$(grep _DISTRO "${trigger_file}" | awk '{print $2}' || true)"
   if [[ -z "${DISTRO}" ]]; then
     echo "Missing --distro=<arg>, and none found in ${trigger_file}"

--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -8,3 +8,5 @@ name: asan-ci
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: tsan
+name: asan-pr
 substitutions:
-  _BUILD_NAME: tsan
-  _DISTRO: ubuntu-bionic
+  _BUILD_NAME: asan
+  _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/checkers-ci.yaml
+++ b/ci/cloudbuild/triggers/checkers-ci.yaml
@@ -8,3 +8,5 @@ name: checkers-ci
 substitutions:
   _BUILD_NAME: checkers
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/checkers-pr.yaml
+++ b/ci/cloudbuild/triggers/checkers-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: clang-38
+name: checkers-pr
 substitutions:
-  _BUILD_NAME: clang-38
+  _BUILD_NAME: checkers
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/clang-38-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-38-ci.yaml
@@ -8,3 +8,5 @@ name: clang-38-ci
 substitutions:
   _BUILD_NAME: clang-38
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/clang-38-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-38-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: quickstart-cmake
+name: clang-38-pr
 substitutions:
-  _BUILD_NAME: quickstart-cmake
-  _DISTRO: ubuntu-bionic
+  _BUILD_NAME: clang-38
+  _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -8,3 +8,5 @@ name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -1,3 +1,4 @@
+disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -5,7 +6,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: asan
+name: clang-tidy-pr
 substitutions:
-  _BUILD_NAME: asan
+  _BUILD_NAME: clang-tidy
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/cmake-clang-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang-ci.yaml
@@ -8,3 +8,5 @@ name: cmake-clang-ci
 substitutions:
   _BUILD_NAME: cmake-clang
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/cmake-clang-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: checkers
+name: cmake-clang-pr
 substitutions:
-  _BUILD_NAME: checkers
+  _BUILD_NAME: cmake-clang
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
@@ -8,3 +8,5 @@ name: cmake-gcc-ci
 substitutions:
   _BUILD_NAME: cmake-gcc
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/cmake-gcc-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: cmake-clang
+name: cmake-gcc-pr
 substitutions:
-  _BUILD_NAME: cmake-clang
+  _BUILD_NAME: cmake-gcc
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -8,3 +8,5 @@ name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -1,4 +1,3 @@
-disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp
@@ -6,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: clang-tidy
+name: cmake-install-pr
 substitutions:
-  _BUILD_NAME: clang-tidy
+  _BUILD_NAME: cmake-install
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/cmake-super-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-super-ci.yaml
@@ -7,4 +7,6 @@ github:
 name: cmake-super-ci
 substitutions:
   _BUILD_NAME: cmake-super
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/cmake-super-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-super-ci.yaml
@@ -7,6 +7,6 @@ github:
 name: cmake-super-ci
 substitutions:
   _BUILD_NAME: cmake-super
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-super-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-super-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: cmake-super
+name: cmake-super-pr
 substitutions:
   _BUILD_NAME: cmake-super
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/cmake-super-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-super-pr.yaml
@@ -8,6 +8,6 @@ github:
 name: cmake-super-pr
 substitutions:
   _BUILD_NAME: cmake-super
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - pr

--- a/ci/cloudbuild/triggers/gcc-54-ci.yaml
+++ b/ci/cloudbuild/triggers/gcc-54-ci.yaml
@@ -8,3 +8,5 @@ name: gcc-54-ci
 substitutions:
   _BUILD_NAME: gcc-54
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/gcc-54-pr.yaml
+++ b/ci/cloudbuild/triggers/gcc-54-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: quickstart-bazel
+name: gcc-54-pr
 substitutions:
-  _BUILD_NAME: quickstart-bazel
-  _DISTRO: ubuntu-bionic
+  _BUILD_NAME: gcc-54
+  _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/integration-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-ci.yaml
@@ -8,3 +8,5 @@ name: integration-ci
 substitutions:
   _BUILD_NAME: integration
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/integration-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: integration
+name: integration-pr
 substitutions:
   _BUILD_NAME: integration
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
@@ -7,4 +7,6 @@ github:
 name: quickstart-bazel-ci
 substitutions:
   _BUILD_NAME: quickstart-bazel
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
@@ -7,6 +7,6 @@ github:
 name: quickstart-bazel-ci
 substitutions:
   _BUILD_NAME: quickstart-bazel
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
@@ -8,6 +8,6 @@ github:
 name: quickstart-bazel-pr
 substitutions:
   _BUILD_NAME: quickstart-bazel
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - pr

--- a/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: gcc-54
+name: quickstart-bazel-pr
 substitutions:
-  _BUILD_NAME: gcc-54
+  _BUILD_NAME: quickstart-bazel
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
@@ -7,6 +7,6 @@ github:
 name: quickstart-cmake-ci
 substitutions:
   _BUILD_NAME: quickstart-cmake
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
@@ -7,4 +7,6 @@ github:
 name: quickstart-cmake-ci
 substitutions:
   _BUILD_NAME: quickstart-cmake
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: cmake-install
+name: quickstart-cmake-pr
 substitutions:
-  _BUILD_NAME: cmake-install
+  _BUILD_NAME: quickstart-cmake
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
@@ -8,6 +8,6 @@ github:
 name: quickstart-cmake-pr
 substitutions:
   _BUILD_NAME: quickstart-cmake
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - pr

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -7,4 +7,6 @@ github:
 name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: ubuntu-bionic
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -7,6 +7,6 @@ github:
 name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -8,6 +8,6 @@ github:
 name: tsan-pr
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: fedora
+  _DISTRO: ubuntu-bionic
 tags:
 - pr

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: cmake-gcc
+name: tsan-pr
 substitutions:
-  _BUILD_NAME: cmake-gcc
+  _BUILD_NAME: tsan
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -8,3 +8,5 @@ name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: ubsan
+name: ubsan-pr
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -8,3 +8,5 @@ name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: xsan
+name: xsan-pr
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
+tags:
+- pr


### PR DESCRIPTION
These tags will make querying our builds easier. This also renames PR builds to include `-pr` in the name.

Fixes: #6182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6215)
<!-- Reviewable:end -->
