### PR TITLE
cleanup: use wildcard matcher (_) even more sparingly

### DIFF
--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_logging_decorator_test.cc
@@ -27,7 +27,6 @@ inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
-using ::testing::_;
 using ::testing::ByMove;
 using ::testing::Contains;
 using ::testing::HasSubstr;

--- a/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_logging_decorator_test.cc
@@ -25,7 +25,6 @@ namespace golden_internal {
 inline namespace GOOGLE_CLOUD_CPP_GENERATED_NS {
 namespace {
 
-using ::testing::_;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -56,7 +56,6 @@ struct MockAsyncFailingRpcFactory {
                                             grpc::ClientContext* context,
                                             RequestType const& request,
                                             grpc::CompletionQueue*) {
-      using ::testing::_;
       EXPECT_STATUS_OK(google::cloud::testing_util::IsContextMDValid(
           *context, method, google::cloud::internal::ApiClientHeader()));
       RequestType expected;
@@ -68,7 +67,7 @@ struct MockAsyncFailingRpcFactory {
       differencer.ReportDifferencesToString(&delta);
       EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
 
-      EXPECT_CALL(*reader, Finish(_, _, _))
+      EXPECT_CALL(*reader, Finish)
           .WillOnce([](ResponseType* response, grpc::Status* status, void*) {
             EXPECT_NE(nullptr, response);
             *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "nooo");

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -24,7 +24,6 @@
 namespace {
 
 //! [helper-aliases]
-using ::testing::_;
 using ::testing::Return;
 namespace spanner = ::google::cloud::spanner;
 //! [helper-aliases]
@@ -76,7 +75,7 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
 
   // Setup the connection mock to return the results previously setup:
   //! [mock-execute-query]
-  EXPECT_CALL(*conn, ExecuteQuery(_))
+  EXPECT_CALL(*conn, ExecuteQuery)
       .WillOnce([&source](spanner::Connection::SqlParams const&)
                     -> spanner::RowStream {
         return spanner::RowStream(std::move(source));

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -24,7 +24,6 @@
 
 namespace {
 
-using ::testing::_;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -52,7 +51,7 @@ TEST(StorageMockingSamples, MockReadObject) {
     return gcs::internal::ReadSourceResult{
         l, gcs::internal::HttpResponse{200, {}, {}}};
   };
-  EXPECT_CALL(*mock, ReadObject(_))
+  EXPECT_CALL(*mock, ReadObject)
       .WillOnce([simulate_read](
                     gcs::internal::ReadObjectRangeRequest const& request) {
         EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
@@ -61,7 +60,7 @@ TEST(StorageMockingSamples, MockReadObject) {
         EXPECT_CALL(*mock_source, IsOpen())
             .WillOnce(Return(true))
             .WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock_source, Read(_, _)).WillRepeatedly(simulate_read);
+        EXPECT_CALL(*mock_source, Read).WillRepeatedly(simulate_read);
 
         return google::cloud::make_status_or(
             std::unique_ptr<gcs::internal::ObjectReadSource>(
@@ -93,7 +92,7 @@ TEST(StorageMockingSamples, MockWriteObject) {
 
   gcs::ObjectMetadata expected_metadata;
 
-  EXPECT_CALL(*mock, CreateResumableSession(_))
+  EXPECT_CALL(*mock, CreateResumableSession)
       .WillOnce([&expected_metadata](
                     gcs::internal::ResumableUploadRequest const& request) {
         EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
@@ -102,14 +101,14 @@ TEST(StorageMockingSamples, MockWriteObject) {
         EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
         EXPECT_CALL(*mock_result, next_expected_byte())
             .WillRepeatedly(Return(0));
-        EXPECT_CALL(*mock_result, UploadChunk(_))
+        EXPECT_CALL(*mock_result, UploadChunk)
             .WillRepeatedly(Return(google::cloud::make_status_or(
                 ResumableUploadResponse{"fake-url",
                                         0,
                                         {},
                                         ResumableUploadResponse::kInProgress,
                                         {}})));
-        EXPECT_CALL(*mock_result, UploadFinalChunk(_, _))
+        EXPECT_CALL(*mock_result, UploadFinalChunk)
             .WillRepeatedly(Return(google::cloud::make_status_or(
                 ResumableUploadResponse{"fake-url",
                                         0,
@@ -143,14 +142,14 @@ TEST(StorageMockingSamples, MockReadObjectFailure) {
   auto client = gcs::testing::ClientFromMock(mock);
 
   std::string text = "this is a mock http response";
-  EXPECT_CALL(*mock, ReadObject(_))
+  EXPECT_CALL(*mock, ReadObject)
       .WillOnce([](gcs::internal::ReadObjectRangeRequest const& request) {
         EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
         auto* mock_source = new gcs::testing::MockObjectReadSource;
         EXPECT_CALL(*mock_source, IsOpen())
             .WillOnce(Return(true))
             .WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock_source, Read(_, _))
+        EXPECT_CALL(*mock_source, Read)
             .WillOnce(Return(google::cloud::Status(
                 google::cloud::StatusCode::kInvalidArgument,
                 "Invalid Argument")));
@@ -180,7 +179,7 @@ TEST(StorageMockingSamples, MockWriteObjectFailure) {
 
   auto client = gcs::testing::ClientFromMock(mock);
 
-  EXPECT_CALL(*mock, CreateResumableSession(_))
+  EXPECT_CALL(*mock, CreateResumableSession)
       .WillOnce([](gcs::internal::ResumableUploadRequest const& request) {
         EXPECT_EQ(request.bucket_name(), "mock-bucket-name") << request;
         auto* mock_result = new gcs::testing::MockResumableUploadSession;
@@ -188,11 +187,11 @@ TEST(StorageMockingSamples, MockWriteObjectFailure) {
         EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
         EXPECT_CALL(*mock_result, next_expected_byte())
             .WillRepeatedly(Return(0));
-        EXPECT_CALL(*mock_result, UploadChunk(_))
+        EXPECT_CALL(*mock_result, UploadChunk)
             .WillRepeatedly(Return(google::cloud::Status(
                 google::cloud::StatusCode::kInvalidArgument,
                 "Invalid Argument")));
-        EXPECT_CALL(*mock_result, UploadFinalChunk(_, _))
+        EXPECT_CALL(*mock_result, UploadFinalChunk)
             .WillRepeatedly(Return(google::cloud::Status(
                 google::cloud::StatusCode::kInvalidArgument,
                 "Invalid Argument")));


### PR DESCRIPTION
A small followup to #6263.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6269)
<!-- Reviewable:end -->
