### PR TITLE
ci(gcb): fix coverage build (hopefully)

### DIFF
--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -24,6 +24,8 @@ export CC=gcc
 export CXX=g++
 
 mapfile -t args < <(bazel::common_args)
+args+=("--instrumentation_filter=/google/cloud[/:],/generator[/:]")
+args+=("--instrument_test_targets")
 bazel coverage "${args[@]}" --test_tag_filters=-integration-test ...
 mapfile -t integration_args < <(integration::args)
 integration::bazel_with_emulators coverage "${args[@]}" "${integration_args[@]}"


### PR DESCRIPTION
The coverage build [failed][failure-log] with

```
lcov: ERROR: no valid records found in tracefile /h/.cache/bazel/_bazel_root/eab0d61a99b6696edb3d2aff87b585e8/execroot/com_github_googleapis_google_cloud_cpp/bazel-out/k8-fastbuild/testlogs/generator/integration_tests/generator_integration_test/coverage.dat
```

I'm not sure why that failed, but in looking into it, I noticed I was
missing some needed flags for coverage, so maybe this is the problem and
will fix it. Note, that I was unable to reproduce the failure in any of
my tests, so I'm not sure if this will fix it, but I think we need these
flags anyway.

[failure-log]: https://pantheon.corp.google.com/cloud-build/builds;region=global/5f4c6f26-4330-44bd-8415-b75c43be2276;step=2?project=cloud-cpp-testing-resources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6273)
<!-- Reviewable:end -->
