### PR TITLE
ci: introduce io::log_cmdline

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -32,9 +32,7 @@ readonly BINARY_DIR="$2"
 # This script is designed to work in the context created by the
 # ci/Dockerfile.* build scripts.
 
-echo
 io::log_yellow "Starting docker build with ${NCPU} cores"
-echo
 
 echo "================================================================"
 readonly BAZEL_BIN="/usr/local/bin/bazel"
@@ -110,7 +108,7 @@ io::log_yellow "Verify generator golden file md5 hashes"
 
 echo "================================================================"
 io::log "Compiling and running unit tests"
-echo "bazel ${BAZEL_VERB}" "${bazel_args[@]}"
+io::log_cmdline "bazel ${BAZEL_VERB}" "${bazel_args[@]}"
 "${BAZEL_BIN}" ${BAZEL_VERB} \
   "${bazel_args[@]}" "--test_tag_filters=-integration-test" ...
 

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -29,9 +29,7 @@ fi
 readonly SOURCE_DIR="$1"
 readonly BINARY_DIR="$2"
 
-echo
 io::log_yellow "Starting docker build with ${NCPU} cores"
-echo
 
 # Run the configure / compile / test cycle inside a docker image.
 # This script is designed to work in the context created by the
@@ -586,7 +584,7 @@ if [[ "${CHECK_STYLE:-}" == "yes" && "${RUNNING_CI}" == "yes" ]]; then
   git diff --ignore-submodules=all --color --exit-code .
 fi
 
-if command -v ccache; then
+if command -v ccache >/dev/null 2>&1; then
   echo "================================================================"
   io::log_yellow "ccache stats"
   ccache --show-stats

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -364,13 +364,13 @@ fi
 
 echo "================================================================"
 io::log_yellow "Creating Docker image with all the development tools."
-echo "    docker build ${docker_build_flags[*]} ci"
-io::log_yellow "Logging to ${BUILD_OUTPUT}/create-build-docker-image.log"
 # We do not want to print the log unless there is an error, so disable the -e
 # flag. Later, we will want to print out the emulator(s) logs *only* if there
 # is an error, so disabling from this point on is the right choice.
 set +e
 mkdir -p "${BUILD_OUTPUT}"
+io::log_yellow "Logging to ${BUILD_OUTPUT}/create-build-docker-image.log"
+io::log_cmdline "docker build ${docker_build_flags[*]} ci"
 if timeout 3600s docker build "${docker_build_flags[@]}" ci \
   >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null; then
   update_cache="true"
@@ -637,7 +637,7 @@ else
 fi
 
 # Run the docker image with that giant collection of flags.
-echo docker run "${docker_flags[@]}" "${IMAGE}:latest" "${commands[@]}"
+io::log_cmdline docker run "${docker_flags[@]}" "${IMAGE}:latest" "${commands[@]}"
 docker run "${docker_flags[@]}" "${IMAGE}:latest" "${commands[@]}"
 
 exit_status=$?
@@ -684,7 +684,6 @@ else
   io::log_yellow "Not a CI build; skipping artifact cleanup"
 fi
 
-echo
 echo "================================================================"
 if [[ ${exit_status} -eq 0 ]]; then
   io::log_green "Build script finished successfully."

--- a/google/cloud/storage/tools/run_emulator_utils.sh
+++ b/google/cloud/storage/tools/run_emulator_utils.sh
@@ -29,12 +29,12 @@ EMULATOR_PID=0
 #   None
 ################################################
 kill_emulator() {
-  echo "${IO_COLOR_GREEN}[ -------- ]${IO_COLOR_RESET} Integration test environment tear-down."
+  echo "${IO_COLOR_GREEN}[ -------- ]${IO_RESET} Integration test environment tear-down."
   echo -n "Killing emulator server [${EMULATOR_PID}] ... "
   kill "${EMULATOR_PID}"
   wait "${EMULATOR_PID}" >/dev/null 2>&1
   echo "done."
-  echo "${IO_COLOR_GREEN}[ ======== ]${IO_COLOR_RESET} Integration test environment tear-down."
+  echo "${IO_COLOR_GREEN}[ ======== ]${IO_RESET} Integration test environment tear-down."
 
 }
 
@@ -55,7 +55,7 @@ kill_emulator() {
 start_emulator() {
   local port="${1:-0}"
 
-  echo "${IO_COLOR_GREEN}[ -------- ]${IO_COLOR_RESET} Integration test environment set-up"
+  echo "${IO_COLOR_GREEN}[ -------- ]${IO_RESET} Integration test environment set-up"
   echo "Launching Cloud Storage emulator in the background"
   trap kill_emulator EXIT
 
@@ -79,7 +79,7 @@ start_emulator() {
   done
 
   if [[ -z "${emulator_port}" ]]; then
-    echo "${IO_COLOR_RED}Cannot find listening port for emulator.${IO_COLOR_RESET}" >&2
+    echo "${IO_COLOR_RED}Cannot find listening port for emulator.${IO_RESET}" >&2
     cat gcs_emulator.log
     exit 1
   fi
@@ -99,7 +99,7 @@ start_emulator() {
   done
 
   if [[ "${connected}" = "no" ]]; then
-    echo "${IO_COLOR_RED}Cannot connect to emulator; aborting test.${IO_COLOR_RESET}" >&2
+    echo "${IO_COLOR_RED}Cannot connect to emulator; aborting test.${IO_RESET}" >&2
     cat gcs_emulator.log
     exit 1
   else
@@ -114,11 +114,11 @@ start_emulator() {
     echo "Successfully connected to gRPC server at port ${grpc_port}"
   else
     echo "${IO_COLOR_RED}${grpc_port} must be an integer" >&2
-    echo "${IO_COLOR_RED}Cannot connect to gRPC server; aborting test.${IO_COLOR_RESET}" >&2
+    echo "${IO_COLOR_RED}Cannot connect to gRPC server; aborting test.${IO_RESET}" >&2
     cat gcs_emulator.log
     exit 1
   fi
   export CLOUD_STORAGE_GRPC_ENDPOINT="localhost:${grpc_port}"
 
-  echo "${IO_COLOR_GREEN}[ ======== ]${IO_COLOR_RESET} Integration test environment set-up."
+  echo "${IO_COLOR_GREEN}[ ======== ]${IO_RESET} Integration test environment set-up."
 }


### PR DESCRIPTION
Add `io::log_cmdline` for logging command execution. It prefixes
the command with `${PS4}`, just like `set -x` would in the shell.
This helps to delineate the command from normal output.

Also print the command in a bold typeface when possible, making
it even easier to distinguish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6264)
<!-- Reviewable:end -->
