### PR TITLE
test(storage): fix emulator offset handling

### DIFF
--- a/google/cloud/storage/emulator/database.py
+++ b/google/cloud/storage/emulator/database.py
@@ -156,7 +156,7 @@ class Database:
                 continue
             if name < start_offset:
                 continue
-            if end_offset is not None and name >= end_offset:
+            if end_offset and name >= end_offset:
                 continue
             delimiter_index = name.find(delimiter, len(prefix))
             if delimiter != "" and delimiter_index > 0:


### PR DESCRIPTION
Object list calls from the Go library weren't working against
the emulator because the endOffset is sent as an empty string
by the library. This matches the actual service behavior for
this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6296)
<!-- Reviewable:end -->
