### PR TITLE
cleanup: use wildcard matcher (`_`) sparingly

### DIFF
--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -90,7 +90,7 @@ class LoggingDecoratorTest : public ::testing::Test {
 
 TEST_F(LoggingDecoratorTest, GenerateAccessToken) {
   ::google::test::admin::database::v1::GenerateAccessTokenResponse response;
-  EXPECT_CALL(*mock_, GenerateAccessToken(_, _)).WillOnce(Return(response));
+  EXPECT_CALL(*mock_, GenerateAccessToken).WillOnce(Return(response));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.GenerateAccessToken(
@@ -102,8 +102,7 @@ TEST_F(LoggingDecoratorTest, GenerateAccessToken) {
 }
 
 TEST_F(LoggingDecoratorTest, GenerateAccessTokenError) {
-  EXPECT_CALL(*mock_, GenerateAccessToken(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GenerateAccessToken).WillOnce(Return(TransientError()));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.GenerateAccessToken(
@@ -117,7 +116,7 @@ TEST_F(LoggingDecoratorTest, GenerateAccessTokenError) {
 
 TEST_F(LoggingDecoratorTest, GenerateIdToken) {
   ::google::test::admin::database::v1::GenerateIdTokenResponse response;
-  EXPECT_CALL(*mock_, GenerateIdToken(_, _)).WillOnce(Return(response));
+  EXPECT_CALL(*mock_, GenerateIdToken).WillOnce(Return(response));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.GenerateIdToken(
@@ -129,7 +128,7 @@ TEST_F(LoggingDecoratorTest, GenerateIdToken) {
 }
 
 TEST_F(LoggingDecoratorTest, GenerateIdTokenError) {
-  EXPECT_CALL(*mock_, GenerateIdToken(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GenerateIdToken).WillOnce(Return(TransientError()));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.GenerateIdToken(
@@ -143,7 +142,7 @@ TEST_F(LoggingDecoratorTest, GenerateIdTokenError) {
 
 TEST_F(LoggingDecoratorTest, WriteLogEntries) {
   ::google::test::admin::database::v1::WriteLogEntriesResponse response;
-  EXPECT_CALL(*mock_, WriteLogEntries(_, _)).WillOnce(Return(response));
+  EXPECT_CALL(*mock_, WriteLogEntries).WillOnce(Return(response));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.WriteLogEntries(
@@ -155,7 +154,7 @@ TEST_F(LoggingDecoratorTest, WriteLogEntries) {
 }
 
 TEST_F(LoggingDecoratorTest, WriteLogEntriesError) {
-  EXPECT_CALL(*mock_, WriteLogEntries(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, WriteLogEntries).WillOnce(Return(TransientError()));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.WriteLogEntries(
@@ -169,7 +168,7 @@ TEST_F(LoggingDecoratorTest, WriteLogEntriesError) {
 
 TEST_F(LoggingDecoratorTest, ListLogs) {
   ::google::test::admin::database::v1::ListLogsResponse response;
-  EXPECT_CALL(*mock_, ListLogs(_, _)).WillOnce(Return(response));
+  EXPECT_CALL(*mock_, ListLogs).WillOnce(Return(response));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.ListLogs(
@@ -181,7 +180,7 @@ TEST_F(LoggingDecoratorTest, ListLogs) {
 }
 
 TEST_F(LoggingDecoratorTest, ListLogsError) {
-  EXPECT_CALL(*mock_, ListLogs(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListLogs).WillOnce(Return(TransientError()));
   GoldenKitchenSinkLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
   auto status = stub.ListLogs(
@@ -207,7 +206,7 @@ class MockTailLogEntriesStreamingReadRpc
 TEST_F(LoggingDecoratorTest, TailLogEntriesRpcNoRpcStreams) {
   auto mock_response = new MockTailLogEntriesStreamingReadRpc;
   EXPECT_CALL(*mock_response, Read).WillOnce(Return(Status()));
-  EXPECT_CALL(*mock_, TailLogEntries(_, _))
+  EXPECT_CALL(*mock_, TailLogEntries)
       .WillOnce(Return(ByMove(
           std::unique_ptr<internal::StreamingReadRpc<
               google::test::admin::database::v1::TailLogEntriesResponse>>(
@@ -227,7 +226,7 @@ TEST_F(LoggingDecoratorTest, TailLogEntriesRpcNoRpcStreams) {
 TEST_F(LoggingDecoratorTest, TailLogEntriesRpcWithRpcStreams) {
   auto mock_response = new MockTailLogEntriesStreamingReadRpc;
   EXPECT_CALL(*mock_response, Read).WillOnce(Return(Status()));
-  EXPECT_CALL(*mock_, TailLogEntries(_, _))
+  EXPECT_CALL(*mock_, TailLogEntries)
       .WillOnce(Return(ByMove(
           std::unique_ptr<internal::StreamingReadRpc<
               google::test::admin::database::v1::TailLogEntriesResponse>>(

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -27,7 +27,6 @@ namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::IsOk;
-using ::testing::_;
 using ::testing::Not;
 using ::testing::Return;
 
@@ -92,7 +91,7 @@ class MetadataDecoratorTest : public ::testing::Test {
 };
 
 TEST_F(MetadataDecoratorTest, GenerateAccessToken) {
-  EXPECT_CALL(*mock_, GenerateAccessToken(_, _))
+  EXPECT_CALL(*mock_, GenerateAccessToken)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            GenerateAccessTokenRequest const&) {
@@ -113,7 +112,7 @@ TEST_F(MetadataDecoratorTest, GenerateAccessToken) {
 }
 
 TEST_F(MetadataDecoratorTest, GenerateIdToken) {
-  EXPECT_CALL(*mock_, GenerateIdToken(_, _))
+  EXPECT_CALL(*mock_, GenerateIdToken)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            GenerateIdTokenRequest const&) {
@@ -133,7 +132,7 @@ TEST_F(MetadataDecoratorTest, GenerateIdToken) {
 }
 
 TEST_F(MetadataDecoratorTest, WriteLogEntries) {
-  EXPECT_CALL(*mock_, WriteLogEntries(_, _))
+  EXPECT_CALL(*mock_, WriteLogEntries)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            WriteLogEntriesRequest const&) {
@@ -152,7 +151,7 @@ TEST_F(MetadataDecoratorTest, WriteLogEntries) {
 }
 
 TEST_F(MetadataDecoratorTest, ListLogs) {
-  EXPECT_CALL(*mock_, ListLogs(_, _))
+  EXPECT_CALL(*mock_, ListLogs)
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::test::admin::database::v1::ListLogsRequest const&) {

--- a/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
@@ -175,7 +175,7 @@ class LoggingDecoratorTest : public ::testing::Test {
 TEST_F(LoggingDecoratorTest, GetDatabaseSuccess) {
   google::test::admin::database::v1::Database database;
   database.set_name("my_database");
-  EXPECT_CALL(*mock_, GetDatabase(_, _)).WillOnce(Return(database));
+  EXPECT_CALL(*mock_, GetDatabase).WillOnce(Return(database));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -189,7 +189,7 @@ TEST_F(LoggingDecoratorTest, GetDatabaseSuccess) {
 }
 
 TEST_F(LoggingDecoratorTest, GetDatabase) {
-  EXPECT_CALL(*mock_, GetDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetDatabase).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -203,7 +203,7 @@ TEST_F(LoggingDecoratorTest, GetDatabase) {
 }
 
 TEST_F(LoggingDecoratorTest, ListDatabases) {
-  EXPECT_CALL(*mock_, ListDatabases(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListDatabases).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -217,7 +217,7 @@ TEST_F(LoggingDecoratorTest, ListDatabases) {
 }
 
 TEST_F(LoggingDecoratorTest, CreateDatabase) {
-  EXPECT_CALL(*mock_, CreateDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CreateDatabase).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -231,8 +231,7 @@ TEST_F(LoggingDecoratorTest, CreateDatabase) {
 }
 
 TEST_F(LoggingDecoratorTest, UpdateDatabaseDdl) {
-  EXPECT_CALL(*mock_, UpdateDatabaseDdl(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, UpdateDatabaseDdl).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -246,7 +245,7 @@ TEST_F(LoggingDecoratorTest, UpdateDatabaseDdl) {
 }
 
 TEST_F(LoggingDecoratorTest, DropDatabase) {
-  EXPECT_CALL(*mock_, DropDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, DropDatabase).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -260,7 +259,7 @@ TEST_F(LoggingDecoratorTest, DropDatabase) {
 }
 
 TEST_F(LoggingDecoratorTest, GetDatabaseDdl) {
-  EXPECT_CALL(*mock_, GetDatabaseDdl(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetDatabaseDdl).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -274,7 +273,7 @@ TEST_F(LoggingDecoratorTest, GetDatabaseDdl) {
 }
 
 TEST_F(LoggingDecoratorTest, SetIamPolicy) {
-  EXPECT_CALL(*mock_, SetIamPolicy(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, SetIamPolicy).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -288,7 +287,7 @@ TEST_F(LoggingDecoratorTest, SetIamPolicy) {
 }
 
 TEST_F(LoggingDecoratorTest, GetIamPolicy) {
-  EXPECT_CALL(*mock_, GetIamPolicy(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetIamPolicy).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -302,8 +301,7 @@ TEST_F(LoggingDecoratorTest, GetIamPolicy) {
 }
 
 TEST_F(LoggingDecoratorTest, TestIamPermissions) {
-  EXPECT_CALL(*mock_, TestIamPermissions(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, TestIamPermissions).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -317,7 +315,7 @@ TEST_F(LoggingDecoratorTest, TestIamPermissions) {
 }
 
 TEST_F(LoggingDecoratorTest, CreateBackup) {
-  EXPECT_CALL(*mock_, CreateBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CreateBackup).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -331,7 +329,7 @@ TEST_F(LoggingDecoratorTest, CreateBackup) {
 }
 
 TEST_F(LoggingDecoratorTest, GetBackup) {
-  EXPECT_CALL(*mock_, GetBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetBackup).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -345,7 +343,7 @@ TEST_F(LoggingDecoratorTest, GetBackup) {
 }
 
 TEST_F(LoggingDecoratorTest, UpdateBackup) {
-  EXPECT_CALL(*mock_, UpdateBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, UpdateBackup).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -359,7 +357,7 @@ TEST_F(LoggingDecoratorTest, UpdateBackup) {
 }
 
 TEST_F(LoggingDecoratorTest, DeleteBackup) {
-  EXPECT_CALL(*mock_, DeleteBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, DeleteBackup).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -373,7 +371,7 @@ TEST_F(LoggingDecoratorTest, DeleteBackup) {
 }
 
 TEST_F(LoggingDecoratorTest, ListBackups) {
-  EXPECT_CALL(*mock_, ListBackups(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListBackups).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -387,7 +385,7 @@ TEST_F(LoggingDecoratorTest, ListBackups) {
 }
 
 TEST_F(LoggingDecoratorTest, RestoreDatabase) {
-  EXPECT_CALL(*mock_, RestoreDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, RestoreDatabase).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -401,7 +399,7 @@ TEST_F(LoggingDecoratorTest, RestoreDatabase) {
 }
 
 TEST_F(LoggingDecoratorTest, ListDatabaseOperations) {
-  EXPECT_CALL(*mock_, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
@@ -417,8 +415,7 @@ TEST_F(LoggingDecoratorTest, ListDatabaseOperations) {
 }
 
 TEST_F(LoggingDecoratorTest, ListBackupOperations) {
-  EXPECT_CALL(*mock_, ListBackupOperations(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListBackupOperations).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -433,7 +430,7 @@ TEST_F(LoggingDecoratorTest, ListBackupOperations) {
 }
 
 TEST_F(LoggingDecoratorTest, GetOperation) {
-  EXPECT_CALL(*mock_, GetOperation(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetOperation).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;
@@ -447,7 +444,7 @@ TEST_F(LoggingDecoratorTest, GetOperation) {
 }
 
 TEST_F(LoggingDecoratorTest, CancelOperation) {
-  EXPECT_CALL(*mock_, CancelOperation(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CancelOperation).WillOnce(Return(TransientError()));
 
   GoldenThingAdminLogging stub(mock_, TracingOptions{}, {});
   grpc::ClientContext context;

--- a/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -26,7 +26,6 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
-using ::testing::_;
 
 class MockGoldenStub
     : public google::cloud::golden_internal::GoldenThingAdminStub {
@@ -174,7 +173,7 @@ class MetadataDecoratorTest : public ::testing::Test {
 };
 
 TEST_F(MetadataDecoratorTest, GetDatabase) {
-  EXPECT_CALL(*mock_, GetDatabase(_, _))
+  EXPECT_CALL(*mock_, GetDatabase)
       .WillOnce(
           [this](grpc::ClientContext& context,
                  google::test::admin::database::v1::GetDatabaseRequest const&) {
@@ -195,7 +194,7 @@ TEST_F(MetadataDecoratorTest, GetDatabase) {
 }
 
 TEST_F(MetadataDecoratorTest, ListDatabases) {
-  EXPECT_CALL(*mock_, ListDatabases(_, _))
+  EXPECT_CALL(*mock_, ListDatabases)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -216,7 +215,7 @@ TEST_F(MetadataDecoratorTest, ListDatabases) {
 }
 
 TEST_F(MetadataDecoratorTest, CreateDatabase) {
-  EXPECT_CALL(*mock_, CreateDatabase(_, _))
+  EXPECT_CALL(*mock_, CreateDatabase)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -237,7 +236,7 @@ TEST_F(MetadataDecoratorTest, CreateDatabase) {
 }
 
 TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
-  EXPECT_CALL(*mock_, UpdateDatabaseDdl(_, _))
+  EXPECT_CALL(*mock_, UpdateDatabaseDdl)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            UpdateDatabaseDdlRequest const&) {
@@ -258,7 +257,7 @@ TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
 }
 
 TEST_F(MetadataDecoratorTest, DropDatabase) {
-  EXPECT_CALL(*mock_, DropDatabase(_, _))
+  EXPECT_CALL(*mock_, DropDatabase)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -280,7 +279,7 @@ TEST_F(MetadataDecoratorTest, DropDatabase) {
 }
 
 TEST_F(MetadataDecoratorTest, GetDatabaseDdl) {
-  EXPECT_CALL(*mock_, GetDatabaseDdl(_, _))
+  EXPECT_CALL(*mock_, GetDatabaseDdl)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -302,7 +301,7 @@ TEST_F(MetadataDecoratorTest, GetDatabaseDdl) {
 }
 
 TEST_F(MetadataDecoratorTest, SetIamPolicy) {
-  EXPECT_CALL(*mock_, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock_, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::SetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
@@ -322,7 +321,7 @@ TEST_F(MetadataDecoratorTest, SetIamPolicy) {
 }
 
 TEST_F(MetadataDecoratorTest, GetIamPolicy) {
-  EXPECT_CALL(*mock_, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock_, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::GetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
@@ -342,7 +341,7 @@ TEST_F(MetadataDecoratorTest, GetIamPolicy) {
 }
 
 TEST_F(MetadataDecoratorTest, TestIamPermissions) {
-  EXPECT_CALL(*mock_, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock_, TestIamPermissions)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::TestIamPermissionsRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(context,
@@ -362,7 +361,7 @@ TEST_F(MetadataDecoratorTest, TestIamPermissions) {
 }
 
 TEST_F(MetadataDecoratorTest, CreateBackup) {
-  EXPECT_CALL(*mock_, CreateBackup(_, _))
+  EXPECT_CALL(*mock_, CreateBackup)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -383,7 +382,7 @@ TEST_F(MetadataDecoratorTest, CreateBackup) {
 }
 
 TEST_F(MetadataDecoratorTest, GetBackup) {
-  EXPECT_CALL(*mock_, GetBackup(_, _))
+  EXPECT_CALL(*mock_, GetBackup)
       .WillOnce(
           [this](grpc::ClientContext& context,
                  google::test::admin::database::v1::GetBackupRequest const&) {
@@ -404,7 +403,7 @@ TEST_F(MetadataDecoratorTest, GetBackup) {
 }
 
 TEST_F(MetadataDecoratorTest, UpdateBackup) {
-  EXPECT_CALL(*mock_, UpdateBackup(_, _))
+  EXPECT_CALL(*mock_, UpdateBackup)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -426,7 +425,7 @@ TEST_F(MetadataDecoratorTest, UpdateBackup) {
 }
 
 TEST_F(MetadataDecoratorTest, DeleteBackup) {
-  EXPECT_CALL(*mock_, DeleteBackup(_, _))
+  EXPECT_CALL(*mock_, DeleteBackup)
       .WillOnce(
           [this](
               grpc::ClientContext& context,
@@ -448,7 +447,7 @@ TEST_F(MetadataDecoratorTest, DeleteBackup) {
 }
 
 TEST_F(MetadataDecoratorTest, ListBackups) {
-  EXPECT_CALL(*mock_, ListBackups(_, _))
+  EXPECT_CALL(*mock_, ListBackups)
       .WillOnce(
           [this](grpc::ClientContext& context,
                  google::test::admin::database::v1::ListBackupsRequest const&) {
@@ -468,7 +467,7 @@ TEST_F(MetadataDecoratorTest, ListBackups) {
 }
 
 TEST_F(MetadataDecoratorTest, RestoreDatabase) {
-  EXPECT_CALL(*mock_, RestoreDatabase(_, _))
+  EXPECT_CALL(*mock_, RestoreDatabase)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            RestoreDatabaseRequest const&) {
@@ -488,7 +487,7 @@ TEST_F(MetadataDecoratorTest, RestoreDatabase) {
 }
 
 TEST_F(MetadataDecoratorTest, ListDatabaseOperations) {
-  EXPECT_CALL(*mock_, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            ListDatabaseOperationsRequest const&) {
@@ -509,7 +508,7 @@ TEST_F(MetadataDecoratorTest, ListDatabaseOperations) {
 }
 
 TEST_F(MetadataDecoratorTest, ListBackupOperations) {
-  EXPECT_CALL(*mock_, ListBackupOperations(_, _))
+  EXPECT_CALL(*mock_, ListBackupOperations)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            ListBackupOperationsRequest const&) {
@@ -530,7 +529,7 @@ TEST_F(MetadataDecoratorTest, ListBackupOperations) {
 }
 
 TEST_F(MetadataDecoratorTest, GetOperation) {
-  EXPECT_CALL(*mock_, GetOperation(_, _))
+  EXPECT_CALL(*mock_, GetOperation)
       .WillOnce([this](grpc::ClientContext& context,
                        google::longrunning::GetOperationRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
@@ -548,7 +547,7 @@ TEST_F(MetadataDecoratorTest, GetOperation) {
 }
 
 TEST_F(MetadataDecoratorTest, CancelOperation) {
-  EXPECT_CALL(*mock_, CancelOperation(_, _))
+  EXPECT_CALL(*mock_, CancelOperation)
       .WillOnce([this](grpc::ClientContext& context,
                        google::longrunning::CancelOperationRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -36,7 +36,6 @@ using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::DescriptorPool;
 using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::FileDescriptorProto;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Return;
@@ -794,7 +793,7 @@ TEST_F(PrintMethodTest, ExactlyOnePattern) {
       absl::make_unique<generator_testing::MockGeneratorContext>();
   auto output =
       absl::make_unique<generator_testing::MockZeroCopyOutputStream>();
-  EXPECT_CALL(*output, Next(_, _));
+  EXPECT_CALL(*output, Next);
   EXPECT_CALL(*generator_context, Open("foo"))
       .WillOnce(Return(output.release()));
   Printer printer(generator_context.get(), "foo");

--- a/generator/internal/printer_test.cc
+++ b/generator/internal/printer_test.cc
@@ -22,8 +22,7 @@ namespace cloud {
 namespace generator_internal {
 namespace {
 
-using testing::_;
-using testing::Return;
+using ::testing::Return;
 
 class MockGeneratorContext
     : public google::protobuf::compiler::GeneratorContext {
@@ -47,7 +46,7 @@ class MockZeroCopyOutputStream
 TEST(PrinterTest, PrintWithMap) {
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
-  EXPECT_CALL(*output, Next(_, _));
+  EXPECT_CALL(*output, Next);
   EXPECT_CALL(*generator_context, Open("foo"))
       .WillOnce(Return(output.release()));
   Printer printer(generator_context.get(), "foo");
@@ -58,7 +57,7 @@ TEST(PrinterTest, PrintWithMap) {
 TEST(PrinterTest, PrintWithVariableArgs) {
   auto generator_context = absl::make_unique<MockGeneratorContext>();
   auto output = absl::make_unique<MockZeroCopyOutputStream>();
-  EXPECT_CALL(*output, Next(_, _));
+  EXPECT_CALL(*output, Next);
   EXPECT_CALL(*generator_context, Open("foo"))
       .WillOnce(Return(output.release()));
   Printer printer(generator_context.get(), "foo");

--- a/google/cloud/bigtable/async_list_app_profiles_test.cc
+++ b/google/cloud/bigtable/async_list_app_profiles_test.cc
@@ -38,7 +38,6 @@ namespace btadmin = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::ReturnRef;
 
 using MockAsyncListAppProfilesReader =
@@ -107,7 +106,7 @@ std::vector<std::string> AppProfileNames(
 
 /// @test One successful page with 1 one profile.
 TEST_F(AsyncListAppProfilesTest, Simple) {
-  EXPECT_CALL(*client_, AsyncListAppProfiles(_, _, _))
+  EXPECT_CALL(*client_, AsyncListAppProfiles)
       .WillOnce([this](grpc::ClientContext* context,
                        btadmin::ListAppProfilesRequest const& request,
                        grpc::CompletionQueue*) {
@@ -120,7 +119,7 @@ TEST_F(AsyncListAppProfilesTest, Simple) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_1_.get());
       });
-  EXPECT_CALL(*profiles_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_1_, Finish)
       .WillOnce(create_list_profiles_lambda("", {"profile_1"}));
 
   Start();
@@ -137,7 +136,7 @@ TEST_F(AsyncListAppProfilesTest, Simple) {
 
 /// @test Test 3 pages, no failures, multiple profiles.
 TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
-  EXPECT_CALL(*client_, AsyncListAppProfiles(_, _, _))
+  EXPECT_CALL(*client_, AsyncListAppProfiles)
       .WillOnce([this](grpc::ClientContext* context,
                        btadmin::ListAppProfilesRequest const& request,
                        grpc::CompletionQueue*) {
@@ -174,12 +173,12 @@ TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_3_.get());
       });
-  EXPECT_CALL(*profiles_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_1_, Finish)
       .WillOnce(create_list_profiles_lambda("token_1", {"profile_1"}));
-  EXPECT_CALL(*profiles_reader_2_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_2_, Finish)
       .WillOnce(
           create_list_profiles_lambda("token_2", {"profile_2", "profile_3"}));
-  EXPECT_CALL(*profiles_reader_3_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_3_, Finish)
       .WillOnce(create_list_profiles_lambda("", {"profile_4"}));
 
   Start();
@@ -210,7 +209,7 @@ TEST_F(AsyncListAppProfilesTest, MultipleProfiles) {
 
 /// @test Test 2 pages, with a failure between them.
 TEST_F(AsyncListAppProfilesTest, FailuresAreRetried) {
-  EXPECT_CALL(*client_, AsyncListAppProfiles(_, _, _))
+  EXPECT_CALL(*client_, AsyncListAppProfiles)
       .WillOnce([this](grpc::ClientContext* context,
                        btadmin::ListAppProfilesRequest const& request,
                        grpc::CompletionQueue*) {
@@ -247,14 +246,14 @@ TEST_F(AsyncListAppProfilesTest, FailuresAreRetried) {
         return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
             btadmin::ListAppProfilesResponse>>(profiles_reader_3_.get());
       });
-  EXPECT_CALL(*profiles_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_1_, Finish)
       .WillOnce(create_list_profiles_lambda("token_1", {"profile_1"}));
-  EXPECT_CALL(*profiles_reader_2_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_2_, Finish)
       .WillOnce(
           [](btadmin::ListAppProfilesResponse*, grpc::Status* status, void*) {
             *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "");
           });
-  EXPECT_CALL(*profiles_reader_3_, Finish(_, _, _))
+  EXPECT_CALL(*profiles_reader_3_, Finish)
       .WillOnce(create_list_profiles_lambda("", {"profile_2"}));
 
   Start();

--- a/google/cloud/bigtable/async_list_clusters_test.cc
+++ b/google/cloud/bigtable/async_list_clusters_test.cc
@@ -38,7 +38,6 @@ namespace btproto = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::ReturnRef;
 
 using MockAsyncListClustersReader =
@@ -113,7 +112,7 @@ std::vector<std::string> ClusterNames(ClusterList const& response) {
 
 /// @test One successful page with 1 one cluster.
 TEST_F(AsyncListClustersTest, Simple) {
-  EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
+  EXPECT_CALL(*client_, AsyncListClusters)
       .WillOnce([this](grpc::ClientContext* context,
                        btproto::ListClustersRequest const& request,
                        grpc::CompletionQueue*) {
@@ -127,7 +126,7 @@ TEST_F(AsyncListClustersTest, Simple) {
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_1_.get());
       });
-  EXPECT_CALL(*clusters_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_1_, Finish)
       .WillOnce(
           create_list_clusters_lambda("", {"cluster_1"}, {"failed_loc_1"}));
 
@@ -146,7 +145,7 @@ TEST_F(AsyncListClustersTest, Simple) {
 
 /// @test Test 3 pages, no failures, multiple clusters and failed locations.
 TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
-  EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
+  EXPECT_CALL(*client_, AsyncListClusters)
       .WillOnce([this](grpc::ClientContext* context,
                        btproto::ListClustersRequest const& request,
                        grpc::CompletionQueue*) {
@@ -186,14 +185,14 @@ TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_3_.get());
       });
-  EXPECT_CALL(*clusters_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_1_, Finish)
       .WillOnce(create_list_clusters_lambda("token_1", {"cluster_1"},
                                             {"failed_loc_1"}));
-  EXPECT_CALL(*clusters_reader_2_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_2_, Finish)
       .WillOnce(create_list_clusters_lambda("token_2",
                                             {"cluster_2", "cluster_3"},
                                             {"failed_loc_1", "failed_loc_2"}));
-  EXPECT_CALL(*clusters_reader_3_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_3_, Finish)
       .WillOnce(
           create_list_clusters_lambda("", {"cluster_4"}, {"failed_loc_1"}));
 
@@ -229,7 +228,7 @@ TEST_F(AsyncListClustersTest, MultipleClustersAndLocations) {
 
 /// @test Test 2 pages, with a failure between them.
 TEST_F(AsyncListClustersTest, FailuresAreRetried) {
-  EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
+  EXPECT_CALL(*client_, AsyncListClusters)
       .WillOnce([this](grpc::ClientContext* context,
                        btproto::ListClustersRequest const& request,
                        grpc::CompletionQueue*) {
@@ -269,15 +268,15 @@ TEST_F(AsyncListClustersTest, FailuresAreRetried) {
             google::bigtable::admin::v2::ListClustersResponse>>(
             clusters_reader_3_.get());
       });
-  EXPECT_CALL(*clusters_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_1_, Finish)
       .WillOnce(create_list_clusters_lambda("token_1", {"cluster_1"},
                                             {"failed_loc_1"}));
-  EXPECT_CALL(*clusters_reader_2_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_2_, Finish)
       .WillOnce(
           [](btproto::ListClustersResponse*, grpc::Status* status, void*) {
             *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "");
           });
-  EXPECT_CALL(*clusters_reader_3_, Finish(_, _, _))
+  EXPECT_CALL(*clusters_reader_3_, Finish)
       .WillOnce(
           create_list_clusters_lambda("", {"cluster_2"}, {"failed_loc_2"}));
 

--- a/google/cloud/bigtable/async_list_instances_test.cc
+++ b/google/cloud/bigtable/async_list_instances_test.cc
@@ -36,7 +36,6 @@ namespace {
 namespace btproto = google::bigtable::admin::v2;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::testing::_;
 using ::testing::ReturnRef;
 using MockAsyncListInstancesReader =
     google::cloud::bigtable::testing::MockAsyncResponseReader<
@@ -109,7 +108,7 @@ std::vector<std::string> InstanceNames(InstanceList const& response) {
 
 /// @test One successful page with 1 one instance.
 TEST_F(AsyncListInstancesTest, Simple) {
-  EXPECT_CALL(*client_, AsyncListInstances(_, _, _))
+  EXPECT_CALL(*client_, AsyncListInstances)
       .WillOnce([this](grpc::ClientContext* context,
                        btproto::ListInstancesRequest const& request,
                        grpc::CompletionQueue*) {
@@ -123,7 +122,7 @@ TEST_F(AsyncListInstancesTest, Simple) {
             google::bigtable::admin::v2::ListInstancesResponse>>(
             instances_reader_1_.get());
       });
-  EXPECT_CALL(*instances_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_1_, Finish)
       .WillOnce(
           create_list_instances_lambda("", {"instance_1"}, {"failed_loc_1"}));
 
@@ -142,7 +141,7 @@ TEST_F(AsyncListInstancesTest, Simple) {
 
 /// @test Test 3 pages, no failures, multiple clusters and failed locations.
 TEST_F(AsyncListInstancesTest, MultipleInstancesAndLocations) {
-  EXPECT_CALL(*client_, AsyncListInstances(_, _, _))
+  EXPECT_CALL(*client_, AsyncListInstances)
       .WillOnce([this](grpc::ClientContext* context,
                        btproto::ListInstancesRequest const& request,
                        grpc::CompletionQueue*) {
@@ -182,14 +181,14 @@ TEST_F(AsyncListInstancesTest, MultipleInstancesAndLocations) {
             google::bigtable::admin::v2::ListInstancesResponse>>(
             instances_reader_3_.get());
       });
-  EXPECT_CALL(*instances_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_1_, Finish)
       .WillOnce(create_list_instances_lambda("token_1", {"instance_1"},
                                              {"failed_loc_1"}));
-  EXPECT_CALL(*instances_reader_2_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_2_, Finish)
       .WillOnce(create_list_instances_lambda("token_2",
                                              {"instance_2", "instance_3"},
                                              {"failed_loc_1", "failed_loc_2"}));
-  EXPECT_CALL(*instances_reader_3_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_3_, Finish)
       .WillOnce(
           create_list_instances_lambda("", {"instance_4"}, {"failed_loc_1"}));
 
@@ -225,7 +224,7 @@ TEST_F(AsyncListInstancesTest, MultipleInstancesAndLocations) {
 
 /// @test Test 2 pages, with a failure between them.
 TEST_F(AsyncListInstancesTest, FailuresAreRetried) {
-  EXPECT_CALL(*client_, AsyncListInstances(_, _, _))
+  EXPECT_CALL(*client_, AsyncListInstances)
       .WillOnce([this](grpc::ClientContext* context,
                        btproto::ListInstancesRequest const& request,
                        grpc::CompletionQueue*) {
@@ -265,15 +264,15 @@ TEST_F(AsyncListInstancesTest, FailuresAreRetried) {
             google::bigtable::admin::v2::ListInstancesResponse>>(
             instances_reader_3_.get());
       });
-  EXPECT_CALL(*instances_reader_1_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_1_, Finish)
       .WillOnce(create_list_instances_lambda("token_1", {"instance_1"},
                                              {"failed_loc_1"}));
-  EXPECT_CALL(*instances_reader_2_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_2_, Finish)
       .WillOnce(
           [](btproto::ListInstancesResponse*, grpc::Status* status, void*) {
             *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "");
           });
-  EXPECT_CALL(*instances_reader_3_, Finish(_, _, _))
+  EXPECT_CALL(*instances_reader_3_, Finish)
       .WillOnce(
           create_list_instances_lambda("", {"instance_2"}, {"failed_loc_2"}));
 

--- a/google/cloud/bigtable/async_row_reader_test.cc
+++ b/google/cloud/bigtable/async_row_reader_test.cc
@@ -38,7 +38,6 @@ using ::google::cloud::bigtable::testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Values;
 using ::testing::WithParamInterface;
@@ -69,7 +68,7 @@ class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
         std::make_shared<decltype(request_expectations)>(
             std::move(request_expectations));
 
-    EXPECT_CALL(*client_, PrepareAsyncReadRows(_, _, _))
+    EXPECT_CALL(*client_, PrepareAsyncReadRows)
         .WillOnce([&reader, request_expectations_ptr](
                       grpc::ClientContext* context,
                       btproto::ReadRowsRequest const& r,
@@ -84,13 +83,13 @@ class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
         })
         .RetiresOnSaturation();
 
-    EXPECT_CALL(reader, StartCall(_)).WillOnce([idx, this](void*) {
+    EXPECT_CALL(reader, StartCall).WillOnce([idx, this](void*) {
       reader_started_[idx] = true;
     });
     if (expect_a_read) {
       // The last call, to which we'll return ok==false.
-      EXPECT_CALL(reader, Read(_, _))
-          .WillOnce([](btproto::ReadRowsResponse*, void*) {});
+      EXPECT_CALL(reader, Read).WillOnce([](btproto::ReadRowsResponse*, void*) {
+      });
     }
     return reader;
   }
@@ -158,7 +157,7 @@ class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
 TEST_F(TableAsyncReadRowsTest, SingleRow) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -172,7 +171,7 @@ TEST_F(TableAsyncReadRowsTest, SingleRow) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -209,7 +208,7 @@ TEST_F(TableAsyncReadRowsTest, SingleRow) {
 TEST_F(TableAsyncReadRowsTest, SingleRowInstantFinish) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -223,7 +222,7 @@ TEST_F(TableAsyncReadRowsTest, SingleRowInstantFinish) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -257,7 +256,7 @@ TEST_F(TableAsyncReadRowsTest, SingleRowInstantFinish) {
 TEST_F(TableAsyncReadRowsTest, MultipleChunks) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -283,7 +282,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunks) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -326,7 +325,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunks) {
 TEST_F(TableAsyncReadRowsTest, MultipleChunksImmediatelySatisfied) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -352,7 +351,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunksImmediatelySatisfied) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -392,7 +391,7 @@ TEST_F(TableAsyncReadRowsTest, MultipleChunksImmediatelySatisfied) {
 TEST_F(TableAsyncReadRowsTest, ResponseInMultipleChunks) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -418,7 +417,7 @@ TEST_F(TableAsyncReadRowsTest, ResponseInMultipleChunks) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -452,7 +451,7 @@ TEST_F(TableAsyncReadRowsTest, ResponseInMultipleChunks) {
 TEST_F(TableAsyncReadRowsTest, ParserEofFailsOnUnfinishedRow) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             // missing final commit
@@ -467,7 +466,7 @@ TEST_F(TableAsyncReadRowsTest, ParserEofFailsOnUnfinishedRow) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -492,7 +491,7 @@ TEST_F(TableAsyncReadRowsTest, ParserEofFailsOnUnfinishedRow) {
 TEST_F(TableAsyncReadRowsTest, ParserEofDoesntFailsOnUnfinishedRowIfRowLimit) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             // missing final commit
@@ -515,7 +514,7 @@ TEST_F(TableAsyncReadRowsTest, ParserEofDoesntFailsOnUnfinishedRowIfRowLimit) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -547,7 +546,7 @@ TEST_F(TableAsyncReadRowsTest, ParserEofDoesntFailsOnUnfinishedRowIfRowLimit) {
 TEST_F(TableAsyncReadRowsTest, PermanentFailure) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "noooo");
   });
 
@@ -580,7 +579,7 @@ TEST_F(TableAsyncReadRowsTest, TransientErrorIsRetried) {
   auto& stream1 = AddReader([](btproto::ReadRowsRequest const&) {});
 
   // Make it a bit trickier by delivering the error while parsing second row.
-  EXPECT_CALL(stream1, Read(_, _))
+  EXPECT_CALL(stream1, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -602,11 +601,11 @@ TEST_F(TableAsyncReadRowsTest, TransientErrorIsRetried) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream1, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream1, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "oh no");
   });
 
-  EXPECT_CALL(stream2, Read(_, _))
+  EXPECT_CALL(stream2, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -620,7 +619,7 @@ TEST_F(TableAsyncReadRowsTest, TransientErrorIsRetried) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream2, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream2, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -666,7 +665,7 @@ TEST_F(TableAsyncReadRowsTest, TransientErrorIsRetried) {
 TEST_F(TableAsyncReadRowsTest, ParserFailure) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             // Row not in increasing order.
@@ -689,7 +688,7 @@ TEST_F(TableAsyncReadRowsTest, ParserFailure) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -732,7 +731,7 @@ class TableAsyncReadRowsCancelMidStreamTest
 TEST_P(TableAsyncReadRowsCancelMidStreamTest, CancelMidStream) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -754,7 +753,7 @@ TEST_P(TableAsyncReadRowsCancelMidStreamTest, CancelMidStream) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -839,7 +838,7 @@ TEST_F(TableAsyncReadRowsTest, CancelAfterStreamFinish) {
   // First two rows are going to be processed, but third will cause the parser
   // to fail (row order violation). This will result in finishing the stream
   // while still keeping the two processed rows for the user.
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -869,7 +868,7 @@ TEST_F(TableAsyncReadRowsTest, CancelAfterStreamFinish) {
                 })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -930,12 +929,12 @@ TEST_F(TableAsyncReadRowsTest, DeepStack) {
     *large_response.add_chunks() = std::move(chunk);
   }
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([large_response](btproto::ReadRowsResponse* r, void*) {
         *r = large_response;
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -977,7 +976,7 @@ TEST_F(TableAsyncReadRowsTest, DeepStack) {
 TEST_F(TableAsyncReadRowsTest, ReadRowSuccess) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Read(_, _))
+  EXPECT_CALL(stream, Read)
       .WillOnce([](btproto::ReadRowsResponse* r, void*) {
         *r = bigtable::testing::ReadRowsResponseFromString(
             R"(
@@ -991,7 +990,7 @@ TEST_F(TableAsyncReadRowsTest, ReadRowSuccess) {
               })");
       })
       .RetiresOnSaturation();
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -1026,7 +1025,7 @@ TEST_F(TableAsyncReadRowsTest, ReadRowSuccess) {
 TEST_F(TableAsyncReadRowsTest, ReadRowNotFound) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
 
@@ -1052,7 +1051,7 @@ TEST_F(TableAsyncReadRowsTest, ReadRowNotFound) {
 TEST_F(TableAsyncReadRowsTest, ReadRowError) {
   auto& stream = AddReader([](btproto::ReadRowsRequest const&) {});
 
-  EXPECT_CALL(stream, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(stream, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "");
   });
 

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -43,7 +43,6 @@ using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::HasSubstr;
 using ::testing::Not;
@@ -260,7 +259,7 @@ TEST_F(InstanceAdminTest, MoveAssignment) {
 TEST_F(InstanceAdminTest, ListInstances) {
   InstanceAdmin tested(client_);
   auto mock_list_instances = create_list_instances_lambda("", "", {"t0", "t1"});
-  EXPECT_CALL(*client_, ListInstances(_, _, _)).WillOnce(mock_list_instances);
+  EXPECT_CALL(*client_, ListInstances).WillOnce(mock_list_instances);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListInstances();
@@ -286,7 +285,7 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
   };
   auto batch0 = create_list_instances_lambda("", "token-001", {"t0", "t1"});
   auto batch1 = create_list_instances_lambda("token-001", "", {"t2", "t3"});
-  EXPECT_CALL(*client_, ListInstances(_, _, _))
+  EXPECT_CALL(*client_, ListInstances)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(batch0)
       .WillOnce(mock_recoverable_failure)
@@ -311,7 +310,7 @@ TEST_F(InstanceAdminTest, ListInstancesRecoverableFailures) {
  */
 TEST_F(InstanceAdminTest, ListInstancesUnrecoverableFailures) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, ListInstances(_, _, _))
+  EXPECT_CALL(*client_, ListInstances)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
@@ -347,7 +346,7 @@ TEST_F(InstanceAdminTest, DeleteInstance) {
   auto mock = MockRpcFactory<btadmin::DeleteInstanceRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteInstance");
-  EXPECT_CALL(*client_, DeleteInstance(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, DeleteInstance).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
   ASSERT_STATUS_OK(tested.DeleteInstance("the-instance"));
 }
@@ -355,7 +354,7 @@ TEST_F(InstanceAdminTest, DeleteInstance) {
 /// @test Verify unrecoverable error for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, DeleteInstance(_, _, _))
+  EXPECT_CALL(*client_, DeleteInstance)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
   // After all the setup, make the actual call we want to test.
@@ -365,7 +364,7 @@ TEST_F(InstanceAdminTest, DeleteInstanceUnrecoverableError) {
 /// @test Verify that recoverable error for DeleteInstance
 TEST_F(InstanceAdminTest, DeleteInstanceRecoverableError) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, DeleteInstance(_, _, _))
+  EXPECT_CALL(*client_, DeleteInstance)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
@@ -380,7 +379,7 @@ TEST_F(InstanceAdminTest, ListClusters) {
   std::string const& instance_id = "the-instance";
   auto mock_list_clusters =
       create_list_clusters_lambda("", "", instance_id, {"t0", "t1"});
-  EXPECT_CALL(*client_, ListClusters(_, _, _)).WillOnce(mock_list_clusters);
+  EXPECT_CALL(*client_, ListClusters).WillOnce(mock_list_clusters);
 
   // After all the setup, make the actual call we want to test.
   auto actual = tested.ListClusters(instance_id);
@@ -407,7 +406,7 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
       create_list_clusters_lambda("", "token-001", instance_id, {"t0", "t1"});
   auto batch1 =
       create_list_clusters_lambda("token-001", "", instance_id, {"t2", "t3"});
-  EXPECT_CALL(*client_, ListClusters(_, _, _))
+  EXPECT_CALL(*client_, ListClusters)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(batch0)
       .WillOnce(mock_recoverable_failure)
@@ -432,7 +431,7 @@ TEST_F(InstanceAdminTest, ListClustersRecoverableFailures) {
  */
 TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, ListClusters(_, _, _))
+  EXPECT_CALL(*client_, ListClusters)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
@@ -445,7 +444,7 @@ TEST_F(InstanceAdminTest, ListClustersUnrecoverableFailures) {
 TEST_F(InstanceAdminTest, GetCluster) {
   InstanceAdmin tested(client_);
   auto mock = create_get_cluster_mock();
-  EXPECT_CALL(*client_, GetCluster(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, GetCluster).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
   auto cluster = tested.GetCluster("the-instance", "the-cluster");
   ASSERT_STATUS_OK(cluster);
@@ -456,7 +455,7 @@ TEST_F(InstanceAdminTest, GetCluster) {
 /// @test Verify unrecoverable error for GetCluster
 TEST_F(InstanceAdminTest, GetClusterUnrecoverableError) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, GetCluster(_, _, _))
+  EXPECT_CALL(*client_, GetCluster)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
   ASSERT_THAT(tested.GetCluster("other-instance", "the-cluster"), Not(IsOk()));
@@ -475,7 +474,7 @@ TEST_F(InstanceAdminTest, GetClusterRecoverableError) {
   };
 
   auto mock_cluster = create_get_cluster_mock();
-  EXPECT_CALL(*client_, GetCluster(_, _, _))
+  EXPECT_CALL(*client_, GetCluster)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_cluster);
@@ -497,7 +496,7 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
   auto mock = MockRpcFactory<btadmin::DeleteClusterRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteCluster");
-  EXPECT_CALL(*client_, DeleteCluster(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, DeleteCluster).WillOnce(mock);
   // After all the setup, make the actual call we want to test.
   ASSERT_STATUS_OK(tested.DeleteCluster("the-instance", "the-cluster"));
 }
@@ -505,7 +504,7 @@ TEST_F(InstanceAdminTest, DeleteCluster) {
 /// @test Verify unrecoverable error for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, DeleteCluster(_, _, _))
+  EXPECT_CALL(*client_, DeleteCluster)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
   // After all the setup, make the actual call we want to test.
@@ -516,7 +515,7 @@ TEST_F(InstanceAdminTest, DeleteClusterUnrecoverableError) {
 /// @test Verify that recoverable error for DeleteCluster
 TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, DeleteCluster(_, _, _))
+  EXPECT_CALL(*client_, DeleteCluster)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
 
@@ -527,11 +526,9 @@ TEST_F(InstanceAdminTest, DeleteClusterRecoverableError) {
 
 /// @test Verify positive scenario for InstanceAdmin::GetIamPolicy.
 TEST_F(InstanceAdminTest, GetIamPolicy) {
-  using ::testing::_;
-
   InstanceAdmin tested(client_);
   auto mock_policy = create_get_policy_mock();
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
+  EXPECT_CALL(*client_, GetIamPolicy).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   tested.GetIamPolicy(resource);
@@ -539,10 +536,8 @@ TEST_F(InstanceAdminTest, GetIamPolicy) {
 
 /// @test Verify that IamPolicies with conditions cause failures.
 TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
-  using ::testing::_;
-
   InstanceAdmin tested(client_);
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, GetIamPolicy)
       .WillOnce([](grpc::ClientContext* context,
                    ::google::iam::v1::GetIamPolicyRequest const&,
                    ::google::iam::v1::Policy* response) {
@@ -569,12 +564,11 @@ TEST_F(InstanceAdminTest, GetIamPolicyWithConditionsFails) {
 
 /// @test Verify unrecoverable errors for InstanceAdmin::GetIamPolicy.
 TEST_F(InstanceAdminTest, GetIamPolicyUnrecoverableError) {
-  using ::testing::_;
   using ::testing::Return;
 
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, GetIamPolicy)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
@@ -585,7 +579,6 @@ TEST_F(InstanceAdminTest, GetIamPolicyUnrecoverableError) {
 
 /// @test Verify recoverable errors for InstanceAdmin::GetIamPolicy.
 TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
   InstanceAdmin tested(client_);
@@ -600,7 +593,7 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
   };
   auto mock_policy = create_get_policy_mock();
 
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, GetIamPolicy)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_policy);
 
@@ -610,11 +603,9 @@ TEST_F(InstanceAdminTest, GetIamPolicyRecoverableError) {
 
 /// @test Verify positive scenario for InstanceAdmin::GetNativeIamPolicy.
 TEST_F(InstanceAdminTest, GetNativeIamPolicy) {
-  using ::testing::_;
-
   InstanceAdmin tested(client_);
   auto mock_policy = create_get_policy_mock();
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _)).WillOnce(mock_policy);
+  EXPECT_CALL(*client_, GetIamPolicy).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto policy = tested.GetNativeIamPolicy(resource);
@@ -625,12 +616,11 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicy) {
 
 /// @test Verify unrecoverable errors for InstanceAdmin::GetNativeIamPolicy.
 TEST_F(InstanceAdminTest, GetNativeIamPolicyUnrecoverableError) {
-  using ::testing::_;
   using ::testing::Return;
 
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, GetIamPolicy)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
@@ -641,7 +631,6 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyUnrecoverableError) {
 
 /// @test Verify recoverable errors for InstanceAdmin::GetNativeIamPolicy.
 TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
   InstanceAdmin tested(client_);
@@ -656,7 +645,7 @@ TEST_F(InstanceAdminTest, GetNativeIamPolicyRecoverableError) {
   };
   auto mock_policy = create_get_policy_mock();
 
-  EXPECT_CALL(*client_, GetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, GetIamPolicy)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_policy);
 
@@ -679,7 +668,7 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
         client_(new MockAdminClient),
         reader_(new MockAsyncIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
-    EXPECT_CALL(*client_, AsyncGetIamPolicy(_, _, _))
+    EXPECT_CALL(*client_, AsyncGetIamPolicy)
         .WillOnce([this](grpc::ClientContext* context,
                          ::google::iam::v1::GetIamPolicyRequest const& request,
                          grpc::CompletionQueue*) {
@@ -718,11 +707,10 @@ class AsyncGetIamPolicyTest : public ::testing::Test {
 
 /// @test Verify that AsyncGetIamPolicy works in simple case.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         response->set_version(3);
@@ -742,11 +730,10 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicy) {
 
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncGetIamPolicy.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
@@ -763,11 +750,10 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetIamPolicyUnrecoverableError) {
 
 /// @test Verify that AsyncGetNativeIamPolicy works in simple case.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicy) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         response->set_version(3);
@@ -787,11 +773,10 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicy) {
 
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncGetNativeIamPolicy.
 TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicyUnrecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
@@ -808,11 +793,9 @@ TEST_F(AsyncGetIamPolicyTest, AsyncGetNativeIamPolicyUnrecoverableError) {
 
 /// @test Verify positive scenario for InstanceAdmin::SetIamPolicy.
 TEST_F(InstanceAdminTest, SetIamPolicy) {
-  using ::testing::_;
-
   InstanceAdmin tested(client_);
   auto mock_policy = create_policy_with_params();
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
+  EXPECT_CALL(*client_, SetIamPolicy).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   google::cloud::IamBindings iam_bindings =
@@ -826,12 +809,11 @@ TEST_F(InstanceAdminTest, SetIamPolicy) {
 
 /// @test Verify unrecoverable errors for InstanceAdmin::SetIamPolicy.
 TEST_F(InstanceAdminTest, SetIamPolicyUnrecoverableError) {
-  using ::testing::_;
   using ::testing::Return;
 
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, SetIamPolicy)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
@@ -843,7 +825,6 @@ TEST_F(InstanceAdminTest, SetIamPolicyUnrecoverableError) {
 
 /// @test Verify recoverable errors for InstanceAdmin::SetIamPolicy.
 TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
   InstanceAdmin tested(client_);
@@ -858,7 +839,7 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
   };
   auto mock_policy = create_policy_with_params();
 
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, SetIamPolicy)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_policy);
 
@@ -874,11 +855,9 @@ TEST_F(InstanceAdminTest, SetIamPolicyRecoverableError) {
 
 /// @test Verify positive scenario for InstanceAdmin::SetIamPolicy (native).
 TEST_F(InstanceAdminTest, SetNativeIamPolicy) {
-  using ::testing::_;
-
   InstanceAdmin tested(client_);
   auto mock_policy = create_policy_with_params();
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _)).WillOnce(mock_policy);
+  EXPECT_CALL(*client_, SetIamPolicy).WillOnce(mock_policy);
 
   std::string resource = "test-resource";
   auto iam_policy =
@@ -893,12 +872,11 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicy) {
 
 /// @test Verify unrecoverable errors for InstanceAdmin::SetIamPolicy (native).
 TEST_F(InstanceAdminTest, SetNativeIamPolicyUnrecoverableError) {
-  using ::testing::_;
   using ::testing::Return;
 
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, SetIamPolicy)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
@@ -911,7 +889,6 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyUnrecoverableError) {
 
 /// @test Verify recoverable errors for InstanceAdmin::SetIamPolicy (native).
 TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
 
   InstanceAdmin tested(client_);
@@ -926,7 +903,7 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
   };
   auto mock_policy = create_policy_with_params();
 
-  EXPECT_CALL(*client_, SetIamPolicy(_, _, _))
+  EXPECT_CALL(*client_, SetIamPolicy)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_policy);
 
@@ -942,7 +919,6 @@ TEST_F(InstanceAdminTest, SetNativeIamPolicyRecoverableError) {
 }
 /// @test Verify that InstanceAdmin::TestIamPermissions works in simple case.
 TEST_F(InstanceAdminTest, TestIamPermissions) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
@@ -961,8 +937,7 @@ TEST_F(InstanceAdminTest, TestIamPermissions) {
         return grpc::Status::OK;
       };
 
-  EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
-      .WillOnce(mock_permission_set);
+  EXPECT_CALL(*client_, TestIamPermissions).WillOnce(mock_permission_set);
 
   std::string resource = "the-resource";
   auto permission_set =
@@ -974,12 +949,11 @@ TEST_F(InstanceAdminTest, TestIamPermissions) {
 
 /// @test Test for unrecoverable errors for InstanceAdmin::TestIamPermissions.
 TEST_F(InstanceAdminTest, TestIamPermissionsUnrecoverableError) {
-  using ::testing::_;
   using ::testing::Return;
 
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
+  EXPECT_CALL(*client_, TestIamPermissions)
       .WillRepeatedly(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "err!")));
 
@@ -991,7 +965,6 @@ TEST_F(InstanceAdminTest, TestIamPermissionsUnrecoverableError) {
 
 /// @test Test for recoverable errors for InstanceAdmin::TestIamPermissions.
 TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
@@ -1019,7 +992,7 @@ TEST_F(InstanceAdminTest, TestIamPermissionsRecoverableError) {
         response->add_permissions(permissions[1]);
         return grpc::Status::OK;
       };
-  EXPECT_CALL(*client_, TestIamPermissions(_, _, _))
+  EXPECT_CALL(*client_, TestIamPermissions)
       .WillOnce(mock_recoverable_failure)
       .WillOnce(mock_permission_set);
 
@@ -1043,7 +1016,7 @@ class AsyncDeleteClusterTest : public ::testing::Test {
         client_(new MockAdminClient),
         reader_(new MockAsyncDeleteClusterReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
-    EXPECT_CALL(*client_, AsyncDeleteCluster(_, _, _))
+    EXPECT_CALL(*client_, AsyncDeleteCluster)
         .WillOnce([this](grpc::ClientContext* context,
                          btadmin::DeleteClusterRequest const& request,
                          grpc::CompletionQueue*) {
@@ -1077,10 +1050,9 @@ class AsyncDeleteClusterTest : public ::testing::Test {
 
 /// @test Verify that AsyncDeleteCluster works in simple case.
 TEST_F(AsyncDeleteClusterTest, AsyncDeleteCluster) {
-  using ::testing::_;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce(
           [](::google::protobuf::Empty* response, grpc::Status* status, void*) {
             EXPECT_NE(nullptr, response);
@@ -1097,10 +1069,9 @@ TEST_F(AsyncDeleteClusterTest, AsyncDeleteCluster) {
 
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncDeleteCluster.
 TEST_F(AsyncDeleteClusterTest, AsyncDeleteClusterUnrecoverableError) {
-  using ::testing::_;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce(
           [](::google::protobuf::Empty* response, grpc::Status* status, void*) {
             EXPECT_NE(nullptr, response);
@@ -1128,7 +1099,7 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
         client_(new MockAdminClient),
         reader_(new MockAsyncSetIamPolicyReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
-    EXPECT_CALL(*client_, AsyncSetIamPolicy(_, _, _))
+    EXPECT_CALL(*client_, AsyncSetIamPolicy)
         .WillOnce([this](grpc::ClientContext* context,
                          ::google::iam::v1::SetIamPolicyRequest const& request,
                          grpc::CompletionQueue*) {
@@ -1174,11 +1145,10 @@ class AsyncSetIamPolicyTest : public ::testing::Test {
 
 /// @test Verify that AsyncSetIamPolicy works in simple case.
 TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
 
@@ -1203,11 +1173,10 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicy) {
 
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncSetIamPolicy.
 TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
@@ -1224,11 +1193,10 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetIamPolicyUnrecoverableError) {
 
 /// @test Verify that AsyncSetIamPolicy works in simple case (native).
 TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicy) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
 
@@ -1253,11 +1221,10 @@ TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicy) {
 
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncSetIamPolicy native.
 TEST_F(AsyncSetIamPolicyTest, AsyncSetNativeIamPolicyUnrecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::Policy* response, grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");
@@ -1284,7 +1251,7 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
         client_(new MockAdminClient),
         reader_(new MockAsyncTestIamPermissionsReader) {
     EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(kProjectId));
-    EXPECT_CALL(*client_, AsyncTestIamPermissions(_, _, _))
+    EXPECT_CALL(*client_, AsyncTestIamPermissions)
         .WillOnce(
             [this](grpc::ClientContext* context,
                    ::google::iam::v1::TestIamPermissionsRequest const& request,
@@ -1320,11 +1287,10 @@ class AsyncTestIamPermissionsTest : public ::testing::Test {
 
 /// @test Verify that AsyncTestIamPermissions works in simple case.
 TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::TestIamPermissionsResponse* response,
                    grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
@@ -1344,11 +1310,10 @@ TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissions) {
 
 /// @test Test unrecoverable errors for InstanceAdmin::AsyncTestIamPermissions.
 TEST_F(AsyncTestIamPermissionsTest, AsyncTestIamPermissionsUnrecoverableError) {
-  using ::testing::_;
   namespace iamproto = ::google::iam::v1;
   InstanceAdmin tested(client_);
 
-  EXPECT_CALL(*reader_, Finish(_, _, _))
+  EXPECT_CALL(*reader_, Finish)
       .WillOnce([](iamproto::TestIamPermissionsResponse* response,
                    grpc::Status* status, void*) {
         EXPECT_NE(nullptr, response);
@@ -1393,11 +1358,10 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 };
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::CreateAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncCreateAppProfile(_, _, _))
+  EXPECT_CALL(*client_, AsyncCreateAppProfile)
       .WillOnce(rpc_factory.Create(
           R"""(
               parent: "projects/the-project/instances/the-instance"
@@ -1410,11 +1374,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateAppProfile) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::DeleteAppProfileRequest, google::protobuf::Empty>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncDeleteAppProfile(_, _, _))
+  EXPECT_CALL(*client_, AsyncDeleteAppProfile)
       .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
@@ -1431,11 +1394,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteAppProfile) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::DeleteInstanceRequest, google::protobuf::Empty>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncDeleteInstance(_, _, _))
+  EXPECT_CALL(*client_, AsyncDeleteInstance)
       .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance"
@@ -1450,11 +1412,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncDeleteInstance) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::GetAppProfileRequest, btadmin::AppProfile>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncGetAppProfile(_, _, _))
+  EXPECT_CALL(*client_, AsyncGetAppProfile)
       .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance/appProfiles/the-profile"
@@ -1465,11 +1426,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetAppProfile) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::GetClusterRequest, btadmin::Cluster>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncGetCluster(_, _, _))
+  EXPECT_CALL(*client_, AsyncGetCluster)
       .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance/clusters/the-cluster"
@@ -1480,11 +1440,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetCluster) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::GetInstanceRequest, btadmin::Instance>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncGetInstance(_, _, _))
+  EXPECT_CALL(*client_, AsyncGetInstance)
       .WillOnce(rpc_factory.Create(
           R"""(
               name: "projects/the-project/instances/the-instance"
@@ -1494,11 +1453,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncGetInstance) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::CreateClusterRequest, google::longrunning::Operation>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncCreateCluster(_, _, _))
+  EXPECT_CALL(*client_, AsyncCreateCluster)
       .WillOnce(rpc_factory.Create(
           R"""(
               parent: "projects/the-project/instances/the-instance"
@@ -1516,11 +1474,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateCluster) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::CreateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncCreateInstance(_, _, _))
+  EXPECT_CALL(*client_, AsyncCreateInstance)
       .WillOnce(rpc_factory.Create(
           R"""(
               parent: "projects/the-project"
@@ -1533,11 +1490,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncCreateInstance) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::UpdateAppProfileRequest, google::longrunning::Operation>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncUpdateAppProfile(_, _, _))
+  EXPECT_CALL(*client_, AsyncUpdateAppProfile)
       .WillOnce(rpc_factory.Create(
           R"""(
               app_profile: {
@@ -1550,11 +1506,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateAppProfile) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::Cluster, google::longrunning::Operation>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncUpdateCluster(_, _, _))
+  EXPECT_CALL(*client_, AsyncUpdateCluster)
       .WillOnce(rpc_factory.Create(
           R"""(
               location: "loc1"
@@ -1571,11 +1526,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncUpdateCluster) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncUpdateInstance) {
-  using ::testing::_;
   ::google::cloud::bigtable::testing::MockAsyncFailingRpcFactory<
       btadmin::PartialUpdateInstanceRequest, google::longrunning::Operation>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncUpdateInstance(_, _, _))
+  EXPECT_CALL(*client_, AsyncUpdateInstance)
       .WillOnce(rpc_factory.Create(
           R"""(
               instance: {
@@ -1601,7 +1555,7 @@ TEST_F(InstanceAdminTest, CreateAppProfile) {
                              btadmin::AppProfile>::
       Create(expected_text,
              "google.bigtable.admin.v2.BigtableInstanceAdmin.CreateAppProfile");
-  EXPECT_CALL(*client_, CreateAppProfile(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, CreateAppProfile).WillOnce(mock);
   ASSERT_STATUS_OK(tested.CreateAppProfile(
       "the-instance", AppProfileConfig::MultiClusterUseAny("prof")));
 }
@@ -1616,7 +1570,7 @@ TEST_F(InstanceAdminTest, DeleteAppProfile) {
   auto mock = MockRpcFactory<btadmin::DeleteAppProfileRequest, Empty>::Create(
       expected_text,
       "google.bigtable.admin.v2.BigtableInstanceAdmin.DeleteAppProfile");
-  EXPECT_CALL(*client_, DeleteAppProfile(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, DeleteAppProfile).WillOnce(mock);
   ASSERT_STATUS_OK(tested.DeleteAppProfile("the-instance", "the-profile"));
 }
 
@@ -1631,7 +1585,7 @@ TEST_F(InstanceAdminTest, GetAppProfile) {
           Create(
               expected_text,
               "google.bigtable.admin.v2.BigtableInstanceAdmin.GetAppProfile");
-  EXPECT_CALL(*client_, GetAppProfile(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, GetAppProfile).WillOnce(mock);
   ASSERT_STATUS_OK(tested.GetAppProfile("the-instance", "the-profile"));
 }
 
@@ -1645,7 +1599,7 @@ TEST_F(InstanceAdminTest, GetInstance) {
       MockRpcFactory<btadmin::GetInstanceRequest, btadmin::Instance>::Create(
           expected_text,
           "google.bigtable.admin.v2.BigtableInstanceAdmin.GetInstance");
-  EXPECT_CALL(*client_, GetInstance(_, _, _)).WillOnce(mock);
+  EXPECT_CALL(*client_, GetInstance).WillOnce(mock);
   ASSERT_STATUS_OK(tested.GetInstance("the-instance"));
 }
 

--- a/google/cloud/bigtable/internal/async_longrunning_op_test.cc
+++ b/google/cloud/bigtable/internal/async_longrunning_op_test.cc
@@ -34,7 +34,6 @@ namespace {
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::bigtable::v2::SampleRowKeysResponse;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::WithParamInterface;
 
 using MockAsyncLongrunningOpReader =
@@ -67,7 +66,7 @@ TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
       ClientOptions().DisableBackgroundThreads(cq_));
 
   auto longrunning_reader = absl::make_unique<MockAsyncLongrunningOpReader>();
-  EXPECT_CALL(*longrunning_reader, Finish(_, _, _))
+  EXPECT_CALL(*longrunning_reader, Finish)
       .WillOnce([success](google::longrunning::Operation* response,
                           grpc::Status* status, void*) {
         if (success) {
@@ -77,7 +76,7 @@ TEST_P(AsyncLongrunningOpFutureTest, EndToEnd) {
         }
       });
 
-  EXPECT_CALL(*client, AsyncGetOperation(_, _, _))
+  EXPECT_CALL(*client, AsyncGetOperation)
       .WillOnce([&longrunning_reader](
                     grpc::ClientContext*,
                     google::longrunning::GetOperationRequest const& request,
@@ -145,13 +144,13 @@ class AsyncLongrunningOperationTest : public ::testing::Test {
       std::function<void(google::longrunning::Operation&, grpc::Status&)> const&
           response_filler,
       google::longrunning::Operation op) {
-    EXPECT_CALL(*longrunning_reader_, Finish(_, _, _))
+    EXPECT_CALL(*longrunning_reader_, Finish)
         .WillOnce([response_filler](google::longrunning::Operation* response,
                                     grpc::Status* status, void*) {
           response_filler(*response, *status);
         });
 
-    EXPECT_CALL(*client_, AsyncGetOperation(_, _, _))
+    EXPECT_CALL(*client_, AsyncGetOperation)
         .WillOnce(
             [this](grpc::ClientContext*,
                    google::longrunning::GetOperationRequest const& request,

--- a/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_multi_page_test.cc
@@ -35,7 +35,6 @@ namespace internal {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::Return;
 
 class BackoffPolicyMock : public bigtable::RPCBackoffPolicy {
@@ -136,7 +135,7 @@ class AsyncMultipageFutureTest : public ::testing::Test {
                                        ? std::string()
                                        : last_success->next_page_token;
 
-      EXPECT_CALL(*client_, AsyncListClusters(_, _, _))
+      EXPECT_CALL(*client_, AsyncListClusters)
           .WillOnce([cluster_reader, expected_token](
                         grpc::ClientContext*,
                         ListClustersRequest const& request,
@@ -148,7 +147,7 @@ class AsyncMultipageFutureTest : public ::testing::Test {
                 cluster_reader);
           })
           .RetiresOnSaturation();
-      EXPECT_CALL(*cluster_reader, Finish(_, _, _))
+      EXPECT_CALL(*cluster_reader, Finish)
           .WillOnce([exchange](ListClustersResponse* response,
                                grpc::Status* status, void*) {
             for (auto const& cluster_name : exchange.clusters) {
@@ -233,7 +232,7 @@ TEST_F(AsyncMultipageFutureTest, DelayGrowsOnFailures) {
   ExpectInteraction({{grpc::StatusCode::UNAVAILABLE, {}, ""},
                      {grpc::StatusCode::UNAVAILABLE, {}, ""},
                      {grpc::StatusCode::OK, {"cluster_1"}, ""}});
-  EXPECT_CALL(*shared_backoff_policy_mock_->state_, OnCompletionHook(_))
+  EXPECT_CALL(*shared_backoff_policy_mock_->state_, OnCompletionHook)
       .WillOnce(Return(std::chrono::milliseconds(1)))
       .WillOnce(Return(std::chrono::milliseconds(1)));
 
@@ -274,7 +273,7 @@ TEST_F(AsyncMultipageFutureTest, SucessResetsBackoffPolicy) {
                      {grpc::StatusCode::OK, {"cluster_1"}, "token1"},
                      {grpc::StatusCode::UNAVAILABLE, {}, ""},
                      {grpc::StatusCode::OK, {"cluster_2"}, ""}});
-  EXPECT_CALL(*shared_backoff_policy_mock_->state_, OnCompletionHook(_))
+  EXPECT_CALL(*shared_backoff_policy_mock_->state_, OnCompletionHook)
       .WillOnce(Return(std::chrono::milliseconds(1)))
       .WillOnce(Return(std::chrono::milliseconds(1)));
 
@@ -319,7 +318,7 @@ TEST_F(AsyncMultipageFutureTest, SucessResetsBackoffPolicy) {
 TEST_F(AsyncMultipageFutureTest, TransientErrorsAreRetried) {
   ExpectInteraction({{grpc::StatusCode::UNAVAILABLE, {}, ""},
                      {grpc::StatusCode::OK, {"cluster_1"}, ""}});
-  EXPECT_CALL(*shared_backoff_policy_mock_->state_, OnCompletionHook(_))
+  EXPECT_CALL(*shared_backoff_policy_mock_->state_, OnCompletionHook)
       .WillOnce(Return(std::chrono::milliseconds(1)));
 
   future<StatusOr<std::vector<std::string>>> clusters_future = StartOp();

--- a/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
+++ b/google/cloud/bigtable/internal/async_retry_unary_rpc_and_poll_test.cc
@@ -74,8 +74,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
         .WillRepeatedly(::testing::ReturnRef(k_project_id));
   }
   void ExpectCreateCluster(grpc::StatusCode mocked_code) {
-    using ::testing::_;
-    EXPECT_CALL(*create_cluster_reader, Finish(_, _, _))
+    EXPECT_CALL(*create_cluster_reader, Finish)
         .WillOnce([mocked_code](longrunning::Operation* response,
                                 grpc::Status* status, void*) {
           response->set_name("create_cluster_op_1");
@@ -83,7 +82,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
                         ? grpc::Status(mocked_code, "mocked-status")
                         : grpc::Status::OK;
         });
-    EXPECT_CALL(*client, AsyncCreateCluster(_, _, _))
+    EXPECT_CALL(*client, AsyncCreateCluster)
         .WillOnce([this](grpc::ClientContext* context,
                          btproto::CreateClusterRequest const& request,
                          grpc::CompletionQueue*) {
@@ -101,8 +100,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
 
   void ExpectPolling(bool polling_finished,
                      grpc::StatusCode polling_error_code) {
-    using ::testing::_;
-    EXPECT_CALL(*get_operation_reader, Finish(_, _, _))
+    EXPECT_CALL(*get_operation_reader, Finish)
         .WillOnce([polling_finished, polling_error_code](
                       longrunning::Operation* response, grpc::Status* status,
                       void*) {
@@ -126,7 +124,7 @@ class AsyncStartPollAfterRetryUnaryRpcTest
             response->set_allocated_response(any.release());
           }
         });
-    EXPECT_CALL(*client, AsyncGetOperation(_, _, _))
+    EXPECT_CALL(*client, AsyncGetOperation)
         .WillOnce([this](grpc::ClientContext* context,
                          longrunning::GetOperationRequest const& request,
                          grpc::CompletionQueue*) {

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -38,7 +38,6 @@ using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using bigtable::testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
-using ::testing::_;
 using ::testing::Not;
 using ::testing::WithParamInterface;
 
@@ -150,23 +149,23 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
       // returning it as a unique_ptr.
       auto* reader =
           new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
-      EXPECT_CALL(*reader, Read(_, _))
+      EXPECT_CALL(*reader, Read)
           .WillOnce([](btproto::MutateRowsResponse*, void*) {});
       // Just like in the outer loop, we need to reverse the order to counter
       // gMock's expectation matching order (from latest added to first).
       for (auto result_piece_it = exchange.res.rbegin();
            result_piece_it != exchange.res.rend(); ++result_piece_it) {
-        EXPECT_CALL(*reader, Read(_, _))
+        EXPECT_CALL(*reader, Read)
             .WillOnce(generate_response_generator(*result_piece_it))
             .RetiresOnSaturation();
       }
 
-      EXPECT_CALL(*reader, Finish(_, _))
-          .WillOnce(
-              [](grpc::Status* status, void*) { *status = grpc::Status::OK; });
-      EXPECT_CALL(*reader, StartCall(_)).Times(1);
+      EXPECT_CALL(*reader, Finish).WillOnce([](grpc::Status* status, void*) {
+        *status = grpc::Status::OK;
+      });
+      EXPECT_CALL(*reader, StartCall).Times(1);
 
-      EXPECT_CALL(*client_, PrepareAsyncMutateRows(_, _, _))
+      EXPECT_CALL(*client_, PrepareAsyncMutateRows)
           .WillOnce([reader, exchange](grpc::ClientContext* context,
                                        btproto::MutateRowsRequest const& r,
                                        grpc::CompletionQueue*) {
@@ -698,17 +697,17 @@ TEST_F(MutationBatcherTest, ApplyCompletesImmediately) {
 
   auto* reader =
       new MockClientAsyncReaderInterface<btproto::MutateRowsResponse>;
-  EXPECT_CALL(*reader, Read(_, _))
+  EXPECT_CALL(*reader, Read)
       .WillOnce([](btproto::MutateRowsResponse* r, void*) {
         auto& e = *r->add_entries();
         e.set_index(0);
         e.mutable_status()->set_code(grpc::StatusCode::OK);
       })
       .WillOnce([](btproto::MutateRowsResponse*, void*) {});
-  EXPECT_CALL(*reader, Finish(_, _)).WillOnce([](grpc::Status* status, void*) {
+  EXPECT_CALL(*reader, Finish).WillOnce([](grpc::Status* status, void*) {
     *status = grpc::Status::OK;
   });
-  EXPECT_CALL(*reader, StartCall(_)).Times(1);
+  EXPECT_CALL(*reader, StartCall).Times(1);
   batcher_raw_ptr->SetOnBulkApply([this] {
     // Simulate completion queue finishing this stream before contol is
     // returned from AsyncBulkApplyImpl
@@ -723,7 +722,7 @@ TEST_F(MutationBatcherTest, ApplyCompletesImmediately) {
     }).get();
   });
 
-  EXPECT_CALL(*client_, PrepareAsyncMutateRows(_, _, _))
+  EXPECT_CALL(*client_, PrepareAsyncMutateRows)
       .WillOnce([reader](grpc::ClientContext*,
                          btproto::MutateRowsRequest const&,
                          grpc::CompletionQueue*) {

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -156,11 +156,10 @@ class ValidContextMdAsyncTest : public ::testing::Test {
 };
 
 TEST_F(ValidContextMdAsyncTest, AsyncApply) {
-  using ::testing::_;
   testing::MockAsyncFailingRpcFactory<btproto::MutateRowRequest,
                                       btproto::MutateRowResponse>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncMutateRow(_, _, _))
+  EXPECT_CALL(*client_, AsyncMutateRow)
       .WillOnce(rpc_factory.Create(
           R"""(
               table_name: "projects/the-project/instances/the-instance/tables/the-table"
@@ -172,11 +171,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncApply) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncCheckAndMutateRow) {
-  using ::testing::_;
   testing::MockAsyncFailingRpcFactory<btproto::CheckAndMutateRowRequest,
                                       btproto::CheckAndMutateRowResponse>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncCheckAndMutateRow(_, _, _))
+  EXPECT_CALL(*client_, AsyncCheckAndMutateRow)
       .WillOnce(rpc_factory.Create(
           R"""(
               table_name: "projects/the-project/instances/the-instance/tables/the-table"
@@ -190,11 +188,10 @@ TEST_F(ValidContextMdAsyncTest, AsyncCheckAndMutateRow) {
 }
 
 TEST_F(ValidContextMdAsyncTest, AsyncReadModifyWriteRow) {
-  using ::testing::_;
   testing::MockAsyncFailingRpcFactory<btproto::ReadModifyWriteRowRequest,
                                       btproto::ReadModifyWriteRowResponse>
       rpc_factory;
-  EXPECT_CALL(*client_, AsyncReadModifyWriteRow(_, _, _))
+  EXPECT_CALL(*client_, AsyncReadModifyWriteRow)
       .WillOnce(rpc_factory.Create(
           R"""(
               table_name: "projects/the-project/instances/the-instance/tables/the-table"

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -35,7 +35,6 @@ namespace btadmin = ::google::bigtable::admin::v2;
 namespace btproto = ::google::bigtable::v2;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::IsOk;
-using ::testing::_;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Not;
@@ -222,13 +221,13 @@ TEST(CompletionQueueTest, MakeUnaryRpc) {
   CompletionQueue cq(mock_cq);
 
   auto mock_reader = absl::make_unique<MockTableReader>();
-  EXPECT_CALL(*mock_reader, Finish(_, _, _))
+  EXPECT_CALL(*mock_reader, Finish)
       .WillOnce([](btadmin::Table* table, grpc::Status* status, void*) {
         table->set_name("test-table-name");
         *status = grpc::Status::OK;
       });
   MockClient mock_client;
-  EXPECT_CALL(mock_client, AsyncGetTable(_, _, _))
+  EXPECT_CALL(mock_client, AsyncGetTable)
       .WillOnce([&mock_reader](grpc::ClientContext*,
                                btadmin::GetTableRequest const& request,
                                grpc::CompletionQueue*) {
@@ -272,12 +271,12 @@ TEST(CompletionQueueTest, MakeStreamingReadRpc) {
   CompletionQueue cq(mock_cq);
 
   auto mock_reader = absl::make_unique<MockRowReader>();
-  EXPECT_CALL(*mock_reader, StartCall(_)).Times(1);
-  EXPECT_CALL(*mock_reader, Read(_, _)).Times(2);
-  EXPECT_CALL(*mock_reader, Finish(_, _)).Times(1);
+  EXPECT_CALL(*mock_reader, StartCall).Times(1);
+  EXPECT_CALL(*mock_reader, Read).Times(2);
+  EXPECT_CALL(*mock_reader, Finish).Times(1);
 
   MockClient mock_client;
-  EXPECT_CALL(mock_client, AsyncReadRows(_, _, _))
+  EXPECT_CALL(mock_client, AsyncReadRows)
       .WillOnce([&mock_reader](grpc::ClientContext*,
                                btproto::ReadRowsRequest const& request,
                                grpc::CompletionQueue*) {

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -34,7 +34,6 @@ using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::MockAsyncResponseReader;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -87,7 +86,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
 
   using ReaderType = MockAsyncResponseReader<btadmin::Table>;
   auto reader = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*reader, Finish(_, _, _))
+  EXPECT_CALL(*reader, Finish)
       .WillOnce([](btadmin::Table* table, grpc::Status* status, void*) {
         // Initialize a value to make sure it is carried all the way back to
         // the caller.
@@ -95,7 +94,7 @@ TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
         *status = grpc::Status::OK;
       });
 
-  EXPECT_CALL(mock, AsyncGetTable(_, _, _))
+  EXPECT_CALL(mock, AsyncGetTable)
       .WillOnce([&reader](grpc::ClientContext*,
                           btadmin::GetTableRequest const& request,
                           grpc::CompletionQueue*) {
@@ -139,12 +138,12 @@ TEST(AsyncRetryUnaryRpcTest, VoidImmediatelySucceeds) {
 
   using ReaderType = MockAsyncResponseReader<google::protobuf::Empty>;
   auto reader = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*reader, Finish(_, _, _))
+  EXPECT_CALL(*reader, Finish)
       .WillOnce([](google::protobuf::Empty*, grpc::Status* status, void*) {
         *status = grpc::Status::OK;
       });
 
-  EXPECT_CALL(mock, AsyncDeleteTable(_, _, _))
+  EXPECT_CALL(mock, AsyncDeleteTable)
       .WillOnce([&reader](grpc::ClientContext*,
                           btadmin::DeleteTableRequest const& request,
                           grpc::CompletionQueue*) {
@@ -187,12 +186,12 @@ TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
 
   using ReaderType = MockAsyncResponseReader<btadmin::Table>;
   auto reader = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*reader, Finish(_, _, _))
+  EXPECT_CALL(*reader, Finish)
       .WillOnce([](btadmin::Table*, grpc::Status* status, void*) {
         *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh");
       });
 
-  EXPECT_CALL(mock, AsyncGetTable(_, _, _))
+  EXPECT_CALL(mock, AsyncGetTable)
       .WillOnce([&reader](grpc::ClientContext*,
                           btadmin::GetTableRequest const& request,
                           grpc::CompletionQueue*) {
@@ -242,13 +241,13 @@ TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
   };
 
   auto r1 = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*r1, Finish(_, _, _)).WillOnce(finish_failure);
+  EXPECT_CALL(*r1, Finish).WillOnce(finish_failure);
   auto r2 = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*r2, Finish(_, _, _)).WillOnce(finish_failure);
+  EXPECT_CALL(*r2, Finish).WillOnce(finish_failure);
   auto r3 = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*r3, Finish(_, _, _)).WillOnce(finish_failure);
+  EXPECT_CALL(*r3, Finish).WillOnce(finish_failure);
 
-  EXPECT_CALL(mock, AsyncGetTable(_, _, _))
+  EXPECT_CALL(mock, AsyncGetTable)
       .WillOnce([&r1](grpc::ClientContext*,
                       btadmin::GetTableRequest const& request,
                       grpc::CompletionQueue*) {
@@ -318,13 +317,13 @@ TEST(AsyncRetryUnaryRpcTest, TransientOnNonIdempotent) {
 
   using ReaderType = MockAsyncResponseReader<google::protobuf::Empty>;
   auto reader = absl::make_unique<ReaderType>();
-  EXPECT_CALL(*reader, Finish(_, _, _))
+  EXPECT_CALL(*reader, Finish)
       .WillOnce([](google::protobuf::Empty*, grpc::Status* status, void*) {
         *status =
             grpc::Status(grpc::StatusCode::UNAVAILABLE, "maybe-try-again");
       });
 
-  EXPECT_CALL(mock, AsyncDeleteTable(_, _, _))
+  EXPECT_CALL(mock, AsyncDeleteTable)
       .WillOnce([&reader](grpc::ClientContext*,
                           btadmin::DeleteTableRequest const& request,
                           grpc::CompletionQueue*) {

--- a/google/cloud/internal/pagination_range_test.cc
+++ b/google/cloud/internal/pagination_range_test.cc
@@ -23,7 +23,6 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 
@@ -83,7 +82,7 @@ TYPED_TEST_SUITE(PaginationRangeTest, ResponseTypes);
 TYPED_TEST(PaginationRangeTest, TypedEmpty) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
-  EXPECT_CALL(mock, Loader(_)).WillOnce([](Request const& request) {
+  EXPECT_CALL(mock, Loader).WillOnce([](Request const& request) {
     EXPECT_TRUE(request.testonly_page_token.empty());
     return ResponseType{};
   });
@@ -96,7 +95,7 @@ TYPED_TEST(PaginationRangeTest, TypedEmpty) {
 TYPED_TEST(PaginationRangeTest, SinglePage) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
-  EXPECT_CALL(mock, Loader(_)).WillOnce([](Request const& request) {
+  EXPECT_CALL(mock, Loader).WillOnce([](Request const& request) {
     EXPECT_TRUE(request.testonly_page_token.empty());
     ResponseType response;
     response.testonly_items.push_back(Item{"p1"});
@@ -118,7 +117,7 @@ TYPED_TEST(PaginationRangeTest, SinglePage) {
 TYPED_TEST(PaginationRangeTest, NonProtoRange) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
-  EXPECT_CALL(mock, Loader(_)).WillOnce([](Request const& request) {
+  EXPECT_CALL(mock, Loader).WillOnce([](Request const& request) {
     EXPECT_TRUE(request.testonly_page_token.empty());
     ResponseType response;
     response.testonly_items.push_back(Item{"p1"});
@@ -148,7 +147,7 @@ TYPED_TEST(PaginationRangeTest, NonProtoRange) {
 TYPED_TEST(PaginationRangeTest, TwoPages) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
-  EXPECT_CALL(mock, Loader(_))
+  EXPECT_CALL(mock, Loader)
       .WillOnce([](Request const& request) {
         EXPECT_TRUE(request.testonly_page_token.empty());
         ResponseType response;
@@ -179,7 +178,7 @@ TYPED_TEST(PaginationRangeTest, TwoPages) {
 TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
-  EXPECT_CALL(mock, Loader(_))
+  EXPECT_CALL(mock, Loader)
       .WillOnce([](Request const& request) {
         EXPECT_TRUE(request.testonly_page_token.empty());
         ResponseType response;
@@ -219,7 +218,7 @@ TYPED_TEST(PaginationRangeTest, TwoPagesWithError) {
 TYPED_TEST(PaginationRangeTest, IteratorCoverage) {
   using ResponseType = TypeParam;
   MockRpc<ResponseType> mock;
-  EXPECT_CALL(mock, Loader(_))
+  EXPECT_CALL(mock, Loader)
       .WillOnce([](Request const& request) {
         EXPECT_TRUE(request.testonly_page_token.empty());
         ResponseType response;

--- a/google/cloud/log_test.cc
+++ b/google/cloud/log_test.cc
@@ -24,7 +24,6 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace {
 
 using ::google::cloud::testing_util::ScopedEnvironment;
-using ::testing::_;
 using ::testing::ExitedWithCode;
 using ::testing::HasSubstr;
 
@@ -107,11 +106,10 @@ TEST(LogSinkTest, ClearBackend) {
 TEST(LogSinkTest, LogEnabled) {
   LogSink sink;
   auto backend = std::make_shared<MockLogBackend>();
-  EXPECT_CALL(*backend, ProcessWithOwnership(_))
-      .WillOnce([](LogRecord const& lr) {
-        EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
-        EXPECT_EQ("test message", lr.message);
-      });
+  EXPECT_CALL(*backend, ProcessWithOwnership).WillOnce([](LogRecord const& lr) {
+    EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
+    EXPECT_EQ("test message", lr.message);
+  });
   sink.AddBackend(backend);
 
   GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_WARNING, sink) << "test message";
@@ -121,12 +119,12 @@ TEST(LogSinkTest, LogEnabledMultipleBackends) {
   LogSink sink;
   auto be1 = std::make_shared<MockLogBackend>();
   auto be2 = std::make_shared<MockLogBackend>();
-  EXPECT_CALL(*be1, Process(_)).WillOnce([](LogRecord const& lr) {
+  EXPECT_CALL(*be1, Process).WillOnce([](LogRecord const& lr) {
     EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
     EXPECT_EQ("test message", lr.message);
   });
   sink.AddBackend(be1);
-  EXPECT_CALL(*be2, Process(_)).WillOnce([](LogRecord const& lr) {
+  EXPECT_CALL(*be2, Process).WillOnce([](LogRecord const& lr) {
     EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
     EXPECT_EQ("test message", lr.message);
   });
@@ -151,11 +149,10 @@ TEST(LogSinkTest, LogDefaultInstance) {
   ScopedEnvironment config(kLogConfigVariable, absl::nullopt);
 
   auto backend = std::make_shared<MockLogBackend>();
-  EXPECT_CALL(*backend, ProcessWithOwnership(_))
-      .WillOnce([](LogRecord const& lr) {
-        EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
-        EXPECT_EQ("test message", lr.message);
-      });
+  EXPECT_CALL(*backend, ProcessWithOwnership).WillOnce([](LogRecord const& lr) {
+    EXPECT_EQ(Severity::GCP_LS_WARNING, lr.severity);
+    EXPECT_EQ("test message", lr.message);
+  });
   LogSink::Instance().AddBackend(backend);
 
   GCP_LOG(WARNING) << "test message";
@@ -229,7 +226,7 @@ TEST(LogSinkTest, LogCheckCounter) {
   // The following tests could pass if the << operator was a no-op, so for
   // extra paranoia check that this is not the case.
   auto backend = std::make_shared<MockLogBackend>();
-  EXPECT_CALL(*backend, ProcessWithOwnership(_)).Times(2);
+  EXPECT_CALL(*backend, ProcessWithOwnership).Times(2);
   sink.AddBackend(backend);
   GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_ALERT, sink) << "count is " << counter;
   GOOGLE_CLOUD_CPP_LOG_I(GCP_LS_FATAL, sink) << "count is " << counter;
@@ -249,7 +246,7 @@ TEST(LogSinkTest, LogDisabledLevels) {
   LogSink sink;
   IOStreamCounter counter{0};
   auto backend = std::make_shared<MockLogBackend>();
-  EXPECT_CALL(*backend, ProcessWithOwnership(_)).Times(1);
+  EXPECT_CALL(*backend, ProcessWithOwnership).Times(1);
   sink.AddBackend(backend);
 
   sink.set_minimum_severity(Severity::GCP_LS_INFO);
@@ -266,7 +263,7 @@ TEST(LogSinkTest, CompileTimeDisabledCannotBeEnabled) {
   LogSink sink;
   IOStreamCounter counter{0};
   auto backend = std::make_shared<MockLogBackend>();
-  EXPECT_CALL(*backend, ProcessWithOwnership(_)).Times(1);
+  EXPECT_CALL(*backend, ProcessWithOwnership).Times(1);
   sink.AddBackend(backend);
 
   // Compile-time disabled logs cannot be enabled at r

--- a/google/cloud/pubsub/publisher_test.cc
+++ b/google/cloud/pubsub/publisher_test.cc
@@ -23,8 +23,6 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::testing::_;
-
 // Tests {copy,move}x{constructor,assignment} + equality.
 TEST(PublisherTest, ValueSemantics) {
   auto mock1 = std::make_shared<pubsub_mocks::MockPublisherConnection>();
@@ -49,12 +47,12 @@ TEST(PublisherTest, ValueSemantics) {
 
 TEST(PublisherTest, PublishSimple) {
   auto mock = std::make_shared<pubsub_mocks::MockPublisherConnection>();
-  EXPECT_CALL(*mock, Publish(_))
+  EXPECT_CALL(*mock, Publish)
       .WillOnce([&](PublisherConnection::PublishParams const& p) {
         EXPECT_EQ("test-data-0", p.message.data());
         return make_ready_future(StatusOr<std::string>("test-id-0"));
       });
-  EXPECT_CALL(*mock, Flush(_)).Times(1);
+  EXPECT_CALL(*mock, Flush).Times(1);
 
   Publisher publisher(mock);
   publisher.Flush();

--- a/google/cloud/pubsub/subscriber_test.cc
+++ b/google/cloud/pubsub/subscriber_test.cc
@@ -25,13 +25,11 @@ namespace pubsub {
 inline namespace GOOGLE_CLOUD_CPP_PUBSUB_NS {
 namespace {
 
-using ::testing::_;
-
 /// @test Verify Subscriber::Subscribe() works, including mocks.
 TEST(SubscriberTest, SubscribeSimple) {
   Subscription const subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_mocks::MockSubscriberConnection>();
-  EXPECT_CALL(*mock, Subscribe(_))
+  EXPECT_CALL(*mock, Subscribe)
       .WillOnce([&](SubscriberConnection::SubscribeParams const& p) {
         {
           auto ack = absl::make_unique<pubsub_mocks::MockAckHandler>();
@@ -67,7 +65,7 @@ TEST(SubscriberTest, SubscribeSimple) {
 TEST(SubscriberTest, SubscribeWithOptions) {
   Subscription const subscription("test-project", "test-subscription");
   auto mock = std::make_shared<pubsub_mocks::MockSubscriberConnection>();
-  EXPECT_CALL(*mock, Subscribe(_))
+  EXPECT_CALL(*mock, Subscribe)
       .WillOnce([&](SubscriberConnection::SubscribeParams const&) {
         return make_ready_future(Status{});
       });

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
@@ -41,7 +40,7 @@ TEST(DatabaseAdminClientTest, CreateDatabase) {
 
   Database dbase("test-project", "test-instance", "test-db");
 
-  EXPECT_CALL(*mock, CreateDatabase(_))
+  EXPECT_CALL(*mock, CreateDatabase)
       .WillOnce(
           [&dbase](DatabaseAdminConnection::CreateDatabaseParams const& p) {
             EXPECT_EQ(p.database, dbase);
@@ -67,7 +66,7 @@ TEST(DatabaseAdminClientTest, GetDatabase) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Database dbase("test-project", "test-instance", "test-db");
 
-  EXPECT_CALL(*mock, GetDatabase(_))
+  EXPECT_CALL(*mock, GetDatabase)
       .WillOnce([&dbase](DatabaseAdminConnection::GetDatabaseParams const& p) {
         EXPECT_EQ(dbase, p.database);
         gcsa::Database response;
@@ -89,7 +88,7 @@ TEST(DatabaseAdminClientTest, GetDatabaseDdl) {
   Database const expected_name("test-project", "test-instance",
                                "test-database");
 
-  EXPECT_CALL(*mock, GetDatabaseDdl(_))
+  EXPECT_CALL(*mock, GetDatabaseDdl)
       .WillOnce([&expected_name](
                     DatabaseAdminConnection::GetDatabaseDdlParams const& p) {
         EXPECT_EQ(expected_name, p.database);
@@ -111,7 +110,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabase) {
 
   Database dbase("test-project", "test-instance", "test-db");
 
-  EXPECT_CALL(*mock, UpdateDatabase(_))
+  EXPECT_CALL(*mock, UpdateDatabase)
       .WillOnce(
           [&dbase](DatabaseAdminConnection::UpdateDatabaseParams const& p) {
             EXPECT_EQ(p.database, dbase);
@@ -133,7 +132,7 @@ TEST(DatabaseAdminClientTest, UpdateDatabase) {
 TEST(DatabaseAdminClientTest, ListDatabases) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Instance const expected_instance("test-project", "test-instance");
-  EXPECT_CALL(*mock, ListDatabases(_))
+  EXPECT_CALL(*mock, ListDatabases)
       .WillOnce([&expected_instance](
                     DatabaseAdminConnection::ListDatabasesParams const& p) {
         EXPECT_EQ(expected_instance, p.instance);
@@ -162,7 +161,7 @@ TEST(DatabaseAdminClientTest, GetIamPolicy) {
   Database const expected_db("test-project", "test-instance", "test-database");
   std::string const expected_role = "roles/spanner.databaseReader";
   std::string const expected_member = "user:foobar@example.com";
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([&expected_db, &expected_role, &expected_member](
                     DatabaseAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_EQ(expected_db, p.database);
@@ -186,7 +185,7 @@ TEST(DatabaseAdminClientTest, GetIamPolicy) {
 TEST(DatabaseAdminClientTest, SetIamPolicy) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Database const expected_db("test-project", "test-instance", "test-database");
-  EXPECT_CALL(*mock, SetIamPolicy(_))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce(
           [&expected_db](DatabaseAdminConnection::SetIamPolicyParams const& p) {
             EXPECT_EQ(expected_db, p.database);
@@ -200,7 +199,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicy) {
 TEST(DatabaseAdminClientTest, SetIamPolicyOccGetFailure) {
   Database const db("test-project", "test-instance", "test-database");
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_EQ(db, p.database);
         return Status(StatusCode::kPermissionDenied, "uh-oh");
@@ -216,14 +215,14 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccGetFailure) {
 TEST(DatabaseAdminClientTest, SetIamPolicyOccNoUpdates) {
   Database const db("test-project", "test-instance", "test-database");
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_EQ(db, p.database);
         google::iam::v1::Policy r;
         r.set_etag("test-etag");
         return r;
       });
-  EXPECT_CALL(*mock, SetIamPolicy(_)).Times(0);
+  EXPECT_CALL(*mock, SetIamPolicy).Times(0);
 
   DatabaseAdminClient client(mock);
   auto actual = client.SetIamPolicy(db, [](google::iam::v1::Policy const& p) {
@@ -249,7 +248,7 @@ std::unique_ptr<BackoffPolicy> BackoffPolicyForTesting() {
 TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAborted) {
   Database const db("test-project", "test-instance", "test-database");
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_EQ(db, p.database);
         google::iam::v1::Policy r;
@@ -262,7 +261,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAborted) {
         r.set_etag("test-etag-2");
         return r;
       });
-  EXPECT_CALL(*mock, SetIamPolicy(_))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([&db](DatabaseAdminConnection::SetIamPolicyParams const& p) {
         EXPECT_EQ(db, p.database);
         EXPECT_EQ("test-etag-1", p.policy.etag());
@@ -292,7 +291,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAborted) {
 TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
   Database const db("test-project", "test-instance", "test-database");
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillRepeatedly(
           [&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
             EXPECT_EQ(db, p.database);
@@ -300,7 +299,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
             r.set_etag("test-etag-1");
             return r;
           });
-  EXPECT_CALL(*mock, SetIamPolicy(_))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .Times(AtLeast(2))
       .WillRepeatedly(
           [&db](DatabaseAdminConnection::SetIamPolicyParams const& p) {
@@ -321,7 +320,7 @@ TEST(DatabaseAdminClientTest, TestIamPermissions) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Database const expected_db("test-project", "test-instance", "test-database");
   std::string expected_permission = "spanner.databases.read";
-  EXPECT_CALL(*mock, TestIamPermissions(_))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce(
           [&expected_db, &expected_permission](
               DatabaseAdminConnection::TestIamPermissionsParams const& p) {
@@ -349,7 +348,7 @@ TEST(DatabaseAdminClientTest, CreateBackup) {
   auto expire_time = MakeTimestamp(now + absl::Hours(7)).value();
   auto version_time = MakeTimestamp(now - absl::Hours(7)).value();
   Backup backup_name(dbase.instance(), backup_id);
-  EXPECT_CALL(*mock, CreateBackup(_))
+  EXPECT_CALL(*mock, CreateBackup)
       .WillOnce([&dbase, &expire_time, &version_time, &backup_id, &backup_name](
                     DatabaseAdminConnection::CreateBackupParams const& p) {
         EXPECT_EQ(p.database, dbase);
@@ -412,7 +411,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabase) {
 
   Database dbase("test-project", "test-instance", "test-db");
   Backup backup(dbase.instance(), "test-backup");
-  EXPECT_CALL(*mock, RestoreDatabase(_))
+  EXPECT_CALL(*mock, RestoreDatabase)
       .WillOnce([&dbase, &backup](
                     DatabaseAdminConnection::RestoreDatabaseParams const& p) {
         EXPECT_EQ(p.database, dbase);
@@ -441,7 +440,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseOverload) {
   Backup backup_name(dbase.instance(), "test-backup");
   gcsa::Backup backup;
   backup.set_name(backup_name.FullName());
-  EXPECT_CALL(*mock, RestoreDatabase(_))
+  EXPECT_CALL(*mock, RestoreDatabase)
       .WillOnce([&dbase, &backup_name](
                     DatabaseAdminConnection::RestoreDatabaseParams const& p) {
         EXPECT_EQ(p.database, dbase);
@@ -467,7 +466,7 @@ TEST(DatabaseAdminClientTest, GetBackup) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Backup backup(Instance("test-project", "test-instance"), "test-backup");
 
-  EXPECT_CALL(*mock, GetBackup(_))
+  EXPECT_CALL(*mock, GetBackup)
       .WillOnce([&backup](DatabaseAdminConnection::GetBackupParams const& p) {
         EXPECT_EQ(backup.FullName(), p.backup_full_name);
         gcsa::Backup response;
@@ -488,7 +487,7 @@ TEST(DatabaseAdminClientTest, DeleteBackup) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Backup backup(Instance("test-project", "test-instance"), "test-backup");
 
-  EXPECT_CALL(*mock, DeleteBackup(_))
+  EXPECT_CALL(*mock, DeleteBackup)
       .WillOnce(
           [&backup](DatabaseAdminConnection::DeleteBackupParams const& p) {
             EXPECT_EQ(backup.FullName(), p.backup_full_name);
@@ -507,7 +506,7 @@ TEST(DatabaseAdminClientTest, DeleteBackupOverload) {
   gcsa::Backup backup;
   backup.set_name(backup_name.FullName());
 
-  EXPECT_CALL(*mock, DeleteBackup(_))
+  EXPECT_CALL(*mock, DeleteBackup)
       .WillOnce(
           [&backup_name](DatabaseAdminConnection::DeleteBackupParams const& p) {
             EXPECT_EQ(backup_name.FullName(), p.backup_full_name);
@@ -523,7 +522,7 @@ TEST(DatabaseAdminClientTest, ListBackups) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Instance const expected_instance("test-project", "test-instance");
   std::string expected_filter("test-filter");
-  EXPECT_CALL(*mock, ListBackups(_))
+  EXPECT_CALL(*mock, ListBackups)
       .WillOnce([&expected_instance, &expected_filter](
                     DatabaseAdminConnection::ListBackupsParams const& p) {
         EXPECT_EQ(expected_instance, p.instance);
@@ -553,7 +552,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTime) {
   Backup backup(Instance("test-project", "test-instance"), "test-backup");
   auto expire_time = MakeTimestamp(absl::Now() + absl::Hours(7)).value();
 
-  EXPECT_CALL(*mock, UpdateBackup(_))
+  EXPECT_CALL(*mock, UpdateBackup)
       .WillOnce([&backup, &expire_time](
                     DatabaseAdminConnection::UpdateBackupParams const& p) {
         EXPECT_EQ(backup.FullName(), p.request.backup().name());
@@ -608,7 +607,7 @@ TEST(DatabaseAdminClientTest, UpdateBackupExpireTimeOverload) {
   backup.set_name(backup_name.FullName());
   auto expire_time = MakeTimestamp(absl::Now() + absl::Hours(7)).value();
 
-  EXPECT_CALL(*mock, UpdateBackup(_))
+  EXPECT_CALL(*mock, UpdateBackup)
       .WillOnce([&backup_name, &expire_time](
                     DatabaseAdminConnection::UpdateBackupParams const& p) {
         EXPECT_EQ(backup_name.FullName(), p.request.backup().name());
@@ -659,7 +658,7 @@ TEST(DatabaseAdminClientTest, ListBackupOperations) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Instance const expected_instance("test-project", "test-instance");
   std::string expected_filter("test-filter");
-  EXPECT_CALL(*mock, ListBackupOperations(_))
+  EXPECT_CALL(*mock, ListBackupOperations)
       .WillOnce(
           [&expected_instance, &expected_filter](
               DatabaseAdminConnection::ListBackupOperationsParams const& p) {
@@ -689,7 +688,7 @@ TEST(DatabaseAdminClientTest, ListDatabaseOperations) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   Instance const expected_instance("test-project", "test-instance");
   std::string expected_filter("test-filter");
-  EXPECT_CALL(*mock, ListDatabaseOperations(_))
+  EXPECT_CALL(*mock, ListDatabaseOperations)
       .WillOnce(
           [&expected_instance, &expected_filter](
               DatabaseAdminConnection::ListDatabaseOperationsParams const& p) {

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -37,7 +37,6 @@ using ::google::cloud::spanner_testing::MockDatabaseAdminStub;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
@@ -67,7 +66,7 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseSuccess) {
   std::string const database_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
+  EXPECT_CALL(*mock, CreateDatabase)
       .WillOnce(
           [](grpc::ClientContext&, gcsa::CreateDatabaseRequest const& request) {
             EXPECT_FALSE(request.has_encryption_config());
@@ -76,7 +75,7 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseSuccess) {
             op.set_done(false);
             return make_status_or(op);
           });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce(
           [&database_name](grpc::ClientContext&,
                            google::longrunning::GetOperationRequest const& r) {
@@ -109,7 +108,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
   std::string const database_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
+  EXPECT_CALL(*mock, CreateDatabase)
       .WillOnce([](grpc::ClientContext&,
                    gcsa::CreateDatabaseRequest const& request) {
         EXPECT_TRUE(request.has_encryption_config());
@@ -123,7 +122,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce(
           [&database_name](grpc::ClientContext&,
                            google::longrunning::GetOperationRequest const& r) {
@@ -167,7 +166,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
 TEST(DatabaseAdminConnectionTest, HandleCreateDatabaseError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
+  EXPECT_CALL(*mock, CreateDatabase)
       .WillOnce([](grpc::ClientContext&, gcsa::CreateDatabaseRequest const&) {
         return StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
@@ -187,7 +186,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseSuccess) {
   std::string const database_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, GetDatabase(_, _))
+  EXPECT_CALL(*mock, GetDatabase)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&database_name](grpc::ClientContext&,
                                  gcsa::GetDatabaseRequest const& request) {
@@ -212,7 +211,7 @@ TEST(DatabaseAdminClientTest, GetDatabaseWithEncryption) {
   std::string const database_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, GetDatabase(_, _))
+  EXPECT_CALL(*mock, GetDatabase)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&database_name](grpc::ClientContext&,
                                  gcsa::GetDatabaseRequest const& request) {
@@ -245,7 +244,7 @@ TEST(DatabaseAdminClientTest, GetDatabaseWithEncryption) {
 TEST(DatabaseAdminConnectionTest, GetDatabasePermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetDatabase(_, _))
+  EXPECT_CALL(*mock, GetDatabase)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -258,7 +257,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabasePermanentError) {
 TEST(DatabaseAdminConnectionTest, GetDatabaseTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetDatabase(_, _))
+  EXPECT_CALL(*mock, GetDatabase)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -274,7 +273,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseDdlSuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, GetDatabaseDdl(_, _))
+  EXPECT_CALL(*mock, GetDatabaseDdl)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::GetDatabaseDdlRequest const& request) {
@@ -296,7 +295,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseDdlSuccess) {
 TEST(DatabaseAdminConnectionTest, GetDatabaseDdlPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetDatabaseDdl(_, _))
+  EXPECT_CALL(*mock, GetDatabaseDdl)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -309,7 +308,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseDdlPermanentError) {
 TEST(DatabaseAdminConnectionTest, GetDatabaseDdlTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetDatabaseDdl(_, _))
+  EXPECT_CALL(*mock, GetDatabaseDdl)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -323,7 +322,7 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseDdlTooManyTransients) {
 TEST(DatabaseAdminConnectionTest, UpdateDatabaseSuccess) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateDatabase(_, _))
+  EXPECT_CALL(*mock, UpdateDatabase)
       .WillOnce(
           [](grpc::ClientContext&, gcsa::UpdateDatabaseDdlRequest const&) {
             google::longrunning::Operation op;
@@ -331,7 +330,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseSuccess) {
             op.set_done(false);
             return make_status_or(op);
           });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce([](grpc::ClientContext&,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
@@ -359,7 +358,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseSuccess) {
 TEST(DatabaseAdminConnectionTest, UpdateDatabaseErrorInPoll) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateDatabase(_, _))
+  EXPECT_CALL(*mock, UpdateDatabase)
       .WillOnce(
           [](grpc::ClientContext&, gcsa::UpdateDatabaseDdlRequest const&) {
             return StatusOr<google::longrunning::Operation>(
@@ -379,14 +378,14 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseErrorInPoll) {
 TEST(DatabaseAdminConnectionTest, CreateDatabaseErrorInPoll) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
+  EXPECT_CALL(*mock, CreateDatabase)
       .WillOnce([](grpc::ClientContext&, gcsa::CreateDatabaseRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
         op.set_done(false);
         return make_status_or(std::move(op));
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce([](grpc::ClientContext&,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
@@ -408,7 +407,7 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseErrorInPoll) {
 TEST(DatabaseAdminConnectionTest, UpdateDatabaseGetOperationError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateDatabase(_, _))
+  EXPECT_CALL(*mock, UpdateDatabase)
       .WillOnce(
           [](grpc::ClientContext&, gcsa::UpdateDatabaseDdlRequest const&) {
             google::longrunning::Operation op;
@@ -416,7 +415,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseGetOperationError) {
             op.set_done(false);
             return make_status_or(std::move(op));
           });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce([](grpc::ClientContext&,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
@@ -443,7 +442,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
   Instance in("test-project", "test-instance");
   std::string const expected_parent = in.FullName();
 
-  EXPECT_CALL(*mock, ListDatabases(_, _))
+  EXPECT_CALL(*mock, ListDatabases)
       .WillOnce([&expected_parent](grpc::ClientContext&,
                                    gcsa::ListDatabasesRequest const& request) {
         EXPECT_EQ(expected_parent, request.parent());
@@ -494,7 +493,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabasesPermanentFailure) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListDatabases(_, _))
+  EXPECT_CALL(*mock, ListDatabases)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -508,7 +507,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabasesTooManyFailures) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListDatabases(_, _))
+  EXPECT_CALL(*mock, ListDatabases)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -525,7 +524,7 @@ TEST(DatabaseAdminConnectionTest, RestoreDatabaseSuccess) {
   std::string const database_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, RestoreDatabase(_, _))
+  EXPECT_CALL(*mock, RestoreDatabase)
       .WillOnce([](grpc::ClientContext&,
                    gcsa::RestoreDatabaseRequest const& request) {
         EXPECT_EQ(request.database_id(), "test-database");
@@ -535,7 +534,7 @@ TEST(DatabaseAdminConnectionTest, RestoreDatabaseSuccess) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce(
           [&database_name](grpc::ClientContext&,
                            google::longrunning::GetOperationRequest const& r) {
@@ -569,7 +568,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseWithEncryption) {
   std::string const database_name =
       "projects/test-project/instances/test-instance/databases/test-database";
 
-  EXPECT_CALL(*mock, RestoreDatabase(_, _))
+  EXPECT_CALL(*mock, RestoreDatabase)
       .WillOnce([](grpc::ClientContext&,
                    gcsa::RestoreDatabaseRequest const& request) {
         EXPECT_EQ(request.database_id(), "test-database");
@@ -587,7 +586,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseWithEncryption) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce(
           [&database_name](grpc::ClientContext&,
                            google::longrunning::GetOperationRequest const& r) {
@@ -633,7 +632,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseWithEncryption) {
 TEST(DatabaseAdminConnectionTest, HandleRestoreDatabaseError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, RestoreDatabase(_, _))
+  EXPECT_CALL(*mock, RestoreDatabase)
       .WillOnce([](grpc::ClientContext&, gcsa::RestoreDatabaseRequest const&) {
         return StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
@@ -656,7 +655,7 @@ TEST(DatabaseAdminConnectionTest, GetIamPolicySuccess) {
   std::string const expected_role = "roles/spanner.databaseReader";
   std::string const expected_member = "user:foobar@example.com";
 
-  EXPECT_CALL(*mock, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name, &expected_role, &expected_member](
                     grpc::ClientContext&,
@@ -683,7 +682,7 @@ TEST(DatabaseAdminConnectionTest, GetIamPolicySuccess) {
 TEST(DatabaseAdminConnectionTest, GetIamPolicyPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -696,7 +695,7 @@ TEST(DatabaseAdminConnectionTest, GetIamPolicyPermanentError) {
 TEST(DatabaseAdminConnectionTest, GetIamPolicyTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -722,7 +721,7 @@ TEST(DatabaseAdminConnectionTest, SetIamPolicySuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_policy));
 
   auto mock = std::make_shared<MockDatabaseAdminStub>();
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([&expected_name](
                     grpc::ClientContext&,
                     google::iam::v1::SetIamPolicyRequest const& request) {
@@ -752,7 +751,7 @@ TEST(DatabaseAdminConnectionTest, SetIamPolicySuccess) {
 TEST(DatabaseAdminConnectionTest, SetIamPolicyPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -766,7 +765,7 @@ TEST(DatabaseAdminConnectionTest, SetIamPolicyPermanentError) {
 TEST(DatabaseAdminConnectionTest, SetIamPolicyNonIdempotent) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -781,7 +780,7 @@ TEST(DatabaseAdminConnectionTest, SetIamPolicyNonIdempotent) {
 TEST(DatabaseAdminConnectionTest, SetIamPolicyIdempotent) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -800,7 +799,7 @@ TEST(DatabaseAdminConnectionTest, TestIamPermissionsSuccess) {
       "projects/test-project/instances/test-instance/databases/test-database";
   std::string const expected_permission = "spanner.databases.read";
 
-  EXPECT_CALL(*mock, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name, &expected_permission](
                     grpc::ClientContext&,
@@ -826,7 +825,7 @@ TEST(DatabaseAdminConnectionTest, TestIamPermissionsSuccess) {
 TEST(DatabaseAdminConnectionTest, TestIamPermissionsPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -839,7 +838,7 @@ TEST(DatabaseAdminConnectionTest, TestIamPermissionsPermanentError) {
 TEST(DatabaseAdminConnectionTest, TestIamPermissionsTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -857,7 +856,7 @@ TEST(DatabaseAdminConnectionTest, CreateBackupSuccess) {
   auto expire_time = MakeTimestamp(now + absl::Hours(7)).value();
   auto version_time = MakeTimestamp(now - absl::Hours(7)).value();
 
-  EXPECT_CALL(*mock, CreateBackup(_, _))
+  EXPECT_CALL(*mock, CreateBackup)
       .WillOnce([&dbase, &expire_time, &version_time](
                     grpc::ClientContext&,
                     gcsa::CreateBackupRequest const& request) {
@@ -872,7 +871,7 @@ TEST(DatabaseAdminConnectionTest, CreateBackupSuccess) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce([&expire_time, &version_time](
                     grpc::ClientContext&,
                     google::longrunning::GetOperationRequest const& r) {
@@ -918,7 +917,7 @@ TEST(DatabaseAdminClientTest, CreateBackupWithEncryption) {
   Mock::AllowLeak(mock.get());
   Database dbase("test-project", "test-instance", "test-database");
 
-  EXPECT_CALL(*mock, CreateBackup(_, _))
+  EXPECT_CALL(*mock, CreateBackup)
       .WillOnce([&dbase](grpc::ClientContext&,
                          gcsa::CreateBackupRequest const& request) {
         EXPECT_EQ(request.parent(), dbase.instance().FullName());
@@ -936,7 +935,7 @@ TEST(DatabaseAdminClientTest, CreateBackupWithEncryption) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce([](grpc::ClientContext&,
                    google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
@@ -977,20 +976,20 @@ TEST(DatabaseAdminConnectionTest, CreateBackupCancel) {
   Mock::AllowLeak(mock.get());
   promise<void> p;
 
-  EXPECT_CALL(*mock, CreateBackup(_, _))
+  EXPECT_CALL(*mock, CreateBackup)
       .WillOnce([](grpc::ClientContext&, gcsa::CreateBackupRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, CancelOperation(_, _))
+  EXPECT_CALL(*mock, CancelOperation)
       .WillOnce([](grpc::ClientContext&,
                    google::longrunning::CancelOperationRequest const& request) {
         EXPECT_EQ("test-operation-name", request.name());
         return google::cloud::Status();
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce([&p](grpc::ClientContext&,
                      google::longrunning::GetOperationRequest const& r) {
         EXPECT_EQ("test-operation-name", r.name());
@@ -1031,7 +1030,7 @@ TEST(DatabaseAdminConnectionTest, CreateBackupCancel) {
 TEST(DatabaseAdminConnectionTest, HandleCreateBackupError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, CreateBackup(_, _))
+  EXPECT_CALL(*mock, CreateBackup)
       .WillOnce([](grpc::ClientContext&, gcsa::CreateBackupRequest const&) {
         return StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
@@ -1052,7 +1051,7 @@ TEST(DatabaseAdminConnectionTest, GetBackupSuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance/backups/test-backup";
 
-  EXPECT_CALL(*mock, GetBackup(_, _))
+  EXPECT_CALL(*mock, GetBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::GetBackupRequest const& request) {
@@ -1079,7 +1078,7 @@ TEST(DatabaseAdminClientTest, GetBackupWithEncryption) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance/backups/test-backup";
 
-  EXPECT_CALL(*mock, GetBackup(_, _))
+  EXPECT_CALL(*mock, GetBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::GetBackupRequest const& request) {
@@ -1117,7 +1116,7 @@ TEST(DatabaseAdminClientTest, GetBackupWithEncryption) {
 TEST(DatabaseAdminConnectionTest, GetBackupPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetBackup(_, _))
+  EXPECT_CALL(*mock, GetBackup)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -1131,7 +1130,7 @@ TEST(DatabaseAdminConnectionTest, GetBackupPermanentError) {
 TEST(DatabaseAdminConnectionTest, GetBackupTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, GetBackup(_, _))
+  EXPECT_CALL(*mock, GetBackup)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -1148,7 +1147,7 @@ TEST(DatabaseAdminConnectionTest, DeleteBackupSuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance/backups/test-backup";
 
-  EXPECT_CALL(*mock, DeleteBackup(_, _))
+  EXPECT_CALL(*mock, DeleteBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::DeleteBackupRequest const& request) {
@@ -1165,7 +1164,7 @@ TEST(DatabaseAdminConnectionTest, DeleteBackupSuccess) {
 TEST(DatabaseAdminConnectionTest, DeleteBackupPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, DeleteBackup(_, _))
+  EXPECT_CALL(*mock, DeleteBackup)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -1178,7 +1177,7 @@ TEST(DatabaseAdminConnectionTest, DeleteBackupPermanentError) {
 TEST(DatabaseAdminConnectionTest, DeleteBackupTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, DeleteBackup(_, _))
+  EXPECT_CALL(*mock, DeleteBackup)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -1194,7 +1193,7 @@ TEST(DatabaseAdminConnectionTest, ListBackups) {
   Instance in("test-project", "test-instance");
   std::string const expected_parent = in.FullName();
 
-  EXPECT_CALL(*mock, ListBackups(_, _))
+  EXPECT_CALL(*mock, ListBackups)
       .WillOnce([&expected_parent](grpc::ClientContext&,
                                    gcsa::ListBackupsRequest const& request) {
         EXPECT_EQ(expected_parent, request.parent());
@@ -1243,7 +1242,7 @@ TEST(DatabaseAdminConnectionTest, ListBackupsPermanentFailure) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListBackups(_, _))
+  EXPECT_CALL(*mock, ListBackups)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -1257,7 +1256,7 @@ TEST(DatabaseAdminConnectionTest, ListBackupsTooManyFailures) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListBackups(_, _))
+  EXPECT_CALL(*mock, ListBackups)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -1274,7 +1273,7 @@ TEST(DatabaseAdminConnectionTest, UpdateBackupSuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance/backups/test-backup";
 
-  EXPECT_CALL(*mock, UpdateBackup(_, _))
+  EXPECT_CALL(*mock, UpdateBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::UpdateBackupRequest const& request) {
@@ -1300,7 +1299,7 @@ TEST(DatabaseAdminConnectionTest, UpdateBackupSuccess) {
 TEST(DatabaseAdminConnectionTest, UpdateBackupPermanentError) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateBackup(_, _))
+  EXPECT_CALL(*mock, UpdateBackup)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -1313,7 +1312,7 @@ TEST(DatabaseAdminConnectionTest, UpdateBackupPermanentError) {
 TEST(DatabaseAdminConnectionTest, UpdateBackupTooManyTransients) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateBackup(_, _))
+  EXPECT_CALL(*mock, UpdateBackup)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -1329,7 +1328,7 @@ TEST(DatabaseAdminConnectionTest, ListBackupOperations) {
   Instance in("test-project", "test-instance");
   std::string const expected_parent = in.FullName();
 
-  EXPECT_CALL(*mock, ListBackupOperations(_, _))
+  EXPECT_CALL(*mock, ListBackupOperations)
       .WillOnce(
           [&expected_parent](grpc::ClientContext&,
                              gcsa::ListBackupOperationsRequest const& request) {
@@ -1380,7 +1379,7 @@ TEST(DatabaseAdminConnectionTest, ListBackupOperationsPermanentFailure) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListBackupOperations(_, _))
+  EXPECT_CALL(*mock, ListBackupOperations)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -1394,7 +1393,7 @@ TEST(DatabaseAdminConnectionTest, ListBackupOperationsTooManyFailures) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListBackupOperations(_, _))
+  EXPECT_CALL(*mock, ListBackupOperations)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -1411,7 +1410,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabaseOperations) {
   Instance in("test-project", "test-instance");
   std::string const expected_parent = in.FullName();
 
-  EXPECT_CALL(*mock, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock, ListDatabaseOperations)
       .WillOnce([&expected_parent](
                     grpc::ClientContext&,
                     gcsa::ListDatabaseOperationsRequest const& request) {
@@ -1462,7 +1461,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabaseOperationsPermanentFailure) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock, ListDatabaseOperations)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = CreateTestingConnection(std::move(mock));
@@ -1476,7 +1475,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabaseOperationsTooManyFailures) {
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   Instance in("test-project", "test-instance");
 
-  EXPECT_CALL(*mock, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock, ListDatabaseOperations)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -26,7 +26,6 @@ namespace {
 
 using ::google::cloud::testing_util::StatusIs;
 using spanner_mocks::MockInstanceAdminConnection;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
@@ -59,7 +58,7 @@ TEST(InstanceAdminClientTest, CopyAndMove) {
 
 TEST(InstanceAdminClientTest, GetInstance) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetInstance(_))
+  EXPECT_CALL(*mock, GetInstance)
       .WillOnce([](InstanceAdminConnection::GetInstanceParams const& p) {
         EXPECT_EQ("projects/test-project/instances/test-instance",
                   p.instance_name);
@@ -73,7 +72,7 @@ TEST(InstanceAdminClientTest, GetInstance) {
 
 TEST(InstanceAdminClientTest, GetInstanceConfig) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetInstanceConfig(_))
+  EXPECT_CALL(*mock, GetInstanceConfig)
       .WillOnce([](InstanceAdminConnection::GetInstanceConfigParams const& p) {
         EXPECT_EQ("projects/test-project/instanceConfigs/test-config",
                   p.instance_config_name);
@@ -88,7 +87,7 @@ TEST(InstanceAdminClientTest, GetInstanceConfig) {
 
 TEST(InstanceAdminClientTest, ListInstanceConfigs) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, ListInstanceConfigs(_))
+  EXPECT_CALL(*mock, ListInstanceConfigs)
       .WillOnce(
           [](InstanceAdminConnection::ListInstanceConfigsParams const& p) {
             EXPECT_EQ("test-project", p.project_id);
@@ -114,7 +113,7 @@ TEST(InstanceAdminClientTest, ListInstanceConfigs) {
 TEST(InstanceAdminClientTest, ListInstances) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
 
-  EXPECT_CALL(*mock, ListInstances(_))
+  EXPECT_CALL(*mock, ListInstances)
       .WillOnce([](InstanceAdminConnection::ListInstancesParams const& p) {
         EXPECT_EQ("test-project", p.project_id);
         EXPECT_EQ("labels.test-key:test-value", p.filter);
@@ -140,7 +139,7 @@ TEST(InstanceAdminClientTest, ListInstances) {
 
 TEST(InstanceAdminClientTest, GetIamPolicy) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_EQ("projects/test-project/instances/test-instance",
                   p.instance_name);
@@ -154,7 +153,7 @@ TEST(InstanceAdminClientTest, GetIamPolicy) {
 
 TEST(InstanceAdminClientTest, SetIamPolicy) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, SetIamPolicy(_))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([](InstanceAdminConnection::SetIamPolicyParams const& p) {
         EXPECT_EQ("projects/test-project/instances/test-instance",
                   p.instance_name);
@@ -169,7 +168,7 @@ TEST(InstanceAdminClientTest, SetIamPolicy) {
 
 TEST(InstanceAdminClientTest, SetIamPolicyOccGetFailure) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
         EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
@@ -187,7 +186,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccGetFailure) {
 
 TEST(InstanceAdminClientTest, SetIamPolicyOccNoUpdates) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
         EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
@@ -195,7 +194,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccNoUpdates) {
         r.set_etag("test-etag");
         return r;
       });
-  EXPECT_CALL(*mock, SetIamPolicy(_)).Times(0);
+  EXPECT_CALL(*mock, SetIamPolicy).Times(0);
 
   InstanceAdminClient client(mock);
   auto actual =
@@ -222,7 +221,7 @@ std::unique_ptr<BackoffPolicy> BackoffPolicyForTesting() {
 
 TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAborted) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
         EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
@@ -237,7 +236,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAborted) {
         r.set_etag("test-etag-2");
         return r;
       });
-  EXPECT_CALL(*mock, SetIamPolicy(_))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([](InstanceAdminConnection::SetIamPolicyParams const& p) {
         EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
         EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
@@ -268,7 +267,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAborted) {
 
 TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, GetIamPolicy(_))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillRepeatedly([](InstanceAdminConnection::GetIamPolicyParams const& p) {
         EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
         EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
@@ -276,7 +275,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
         r.set_etag("test-etag-1");
         return r;
       });
-  EXPECT_CALL(*mock, SetIamPolicy(_))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .Times(AtLeast(2))
       .WillRepeatedly([](InstanceAdminConnection::SetIamPolicyParams const& p) {
         EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
@@ -295,7 +294,7 @@ TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
 
 TEST(InstanceAdminClientTest, TestIamPermissions) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
-  EXPECT_CALL(*mock, TestIamPermissions(_))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce([](InstanceAdminConnection::TestIamPermissionsParams const& p) {
         EXPECT_EQ("projects/test-project/instances/test-instance",
                   p.instance_name);

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -32,7 +32,6 @@ namespace {
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Return;
 
@@ -75,7 +74,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_instance));
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetInstance(_, _))
+  EXPECT_CALL(*mock, GetInstance)
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::GetInstanceRequest const& request) {
         EXPECT_EQ(expected_name, request.name());
@@ -95,7 +94,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {
 
 TEST(InstanceAdminConnectionTest, GetInstancePermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetInstance(_, _))
+  EXPECT_CALL(*mock, GetInstance)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -105,7 +104,7 @@ TEST(InstanceAdminConnectionTest, GetInstancePermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, GetInstanceTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetInstance(_, _))
+  EXPECT_CALL(*mock, GetInstance)
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -118,7 +117,7 @@ TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance";
 
-  EXPECT_CALL(*mock, CreateInstance(_, _))
+  EXPECT_CALL(*mock, CreateInstance)
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::CreateInstanceRequest const& r) {
         EXPECT_EQ("test-instance", r.instance_id());
@@ -135,7 +134,7 @@ TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce(
           [&expected_name](grpc::ClientContext&,
                            google::longrunning::GetOperationRequest const& r) {
@@ -167,7 +166,7 @@ TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
 TEST(InstanceAdminClientTest, CreateInstanceError) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
 
-  EXPECT_CALL(*mock, CreateInstance(_, _))
+  EXPECT_CALL(*mock, CreateInstance)
       .WillOnce([](grpc::ClientContext&, gcsa::CreateInstanceRequest const&) {
         return StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
@@ -190,7 +189,7 @@ TEST(InstanceAdminClientTest, UpdateInstanceSuccess) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   std::string expected_name = "projects/test-project/instances/test-instance";
 
-  EXPECT_CALL(*mock, UpdateInstance(_, _))
+  EXPECT_CALL(*mock, UpdateInstance)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::UpdateInstanceRequest const& r) {
@@ -200,7 +199,7 @@ TEST(InstanceAdminClientTest, UpdateInstanceSuccess) {
         op.set_done(false);
         return make_status_or(op);
       });
-  EXPECT_CALL(*mock, GetOperation(_, _))
+  EXPECT_CALL(*mock, GetOperation)
       .WillOnce(
           [&expected_name](grpc::ClientContext&,
                            google::longrunning::GetOperationRequest const& r) {
@@ -228,7 +227,7 @@ TEST(InstanceAdminClientTest, UpdateInstanceSuccess) {
 TEST(InstanceAdminClientTest, UpdateInstancePermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateInstance(_, _))
+  EXPECT_CALL(*mock, UpdateInstance)
       .WillOnce([](grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) {
         return StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh"));
@@ -244,7 +243,7 @@ TEST(InstanceAdminClientTest, UpdateInstancePermanentFailure) {
 TEST(InstanceAdminClientTest, UpdateInstanceTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
 
-  EXPECT_CALL(*mock, UpdateInstance(_, _))
+  EXPECT_CALL(*mock, UpdateInstance)
       .Times(AtLeast(2))
       .WillRepeatedly(
           [](grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) {
@@ -263,7 +262,7 @@ TEST(InstanceAdminConnectionTest, DeleteInstanceSuccess) {
       "projects/test-project/instances/test-instance";
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, DeleteInstance(_, _))
+  EXPECT_CALL(*mock, DeleteInstance)
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  gcsa::DeleteInstanceRequest const& request) {
         EXPECT_EQ(expected_name, request.name());
@@ -282,7 +281,7 @@ TEST(InstanceAdminConnectionTest, DeleteInstanceSuccess) {
 
 TEST(InstanceAdminConnectionTest, DeleteInstancePermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, DeleteInstance(_, _))
+  EXPECT_CALL(*mock, DeleteInstance)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -292,7 +291,7 @@ TEST(InstanceAdminConnectionTest, DeleteInstancePermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, DeleteInstanceTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, DeleteInstance(_, _))
+  EXPECT_CALL(*mock, DeleteInstance)
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -311,7 +310,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigSuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_instance_config));
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetInstanceConfig(_, _))
+  EXPECT_CALL(*mock, GetInstanceConfig)
       .WillOnce(
           [&expected_name](grpc::ClientContext&,
                            gcsa::GetInstanceConfigRequest const& request) {
@@ -332,7 +331,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigSuccess) {
 
 TEST(InstanceAdminConnectionTest, GetInstanceConfigPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetInstanceConfig(_, _))
+  EXPECT_CALL(*mock, GetInstanceConfig)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -343,7 +342,7 @@ TEST(InstanceAdminConnectionTest, GetInstanceConfigPermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, GetInstanceConfigTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetInstanceConfig(_, _))
+  EXPECT_CALL(*mock, GetInstanceConfig)
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -356,7 +355,7 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
   std::string const expected_parent = "projects/test-project";
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, ListInstanceConfigs(_, _))
+  EXPECT_CALL(*mock, ListInstanceConfigs)
       .WillOnce([&](grpc::ClientContext&,
                     gcsa::ListInstanceConfigsRequest const& request) {
         EXPECT_EQ(expected_parent, request.parent());
@@ -397,7 +396,7 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsSuccess) {
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, ListInstanceConfigs(_, _))
+  EXPECT_CALL(*mock, ListInstanceConfigs)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -409,7 +408,7 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigsPermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, ListInstanceConfigsTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, ListInstanceConfigs(_, _))
+  EXPECT_CALL(*mock, ListInstanceConfigs)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -424,7 +423,7 @@ TEST(InstanceAdminConnectionTest, ListInstancesSuccess) {
   std::string const expected_parent = "projects/test-project";
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, ListInstances(_, _))
+  EXPECT_CALL(*mock, ListInstances)
       .WillOnce(
           [&](grpc::ClientContext&, gcsa::ListInstancesRequest const& request) {
             EXPECT_EQ(expected_parent, request.parent());
@@ -468,7 +467,7 @@ TEST(InstanceAdminConnectionTest, ListInstancesSuccess) {
 
 TEST(InstanceAdminConnectionTest, ListInstancesPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, ListInstances(_, _))
+  EXPECT_CALL(*mock, ListInstances)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -480,7 +479,7 @@ TEST(InstanceAdminConnectionTest, ListInstancesPermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, ListInstancesTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, ListInstances(_, _))
+  EXPECT_CALL(*mock, ListInstances)
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -495,7 +494,7 @@ TEST(InstanceAdminConnectionTest, GetIamPolicySuccess) {
       "projects/test-project/instances/test-instance";
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  giam::GetIamPolicyRequest const& request) {
         EXPECT_EQ(expected_name, request.resource());
@@ -522,7 +521,7 @@ TEST(InstanceAdminConnectionTest, GetIamPolicySuccess) {
 
 TEST(InstanceAdminConnectionTest, GetIamPolicyPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -532,7 +531,7 @@ TEST(InstanceAdminConnectionTest, GetIamPolicyPermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, GetIamPolicyTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock, GetIamPolicy)
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -556,7 +555,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicySuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected_policy));
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([&expected_name](grpc::ClientContext&,
                                  giam::SetIamPolicyRequest const& request) {
         EXPECT_EQ(expected_name, request.resource());
@@ -581,7 +580,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicySuccess) {
 
 TEST(InstanceAdminConnectionTest, SetIamPolicyPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -593,7 +592,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicyNonIdempotent) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   // If the Etag field is not set, then the RPC is not idempotent and should
   // fail on the first transient error.
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -604,7 +603,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicyNonIdempotent) {
 
 TEST(InstanceAdminConnectionTest, SetIamPolicyIdempotent) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock, SetIamPolicy)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
@@ -620,7 +619,7 @@ TEST(InstanceAdminConnectionTest, TestIamPermissionsSuccess) {
       "projects/test-project/instances/test-instance";
 
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce(
           [&expected_name](grpc::ClientContext&,
                            giam::TestIamPermissionsRequest const& request) {
@@ -646,7 +645,7 @@ TEST(InstanceAdminConnectionTest, TestIamPermissionsSuccess) {
 
 TEST(InstanceAdminConnectionTest, TestIamPermissionsPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
 
   auto conn = MakeLimitedRetryConnection(mock);
@@ -657,7 +656,7 @@ TEST(InstanceAdminConnectionTest, TestIamPermissionsPermanentFailure) {
 
 TEST(InstanceAdminConnectionTest, TestIamPermissionsTooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
-  EXPECT_CALL(*mock, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock, TestIamPermissions)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -27,7 +27,6 @@ namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::testing::_;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -48,7 +47,7 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
 };
 
 TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
-  EXPECT_CALL(*mock_, CreateDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CreateDatabase).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -62,7 +61,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetDatabase) {
-  EXPECT_CALL(*mock_, GetDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetDatabase).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -76,7 +75,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabase) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
-  EXPECT_CALL(*mock_, GetDatabaseDdl(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetDatabaseDdl).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -90,7 +89,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
-  EXPECT_CALL(*mock_, UpdateDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, UpdateDatabase).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -104,7 +103,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, DropDatabase) {
-  EXPECT_CALL(*mock_, DropDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, DropDatabase).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -118,7 +117,7 @@ TEST_F(DatabaseAdminLoggingTest, DropDatabase) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
-  EXPECT_CALL(*mock_, ListDatabases(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListDatabases).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -132,7 +131,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
-  EXPECT_CALL(*mock_, RestoreDatabase(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, RestoreDatabase).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -146,7 +145,7 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetIamPolicy) {
-  EXPECT_CALL(*mock_, GetIamPolicy(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetIamPolicy).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -161,7 +160,7 @@ TEST_F(DatabaseAdminLoggingTest, GetIamPolicy) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, SetIamPolicy) {
-  EXPECT_CALL(*mock_, SetIamPolicy(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, SetIamPolicy).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -176,8 +175,7 @@ TEST_F(DatabaseAdminLoggingTest, SetIamPolicy) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
-  EXPECT_CALL(*mock_, TestIamPermissions(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, TestIamPermissions).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -192,7 +190,7 @@ TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
-  EXPECT_CALL(*mock_, CreateBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CreateBackup).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -206,7 +204,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetBackup) {
-  EXPECT_CALL(*mock_, GetBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetBackup).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -220,7 +218,7 @@ TEST_F(DatabaseAdminLoggingTest, GetBackup) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, DeleteBackup) {
-  EXPECT_CALL(*mock_, DeleteBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, DeleteBackup).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -234,7 +232,7 @@ TEST_F(DatabaseAdminLoggingTest, DeleteBackup) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListBackups) {
-  EXPECT_CALL(*mock_, ListBackups(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListBackups).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -248,7 +246,7 @@ TEST_F(DatabaseAdminLoggingTest, ListBackups) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, UpdateBackup) {
-  EXPECT_CALL(*mock_, UpdateBackup(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, UpdateBackup).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -262,8 +260,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateBackup) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListBackupOperations) {
-  EXPECT_CALL(*mock_, ListBackupOperations(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListBackupOperations).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -278,7 +275,7 @@ TEST_F(DatabaseAdminLoggingTest, ListBackupOperations) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
-  EXPECT_CALL(*mock_, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
@@ -294,7 +291,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, GetOperation) {
-  EXPECT_CALL(*mock_, GetOperation(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetOperation).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
@@ -309,7 +306,7 @@ TEST_F(DatabaseAdminLoggingTest, GetOperation) {
 }
 
 TEST_F(DatabaseAdminLoggingTest, CancelOperation) {
-  EXPECT_CALL(*mock_, CancelOperation(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CancelOperation).WillOnce(Return(TransientError()));
 
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -27,7 +27,6 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
-using ::testing::_;
 namespace gcsa = ::google::spanner::admin::database::v1;
 
 class DatabaseAdminMetadataTest : public ::testing::Test {
@@ -49,7 +48,7 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 };
 
 TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
-  EXPECT_CALL(*mock_, CreateDatabase(_, _))
+  EXPECT_CALL(*mock_, CreateDatabase)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::CreateDatabaseRequest const&) {
         EXPECT_STATUS_OK(
@@ -71,7 +70,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
-  EXPECT_CALL(*mock_, UpdateDatabase(_, _))
+  EXPECT_CALL(*mock_, UpdateDatabase)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::UpdateDatabaseDdlRequest const&) {
         EXPECT_STATUS_OK(
@@ -94,7 +93,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
-  EXPECT_CALL(*mock_, DropDatabase(_, _))
+  EXPECT_CALL(*mock_, DropDatabase)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::DropDatabaseRequest const&) {
         EXPECT_STATUS_OK(
@@ -117,7 +116,7 @@ TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
-  EXPECT_CALL(*mock_, ListDatabases(_, _))
+  EXPECT_CALL(*mock_, ListDatabases)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::ListDatabasesRequest const&) {
         EXPECT_STATUS_OK(
@@ -139,7 +138,7 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
-  EXPECT_CALL(*mock_, RestoreDatabase(_, _))
+  EXPECT_CALL(*mock_, RestoreDatabase)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::RestoreDatabaseRequest const&) {
         EXPECT_STATUS_OK(
@@ -161,7 +160,7 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
-  EXPECT_CALL(*mock_, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock_, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::GetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(
@@ -184,7 +183,7 @@ TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
-  EXPECT_CALL(*mock_, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock_, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::SetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(
@@ -213,7 +212,7 @@ TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
-  EXPECT_CALL(*mock_, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock_, TestIamPermissions)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::TestIamPermissionsRequest const&) {
         EXPECT_STATUS_OK(
@@ -236,7 +235,7 @@ TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
-  EXPECT_CALL(*mock_, CreateBackup(_, _))
+  EXPECT_CALL(*mock_, CreateBackup)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::CreateBackupRequest const&) {
         EXPECT_STATUS_OK(
@@ -258,7 +257,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, GetBackup) {
-  EXPECT_CALL(*mock_, GetBackup(_, _))
+  EXPECT_CALL(*mock_, GetBackup)
       .WillOnce(
           [this](grpc::ClientContext& context, gcsa::GetBackupRequest const&) {
             EXPECT_STATUS_OK(IsContextMDValid(
@@ -281,7 +280,7 @@ TEST_F(DatabaseAdminMetadataTest, GetBackup) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
-  EXPECT_CALL(*mock_, DeleteBackup(_, _))
+  EXPECT_CALL(*mock_, DeleteBackup)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::DeleteBackupRequest const&) {
         EXPECT_STATUS_OK(
@@ -304,7 +303,7 @@ TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, ListBackups) {
-  EXPECT_CALL(*mock_, ListBackups(_, _))
+  EXPECT_CALL(*mock_, ListBackups)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::ListBackupsRequest const&) {
         EXPECT_STATUS_OK(
@@ -326,7 +325,7 @@ TEST_F(DatabaseAdminMetadataTest, ListBackups) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
-  EXPECT_CALL(*mock_, UpdateBackup(_, _))
+  EXPECT_CALL(*mock_, UpdateBackup)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::UpdateBackupRequest const&) {
         EXPECT_STATUS_OK(
@@ -349,7 +348,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
-  EXPECT_CALL(*mock_, ListBackupOperations(_, _))
+  EXPECT_CALL(*mock_, ListBackupOperations)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::ListBackupOperationsRequest const&) {
         EXPECT_STATUS_OK(
@@ -371,7 +370,7 @@ TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
-  EXPECT_CALL(*mock_, ListDatabaseOperations(_, _))
+  EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::ListDatabaseOperationsRequest const&) {
         EXPECT_STATUS_OK(
@@ -393,7 +392,7 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, GetOperation) {
-  EXPECT_CALL(*mock_, GetOperation(_, _))
+  EXPECT_CALL(*mock_, GetOperation)
       .WillOnce([this](grpc::ClientContext& context,
                        google::longrunning::GetOperationRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
@@ -411,7 +410,7 @@ TEST_F(DatabaseAdminMetadataTest, GetOperation) {
 }
 
 TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
-  EXPECT_CALL(*mock_, CancelOperation(_, _))
+  EXPECT_CALL(*mock_, CancelOperation)
       .WillOnce([this](grpc::ClientContext& context,
                        google::longrunning::CancelOperationRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -27,7 +27,6 @@ namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::testing::_;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -48,7 +47,7 @@ class InstanceAdminLoggingTest : public ::testing::Test {
 };
 
 TEST_F(InstanceAdminLoggingTest, GetInstance) {
-  EXPECT_CALL(*mock_, GetInstance(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetInstance).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -62,7 +61,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
 }
 
 TEST_F(InstanceAdminLoggingTest, CreateInstance) {
-  EXPECT_CALL(*mock_, CreateInstance(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CreateInstance).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -76,7 +75,7 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
 }
 
 TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
-  EXPECT_CALL(*mock_, UpdateInstance(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, UpdateInstance).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -90,7 +89,7 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
 }
 
 TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
-  EXPECT_CALL(*mock_, DeleteInstance(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, DeleteInstance).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -104,8 +103,7 @@ TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
 }
 
 TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
-  EXPECT_CALL(*mock_, GetInstanceConfig(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetInstanceConfig).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -120,8 +118,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
 }
 
 TEST_F(InstanceAdminLoggingTest, ListInstanceConfigs) {
-  EXPECT_CALL(*mock_, ListInstanceConfigs(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListInstanceConfigs).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -136,7 +133,7 @@ TEST_F(InstanceAdminLoggingTest, ListInstanceConfigs) {
 }
 
 TEST_F(InstanceAdminLoggingTest, ListInstances) {
-  EXPECT_CALL(*mock_, ListInstances(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListInstances).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -150,7 +147,7 @@ TEST_F(InstanceAdminLoggingTest, ListInstances) {
 }
 
 TEST_F(InstanceAdminLoggingTest, GetIamPolicy) {
-  EXPECT_CALL(*mock_, GetIamPolicy(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetIamPolicy).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -165,7 +162,7 @@ TEST_F(InstanceAdminLoggingTest, GetIamPolicy) {
 }
 
 TEST_F(InstanceAdminLoggingTest, SetIamPolicy) {
-  EXPECT_CALL(*mock_, SetIamPolicy(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, SetIamPolicy).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
@@ -180,8 +177,7 @@ TEST_F(InstanceAdminLoggingTest, SetIamPolicy) {
 }
 
 TEST_F(InstanceAdminLoggingTest, TestIamPermissions) {
-  EXPECT_CALL(*mock_, TestIamPermissions(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, TestIamPermissions).WillOnce(Return(TransientError()));
 
   InstanceAdminLogging stub(mock_, TracingOptions{});
 

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -27,7 +27,6 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
-using ::testing::_;
 namespace gcsa = ::google::spanner::admin::instance::v1;
 
 class InstanceAdminMetadataTest : public ::testing::Test {
@@ -49,7 +48,7 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 };
 
 TEST_F(InstanceAdminMetadataTest, GetInstance) {
-  EXPECT_CALL(*mock_, GetInstance(_, _))
+  EXPECT_CALL(*mock_, GetInstance)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::GetInstanceRequest const&) {
         EXPECT_STATUS_OK(
@@ -71,7 +70,7 @@ TEST_F(InstanceAdminMetadataTest, GetInstance) {
 }
 
 TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
-  EXPECT_CALL(*mock_, GetInstanceConfig(_, _))
+  EXPECT_CALL(*mock_, GetInstanceConfig)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::GetInstanceConfigRequest const&) {
         EXPECT_STATUS_OK(
@@ -93,7 +92,7 @@ TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
 }
 
 TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
-  EXPECT_CALL(*mock_, ListInstanceConfigs(_, _))
+  EXPECT_CALL(*mock_, ListInstanceConfigs)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::ListInstanceConfigsRequest const&) {
         EXPECT_STATUS_OK(
@@ -113,7 +112,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
 }
 
 TEST_F(InstanceAdminMetadataTest, CreateInstance) {
-  EXPECT_CALL(*mock_, CreateInstance(_, _))
+  EXPECT_CALL(*mock_, CreateInstance)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::CreateInstanceRequest const&) {
         EXPECT_STATUS_OK(
@@ -134,7 +133,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
 }
 
 TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
-  EXPECT_CALL(*mock_, UpdateInstance(_, _))
+  EXPECT_CALL(*mock_, UpdateInstance)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::UpdateInstanceRequest const&) {
         EXPECT_STATUS_OK(
@@ -155,7 +154,7 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 }
 
 TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
-  EXPECT_CALL(*mock_, DeleteInstance(_, _))
+  EXPECT_CALL(*mock_, DeleteInstance)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::DeleteInstanceRequest const&) {
         EXPECT_STATUS_OK(
@@ -175,7 +174,7 @@ TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
 }
 
 TEST_F(InstanceAdminMetadataTest, ListInstances) {
-  EXPECT_CALL(*mock_, ListInstances(_, _))
+  EXPECT_CALL(*mock_, ListInstances)
       .WillOnce([this](grpc::ClientContext& context,
                        gcsa::ListInstancesRequest const&) {
         EXPECT_STATUS_OK(
@@ -195,7 +194,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstances) {
 }
 
 TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
-  EXPECT_CALL(*mock_, GetIamPolicy(_, _))
+  EXPECT_CALL(*mock_, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::GetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(
@@ -216,7 +215,7 @@ TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
 }
 
 TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
-  EXPECT_CALL(*mock_, SetIamPolicy(_, _))
+  EXPECT_CALL(*mock_, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::SetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(
@@ -236,7 +235,7 @@ TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
 }
 
 TEST_F(InstanceAdminMetadataTest, TestIamPermissions) {
-  EXPECT_CALL(*mock_, TestIamPermissions(_, _))
+  EXPECT_CALL(*mock_, TestIamPermissions)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::TestIamPermissionsRequest const&) {
         EXPECT_STATUS_OK(

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -27,7 +27,6 @@ namespace spanner_internal {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::testing::_;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -57,7 +56,7 @@ class LoggingSpannerStubTest : public ::testing::Test {
 TEST_F(LoggingSpannerStubTest, CreateSessionSuccess) {
   spanner_proto::Session session;
   session.set_name("test-session-name");
-  EXPECT_CALL(*mock_, CreateSession(_, _)).WillOnce(Return(session));
+  EXPECT_CALL(*mock_, CreateSession).WillOnce(Return(session));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -71,7 +70,7 @@ TEST_F(LoggingSpannerStubTest, CreateSessionSuccess) {
 }
 
 TEST_F(LoggingSpannerStubTest, CreateSession) {
-  EXPECT_CALL(*mock_, CreateSession(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, CreateSession).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -85,8 +84,7 @@ TEST_F(LoggingSpannerStubTest, CreateSession) {
 }
 
 TEST_F(LoggingSpannerStubTest, BatchCreateSessions) {
-  EXPECT_CALL(*mock_, BatchCreateSessions(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, BatchCreateSessions).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -100,7 +98,7 @@ TEST_F(LoggingSpannerStubTest, BatchCreateSessions) {
 }
 
 TEST_F(LoggingSpannerStubTest, GetSession) {
-  EXPECT_CALL(*mock_, GetSession(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, GetSession).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -113,7 +111,7 @@ TEST_F(LoggingSpannerStubTest, GetSession) {
 }
 
 TEST_F(LoggingSpannerStubTest, ListSessions) {
-  EXPECT_CALL(*mock_, ListSessions(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ListSessions).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -127,7 +125,7 @@ TEST_F(LoggingSpannerStubTest, ListSessions) {
 }
 
 TEST_F(LoggingSpannerStubTest, DeleteSession) {
-  EXPECT_CALL(*mock_, DeleteSession(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, DeleteSession).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -140,7 +138,7 @@ TEST_F(LoggingSpannerStubTest, DeleteSession) {
 }
 
 TEST_F(LoggingSpannerStubTest, ExecuteSql) {
-  EXPECT_CALL(*mock_, ExecuteSql(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ExecuteSql).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -152,7 +150,7 @@ TEST_F(LoggingSpannerStubTest, ExecuteSql) {
 }
 
 TEST_F(LoggingSpannerStubTest, ExecuteStreamingSql) {
-  EXPECT_CALL(*mock_, ExecuteStreamingSql(_, _))
+  EXPECT_CALL(*mock_, ExecuteStreamingSql)
       .WillOnce(
           [](grpc::ClientContext&, spanner_proto::ExecuteSqlRequest const&) {
             return std::unique_ptr<
@@ -169,7 +167,7 @@ TEST_F(LoggingSpannerStubTest, ExecuteStreamingSql) {
 }
 
 TEST_F(LoggingSpannerStubTest, ExecuteBatchDml) {
-  EXPECT_CALL(*mock_, ExecuteBatchDml(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, ExecuteBatchDml).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -182,7 +180,7 @@ TEST_F(LoggingSpannerStubTest, ExecuteBatchDml) {
 }
 
 TEST_F(LoggingSpannerStubTest, StreamingRead) {
-  EXPECT_CALL(*mock_, StreamingRead(_, _))
+  EXPECT_CALL(*mock_, StreamingRead)
       .WillOnce([](grpc::ClientContext&, spanner_proto::ReadRequest const&) {
         return std::unique_ptr<
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
@@ -197,8 +195,7 @@ TEST_F(LoggingSpannerStubTest, StreamingRead) {
 }
 
 TEST_F(LoggingSpannerStubTest, BeginTransaction) {
-  EXPECT_CALL(*mock_, BeginTransaction(_, _))
-      .WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, BeginTransaction).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -211,7 +208,7 @@ TEST_F(LoggingSpannerStubTest, BeginTransaction) {
 }
 
 TEST_F(LoggingSpannerStubTest, Commit) {
-  EXPECT_CALL(*mock_, Commit(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, Commit).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -223,7 +220,7 @@ TEST_F(LoggingSpannerStubTest, Commit) {
 }
 
 TEST_F(LoggingSpannerStubTest, Rollback) {
-  EXPECT_CALL(*mock_, Rollback(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, Rollback).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -235,7 +232,7 @@ TEST_F(LoggingSpannerStubTest, Rollback) {
 }
 
 TEST_F(LoggingSpannerStubTest, PartitionQuery) {
-  EXPECT_CALL(*mock_, PartitionQuery(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, PartitionQuery).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
@@ -248,7 +245,7 @@ TEST_F(LoggingSpannerStubTest, PartitionQuery) {
 }
 
 TEST_F(LoggingSpannerStubTest, PartitionRead) {
-  EXPECT_CALL(*mock_, PartitionRead(_, _)).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock_, PartitionRead).WillOnce(Return(TransientError()));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -28,13 +28,12 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsContextMDValid;
-using ::testing::_;
 namespace spanner_proto = ::google::spanner::v1;
 
 // This ugly macro and the supporting template member function refactor most
 // of this test to one-liners.
 #define SESSION_TEST(X, Y) \
-  ExpectSession(EXPECT_CALL(*mock_, X(_, _)), Y(), #X, &MetadataSpannerStub::X)
+  ExpectSession(EXPECT_CALL(*mock_, X), Y(), #X, &MetadataSpannerStub::X)
 
 class MetadataSpannerStubTest : public ::testing::Test {
  protected:
@@ -88,7 +87,7 @@ class MetadataSpannerStubTest : public ::testing::Test {
 };
 
 TEST_F(MetadataSpannerStubTest, CreateSession) {
-  EXPECT_CALL(*mock_, CreateSession(_, _))
+  EXPECT_CALL(*mock_, CreateSession)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::CreateSessionRequest const&) {
         EXPECT_STATUS_OK(
@@ -106,7 +105,7 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
 }
 
 TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
-  EXPECT_CALL(*mock_, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock_, BatchCreateSessions)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::BatchCreateSessionsRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
@@ -125,7 +124,7 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
 }
 
 TEST_F(MetadataSpannerStubTest, GetSession) {
-  EXPECT_CALL(*mock_, GetSession(_, _))
+  EXPECT_CALL(*mock_, GetSession)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::GetSessionRequest const&) {
         EXPECT_STATUS_OK(
@@ -147,7 +146,7 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
 }
 
 TEST_F(MetadataSpannerStubTest, ListSessions) {
-  EXPECT_CALL(*mock_, ListSessions(_, _))
+  EXPECT_CALL(*mock_, ListSessions)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::ListSessionsRequest const&) {
         EXPECT_STATUS_OK(
@@ -165,7 +164,7 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
 }
 
 TEST_F(MetadataSpannerStubTest, DeleteSession) {
-  EXPECT_CALL(*mock_, DeleteSession(_, _))
+  EXPECT_CALL(*mock_, DeleteSession)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::DeleteSessionRequest const&) {
         EXPECT_STATUS_OK(
@@ -191,7 +190,7 @@ TEST_F(MetadataSpannerStubTest, ExecuteSql) {
 }
 
 TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
-  EXPECT_CALL(*mock_, ExecuteStreamingSql(_, _))
+  EXPECT_CALL(*mock_, ExecuteStreamingSql)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::ExecuteSqlRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
@@ -218,7 +217,7 @@ TEST_F(MetadataSpannerStubTest, ExecuteBatchDml) {
 }
 
 TEST_F(MetadataSpannerStubTest, StreamingRead) {
-  EXPECT_CALL(*mock_, StreamingRead(_, _))
+  EXPECT_CALL(*mock_, StreamingRead)
       .WillOnce([this](grpc::ClientContext& context,
                        spanner_proto::ReadRequest const&) {
         EXPECT_STATUS_OK(

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -37,7 +37,6 @@ using ::google::cloud::spanner_testing::MockPartialResultSetReader;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::TextFormat;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -80,7 +79,7 @@ TEST(PartialResultSetResume, Success) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
 
   MockFactory mock_factory;
-  EXPECT_CALL(mock_factory, MakeReader(_))
+  EXPECT_CALL(mock_factory, MakeReader)
       .WillOnce([&response](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = absl::make_unique<MockPartialResultSetReader>();
@@ -130,7 +129,7 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText1, &r1));
 
   MockFactory mock_factory;
-  EXPECT_CALL(mock_factory, MakeReader(_))
+  EXPECT_CALL(mock_factory, MakeReader)
       .WillOnce([&r0](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = absl::make_unique<MockPartialResultSetReader>();
@@ -194,7 +193,7 @@ TEST(PartialResultSetResume, PermanentError) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &r0));
 
   MockFactory mock_factory;
-  EXPECT_CALL(mock_factory, MakeReader(_))
+  EXPECT_CALL(mock_factory, MakeReader)
       .WillOnce([&r0](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = absl::make_unique<MockPartialResultSetReader>();
@@ -246,7 +245,7 @@ TEST(PartialResultSetResume, TransientNonIdempotent) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &r0));
 
   MockFactory mock_factory;
-  EXPECT_CALL(mock_factory, MakeReader(_))
+  EXPECT_CALL(mock_factory, MakeReader)
       .WillOnce([&r0](std::string const& token) {
         EXPECT_TRUE(token.empty());
         auto mock = absl::make_unique<MockPartialResultSetReader>();
@@ -274,7 +273,7 @@ TEST(PartialResultSetResume, TransientNonIdempotent) {
 
 TEST(PartialResultSetResume, TooManyTransients) {
   MockFactory mock_factory;
-  EXPECT_CALL(mock_factory, MakeReader(_))
+  EXPECT_CALL(mock_factory, MakeReader)
       .Times(AtLeast(2))
       .WillRepeatedly([](std::string const& token) {
         EXPECT_TRUE(token.empty());

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -93,7 +93,7 @@ std::shared_ptr<SessionPool> MakeTestSessionPool(
 TEST(SessionPool, Allocate) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(
           [&db](grpc::ClientContext&,
                 spanner_proto::BatchCreateSessionsRequest const& request) {
@@ -113,7 +113,7 @@ TEST(SessionPool, Allocate) {
 TEST(SessionPool, ReleaseBadSession) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(
           [&db](grpc::ClientContext&,
                 spanner_proto::BatchCreateSessionsRequest const& request) {
@@ -152,7 +152,7 @@ TEST(SessionPool, ReleaseBadSession) {
 TEST(SessionPool, CreateError) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(Status(StatusCode::kInternal, "some failure"))));
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads threads;
@@ -165,7 +165,7 @@ TEST(SessionPool, CreateError) {
 TEST(SessionPool, ReuseSession) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"session1"}))));
 
   google::cloud::internal::AutomaticallyCreatedBackgroundThreads threads;
@@ -183,7 +183,7 @@ TEST(SessionPool, ReuseSession) {
 TEST(SessionPool, Lifo) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"session1"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"session2"}))));
 
@@ -215,7 +215,7 @@ TEST(SessionPool, MinSessionsEagerAllocation) {
   int const min_sessions = 3;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3", "s2", "s1"}))));
 
   Options opts;
@@ -257,7 +257,7 @@ TEST(SessionPool, MaxSessionsFailOnExhaustion) {
   int const max_sessions_per_channel = 3;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s2"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3"}))));
@@ -287,7 +287,7 @@ TEST(SessionPool, MaxSessionsBlockUntilRelease) {
   int const max_sessions_per_channel = 1;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))));
 
   Options opts;
@@ -333,11 +333,11 @@ TEST(SessionPool, MultipleChannels) {
   auto mock1 = std::make_shared<spanner_testing::MockSpannerStub>();
   auto mock2 = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock1, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock1, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c1s1"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c1s2"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c1s3"}))));
-  EXPECT_CALL(*mock2, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock2, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c2s1"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c2s2"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c2s3"}))));
@@ -361,11 +361,11 @@ TEST(SessionPool, MultipleChannelsPreAllocation) {
   auto mock2 = std::make_shared<spanner_testing::MockSpannerStub>();
   auto mock3 = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = spanner::Database("project", "instance", "database");
-  EXPECT_CALL(*mock1, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock1, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c1s1", "c1s2", "c1s3"}))));
-  EXPECT_CALL(*mock2, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock2, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c2s1", "c2s2", "c2s3"}))));
-  EXPECT_CALL(*mock3, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock3, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c3s1", "c3s2", "c3s3"}))));
 
   // note that min_sessions will effectively be reduced to 9
@@ -405,13 +405,13 @@ TEST(SessionPool, GetStubForStublessSession) {
 
 TEST(SessionPool, SessionRefresh) {
   auto mock = std::make_shared<StrictMock<spanner_testing::MockSpannerStub>>();
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+  EXPECT_CALL(*mock, BatchCreateSessions)
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s2"}))));
 
   auto reader = absl::make_unique<
       StrictMock<MockAsyncResponseReader<spanner_proto::ResultSet>>>();
-  EXPECT_CALL(*mock, AsyncExecuteSql(_, _, _))
+  EXPECT_CALL(*mock, AsyncExecuteSql)
       .WillOnce([&reader](grpc::ClientContext&,
                           spanner_proto::ExecuteSqlRequest const& request,
                           grpc::CompletionQueue*) {
@@ -421,7 +421,7 @@ TEST(SessionPool, SessionRefresh) {
             grpc::ClientAsyncResponseReaderInterface<spanner_proto::ResultSet>>(
             reader.get());
       });
-  EXPECT_CALL(*reader, Finish(_, _, _))
+  EXPECT_CALL(*reader, Finish)
       .WillOnce(
           [](spanner_proto::ResultSet* result, grpc::Status* status, void*) {
             // This is the actual spanner response to a "SELECT 1"

--- a/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases_test.cc
@@ -27,7 +27,6 @@ namespace {
 
 using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::UnorderedElementsAreArray;
 namespace gcsa = ::google::spanner::admin::database::v1;
 namespace spanner = ::google::cloud::spanner;
@@ -35,7 +34,7 @@ namespace spanner = ::google::cloud::spanner;
 TEST(CleanupStaleDatabases, Empty) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   spanner::Instance const expected_instance("test-project", "test-instance");
-  EXPECT_CALL(*mock, ListDatabases(_))
+  EXPECT_CALL(*mock, ListDatabases)
       .WillOnce(
           [&expected_instance](
               spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
@@ -62,7 +61,7 @@ TEST(CleanupStaleDatabases, Empty) {
 TEST(CleanupStaleDatabases, ListError) {
   auto mock = std::make_shared<MockDatabaseAdminConnection>();
   spanner::Instance const expected_instance("test-project", "test-instance");
-  EXPECT_CALL(*mock, ListDatabases(_))
+  EXPECT_CALL(*mock, ListDatabases)
       .WillOnce(
           [&expected_instance](
               spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
@@ -107,7 +106,7 @@ TEST(CleanupStaleDatabases, RemovesMatching) {
   };
 
   spanner::Instance const expected_instance("test-project", "test-instance");
-  EXPECT_CALL(*mock, ListDatabases(_))
+  EXPECT_CALL(*mock, ListDatabases)
       .WillOnce(
           [&](spanner::DatabaseAdminConnection::ListDatabasesParams const& p) {
             EXPECT_EQ(expected_instance, p.instance);
@@ -138,7 +137,7 @@ TEST(CleanupStaleDatabases, RemovesMatching) {
           });
 
   std::vector<std::string> dropped;
-  EXPECT_CALL(*mock, DropDatabase(_))
+  EXPECT_CALL(*mock, DropDatabase)
       .WillRepeatedly(
           [&](spanner::DatabaseAdminConnection::DropDatabaseParams const& p) {
             EXPECT_EQ(p.database.instance(), expected_instance);

--- a/google/cloud/storage/bucket_test.cc
+++ b/google/cloud/storage/bucket_test.cc
@@ -32,7 +32,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
@@ -68,7 +67,7 @@ TEST_F(BucketTest, CreateBucket) {
   mock_options.set_project_id("test-project-name");
 
   EXPECT_CALL(*mock_, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock_, CreateBucket(_))
+  EXPECT_CALL(*mock_, CreateBucket)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce([&expected](internal::CreateBucketRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.metadata().name());
@@ -87,7 +86,7 @@ TEST_F(BucketTest, CreateBucket) {
 
 TEST_F(BucketTest, CreateBucketTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketMetadata>(
-      mock_, EXPECT_CALL(*mock_, CreateBucket(_)),
+      mock_, EXPECT_CALL(*mock_, CreateBucket),
       [](Client& client) {
         return client
             .CreateBucketForProject("test-bucket-name", "test-project-name",
@@ -100,7 +99,7 @@ TEST_F(BucketTest, CreateBucketTooManyFailures) {
 TEST_F(BucketTest, CreateBucketPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketMetadata>(
-      client, EXPECT_CALL(*mock_, CreateBucket(_)),
+      client, EXPECT_CALL(*mock_, CreateBucket),
       [](Client& client) {
         return client
             .CreateBucketForProject("test-bucket-name", "test-project-name",
@@ -127,7 +126,7 @@ TEST_F(BucketTest, GetBucketMetadata) {
 })""";
   auto expected = internal::BucketMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, GetBucketMetadata(_))
+  EXPECT_CALL(*mock_, GetBucketMetadata)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce([&expected](internal::GetBucketMetadataRequest const& r) {
         EXPECT_EQ("foo-bar-baz", r.bucket_name());
@@ -141,7 +140,7 @@ TEST_F(BucketTest, GetBucketMetadata) {
 
 TEST_F(BucketTest, GetMetadataTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketMetadata>(
-      mock_, EXPECT_CALL(*mock_, GetBucketMetadata(_)),
+      mock_, EXPECT_CALL(*mock_, GetBucketMetadata),
       [](Client& client) {
         return client.GetBucketMetadata("test-bucket-name").status();
       },
@@ -151,7 +150,7 @@ TEST_F(BucketTest, GetMetadataTooManyFailures) {
 TEST_F(BucketTest, GetMetadataPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketMetadata>(
-      client, EXPECT_CALL(*mock_, GetBucketMetadata(_)),
+      client, EXPECT_CALL(*mock_, GetBucketMetadata),
       [](Client& client) {
         return client.GetBucketMetadata("test-bucket-name").status();
       },
@@ -159,7 +158,7 @@ TEST_F(BucketTest, GetMetadataPermanentFailure) {
 }
 
 TEST_F(BucketTest, DeleteBucket) {
-  EXPECT_CALL(*mock_, DeleteBucket(_))
+  EXPECT_CALL(*mock_, DeleteBucket)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteBucketRequest const& r) {
         EXPECT_EQ("foo-bar-baz", r.bucket_name());
@@ -172,7 +171,7 @@ TEST_F(BucketTest, DeleteBucket) {
 
 TEST_F(BucketTest, DeleteBucketTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteBucket(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteBucket),
       [](Client& client) { return client.DeleteBucket("test-bucket-name"); },
       [](Client& client) {
         return client.DeleteBucket("test-bucket-name",
@@ -184,7 +183,7 @@ TEST_F(BucketTest, DeleteBucketTooManyFailures) {
 TEST_F(BucketTest, DeleteBucketPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteBucket(_)),
+      client, EXPECT_CALL(*mock_, DeleteBucket),
       [](Client& client) { return client.DeleteBucket("test-bucket-name"); },
       "DeleteBucket");
 }
@@ -206,7 +205,7 @@ TEST_F(BucketTest, UpdateBucket) {
 })""";
   auto expected = internal::BucketMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, UpdateBucket(_))
+  EXPECT_CALL(*mock_, UpdateBucket)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce([&expected](internal::UpdateBucketRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.metadata().name());
@@ -224,7 +223,7 @@ TEST_F(BucketTest, UpdateBucket) {
 
 TEST_F(BucketTest, UpdateBucketTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketMetadata>(
-      mock_, EXPECT_CALL(*mock_, UpdateBucket(_)),
+      mock_, EXPECT_CALL(*mock_, UpdateBucket),
       [](Client& client) {
         return client.UpdateBucket("test-bucket-name", BucketMetadata())
             .status();
@@ -241,7 +240,7 @@ TEST_F(BucketTest, UpdateBucketTooManyFailures) {
 TEST_F(BucketTest, UpdateBucketPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketMetadata>(
-      client, EXPECT_CALL(*mock_, UpdateBucket(_)),
+      client, EXPECT_CALL(*mock_, UpdateBucket),
       [](Client& client) {
         return client.UpdateBucket("test-bucket-name", BucketMetadata())
             .status();
@@ -265,7 +264,7 @@ TEST_F(BucketTest, PatchBucket) {
 })""";
   auto expected = internal::BucketMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, PatchBucket(_))
+  EXPECT_CALL(*mock_, PatchBucket)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce([&expected](internal::PatchBucketRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket());
@@ -282,7 +281,7 @@ TEST_F(BucketTest, PatchBucket) {
 
 TEST_F(BucketTest, PatchBucketTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketMetadata>(
-      mock_, EXPECT_CALL(*mock_, PatchBucket(_)),
+      mock_, EXPECT_CALL(*mock_, PatchBucket),
       [](Client& client) {
         return client
             .PatchBucket("test-bucket-name", BucketMetadataPatchBuilder())
@@ -300,7 +299,7 @@ TEST_F(BucketTest, PatchBucketTooManyFailures) {
 TEST_F(BucketTest, PatchBucketPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketMetadata>(
-      client, EXPECT_CALL(*mock_, PatchBucket(_)),
+      client, EXPECT_CALL(*mock_, PatchBucket),
       [](Client& client) {
         return client
             .PatchBucket("test-bucket-name", BucketMetadataPatchBuilder())
@@ -314,7 +313,7 @@ TEST_F(BucketTest, GetBucketIamPolicy) {
   bindings.AddMember("roles/storage.admin", "test-user");
   IamPolicy expected{0, bindings, "XYZ="};
 
-  EXPECT_CALL(*mock_, GetBucketIamPolicy(_))
+  EXPECT_CALL(*mock_, GetBucketIamPolicy)
       .WillOnce(Return(StatusOr<IamPolicy>(TransientError())))
       .WillOnce([&expected](internal::GetBucketIamPolicyRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -328,7 +327,7 @@ TEST_F(BucketTest, GetBucketIamPolicy) {
 
 TEST_F(BucketTest, GetBucketIamPolicyTooManyFailures) {
   testing::TooManyFailuresStatusTest<IamPolicy>(
-      mock_, EXPECT_CALL(*mock_, GetBucketIamPolicy(_)),
+      mock_, EXPECT_CALL(*mock_, GetBucketIamPolicy),
       [](Client& client) {
         return client.GetBucketIamPolicy("test-bucket-name").status();
       },
@@ -338,7 +337,7 @@ TEST_F(BucketTest, GetBucketIamPolicyTooManyFailures) {
 TEST_F(BucketTest, GetBucketIamPolicyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<IamPolicy>(
-      client, EXPECT_CALL(*mock_, GetBucketIamPolicy(_)),
+      client, EXPECT_CALL(*mock_, GetBucketIamPolicy),
       [](Client& client) {
         return client.GetBucketIamPolicy("test-bucket-name").status();
       },
@@ -350,7 +349,7 @@ TEST_F(BucketTest, SetBucketIamPolicy) {
   bindings.AddMember("roles/storage.admin", "test-user");
   IamPolicy expected{0, bindings, "XYZ="};
 
-  EXPECT_CALL(*mock_, SetBucketIamPolicy(_))
+  EXPECT_CALL(*mock_, SetBucketIamPolicy)
       .WillOnce(Return(StatusOr<IamPolicy>(TransientError())))
       .WillOnce([&expected](internal::SetBucketIamPolicyRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -365,7 +364,7 @@ TEST_F(BucketTest, SetBucketIamPolicy) {
 
 TEST_F(BucketTest, SetBucketIamPolicyTooManyFailures) {
   testing::TooManyFailuresStatusTest<IamPolicy>(
-      mock_, EXPECT_CALL(*mock_, SetBucketIamPolicy(_)),
+      mock_, EXPECT_CALL(*mock_, SetBucketIamPolicy),
       [](Client& client) {
         return client.SetBucketIamPolicy("test-bucket-name", IamPolicy{})
             .status();
@@ -382,7 +381,7 @@ TEST_F(BucketTest, SetBucketIamPolicyTooManyFailures) {
 TEST_F(BucketTest, SetBucketIamPolicyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<IamPolicy>(
-      client, EXPECT_CALL(*mock_, SetBucketIamPolicy(_)),
+      client, EXPECT_CALL(*mock_, SetBucketIamPolicy),
       [](Client& client) {
         return client.SetBucketIamPolicy("test-bucket-name", IamPolicy{})
             .status();
@@ -394,7 +393,7 @@ TEST_F(BucketTest, TestBucketIamPermissions) {
   internal::TestBucketIamPermissionsResponse expected;
   expected.permissions.emplace_back("storage.buckets.delete");
 
-  EXPECT_CALL(*mock_, TestBucketIamPermissions(_))
+  EXPECT_CALL(*mock_, TestBucketIamPermissions)
       .WillOnce(Return(StatusOr<internal::TestBucketIamPermissionsResponse>(
           TransientError())))
       .WillOnce(
@@ -413,7 +412,7 @@ TEST_F(BucketTest, TestBucketIamPermissions) {
 TEST_F(BucketTest, TestBucketIamPermissionsTooManyFailures) {
   testing::TooManyFailuresStatusTest<
       internal::TestBucketIamPermissionsResponse>(
-      mock_, EXPECT_CALL(*mock_, TestBucketIamPermissions(_)),
+      mock_, EXPECT_CALL(*mock_, TestBucketIamPermissions),
       [](Client& client) {
         return client.TestBucketIamPermissions("test-bucket-name", {}).status();
       },
@@ -424,7 +423,7 @@ TEST_F(BucketTest, TestBucketIamPermissionsPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<
       internal::TestBucketIamPermissionsResponse>(
-      client, EXPECT_CALL(*mock_, TestBucketIamPermissions(_)),
+      client, EXPECT_CALL(*mock_, TestBucketIamPermissions),
       [](Client& client) {
         return client.TestBucketIamPermissions("test-bucket-name", {}).status();
       },
@@ -447,7 +446,7 @@ TEST_F(BucketTest, LockBucketRetentionPolicy) {
 })""";
   auto expected = internal::BucketMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, LockBucketRetentionPolicy(_))
+  EXPECT_CALL(*mock_, LockBucketRetentionPolicy)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce(
           [expected](internal::LockBucketRetentionPolicyRequest const& r) {
@@ -463,7 +462,7 @@ TEST_F(BucketTest, LockBucketRetentionPolicy) {
 
 TEST_F(BucketTest, LockBucketRetentionPolicyTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketMetadata>(
-      mock_, EXPECT_CALL(*mock_, LockBucketRetentionPolicy(_)),
+      mock_, EXPECT_CALL(*mock_, LockBucketRetentionPolicy),
       [](Client& client) {
         return client.LockBucketRetentionPolicy("test-bucket-name", 1U)
             .status();
@@ -474,7 +473,7 @@ TEST_F(BucketTest, LockBucketRetentionPolicyTooManyFailures) {
 TEST_F(BucketTest, LockBucketRetentionPolicyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketMetadata>(
-      client, EXPECT_CALL(*mock_, LockBucketRetentionPolicy(_)),
+      client, EXPECT_CALL(*mock_, LockBucketRetentionPolicy),
       [](Client& client) {
         return client.LockBucketRetentionPolicy("test-bucket-name", 1U)
             .status();

--- a/google/cloud/storage/client_bucket_acl_test.cc
+++ b/google/cloud/storage/client_bucket_acl_test.cc
@@ -30,7 +30,6 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::IsOk;
-using ::testing::_;
 using ::testing::Not;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
@@ -95,7 +94,7 @@ TEST_F(BucketAccessControlsTest, ListBucketAcl) {
           .value(),
   };
 
-  EXPECT_CALL(*mock_, ListBucketAcl(_))
+  EXPECT_CALL(*mock_, ListBucketAcl)
       .WillOnce(
           Return(StatusOr<internal::ListBucketAclResponse>(TransientError())))
       .WillOnce([&expected](internal::ListBucketAclRequest const& r) {
@@ -113,7 +112,7 @@ TEST_F(BucketAccessControlsTest, ListBucketAcl) {
 
 TEST_F(BucketAccessControlsTest, ListBucketAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::ListBucketAclResponse>(
-      mock_, EXPECT_CALL(*mock_, ListBucketAcl(_)),
+      mock_, EXPECT_CALL(*mock_, ListBucketAcl),
       [](Client& client) {
         return client.ListBucketAcl("test-bucket-name").status();
       },
@@ -123,7 +122,7 @@ TEST_F(BucketAccessControlsTest, ListBucketAclTooManyFailures) {
 TEST_F(BucketAccessControlsTest, ListBucketAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::ListBucketAclResponse>(
-      client, EXPECT_CALL(*mock_, ListBucketAcl(_)),
+      client, EXPECT_CALL(*mock_, ListBucketAcl),
       [](Client& client) {
         return client.ListBucketAcl("test-bucket-name").status();
       },
@@ -138,7 +137,7 @@ TEST_F(BucketAccessControlsTest, CreateBucketAcl) {
       })""")
                       .value();
 
-  EXPECT_CALL(*mock_, CreateBucketAcl(_))
+  EXPECT_CALL(*mock_, CreateBucketAcl)
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce([&expected](internal::CreateBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -161,7 +160,7 @@ TEST_F(BucketAccessControlsTest, CreateBucketAcl) {
 
 TEST_F(BucketAccessControlsTest, CreateBucketAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketAccessControl>(
-      mock_, EXPECT_CALL(*mock_, CreateBucketAcl(_)),
+      mock_, EXPECT_CALL(*mock_, CreateBucketAcl),
       [](Client& client) {
         return client
             .CreateBucketAcl("test-bucket-name", "user-test-user-1", "READER")
@@ -179,7 +178,7 @@ TEST_F(BucketAccessControlsTest, CreateBucketAclTooManyFailures) {
 TEST_F(BucketAccessControlsTest, CreateBucketAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketAccessControl>(
-      client, EXPECT_CALL(*mock_, CreateBucketAcl(_)),
+      client, EXPECT_CALL(*mock_, CreateBucketAcl),
       [](Client& client) {
         return client
             .CreateBucketAcl("test-bucket-name", "user-test-user", "READER")
@@ -189,7 +188,7 @@ TEST_F(BucketAccessControlsTest, CreateBucketAclPermanentFailure) {
 }
 
 TEST_F(BucketAccessControlsTest, DeleteBucketAcl) {
-  EXPECT_CALL(*mock_, DeleteBucketAcl(_))
+  EXPECT_CALL(*mock_, DeleteBucketAcl)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -204,7 +203,7 @@ TEST_F(BucketAccessControlsTest, DeleteBucketAcl) {
 
 TEST_F(BucketAccessControlsTest, DeleteBucketAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteBucketAcl(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteBucketAcl),
       [](Client& client) {
         return client.DeleteBucketAcl("test-bucket-name", "user-test-user-1");
       },
@@ -218,7 +217,7 @@ TEST_F(BucketAccessControlsTest, DeleteBucketAclTooManyFailures) {
 TEST_F(BucketAccessControlsTest, DeleteBucketAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteBucketAcl(_)),
+      client, EXPECT_CALL(*mock_, DeleteBucketAcl),
       [](Client& client) {
         return client.DeleteBucketAcl("test-bucket-name", "user-test-user");
       },
@@ -234,7 +233,7 @@ TEST_F(BucketAccessControlsTest, GetBucketAcl) {
       })""")
           .value();
 
-  EXPECT_CALL(*mock_, GetBucketAcl(_))
+  EXPECT_CALL(*mock_, GetBucketAcl)
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce([&expected](internal::GetBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -252,7 +251,7 @@ TEST_F(BucketAccessControlsTest, GetBucketAcl) {
 
 TEST_F(BucketAccessControlsTest, GetBucketAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketAccessControl>(
-      mock_, EXPECT_CALL(*mock_, GetBucketAcl(_)),
+      mock_, EXPECT_CALL(*mock_, GetBucketAcl),
       [](Client& client) {
         return client.GetBucketAcl("test-bucket-name", "user-test-user-1")
             .status();
@@ -263,7 +262,7 @@ TEST_F(BucketAccessControlsTest, GetBucketAclTooManyFailures) {
 TEST_F(BucketAccessControlsTest, GetBucketAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketAccessControl>(
-      client, EXPECT_CALL(*mock_, GetBucketAcl(_)),
+      client, EXPECT_CALL(*mock_, GetBucketAcl),
       [](Client& client) {
         return client.GetBucketAcl("test-bucket-name", "user-test-user-1")
             .status();
@@ -280,7 +279,7 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAcl) {
       })""")
           .value();
 
-  EXPECT_CALL(*mock_, UpdateBucketAcl(_))
+  EXPECT_CALL(*mock_, UpdateBucketAcl)
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce([&expected](internal::UpdateBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -300,7 +299,7 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAcl) {
 
 TEST_F(BucketAccessControlsTest, UpdateBucketAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketAccessControl>(
-      mock_, EXPECT_CALL(*mock_, UpdateBucketAcl(_)),
+      mock_, EXPECT_CALL(*mock_, UpdateBucketAcl),
       [](Client& client) {
         return client
             .UpdateBucketAcl("test-bucket", BucketAccessControl()
@@ -323,7 +322,7 @@ TEST_F(BucketAccessControlsTest, UpdateBucketAclTooManyFailures) {
 TEST_F(BucketAccessControlsTest, UpdateBucketAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketAccessControl>(
-      client, EXPECT_CALL(*mock_, UpdateBucketAcl(_)),
+      client, EXPECT_CALL(*mock_, UpdateBucketAcl),
       [](Client& client) {
         return client
             .UpdateBucketAcl("test-bucket", BucketAccessControl()
@@ -343,7 +342,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
       })""")
           .value();
 
-  EXPECT_CALL(*mock_, PatchBucketAcl(_))
+  EXPECT_CALL(*mock_, PatchBucketAcl)
       .WillOnce(Return(StatusOr<BucketAccessControl>(TransientError())))
       .WillOnce([&result](internal::PatchBucketAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -365,7 +364,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAcl) {
 
 TEST_F(BucketAccessControlsTest, PatchBucketAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<BucketAccessControl>(
-      mock_, EXPECT_CALL(*mock_, PatchBucketAcl(_)),
+      mock_, EXPECT_CALL(*mock_, PatchBucketAcl),
       [](Client& client) {
         return client
             .PatchBucketAcl("test-bucket", "user-test-user-1",
@@ -385,7 +384,7 @@ TEST_F(BucketAccessControlsTest, PatchBucketAclTooManyFailures) {
 TEST_F(BucketAccessControlsTest, PatchBucketAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<BucketAccessControl>(
-      client, EXPECT_CALL(*mock_, PatchBucketAcl(_)),
+      client, EXPECT_CALL(*mock_, PatchBucketAcl),
       [](Client& client) {
         return client
             .PatchBucketAcl("test-bucket", "user-test-user-1",

--- a/google/cloud/storage/client_default_object_acl_test.cc
+++ b/google/cloud/storage/client_default_object_acl_test.cc
@@ -29,7 +29,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
 
@@ -55,7 +54,7 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
           .value(),
   };
 
-  EXPECT_CALL(*mock_, ListDefaultObjectAcl(_))
+  EXPECT_CALL(*mock_, ListDefaultObjectAcl)
       .WillOnce(Return(
           StatusOr<internal::ListDefaultObjectAclResponse>(TransientError())))
       .WillOnce([&expected](internal::ListDefaultObjectAclRequest const& r) {
@@ -73,7 +72,7 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAcl) {
 
 TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::ListDefaultObjectAclResponse>(
-      mock_, EXPECT_CALL(*mock_, ListDefaultObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, ListDefaultObjectAcl),
       [](Client& client) {
         return client.ListDefaultObjectAcl("test-bucket-name").status();
       },
@@ -83,7 +82,7 @@ TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclTooManyFailures) {
 TEST_F(DefaultObjectAccessControlsTest, ListDefaultObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::ListDefaultObjectAclResponse>(
-      client, EXPECT_CALL(*mock_, ListDefaultObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, ListDefaultObjectAcl),
       [](Client& client) {
         return client.ListDefaultObjectAcl("test-bucket-name").status();
       },
@@ -98,7 +97,7 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
       })""")
                       .value();
 
-  EXPECT_CALL(*mock_, CreateDefaultObjectAcl(_))
+  EXPECT_CALL(*mock_, CreateDefaultObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([&expected](internal::CreateDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -120,7 +119,7 @@ TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAcl) {
 
 TEST_F(DefaultObjectAccessControlsTest, CreateDefaultObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, CreateDefaultObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, CreateDefaultObjectAcl),
       [](Client& client) {
         return client
             .CreateDefaultObjectAcl("test-bucket-name", "user-test-user-1",
@@ -140,7 +139,7 @@ TEST_F(DefaultObjectAccessControlsTest,
        CreateDefaultObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, CreateDefaultObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, CreateDefaultObjectAcl),
       [](Client& client) {
         return client
             .CreateDefaultObjectAcl("test-bucket-name", "user-test-user",
@@ -151,7 +150,7 @@ TEST_F(DefaultObjectAccessControlsTest,
 }
 
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
-  EXPECT_CALL(*mock_, DeleteDefaultObjectAcl(_))
+  EXPECT_CALL(*mock_, DeleteDefaultObjectAcl)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -166,7 +165,7 @@ TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAcl) {
 
 TEST_F(DefaultObjectAccessControlsTest, DeleteDefaultObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteDefaultObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteDefaultObjectAcl),
       [](Client& client) {
         return client.DeleteDefaultObjectAcl("test-bucket-name",
                                              "user-test-user-1");
@@ -182,7 +181,7 @@ TEST_F(DefaultObjectAccessControlsTest,
        DeleteDefaultObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteDefaultObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, DeleteDefaultObjectAcl),
       [](Client& client) {
         return client.DeleteDefaultObjectAcl("test-bucket-name",
                                              "user-test-user-1");
@@ -199,7 +198,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
       })""")
           .value();
 
-  EXPECT_CALL(*mock_, GetDefaultObjectAcl(_))
+  EXPECT_CALL(*mock_, GetDefaultObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([&expected](internal::GetDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -216,7 +215,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAcl) {
 
 TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, GetDefaultObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, GetDefaultObjectAcl),
       [](Client& client) {
         return client
             .GetDefaultObjectAcl("test-bucket-name", "user-test-user-1")
@@ -228,7 +227,7 @@ TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAclTooManyFailures) {
 TEST_F(DefaultObjectAccessControlsTest, GetDefaultObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, GetDefaultObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, GetDefaultObjectAcl),
       [](Client& client) {
         return client
             .GetDefaultObjectAcl("test-bucket-name", "user-test-user-1")
@@ -245,7 +244,7 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
       })""")
                       .value();
 
-  EXPECT_CALL(*mock_, UpdateDefaultObjectAcl(_))
+  EXPECT_CALL(*mock_, UpdateDefaultObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([&expected](internal::UpdateDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -269,7 +268,7 @@ TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAcl) {
 
 TEST_F(DefaultObjectAccessControlsTest, UpdateDefaultObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, UpdateDefaultObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, UpdateDefaultObjectAcl),
       [](Client& client) {
         return client
             .UpdateDefaultObjectAcl("test-bucket-name", ObjectAccessControl())
@@ -288,7 +287,7 @@ TEST_F(DefaultObjectAccessControlsTest,
        UpdateDefaultObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, UpdateDefaultObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, UpdateDefaultObjectAcl),
       [](Client& client) {
         return client
             .UpdateDefaultObjectAcl("test-bucket-name", ObjectAccessControl())
@@ -305,7 +304,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
       })""")
                     .value();
 
-  EXPECT_CALL(*mock_, PatchDefaultObjectAcl(_))
+  EXPECT_CALL(*mock_, PatchDefaultObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([result](internal::PatchDefaultObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -326,7 +325,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAcl) {
 
 TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, PatchDefaultObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, PatchDefaultObjectAcl),
       [](Client& client) {
         return client
             .PatchDefaultObjectAcl("test-bucket-name", "user-test-user-1",
@@ -346,7 +345,7 @@ TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAclTooManyFailures) {
 TEST_F(DefaultObjectAccessControlsTest, PatchDefaultObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, PatchDefaultObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, PatchDefaultObjectAcl),
       [](Client& client) {
         return client
             .PatchDefaultObjectAcl("test-bucket-name", "user-test-user-1",

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -31,7 +31,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
@@ -56,7 +55,7 @@ TEST_F(NotificationsTest, ListNotifications) {
           .value(),
   };
 
-  EXPECT_CALL(*mock_, ListNotifications(_))
+  EXPECT_CALL(*mock_, ListNotifications)
       .WillOnce(Return(
           StatusOr<internal::ListNotificationsResponse>(TransientError())))
       .WillOnce([&expected](internal::ListNotificationsRequest const& r) {
@@ -73,7 +72,7 @@ TEST_F(NotificationsTest, ListNotifications) {
 
 TEST_F(NotificationsTest, ListNotificationsTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::ListNotificationsResponse>(
-      mock_, EXPECT_CALL(*mock_, ListNotifications(_)),
+      mock_, EXPECT_CALL(*mock_, ListNotifications),
       [](Client& client) {
         return client.ListNotifications("test-bucket-name").status();
       },
@@ -83,7 +82,7 @@ TEST_F(NotificationsTest, ListNotificationsTooManyFailures) {
 TEST_F(NotificationsTest, ListNotificationsPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::ListNotificationsResponse>(
-      client, EXPECT_CALL(*mock_, ListNotifications(_)),
+      client, EXPECT_CALL(*mock_, ListNotifications),
       [](Client& client) {
         return client.ListNotifications("test-bucket-name").status();
       },
@@ -101,7 +100,7 @@ TEST_F(NotificationsTest, CreateNotification) {
       })""")
           .value();
 
-  EXPECT_CALL(*mock_, CreateNotification(_))
+  EXPECT_CALL(*mock_, CreateNotification)
       .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce([&expected](internal::CreateNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -124,7 +123,7 @@ TEST_F(NotificationsTest, CreateNotification) {
 
 TEST_F(NotificationsTest, CreateNotificationTooManyFailures) {
   testing::TooManyFailuresStatusTest<NotificationMetadata>(
-      mock_, EXPECT_CALL(*mock_, CreateNotification(_)),
+      mock_, EXPECT_CALL(*mock_, CreateNotification),
       [](Client& client) {
         return client
             .CreateNotification("test-bucket-name", "test-topic-1",
@@ -138,7 +137,7 @@ TEST_F(NotificationsTest, CreateNotificationTooManyFailures) {
 TEST_F(NotificationsTest, CreateNotificationPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<NotificationMetadata>(
-      client, EXPECT_CALL(*mock_, CreateNotification(_)),
+      client, EXPECT_CALL(*mock_, CreateNotification),
       [](Client& client) {
         return client
             .CreateNotification("test-bucket-name", "test-topic-1",
@@ -160,7 +159,7 @@ TEST_F(NotificationsTest, GetNotification) {
       })""")
           .value();
 
-  EXPECT_CALL(*mock_, GetNotification(_))
+  EXPECT_CALL(*mock_, GetNotification)
       .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce([&expected](internal::GetNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -177,7 +176,7 @@ TEST_F(NotificationsTest, GetNotification) {
 
 TEST_F(NotificationsTest, GetNotificationTooManyFailures) {
   testing::TooManyFailuresStatusTest<NotificationMetadata>(
-      mock_, EXPECT_CALL(*mock_, GetNotification(_)),
+      mock_, EXPECT_CALL(*mock_, GetNotification),
       [](Client& client) {
         return client.GetNotification("test-bucket-name", "test-notification-1")
             .status();
@@ -188,7 +187,7 @@ TEST_F(NotificationsTest, GetNotificationTooManyFailures) {
 TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<NotificationMetadata>(
-      client, EXPECT_CALL(*mock_, GetNotification(_)),
+      client, EXPECT_CALL(*mock_, GetNotification),
       [](Client& client) {
         return client.GetNotification("test-bucket-name", "test-notification-1")
             .status();
@@ -197,7 +196,7 @@ TEST_F(NotificationsTest, GetNotificationPermanentFailure) {
 }
 
 TEST_F(NotificationsTest, DeleteNotification) {
-  EXPECT_CALL(*mock_, DeleteNotification(_))
+  EXPECT_CALL(*mock_, DeleteNotification)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteNotificationRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -212,7 +211,7 @@ TEST_F(NotificationsTest, DeleteNotification) {
 
 TEST_F(NotificationsTest, DeleteNotificationTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteNotification(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteNotification),
       [](Client& client) {
         return client.DeleteNotification("test-bucket-name",
                                          "test-notification-1");
@@ -223,7 +222,7 @@ TEST_F(NotificationsTest, DeleteNotificationTooManyFailures) {
 TEST_F(NotificationsTest, DeleteNotificationPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteNotification(_)),
+      client, EXPECT_CALL(*mock_, DeleteNotification),
       [](Client& client) {
         return client.DeleteNotification("test-bucket-name",
                                          "test-notification-1");

--- a/google/cloud/storage/client_object_acl_test.cc
+++ b/google/cloud/storage/client_object_acl_test.cc
@@ -28,7 +28,6 @@ namespace storage {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
 
@@ -56,7 +55,7 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
           .value(),
   };
 
-  EXPECT_CALL(*mock_, ListObjectAcl(_))
+  EXPECT_CALL(*mock_, ListObjectAcl)
       .WillOnce(
           Return(StatusOr<internal::ListObjectAclResponse>(TransientError())))
       .WillOnce([&expected](internal::ListObjectAclRequest const& r) {
@@ -74,7 +73,7 @@ TEST_F(ObjectAccessControlsTest, ListObjectAcl) {
 
 TEST_F(ObjectAccessControlsTest, ListObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::ListObjectAclResponse>(
-      mock_, EXPECT_CALL(*mock_, ListObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, ListObjectAcl),
       [](Client& client) {
         return client.ListObjectAcl("test-bucket-name", "test-object-name")
             .status();
@@ -85,7 +84,7 @@ TEST_F(ObjectAccessControlsTest, ListObjectAclTooManyFailures) {
 TEST_F(ObjectAccessControlsTest, ListObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::ListObjectAclResponse>(
-      client, EXPECT_CALL(*mock_, ListObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, ListObjectAcl),
       [](Client& client) {
         return client.ListObjectAcl("test-bucket-name", "test-object-name")
             .status();
@@ -102,7 +101,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
       })""")
                       .value();
 
-  EXPECT_CALL(*mock_, CreateObjectAcl(_))
+  EXPECT_CALL(*mock_, CreateObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([&expected](internal::CreateObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -127,7 +126,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAcl) {
 
 TEST_F(ObjectAccessControlsTest, CreateObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, CreateObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, CreateObjectAcl),
       [](Client& client) {
         return client
             .CreateObjectAcl("test-bucket-name", "test-object-name",
@@ -146,7 +145,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAclTooManyFailures) {
 TEST_F(ObjectAccessControlsTest, CreateObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, CreateObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, CreateObjectAcl),
       [](Client& client) {
         return client
             .CreateObjectAcl("test-bucket-name", "test-object-name",
@@ -157,7 +156,7 @@ TEST_F(ObjectAccessControlsTest, CreateObjectAclPermanentFailure) {
 }
 
 TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
-  EXPECT_CALL(*mock_, DeleteObjectAcl(_))
+  EXPECT_CALL(*mock_, DeleteObjectAcl)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -173,7 +172,7 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAcl) {
 
 TEST_F(ObjectAccessControlsTest, DeleteObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteObjectAcl),
       [](Client& client) {
         return client.DeleteObjectAcl("test-bucket-name", "test-object-name",
                                       "user-test-user-1");
@@ -188,7 +187,7 @@ TEST_F(ObjectAccessControlsTest, DeleteObjectAclTooManyFailures) {
 TEST_F(ObjectAccessControlsTest, DeleteObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, DeleteObjectAcl),
       [](Client& client) {
         return client.DeleteObjectAcl("test-bucket-name", "test-object-name",
                                       "user-test-user-1");
@@ -205,7 +204,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
       })""")
                       .value();
 
-  EXPECT_CALL(*mock_, GetObjectAcl(_))
+  EXPECT_CALL(*mock_, GetObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([&expected](internal::GetObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -223,7 +222,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAcl) {
 
 TEST_F(ObjectAccessControlsTest, GetObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, GetObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, GetObjectAcl),
       [](Client& client) {
         return client
             .GetObjectAcl("test-bucket-name", "test-object-name",
@@ -236,7 +235,7 @@ TEST_F(ObjectAccessControlsTest, GetObjectAclTooManyFailures) {
 TEST_F(ObjectAccessControlsTest, GetObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, GetObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, GetObjectAcl),
       [](Client& client) {
         return client
             .GetObjectAcl("test-bucket-name", "test-object-name",
@@ -254,7 +253,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
           "role": "OWNER"
       })""")
                       .value();
-  EXPECT_CALL(*mock_, UpdateObjectAcl(_))
+  EXPECT_CALL(*mock_, UpdateObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([expected](internal::UpdateObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -274,7 +273,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAcl) {
 
 TEST_F(ObjectAccessControlsTest, UpdateObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, UpdateObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, UpdateObjectAcl),
       [](Client& client) {
         return client
             .UpdateObjectAcl("test-bucket-name", "test-object-name",
@@ -293,7 +292,7 @@ TEST_F(ObjectAccessControlsTest, UpdateObjectAclTooManyFailures) {
 TEST_F(ObjectAccessControlsTest, UpdateObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, UpdateObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, UpdateObjectAcl),
       [](Client& client) {
         return client
             .UpdateObjectAcl("test-bucket-name", "test-object-name",
@@ -311,7 +310,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
           "role": "OWNER"
       })""")
                     .value();
-  EXPECT_CALL(*mock_, PatchObjectAcl(_))
+  EXPECT_CALL(*mock_, PatchObjectAcl)
       .WillOnce(Return(StatusOr<ObjectAccessControl>(TransientError())))
       .WillOnce([result](internal::PatchObjectAclRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
@@ -333,7 +332,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAcl) {
 
 TEST_F(ObjectAccessControlsTest, PatchObjectAclTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectAccessControl>(
-      mock_, EXPECT_CALL(*mock_, PatchObjectAcl(_)),
+      mock_, EXPECT_CALL(*mock_, PatchObjectAcl),
       [](Client& client) {
         return client
             .PatchObjectAcl("test-bucket-name", "test-object-name",
@@ -354,7 +353,7 @@ TEST_F(ObjectAccessControlsTest, PatchObjectAclTooManyFailures) {
 TEST_F(ObjectAccessControlsTest, PatchObjectAclPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectAccessControl>(
-      client, EXPECT_CALL(*mock_, PatchObjectAcl(_)),
+      client, EXPECT_CALL(*mock_, PatchObjectAcl),
       [](Client& client) {
         return client
             .PatchObjectAcl("test-bucket-name", "test-object-name",

--- a/google/cloud/storage/client_object_copy_test.cc
+++ b/google/cloud/storage/client_object_copy_test.cc
@@ -29,7 +29,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
 
@@ -48,7 +47,7 @@ TEST_F(ObjectCopyTest, CopyObject) {
   auto expected =
       storage::internal::ObjectMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, CopyObject(_))
+  EXPECT_CALL(*mock_, CopyObject)
       .WillOnce([&expected](internal::CopyObjectRequest const& request) {
         EXPECT_EQ("test-bucket-name", request.destination_bucket());
         EXPECT_EQ("test-object-name", request.destination_object());
@@ -66,7 +65,7 @@ TEST_F(ObjectCopyTest, CopyObject) {
 
 TEST_F(ObjectCopyTest, CopyObjectTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectMetadata>(
-      mock_, EXPECT_CALL(*mock_, CopyObject(_)),
+      mock_, EXPECT_CALL(*mock_, CopyObject),
       [](Client& client) {
         return client
             .CopyObject("source-bucket-name", "source-object-name",
@@ -86,7 +85,7 @@ TEST_F(ObjectCopyTest, CopyObjectTooManyFailures) {
 TEST_F(ObjectCopyTest, CopyObjectPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectMetadata>(
-      client, EXPECT_CALL(*mock_, CopyObject(_)),
+      client, EXPECT_CALL(*mock_, CopyObject),
       [](Client& client) {
         return client
             .CopyObject("source-bucket-name", "source-object-name",
@@ -122,7 +121,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
   })""";
   auto expected = internal::ObjectMetadataParser::FromString(response).value();
 
-  EXPECT_CALL(*mock_, ComposeObject(_))
+  EXPECT_CALL(*mock_, ComposeObject)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::ComposeObjectRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -144,7 +143,7 @@ TEST_F(ObjectCopyTest, ComposeObject) {
 
 TEST_F(ObjectCopyTest, ComposeObjectTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectMetadata>(
-      mock_, EXPECT_CALL(*mock_, ComposeObject(_)),
+      mock_, EXPECT_CALL(*mock_, ComposeObject),
       [](Client& client) {
         return client
             .ComposeObject("test-bucket-name",
@@ -165,7 +164,7 @@ TEST_F(ObjectCopyTest, ComposeObjectTooManyFailures) {
 TEST_F(ObjectCopyTest, ComposeObjectPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectMetadata>(
-      client, EXPECT_CALL(*mock_, ComposeObject(_)),
+      client, EXPECT_CALL(*mock_, ComposeObject),
       [](Client& client) {
         return client
             .ComposeObject("test-bucket-name",
@@ -177,7 +176,7 @@ TEST_F(ObjectCopyTest, ComposeObjectPermanentFailure) {
 }
 
 TEST_F(ObjectCopyTest, RewriteObject) {
-  EXPECT_CALL(*mock_, RewriteObject(_))
+  EXPECT_CALL(*mock_, RewriteObject)
       .WillOnce(
           Return(StatusOr<internal::RewriteObjectResponse>(TransientError())))
       .WillOnce([](internal::RewriteObjectRequest const& r) {
@@ -264,7 +263,7 @@ TEST_F(ObjectCopyTest, RewriteObject) {
 
 TEST_F(ObjectCopyTest, RewriteObjectTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::RewriteObjectResponse>(
-      mock_, EXPECT_CALL(*mock_, RewriteObject(_)),
+      mock_, EXPECT_CALL(*mock_, RewriteObject),
       [](Client& client) {
         auto rewrite = client.RewriteObject(
             "test-source-bucket-name", "test-source-object",
@@ -285,7 +284,7 @@ TEST_F(ObjectCopyTest, RewriteObjectTooManyFailures) {
 TEST_F(ObjectCopyTest, RewriteObjectPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::RewriteObjectResponse>(
-      client, EXPECT_CALL(*mock_, RewriteObject(_)),
+      client, EXPECT_CALL(*mock_, RewriteObject),
       [](Client& client) {
         auto rewrite = client.RewriteObject(
             "test-source-bucket-name", "test-source-object",

--- a/google/cloud/storage/client_service_account_test.cc
+++ b/google/cloud/storage/client_service_account_test.cc
@@ -30,7 +30,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
 
@@ -46,7 +45,7 @@ TEST_F(ServiceAccountTest, GetProjectServiceAccount) {
           R"""({"email_address": "test-service-account@test-domain.com"})""")
           .value();
 
-  EXPECT_CALL(*mock_, GetServiceAccount(_))
+  EXPECT_CALL(*mock_, GetServiceAccount)
       .WillOnce(Return(StatusOr<ServiceAccount>(TransientError())))
       .WillOnce(
           [&expected](internal::GetProjectServiceAccountRequest const& r) {
@@ -63,7 +62,7 @@ TEST_F(ServiceAccountTest, GetProjectServiceAccount) {
 
 TEST_F(ServiceAccountTest, GetProjectServiceAccountTooManyFailures) {
   testing::TooManyFailuresStatusTest<ServiceAccount>(
-      mock_, EXPECT_CALL(*mock_, GetServiceAccount(_)),
+      mock_, EXPECT_CALL(*mock_, GetServiceAccount),
       [](Client& client) {
         return client.GetServiceAccountForProject("test-project").status();
       },
@@ -73,7 +72,7 @@ TEST_F(ServiceAccountTest, GetProjectServiceAccountTooManyFailures) {
 TEST_F(ServiceAccountTest, GetProjectServiceAccountPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ServiceAccount>(
-      client, EXPECT_CALL(*mock_, GetServiceAccount(_)),
+      client, EXPECT_CALL(*mock_, GetServiceAccount),
       [](Client& client) {
         return client.GetServiceAccountForProject("test-project").status();
       },
@@ -86,7 +85,7 @@ TEST_F(ServiceAccountTest, CreateHmacKey) {
           R"""({"secretKey": "dGVzdC1zZWNyZXQ=", "resource": {}})""")
           .value();
 
-  EXPECT_CALL(*mock_, CreateHmacKey(_))
+  EXPECT_CALL(*mock_, CreateHmacKey)
       .WillOnce(
           Return(StatusOr<internal::CreateHmacKeyResponse>(TransientError())))
       .WillOnce([&expected](internal::CreateHmacKeyRequest const& r) {
@@ -106,7 +105,7 @@ TEST_F(ServiceAccountTest, CreateHmacKey) {
 
 TEST_F(ServiceAccountTest, CreateHmacKeyTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::CreateHmacKeyResponse>(
-      mock_, EXPECT_CALL(*mock_, CreateHmacKey(_)),
+      mock_, EXPECT_CALL(*mock_, CreateHmacKey),
       [](Client& client) {
         return client.CreateHmacKey("test-service-account").status();
       },
@@ -116,7 +115,7 @@ TEST_F(ServiceAccountTest, CreateHmacKeyTooManyFailures) {
 TEST_F(ServiceAccountTest, CreateHmacKeyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::CreateHmacKeyResponse>(
-      client, EXPECT_CALL(*mock_, CreateHmacKey(_)),
+      client, EXPECT_CALL(*mock_, CreateHmacKey),
       [](Client& client) {
         return client.CreateHmacKey("test-service-account").status();
       },
@@ -124,7 +123,7 @@ TEST_F(ServiceAccountTest, CreateHmacKeyPermanentFailure) {
 }
 
 TEST_F(ServiceAccountTest, DeleteHmacKey) {
-  EXPECT_CALL(*mock_, DeleteHmacKey(_))
+  EXPECT_CALL(*mock_, DeleteHmacKey)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
@@ -140,7 +139,7 @@ TEST_F(ServiceAccountTest, DeleteHmacKey) {
 
 TEST_F(ServiceAccountTest, DeleteHmacKeyTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteHmacKey(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteHmacKey),
       [](Client& client) { return client.DeleteHmacKey("test-access-id"); },
       "DeleteHmacKey");
 }
@@ -148,7 +147,7 @@ TEST_F(ServiceAccountTest, DeleteHmacKeyTooManyFailures) {
 TEST_F(ServiceAccountTest, DeleteHmacKeyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteHmacKey(_)),
+      client, EXPECT_CALL(*mock_, DeleteHmacKey),
       [](Client& client) { return client.DeleteHmacKey("test-access-id"); },
       "DeleteHmacKey");
 }
@@ -159,7 +158,7 @@ TEST_F(ServiceAccountTest, GetHmacKey) {
           R"""({"accessId": "test-access-id-1", "state": "ACTIVE"})""")
           .value();
 
-  EXPECT_CALL(*mock_, GetHmacKey(_))
+  EXPECT_CALL(*mock_, GetHmacKey)
       .WillOnce(Return(StatusOr<HmacKeyMetadata>(TransientError())))
       .WillOnce([&expected](internal::GetHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
@@ -177,7 +176,7 @@ TEST_F(ServiceAccountTest, GetHmacKey) {
 
 TEST_F(ServiceAccountTest, GetHmacKeyTooManyFailures) {
   testing::TooManyFailuresStatusTest<HmacKeyMetadata>(
-      mock_, EXPECT_CALL(*mock_, GetHmacKey(_)),
+      mock_, EXPECT_CALL(*mock_, GetHmacKey),
       [](Client& client) {
         return client.GetHmacKey("test-access-id").status();
       },
@@ -187,7 +186,7 @@ TEST_F(ServiceAccountTest, GetHmacKeyTooManyFailures) {
 TEST_F(ServiceAccountTest, GetHmacKeyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<HmacKeyMetadata>(
-      client, EXPECT_CALL(*mock_, GetHmacKey(_)),
+      client, EXPECT_CALL(*mock_, GetHmacKey),
       [](Client& client) {
         return client.GetHmacKey("test-access-id").status();
       },
@@ -200,7 +199,7 @@ TEST_F(ServiceAccountTest, UpdateHmacKey) {
           R"""({"accessId": "test-access-id-1", "state": "ACTIVE"})""")
           .value();
 
-  EXPECT_CALL(*mock_, UpdateHmacKey(_))
+  EXPECT_CALL(*mock_, UpdateHmacKey)
       .WillOnce(Return(StatusOr<HmacKeyMetadata>(TransientError())))
       .WillOnce([&expected](internal::UpdateHmacKeyRequest const& r) {
         EXPECT_EQ("test-project", r.project_id());
@@ -219,7 +218,7 @@ TEST_F(ServiceAccountTest, UpdateHmacKey) {
 
 TEST_F(ServiceAccountTest, UpdateHmacKeyTooManyFailures) {
   testing::TooManyFailuresStatusTest<HmacKeyMetadata>(
-      mock_, EXPECT_CALL(*mock_, UpdateHmacKey(_)),
+      mock_, EXPECT_CALL(*mock_, UpdateHmacKey),
       [](Client& client) {
         return client.UpdateHmacKey("test-access-id", HmacKeyMetadata())
             .status();
@@ -230,7 +229,7 @@ TEST_F(ServiceAccountTest, UpdateHmacKeyTooManyFailures) {
 TEST_F(ServiceAccountTest, UpdateHmacKeyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<HmacKeyMetadata>(
-      client, EXPECT_CALL(*mock_, UpdateHmacKey(_)),
+      client, EXPECT_CALL(*mock_, UpdateHmacKey),
       [](Client& client) {
         return client.UpdateHmacKey("test-access-id", HmacKeyMetadata())
             .status();

--- a/google/cloud/storage/client_sign_policy_document_test.cc
+++ b/google/cloud/storage/client_sign_policy_document_test.cc
@@ -30,7 +30,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -129,7 +128,7 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignRemote) {
   // string.
   std::string expected_signed_blob = "dGVzdC1zaWduZWQtYmxvYg==";
 
-  EXPECT_CALL(*mock_, SignBlob(_))
+  EXPECT_CALL(*mock_, SignBlob)
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
       .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
         return make_status_or(
@@ -146,7 +145,7 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignRemote) {
 /// policies.
 TEST_F(CreateSignedPolicyDocRPCTest, SignPolicyTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::SignBlobResponse>(
-      mock_, EXPECT_CALL(*mock_, SignBlob(_)),
+      mock_, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
         return client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest())
             .status();
@@ -159,7 +158,7 @@ TEST_F(CreateSignedPolicyDocRPCTest, SignPolicyTooManyFailures) {
 TEST_F(CreateSignedPolicyDocRPCTest, SignPolicyPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::SignBlobResponse>(
-      client, EXPECT_CALL(*mock_, SignBlob(_)),
+      client, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
         return client.CreateSignedPolicyDocument(CreatePolicyDocumentForTest())
             .status();

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -28,7 +28,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -96,7 +95,7 @@ TEST_F(CreateSignedUrlTest, V2SignRemote) {
   std::string expected_signed_blob = "dGVzdC1zaWduZWQtYmxvYg==";
   std::string expected_signed_blob_safe = "dGVzdC1zaWduZWQtYmxvYg%3D%3D";
 
-  EXPECT_CALL(*mock_, SignBlob(_))
+  EXPECT_CALL(*mock_, SignBlob)
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
       .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
         return make_status_or(
@@ -112,7 +111,7 @@ TEST_F(CreateSignedUrlTest, V2SignRemote) {
 /// @test Verify that CreateV2SignedUrl() + SignBlob() respects retry policies.
 TEST_F(CreateSignedUrlTest, V2SignTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::SignBlobResponse>(
-      mock_, EXPECT_CALL(*mock_, SignBlob(_)),
+      mock_, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
         return client.CreateV2SignedUrl("GET", "test-bucket", "test-object")
             .status();
@@ -124,7 +123,7 @@ TEST_F(CreateSignedUrlTest, V2SignTooManyFailures) {
 TEST_F(CreateSignedUrlTest, V2SignPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::SignBlobResponse>(
-      client, EXPECT_CALL(*mock_, SignBlob(_)),
+      client, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
         return client.CreateV2SignedUrl("GET", "test-bucket", "test-object")
             .status();
@@ -246,7 +245,7 @@ TEST_F(CreateSignedUrlTest, V4SignRemote) {
   // Use `echo -n test-signed-blob | od -x` to create the magic string.
   std::string expected_signed_blob_hex = "746573742d7369676e65642d626c6f62";
 
-  EXPECT_CALL(*mock_, SignBlob(_))
+  EXPECT_CALL(*mock_, SignBlob)
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
       .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
         return make_status_or(
@@ -262,7 +261,7 @@ TEST_F(CreateSignedUrlTest, V4SignRemote) {
 /// @test Verify that CreateV4SignedUrl() + SignBlob() respects retry policies.
 TEST_F(CreateSignedUrlTest, V4SignTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::SignBlobResponse>(
-      mock_, EXPECT_CALL(*mock_, SignBlob(_)),
+      mock_, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
         return client.CreateV4SignedUrl("GET", "test-bucket", "test-object")
             .status();
@@ -274,7 +273,7 @@ TEST_F(CreateSignedUrlTest, V4SignTooManyFailures) {
 TEST_F(CreateSignedUrlTest, V4SignPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::SignBlobResponse>(
-      client, EXPECT_CALL(*mock_, SignBlob(_)),
+      client, EXPECT_CALL(*mock_, SignBlob),
       [](Client& client) {
         return client.CreateV4SignedUrl("GET", "test-bucket", "test-object")
             .status();

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -28,7 +28,6 @@ namespace {
 
 using ::google::cloud::storage::internal::ClientImplDetails;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -94,7 +93,7 @@ TEST_F(ClientTest, OverrideRetryPolicy) {
 
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
-  EXPECT_CALL(*mock_, GetBucketMetadata(_))
+  EXPECT_CALL(*mock_, GetBucketMetadata)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce(Return(make_status_or(BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
@@ -112,7 +111,7 @@ TEST_F(ClientTest, OverrideBackoffPolicy) {
 
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
-  EXPECT_CALL(*mock_, GetBucketMetadata(_))
+  EXPECT_CALL(*mock_, GetBucketMetadata)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce(Return(make_status_or(BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");
@@ -130,7 +129,7 @@ TEST_F(ClientTest, OverrideBothPolicies) {
 
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
-  EXPECT_CALL(*mock_, GetBucketMetadata(_))
+  EXPECT_CALL(*mock_, GetBucketMetadata)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())))
       .WillOnce(Return(make_status_or(BucketMetadata{})));
   (void)client.GetBucketMetadata("foo-bar-baz");

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -26,7 +26,6 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
-using ::testing::_;
 using ::testing::Not;
 
 class MockCurlClient : public CurlClient {
@@ -64,7 +63,7 @@ TEST(CurlResumableUploadSessionTest, Simple) {
 
   EXPECT_FALSE(session.done());
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, UploadChunk(_))
+  EXPECT_CALL(*mock, UploadChunk)
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));
@@ -105,7 +104,7 @@ TEST(CurlResumableUploadSessionTest, Reset) {
   auto const size = payload.size();
 
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, UploadChunk(_))
+  EXPECT_CALL(*mock, UploadChunk)
       .WillOnce([&](UploadChunkRequest const&) {
         return make_status_or(ResumableUploadResponse{
             "", size - 1, {}, ResumableUploadResponse::kInProgress, {}});
@@ -116,7 +115,7 @@ TEST(CurlResumableUploadSessionTest, Reset) {
       });
   const ResumableUploadResponse resume_response{
       url2, 2 * size - 1, {}, ResumableUploadResponse::kInProgress, {}};
-  EXPECT_CALL(*mock, QueryResumableUpload(_))
+  EXPECT_CALL(*mock, QueryResumableUpload)
       .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ(url1, request.upload_session_url());
         return make_status_or(resume_response);
@@ -150,7 +149,7 @@ TEST(CurlResumableUploadSessionTest, SessionUpdatedInChunkUpload) {
   auto const size = payload.size();
 
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, UploadChunk(_))
+  EXPECT_CALL(*mock, UploadChunk)
       .WillOnce([&](UploadChunkRequest const&) {
         return make_status_or(ResumableUploadResponse{
             "", size - 1, {}, ResumableUploadResponse::kInProgress, {}});
@@ -180,7 +179,7 @@ TEST(CurlResumableUploadSessionTest, Empty) {
 
   EXPECT_FALSE(session.done());
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, UploadChunk(_))
+  EXPECT_CALL(*mock, UploadChunk)
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -28,7 +28,6 @@ namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
@@ -73,7 +72,7 @@ class MockMediaReader : public grpc::ClientReaderInterface<
 
 TEST(GrpcObjectReadSource, Simple) {
   auto mock = absl::make_unique<MockMediaReader>();
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content("0123456789");
         return true;
@@ -107,7 +106,7 @@ TEST(GrpcObjectReadSource, Simple) {
 
 TEST(GrpcObjectReadSource, EmptyWithError) {
   auto mock = absl::make_unique<MockMediaReader>();
-  EXPECT_CALL(*mock, Read(_)).WillOnce(Return(false));
+  EXPECT_CALL(*mock, Read).WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish())
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
@@ -126,7 +125,7 @@ TEST(GrpcObjectReadSource, EmptyWithError) {
 
 TEST(GrpcObjectReadSource, DataWithError) {
   auto mock = absl::make_unique<MockMediaReader>();
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content("0123456789");
         return true;
@@ -162,7 +161,7 @@ TEST(GrpcObjectReadSource, UseSpillBuffer) {
   std::string const expected_2(trailer_size, 'A');
   ASSERT_LT(expected_1.size(), expected_2.size());
   std::string const contents = expected_1 + expected_2;
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce([&contents](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content(contents);
         return true;
@@ -198,7 +197,7 @@ TEST(GrpcObjectReadSource, UseSpillBuffer) {
 TEST(GrpcObjectReadSource, UseSpillBufferMany) {
   auto mock = absl::make_unique<MockMediaReader>();
   std::string const contents = "0123456789";
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce([&contents](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content(contents);
         return true;
@@ -241,7 +240,7 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
   auto mock = absl::make_unique<MockMediaReader>();
   std::string const expected_md5 = "nhB9nTcrtoJr2B01QqQZ1g==";
   std::string const expected_crc32c = "ImIEBA==";
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce([&](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content("The quick brown");
         response->mutable_object_checksums()->set_md5_hash(
@@ -290,7 +289,7 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
 
 TEST(GrpcObjectReadSource, HandleEmptyResponses) {
   auto mock = absl::make_unique<MockMediaReader>();
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce(Return(true))
       .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content("The quick brown ");
@@ -330,7 +329,7 @@ TEST(GrpcObjectReadSource, HandleEmptyResponses) {
 
 TEST(GrpcObjectReadSource, HandleExtraRead) {
   auto mock = absl::make_unique<MockMediaReader>();
-  EXPECT_CALL(*mock, Read(_))
+  EXPECT_CALL(*mock, Read)
       .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
         response->mutable_checksummed_data()->set_content(
             "The quick brown fox jumps over the lazy dog");

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -29,7 +29,6 @@ namespace {
 
 using ::google::cloud::storage::testing::MakeRandomData;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Return;
 
@@ -70,11 +69,11 @@ TEST(GrpcResumableUploadSessionTest, Simple) {
 
   EXPECT_FALSE(session.done());
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, CreateUploadWriter(_, _))
+  EXPECT_CALL(*mock, CreateUploadWriter)
       .WillOnce([&](grpc::ClientContext&, google::storage::v1::Object&) {
         auto writer = absl::make_unique<MockGrpcUploadWriter>();
 
-        EXPECT_CALL(*writer, Write(_, _))
+        EXPECT_CALL(*writer, Write)
             .WillOnce([&](google::storage::v1::InsertObjectRequest const& r,
                           grpc::WriteOptions const& options) {
               EXPECT_EQ("test-upload-id", r.upload_id());
@@ -169,11 +168,11 @@ TEST(GrpcResumableUploadSessionTest, Reset) {
   auto const size = payload.size();
 
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, CreateUploadWriter(_, _))
+  EXPECT_CALL(*mock, CreateUploadWriter)
       .WillOnce([&](grpc::ClientContext&, google::storage::v1::Object&) {
         auto writer = absl::make_unique<MockGrpcUploadWriter>();
 
-        EXPECT_CALL(*writer, Write(_, _))
+        EXPECT_CALL(*writer, Write)
             .WillOnce([&](google::storage::v1::InsertObjectRequest const& r,
                           grpc::WriteOptions const&) {
               EXPECT_EQ("test-upload-id", r.upload_id());
@@ -199,7 +198,7 @@ TEST(GrpcResumableUploadSessionTest, Reset) {
 
   ResumableUploadResponse const resume_response{
       {}, 2 * size - 1, {}, ResumableUploadResponse::kInProgress, {}};
-  EXPECT_CALL(*mock, QueryResumableUpload(_))
+  EXPECT_CALL(*mock, QueryResumableUpload)
       .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ("test-upload-id", request.upload_session_url());
         return make_status_or(resume_response);
@@ -232,11 +231,11 @@ TEST(GrpcResumableUploadSessionTest, ResumeFromEmpty) {
   auto const size = payload.size();
 
   EXPECT_EQ(0, session.next_expected_byte());
-  EXPECT_CALL(*mock, CreateUploadWriter(_, _))
+  EXPECT_CALL(*mock, CreateUploadWriter)
       .WillOnce([&](grpc::ClientContext&, google::storage::v1::Object&) {
         auto writer = absl::make_unique<MockGrpcUploadWriter>();
 
-        EXPECT_CALL(*writer, Write(_, _))
+        EXPECT_CALL(*writer, Write)
             .WillOnce([&](google::storage::v1::InsertObjectRequest const& r,
                           grpc::WriteOptions const&) {
               EXPECT_EQ("test-upload-id", r.upload_id());
@@ -254,7 +253,7 @@ TEST(GrpcResumableUploadSessionTest, ResumeFromEmpty) {
       .WillOnce([&](grpc::ClientContext&, google::storage::v1::Object&) {
         auto writer = absl::make_unique<MockGrpcUploadWriter>();
 
-        EXPECT_CALL(*writer, Write(_, _))
+        EXPECT_CALL(*writer, Write)
             .WillOnce([&](google::storage::v1::InsertObjectRequest const& r,
                           grpc::WriteOptions const&) {
               EXPECT_EQ("test-upload-id", r.upload_id());
@@ -270,7 +269,7 @@ TEST(GrpcResumableUploadSessionTest, ResumeFromEmpty) {
 
   ResumableUploadResponse const resume_response{
       {}, 0, {}, ResumableUploadResponse::kInProgress, {}};
-  EXPECT_CALL(*mock, QueryResumableUpload(_))
+  EXPECT_CALL(*mock, QueryResumableUpload)
       .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ("test-upload-id", request.upload_session_url());
         return make_status_or(resume_response);

--- a/google/cloud/storage/internal/logging_client_test.cc
+++ b/google/cloud/storage/internal/logging_client_test.cc
@@ -28,7 +28,6 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -67,13 +66,13 @@ TEST_F(LoggingClientTest, GetBucketMetadata) {
 })""";
 
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, GetBucketMetadata(_))
+  EXPECT_CALL(*mock, GetBucketMetadata)
       .WillOnce(
           Return(internal::BucketMetadataParser::FromString(text).value()));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
-  EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("GetBucketMetadataRequest={"));
@@ -92,12 +91,12 @@ TEST_F(LoggingClientTest, GetBucketMetadata) {
 
 TEST_F(LoggingClientTest, GetBucketMetadataWithError) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, GetBucketMetadata(_))
+  EXPECT_CALL(*mock, GetBucketMetadata)
       .WillOnce(Return(StatusOr<BucketMetadata>(TransientError())));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
-  EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("GetBucketMetadataRequest={"));
@@ -120,13 +119,13 @@ TEST_F(LoggingClientTest, InsertObjectMedia) {
 })""";
 
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce(
           Return(internal::ObjectMetadataParser::FromString(text).value()));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
-  EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("InsertObjectMediaRequest={"));
@@ -166,12 +165,12 @@ TEST_F(LoggingClientTest, ListBuckets) {
           .value(),
   };
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, ListBuckets(_))
+  EXPECT_CALL(*mock, ListBuckets)
       .WillOnce(Return(make_status_or(ListBucketsResponse{"a-token", items})));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
-  EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("ListBucketsRequest={"));
@@ -203,13 +202,13 @@ TEST_F(LoggingClientTest, ListObjects) {
           .value(),
   };
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce(
           Return(make_status_or(ListObjectsResponse{"a-token", items, {}})));
 
   // We want to test that the key elements are logged, but do not want a
   // "change detection test", so this is intentionally not exhaustive.
-  EXPECT_CALL(*log_backend_, ProcessWithOwnership(_))
+  EXPECT_CALL(*log_backend_, ProcessWithOwnership)
       .WillOnce([](LogRecord const& lr) {
         EXPECT_THAT(lr.message, HasSubstr(" << "));
         EXPECT_THAT(lr.message, HasSubstr("ListObjectsRequest={"));

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -30,7 +30,6 @@ namespace {
 
 using ::google::cloud::testing_util::ContainsOnce;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::ReturnRef;
@@ -44,12 +43,11 @@ TEST_F(LoggingResumableUploadSessionTest, UploadChunk) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
   std::string const payload = "test-payload-data";
-  EXPECT_CALL(*mock, UploadChunk(_))
-      .WillOnce([&](ConstBufferSequence const& p) {
-        EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
-        return StatusOr<ResumableUploadResponse>(
-            AsStatus(HttpResponse{503, "uh oh", {}}));
-      });
+  EXPECT_CALL(*mock, UploadChunk).WillOnce([&](ConstBufferSequence const& p) {
+    EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
+    return StatusOr<ResumableUploadResponse>(
+        AsStatus(HttpResponse{503, "uh oh", {}}));
+  });
 
   LoggingResumableUploadSession session(std::move(mock));
 
@@ -64,7 +62,7 @@ TEST_F(LoggingResumableUploadSessionTest, UploadFinalChunk) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
   std::string const payload = "test-payload-data";
-  EXPECT_CALL(*mock, UploadFinalChunk(_, _))
+  EXPECT_CALL(*mock, UploadFinalChunk)
       .WillOnce([&](ConstBufferSequence const& p, std::uint64_t s) {
         EXPECT_THAT(p, ElementsAre(ConstBuffer{payload}));
         EXPECT_EQ(513 * 1024, s);

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -30,7 +30,6 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -49,7 +48,7 @@ TEST_F(RetryClientTest, NonIdempotentErrorHandling) {
                      // Make the tests faster.
                      ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*mock_, DeleteObject(_))
+  EXPECT_CALL(*mock_, DeleteObject)
       .WillOnce(Return(StatusOr<EmptyResponse>(TransientError())));
 
   // Use a delete operation because this is idempotent only if the it has
@@ -67,7 +66,7 @@ TEST_F(RetryClientTest, PermanentErrorHandling) {
                      ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   // Use a read-only operation because these are always idempotent.
-  EXPECT_CALL(*mock_, GetObjectMetadata(_))
+  EXPECT_CALL(*mock_, GetObjectMetadata)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce(Return(StatusOr<ObjectMetadata>(PermanentError())));
 
@@ -84,7 +83,7 @@ TEST_F(RetryClientTest, TooManyTransientsHandling) {
                      ExponentialBackoffPolicy(1_us, 2_us, 2));
 
   // Use a read-only operation because these are always idempotent.
-  EXPECT_CALL(*mock_, GetObjectMetadata(_))
+  EXPECT_CALL(*mock_, GetObjectMetadata)
       .WillRepeatedly(Return(StatusOr<ObjectMetadata>(TransientError())));
 
   StatusOr<ObjectMetadata> result = client.GetObjectMetadata(

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -29,7 +29,6 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::testing::_;
 using ::testing::HasSubstr;
 using testing::MockObjectReadSource;
 using ::testing::Return;
@@ -76,7 +75,7 @@ TEST(RetryObjectReadSourceTest, NoFailures) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .WillOnce([](ReadObjectRangeRequest const&) {
         auto source = absl::make_unique<MockObjectReadSource>();
         EXPECT_CALL(*source, Read).WillOnce(Return(ReadSourceResult{}));
@@ -96,7 +95,7 @@ TEST(RetryObjectReadSourceTest, PermanentFailureOnSessionCreation) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .WillOnce([](ReadObjectRangeRequest const&) { return PermanentError(); });
 
   auto source = client->ReadObject(ReadObjectRangeRequest{});
@@ -112,7 +111,7 @@ TEST(RetryObjectReadSourceTest, TransientFailuresExhaustOnSessionCreation) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .Times(4)
       .WillRepeatedly(
           [](ReadObjectRangeRequest const&) { return TransientError(); });
@@ -130,7 +129,7 @@ TEST(RetryObjectReadSourceTest, SessionCreationRecoversFromTransientFailures) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .WillOnce([](ReadObjectRangeRequest const&) { return TransientError(); })
       .WillOnce([](ReadObjectRangeRequest const&) { return TransientError(); })
       .WillOnce([](ReadObjectRangeRequest const&) {
@@ -153,11 +152,11 @@ TEST(RetryObjectReadSourceTest, PermanentReadFailure) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .WillOnce([raw_source](ReadObjectRangeRequest const&) {
         return std::unique_ptr<ObjectReadSource>(raw_source);
       });
-  EXPECT_CALL(*raw_source, Read(_, _))
+  EXPECT_CALL(*raw_source, Read)
       .WillOnce(Return(ReadSourceResult{}))
       .WillOnce(Return(PermanentError()));
 
@@ -242,7 +241,7 @@ TEST(RetryObjectReadSourceTest, RetryPolicyExhaustedOnResetSession) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .WillOnce([](ReadObjectRangeRequest const&) {
         auto source = absl::make_unique<MockObjectReadSource>();
         EXPECT_CALL(*source, Read)
@@ -273,7 +272,7 @@ TEST(RetryObjectReadSourceTest, TransientFailureWithReadLastOption) {
       LimitedErrorCountRetryPolicy(3), StrictIdempotencyPolicy(),
       ExponentialBackoffPolicy(1_us, 2_us, 2));
 
-  EXPECT_CALL(*raw_client, ReadObject(_))
+  EXPECT_CALL(*raw_client, ReadObject)
       .WillOnce([](ReadObjectRangeRequest const& req) {
         EXPECT_EQ(1029, req.GetOption<ReadLast>().value());
         auto source = absl::make_unique<MockObjectReadSource>();

--- a/google/cloud/storage/list_buckets_reader_test.cc
+++ b/google/cloud/storage/list_buckets_reader_test.cc
@@ -30,7 +30,6 @@ using ::google::cloud::storage::internal::ListBucketsRequest;
 using ::google::cloud::storage::internal::ListBucketsResponse;
 using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
-using ::testing::_;
 using ::testing::ContainerEq;
 using ::testing::Return;
 
@@ -72,7 +71,7 @@ TEST(ListBucketsReaderTest, Basic) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListBuckets(_))
+  EXPECT_CALL(*mock, ListBuckets)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce(create_mock(2));
@@ -91,7 +90,7 @@ TEST(ListBucketsReaderTest, Basic) {
 
 TEST(ListBucketsReaderTest, Empty) {
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListBuckets(_))
+  EXPECT_CALL(*mock, ListBuckets)
       .WillOnce(Return(make_status_or(ListBucketsResponse())));
 
   auto reader = google::cloud::internal::MakePaginationRange<ListBucketsReader>(
@@ -123,7 +122,7 @@ TEST(ListBucketsReaderTest, PermanentFailure) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListBuckets(_))
+  EXPECT_CALL(*mock, ListBuckets)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce([](ListBucketsRequest const&) {

--- a/google/cloud/storage/list_hmac_keys_reader_test.cc
+++ b/google/cloud/storage/list_hmac_keys_reader_test.cc
@@ -31,7 +31,6 @@ using ::google::cloud::storage::internal::ListHmacKeysRequest;
 using ::google::cloud::storage::internal::ListHmacKeysResponse;
 using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
-using ::testing::_;
 using ::testing::ContainerEq;
 using ::testing::Return;
 
@@ -73,7 +72,7 @@ TEST(ListHmacKeysReaderTest, Basic) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListHmacKeys(_))
+  EXPECT_CALL(*mock, ListHmacKeys)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce(create_mock(2));
@@ -95,7 +94,7 @@ TEST(ListHmacKeysReaderTest, Basic) {
 
 TEST(ListHmacKeysReaderTest, Empty) {
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListHmacKeys(_))
+  EXPECT_CALL(*mock, ListHmacKeys)
       .WillOnce(Return(make_status_or(ListHmacKeysResponse())));
 
   auto reader =
@@ -130,7 +129,7 @@ TEST(ListHmacKeysReaderTest, PermanentFailure) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListHmacKeys(_))
+  EXPECT_CALL(*mock, ListHmacKeys)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce([](ListHmacKeysRequest const&) {

--- a/google/cloud/storage/list_objects_and_prefixes_reader_test.cc
+++ b/google/cloud/storage/list_objects_and_prefixes_reader_test.cc
@@ -29,7 +29,6 @@ using ::google::cloud::storage::internal::ListObjectsRequest;
 using ::google::cloud::storage::internal::ListObjectsResponse;
 using ::google::cloud::storage::internal::SortObjectsAndPrefixes;
 using ::google::cloud::storage::testing::MockClient;
-using ::testing::_;
 using ::testing::ContainerEq;
 
 ObjectMetadata CreateElement(int index) {
@@ -77,7 +76,7 @@ TEST(ListObjectsAndPrefixesReaderTest, Basic) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce(create_mock(2));

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -30,7 +30,6 @@ using ::google::cloud::storage::internal::ListObjectsRequest;
 using ::google::cloud::storage::internal::ListObjectsResponse;
 using ::google::cloud::storage::testing::MockClient;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
-using ::testing::_;
 using ::testing::ContainerEq;
 using ::testing::Return;
 
@@ -74,7 +73,7 @@ TEST(ListObjectsReaderTest, Basic) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce(create_mock(2));
@@ -93,7 +92,7 @@ TEST(ListObjectsReaderTest, Basic) {
 
 TEST(ListObjectsReaderTest, Empty) {
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce(Return(make_status_or(ListObjectsResponse{})));
 
   auto reader = google::cloud::internal::MakePaginationRange<ListObjectsReader>(
@@ -125,7 +124,7 @@ TEST(ListObjectsReaderTest, PermanentFailure) {
   };
 
   auto mock = std::make_shared<MockClient>();
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce(create_mock(0))
       .WillOnce(create_mock(1))
       .WillOnce([](ListObjectsRequest const&) {

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -35,7 +35,6 @@ using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::AllOf;
 using ::testing::An;
 using ::testing::HasSubstr;
@@ -61,7 +60,7 @@ TEST_F(AuthorizedUserCredentialsTest, Simple) {
     "expires_in": 1234
 })""";
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*mock_request, MakeRequest(_))
+  EXPECT_CALL(*mock_request, MakeRequest)
       .WillOnce([response](std::string const& payload) {
         EXPECT_THAT(payload, HasSubstr("grant_type=refresh_token"));
         EXPECT_THAT(payload, HasSubstr("client_id=a-client-id.example.com"));
@@ -119,7 +118,7 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
     "expires_in": 1000
 })""";
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*mock_request, MakeRequest(_))
+  EXPECT_CALL(*mock_request, MakeRequest)
       .WillOnce(Return(HttpResponse{200, r1, {}}))
       .WillOnce(Return(HttpResponse{200, r2, {}}));
 
@@ -160,7 +159,7 @@ TEST_F(AuthorizedUserCredentialsTest, Refresh) {
 /// @test Mock a failed refresh response.
 TEST_F(AuthorizedUserCredentialsTest, FailedRefresh) {
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*mock_request, MakeRequest(_))
+  EXPECT_CALL(*mock_request, MakeRequest)
       .WillOnce(Return(Status(StatusCode::kAborted, "Fake Curl error")))
       .WillOnce(Return(HttpResponse{400, "", {}}));
 

--- a/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials_test.cc
@@ -38,7 +38,6 @@ using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Return;
@@ -71,10 +70,10 @@ TEST_F(ComputeEngineCredentialsTest,
   })""";
 
   auto first_mock_req_impl = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*first_mock_req_impl, MakeRequest(_))
+  EXPECT_CALL(*first_mock_req_impl, MakeRequest)
       .WillOnce(Return(HttpResponse{200, svc_acct_info_resp, {}}));
   auto second_mock_req_impl = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*second_mock_req_impl, MakeRequest(_))
+  EXPECT_CALL(*second_mock_req_impl, MakeRequest)
       .WillOnce(Return(HttpResponse{200, token_info_resp, {}}));
 
   auto mock_req_builder = MockHttpRequestBuilder::mock_;
@@ -218,7 +217,7 @@ TEST_F(ComputeEngineCredentialsTest, FailedRetrieveServiceAccountInfo) {
   })""";
 
   auto first_mock_req_impl = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*first_mock_req_impl, MakeRequest(_))
+  EXPECT_CALL(*first_mock_req_impl, MakeRequest)
       // Fail the first call to DoMetadataServerGetRequest immediately.
       .WillOnce(Return(Status(StatusCode::kAborted, "Fake Curl error")))
       // Likewise, except with a >= 300 status code.
@@ -277,7 +276,7 @@ TEST_F(ComputeEngineCredentialsTest, FailedRefresh) {
   })""";
 
   auto mock_req = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*mock_req, MakeRequest(_))
+  EXPECT_CALL(*mock_req, MakeRequest)
       // Fail the first call to RetrieveServiceAccountInfo immediately.
       .WillOnce(Return(Status(StatusCode::kAborted, "Fake Curl error")))
       // Make the call to RetrieveServiceAccountInfo return a good response,
@@ -359,7 +358,7 @@ TEST_F(ComputeEngineCredentialsTest, AccountEmail) {
   })""";
 
   auto first_mock_req_impl = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*first_mock_req_impl, MakeRequest(_))
+  EXPECT_CALL(*first_mock_req_impl, MakeRequest)
       .WillOnce(Return(HttpResponse{200, svc_acct_info_resp, {}}));
 
   auto mock_req_builder = MockHttpRequestBuilder::mock_;

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -46,7 +46,6 @@ using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::storage::testing::WriteBase64AsBinary;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::An;
 using ::testing::HasSubstr;
 using ::testing::Not;
@@ -117,7 +116,7 @@ void CheckInfoYieldsExpectedAssertion(ServiceAccountCredentialsInfo const& info,
       "access_token": "access-token-value",
       "expires_in": 1234
   })""";
-  EXPECT_CALL(*mock_request, MakeRequest(_))
+  EXPECT_CALL(*mock_request, MakeRequest)
       .WillOnce([response, assertion](std::string const& payload) {
         EXPECT_THAT(payload, HasSubstr(assertion));
         // Hard-coded in this order in ServiceAccountCredentials class.
@@ -190,7 +189,7 @@ TEST_F(ServiceAccountCredentialsTest,
     "expires_in": 1000
 })""";
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
-  EXPECT_CALL(*mock_request, MakeRequest(_))
+  EXPECT_CALL(*mock_request, MakeRequest)
       .WillOnce(Return(HttpResponse{200, r1, {}}))
       .WillOnce(Return(HttpResponse{200, r2, {}}));
 
@@ -408,7 +407,7 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
   auto mock_request = std::make_shared<MockHttpRequest::Impl>();
   auto const clock_value_1 = 10000;
   auto const clock_value_2 = 20000;
-  EXPECT_CALL(*mock_request, MakeRequest(_))
+  EXPECT_CALL(*mock_request, MakeRequest)
       .WillOnce(make_request_assertion(clock_value_1))
       .WillOnce(make_request_assertion(clock_value_2));
 

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -32,7 +32,6 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::HasSubstr;
 using ::testing::Return;
 using ::testing::ReturnRef;
@@ -54,7 +53,7 @@ TEST_F(ObjectTest, InsertObjectMedia) {
   auto expected =
       storage::internal::ObjectMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, InsertObjectMedia(_))
+  EXPECT_CALL(*mock_, InsertObjectMedia)
       .WillOnce([&expected](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket-name", request.bucket_name());
         EXPECT_EQ("test-object-name", request.object_name());
@@ -71,7 +70,7 @@ TEST_F(ObjectTest, InsertObjectMedia) {
 
 TEST_F(ObjectTest, InsertObjectMediaTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectMetadata>(
-      mock_, EXPECT_CALL(*mock_, InsertObjectMedia(_)),
+      mock_, EXPECT_CALL(*mock_, InsertObjectMedia),
       [](Client& client) {
         return client
             .InsertObject("test-bucket-name", "test-object-name",
@@ -90,7 +89,7 @@ TEST_F(ObjectTest, InsertObjectMediaTooManyFailures) {
 TEST_F(ObjectTest, InsertObjectMediaPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectMetadata>(
-      client, EXPECT_CALL(*mock_, InsertObjectMedia(_)),
+      client, EXPECT_CALL(*mock_, InsertObjectMedia),
       [](Client& client) {
         return client
             .InsertObject("test-bucket-name", "test-object-name",
@@ -125,7 +124,7 @@ TEST_F(ObjectTest, GetObjectMetadata) {
 })""";
   auto expected = internal::ObjectMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, GetObjectMetadata(_))
+  EXPECT_CALL(*mock_, GetObjectMetadata)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::GetObjectMetadataRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -141,7 +140,7 @@ TEST_F(ObjectTest, GetObjectMetadata) {
 
 TEST_F(ObjectTest, GetObjectMetadataTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectMetadata>(
-      mock_, EXPECT_CALL(*mock_, GetObjectMetadata(_)),
+      mock_, EXPECT_CALL(*mock_, GetObjectMetadata),
       [](Client& client) {
         return client.GetObjectMetadata("test-bucket-name", "test-object-name")
             .status();
@@ -152,7 +151,7 @@ TEST_F(ObjectTest, GetObjectMetadataTooManyFailures) {
 TEST_F(ObjectTest, GetObjectMetadataPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectMetadata>(
-      client, EXPECT_CALL(*mock_, GetObjectMetadata(_)),
+      client, EXPECT_CALL(*mock_, GetObjectMetadata),
       [](Client& client) {
         return client.GetObjectMetadata("test-bucket-name", "test-object-name")
             .status();
@@ -161,7 +160,7 @@ TEST_F(ObjectTest, GetObjectMetadataPermanentFailure) {
 }
 
 TEST_F(ObjectTest, DeleteObject) {
-  EXPECT_CALL(*mock_, DeleteObject(_))
+  EXPECT_CALL(*mock_, DeleteObject)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -175,7 +174,7 @@ TEST_F(ObjectTest, DeleteObject) {
 
 TEST_F(ObjectTest, DeleteObjectTooManyFailures) {
   testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
-      mock_, EXPECT_CALL(*mock_, DeleteObject(_)),
+      mock_, EXPECT_CALL(*mock_, DeleteObject),
       [](Client& client) {
         return client.DeleteObject("test-bucket-name", "test-object-name");
       },
@@ -189,7 +188,7 @@ TEST_F(ObjectTest, DeleteObjectTooManyFailures) {
 TEST_F(ObjectTest, DeleteObjectPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<internal::EmptyResponse>(
-      client, EXPECT_CALL(*mock_, DeleteObject(_)),
+      client, EXPECT_CALL(*mock_, DeleteObject),
       [](Client& client) {
         return client.DeleteObject("test-bucket-name", "test-object-name");
       },
@@ -221,7 +220,7 @@ TEST_F(ObjectTest, UpdateObject) {
 })""";
   auto expected = internal::ObjectMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, UpdateObject(_))
+  EXPECT_CALL(*mock_, UpdateObject)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::UpdateObjectRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -264,7 +263,7 @@ TEST_F(ObjectTest, UpdateObject) {
 
 TEST_F(ObjectTest, UpdateObjectTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectMetadata>(
-      mock_, EXPECT_CALL(*mock_, UpdateObject(_)),
+      mock_, EXPECT_CALL(*mock_, UpdateObject),
       [](Client& client) {
         return client
             .UpdateObject("test-bucket-name", "test-object-name",
@@ -284,7 +283,7 @@ TEST_F(ObjectTest, UpdateObjectTooManyFailures) {
 TEST_F(ObjectTest, UpdateObjectPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectMetadata>(
-      client, EXPECT_CALL(*mock_, UpdateObject(_)),
+      client, EXPECT_CALL(*mock_, UpdateObject),
       [](Client& client) {
         return client
             .UpdateObject("test-bucket-name", "test-object-name",
@@ -319,7 +318,7 @@ TEST_F(ObjectTest, PatchObject) {
 })""";
   auto expected = internal::ObjectMetadataParser::FromString(text).value();
 
-  EXPECT_CALL(*mock_, PatchObject(_))
+  EXPECT_CALL(*mock_, PatchObject)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::PatchObjectRequest const& r) {
         EXPECT_EQ("test-bucket-name", r.bucket_name());
@@ -339,7 +338,7 @@ TEST_F(ObjectTest, PatchObject) {
 
 TEST_F(ObjectTest, PatchObjectTooManyFailures) {
   testing::TooManyFailuresStatusTest<ObjectMetadata>(
-      mock_, EXPECT_CALL(*mock_, PatchObject(_)),
+      mock_, EXPECT_CALL(*mock_, PatchObject),
       [](Client& client) {
         return client
             .PatchObject(
@@ -361,7 +360,7 @@ TEST_F(ObjectTest, PatchObjectTooManyFailures) {
 TEST_F(ObjectTest, PatchObjectPermanentFailure) {
   auto client = ClientForMock();
   testing::PermanentFailureStatusTest<ObjectMetadata>(
-      client, EXPECT_CALL(*mock_, PatchObject(_)),
+      client, EXPECT_CALL(*mock_, PatchObject),
       [](Client& client) {
         return client
             .PatchObject(
@@ -381,7 +380,7 @@ TEST_F(ObjectTest, ReadObjectTooManyFailures) {
   auto transient_error = [](internal::ReadObjectRangeRequest const&) {
     return StatusOr<ReturnType>(TransientError());
   };
-  EXPECT_CALL(*mock_, ReadObject(_))
+  EXPECT_CALL(*mock_, ReadObject)
       .WillOnce(transient_error)
       .WillOnce(transient_error)
       .WillOnce(transient_error);
@@ -403,7 +402,7 @@ TEST_F(ObjectTest, ReadObjectPermanentFailure) {
   auto permanent_error = [](internal::ReadObjectRangeRequest const&) {
     return StatusOr<ReturnType>(PermanentError());
   };
-  EXPECT_CALL(*mock_, ReadObject(_)).WillOnce(permanent_error);
+  EXPECT_CALL(*mock_, ReadObject).WillOnce(permanent_error);
 
   auto client = ClientForMock();
   Status status =
@@ -434,7 +433,7 @@ TEST_F(ObjectTest, DeleteByPrefix) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
         EXPECT_EQ("test-bucket", req.bucket_name());
@@ -449,7 +448,7 @@ TEST_F(ObjectTest, DeleteByPrefix) {
         response.items.emplace_back(CreateObject(3));
         return response;
       });
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("object-1", r.object_name());
@@ -477,7 +476,7 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
         EXPECT_EQ("test-bucket", req.bucket_name());
@@ -488,7 +487,7 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
         response.items.emplace_back(CreateObject(3));
         return response;
       });
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("object-1", r.object_name());
@@ -516,7 +515,7 @@ TEST_F(ObjectTest, DeleteByPrefixListFailure) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce(Return(StatusOr<internal::ListObjectsResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
   auto client = testing::ClientFromMock(mock);
@@ -531,7 +530,7 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock, ListObjects(_))
+  EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
         EXPECT_EQ("test-bucket", req.bucket_name());
@@ -542,7 +541,7 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
         response.items.emplace_back(CreateObject(3));
         return response;
       });
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("object-1", r.object_name());
@@ -601,7 +600,7 @@ TEST_F(ObjectTest, ComposeManyOne) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock, ComposeObject(_))
+  EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
         EXPECT_EQ("test-bucket", req.bucket_name());
@@ -613,14 +612,14 @@ TEST_F(ObjectTest, ComposeManyOne) {
 
         return MockObject("test-bucket", "test-object", 42);
       });
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
         EXPECT_EQ("", request.contents());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("prefix", r.object_name());
@@ -638,7 +637,7 @@ TEST_F(ObjectTest, ComposeManyThree) {
   auto mock = std::make_shared<testing::MockClient>();
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
-  EXPECT_CALL(*mock, ComposeObject(_))
+  EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
         EXPECT_EQ("test-bucket", req.bucket_name());
@@ -654,14 +653,14 @@ TEST_F(ObjectTest, ComposeManyThree) {
 
         return MockObject("test-bucket", "test-object", 42);
       });
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
         EXPECT_EQ("", request.contents());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("prefix", r.object_name());
@@ -684,7 +683,7 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
 
   // Test 63 sources.
 
-  EXPECT_CALL(*mock, ComposeObject(_))
+  EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
         EXPECT_EQ("test-bucket", req.bucket_name());
@@ -728,14 +727,14 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
 
         return MockObject(req.bucket_name(), req.object_name(), 42);
       });
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
         EXPECT_EQ("", request.contents());
         return make_status_or(MockObject("test-bucket", "prefix", 42));
       });
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("prefix.compose-tmp-1", r.object_name());
@@ -774,13 +773,13 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
 
   // Test 63 sources - second composition fails.
 
-  EXPECT_CALL(*mock, ComposeObject(_))
+  EXPECT_CALL(*mock, ComposeObject)
       .WillOnce(Return(make_status_or(
           MockObject("test-bucket", "prefix.compose-tmp-0", 42))))
       .WillOnce(Return(
           StatusOr<ObjectMetadata>(Status(StatusCode::kPermissionDenied, ""))));
 
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
@@ -789,7 +788,7 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
       });
 
   // Cleanup is still expected
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce([](internal::DeleteObjectRequest const& r) {
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("prefix.compose-tmp-0", r.object_name());
@@ -822,7 +821,7 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
 
   // Test 63 sources - second composition fails.
 
-  EXPECT_CALL(*mock, ComposeObject(_))
+  EXPECT_CALL(*mock, ComposeObject)
       .WillOnce(Return(make_status_or(
           MockObject("test-bucket", "prefix.compose-tmp-0", 42))))
       .WillOnce(Return(make_status_or(
@@ -830,10 +829,10 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
       .WillOnce(Return(make_status_or(MockObject("test-bucket", "dest", 42))));
 
   // Cleanup is still expected
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
@@ -862,7 +861,7 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
 
   // Test 63 sources - second composition fails.
 
-  EXPECT_CALL(*mock, ComposeObject(_))
+  EXPECT_CALL(*mock, ComposeObject)
       .WillOnce(Return(make_status_or(
           MockObject("test-bucket", "prefix.compose-tmp-0", 42))))
       .WillOnce(Return(make_status_or(
@@ -870,11 +869,11 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
       .WillOnce(Return(make_status_or(MockObject("test-bucket", "dest", 42))));
 
   // Cleanup is still expected
-  EXPECT_CALL(*mock, DeleteObject(_))
+  EXPECT_CALL(*mock, DeleteObject)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
 
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce([](internal::InsertObjectMediaRequest const& request) {
         EXPECT_EQ("test-bucket", request.bucket_name());
         EXPECT_EQ("prefix", request.object_name());
@@ -901,7 +900,7 @@ TEST_F(ObjectTest, ComposeManyLockingPrefixFails) {
   auto const mock_options = ClientOptions(oauth2::CreateAnonymousCredentials());
   EXPECT_CALL(*mock, client_options()).WillRepeatedly(ReturnRef(mock_options));
 
-  EXPECT_CALL(*mock, InsertObjectMedia(_))
+  EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce(Return(
           Status(StatusCode::kFailedPrecondition, "Generation mismatch")));
   auto client = testing::ClientFromMock(mock);

--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -489,10 +489,8 @@ TEST(CurlRequestTest, Logging) {
   auto mock_logger = std::make_shared<MockLogBackend>();
   google::cloud::LogSink::Instance().AddBackend(mock_logger);
 
-  using ::testing::_;
-
   std::string log_messages;
-  EXPECT_CALL(*mock_logger, ProcessWithOwnership(_))
+  EXPECT_CALL(*mock_logger, ProcessWithOwnership)
       .WillRepeatedly([&log_messages](google::cloud::LogRecord const& lr) {
         log_messages += lr.message;
         log_messages += "\n";


### PR DESCRIPTION
Many of our mocks said `EXPECT_CALL(..., Foo(_, _))` when one can simply
say `EXPECT_CALL(..., Foo)` for the same effect. Furthermore, we were
inconsistent about this, with newer libraries generally ommitting the
extra `_` wildcards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6263)
<!-- Reviewable:end -->
