### PR TITLE
ci(gcb): enable coverage build

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -267,7 +267,7 @@ account="$(gcloud config list account --format "value(core.account)")"
 subs="_DISTRO=${DISTRO_FLAG}"
 subs+=",_BUILD_NAME=${BUILD_NAME}"
 subs+=",_CACHE_TYPE=manual-${account}"
-subs+=",_PR_NUMBER="  # Must be empty or a number, and this is not a PR
+subs+=",_PR_NUMBER=" # Must be empty or a number, and this is not a PR
 subs+=",BRANCH_NAME=${BRANCH_NAME}"
 subs+=",COMMIT_SHA=${COMMIT_SHA}"
 io::log "Substitutions ${subs}"

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+
+export CC=gcc
+export CXX=g++
+
+mapfile -t args < <(bazel::common_args)
+bazel coverage "${args[@]}" --test_tag_filters=-integration-test ...
+mapfile -t integration_args < <(integration::args)
+integration::bazel_with_emulators coverage "${args[@]}" "${integration_args[@]}"
+
+# Where does this token come from? For triggered ci/pr builds GCB will securely
+# inject this into the environment. See the "secretEnv" setting in the
+# cloudbuild.yaml file. The value is stored in Secret Manager. You can store
+# your own token in your personal project's Secret Manager so that your
+# personal builds have coverage data uploaded to your own account. See also
+# https://cloud.google.com/build/docs/securing-builds/use-secrets
+if [[ -z "${CODECOV_TOKEN:-}" ]]; then
+  io::log_h2 "No codecov token. Skipping upload."
+  exit 0
+fi
+
+# Merges the coverage.dat files, which reduces the overall size by about 90%.
+readonly MERGED_COVERAGE="/var/tmp/merged-coverage.lcov"
+io::log_h2 "Merging coverage data into ${MERGED_COVERAGE}"
+TIMEFORMAT="==> 🕑 merging done in %R seconds"
+time {
+  mapfile -t coverage_dat < <(find "$(bazel info output_path)" -name "coverage.dat")
+  io::log "Found ${#coverage_dat[@]} coverage.dat files"
+  lcov_flags=($(printf -- "--add-tracefile=%s " "${coverage_dat[@]}"))
+  lcov --quiet "${lcov_flags[@]}" --output-file "${MERGED_COVERAGE}"
+  ls -lh "${MERGED_COVERAGE}"
+}
+
+codecov_args=(
+  "-X" "gcov"
+  "-f" "${MERGED_COVERAGE}"
+  "-q" "${HOME}/coverage-report.txt"
+  "-B" "${BRANCH_NAME}"
+  "-C" "${COMMIT_SHA}"
+  "-P" "${PR_NUMBER:-}"
+  "-b" "${BUILD_ID:-}"
+)
+io::log_h2 "Uploading ${MERGED_COVERAGE} to codecov.io"
+io::log "Flags: ${codecov_args[*]}"
+TIMEFORMAT="==> 🕑 codecov.io upload done in %R seconds"
+time {
+  env -i CODECOV_TOKEN="${CODECOV_TOKEN:-}" HOME="${HOME}" \
+    bash <(curl -s https://codecov.io/bash) "${codecov_args[@]}"
+}

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -46,7 +46,7 @@ TIMEFORMAT="==> 🕑 merging done in %R seconds"
 time {
   mapfile -t coverage_dat < <(find "$(bazel info output_path)" -name "coverage.dat")
   io::log "Found ${#coverage_dat[@]} coverage.dat files"
-  lcov_flags=($(printf -- "--add-tracefile=%s " "${coverage_dat[@]}"))
+  mapfile -t lcov_flags < <(printf -- "--add-tracefile=%s\n" "${coverage_dat[@]}")
   lcov --quiet "${lcov_flags[@]}" --output-file "${MERGED_COVERAGE}"
   ls -lh "${MERGED_COVERAGE}"
 }

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -21,7 +21,10 @@ options:
     'TZ=UTC0',
     'GOOGLE_CLOUD_BUILD=yes',
     'PROJECT_ID=${PROJECT_ID}',
-    'BUILD_ID=${BUILD_ID}'
+    'BUILD_ID=${BUILD_ID}',
+    'BRANCH_NAME=${BRANCH_NAME}',
+    'COMMIT_SHA=${COMMIT_SHA}',
+    'PR_NUMBER=${_PR_NUMBER}'
   ]
   volumes:
     - name: 'home'
@@ -39,6 +42,11 @@ substitutions:
 
 tags: [ '${_TRIGGER_TYPE}', '${_BUILD_NAME}', '${_DISTRO}' ]
 timeout: 3600s
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/1
+    env: 'CODECOV_TOKEN'
 
 steps:
   # Builds the docker image that will be used by the main build step.
@@ -66,6 +74,7 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '--local', '${_BUILD_NAME}' ]
+  secretEnv: ['CODECOV_TOKEN']
   env: [
     'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}',
     'VCPKG_BINARY_SOURCES=x-gcs,gs://${_CACHE_BUCKET}/vcpkg-cache/${_DISTRO}-${_BUILD_NAME},readwrite'

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -45,7 +45,7 @@ timeout: 3600s
 
 availableSecrets:
   secretManager:
-  - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/1
+  - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest
     env: 'CODECOV_TOKEN'
 
 steps:

--- a/ci/cloudbuild/triggers/coverage-ci.yaml
+++ b/ci/cloudbuild/triggers/coverage-ci.yaml
@@ -1,0 +1,12 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: coverage-ci
+substitutions:
+  _BUILD_NAME: coverage
+  _DISTRO: fedora
+tags:
+- ci

--- a/ci/cloudbuild/triggers/coverage-pr.yaml
+++ b/ci/cloudbuild/triggers/coverage-pr.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: coverage-pr
+substitutions:
+  _BUILD_NAME: coverage
+  _DISTRO: fedora
+tags:
+- pr


### PR DESCRIPTION
This seems to be working in my tests. For now, it's configured to upload
coverage data to devjgm's personal codecov account at
https://app.codecov.io/gh/devjgm/google-cloud-cpp/. Once we see that
this build works and uploads coverage data correctly, we can change it
to use the _real_ token, which can be done in Secret Manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6270)
<!-- Reviewable:end -->
