### PR TITLE
ci(gcb): set LD_LIBRARY_PATH for quickstart builds

### DIFF
--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -59,6 +59,7 @@ function quickstart::run_cmake_and_make() {
 
     echo
     io::log "[ Make ]"
+    LD_LIBRARY_PATH="${prefix}/lib64:${prefix}/lib:${LD_LIBRARY_PATH:-}" \
     PKG_CONFIG_PATH="${prefix}/lib64/pkgconfig:${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
       make -C "${src_dir}"
     test "${#run_args[@]}" -eq 0 || "${src_dir}/quickstart" "${run_args[@]}"

--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -60,7 +60,7 @@ function quickstart::run_cmake_and_make() {
     echo
     io::log "[ Make ]"
     LD_LIBRARY_PATH="${prefix}/lib64:${prefix}/lib:${LD_LIBRARY_PATH:-}" \
-    PKG_CONFIG_PATH="${prefix}/lib64/pkgconfig:${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
+      PKG_CONFIG_PATH="${prefix}/lib64/pkgconfig:${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
       make -C "${src_dir}"
     test "${#run_args[@]}" -eq 0 || "${src_dir}/quickstart" "${run_args[@]}"
   done


### PR DESCRIPTION
Fixes: #6278

This is needed to find the shared libraries that the Makefile
quickstarts will need to link with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6279)
<!-- Reviewable:end -->
