### PR TITLE
ci(gcb): add gcs-grpc build

### DIFF
--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -27,6 +27,8 @@ mapfile -t args < <(bazel::common_args)
 bazel test "${args[@]}" --test_tag_filters=-integration-test google/cloud/storage/...
 
 mapfile -t integration_args < <(integration::args)
+# "media" says to use the hybrid gRPC/REST client. For more details see
+# https://github.com/googleapis/google-cloud-cpp/issues/6268
 GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media # Uses the gRPC data plane
 io::log_h2 "Running Storage integration tests (with emulator)"
 google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh \

--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+
+export CC=clang
+export CXX=clang++
+
+mapfile -t args < <(bazel::common_args)
+bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::args)
+GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media # Uses the gRPC data plane
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -28,4 +28,6 @@ bazel test "${args[@]}" --test_tag_filters=-integration-test ...
 
 mapfile -t integration_args < <(integration::args)
 GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media # Uses the gRPC data plane
-integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+io::log_h2 "Running Storage integration tests (with emulator)"
+google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh \
+  bazel test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -24,7 +24,7 @@ export CC=clang
 export CXX=clang++
 
 mapfile -t args < <(bazel::common_args)
-bazel test "${args[@]}" --test_tag_filters=-integration-test ...
+bazel test "${args[@]}" --test_tag_filters=-integration-test google/cloud/storage/...
 
 mapfile -t integration_args < <(integration::args)
 GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media # Uses the gRPC data plane

--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -1,0 +1,12 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: gcs-grpc-ci
+substitutions:
+  _BUILD_NAME: gcs-grpc
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: gcs-grpc-pr
+substitutions:
+  _BUILD_NAME: gcs-grpc
+  _DISTRO: fedora
+tags:
+- pr


### PR DESCRIPTION
From my understanding of the existing gcs-grpc build, I _think_ this is equivalent and testing the right things. However, is there a way for me to verify that the correct gcs + grpc logic/tests were run? Here's [output from a manual run](https://pantheon.corp.google.com/cloud-build/builds/3ff77a4e-3058-4134-8a22-8293cfdae02c?project=cloud-cpp-testing-resources) I did of this build in case this will show you whether or not the correct things ran.

Context: **current** `gcs-grpc` build:
https://github.com/googleapis/google-cloud-cpp/blob/21f3d910814fd9b5df5e511eecf3c141e2a3e1db/ci/kokoro/docker/build.sh#L278-L292

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6267)
<!-- Reviewable:end -->
