### PR TITLE
ci(gcb): add the log-linker script

### DIFF
--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -49,4 +49,4 @@ EOF
 
 io::log_h2 "Commenting on ${PR_NUMBER}"
 echo "${body}"
-gh --repo googleapis/google-cloud-cpp comment "${PR_NUMBER}" --body "${body}"
+gh --repo googleapis/google-cloud-cpp pr comment "${PR_NUMBER}" --body "${body}"

--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -32,19 +32,20 @@ fi
 console_link="https://console.cloud.google.com/cloud-build/builds?project=cloud-cpp-testing-resources"
 storage_link="http://storage.googleapis.com/cloud-cpp-testing-resources_publiclogs/logs/google-cloud-cpp/${PR_NUMBER}/${COMMIT_SHA}"
 
-body="$(cat <<EOF
+body="$(
+  cat <<EOF
 **Google Cloud Build log links**
 
-* [Cloud Build Console](${console_link}) 
-* [Cloud Storage Logs Bucket](${storage_link}) 
+* [Cloud Build Console](${console_link})
+* [Cloud Storage Logs Bucket](${storage_link})
 
-:information_source: Log links 
+:information_source: Log links
 
-This is a robocomment from google-cloud-cpp-bot. 
+This is a robocomment from google-cloud-cpp-bot.
 EOF
 )"
 
 io::log_h2 "Commenting on ${PR_NUMBER}"
 echo "${body}"
 
-gh --repo googleapis/google-cloud-cpp "${PR_NUMBER}" --body "${body}"
+gh --repo googleapis/google-cloud-cpp comment "${PR_NUMBER}" --body "${body}"

--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -29,9 +29,11 @@ if [[ -z "${PR_NUMBER:-}" ]]; then
   exit
 fi
 
+io::log_h2 "Authenticating"
+gh auth login --with-token <<<"${LOG_LINKER_PAT}"
+
 console_link="https://console.cloud.google.com/cloud-build/builds?project=cloud-cpp-testing-resources"
 storage_link="http://storage.googleapis.com/cloud-cpp-testing-resources_publiclogs/logs/google-cloud-cpp/${PR_NUMBER}/${COMMIT_SHA}"
-
 body="$(
   cat <<EOF
 **Google Cloud Build log links**
@@ -47,5 +49,4 @@ EOF
 
 io::log_h2 "Commenting on ${PR_NUMBER}"
 echo "${body}"
-
 gh --repo googleapis/google-cloud-cpp comment "${PR_NUMBER}" --body "${body}"

--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -38,10 +38,10 @@ body="$(
   cat <<EOF
 **Google Cloud Build log links**
 
-* [Cloud Build Console](${console_link})
-* [Cloud Storage Logs Bucket](${storage_link})
+* [Cloud Build Console](${console_link}) (for team members with access)
+* [Cloud Storage Logs Bucket](${storage_link}) (public access *coming soon*)
 
-:information_source: Log links
+:information_source: Kokoro logs are linked from "Details" below.
 
 This is a robocomment from google-cloud-cpp-bot.
 EOF

--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module /ci/lib/io.sh
+
+if [[ -z "${LOG_LINKER_PAT:-}" ]]; then
+  io::log_h2 "No Personal Access Token. Skipping Log Linker."
+  exit
+fi
+
+if [[ -z "${PR_NUMBER:-}" ]]; then
+  io::log_h2 "Missing PR_NUMBER. Skipping Log Linker."
+  exit
+fi
+
+console_link="https://console.cloud.google.com/cloud-build/builds?project=cloud-cpp-testing-resources"
+storage_link="http://storage.googleapis.com/cloud-cpp-testing-resources_publiclogs/logs/google-cloud-cpp/${PR_NUMBER}/${COMMIT_SHA}"
+
+body="$(cat <<EOF
+**Google Cloud Build log links**
+
+* [Cloud Build Console](${console_link}) 
+* [Cloud Storage Logs Bucket](${storage_link}) 
+
+:information_source: Log links 
+
+This is a robocomment from google-cloud-cpp-bot. 
+EOF
+)"
+
+io::log_h2 "Commenting on ${PR_NUMBER}"
+echo "${body}"
+
+gh --repo googleapis/google-cloud-cpp "${PR_NUMBER}" --body "${body}"

--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -36,17 +36,18 @@ console_link="https://console.cloud.google.com/cloud-build/builds?project=cloud-
 storage_link="http://storage.googleapis.com/cloud-cpp-testing-resources_publiclogs/logs/google-cloud-cpp/${PR_NUMBER}/${COMMIT_SHA}"
 body="$(
   cat <<EOF
-**Google Cloud Build log links**
+**Google Cloud Build Logs**
+For commit: \`${COMMIT_SHA}\`
 
 * [Cloud Build Console](${console_link}) (for team members with access)
 * [Cloud Storage Logs Bucket](${storage_link}) (public access *coming soon*)
 
-:information_source: Kokoro logs are linked from "Details" below.
-
-This is a robocomment from google-cloud-cpp-bot.
+:information_source: NOTE: Kokoro logs are linked from "Details" below.
 EOF
 )"
 
 io::log_h2 "Commenting on ${PR_NUMBER}"
 echo "${body}"
+# TODO(#6295): See if there's a way to edit an existing log-linker comment
+# rather than creating a new one.
 gh --repo googleapis/google-cloud-cpp pr comment "${PR_NUMBER}" --body "${body}"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -53,6 +53,8 @@ availableSecrets:
   secretManager:
   - versionName: 'projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest'
     env: 'CODECOV_TOKEN'
+  - versionName: 'projects/${PROJECT_ID}/secrets/LOG_LINKER_PAT/versions/latest'
+    env: 'LOG_LINKER_PAT'
 
 logsBucket: 'gs://${PROJECT_ID}_${_LOGS_BUCKET_SUFFIX}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}'
 
@@ -82,7 +84,7 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
   entrypoint: 'ci/cloudbuild/build.sh'
   args: [ '--local', '${_BUILD_NAME}' ]
-  secretEnv: ['CODECOV_TOKEN']
+  secretEnv: ['CODECOV_TOKEN', 'LOG_LINKER_PAT']
   env: [
     'BAZEL_REMOTE_CACHE=https://storage.googleapis.com/${_CACHE_BUCKET}/bazel-cache/${_DISTRO}-${_BUILD_NAME}',
     'VCPKG_BINARY_SOURCES=x-gcs,gs://${_CACHE_BUCKET}/vcpkg-cache/${_DISTRO}-${_BUILD_NAME},readwrite'

--- a/ci/cloudbuild/dockerfiles/debian-github.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/debian-github.Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:bullseye-slim
+ARG NCPU=4
+
+RUN apt-get update && apt-get install -y curl git
+WORKDIR /var/tmp
+RUN curl -sSL -o gh.deb https://github.com/cli/cli/releases/download/v1.9.1/gh_1.9.1_linux_amd64.deb && \
+    dpkg --install gh.deb

--- a/ci/cloudbuild/triggers/log-linker-pr.yaml
+++ b/ci/cloudbuild/triggers/log-linker-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: log-linker-pr
+substitutions:
+  _BUILD_NAME: log-linker
+  _DISTRO: debian-github
+  _TRIGGER_TYPE: pr
+tags:
+- pr


### PR DESCRIPTION
Adds a build script that posts a comment to PRs with a link to the GCB logs. One of the link will (soon) contain publicly accessible logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6292)
<!-- Reviewable:end -->
