### PR TITLE
cleanup(storage): simplify RawGrpc initialization

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -20,7 +20,10 @@
 #include "google/cloud/storage/internal/grpc_client.h"
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/getenv.h"
+#include "absl/algorithm/container.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/str_split.h"
 #include <google/storage/v1/storage.grpc.pb.h>
 #include <curl/curl.h>
 #include <vector>
@@ -246,16 +249,32 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
   ApiName api_;
 };
 
+auto constexpr kDirectPathConfig = R"json({
+    "loadBalancingConfig": [{
+      "grpclb": {
+        "childPolicy": [{
+          "pick_first": {}
+        }]
+      }
+    }]
+  })json";
+
+bool DirectPathEnabled() {
+  auto const direct_path_settings =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH")
+          .value_or("");
+  return absl::c_any_of(absl::StrSplit(direct_path_settings, ','),
+                        [](absl::string_view v) { return v == "storage"; });
+}
+
 std::shared_ptr<grpc::ChannelInterface> CreateGcsChannel(int thread_id) {
-#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
-  return gcs::internal::CreateGrpcChannel(gcs::internal::DefaultOptionsGrpc(),
-                                          thread_id);
-#else
   grpc::ChannelArguments args;
   args.SetInt("grpc.channel_id", thread_id);
+  if (DirectPathEnabled()) {
+    args.SetServiceConfigJSON(kDirectPathConfig);
+  }
   return grpc::CreateCustomChannel("storage.googleapis.com",
                                    grpc::GoogleDefaultCredentials(), args);
-#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 }
 
 class DownloadObjectRawGrpc : public ThroughputExperiment {


### PR DESCRIPTION
Decouple the initialization of the `grpc::Channel` objects used for
`*RawGrpc` experiments. The previous approach used implementation
details for the GCS+gRPC plugin, which are about to change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6297)
<!-- Reviewable:end -->
