### PR TITLE
ci(gcb): add shared library build

### DIFF
--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This build script serves two main purposes:
+#
+# 1. It demonstrates to users how to install `google-cloud-cpp`. We will
+#    extract part of this script into user-facing markdown documentation.
+# 2. It verifies that the installed artifacts work by compiling and running the
+#    quickstart programs against the installed artifacts.
+
+# Make our include guard clean against set -o nounset.
+test -n "${CI_CLOUDBUILD_BUILDS_LIB_QUICKSTART_SH__:-}" || declare -i CI_CLOUDBUILD_BUILDS_LIB_QUICKSTART_SH__=0
+if ((CI_CLOUDBUILD_BUILDS_LIB_QUICKSTART_SH__++ != 0)); then
+  return 0
+fi # include guard
+
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/etc/quickstart-config.sh
+source module ci/lib/io.sh
+
+# Builds and runs the CMake and Makefile quickstart programs. This is a useful
+# way to test that the artifacts installed by `google-cloud-cpp` work. This
+# function requires a single argument specifying the directory where the
+# `google-cloud-cpp` library was installed.
+#
+# Example:
+#   
+#   quickstart::run_cmake_and_make "/usr/local"
+function quickstart::run_cmake_and_make() {
+  local prefix="$1"
+  for lib in $(quickstart::libraries); do
+    mapfile -t run_args < <(quickstart::arguments "${lib}")
+    io::log_h2 "Building quickstart: ${lib}"
+    if [[ "${PROJECT_ID:-}" != "cloud-cpp-testing-resources" ]]; then
+      run_args=() # Empties these args so we don't execute quickstarts below
+      io::log_yellow "Not executing quickstarts," \
+        "which can only run in GCB project 'cloud-cpp-testing-resources'"
+    fi
+
+    io::log "[ CMake ]"
+    src_dir="${PROJECT_ROOT}/google/cloud/${lib}/quickstart"
+    bin_dir="${PROJECT_ROOT}/cmake-out/quickstart-${lib}"
+    cmake -H"${src_dir}" -B"${bin_dir}" "-DCMAKE_PREFIX_PATH=${prefix}"
+    cmake --build "${bin_dir}"
+    test "${#run_args[@]}" -eq 0 || "${bin_dir}/quickstart" "${run_args[@]}"
+
+    echo
+    io::log "[ Make ]"
+    PKG_CONFIG_PATH="${prefix}/lib64/pkgconfig:${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
+      make -C "${src_dir}"
+    test "${#run_args[@]}" -eq 0 || "${src_dir}/quickstart" "${run_args[@]}"
+  done
+}

--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -37,7 +37,7 @@ source module ci/lib/io.sh
 # `google-cloud-cpp` library was installed.
 #
 # Example:
-#   
+#
 #   quickstart::run_cmake_and_make "/usr/local"
 function quickstart::run_cmake_and_make() {
   local prefix="$1"

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -13,30 +13,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# This build script serves two main purposes:
-#
-# 1. It demonstrates to users how to install `google-cloud-cpp`. We will
-#    extract part of this script into user-facing markdown documentation.
-# 2. It verifies that the installed artifacts work by compiling and running the
-#    quickstart programs against the installed artifacts.
 
 set -eu
 
 source "$(dirname "$0")/../../lib/init.sh"
 source module ci/cloudbuild/builds/lib/cmake.sh
 source module ci/cloudbuild/builds/lib/quickstart.sh
-source module ci/lib/io.sh
 
-## [START packaging.md]
+export CC=gcc
+export CXX=g++
 
-# Pick a location to install the artifacts, e.g., `/usr/local` or `/opt`
-PREFIX="${HOME}/google-cloud-cpp-installed"
-cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX="${PREFIX}" -H. -Bcmake-out
-cmake --build cmake-out -- -j "$(nproc)"
+INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
+cmake -GNinja \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -S . -B cmake-out
+cmake --build cmake-out
+env -C cmake-out ctest -LE "integration-test"
 cmake --build cmake-out --target install
 
-## [END packaging.md]
-
 # Tests the installed artifacts by building and running the quickstarts.
-quickstart::run_cmake_and_make "${PREFIX}"
+quickstart::run_cmake_and_make "${INSTALL_PREFIX}"

--- a/ci/cloudbuild/triggers/shared-ci.yaml
+++ b/ci/cloudbuild/triggers/shared-ci.yaml
@@ -1,0 +1,12 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: shared-ci
+substitutions:
+  _BUILD_NAME: shared
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/shared-pr.yaml
+++ b/ci/cloudbuild/triggers/shared-pr.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: shared-pr
+substitutions:
+  _BUILD_NAME: shared
+  _DISTRO: fedora
+tags:
+- pr

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -596,7 +596,8 @@ target_link_libraries(
     PUBLIC google-cloud-cpp::api_annotations_protos
            google-cloud-cpp::api_client_protos
            google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_resource_protos)
+           google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::rpc_status_protos)
 
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_spanner_protos


### PR DESCRIPTION
Also fixed an issue where the pubsub protos were missing a needed dep.

This PR refactors the logic to run the CMake and Makefile quickstart
builds into a library, because it turns out that this is a useful way to
verify that our installed artifacts work, and we end up calling this
from a few places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6257)
<!-- Reviewable:end -->
