### PR TITLE
ci(gcb): use ctcache to speed up clang-tidy builds

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -19,6 +19,16 @@ set -eu
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 
-cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=clang-tidy -S . -B cmake-out
+export CC=clang
+export CXX=clang++
+export CTCACHE_DIR=~/.cache/ctcache
+
+# See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
+cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper -S . -B cmake-out
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test"
+
+io::log_h2 "clang-tidy cache"
+printf "%s: %s\n" "total size" "$(du -sh "${CTCACHE_DIR}")"
+printf "%s: %s\n" " num files" "$(find "${CTCACHE_DIR}" | wc -l)"
+echo

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -79,6 +79,7 @@ steps:
     '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
     '--path=.ccache',
     '--path=.cache/ccache',
+    '--path=.cache/ctcache',
     '--path=.cache/vcpkg',
     '--path=.cache/google-cloud-cpp'
   ]

--- a/ci/cloudbuild/fedora.Dockerfile
+++ b/ci/cloudbuild/fedora.Dockerfile
@@ -131,6 +131,14 @@ RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
     ldconfig && \
     cd /var/tmp && rm -fr build
 
+# Install ctcache to speed up our clang-tidy build
+WORKDIR /var/tmp/build
+RUN curl -sSL https://github.com/matus-chochlik/ctcache/archive/0ad2e227e8a981a9c1a6060ee6c8ec144bb976c6.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cp clang-tidy /usr/local/bin/clang-tidy-wrapper && \
+    cp clang-tidy-cache /usr/local/bin/clang-tidy-cache && \
+    cd /var/tmp && rm -fr build
+
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.
 COPY . /var/tmp/ci

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -1,4 +1,3 @@
-disabled: true
 filename: ci/cloudbuild/cloudbuild.yaml
 github:
   name: google-cloud-cpp


### PR DESCRIPTION
Fixes #6170

This PR starts using https://github.com/matus-chochlik/ctcache, which is
a clang-tidy cache, to speed up our clang-tidy builds. This PR also
re-enables clang-tidy for PR builds because they should be fast enough
now.

In my experiments using ctcache vs using no clang-tidy cache, I see
builds taking ~7% *longer* on clean full builds. This makes sense as the
cache needs to compute hashes, check for cache hits, etc. But on builds
with a populated `~/.cache/ctcache` I see builds completing ~50%
*faster*. I think these stats look good, and I think this is worth
trying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6228)
<!-- Reviewable:end -->
