### PR TITLE
feat(common): support unified credentials in gRPC

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -397,6 +397,10 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/completion_queue_impl.h
         internal/default_completion_queue_impl.cc
         internal/default_completion_queue_impl.h
+        internal/grpc_access_token_authentication.cc
+        internal/grpc_access_token_authentication.h
+        internal/grpc_channel_credentials_authentication.cc
+        internal/grpc_channel_credentials_authentication.h
         internal/log_wrapper.cc
         internal/log_wrapper.h
         internal/polling_loop.h
@@ -409,7 +413,9 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/streaming_read_rpc.h
         internal/streaming_read_rpc_logging.h
         internal/time_utils.cc
-        internal/time_utils.h)
+        internal/time_utils.h
+        internal/unified_grpc_credentials.cc
+        internal/unified_grpc_credentials.h)
     target_link_libraries(
         google_cloud_cpp_grpc_utils
         PUBLIC absl::function_ref
@@ -482,13 +488,16 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/async_retry_loop_test.cc
             internal/async_retry_unary_rpc_test.cc
             internal/background_threads_impl_test.cc
+            internal/grpc_access_token_authentication_test.cc
+            internal/grpc_channel_credentials_authentication_test.cc
             internal/log_wrapper_test.cc
             internal/polling_loop_test.cc
             internal/resumable_streaming_read_rpc_test.cc
             internal/retry_loop_test.cc
             internal/streaming_read_rpc_logging_test.cc
             internal/streaming_read_rpc_test.cc
-            internal/time_utils_test.cc)
+            internal/time_utils_test.cc
+            internal/unified_grpc_credentials_test.cc)
 
         # Export the list of unit tests so the Bazel BUILD file can pick it up.
         export_list_to_bazel("google_cloud_cpp_grpc_utils_unit_tests.bzl"

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -36,6 +36,8 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/background_threads_impl.h",
     "internal/completion_queue_impl.h",
     "internal/default_completion_queue_impl.h",
+    "internal/grpc_access_token_authentication.h",
+    "internal/grpc_channel_credentials_authentication.h",
     "internal/log_wrapper.h",
     "internal/polling_loop.h",
     "internal/resumable_streaming_read_rpc.h",
@@ -45,6 +47,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/streaming_read_rpc.h",
     "internal/streaming_read_rpc_logging.h",
     "internal/time_utils.h",
+    "internal/unified_grpc_credentials.h",
 ]
 
 google_cloud_cpp_grpc_utils_srcs = [
@@ -55,8 +58,11 @@ google_cloud_cpp_grpc_utils_srcs = [
     "internal/async_connection_ready.cc",
     "internal/background_threads_impl.cc",
     "internal/default_completion_queue_impl.cc",
+    "internal/grpc_access_token_authentication.cc",
+    "internal/grpc_channel_credentials_authentication.cc",
     "internal/log_wrapper.cc",
     "internal/retry_loop_helpers.cc",
     "internal/streaming_read_rpc.cc",
     "internal/time_utils.cc",
+    "internal/unified_grpc_credentials.cc",
 ]

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -26,6 +26,8 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/async_retry_loop_test.cc",
     "internal/async_retry_unary_rpc_test.cc",
     "internal/background_threads_impl_test.cc",
+    "internal/grpc_access_token_authentication_test.cc",
+    "internal/grpc_channel_credentials_authentication_test.cc",
     "internal/log_wrapper_test.cc",
     "internal/polling_loop_test.cc",
     "internal/resumable_streaming_read_rpc_test.cc",
@@ -33,4 +35,5 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/streaming_read_rpc_logging_test.cc",
     "internal/streaming_read_rpc_test.cc",
     "internal/time_utils_test.cc",
+    "internal/unified_grpc_credentials_test.cc",
 ]

--- a/google/cloud/internal/grpc_access_token_authentication.cc
+++ b/google/cloud/internal/grpc_access_token_authentication.cc
@@ -23,7 +23,7 @@ auto constexpr kExpirationSlack = std::chrono::minutes(5);
 
 std::shared_ptr<grpc::Channel> GrpcAccessTokenAuthentication::CreateChannel(
     std::string const& endpoint, grpc::ChannelArguments const& arguments) {
-  // TODO(#....) - support setting SSL options
+  // TODO(#6311) - support setting SSL options
   auto credentials = grpc::SslCredentials(grpc::SslCredentialsOptions{});
   return grpc::CreateCustomChannel(endpoint, credentials, arguments);
 }

--- a/google/cloud/internal/grpc_access_token_authentication.cc
+++ b/google/cloud/internal/grpc_access_token_authentication.cc
@@ -1,0 +1,55 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/grpc_access_token_authentication.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+auto constexpr kExpirationSlack = std::chrono::minutes(5);
+
+std::shared_ptr<grpc::Channel> GrpcAccessTokenAuthentication::CreateChannel(
+    std::string const& endpoint, grpc::ChannelArguments const& arguments) {
+  // TODO(#....) - support setting SSL options
+  auto credentials = grpc::SslCredentials(grpc::SslCredentialsOptions{});
+  return grpc::CreateCustomChannel(endpoint, credentials, arguments);
+}
+
+Status GrpcAccessTokenAuthentication::Setup(grpc::ClientContext& context) {
+  std::unique_lock<std::mutex> lk(mu_);
+  cv_.wait(lk, [this] { return !refreshing_; });
+  auto const deadline = std::chrono::system_clock::now() + kExpirationSlack;
+  if (deadline < expiration_) {
+    context.set_credentials(credentials_);
+    return {};
+  }
+  refreshing_ = true;
+  lk.unlock();
+  auto refresh = source_();
+  lk.lock();
+  refreshing_ = false;
+  token_ = std::move(refresh.token);
+  expiration_ = refresh.expiration;
+  credentials_ = grpc::AccessTokenCredentials(token_);
+  context.set_credentials(credentials_);
+  cv_.notify_all();
+  return Status{};
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/grpc_access_token_authentication.cc
+++ b/google/cloud/internal/grpc_access_token_authentication.cc
@@ -28,7 +28,8 @@ std::shared_ptr<grpc::Channel> GrpcAccessTokenAuthentication::CreateChannel(
   return grpc::CreateCustomChannel(endpoint, credentials, arguments);
 }
 
-Status GrpcAccessTokenAuthentication::Setup(grpc::ClientContext& context) {
+Status GrpcAccessTokenAuthentication::ConfigureContext(
+    grpc::ClientContext& context) {
   std::unique_lock<std::mutex> lk(mu_);
   cv_.wait(lk, [this] { return !refreshing_; });
   auto const deadline = std::chrono::system_clock::now() + kExpirationSlack;

--- a/google/cloud/internal/grpc_access_token_authentication.h
+++ b/google/cloud/internal/grpc_access_token_authentication.h
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_ACCESS_TOKEN_AUTHENTICATION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_ACCESS_TOKEN_AUTHENTICATION_H
+
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+class GrpcAccessTokenAuthentication : public GrpcAuthenticationStrategy {
+ public:
+  explicit GrpcAccessTokenAuthentication(AccessTokenSource source)
+      : source_(std::move(source)) {}
+  ~GrpcAccessTokenAuthentication() override = default;
+
+  std::shared_ptr<grpc::Channel> CreateChannel(
+      std::string const& endpoint,
+      grpc::ChannelArguments const& arguments) override;
+  Status Setup(grpc::ClientContext&) override;
+
+ private:
+  AccessTokenSource source_;
+  std::mutex mu_;
+  std::string token_;
+  std::shared_ptr<grpc::CallCredentials> credentials_;
+  std::chrono::system_clock::time_point expiration_;
+  bool refreshing_ = false;
+  std::condition_variable cv_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_ACCESS_TOKEN_AUTHENTICATION_H

--- a/google/cloud/internal/grpc_access_token_authentication.h
+++ b/google/cloud/internal/grpc_access_token_authentication.h
@@ -33,7 +33,7 @@ class GrpcAccessTokenAuthentication : public GrpcAuthenticationStrategy {
   std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint,
       grpc::ChannelArguments const& arguments) override;
-  Status Setup(grpc::ClientContext&) override;
+  Status ConfigureContext(grpc::ClientContext&) override;
 
  private:
   AccessTokenSource source_;

--- a/google/cloud/internal/grpc_access_token_authentication_test.cc
+++ b/google/cloud/internal/grpc_access_token_authentication_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/grpc_access_token_authentication.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::testing::Return;
+
+TEST(GrpcAccessTokenAuthenticationTest, Simple) {
+  ::testing::MockFunction<AccessToken()> mock_source;
+  auto const expiration =
+      std::chrono::system_clock::now() - std::chrono::minutes(10);
+  EXPECT_CALL(mock_source, Call)
+      .WillOnce(Return(AccessToken{"token1", expiration}))
+      .WillOnce(Return(AccessToken{"token2", expiration}))
+      .WillOnce(Return(AccessToken{"token3", expiration}));
+
+  GrpcAccessTokenAuthentication auth(mock_source.AsStdFunction());
+
+  auto channel = auth.CreateChannel("localhost:1", grpc::ChannelArguments{});
+  EXPECT_NE(nullptr, channel.get());
+
+  for (auto attempt : {1, 2, 3}) {
+    SCOPED_TRACE("Running attempt " + std::to_string(attempt));
+    grpc::ClientContext context;
+    EXPECT_EQ(nullptr, context.credentials());
+    auth.Setup(context);
+    EXPECT_NE(nullptr, context.credentials());
+  }
+}
+
+TEST(GrpcAccessTokenAuthenticationTest, NotExpired) {
+  ::testing::MockFunction<AccessToken()> mock_source;
+  auto const expiration =
+      std::chrono::system_clock::now() + std::chrono::minutes(10);
+  EXPECT_CALL(mock_source, Call)
+      .WillOnce(Return(AccessToken{"token1", expiration}));
+
+  GrpcAccessTokenAuthentication auth(mock_source.AsStdFunction());
+
+  auto channel = auth.CreateChannel("localhost:1", grpc::ChannelArguments{});
+  EXPECT_NE(nullptr, channel.get());
+
+  for (auto attempt : {1, 2, 3}) {
+    SCOPED_TRACE("Running attempt " + std::to_string(attempt));
+    grpc::ClientContext context;
+    EXPECT_EQ(nullptr, context.credentials());
+    auth.Setup(context);
+    EXPECT_NE(nullptr, context.credentials());
+  }
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/grpc_access_token_authentication_test.cc
+++ b/google/cloud/internal/grpc_access_token_authentication_test.cc
@@ -41,7 +41,7 @@ TEST(GrpcAccessTokenAuthenticationTest, Simple) {
     SCOPED_TRACE("Running attempt " + std::to_string(attempt));
     grpc::ClientContext context;
     EXPECT_EQ(nullptr, context.credentials());
-    auth.Setup(context);
+    auth.ConfigureContext(context);
     EXPECT_NE(nullptr, context.credentials());
   }
 }
@@ -62,7 +62,7 @@ TEST(GrpcAccessTokenAuthenticationTest, NotExpired) {
     SCOPED_TRACE("Running attempt " + std::to_string(attempt));
     grpc::ClientContext context;
     EXPECT_EQ(nullptr, context.credentials());
-    auth.Setup(context);
+    auth.ConfigureContext(context);
     EXPECT_NE(nullptr, context.credentials());
   }
 }

--- a/google/cloud/internal/grpc_channel_credentials_authentication.cc
+++ b/google/cloud/internal/grpc_channel_credentials_authentication.cc
@@ -1,0 +1,35 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/grpc_channel_credentials_authentication.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+std::shared_ptr<grpc::Channel>
+GrpcChannelCredentialsAuthentication::CreateChannel(
+    std::string const& endpoint, grpc::ChannelArguments const& arguments) {
+  return grpc::CreateCustomChannel(endpoint, credentials_, arguments);
+}
+
+Status GrpcChannelCredentialsAuthentication::Setup(grpc::ClientContext&) {
+  return Status{};
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/grpc_channel_credentials_authentication.cc
+++ b/google/cloud/internal/grpc_channel_credentials_authentication.cc
@@ -25,7 +25,8 @@ GrpcChannelCredentialsAuthentication::CreateChannel(
   return grpc::CreateCustomChannel(endpoint, credentials_, arguments);
 }
 
-Status GrpcChannelCredentialsAuthentication::Setup(grpc::ClientContext&) {
+Status GrpcChannelCredentialsAuthentication::ConfigureContext(
+    grpc::ClientContext&) {
   return Status{};
 }
 

--- a/google/cloud/internal/grpc_channel_credentials_authentication.h
+++ b/google/cloud/internal/grpc_channel_credentials_authentication.h
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_CHANNEL_CREDENTIALS_AUTHENTICATION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_CHANNEL_CREDENTIALS_AUTHENTICATION_H
+
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+class GrpcChannelCredentialsAuthentication : public GrpcAuthenticationStrategy {
+ public:
+  explicit GrpcChannelCredentialsAuthentication(
+      std::shared_ptr<grpc::ChannelCredentials> c)
+      : credentials_(std::move(c)) {}
+  ~GrpcChannelCredentialsAuthentication() override = default;
+
+  std::shared_ptr<grpc::Channel> CreateChannel(
+      std::string const& endpoint,
+      grpc::ChannelArguments const& arguments) override;
+  Status Setup(grpc::ClientContext&) override;
+
+ private:
+  std::shared_ptr<grpc::ChannelCredentials> credentials_;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GRPC_CHANNEL_CREDENTIALS_AUTHENTICATION_H

--- a/google/cloud/internal/grpc_channel_credentials_authentication.h
+++ b/google/cloud/internal/grpc_channel_credentials_authentication.h
@@ -34,7 +34,7 @@ class GrpcChannelCredentialsAuthentication : public GrpcAuthenticationStrategy {
   std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint,
       grpc::ChannelArguments const& arguments) override;
-  Status Setup(grpc::ClientContext&) override;
+  Status ConfigureContext(grpc::ClientContext&) override;
 
  private:
   std::shared_ptr<grpc::ChannelCredentials> credentials_;

--- a/google/cloud/internal/grpc_channel_credentials_authentication_test.cc
+++ b/google/cloud/internal/grpc_channel_credentials_authentication_test.cc
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/grpc_channel_credentials_authentication.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+TEST(GrpcChannelCredentialsAuthenticationTest, Basic) {
+  GrpcChannelCredentialsAuthentication auth(grpc::InsecureChannelCredentials());
+
+  auto channel = auth.CreateChannel("localhost:1", grpc::ChannelArguments{});
+  EXPECT_NE(nullptr, channel.get());
+
+  grpc::ClientContext context;
+  EXPECT_EQ(nullptr, context.credentials());
+  auth.Setup(context);
+  EXPECT_EQ(nullptr, context.credentials());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/grpc_channel_credentials_authentication_test.cc
+++ b/google/cloud/internal/grpc_channel_credentials_authentication_test.cc
@@ -29,7 +29,7 @@ TEST(GrpcChannelCredentialsAuthenticationTest, Basic) {
 
   grpc::ClientContext context;
   EXPECT_EQ(nullptr, context.credentials());
-  auth.Setup(context);
+  auth.ConfigureContext(context);
   EXPECT_EQ(nullptr, context.credentials());
 }
 

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/grpc_access_token_authentication.h"
+#include "google/cloud/internal/grpc_channel_credentials_authentication.h"
+#include "google/cloud/internal/time_utils.h"
+#include "absl/memory/memory.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
+    std::shared_ptr<Credentials> const& credentials) {
+  struct Visitor : public CredentialsVisitor {
+    std::unique_ptr<GrpcAuthenticationStrategy> result;
+
+    void visit(GoogleDefaultCredentialsConfig&) override {
+      result = absl::make_unique<GrpcChannelCredentialsAuthentication>(
+          grpc::GoogleDefaultCredentials());
+    }
+    void visit(DynamicAccessTokenConfig& cfg) override {
+      result = absl::make_unique<GrpcAccessTokenAuthentication>(cfg.source());
+    }
+  } visitor;
+
+  CredentialsVisitor::dispatch(*credentials, visitor);
+  return std::move(visitor.result);
+}
+
+std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
+    std::shared_ptr<grpc::ChannelCredentials> const& credentials) {
+  return absl::make_unique<GrpcChannelCredentialsAuthentication>(credentials);
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -35,7 +35,7 @@ class GrpcAuthenticationStrategy {
   virtual std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint, grpc::ChannelArguments const& arguments) = 0;
   virtual Status Setup(grpc::ClientContext&) = 0;
-  // TODO(#...) - support asynchronous refresh
+  // TODO(#6310) - support asynchronous refresh
   //     virtual future<Status>
   //     SetupAsync(std::unique_ptr<grpc::ClientContext>, CompletionQueue& cq) =
   //     0;

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -1,0 +1,55 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UNIFIED_GRPC_CREDENTIALS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UNIFIED_GRPC_CREDENTIALS_H
+
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
+#include "google/cloud/internal/credentials.h"
+#include "google/cloud/status.h"
+#include "google/cloud/version.h"
+#include <grpcpp/grpcpp.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+class GrpcAuthenticationStrategy {
+ public:
+  virtual ~GrpcAuthenticationStrategy() = default;
+
+  virtual std::shared_ptr<grpc::Channel> CreateChannel(
+      std::string const& endpoint, grpc::ChannelArguments const& arguments) = 0;
+  virtual Status Setup(grpc::ClientContext&) = 0;
+  // TODO(#...) - support asynchronous refresh
+  //     virtual future<Status>
+  //     SetupAsync(std::unique_ptr<grpc::ClientContext>, CompletionQueue& cq) =
+  //     0;
+};
+
+std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
+    std::shared_ptr<Credentials> const& credentials);
+
+std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
+    std::shared_ptr<grpc::ChannelCredentials> const& credentials);
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_UNIFIED_GRPC_CREDENTIALS_H

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -34,7 +34,7 @@ class GrpcAuthenticationStrategy {
 
   virtual std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint, grpc::ChannelArguments const& arguments) = 0;
-  virtual Status Setup(grpc::ClientContext&) = 0;
+  virtual Status ConfigureContext(grpc::ClientContext& context) = 0;
   // TODO(#6310) - support asynchronous refresh
   //     virtual future<Status>
   //     SetupAsync(std::unique_ptr<grpc::ClientContext>, CompletionQueue& cq) =

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -1,0 +1,64 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/unified_grpc_credentials.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using google::cloud::testing_util::ScopedEnvironment;
+
+TEST(UnifiedGrpcCredentialsTest, WithGrpcCredentials) {
+  auto result =
+      CreateAuthenticationStrategy(grpc::InsecureChannelCredentials());
+  ASSERT_NE(nullptr, result.get());
+  grpc::ClientContext context;
+  result->Setup(context);
+  ASSERT_EQ(nullptr, context.credentials());
+}
+
+TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
+  // Create a filename for a file that (most likely) does not exist. We just
+  // want to initialize the default credentials, the filename won't be used by
+  // the test.
+  ScopedEnvironment env("GOOGLE_APPLICATION_CREDENTIALS", "unused.json");
+
+  auto result = CreateAuthenticationStrategy(MakeGoogleDefaultCredentials());
+  ASSERT_NE(nullptr, result.get());
+  grpc::ClientContext context;
+  result->Setup(context);
+  ASSERT_EQ(nullptr, context.credentials());
+}
+
+TEST(UnifiedGrpcCredentialsTest, WithAccessTokenCredentials) {
+  auto const expiration =
+      std::chrono::system_clock::now() + std::chrono::hours(1);
+  auto result = CreateAuthenticationStrategy(
+      MakeAccessTokenCredentials("test-token", expiration));
+  ASSERT_NE(nullptr, result.get());
+  grpc::ClientContext context;
+  result->Setup(context);
+  ASSERT_NE(nullptr, context.credentials());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -29,7 +29,7 @@ TEST(UnifiedGrpcCredentialsTest, WithGrpcCredentials) {
       CreateAuthenticationStrategy(grpc::InsecureChannelCredentials());
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
-  result->Setup(context);
+  result->ConfigureContext(context);
   ASSERT_EQ(nullptr, context.credentials());
 }
 
@@ -42,7 +42,7 @@ TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
   auto result = CreateAuthenticationStrategy(MakeGoogleDefaultCredentials());
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
-  result->Setup(context);
+  result->ConfigureContext(context);
   ASSERT_EQ(nullptr, context.credentials());
 }
 
@@ -53,7 +53,7 @@ TEST(UnifiedGrpcCredentialsTest, WithAccessTokenCredentials) {
       MakeAccessTokenCredentials("test-token", expiration));
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
-  result->Setup(context);
+  result->ConfigureContext(context);
   ASSERT_NE(nullptr, context.credentials());
 }
 


### PR DESCRIPTION
To use the unified authentication client credentials with gRPC we need
to map said credentials to the gRPC authentication abstractions. These
come in two flavors:

- For short-lived tokens (such as access tokens), one needs to create a
  `grpc::CallCredentials` object and pass it to `grpc::ClientContext`
  before each call.
- For long-lived credentials (e.g. `grpc::GoogleDefaultCredentials`) the
  credentials are associated with the gRPC channel and gRPC takes care
  of refreshing them.

This suggests that we need an abstraction to (a) create properly
configured channels when the unified credentials can be represented by a
`grpc::ChannelCredentials`, and (b) create (and if necessary cache) the
right `grpc::CallCredentials` and then set them before each RPC.

This change introduces the first versions of these components, and
creates a mapping function. For backwards compatibility we can also map
a `std::shared_ptr<grpc::ChannelCredentials>`.

Part of the changes for #6105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6304)
<!-- Reviewable:end -->
