### PR TITLE
ci(gcb): run integration tests from sanitizer builds

### DIFF
--- a/ci/cloudbuild/builds/asan.sh
+++ b/ci/cloudbuild/builds/asan.sh
@@ -18,11 +18,14 @@ set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=asan")
-args+=("--test_tag_filters=-integration-test")
-bazel test "${args[@]}" ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::args)
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/integration.sh
+++ b/ci/cloudbuild/builds/integration.sh
@@ -18,99 +18,15 @@ set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
-source module ci/etc/integration-tests-config.sh
+source module ci/cloudbuild/builds/lib/integration.sh
 source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
-readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
 
 mapfile -t args < <(bazel::common_args)
 bazel test "${args[@]}" --test_tag_filters=-integration-test ...
 
-# Common configuration for all integration tests that follow.
-args+=(
-  "--test_timeout=600"
-  "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
-  "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
-  "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING"
-  "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc"
-  "--test_env=CLOUD_STORAGE_ENABLE_TRACING=raw-client"
-)
-
-io::log_h2 "Running Generator integration tests (with emulator)"
-env \
-  GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS=yes \
-  GOOGLE_CLOUD_CPP_GENERATOR_CODE_PATH=/workspace \
-  "./generator/ci/${EMULATOR_SCRIPT}" \
-  bazel test "${args[@]}"
-
-io::log_h2 "Running IAM Credentials integration tests"
-iam_args=(
-  "--test_tag_filters=integration-test"
-  "--test_env=GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT}"
-  "--test_env=GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT}"
-)
-echo bazel test "${args[@]}" "${iam_args[@]}" google/cloud/iam/...
-bazel test "${args[@]}" "${iam_args[@]}" google/cloud/iam/...
-
-io::log_h2 "Running Pub/Sub integration tests (with emulator)"
-"./google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
-  bazel test "${args[@]}"
-
-# TODO(#441) - remove the `retry-command.sh` below.
-# Sometimes the integration tests manage to crash the Bigtable emulator. Use a
-# (short) timeout to run the test and try 3 times.
-io::log_h2 "Running Bigtable integration tests (with emulator)"
-bigtable_args=(
-  "--test_timeout=100"
-  "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID}"
-  "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID}"
-  "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A}"
-  "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B}"
-  "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT}"
-  "--test_env=ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS=${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS:-no}"
-)
-env \
-  CBT=/usr/local/google-cloud-sdk/bin/cbt \
-  CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
-  GOPATH="${GOPATH:-}" \
-  ./ci/retry-command.sh 3 0 \
-  "./google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
-  bazel test "${args[@]}" "${bigtable_args[@]}"
-# TODO(#6083): Run //google/cloud/bigtable/examples:bigtable_grpc_credentials
-# separately w/ an access token.
-
-io::log_h2 "Running Storage integration tests (with emulator)"
-key_base="key-$(date +"%Y-%m")"
-readonly KEY_DIR="/dev/shm"
-readonly SECRETS_BUCKET="gs://cloud-cpp-testing-resources-secrets"
-gsutil cp "${SECRETS_BUCKET}/${key_base}.json" "${KEY_DIR}/${key_base}.json"
-gsutil cp "${SECRETS_BUCKET}/${key_base}.p12" "${KEY_DIR}/${key_base}.p12"
-storage_args=(
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=${GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG:-}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID=${GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY=${GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY}"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE=${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME=${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON=${KEY_DIR}/${key_base}.json"
-  "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12=${KEY_DIR}/${key_base}.p12"
-)
-"./google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
-  bazel test "${args[@]}" "${storage_args[@]}"
-
-io::log_h2 "Running Spanner integration tests"
-# TODO(#6083): Add support for:
-# - GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS
-# - GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT
-spanner_args=(
-  "--test_tag_filters=integration-test"
-  "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}"
-  "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT}"
-)
-bazel test "${args[@]}" "${spanner_args[@]}" google/cloud/spanner/...
+mapfile -t integration_args < <(integration::args)
+# TODO(#6181): Run this build against production, not emulators.
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines helper functions for running integration tests.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_INTEGRATION_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_INTEGRATION_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_INTEGRATION_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module ci/lib/io.sh
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/etc/integration-tests-config.sh
+source module ci/lib/io.sh
+
+# Outputs a list of Bazel arguments that should be used when running
+# integration tests. These do not include the common `bazel::common_args`.
+#
+# Example usage:
+#
+#   mapfile -t args < <(bazel::common_args)
+#   mapfile -t integration_args < <(integration::args)
+#   integration::bazel_with_emulators test "${args[@]}" "${integration_args}"
+#
+function integration::args() {
+  declare -a args
+  args+=(
+    # Common flags
+    "--test_timeout=600"
+    # "--test_tag_filters=integration-test"
+    "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
+    "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
+    "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG=lastN,100,WARNING"
+    "--test_env=GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc"
+    "--test_env=CLOUD_STORAGE_ENABLE_TRACING=raw-client"
+    "--test_env=HOME=${HOME}"
+
+    # IAM
+    "--test_env=GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_IAM_TEST_SERVICE_ACCOUNT}"
+    "--test_env=GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_IAM_INVALID_TEST_SERVICE_ACCOUNT}"
+
+    # Bigtable
+    "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID}"
+    "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID}"
+    "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A}"
+    "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B}"
+    "--test_env=GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT}"
+    "--test_env=ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS=${ENABLE_BIGTABLE_ADMIN_INTEGRATION_TESTS:-no}"
+
+    # Storage
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=${GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG:-}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID=${GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY=${GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE=${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME=${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
+    # Spanner
+    "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}"
+    "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT}"
+  )
+
+  # Adds some special GCS flags that rely on keys that we copy out of a GCS bucket
+  key_base="key-$(date +"%Y-%m")"
+  readonly KEY_DIR="/dev/shm"
+  readonly SECRETS_BUCKET="gs://cloud-cpp-testing-resources-secrets"
+  gsutil cp "${SECRETS_BUCKET}/${key_base}.json" "${KEY_DIR}/${key_base}.json"
+  gsutil cp "${SECRETS_BUCKET}/${key_base}.p12" "${KEY_DIR}/${key_base}.p12"
+  args+=(
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_JSON=${KEY_DIR}/${key_base}.json"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_KEY_FILE_P12=${KEY_DIR}/${key_base}.p12"
+  )
+  printf "%s\n" "${args[@]}"
+}
+
+# Runs integration tests with bazel using emulators when possible. This
+# function requires a first argument that is the bazel verb to do, valid verbs
+# are "test" and "coverage". Additional arguments are assumed to be bazel args.
+# Almost certainly the caller should pass the arguments returned from the
+# `integration::args` function defined above.
+#
+# Example usage:
+#
+#   mapfile -t args < <(bazel::common_args)
+#   mapfile -t integration_args < <(integration::args)
+#   integration::bazel_with_emulators test "${args[@]}" "${integration_args}"
+#
+function integration::bazel_with_emulators() {
+  readonly EMULATOR_SCRIPT="run_integration_tests_emulator_bazel.sh"
+  if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
+    io::log_h2 "Skipping integration tests," \
+      "which must run in GCB project 'cloud-cpp-testing-resources'"
+    return 0
+  fi
+
+  if [[ $# == 0 ]]; then
+    io::log_red "error: bazel verb required"
+    return 1
+  fi
+
+  local verb="$1"
+  local args=("${@:2}")
+
+  io::log_h2 "Running Generator integration tests (with emulator)"
+  env \
+    GOOGLE_CLOUD_CPP_GENERATOR_RUN_INTEGRATION_TESTS=yes \
+    GOOGLE_CLOUD_CPP_GENERATOR_CODE_PATH=/workspace \
+    "./generator/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+
+  io::log_h2 "Running IAM Credentials integration tests"
+  bazel "${verb}" "${args[@]}" --test_tag_filters=integration-test \
+    google/cloud/iam/...
+
+  io::log_h2 "Running Pub/Sub integration tests (with emulator)"
+  "./google/cloud/pubsub/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+
+  # We retry these tests because the emulator crashes due to #441.
+  io::log_h2 "Running Bigtable integration tests (with emulator)"
+  env \
+    CBT=/usr/local/google-cloud-sdk/bin/cbt \
+    CBT_EMULATOR=/usr/local/google-cloud-sdk/platform/bigtable-emulator/cbtemulator \
+    GOPATH="${GOPATH:-}" \
+    ./ci/retry-command.sh 3 0 \
+    "./google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+  # TODO(#6083): Run //google/cloud/bigtable/examples:bigtable_grpc_credentials
+  # separately w/ an access token.
+
+  io::log_h2 "Running Storage integration tests (with emulator)"
+  "./google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
+    bazel "${verb}" "${args[@]}"
+
+  # TODO(#6083): Add support for:
+  # - GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS
+  # - GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT
+  io::log_h2 "Running Spanner integration tests"
+  bazel "${verb}" "${args[@]}" --test_tag_filters=integration-test \
+    google/cloud/spanner/...
+}

--- a/ci/cloudbuild/builds/tsan.sh
+++ b/ci/cloudbuild/builds/tsan.sh
@@ -18,6 +18,7 @@ set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
 
 # Compile with the ThreadSanitizer enabled.
 # We need to use clang-9 for the TSAN build because:
@@ -29,5 +30,7 @@ export CXX=clang++-9
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=tsan")
-args+=("--test_tag_filters=-integration-test")
-bazel test "${args[@]}" ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::args)
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/ubsan.sh
+++ b/ci/cloudbuild/builds/ubsan.sh
@@ -18,11 +18,14 @@ set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=ubsan")
-args+=("--test_tag_filters=-integration-test")
-bazel test "${args[@]}" ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::args)
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/xsan.sh
+++ b/ci/cloudbuild/builds/xsan.sh
@@ -18,11 +18,14 @@ set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
 
 export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
 args+=("--config=xsan")
-args+=("--test_tag_filters=-integration-test")
-bazel test "${args[@]}" ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::args)
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"


### PR DESCRIPTION
Fixes #6179
Part of #6181

The basic idea of this PR is that the `builds/integration.sh` script was refactored into a `builds/lib/integration.sh` library, and the `args` and the `bazel_with_emulators` functionality was split into two functions. This will allow us to run the integration tests with emulators and against prod (in a future PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6227)
<!-- Reviewable:end -->
