### PR TITLE
cleanup(storage): deprecate overly permissive functions

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -51,7 +51,9 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   options.minimum_write_size = 1 * kMiB;
   options.enabled_apis = {GetParam()};
 
-  auto const& client_options = client->raw_client()->client_options();
+  auto const& client_options =
+      google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
+          ->client_options();
   auto experiments =
       CreateUploadExperiments(options, client_options, /*thread_id=*/0);
   for (auto& e : experiments) {
@@ -81,7 +83,9 @@ TEST_P(ThroughputExperimentIntegrationTest, Download) {
   options.minimum_write_size = 1 * kMiB;
   options.enabled_apis = {GetParam()};
 
-  auto const& client_options = client->raw_client()->client_options();
+  auto const& client_options =
+      google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
+          ->client_options();
   auto experiments =
       CreateDownloadExperiments(options, client_options, /*thread_id=*/0);
   for (auto& e : experiments) {

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -98,7 +98,7 @@ bool Client::UseSimpleUpload(std::string const& file_name,
     return false;
   }
   auto const fs = google::cloud::internal::file_size(file_name);
-  if (fs <= raw_client()->client_options().maximum_simple_upload_size()) {
+  if (fs <= raw_client_->client_options().maximum_simple_upload_size()) {
     size = static_cast<std::size_t>(fs);
     return true;
   }
@@ -198,7 +198,7 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
 StatusOr<ObjectMetadata> Client::UploadStreamResumable(
     std::istream& source, internal::ResumableUploadRequest const& request) {
   StatusOr<std::unique_ptr<internal::ResumableUploadSession>> session_status =
-      raw_client()->CreateResumableSession(request);
+      raw_client_->CreateResumableSession(request);
   if (!session_status) {
     return std::move(session_status).status();
   }
@@ -220,7 +220,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
 
   // GCS requires chunks to be a multiple of 256KiB.
   auto chunk_size = internal::UploadChunkRequest::RoundUpToQuantum(
-      raw_client()->client_options().upload_buffer_size());
+      raw_client_->client_options().upload_buffer_size());
 
   StatusOr<internal::ResumableUploadResponse> upload_response(
       internal::ResumableUploadResponse{});
@@ -320,12 +320,12 @@ std::string Client::SigningEmail(SigningAccount const& signing_account) {
   if (signing_account.has_value()) {
     return signing_account.value();
   }
-  return raw_client()->client_options().credentials()->AccountEmail();
+  return raw_client_->client_options().credentials()->AccountEmail();
 }
 
 StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
     SigningAccount const& signing_account, std::string const& string_to_sign) {
-  auto credentials = raw_client()->client_options().credentials();
+  auto credentials = raw_client_->client_options().credentials();
 
   std::string signing_account_email = SigningEmail(signing_account);
   // First try to sign locally.
@@ -339,7 +339,7 @@ StatusOr<Client::SignBlobResponseRaw> Client::SignBlobImpl(
   // credentials account. In either case, try to sign using the API.
   internal::SignBlobRequest sign_request(
       signing_account_email, internal::Base64Encode(string_to_sign), {});
-  auto response = raw_client()->SignBlob(sign_request);
+  auto response = raw_client_->SignBlob(sign_request);
   if (!response) {
     return response.status();
   }

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -45,13 +45,11 @@
 namespace google {
 namespace cloud {
 namespace storage {
-namespace testing {
-class ClientTester;
-}  // namespace testing
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 class NonResumableParallelUploadState;
 class ResumableParallelUploadState;
+struct ClientImplDetails;
 }  // namespace internal
 /**
  * The Google Cloud Storage (GCS) Client.
@@ -66,7 +64,7 @@ class ResumableParallelUploadState;
  * comparable to copying a few shared pointers. The first request (or any
  * request that requires a new connection) incurs the cost of creating the
  * connection and authenticating with the service. Note that the library may
- * need to perform other bookeeping operations that may impact performance.
+ * need to perform other book keeping operations that may impact performance.
  * For example, access tokens need to be refreshed from time to time, and this
  * may impact the performance of some operations.
  *
@@ -227,7 +225,7 @@ class Client {
    */
   template <typename... Policies>
   explicit Client(ClientOptions options, Policies&&... policies)
-      : Client(CreateDefaultInternalClient(std::move(options)),
+      : Client(InternalOnly{}, CreateDefaultInternalClient(std::move(options)),
                std::forward<Policies>(policies)...) {}
 
   /**
@@ -251,25 +249,45 @@ class Client {
       : Client(ClientOptions(std::move(credentials)),
                std::forward<Policies>(policies)...) {}
 
+  /// Create a Client using ClientOptions::CreateDefaultClientOptions().
+  static StatusOr<Client> CreateDefaultClient();
+
   /// Builds a client and maybe override the retry, idempotency, and/or backoff
   /// policies.
+  /// @deprecated This was intended only for test code, applications should not
+  /// use it.
   template <typename... Policies>
+  GOOGLE_CLOUD_CPP_DEPRECATED(
+      "applications should not need this."
+      " Please use the constructors from ClientOptions instead."
+      " For mocking, please use testing::ClientFromMock() instead."
+      " Please file a bug at https://github.com/googleapis/google-cloud-cpp"
+      " if you have a use-case not covered by these.")
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit Client(std::shared_ptr<internal::RawClient> client,
                   Policies&&... policies)
-      : raw_client_(
-            Decorate(std::move(client), std::forward<Policies>(policies)...)) {}
+      : Client(InternalOnly{}, std::move(client),
+               std::forward<Policies>(policies)...) {}
 
   /// Define a tag to disable automatic decorations of the RawClient.
   struct NoDecorations {};
 
   /// Builds a client with a specific RawClient, without decorations.
+  /// @deprecated This was intended only for test code, applications should not
+  /// use it.
+  GOOGLE_CLOUD_CPP_DEPRECATED(
+      "applications should not need this."
+      " Please file a bug at https://github.com/googleapis/google-cloud-cpp"
+      " if you do.")
   explicit Client(std::shared_ptr<internal::RawClient> client, NoDecorations)
-      : raw_client_(std::move(client)) {}
-
-  /// Create a Client using ClientOptions::CreateDefaultClientOptions().
-  static StatusOr<Client> CreateDefaultClient();
+      : Client(InternalOnlyNoDecorations{}, std::move(client)) {}
 
   /// Access the underlying `RawClient`.
+  /// @deprecated Only intended for implementors, do not use.
+  GOOGLE_CLOUD_CPP_DEPRECATED(
+      "applications should not need this."
+      " Please file a bug at https://github.com/googleapis/google-cloud-cpp"
+      " if you do.")
   std::shared_ptr<internal::RawClient> raw_client() const {
     return raw_client_;
   }
@@ -3103,7 +3121,17 @@ class Client {
   //@}
 
  private:
+  friend internal::ClientImplDetails;
+
   Client() = default;
+  struct InternalOnly {};
+  struct InternalOnlyNoDecorations {};
+
+  template <typename... Policies>
+  Client(InternalOnly, std::shared_ptr<internal::RawClient> c, Policies&&... p)
+      : raw_client_(Decorate(std::move(c), std::forward<Policies>(p)...)) {}
+  Client(InternalOnlyNoDecorations, std::shared_ptr<internal::RawClient> c)
+      : raw_client_(std::move(c)) {}
   static std::shared_ptr<internal::RawClient> CreateDefaultInternalClient(
       ClientOptions options);
 
@@ -3199,7 +3227,6 @@ class Client {
 
   friend class internal::NonResumableParallelUploadState;
   friend class internal::ResumableParallelUploadState;
-  friend class testing::ClientTester;
 };
 
 /**
@@ -3221,6 +3248,26 @@ class Client {
 std::string CreateRandomPrefixName(std::string const& prefix = "");
 
 namespace internal {
+struct ClientImplDetails {
+  static std::shared_ptr<RawClient> GetRawClient(Client& c) {
+    return c.raw_client_;
+  }
+  static StatusOr<ObjectMetadata> UploadStreamResumable(
+      Client& client, std::istream& source,
+      internal::ResumableUploadRequest const& request) {
+    return client.UploadStreamResumable(source, request);
+  }
+  template <typename... Policies>
+  static Client CreateClient(std::shared_ptr<internal::RawClient> c,
+                             Policies&&... p) {
+    return Client(Client::InternalOnly{}, std::move(c),
+                  std::forward<Policies>(p)...);
+  }
+  static Client CreateWithoutDecorations(
+      std::shared_ptr<internal::RawClient> c) {
+    return Client(Client::InternalOnlyNoDecorations{}, std::move(c));
+  }
+};
 
 // Just a wrapper to allow for using in `google::cloud::internal::apply`.
 struct DeleteApplyHelper {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -64,7 +64,7 @@ struct ClientImplDetails;
  * comparable to copying a few shared pointers. The first request (or any
  * request that requires a new connection) incurs the cost of creating the
  * connection and authenticating with the service. Note that the library may
- * need to perform other book keeping operations that may impact performance.
+ * need to perform other bookkeeping operations that may impact performance.
  * For example, access tokens need to be refreshed from time to time, and this
  * may impact the performance of some operations.
  *

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3347,10 +3347,10 @@ Status DeleteByPrefix(Client& client, std::string const& bucket_name,
   auto all_options = std::tie(options...);
 
   static_assert(
-      std::tuple_size<
-          decltype(StaticTupleFilter<
-                   NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
-              all_options))>::value == 0,
+      std::tuple_size<decltype(
+              StaticTupleFilter<
+                  NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
+                  all_options))>::value == 0,
       "This functions accepts only options of type QuotaUser, UserIp, "
       "UserProject or Versions.");
   for (auto const& object :
@@ -3483,13 +3483,12 @@ StatusOr<ObjectMetadata> ComposeMany(
 
   // TODO(#3247): this list of type should somehow be generated
   static_assert(
-      std::tuple_size<
-          decltype(StaticTupleFilter<
-                   NotAmong<DestinationPredefinedAcl, EncryptionKey,
-                            IfGenerationMatch, IfMetagenerationMatch,
-                            KmsKeyName, QuotaUser, UserIp, UserProject,
-                            WithObjectMetadata>::TPred>(all_options))>::value ==
-          0,
+      std::tuple_size<decltype(
+              StaticTupleFilter<NotAmong<
+                  DestinationPredefinedAcl, EncryptionKey, IfGenerationMatch,
+                  IfMetagenerationMatch, KmsKeyName, QuotaUser, UserIp,
+                  UserProject, WithObjectMetadata>::TPred>(
+                  all_options))>::value == 0,
       "This functions accepts only options of type DestinationPredefinedAcl, "
       "EncryptionKey, IfGenerationMatch, IfMetagenerationMatch, KmsKeyName, "
       "QuotaUser, UserIp, UserProject or WithObjectMetadata.");

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -264,12 +264,13 @@ class Client {
       " For mocking, please use testing::ClientFromMock() instead."
       " Please file a bug at https://github.com/googleapis/google-cloud-cpp"
       " if you have a use-case not covered by these.")
-#endif // _MSC_VER
+#endif  // _MSC_VER
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit Client(std::shared_ptr<internal::RawClient> client,
                   Policies&&... policies)
       : Client(InternalOnly{}, std::move(client),
-               std::forward<Policies>(policies)...) {}
+               std::forward<Policies>(policies)...) {
+  }
 
   /// Define a tag to disable automatic decorations of the RawClient.
   struct NoDecorations {};
@@ -3346,10 +3347,10 @@ Status DeleteByPrefix(Client& client, std::string const& bucket_name,
   auto all_options = std::tie(options...);
 
   static_assert(
-      std::tuple_size<decltype(
-              StaticTupleFilter<
-                  NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
-                  all_options))>::value == 0,
+      std::tuple_size<
+          decltype(StaticTupleFilter<
+                   NotAmong<QuotaUser, UserIp, UserProject, Versions>::TPred>(
+              all_options))>::value == 0,
       "This functions accepts only options of type QuotaUser, UserIp, "
       "UserProject or Versions.");
   for (auto const& object :
@@ -3482,12 +3483,13 @@ StatusOr<ObjectMetadata> ComposeMany(
 
   // TODO(#3247): this list of type should somehow be generated
   static_assert(
-      std::tuple_size<decltype(
-              StaticTupleFilter<NotAmong<
-                  DestinationPredefinedAcl, EncryptionKey, IfGenerationMatch,
-                  IfMetagenerationMatch, KmsKeyName, QuotaUser, UserIp,
-                  UserProject, WithObjectMetadata>::TPred>(
-                  all_options))>::value == 0,
+      std::tuple_size<
+          decltype(StaticTupleFilter<
+                   NotAmong<DestinationPredefinedAcl, EncryptionKey,
+                            IfGenerationMatch, IfMetagenerationMatch,
+                            KmsKeyName, QuotaUser, UserIp, UserProject,
+                            WithObjectMetadata>::TPred>(all_options))>::value ==
+          0,
       "This functions accepts only options of type DestinationPredefinedAcl, "
       "EncryptionKey, IfGenerationMatch, IfMetagenerationMatch, KmsKeyName, "
       "QuotaUser, UserIp, UserProject or WithObjectMetadata.");

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -257,12 +257,14 @@ class Client {
   /// @deprecated This was intended only for test code, applications should not
   /// use it.
   template <typename... Policies>
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
   GOOGLE_CLOUD_CPP_DEPRECATED(
       "applications should not need this."
       " Please use the constructors from ClientOptions instead."
       " For mocking, please use testing::ClientFromMock() instead."
       " Please file a bug at https://github.com/googleapis/google-cloud-cpp"
       " if you have a use-case not covered by these.")
+#endif // _MSC_VER
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit Client(std::shared_ptr<internal::RawClient> client,
                   Policies&&... policies)

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -40,7 +40,7 @@ TEST(StorageMockingSamples, MockReadObject) {
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(ReturnRef(client_options));
 
-  gcs::Client client(mock);
+  auto client = gcs::testing::ClientFromMock(mock);
 
   std::string const text = "this is a mock http response";
   std::size_t offset = 0;
@@ -89,7 +89,7 @@ TEST(StorageMockingSamples, MockWriteObject) {
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(ReturnRef(client_options));
 
-  gcs::Client client(mock);
+  auto client = gcs::testing::ClientFromMock(mock);
 
   gcs::ObjectMetadata expected_metadata;
 
@@ -140,7 +140,7 @@ TEST(StorageMockingSamples, MockReadObjectFailure) {
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(ReturnRef(client_options));
 
-  gcs::Client client(mock);
+  auto client = gcs::testing::ClientFromMock(mock);
 
   std::string text = "this is a mock http response";
   EXPECT_CALL(*mock, ReadObject(_))
@@ -178,7 +178,7 @@ TEST(StorageMockingSamples, MockWriteObjectFailure) {
   EXPECT_CALL(*mock, client_options())
       .WillRepeatedly(ReturnRef(client_options));
 
-  gcs::Client client(mock);
+  auto client = gcs::testing::ClientFromMock(mock);
 
   EXPECT_CALL(*mock, CreateResumableSession(_))
       .WillOnce([](gcs::internal::ResumableUploadRequest const& request) {

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -41,15 +41,17 @@ StatusOr<google::cloud::storage::Client> DefaultGrpcClient() {
 google::cloud::storage::Client DefaultGrpcClient(
     google::cloud::storage::ClientOptions options, int channel_id) {
   if (UseGrpcForMetadata()) {
-    return storage::Client(storage::internal::GrpcClient::Create(
-        google::cloud::storage::internal::MakeOptions(std::move(options)),
-        channel_id));
+    return storage::internal::ClientImplDetails::CreateClient(
+        storage::internal::GrpcClient::Create(
+            google::cloud::storage::internal::MakeOptions(std::move(options)),
+            channel_id));
   }
   auto credentials = options.credentials();
-  return storage::Client(storage::internal::HybridClient::Create(
-      std::move(credentials),
-      google::cloud::storage::internal::MakeOptions(std::move(options)),
-      channel_id));
+  return storage::internal::ClientImplDetails::CreateClient(
+      storage::internal::HybridClient::Create(
+          std::move(credentials),
+          google::cloud::storage::internal::MakeOptions(std::move(options)),
+          channel_id));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -465,8 +465,7 @@ TEST_F(ObjectTest, DeleteByPrefix) {
         EXPECT_EQ("object-3", r.object_name());
         return make_status_or(internal::EmptyResponse{});
       });
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto status = DeleteByPrefix(client, "test-bucket", "object-", Versions(),
                                UserProject("project-to-bill"));
   EXPECT_STATUS_OK(status);
@@ -505,8 +504,7 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
         EXPECT_EQ("object-3", r.object_name());
         return make_status_or(internal::EmptyResponse{});
       });
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto status = DeleteByPrefix(client, "test-bucket", "object-");
 
   EXPECT_STATUS_OK(status);
@@ -521,8 +519,7 @@ TEST_F(ObjectTest, DeleteByPrefixListFailure) {
   EXPECT_CALL(*mock, ListObjects(_))
       .WillOnce(Return(StatusOr<internal::ListObjectsResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto status = DeleteByPrefix(client, "test-bucket", "object-", Versions(),
                                UserProject("project-to-bill"));
   EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
@@ -553,8 +550,7 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
       })
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto status = DeleteByPrefix(client, "test-bucket", "object-", Versions(),
                                UserProject("project-to-bill"));
   EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
@@ -564,8 +560,7 @@ TEST_F(ObjectTest, ComposeManyNone) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto res =
       ComposeMany(client, "test-bucket", std::vector<ComposeSourceObject>{},
                   "prefix", "dest", false);
@@ -631,8 +626,7 @@ TEST_F(ObjectTest, ComposeManyOne) {
         EXPECT_EQ("prefix", r.object_name());
         return make_status_or(internal::EmptyResponse{});
       });
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto status = ComposeMany(
       client, "test-bucket",
       std::vector<ComposeSourceObject>{ComposeSourceObject{"1", 42, {}}},
@@ -673,8 +667,7 @@ TEST_F(ObjectTest, ComposeManyThree) {
         EXPECT_EQ("prefix", r.object_name());
         return make_status_or(internal::EmptyResponse{});
       });
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto status = ComposeMany(
       client, "test-bucket",
       std::vector<ComposeSourceObject>{ComposeSourceObject{"1", 42, {}},
@@ -759,7 +752,7 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
         return make_status_or(internal::EmptyResponse{});
       });
 
-  Client client(mock);
+  auto client = testing::ClientFromMock(mock);
 
   std::vector<ComposeSourceObject> sources;
 
@@ -808,7 +801,7 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
         return make_status_or(internal::EmptyResponse{});
       });
 
-  Client client(mock);
+  auto client = testing::ClientFromMock(mock);
 
   std::vector<ComposeSourceObject> sources;
   std::size_t i = 0;
@@ -848,7 +841,7 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
 
-  Client client(mock);
+  auto client = testing::ClientFromMock(mock);
 
   std::vector<ComposeSourceObject> sources;
   std::size_t i = 0;
@@ -889,7 +882,7 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
 
-  Client client(mock);
+  auto client = testing::ClientFromMock(mock);
 
   std::vector<ComposeSourceObject> sources;
   std::size_t i = 0;
@@ -911,8 +904,7 @@ TEST_F(ObjectTest, ComposeManyLockingPrefixFails) {
   EXPECT_CALL(*mock, InsertObjectMedia(_))
       .WillOnce(Return(
           Status(StatusCode::kFailedPrecondition, "Generation mismatch")));
-  Client client(mock);
-
+  auto client = testing::ClientFromMock(mock);
   auto res = ComposeMany(
       client, "test-bucket",
       std::vector<ComposeSourceObject>{ComposeSourceObject{"1", 42, {}}},

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -1093,7 +1093,10 @@ struct CreateParallelUploadShards {
     // Everything ready - we've got the shared state and the files open, let's
     // prepare the returned objects.
     auto upload_buffer_size =
-        client.raw_client()->client_options().upload_buffer_size();
+        google::cloud::storage::internal::ClientImplDetails::GetRawClient(
+            client)
+            ->client_options()
+            .upload_buffer_size();
 
     file_split_points.emplace_back(file_size);
     assert(file_split_points.size() == state->shards().size());

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -188,10 +188,12 @@ class MockStreambuf : public internal::ObjectWriteStreambuf {
   MOCK_METHOD(std::uint64_t, next_expected_byte, (), (const, override));
 };
 
+/// Create a client configured to use the given mock.
 template <typename... Policies>
 Client ClientFromMock(std::shared_ptr<MockClient> const& mock,
                       Policies&&... p) {
-  return Client{mock, std::forward<Policies>(p)...};
+  return internal::ClientImplDetails::CreateClient(
+      mock, std::forward<Policies>(p)...);
 }
 
 }  // namespace testing

--- a/google/cloud/storage/testing/remove_stale_buckets_test.cc
+++ b/google/cloud/storage/testing/remove_stale_buckets_test.cc
@@ -69,7 +69,7 @@ TEST(CleanupStaleBucketsTest, RemoveBucketContents) {
         response.items.push_back(CreateObject("baz", 1));
         return response;
       });
-  Client client(mock, Client::NoDecorations{});
+  auto client = internal::ClientImplDetails::CreateWithoutDecorations(mock);
   auto const actual = RemoveBucketAndContents(client, "fake-bucket");
   EXPECT_STATUS_OK(actual);
 }
@@ -111,7 +111,7 @@ TEST(CleanupStaleBucketsTest, RemoveStaleBuckets) {
         return response;
       });
 
-  Client client(mock, Client::NoDecorations{});
+  auto client = internal::ClientImplDetails::CreateWithoutDecorations(mock);
   auto const actual = RemoveStaleBuckets(client, "matching", create_time_limit);
   EXPECT_STATUS_OK(actual);
 }

--- a/google/cloud/storage/testing/retry_tests.h
+++ b/google/cloud/storage/testing/retry_tests.h
@@ -58,10 +58,11 @@ void TooManyFailuresStatusTest(
   using ::testing::HasSubstr;
   using ::testing::Return;
   // A storage::Client with a simple to test policy.
-  Client client{std::shared_ptr<internal::RawClient>(mock),
-                LimitedErrorCountRetryPolicy(2),
-                ExponentialBackoffPolicy(std::chrono::milliseconds(1),
-                                         std::chrono::milliseconds(1), 2.0)};
+  auto client = internal::ClientImplDetails::CreateClient(
+      std::shared_ptr<internal::RawClient>(mock),
+      LimitedErrorCountRetryPolicy(2),
+      ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                               std::chrono::milliseconds(1), 2.0));
 
   // Expect exactly 3 calls before the retry policy is exhausted and an error
   // status is returned.
@@ -109,10 +110,10 @@ void NonIdempotentFailuresStatusTest(
   using ::testing::Return;
   // A storage::Client with the strict idempotency policy, but with a generous
   // retry policy.
-  Client client{std::shared_ptr<internal::RawClient>(mock),
-                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(10),
-                ExponentialBackoffPolicy(std::chrono::milliseconds(1),
-                                         std::chrono::milliseconds(1), 2.0)};
+  auto client = testing::ClientFromMock(
+      mock, StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(10),
+      ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                               std::chrono::milliseconds(1), 2.0));
 
   // The first transient error should stop the retries for non-idempotent
   // operations.
@@ -159,10 +160,10 @@ void IdempotentFailuresStatusTest(
   using ::testing::Return;
   // A storage::Client with the strict idempotency policy, and with an
   // easy-to-test retry policy.
-  Client client{std::shared_ptr<internal::RawClient>(mock),
-                StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2),
-                ExponentialBackoffPolicy(std::chrono::milliseconds(1),
-                                         std::chrono::milliseconds(1), 2.0)};
+  auto client = testing::ClientFromMock(
+      mock, StrictIdempotencyPolicy(), LimitedErrorCountRetryPolicy(2),
+      ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                               std::chrono::milliseconds(1), 2.0));
 
   // Expect exactly 3 calls before the retry policy is exhausted and an error
   // status is returned.

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -77,11 +77,12 @@ StorageIntegrationTest::MakeIntegrationTestClient(
 
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   if (UseGrpcForMetadata()) {
-    return Client(internal::GrpcClient::Create(Options{}), *retry_policy,
-                  *backoff_policy);
+    return internal::ClientImplDetails::CreateClient(
+        internal::GrpcClient::Create(Options{}), *retry_policy,
+        *backoff_policy);
   }
   if (UseGrpcForMedia()) {
-    return Client(
+    return internal::ClientImplDetails::CreateClient(
         internal::HybridClient::Create(options->credentials(), Options{}),
         *retry_policy, *backoff_policy);
   }

--- a/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
+++ b/google/cloud/storage/tests/curl_resumable_upload_session_integration_test.cc
@@ -231,7 +231,7 @@ TEST_F(CurlResumableUploadIntegrationTest, ResetWithParameters) {
   ASSERT_STATUS_OK(client_options);
   auto raw_client =
       CurlClient::Create(client_options->set_project_id(project_id_));
-  Client client(raw_client);
+  auto client = ClientImplDetails::CreateClient(raw_client);
   auto object_name = MakeRandomObjectName();
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto bucket_name = MakeRandomBucketName();

--- a/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
+++ b/google/cloud/storage/tests/curl_sign_blob_integration_test.cc
@@ -48,7 +48,8 @@ TEST_F(CurlSignBlobIntegrationTest, Simple) {
 
   SignBlobRequest request(service_account_, encoded, {});
 
-  StatusOr<SignBlobResponse> response = client->raw_client()->SignBlob(request);
+  StatusOr<SignBlobResponse> response =
+      internal::ClientImplDetails::GetRawClient(*client)->SignBlob(request);
   ASSERT_STATUS_OK(response);
 
   EXPECT_FALSE(response->key_id.empty());

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -169,7 +169,10 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteNotChunked) {
   auto object_name = MakeRandomObjectName();
   auto constexpr kUploadQuantum = 256 * 1024;
   auto const payload = std::string(
-      client->raw_client()->client_options().upload_buffer_size(), '*');
+      google::cloud::storage::internal::ClientImplDetails::GetRawClient(*client)
+          ->client_options()
+          .upload_buffer_size(),
+      '*');
   auto const header = MakeRandomData(kUploadQuantum / 2);
 
   auto os =

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -47,12 +47,15 @@ class ObjectWriteStreambufIntegrationTest
     request.set_multiple_options(IfGenerationMatch(0));
 
     StatusOr<std::unique_ptr<ResumableUploadSession>> session =
-        client->raw_client()->CreateResumableSession(request);
+        internal::ClientImplDetails::GetRawClient(*client)
+            ->CreateResumableSession(request);
     ASSERT_STATUS_OK(session);
 
     ObjectWriteStream writer(absl::make_unique<ObjectWriteStreambuf>(
         std::move(session).value(),
-        client->raw_client()->client_options().upload_buffer_size(),
+        internal::ClientImplDetails::GetRawClient(*client)
+            ->client_options()
+            .upload_buffer_size(),
         absl::make_unique<NullHashValidator>()));
 
     std::ostringstream expected_stream;


### PR DESCRIPTION
`storage::Client` has a number of functions that expose more details of
the implementation than they should, or are only intended for tests,
benchmarks, or to implement additional functionality in the library.
This change marks these functions as deprecated, and recommends what to
do instead. We also changed our tests, examples, and implementation to
use a helper in `google::cloud::internal` to access this functionality.

Part of the changes for #6161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6258)
<!-- Reviewable:end -->
