### PR TITLE
refactor(storage): use g::c::Options in RawClients

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -218,6 +218,7 @@ add_library(
     object_rewriter.h
     object_stream.cc
     object_stream.h
+    options.h
     override_default_project.h
     parallel_upload.cc
     parallel_upload.h

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -321,7 +321,9 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
       case ApiName::kApiRawGrpc: {
         gcs::Client grpc_client =
             google::cloud::storage_experimental::DefaultGrpcClient(
-                client_options, thread_id);
+                thread_id,
+                google::cloud::storage::internal::MakeOptions(client_options))
+                .value();
         result.push_back(
             absl::make_unique<UploadObject>(grpc_client, a, contents, false));
         result.push_back(
@@ -363,7 +365,9 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
       case ApiName::kApiGrpc:
         result.push_back(absl::make_unique<DownloadObject>(
             google::cloud::storage_experimental::DefaultGrpcClient(
-                client_options),
+                thread_id,
+                google::cloud::storage::internal::MakeOptions(client_options))
+                .value(),
             a));
         break;
 #else

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_OPTIONS_H
 
 #include "google/cloud/storage/oauth2/credentials.h"
+#include "google/cloud/storage/options.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/options.h"
@@ -35,73 +36,23 @@ std::string XmlEndpoint(Options const&);
 std::string IamEndpoint(Options const&);
 
 Options MakeOptions(ClientOptions);
+
 ClientOptions MakeBackwardsCompatibleClientOptions(Options);
+
+Options ApplyPolicy(Options opts, RetryPolicy const& p);
+Options ApplyPolicy(Options opts, BackoffPolicy const& p);
+Options ApplyPolicy(Options opts, IdempotencyPolicy const& p);
+
+inline Options ApplyPolicies(Options opts) { return opts; }
+
+template <typename P, typename... Policies>
+Options ApplyPolicies(Options opts, P&& head, Policies&&... tail) {
+  opts = ApplyPolicy(std::move(opts), std::forward<P>(head));
+  return ApplyPolicies(std::move(opts), std::forward<Policies>(tail)...);
+}
+
 Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
                        Options opts = {});
-
-/// Configure the IAM endpoint for the GCS client library.
-struct GcsRestEndpointOption {
-  using Type = std::string;
-};
-
-struct GcsIamEndpointOption {
-  using Type = std::string;
-};
-
-/// Configure oauth2::Credentials for the GCS client library.
-struct Oauth2CredentialsOption {
-  using Type = std::shared_ptr<oauth2::Credentials>;
-};
-
-/// This is only intended for testing against staging or development versions
-/// of the service. It should *remain* in the internal:: namespace.
-struct TargetApiVersionOption {
-  using Type = std::string;
-};
-
-struct ProjectIdOption {
-  using Type = std::string;
-};
-
-struct ConnectionPoolSizeOption {
-  using Type = std::size_t;
-};
-
-struct DownloadBufferSizeOption {
-  using Type = std::size_t;
-};
-
-struct UploadBufferSizeOption {
-  using Type = std::size_t;
-};
-
-struct MaximumSimpleUploadSizeOption {
-  using Type = std::size_t;
-};
-
-struct EnableCurlSslLockingOption {
-  using Type = bool;
-};
-
-struct EnableCurlSigpipeHandlerOption {
-  using Type = bool;
-};
-
-struct MaximumCurlSocketRecvSizeOption {
-  using Type = std::size_t;
-};
-
-struct MaximumCurlSocketSendSizeOption {
-  using Type = std::size_t;
-};
-
-struct DownloadStallTimeoutOption {
-  using Type = std::chrono::seconds;
-};
-
-struct SslRootPathOption {
-  using Type = std::string;
-};
 
 }  // namespace internal
 
@@ -173,18 +124,18 @@ class ClientOptions {
   }
 
   std::string const& endpoint() const {
-    return opts_.get<internal::GcsRestEndpointOption>();
+    return opts_.get<internal::RestEndpointOption>();
   }
   ClientOptions& set_endpoint(std::string endpoint) {
-    opts_.set<internal::GcsRestEndpointOption>(std::move(endpoint));
+    opts_.set<internal::RestEndpointOption>(std::move(endpoint));
     return *this;
   }
 
   std::string const& iam_endpoint() const {
-    return opts_.get<internal::GcsIamEndpointOption>();
+    return opts_.get<internal::IamEndpointOption>();
   }
   ClientOptions& set_iam_endpoint(std::string endpoint) {
-    opts_.set<internal::GcsIamEndpointOption>(std::move(endpoint));
+    opts_.set<internal::IamEndpointOption>(std::move(endpoint));
     return *this;
   }
 

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -309,9 +309,9 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   auto const opts = internal::MakeOptions(
       ClientOptions(oauth2::CreateAnonymousCredentials()));
   EXPECT_EQ("https://storage.googleapis.com",
-            opts.get<internal::GcsRestEndpointOption>());
+            opts.get<internal::RestEndpointOption>());
   EXPECT_EQ("https://iamcredentials.googleapis.com/v1",
-            opts.get<internal::GcsIamEndpointOption>());
+            opts.get<internal::IamEndpointOption>());
   EXPECT_TRUE(opts.has<internal::Oauth2CredentialsOption>());
   EXPECT_EQ("v1", opts.get<internal::TargetApiVersionOption>());
   EXPECT_EQ("test-project-id", opts.get<internal::ProjectIdOption>());
@@ -330,14 +330,14 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
 TEST_F(ClientOptionsTest, DefaultOptions) {
   auto o = internal::DefaultOptions(oauth2::CreateAnonymousCredentials(), {});
   EXPECT_EQ("https://storage.googleapis.com",
-            o.get<internal::GcsRestEndpointOption>());
+            o.get<internal::RestEndpointOption>());
 
   // Verify any set values are respected overriden.
   o = internal::DefaultOptions(oauth2::CreateAnonymousCredentials(),
-                               Options{}.set<internal::GcsRestEndpointOption>(
+                               Options{}.set<internal::RestEndpointOption>(
                                    "https://private.googleapis.com"));
   EXPECT_EQ("https://private.googleapis.com",
-            o.get<internal::GcsRestEndpointOption>());
+            o.get<internal::RestEndpointOption>());
 }
 
 }  // namespace

--- a/google/cloud/storage/examples/storage_grpc_samples.cc
+++ b/google/cloud/storage/examples/storage_grpc_samples.cc
@@ -64,10 +64,10 @@ void GrpcReadWriteCommand(std::vector<std::string> argv) {
 //! [grpc-client-with-project]
 void GrpcClientWithProject(std::string project_id) {
   namespace gcs = google::cloud::storage;
-  auto options = gcs::ClientOptions::CreateDefaultClientOptions();
-  if (!options) throw std::runtime_error(options.status().message());
   auto client = google::cloud::storage_experimental::DefaultGrpcClient(
-      options->set_project_id(std::move(project_id)));
+      google::cloud::Options{}.set<gcs::internal::ProjectIdOption>(
+          std::move(project_id)));
+  if (!client) throw std::runtime_error(client.status().message());
   std::cout << "Successfully created a gcs::Client configured to use gRPC\n";
 }
 //! [grpc-client-with-project]

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -107,6 +107,7 @@ google_cloud_cpp_storage_hdrs = [
     "object_metadata.h",
     "object_rewriter.h",
     "object_stream.h",
+    "options.h",
     "override_default_project.h",
     "parallel_upload.h",
     "policy_document.h",

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -31,27 +31,30 @@ bool UseGrpcForMetadata() {
 }
 }  // namespace
 
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient() {
-  auto options = storage::ClientOptions::CreateDefaultClientOptions();
-  if (!options) return std::move(options).status();
-
-  return DefaultGrpcClient(*std::move(options));
+StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts) {
+  return DefaultGrpcClient(0, std::move(opts));
 }
 
-google::cloud::storage::Client DefaultGrpcClient(
-    google::cloud::storage::ClientOptions options, int channel_id) {
+StatusOr<google::cloud::storage::Client> DefaultGrpcClient(int channel_id,
+                                                           Options opts) {
+  opts = google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
   if (UseGrpcForMetadata()) {
     return storage::internal::ClientImplDetails::CreateClient(
-        storage::internal::GrpcClient::Create(
-            google::cloud::storage::internal::MakeOptions(std::move(options)),
-            channel_id));
+        storage::internal::GrpcClient::Create(opts, channel_id));
   }
-  auto credentials = options.credentials();
+  // The hybrid client might need the OAuth2 credentials
+  if (!opts.has<storage::internal::Oauth2CredentialsOption>()) {
+    storage::ChannelOptions channel_options;
+    channel_options.set_ssl_root_path(
+        opts.get<storage::internal::SslRootPathOption>());
+    auto credentials =
+        storage::oauth2::GoogleDefaultCredentials(channel_options);
+    if (!credentials) return std::move(credentials).status();
+    opts.set<storage::internal::Oauth2CredentialsOption>(
+        *std::move(credentials));
+  }
   return storage::internal::ClientImplDetails::CreateClient(
-      storage::internal::HybridClient::Create(
-          std::move(credentials),
-          google::cloud::storage::internal::MakeOptions(std::move(options)),
-          channel_id));
+      storage::internal::HybridClient::Create(opts, channel_id));
 }
 
 }  // namespace STORAGE_CLIENT_NS

--- a/google/cloud/storage/grpc_plugin.h
+++ b/google/cloud/storage/grpc_plugin.h
@@ -44,8 +44,8 @@ inline namespace STORAGE_CLIENT_NS {
  * @warning this is an experimental feature, and subject to change without
  *     notice.
  */
-google::cloud::storage::Client DefaultGrpcClient(
-    google::cloud::storage::ClientOptions options, int channel_id);
+StatusOr<google::cloud::storage::Client> DefaultGrpcClient(int channel_id,
+                                                           Options opts = {});
 
 /**
  * Create a `google::cloud::storage::Client` object configured to use gRPC.
@@ -56,23 +56,7 @@ google::cloud::storage::Client DefaultGrpcClient(
  * @par Example
  * @snippet storage_grpc_samples.cc grpc-default-client
  */
-StatusOr<google::cloud::storage::Client> DefaultGrpcClient();
-
-/**
- * Create a `google::cloud::storage::Client` object configured to use gRPC.
- *
- * @note the Credentials parameter in the configuration is ignored. The gRPC
- *     client only supports Google Default Credentials.
- *
- * @param options the configuration parameters for the Client.
- *
- * @warning this is an experimental feature, and subject to change without
- *     notice.
- */
-inline google::cloud::storage::Client DefaultGrpcClient(
-    google::cloud::storage::ClientOptions options) {
-  return DefaultGrpcClient(std::move(options), 0);
-}
+StatusOr<google::cloud::storage::Client> DefaultGrpcClient(Options opts = {});
 
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage_experimental

--- a/google/cloud/storage/idempotency_policy.h
+++ b/google/cloud/storage/idempotency_policy.h
@@ -15,8 +15,17 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_IDEMPOTENCY_POLICY_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_IDEMPOTENCY_POLICY_H
 
-#include "google/cloud/storage/internal/raw_client.h"
+#include "google/cloud/storage/internal/bucket_acl_requests.h"
+#include "google/cloud/storage/internal/bucket_requests.h"
+#include "google/cloud/storage/internal/default_object_acl_requests.h"
+#include "google/cloud/storage/internal/hmac_key_requests.h"
+#include "google/cloud/storage/internal/notification_requests.h"
+#include "google/cloud/storage/internal/object_acl_requests.h"
+#include "google/cloud/storage/internal/object_requests.h"
+#include "google/cloud/storage/internal/service_account_requests.h"
+#include "google/cloud/storage/internal/sign_blob_requests.h"
 #include "google/cloud/storage/version.h"
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -37,19 +37,12 @@ class CurlRequestBuilder;
 class CurlClient : public RawClient,
                    public std::enable_shared_from_this<CurlClient> {
  public:
-  static std::shared_ptr<CurlClient> Create(
-      std::shared_ptr<oauth2::Credentials> credentials, Options options) {
+  static std::shared_ptr<CurlClient> Create(Options options) {
     // Cannot use std::make_shared because the constructor is private.
-    return std::shared_ptr<CurlClient>(new CurlClient(
-        DefaultOptions(std::move(credentials), std::move(options))));
+    return std::shared_ptr<CurlClient>(new CurlClient(std::move(options)));
   }
   static std::shared_ptr<CurlClient> Create(ClientOptions options) {
-    auto credentials = options.credentials();
-    return Create(std::move(credentials), MakeOptions(std::move(options)));
-  }
-  static std::shared_ptr<CurlClient> Create(
-      std::shared_ptr<oauth2::Credentials> credentials) {
-    return Create(std::move(credentials), Options{});
+    return Create(MakeOptions(std::move(options)));
   }
 
   CurlClient(CurlClient const& rhs) = delete;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -60,7 +60,8 @@ class CurlClientTest : public ::testing::Test,
   void SetUp() override {
     std::string const error_type = GetParam();
     if (error_type == "credentials-failure") {
-      client_ = CurlClient::Create(std::make_shared<FailingCredentials>());
+      client_ = CurlClient::Create(Options{}.set<Oauth2CredentialsOption>(
+          std::make_shared<FailingCredentials>()));
       // We know exactly what error to expect, so setup the assertions to be
       // very strict.
       check_status_ = [](Status const& actual) {
@@ -70,9 +71,11 @@ class CurlClientTest : public ::testing::Test,
     } else if (error_type == "libcurl-failure") {
       google::cloud::internal::SetEnv("CLOUD_STORAGE_EMULATOR_ENDPOINT",
                                       "http://localhost:1");
-      client_ =
-          CurlClient::Create(ClientOptions(oauth2::CreateAnonymousCredentials())
-                                 .set_endpoint("http://localhost:1"));
+      client_ = CurlClient::Create(
+          Options{}
+              .set<Oauth2CredentialsOption>(
+                  oauth2::CreateAnonymousCredentials())
+              .set<RestEndpointOption>("http://localhost:1"));
       // We do not know what libcurl will return. Some kind of error, but varies
       // by version of libcurl. Just make sure it is an error and the CURL
       // details are included in the error message.

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -91,22 +91,21 @@ std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
                                    std::move(args));
 }
 
-std::shared_ptr<GrpcClient> GrpcClient::Create(Options options) {
-  return Create(std::move(options), /*channel_id=*/0);
+std::shared_ptr<GrpcClient> GrpcClient::Create(Options const& opts) {
+  return Create(opts, /*channel_id=*/0);
 }
 
-std::shared_ptr<GrpcClient> GrpcClient::Create(Options options,
+std::shared_ptr<GrpcClient> GrpcClient::Create(Options const& opts,
                                                int channel_id) {
   // Cannot use std::make_shared<> as the constructor is private.
-  return std::shared_ptr<GrpcClient>(
-      new GrpcClient(DefaultOptionsGrpc(std::move(options)), channel_id));
+  return std::shared_ptr<GrpcClient>(new GrpcClient(opts, channel_id));
 }
 
-GrpcClient::GrpcClient(Options const& options, int channel_id)
+GrpcClient::GrpcClient(Options const& opts, int channel_id)
     : backwards_compatibility_options_(
-          MakeBackwardsCompatibleClientOptions(options)),
+          MakeBackwardsCompatibleClientOptions(opts)),
       stub_(google::storage::v1::Storage::NewStub(
-          CreateGrpcChannel(options, channel_id))) {}
+          CreateGrpcChannel(opts, channel_id))) {}
 
 std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
     grpc::ClientContext& context, google::storage::v1::Object& result) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -36,8 +36,9 @@ std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(Options const&,
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
-  static std::shared_ptr<GrpcClient> Create(Options options);
-  static std::shared_ptr<GrpcClient> Create(Options options, int channel_id);
+  static std::shared_ptr<GrpcClient> Create(Options const& opts);
+  static std::shared_ptr<GrpcClient> Create(Options const& opts,
+                                            int channel_id);
   ~GrpcClient() override = default;
 
   //@{
@@ -318,7 +319,7 @@ class GrpcClient : public RawClient,
   static std::string MD5ToProto(std::string const&);
 
  protected:
-  explicit GrpcClient(Options const& options, int channel_id);
+  explicit GrpcClient(Options const& opts, int channel_id);
 
  private:
   ClientOptions backwards_compatibility_options_;

--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -43,17 +43,25 @@ class GrpcClientFailuresTest
  protected:
   GrpcClientFailuresTest()
       : grpc_config_("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", {}),
-        rest_endpoint_("CLOUD_STORAGE_EMULATOR_ENDPOINT", "http://localhost:1"),
-        grpc_endpoint_("CLOUD_STORAGE_GRPC_ENDPOINT", "localhost:1") {}
+        rest_endpoint_("CLOUD_STORAGE_EMULATOR_ENDPOINT", {}),
+        grpc_endpoint_("CLOUD_STORAGE_GRPC_ENDPOINT", {}) {}
 
   void SetUp() override {
     std::string const grpc_config = GetParam();
     google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                     grpc_config);
+    auto options =
+        Options{}
+            .set<internal::RestEndpointOption>("http://localhost:1")
+            .set<internal::IamEndpointOption>("http://localhost:1")
+            .set<EndpointOption>("localhost:1")
+            .set<internal::Oauth2CredentialsOption>(
+                oauth2::CreateAnonymousCredentials())
+            .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
     if (grpc_config == "metadata") {
-      client_ = GrpcClient::Create({});
+      client_ = GrpcClient::Create(std::move(options));
     } else {
-      client_ = HybridClient::Create(oauth2::CreateAnonymousCredentials(), {});
+      client_ = HybridClient::Create(std::move(options));
     }
   }
 

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -21,17 +21,14 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-std::shared_ptr<RawClient> HybridClient::Create(
-    std::shared_ptr<oauth2::Credentials> credentials, Options options,
-    int channel_id) {
-  return std::shared_ptr<RawClient>(
-      new HybridClient(std::move(credentials), std::move(options), channel_id));
+std::shared_ptr<RawClient> HybridClient::Create(Options const& options,
+                                                int channel_id) {
+  return std::shared_ptr<RawClient>(new HybridClient(options, channel_id));
 }
 
-HybridClient::HybridClient(std::shared_ptr<oauth2::Credentials> credentials,
-                           Options options, int channel_id)
+HybridClient::HybridClient(Options const& options, int channel_id)
     : grpc_(GrpcClient::Create(options, channel_id)),
-      curl_(CurlClient::Create(std::move(credentials), std::move(options))) {}
+      curl_(CurlClient::Create(options)) {}
 
 ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -29,13 +29,11 @@ namespace internal {
 
 class HybridClient : public RawClient {
  public:
-  static std::shared_ptr<RawClient> Create(
-      std::shared_ptr<oauth2::Credentials> credentials, Options options) {
-    return Create(std::move(credentials), std::move(options), /*channel_id=*/0);
+  static std::shared_ptr<RawClient> Create(Options const& options) {
+    return Create(std::move(options), /*channel_id=*/0);
   }
-  static std::shared_ptr<RawClient> Create(
-      std::shared_ptr<oauth2::Credentials> credentials, Options options,
-      int channel_id);
+  static std::shared_ptr<RawClient> Create(Options const& options,
+                                           int channel_id);
   ~HybridClient() override = default;
 
   ClientOptions const& client_options() const override;
@@ -151,8 +149,7 @@ class HybridClient : public RawClient {
       DeleteNotificationRequest const&) override;
 
  private:
-  explicit HybridClient(std::shared_ptr<oauth2::Credentials> credentials,
-                        Options options, int channel_id);
+  explicit HybridClient(Options const& options, int channel_id);
 
   std::shared_ptr<GrpcClient> grpc_;
   std::shared_ptr<CurlClient> curl_;

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -21,25 +21,6 @@
 #include <sstream>
 #include <thread>
 
-// Define the defaults using a pre-processor macro, this allows the application
-// developers to change the defaults for their application by compiling with
-// different values.
-#ifndef STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD
-#define STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD std::chrono::minutes(15)
-#endif  // STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD
-
-#ifndef STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY
-#define STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY std::chrono::seconds(1)
-#endif  // STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY
-
-#ifndef STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY
-#define STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY std::chrono::minutes(5)
-#endif  // STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY
-
-#ifndef STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING
-#define STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING 2.0
-#endif  //  STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING
-
 namespace google {
 namespace cloud {
 namespace storage {
@@ -112,18 +93,12 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
 }
 }  // namespace
 
-RetryClient::RetryClient(std::shared_ptr<RawClient> client, DefaultPolicies)
-    : client_(std::move(client)) {
-  retry_policy_prototype_ =
-      LimitedTimeRetryPolicy(STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD)
-          .clone();
-  backoff_policy_prototype_ =
-      ExponentialBackoffPolicy(STORAGE_CLIENT_DEFAULT_INITIAL_BACKOFF_DELAY,
-                               STORAGE_CLIENT_DEFAULT_MAXIMUM_BACKOFF_DELAY,
-                               STORAGE_CLIENT_DEFAULT_BACKOFF_SCALING)
-          .clone();
-  idempotency_policy_ = AlwaysRetryIdempotencyPolicy().clone();
-}
+RetryClient::RetryClient(std::shared_ptr<RawClient> client,
+                         Options const& options)
+    : client_(std::move(client)),
+      retry_policy_prototype_(options.get<RetryPolicyOption>()->clone()),
+      backoff_policy_prototype_(options.get<BackoffPolicyOption>()->clone()),
+      idempotency_policy_(options.get<IdempotencyPolicyOption>()->clone()) {}
 
 ClientOptions const& RetryClient::client_options() const {
   return client_->client_options();

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -1,0 +1,230 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OPTIONS_H
+
+#include "google/cloud/storage/idempotency_policy.h"
+#include "google/cloud/storage/retry_policy.h"
+#include "google/cloud/storage/version.h"
+#include "google/cloud/backoff_policy.h"
+#include "google/cloud/options.h"
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+/// This is only intended for testing against staging or development versions
+/// of the service. It is not for public use.
+struct TargetApiVersionOption {
+  using Type = std::string;
+};
+
+}  // namespace internal
+
+// TODO(#6161) - move the following options to the public API
+namespace internal {
+
+/// Configure the REST endpoint for the GCS client library.
+struct RestEndpointOption {
+  using Type = std::string;
+};
+
+/// Configure the IAM endpoint for the GCS client library.
+struct IamEndpointOption {
+  using Type = std::string;
+};
+
+/// Configure oauth2::Credentials for the GCS client library.
+struct Oauth2CredentialsOption {
+  using Type = std::shared_ptr<oauth2::Credentials>;
+};
+
+/// Set the Google Cloud Platform project id.
+struct ProjectIdOption {
+  using Type = std::string;
+};
+
+/***
+ * Set the maximum connection pool size.
+ *
+ * The C++ client library uses this value to limit the growth of the
+ * connection pool. Once an operation (a RPC or a download) completes the
+ * connection used for that operation is returned to the pool. If the pool is
+ * full the connection is immediately released. If the pool has room the
+ * connection is cached for the next RPC or download.
+ *
+ * @note The behavior of this pool may change in the future, depending on the
+ * low-level implementation details of the library.
+ *
+ * @note The library does not create connections proactively, setting a high
+ * value may result in very few connections if your application does not need
+ * them.
+ *
+ * @warning The library may create more connections than this option configures,
+ * for example if your application requests many simultaneous downloads.
+ */
+struct ConnectionPoolSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Control the formatted I/O download buffer.
+ *
+ * When using formatted I/O operations (typically `operator>>(std::istream&...)`
+ * this option controls the size of the in-memory buffer kept to satisfy any I/O
+ * requests.
+ *
+ * Applications seeking optional performance for downloads should avoid
+ * formatted I/O, and prefer using `std::istream::read()`. This option has no
+ * effect in that case.
+ */
+struct DownloadBufferSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Control the formatted I/O upload buffer.
+ *
+ * When using formatted I/O operations (typically `operator<<(std::istream&...)`
+ * this option controls the size of the in-memory buffer kept before a chunk is
+ * uploaded. Note that GCS only accepts chunks in multiples of 256KiB, so this
+ * option is always rounded up to the next such multiple.
+ *
+ * Applications seeking optional performance for downloads should avoid
+ * formatted I/O, and prefer using `std::istream::write()`. This option has no
+ * effect in that case.
+ */
+struct UploadBufferSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Defines the threshold to switch from simple to resumable uploads for files.
+ *
+ * When uploading small files the faster approach is to use a simple upload. For
+ * very large files this is not feasible, as the whole file may not fit in
+ * memory (we are ignoring memory mapped files in this discussion). The library
+ * automatically switches to resumable upload for files larger than this
+ * threshold.
+ */
+struct MaximumSimpleUploadSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Disables automatic OpenSSL locking.
+ *
+ * With older versions of OpenSSL any locking must be provided by locking
+ * callbacks in the application or intermediate libraries. The C++ client
+ * library automatically provides the locking callbacks. If your application
+ * already provides such callbacks, and you prefer to use them, set this option
+ * to `false`.
+ *
+ * @note This option is only useful for applications linking against
+ * OpenSSL 1.0.2.
+ */
+struct EnableCurlSslLockingOption {
+  using Type = bool;
+};
+
+/**
+ * Disables automatic OpenSSL sigpipe handler.
+ *
+ * With some versions of OpenSSL it might be necessary to setup a SIGPIPE
+ * handler. If your application already provides such a handler, set this option
+ * to `false` to disable the handler in the GCS C++ client library.
+ */
+struct EnableCurlSigpipeHandlerOption {
+  using Type = bool;
+};
+
+/**
+ * Control the maximum socket receive buffer.
+ *
+ * The default is to let the operating system pick a value. Applications that
+ * perform multiple downloads in parallel may need to use smaller receive
+ * buffers to avoid exhausting the OS resources dedicated to TCP buffers.
+ */
+struct MaximumCurlSocketRecvSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Control the maximum socket send buffer.
+ *
+ * The default is to let the operating system pick a value, this is almost
+ * always a good choice.
+ */
+struct MaximumCurlSocketSendSizeOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Sets the "stall" timeout.
+ *
+ * If the download "stalls", i.e., no bytes are received for a significant
+ * period, it may be better to restart the download as this may indicate a
+ * network glitch.
+ */
+struct DownloadStallTimeoutOption {
+  using Type = std::chrono::seconds;
+};
+
+/**
+ * Sets the default path for the SSL root of trust.
+ *
+ * Some applications (say those running in a container) may not have access to
+ * the SSL root of trust, or this may be installed in a non-standard location.
+ */
+struct SslRootPathOption {
+  using Type = std::string;
+};
+
+/// Set the retry policy for a GCS client.
+struct RetryPolicyOption {
+  using Type = std::shared_ptr<RetryPolicy>;
+};
+
+/// Set the backoff policy for a GCS client.
+struct BackoffPolicyOption {
+  using Type = std::shared_ptr<BackoffPolicy>;
+};
+
+/// Set the idempotency policy for a GCS client.
+struct IdempotencyPolicyOption {
+  using Type = std::shared_ptr<IdempotencyPolicy>;
+};
+
+/// The complete list of options accepted by `storage::Client`.
+using ClientOptionList = ::google::cloud::OptionList<
+    RestEndpointOption, IamEndpointOption, Oauth2CredentialsOption,
+    TargetApiVersionOption, ProjectIdOption, ProjectIdOption,
+    ConnectionPoolSizeOption, DownloadBufferSizeOption, UploadBufferSizeOption,
+    EnableCurlSslLockingOption, EnableCurlSigpipeHandlerOption,
+    MaximumCurlSocketRecvSizeOption, MaximumCurlSocketSendSizeOption,
+    DownloadStallTimeoutOption, SslRootPathOption, RetryPolicyOption,
+    BackoffPolicyOption, IdempotencyPolicyOption>;
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OPTIONS_H

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_OPTIONS_H
 
 #include "google/cloud/storage/idempotency_policy.h"
+#include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/backoff_policy.h"


### PR DESCRIPTION
Change the classes derived from `RawClient` to use a `g::c::Options`
object as its only configuration parameter. These classes assume the
object is fully initialized, and contains the default values if needed.
Add options to pass the retry, backoff, and idempotency policies as
option values too.

Part of the changes for #6161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6282)
<!-- Reviewable:end -->
