### PR TITLE
ci(gcb): build quickstarts during install test

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -18,6 +18,8 @@ set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/etc/quickstart-config.sh
+source module ci/lib/io.sh
 
 export CC=clang
 export CXX=clang++
@@ -140,5 +142,29 @@ while IFS= read -r -d '' f; do
     exit_code=1
   fi
 done < <(find "${INSTALL_PREFIX}" -type f -print0)
+
+# Verify that our installed artifacts are usable by compiling our quickstart
+# binaries against our installed artifacts.
+for lib in $(quickstart::libraries); do
+  mapfile -t run_args < <(quickstart::arguments "${lib}")
+  io::log_h2 "Building quickstart: ${lib}"
+  if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
+    run_args=() # Empties these args so we don't execute quickstarts below
+    io::log_yellow "Not executing quickstarts," \
+      "which can only run in GCB project 'cloud-cpp-testing-resources'"
+  fi
+
+  io::log "[ CMake ]"
+  src_dir="${PROJECT_ROOT}/google/cloud/${lib}/quickstart"
+  bin_dir="${PROJECT_ROOT}/cmake-out/quickstart-${lib}"
+  cmake -H"${src_dir}" -B"${bin_dir}" "-DCMAKE_PREFIX_PATH=${INSTALL_PREFIX}"
+  cmake --build "${bin_dir}"
+  test "${#run_args[@]}" -ne 0 && "${bin_dir}/quickstart" "${run_args[@]}"
+
+  echo
+  io::log "[ Make ]"
+  make -C "${src_dir}"
+  test "${#run_args[@]}" -ne 0 && "${src_dir}/quickstart" "${run_args[@]}"
+done
 
 exit "${exit_code}"

--- a/ci/cloudbuild/fedora.Dockerfile
+++ b/ci/cloudbuild/fedora.Dockerfile
@@ -153,3 +153,7 @@ RUN dnf makecache && dnf install -y java-latest-openjdk-devel
 
 # Install Bazel because some of the builds need it.
 RUN /var/tmp/ci/install-bazel.sh
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*


### PR DESCRIPTION
In order to verify that our installed artifacts work, this PR compiles
our quickstarts against our installed artifacts.

Part of #6163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6233)
<!-- Reviewable:end -->
