### PR TITLE
ci(gcb): add missing bazel trigger files

### DIFF
--- a/ci/cloudbuild/triggers/bazel-clang-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-clang-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: bazel-gcc
+name: bazel-clang-pr
 substitutions:
-  _BUILD_NAME: bazel-gcc
+  _BUILD_NAME: bazel-clang
   _DISTRO: fedora
+tags:
+- pr

--- a/ci/cloudbuild/triggers/bazel-gcc-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcc-pr.yaml
@@ -5,7 +5,9 @@ github:
   pullRequest:
     branch: ^master$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: bazel-clang
+name: bazel-gcc-pr
 substitutions:
-  _BUILD_NAME: bazel-clang
+  _BUILD_NAME: bazel-gcc
   _DISTRO: fedora
+tags:
+- pr


### PR DESCRIPTION
These triggers are currently active, but the trigger files weren't
committed to git due to an overly broad `.gitignore` file. That was
fixed in https://github.com/googleapis/google-cloud-cpp/pull/6223 and so
these files can be added now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6225)
<!-- Reviewable:end -->
