### PR TITLE
fix(gcb): ldconfig /usr/local/lib after installing stuff

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -192,3 +192,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
@@ -152,3 +152,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -102,3 +102,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
@@ -183,3 +183,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -108,3 +108,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -167,3 +167,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -157,3 +157,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -140,3 +140,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
@@ -176,3 +176,7 @@ RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
 # ```
 
 ## [END packaging.md]
+
+# Some of the above libraries may have installed in /usr/local, so make sure
+# those library directories will be found.
+RUN ldconfig /usr/local/lib*


### PR DESCRIPTION
Fixes: #6247

`ldconfig` doesn't always add stuff in `/usr/local/lib` directories, so
in Dockerfiles when we install a bunch of stuff that might land in
`/usr/local`, we should be sure to run ldconfig on /usr/local before we
attempt to use those things (or expect pkg-config to find them).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6248)
<!-- Reviewable:end -->
