### PR TITLE
ci(gcb): add 'update abi' behavior to 'check-abi'

### DIFF
--- a/ci/cloudbuild/builds/check-abi.sh
+++ b/ci/cloudbuild/builds/check-abi.sh
@@ -67,7 +67,7 @@ for lib in "${libraries[@]}"; do
   actual_dump_file="${lib}.actual.abi.dump"
   expected_dump_file="${lib}.expected.abi.dump"
   expected_dump_path="${PROJECT_ROOT}/ci/test-abi/${expected_dump_file}.gz"
-  zcat "${expected_dump_path}" > "cmake-out/${expected_dump_file}"
+  zcat "${expected_dump_path}" >"cmake-out/${expected_dump_file}"
   # We ignore all symbols in internal namespaces, because these are not part
   # of our public API. We do this by specifying a regex that matches against
   # the mangled symbol names. For example, 8 is the number of characters in

--- a/ci/cloudbuild/builds/check-abi.sh
+++ b/ci/cloudbuild/builds/check-abi.sh
@@ -66,8 +66,8 @@ for lib in "${libraries[@]}"; do
   io::log_h2 "Checking ${lib}"
   actual_dump_file="${lib}.actual.abi.dump"
   expected_dump_file="${lib}.expected.abi.dump"
-  zcat "${PROJECT_ROOT}/ci/test-abi/${expected_dump_file}.gz" > \
-    "cmake-out/${expected_dump_file}"
+  expected_dump_path="${PROJECT_ROOT}/ci/test-abi/${expected_dump_file}.gz"
+  zcat "${expected_dump_path}" > "cmake-out/${expected_dump_file}"
   # We ignore all symbols in internal namespaces, because these are not part
   # of our public API. We do this by specifying a regex that matches against
   # the mangled symbol names. For example, 8 is the number of characters in
@@ -85,6 +85,9 @@ for lib in "${libraries[@]}"; do
     io::log "Report file: ${report}"
     w3m -dump "${report}"
   fi
+  # Replaces the (old) expected dump file with the (new) actual one.
+  gzip "cmake-out/${actual_dump_file}"
+  mv -f "cmake-out/${actual_dump_file}.gz" "${expected_dump_path}"
 done
 echo
 exit "${errors}"


### PR DESCRIPTION
This PR is my proposal for merging the behavior of the old (kokoro)
"update-abi" build behavior _into_ the new (GCB) "check-abi" build.

Specifically, this change makes GCB's `check-abi` build always replace
the "expected" ABI dump files in `ci/test-abi/*.gz` with the newly
generated dumps that were created for the `check-abi` build, and it
leaves these new `*.gz` files edited in the local repo. If the user
wants to update the ABI they only need to create a new PR w/ the changed
`*.gz` files. If they don't want to update the `*.gz` files, they can
just `git restore ci/test-abi`. In both cases, the return value of the
`check-abi` build is successful if there were no ABI incompatibilities
and an error if there were incompatibilities. And again, whether or not
to check-in the changed `.gz` files is up to the user.

NOTE: These ABI dump files will change even if there are no API
incompatibilities, for example, if private info changes, etc. So the
fact that the `.gz` files change is not an indication that the API
broke.

This proposed change to leave the changed `.gz` files in the repo
follows the pattern that we already use for `check-style.sh` where we
leave the formatted files in the repo. This change is simpler than
having a separate "update-abi" build, and it will work well with _my_
workflows, however, I realize that it's possible other folks have
workflows that this would disrupt. Feel free to push back if you think
this is not a good change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6321)
<!-- Reviewable:end -->
