### PR TITLE
ci(gcb): create secrets if necessary

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -278,8 +278,7 @@ if [[ "${project}" != "cloud-cpp-testing-resources" ]]; then
   for secret in "CODECOV_TOKEN" "LOG_LINKER_PAT"; do
     if ! gcloud --project "${project}" secrets describe "${secret}" >/dev/null; then
       io::log_yellow "Adding missing secret ${secret} to ${project}"
-      gcloud --project "${project}" secrets create "${secret}" --data-file=- \
-        </dev/null
+      echo | gcloud --project "${project}" secrets create "${secret}" --data-file=-
     fi
   done
 fi

--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -164,6 +164,11 @@ fi
 # https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
 BRANCH_NAME="${BRANCH_NAME:-$(git branch --show-current)}"
 COMMIT_SHA="${COMMIT_SHA:-$(git rev-parse HEAD)}"
+# GCB builds get these vars from Secret Manager, which uses a single newline
+# instead of an empty string. We remove all whitespace here so that `test -z`
+# and similar work in the invoked build scripts.
+CODECOV_TOKEN="$(tr -d '[:space:]' <<<"${CODECOV_TOKEN:-}")"
+LOG_LINKER_PAT="$(tr -d '[:space:]' <<<"${LOG_LINKER_PAT:-}")"
 
 # --local is the most fundamental build mode, in that all other builds
 # eventually call this one. For example, a --docker build will build the
@@ -264,8 +269,20 @@ fi
 
 # Uses Google Cloud build to run the specified build.
 io::log_h1 "Starting cloud build: ${BUILD_NAME}"
-project="${PROJECT_FLAG:-$(gcloud config get-value project)}"
-account="$(gcloud config get-value account)"
+project="${PROJECT_FLAG:-$(gcloud config get-value project 2>/dev/null)}"
+account="$(gcloud config get-value account 2>/dev/null)"
+# The cloudbuild.yaml file expects certain "secrets" to be present in the
+# project's "Secret Manager". This is true for our main production project, but
+# for personal projects we may need to create them (with empty strings).
+if [[ "${project}" != "cloud-cpp-testing-resources" ]]; then
+  for secret in "CODECOV_TOKEN" "LOG_LINKER_PAT"; do
+    if ! gcloud --project "${project}" secrets describe "${secret}" >/dev/null; then
+      io::log_yellow "Adding missing secret ${secret} to ${project}"
+      gcloud --project "${project}" secrets create "${secret}" --data-file=- \
+        </dev/null
+    fi
+  done
+fi
 subs=("_DISTRO=${DISTRO_FLAG}")
 subs+=("_BUILD_NAME=${BUILD_NAME}")
 subs+=("_TRIGGER_SOURCE=manual-${account}")


### PR DESCRIPTION
Our GCB builds expect secrets for the `CODECOV_TOKEN` and the
`LOG_LINKER_PAT`. These exist in our main GCB project, but not in our
personal projects. This PR creates these secrets with empty data if
they don't already exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6316)
<!-- Reviewable:end -->
