### PR TITLE
refactor(generator): generate libraries using generator config file

### DIFF
--- a/generator/generate-libraries.sh
+++ b/generator/generate-libraries.sh
@@ -26,41 +26,26 @@ fi
 readonly BAZEL_BIN=${BAZEL_BIN:-/usr/local/bin/bazel}
 readonly BAZEL_OUTPUT_BASE=$("${BAZEL_BIN}" info output_base)
 readonly BAZEL_BIN_DIR=$("${BAZEL_BIN}" info bazel-bin)
-readonly BAZEL_DEPS_GOOGLEAPIS_HASH=$("${BAZEL_BIN}" query 'kind(http_archive, //external:com_google_googleapis)' --output=build | sed -n 's/^.*strip_prefix = "googleapis-\(\S*\)"\,.*$/\1/p')
+readonly BAZEL_DEPS_GOOGLEAPIS_HASH=$("${BAZEL_BIN}" query \
+  'kind(http_archive, //external:com_google_googleapis)' --output=build |
+  sed -n 's/^.*strip_prefix = "googleapis-\(\S*\)"\,.*$/\1/p')
 
 io::log_yellow "Build protoc binary"
 ${BAZEL_BIN} build @com_google_protobuf//:protoc
 
-io::log_yellow "Build microgenerator plugin"
+io::log_yellow "Build microgenerator standalone executable"
 ${BAZEL_BIN} build //generator:protoc-gen-cpp_codegen
-
-# "year product_path proto_path_in_googleapis_repo"
-product_path_proto_path_to_generate=(
-  "2021 google/cloud/bigquery google/cloud/bigquery/storage/v1/storage.proto"
-  "2020 google/cloud/iam google/iam/credentials/v1/iamcredentials.proto"
-  "2021 google/cloud/logging google/logging/v2/logging.proto"
-)
 
 io::log_yellow "Run protoc and format generated .h and .cc files:"
 cd "${PROJECT_ROOT}"
-for proto in "${product_path_proto_path_to_generate[@]}"; do
-  read -r -a tuple <<<"${proto}"
-  copyright_year=${tuple[0]}
-  product_path=${tuple[1]}
-  proto_file=${tuple[2]}
-  echo "Generate code from ${proto_file} to ${product_path}"
-  GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes "${BAZEL_BIN_DIR}"/external/com_google_protobuf/protoc \
-    --plugin=protoc-gen-cpp_codegen="${BAZEL_BIN_DIR}"/generator/protoc-gen-cpp_codegen \
-    --cpp_codegen_out=. \
-    --cpp_codegen_opt=product_path="${product_path}" \
-    --proto_path="${BAZEL_OUTPUT_BASE}"/external/com_google_protobuf/src \
-    --proto_path="${BAZEL_OUTPUT_BASE}"/external/com_google_googleapis \
-    --cpp_codegen_opt=googleapis_commit_hash="${BAZEL_DEPS_GOOGLEAPIS_HASH}" \
-    --cpp_codegen_opt=copyright_year="${copyright_year}" \
-    "${BAZEL_OUTPUT_BASE}"/external/com_google_googleapis/"${proto_file}"
+GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes "${BAZEL_BIN_DIR}"/generator/google-cloud-cpp-codegen \
+  --googleapis_commit_hash="${BAZEL_DEPS_GOOGLEAPIS_HASH}" \
+  --protobuf_proto_path="${BAZEL_OUTPUT_BASE}"/external/com_google_protobuf/src \
+  --googleapis_proto_path="${BAZEL_OUTPUT_BASE}"/external/com_google_googleapis \
+  --output_path=. \
+  --config_file=generator/generator_config.textproto
 
-  find "${product_path}" \( -name '*.cc' -o -name '*.h' \) -exec clang-format -i {} \;
-done
+find google/cloud \( -name '*.cc' -o -name '*.h' \) -exec clang-format -i {} \;
 
 io::log_yellow "Update generator-googlapis-commit-hash.sh file."
 cat >"${PROJECT_ROOT}"/ci/etc/generator-googleapis-commit-hash.sh <<EOF

--- a/generator/generate-libraries.sh
+++ b/generator/generate-libraries.sh
@@ -34,7 +34,7 @@ io::log_yellow "Build protoc binary"
 ${BAZEL_BIN} build @com_google_protobuf//:protoc
 
 io::log_yellow "Build microgenerator standalone executable"
-${BAZEL_BIN} build //generator:protoc-gen-cpp_codegen
+${BAZEL_BIN} build //generator:google-cloud-cpp-codegen
 
 io::log_yellow "Run protoc and format generated .h and .cc files:"
 cd "${PROJECT_ROOT}"
@@ -45,7 +45,17 @@ GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes "${BAZEL_BIN_DIR}"/generator/google-cloud-cpp-c
   --output_path=. \
   --config_file=generator/generator_config.textproto
 
-find google/cloud \( -name '*.cc' -o -name '*.h' \) -exec clang-format -i {} \;
+io::log_yellow "clang-format generated code."
+find google/cloud -path google/cloud/bigtable -prune -o \
+  -path google/cloud/examples -prune -o \
+  -path google/cloud/firestore -prune -o \
+  -path google/cloud/grpc_utils -prune -o \
+  -path google/cloud/internal -prune -o \
+  -path google/cloud/pubsub -prune -o \
+  -path google/cloud/spanner -prune -o \
+  -path google/cloud/storage -prune -o \
+  -path google/cloud/testing_util -prune -o \
+  \( -name '*.cc' -o -name '*.h' \) -exec clang-format -i {} \;
 
 io::log_yellow "Update generator-googlapis-commit-hash.sh file."
 cat >"${PROJECT_ROOT}"/ci/etc/generator-googleapis-commit-hash.sh <<EOF


### PR DESCRIPTION
Switch generate-libraries build to use new standalone binary for the microgenerator and the new textproto config file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6290)
<!-- Reviewable:end -->
