### PR TITLE
ci(gcb): set CLOUD_SDK_LOCATION in Dockerfile

### DIFF
--- a/ci/cloudbuild/builds/integration.sh
+++ b/ci/cloudbuild/builds/integration.sh
@@ -23,7 +23,6 @@ source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
-export CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
 readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
 
 mapfile -t args < <(bazel::common_args)

--- a/ci/cloudbuild/fedora.Dockerfile
+++ b/ci/cloudbuild/fedora.Dockerfile
@@ -137,7 +137,8 @@ COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 ENV CLOUDSDK_PYTHON=python3.8
 RUN /var/tmp/ci/install-cloud-sdk.sh
-ENV PATH=/usr/local/google-cloud-sdk/bin/:${PATH}
+ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
+ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
 # The Cloud Pub/Sub emulator needs Java, and so does `bazel coverage` :shrug:
 # Bazel needs the '-devel' version with javac.
 RUN dnf makecache && dnf install -y java-latest-openjdk-devel

--- a/ci/cloudbuild/ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/ubuntu-bionic.Dockerfile
@@ -63,7 +63,8 @@ RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
 COPY . /var/tmp/ci
 WORKDIR /var/tmp/downloads
 RUN /var/tmp/ci/install-cloud-sdk.sh
-ENV PATH=/usr/local/google-cloud-sdk/bin/:${PATH}
+ENV CLOUD_SDK_LOCATION=/usr/local/google-cloud-sdk
+ENV PATH=${CLOUD_SDK_LOCATION}/bin:${PATH}
 # The Cloud Pub/Sub emulator needs Java :shrug:
 RUN apt update && (apt install -y openjdk-11-jre || apt install -y openjdk-9-jre)
 


### PR DESCRIPTION
Some of our emulators expect this path to be set, and it makes sense to
set it in the Dockerfile where the cloud SDK is installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6219)
<!-- Reviewable:end -->
