### PR TITLE
ci(gcb): add useful tags to all builds

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -35,7 +35,9 @@ substitutions:
   _CACHE_BUCKET: '${PROJECT_ID}_cloudbuild'
   _CACHE_TYPE: '${_PR_NUMBER:-main}'
   _IMAGE: 'cloudbuild/${_DISTRO}'
+  _TRIGGER_TYPE: 'manual'
 
+tags: [ '${_TRIGGER_TYPE}', '${_BUILD_NAME}', '${_DISTRO}' ]
 timeout: 3600s
 
 steps:

--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -8,5 +8,6 @@ name: asan-ci
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -9,5 +9,6 @@ name: asan-pr
 substitutions:
   _BUILD_NAME: asan
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/bazel-clang-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-clang-ci.yaml
@@ -8,3 +8,6 @@ name: bazel-clang-ci
 substitutions:
   _BUILD_NAME: bazel-clang
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/bazel-clang-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-clang-pr.yaml
@@ -9,5 +9,6 @@ name: bazel-clang-pr
 substitutions:
   _BUILD_NAME: bazel-clang
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/bazel-gcc-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcc-ci.yaml
@@ -8,3 +8,6 @@ name: bazel-gcc-ci
 substitutions:
   _BUILD_NAME: bazel-gcc
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/bazel-gcc-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcc-pr.yaml
@@ -9,5 +9,6 @@ name: bazel-gcc-pr
 substitutions:
   _BUILD_NAME: bazel-gcc
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/checkers-ci.yaml
+++ b/ci/cloudbuild/triggers/checkers-ci.yaml
@@ -8,5 +8,6 @@ name: checkers-ci
 substitutions:
   _BUILD_NAME: checkers
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/checkers-pr.yaml
+++ b/ci/cloudbuild/triggers/checkers-pr.yaml
@@ -9,5 +9,6 @@ name: checkers-pr
 substitutions:
   _BUILD_NAME: checkers
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/clang-38-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-38-ci.yaml
@@ -8,5 +8,6 @@ name: clang-38-ci
 substitutions:
   _BUILD_NAME: clang-38
   _DISTRO: ubuntu-xenial
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/clang-38-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-38-pr.yaml
@@ -9,5 +9,6 @@ name: clang-38-pr
 substitutions:
   _BUILD_NAME: clang-38
   _DISTRO: ubuntu-xenial
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -8,5 +8,6 @@ name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -9,5 +9,6 @@ name: clang-tidy-pr
 substitutions:
   _BUILD_NAME: clang-tidy
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-clang-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang-ci.yaml
@@ -8,5 +8,6 @@ name: cmake-clang-ci
 substitutions:
   _BUILD_NAME: cmake-clang
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-clang-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-clang-pr.yaml
@@ -9,5 +9,6 @@ name: cmake-clang-pr
 substitutions:
   _BUILD_NAME: cmake-clang
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc-ci.yaml
@@ -8,5 +8,6 @@ name: cmake-gcc-ci
 substitutions:
   _BUILD_NAME: cmake-gcc
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-gcc-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcc-pr.yaml
@@ -9,5 +9,6 @@ name: cmake-gcc-pr
 substitutions:
   _BUILD_NAME: cmake-gcc
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -8,5 +8,6 @@ name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -9,5 +9,6 @@ name: cmake-install-pr
 substitutions:
   _BUILD_NAME: cmake-install
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cmake-super-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-super-ci.yaml
@@ -8,5 +8,6 @@ name: cmake-super-ci
 substitutions:
   _BUILD_NAME: cmake-super
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-super-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-super-pr.yaml
@@ -9,5 +9,6 @@ name: cmake-super-pr
 substitutions:
   _BUILD_NAME: cmake-super
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/gcc-54-ci.yaml
+++ b/ci/cloudbuild/triggers/gcc-54-ci.yaml
@@ -8,5 +8,6 @@ name: gcc-54-ci
 substitutions:
   _BUILD_NAME: gcc-54
   _DISTRO: ubuntu-xenial
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/gcc-54-pr.yaml
+++ b/ci/cloudbuild/triggers/gcc-54-pr.yaml
@@ -9,5 +9,6 @@ name: gcc-54-pr
 substitutions:
   _BUILD_NAME: gcc-54
   _DISTRO: ubuntu-xenial
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/integration-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-ci.yaml
@@ -8,5 +8,6 @@ name: integration-ci
 substitutions:
   _BUILD_NAME: integration
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/integration-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-pr.yaml
@@ -9,5 +9,6 @@ name: integration-pr
 substitutions:
   _BUILD_NAME: integration
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
@@ -8,5 +8,6 @@ name: quickstart-bazel-ci
 substitutions:
   _BUILD_NAME: quickstart-bazel
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
@@ -9,5 +9,6 @@ name: quickstart-bazel-pr
 substitutions:
   _BUILD_NAME: quickstart-bazel
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
@@ -8,5 +8,6 @@ name: quickstart-cmake-ci
 substitutions:
   _BUILD_NAME: quickstart-cmake
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
@@ -9,5 +9,6 @@ name: quickstart-cmake-pr
 substitutions:
   _BUILD_NAME: quickstart-cmake
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -8,5 +8,6 @@ name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -9,5 +9,6 @@ name: tsan-pr
 substitutions:
   _BUILD_NAME: tsan
   _DISTRO: ubuntu-bionic
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -8,5 +8,6 @@ name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -9,5 +9,6 @@ name: ubsan-pr
 substitutions:
   _BUILD_NAME: ubsan
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -8,5 +8,6 @@ name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -9,5 +9,6 @@ name: xsan-pr
 substitutions:
   _BUILD_NAME: xsan
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
This will let us filter on builds based on whether they're CI, PR, or
manually triggered builds. I'm also tagged based on distro and build
name, which may be useful too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6229)
<!-- Reviewable:end -->
