### PR TITLE
ci(gcb): write build logs to `cloud-cpp-community-publiclogs` bucket

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -264,12 +264,13 @@ fi
 
 # Uses Google Cloud build to run the specified build.
 io::log_h1 "Starting cloud build: ${BUILD_NAME}"
-account="$(gcloud config list account --format "value(core.account)")"
+project="${PROJECT_FLAG:-$(gcloud config get-value project)}"
+account="$(gcloud config get-value account)"
 subs=("_DISTRO=${DISTRO_FLAG}")
 subs+=("_BUILD_NAME=${BUILD_NAME}")
 subs+=("_TRIGGER_SOURCE=manual-${account}")
 subs+=("_PR_NUMBER=") # Must be empty or a number, and this is not a PR
-subs+=("_LOGS_BUCKET_SUFFIX=cloudbuild")
+subs+=("_LOGS_BUCKET=${project}_cloudbuild")
 subs+=("BRANCH_NAME=${BRANCH_NAME}")
 subs+=("COMMIT_SHA=${COMMIT_SHA}")
 printf "Substitutions:\n"
@@ -277,8 +278,6 @@ printf "  %s\n" "${subs[@]}"
 args=(
   "--config=ci/cloudbuild/cloudbuild.yaml"
   "--substitutions=$(printf "%s," "${subs[@]}")"
+  "--project=${project}"
 )
-if [[ -n "${PROJECT_FLAG}" ]]; then
-  args+=("--project=${PROJECT_FLAG}")
-fi
 gcloud builds submit "${args[@]}" .

--- a/ci/cloudbuild/builds/log-linker.sh
+++ b/ci/cloudbuild/builds/log-linker.sh
@@ -33,7 +33,7 @@ io::log_h2 "Authenticating"
 gh auth login --with-token <<<"${LOG_LINKER_PAT}"
 
 console_link="https://console.cloud.google.com/cloud-build/builds?project=cloud-cpp-testing-resources"
-storage_link="http://storage.googleapis.com/cloud-cpp-testing-resources_publiclogs/logs/google-cloud-cpp/${PR_NUMBER}/${COMMIT_SHA}"
+storage_link="http://storage.googleapis.com/cloud-cpp-community-publiclogs/logs/google-cloud-cpp/${PR_NUMBER}/${COMMIT_SHA}"
 body="$(
   cat <<EOF
 **Google Cloud Build Logs**

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -39,7 +39,7 @@ substitutions:
   _IMAGE: 'cloudbuild/${_DISTRO}'
   _TRIGGER_SOURCE: '${_PR_NUMBER:-main}'
   _TRIGGER_TYPE: 'manual'
-  _LOGS_BUCKET_SUFFIX: 'publiclogs'
+  _LOGS_BUCKET: 'cloud-cpp-community-publiclogs'
 
 timeout: 3600s
 tags: [
@@ -56,7 +56,7 @@ availableSecrets:
   - versionName: 'projects/${PROJECT_ID}/secrets/LOG_LINKER_PAT/versions/latest'
     env: 'LOG_LINKER_PAT'
 
-logsBucket: 'gs://${PROJECT_ID}_${_LOGS_BUCKET_SUFFIX}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}'
+logsBucket: 'gs://${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COMMIT_SHA}/${_DISTRO}-${_BUILD_NAME}'
 
 steps:
   # Builds the docker image that will be used by the main build step.


### PR DESCRIPTION
PR and CI builds will write build logs to `gs://cloud-cpp-community-publiclogs`, which we will (soon) be able to make publicly viewable.

Manually triggered builds will continue to be written to `${PROJECT_ID}_cloudbuild`, which means that manually triggered build logs will NOT be public, as they are today.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6298)
<!-- Reviewable:end -->
