### PR TITLE
cleanup: avoid CMake warning-message markup

### DIFF
--- a/super/ExternalProjectHelper.cmake
+++ b/super/ExternalProjectHelper.cmake
@@ -20,10 +20,10 @@ include(GNUInstallDirs)
 message(
     WARNING
         [==[
-Super builds are no longer recommended, and will be removed on 2022-05-01
-or shortly after.  If you want to automatically download and build the
-`google-cloud-cpp` dependencies we recommend that you use `vcpkg` as
-described in /doc/contributor/howto-guide-setup-cmake-environment.md
+  Super builds are no longer recommended, and will be removed on 2022-05-01
+  or shortly after.  If you want to automatically download and build the
+  `google-cloud-cpp` dependencies we recommend that you use `vcpkg` as
+  described in /doc/contributor/howto-guide-setup-cmake-environment.md
 ]==])
 
 set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX


### PR DESCRIPTION
CMake `message(WARNING "message to display")` uses a simple markup
language, where newlines in non-indented text are presumed to
delineate paragraphs that should be wrapped and separated. Avoid
that by adding a little indentation, so the text renders as a
single block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6265)
<!-- Reviewable:end -->
