### PR TITLE
ci(gcb): pass PROJECT_ID and BUILD_ID to build scripts

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -16,7 +16,13 @@ options:
   machineType: 'N1_HIGHCPU_32'
   diskSizeGb: '512'
   dynamic_substitutions: true
-  env: [ 'HOME=/h', 'TZ=UTC0', 'GOOGLE_CLOUD_BUILD=yes' ]
+  env: [
+    'HOME=/h',
+    'TZ=UTC0',
+    'GOOGLE_CLOUD_BUILD=yes',
+    'PROJECT_ID=${PROJECT_ID}',
+    'BUILD_ID=${BUILD_ID}'
+  ]
   volumes:
     - name: 'home'
       path: '/h'


### PR DESCRIPTION
I'll need the PROJECT_ID in an upcoming PR. I don't need BUILD_ID yet,
but it seemed useful to pass along too.

PROJECT_ID shadowed a variable in the build.sh script, so I renamed the
flag arguments in the build.sh script to have a `_FLAG` suffix. The
`build.sh` changes are purely renames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6222)
<!-- Reviewable:end -->
