### PR TITLE
fix(ci): gitignore pattern that was too broad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build-out/
 cmake-out/
 
 # Common bazel output directories
-bazel-*
+/bazel-*
 !bazel-*.cfg
 
 # Used by some IDEs and LSP plugins

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cmake-out/
 
 # Common bazel output directories
 /bazel-*
+/google/cloud/*/quickstart/bazel-*
 !bazel-*.cfg
 
 # Used by some IDEs and LSP plugins

--- a/ci/cloudbuild/triggers/bazel-clang-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-clang-ci.yaml
@@ -1,0 +1,10 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+name: bazel-clang-ci
+substitutions:
+  _BUILD_NAME: bazel-clang
+  _DISTRO: fedora

--- a/ci/cloudbuild/triggers/bazel-clang.yaml
+++ b/ci/cloudbuild/triggers/bazel-clang.yaml
@@ -1,0 +1,11 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: bazel-clang
+substitutions:
+  _BUILD_NAME: bazel-clang
+  _DISTRO: fedora

--- a/ci/cloudbuild/triggers/bazel-gcc-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcc-ci.yaml
@@ -1,0 +1,10 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^master$
+name: bazel-gcc-ci
+substitutions:
+  _BUILD_NAME: bazel-gcc
+  _DISTRO: fedora

--- a/ci/cloudbuild/triggers/bazel-gcc.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcc.yaml
@@ -1,0 +1,11 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: bazel-gcc
+substitutions:
+  _BUILD_NAME: bazel-gcc
+  _DISTRO: fedora


### PR DESCRIPTION
We were ignoring all `bazel-*` files, which included some trigger files
that I thought were checked in. The triggers are active and running, but
apparently they weren't in git.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6223)
<!-- Reviewable:end -->
