### PR TITLE
ci(gcb): set LD_LIBRARY_PATH when running `quickstart`

### DIFF
--- a/ci/cloudbuild/builds/lib/quickstart.sh
+++ b/ci/cloudbuild/builds/lib/quickstart.sh
@@ -61,6 +61,8 @@ function quickstart::run_cmake_and_make() {
     io::log "[ Make ]"
     PKG_CONFIG_PATH="${prefix}/lib64/pkgconfig:${prefix}/lib/pkgconfig:${PKG_CONFIG_PATH:-}" \
       make -C "${src_dir}"
-    test "${#run_args[@]}" -eq 0 || "${src_dir}/quickstart" "${run_args[@]}"
+    test "${#run_args[@]}" -eq 0 ||
+      LD_LIBRARY_PATH="${prefix}/lib64:${prefix}/lib:${LD_LIBRARY_PATH:-}" \
+        "${src_dir}/quickstart" "${run_args[@]}"
   done
 }


### PR DESCRIPTION
Fixes: #6278

This is needed to find the shared libraries that the Makefile
quickstarts will need to link with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6280)
<!-- Reviewable:end -->
