### PR TITLE
ci!: generator/ is no longer built by default in CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@
 
 ## v1.27.0 - TBD
 
+### Misc.
+
+**BREAKING CHANGES**:
+* In #6243 we stopped compiling the code in `generator/` by default in CMake
+  builds. In most cases this should just be a performance win as this code is
+  not used by client libraries. However, if anyone was relying on the
+  `generator/` being compiled, it can be re-enabled with
+  `-DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=ON`
+
 ## v1.26.0 - 2021-04
 
 ### BigQuery

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,13 +159,13 @@ option(GOOGLE_CLOUD_CPP_ENABLE_PUBSUB "Enable building the Pub/Sub library." ON)
 option(GOOGLE_CLOUD_CPP_ENABLE_IAM "Enable building the IAM library." ON)
 option(GOOGLE_CLOUD_CPP_ENABLE_LOGGING "Enable building the Logging library."
        ON)
-option(GOOGLE_CLOUD_CPP_ENABLE_GENERATOR "Enable building the generator." ON)
+option(GOOGLE_CLOUD_CPP_ENABLE_GENERATOR "Enable building the generator." OFF)
 
 # The default list of libraries to build. These can be overridden by the user by
 # passing a comma-separated list, i.e
 # `-DGOOGLE_CLOUD_CPP_ENABLE=spanner,storage`.
 set(GOOGLE_CLOUD_CPP_ENABLE
-    "bigtable;bigquery;iam;firestore;logging;pubsub;spanner;storage;generator"
+    "bigtable;bigquery;iam;firestore;logging;pubsub;spanner;storage"
     CACHE STRING "The list of libraries to build.")
 
 string(REPLACE "," ";" GOOGLE_CLOUD_CPP_ENABLE "${GOOGLE_CLOUD_CPP_ENABLE}")

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -24,7 +24,9 @@ export CXX=clang++
 export CTCACHE_DIR=~/.cache/ctcache
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
-cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper -S . -B cmake-out
+cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
+  -DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=ON \
+  -S . -B cmake-out
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test"
 

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -86,6 +86,7 @@ if [[ "${BUILD_TESTING:-}" == "no" ]]; then
 fi
 
 if [[ "${CLANG_TIDY:-}" == "yes" ]]; then
+  cmake_extra_flags+=("-DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=ON")
   cmake_extra_flags+=("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
   # On pre-submit builds we run clang-tidy on only the changed files (see below)
   # in other cases (interactive builds, continuous builds) we run clang-tidy as

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -125,7 +125,7 @@ RUN mkdir -p /h/.ccache; \
     fi; \
     true # Ignore all errors, failures in caching should not break the build
 ## [END IGNORED]
-RUN cmake -DBUILD_TESTING=OFF -DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=OFF -H. -Bcmake-out
+RUN cmake -DBUILD_TESTING=OFF -H. -Bcmake-out
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
 RUN cmake --build cmake-out --target install
 # ```

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -1034,7 +1034,7 @@ We can now compile, test, and install `google-cloud-cpp`.
 
 ```bash
 cd $HOME/google-cloud-cpp
-cmake -DBUILD_TESTING=OFF -DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=OFF -H. -Bcmake-out
+cmake -DBUILD_TESTING=OFF -H. -Bcmake-out
 cmake --build cmake-out -- -j "${NCPU:-4}"
 sudo cmake --build cmake-out --target install
 ```


### PR DESCRIPTION
Our `generator/` code is an implementation that our users will rarely,
if ever, need to build or use directly. So it seems it would be better
to not compile it by default in our CMake builds. This PR changes the
generator to not be build by default in CMake builds.

It also explicitly enables the generator in our clang-tidy builds
(kokoro and GCB) so that the generator is checked. All the sanitizer
builds use bazel so they will be unaffected.

This is technically a breaking change, but it's very unlikely to affect
anyone in practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6243)
<!-- Reviewable:end -->
