### PR TITLE
ci(gcb): fix missing trigger type in some builds

### DIFF
--- a/ci/cloudbuild/trigger.sh
+++ b/ci/cloudbuild/trigger.sh
@@ -55,6 +55,7 @@ name: ${name}-ci
 substitutions:
   _BUILD_NAME: ${name}
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci
 EOF
@@ -74,6 +75,7 @@ name: ${name}-pr
 substitutions:
   _BUILD_NAME: ${name}
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr
 EOF

--- a/ci/cloudbuild/triggers/coverage-ci.yaml
+++ b/ci/cloudbuild/triggers/coverage-ci.yaml
@@ -8,5 +8,6 @@ name: coverage-ci
 substitutions:
   _BUILD_NAME: coverage
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/coverage-pr.yaml
+++ b/ci/cloudbuild/triggers/coverage-pr.yaml
@@ -9,5 +9,6 @@ name: coverage-pr
 substitutions:
   _BUILD_NAME: coverage
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/cxx17-ci.yaml
+++ b/ci/cloudbuild/triggers/cxx17-ci.yaml
@@ -8,5 +8,6 @@ name: cxx17-ci
 substitutions:
   _BUILD_NAME: cxx17
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cxx17-pr.yaml
+++ b/ci/cloudbuild/triggers/cxx17-pr.yaml
@@ -9,5 +9,6 @@ name: cxx17-pr
 substitutions:
   _BUILD_NAME: cxx17
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -8,5 +8,6 @@ name: gcs-grpc-ci
 substitutions:
   _BUILD_NAME: gcs-grpc
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -9,5 +9,6 @@ name: gcs-grpc-pr
 substitutions:
   _BUILD_NAME: gcs-grpc
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/libcxx-ci.yaml
+++ b/ci/cloudbuild/triggers/libcxx-ci.yaml
@@ -8,5 +8,6 @@ name: libcxx-ci
 substitutions:
   _BUILD_NAME: libcxx
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/libcxx-pr.yaml
+++ b/ci/cloudbuild/triggers/libcxx-pr.yaml
@@ -9,5 +9,6 @@ name: libcxx-pr
 substitutions:
   _BUILD_NAME: libcxx
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/msan-ci.yaml
+++ b/ci/cloudbuild/triggers/msan-ci.yaml
@@ -8,5 +8,6 @@ name: msan-ci
 substitutions:
   _BUILD_NAME: msan
   _DISTRO: fedora-msan
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/msan-pr.yaml
+++ b/ci/cloudbuild/triggers/msan-pr.yaml
@@ -9,5 +9,6 @@ name: msan-pr
 substitutions:
   _BUILD_NAME: msan
   _DISTRO: fedora-msan
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/noex-ci.yaml
+++ b/ci/cloudbuild/triggers/noex-ci.yaml
@@ -8,5 +8,6 @@ name: noex-ci
 substitutions:
   _BUILD_NAME: noex
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/noex-pr.yaml
+++ b/ci/cloudbuild/triggers/noex-pr.yaml
@@ -9,5 +9,6 @@ name: noex-pr
 substitutions:
   _BUILD_NAME: noex
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/shared-ci.yaml
+++ b/ci/cloudbuild/triggers/shared-ci.yaml
@@ -8,5 +8,6 @@ name: shared-ci
 substitutions:
   _BUILD_NAME: shared
   _DISTRO: fedora
+  _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/shared-pr.yaml
+++ b/ci/cloudbuild/triggers/shared-pr.yaml
@@ -9,5 +9,6 @@ name: shared-pr
 substitutions:
   _BUILD_NAME: shared
   _DISTRO: fedora
+  _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Also fix the `trigger.sh` script that was generating these files w/o the
`_TRIGGER_TYPE` set correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6275)
<!-- Reviewable:end -->
