### PR TITLE
ci(gcb): rename _CACHE_TYPE -> _TRIGGER_SOURCE

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -267,7 +267,7 @@ io::log_h1 "Starting cloud build: ${BUILD_NAME}"
 account="$(gcloud config list account --format "value(core.account)")"
 subs=("_DISTRO=${DISTRO_FLAG}")
 subs+=("_BUILD_NAME=${BUILD_NAME}")
-subs+=("_CACHE_TYPE=manual-${account}")
+subs+=("_TRIGGER_SOURCE=manual-${account}")
 subs+=("_PR_NUMBER=") # Must be empty or a number, and this is not a PR
 subs+=("_LOGS_BUCKET_SUFFIX=cloudbuild")
 subs+=("BRANCH_NAME=${BRANCH_NAME}")

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -36,8 +36,8 @@ substitutions:
   _DISTRO: 'unknown'
   _BUILD_NAME: 'unknown'
   _CACHE_BUCKET: '${PROJECT_ID}_cloudbuild'
-  _CACHE_TYPE: '${_PR_NUMBER:-main}'
   _IMAGE: 'cloudbuild/${_DISTRO}'
+  _TRIGGER_SOURCE: '${_PR_NUMBER:-main}'
   _TRIGGER_TYPE: 'manual'
   _LOGS_BUCKET_SUFFIX: 'publiclogs'
 
@@ -46,10 +46,10 @@ timeout: 3600s
 
 availableSecrets:
   secretManager:
-  - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest
+  - versionName: 'projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest'
     env: 'CODECOV_TOKEN'
 
-logsBucket: 'gs://${PROJECT_ID}_${_LOGS_BUCKET_SUFFIX}/logs/google-cloud-cpp/${_CACHE_TYPE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}'
+logsBucket: 'gs://${PROJECT_ID}_${_LOGS_BUCKET_SUFFIX}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}'
 
 steps:
   # Builds the docker image that will be used by the main build step.
@@ -69,7 +69,7 @@ steps:
   args: [
     'restore',
     '--bucket_url=gs://${_CACHE_BUCKET}/build-cache/google-cloud-cpp',
-    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
+    '--key=${_TRIGGER_SOURCE}/${_DISTRO}-${_BUILD_NAME}/h',
     '--fallback_key=main/${_DISTRO}-${_BUILD_NAME}/h'
   ]
 
@@ -90,7 +90,7 @@ steps:
   args: [
     'save',
     '--bucket_url=gs://${_CACHE_BUCKET}/build-cache/google-cloud-cpp',
-    '--key=${_CACHE_TYPE}/${_DISTRO}-${_BUILD_NAME}/h',
+    '--key=${_TRIGGER_SOURCE}/${_DISTRO}-${_BUILD_NAME}/h',
     '--path=.ccache',
     '--path=.cache/ccache',
     '--path=.cache/ctcache',


### PR DESCRIPTION
`_CACHE_TYPE` somewhat made sense when it was only used for the caching
URLs, but now that it's also used for the logging bucket directory it
needs a cache-agnostic name. This name seems a bit better, but I'm open
to other names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6285)
<!-- Reviewable:end -->
