### PR TITLE
ci(gcb): write logs to our own bucket

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -269,6 +269,7 @@ subs=("_DISTRO=${DISTRO_FLAG}")
 subs+=("_BUILD_NAME=${BUILD_NAME}")
 subs+=("_CACHE_TYPE=manual-${account}")
 subs+=("_PR_NUMBER=") # Must be empty or a number, and this is not a PR
+subs+=("_LOGS_BUCKET_SUFFIX=cloudbuild")
 subs+=("BRANCH_NAME=${BRANCH_NAME}")
 subs+=("COMMIT_SHA=${COMMIT_SHA}")
 printf "Substitutions:\n"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -39,6 +39,7 @@ substitutions:
   _CACHE_TYPE: '${_PR_NUMBER:-main}'
   _IMAGE: 'cloudbuild/${_DISTRO}'
   _TRIGGER_TYPE: 'manual'
+  _LOGS_BUCKET_SUFFIX: 'publiclogs'
 
 tags: [ '${_TRIGGER_TYPE}', '${_BUILD_NAME}', '${_DISTRO}' ]
 timeout: 3600s
@@ -47,6 +48,8 @@ availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest
     env: 'CODECOV_TOKEN'
+
+logsBucket: 'gs://${PROJECT_ID}_${_LOGS_BUCKET_SUFFIX}/logs/google-cloud-cpp/${_CACHE_TYPE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}'
 
 steps:
   # Builds the docker image that will be used by the main build step.


### PR DESCRIPTION
By default GCB writes logs to a bucket they GCB controls and that we
have no access to. This PR changes our builds to write to our own
bucket, which will give us the ability to control the lifetime and
permissions for the build logs.

NOTE: This PR doesn't change anything wrt to log visibility or anything. This PR simply makes our build logs live in our bucket that we control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6284)
<!-- Reviewable:end -->
