### PR TITLE
chore(spanner): quash warning about a leaked mocked object

### DIFF
--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -912,6 +912,10 @@ TEST(DatabaseAdminConnectionTest, CreateBackupSuccess) {
 /// @test Verify that using an encryption key works.
 TEST(DatabaseAdminClientTest, CreateBackupWithEncryption) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
+  // Suppress a false leak.
+  // TODO(#4038): After we fix the issue #4038, we won't need to use
+  // `AllowLeak()` any more.
+  Mock::AllowLeak(mock.get());
   Database dbase("test-project", "test-instance", "test-database");
 
   EXPECT_CALL(*mock, CreateBackup(_, _))


### PR DESCRIPTION
Suppress the warning about leaking the mock stub until #4038
is fixed.

Fixes #6145.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6261)
<!-- Reviewable:end -->
