### PR TITLE
feat(storage): use the unified authentication client

### DIFF
--- a/google/cloud/internal/grpc_access_token_authentication_test.cc
+++ b/google/cloud/internal/grpc_access_token_authentication_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/grpc_access_token_authentication.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -21,6 +22,7 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::testing::Return;
 
 TEST(GrpcAccessTokenAuthenticationTest, Simple) {
@@ -41,7 +43,8 @@ TEST(GrpcAccessTokenAuthenticationTest, Simple) {
     SCOPED_TRACE("Running attempt " + std::to_string(attempt));
     grpc::ClientContext context;
     EXPECT_EQ(nullptr, context.credentials());
-    auth.ConfigureContext(context);
+    auto status = auth.ConfigureContext(context);
+    EXPECT_THAT(status, IsOk());
     EXPECT_NE(nullptr, context.credentials());
   }
 }
@@ -62,7 +65,8 @@ TEST(GrpcAccessTokenAuthenticationTest, NotExpired) {
     SCOPED_TRACE("Running attempt " + std::to_string(attempt));
     grpc::ClientContext context;
     EXPECT_EQ(nullptr, context.credentials());
-    auth.ConfigureContext(context);
+    auto status = auth.ConfigureContext(context);
+    EXPECT_THAT(status, IsOk());
     EXPECT_NE(nullptr, context.credentials());
   }
 }

--- a/google/cloud/internal/grpc_channel_credentials_authentication_test.cc
+++ b/google/cloud/internal/grpc_channel_credentials_authentication_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/grpc_channel_credentials_authentication.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -20,6 +21,8 @@ namespace cloud {
 inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
+
+using ::google::cloud::testing_util::IsOk;
 
 TEST(GrpcChannelCredentialsAuthenticationTest, Basic) {
   GrpcChannelCredentialsAuthentication auth(grpc::InsecureChannelCredentials());
@@ -29,7 +32,8 @@ TEST(GrpcChannelCredentialsAuthenticationTest, Basic) {
 
   grpc::ClientContext context;
   EXPECT_EQ(nullptr, context.credentials());
-  auth.ConfigureContext(context);
+  auto status = auth.ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
   EXPECT_EQ(nullptr, context.credentials());
 }
 

--- a/google/cloud/internal/unified_grpc_credentials_test.cc
+++ b/google/cloud/internal/unified_grpc_credentials_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -22,14 +23,15 @@ inline namespace GOOGLE_CLOUD_CPP_NS {
 namespace internal {
 namespace {
 
-using google::cloud::testing_util::ScopedEnvironment;
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::ScopedEnvironment;
 
 TEST(UnifiedGrpcCredentialsTest, WithGrpcCredentials) {
   auto result =
       CreateAuthenticationStrategy(grpc::InsecureChannelCredentials());
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
-  result->ConfigureContext(context);
+  auto status = result->ConfigureContext(context);
   ASSERT_EQ(nullptr, context.credentials());
 }
 
@@ -42,7 +44,8 @@ TEST(UnifiedGrpcCredentialsTest, WithDefaultCredentials) {
   auto result = CreateAuthenticationStrategy(MakeGoogleDefaultCredentials());
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
-  result->ConfigureContext(context);
+  auto status = result->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
   ASSERT_EQ(nullptr, context.credentials());
 }
 
@@ -53,7 +56,8 @@ TEST(UnifiedGrpcCredentialsTest, WithAccessTokenCredentials) {
       MakeAccessTokenCredentials("test-token", expiration));
   ASSERT_NE(nullptr, result.get());
   grpc::ClientContext context;
-  result->ConfigureContext(context);
+  auto status = result->ConfigureContext(context);
+  EXPECT_THAT(status, IsOk());
   ASSERT_NE(nullptr, context.credentials());
 }
 

--- a/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/storage/ci/run_integration_tests_emulator_bazel.sh
@@ -50,6 +50,7 @@ production_only_targets=(
   "//google/cloud/storage/examples:storage_signed_url_v4_samples"
   "//google/cloud/storage/tests:key_file_integration_test"
   "//google/cloud/storage/tests:signed_url_integration_test"
+  "//google/cloud/storage/tests:unified_credentials_integration_test"
 )
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \
   --test_tag_filters="integration-test" -- \

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -80,15 +80,26 @@ Options DefaultOptionsGrpc(Options options) {
 }
 
 std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
+    std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> const&
+        authentication_strategy,
     Options const& options, int channel_id) {
   grpc::ChannelArguments args;
   args.SetInt("grpc.channel_id", channel_id);
   if (DirectPathEnabled()) {
     args.SetServiceConfigJSON(kDirectPathConfig);
   }
-  return grpc::CreateCustomChannel(options.get<EndpointOption>(),
-                                   options.get<GrpcCredentialOption>(),
-                                   std::move(args));
+  return authentication_strategy->CreateChannel(options.get<EndpointOption>(),
+                                                std::move(args));
+}
+
+std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy>
+CreateAuthenticationStrategy(Options const& opts) {
+  if (opts.has<google::cloud::internal::UnifiedCredentialsOption>()) {
+    return google::cloud::internal::CreateAuthenticationStrategy(
+        opts.get<google::cloud::internal::UnifiedCredentialsOption>());
+  }
+  return google::cloud::internal::CreateAuthenticationStrategy(
+      opts.get<google::cloud::GrpcCredentialOption>());
 }
 
 std::shared_ptr<GrpcClient> GrpcClient::Create(Options const& opts) {
@@ -104,8 +115,9 @@ std::shared_ptr<GrpcClient> GrpcClient::Create(Options const& opts,
 GrpcClient::GrpcClient(Options const& opts, int channel_id)
     : backwards_compatibility_options_(
           MakeBackwardsCompatibleClientOptions(opts)),
+      auth_strategy_(CreateAuthenticationStrategy(opts)),
       stub_(google::storage::v1::Storage::NewStub(
-          CreateGrpcChannel(opts, channel_id))) {}
+          CreateGrpcChannel(auth_strategy_, opts, channel_id))) {}
 
 std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
     grpc::ClientContext& context, google::storage::v1::Object& result) {
@@ -116,6 +128,8 @@ std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
 StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
     QueryResumableUploadRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto const proto_request = ToProto(request);
   google::storage::v1::QueryWriteStatusResponse response;
   auto status = stub_->QueryWriteStatus(&context, proto_request, &response);
@@ -138,6 +152,8 @@ ClientOptions const& GrpcClient::client_options() const {
 StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
     ListBucketsRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ListBucketsResponse response;
   auto status = stub_->ListBuckets(&context, proto_request, &response);
@@ -155,6 +171,8 @@ StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
 StatusOr<BucketMetadata> GrpcClient::CreateBucket(
     CreateBucketRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::Bucket response;
   auto status = stub_->InsertBucket(&context, proto_request, &response);
@@ -166,6 +184,8 @@ StatusOr<BucketMetadata> GrpcClient::CreateBucket(
 StatusOr<BucketMetadata> GrpcClient::GetBucketMetadata(
     GetBucketMetadataRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   google::storage::v1::Bucket response;
   auto proto_request = ToProto(request);
   auto status = stub_->GetBucket(&context, proto_request, &response);
@@ -177,6 +197,8 @@ StatusOr<BucketMetadata> GrpcClient::GetBucketMetadata(
 StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
     DeleteBucketRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::protobuf::Empty response;
   auto status = stub_->DeleteBucket(&context, proto_request, &response);
@@ -188,6 +210,8 @@ StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
 StatusOr<BucketMetadata> GrpcClient::UpdateBucket(
     UpdateBucketRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   google::storage::v1::Bucket response;
   auto proto_request = ToProto(request);
   auto status = stub_->UpdateBucket(&context, proto_request, &response);
@@ -208,6 +232,8 @@ StatusOr<IamPolicy> GrpcClient::GetBucketIamPolicy(
 StatusOr<NativeIamPolicy> GrpcClient::GetNativeBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::iam::v1::Policy response;
   auto status = stub_->GetBucketIamPolicy(&context, proto_request, &response);
@@ -224,6 +250,8 @@ StatusOr<IamPolicy> GrpcClient::SetBucketIamPolicy(
 StatusOr<NativeIamPolicy> GrpcClient::SetNativeBucketIamPolicy(
     SetNativeBucketIamPolicyRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::iam::v1::Policy response;
   auto status = stub_->SetBucketIamPolicy(&context, proto_request, &response);
@@ -235,6 +263,8 @@ StatusOr<NativeIamPolicy> GrpcClient::SetNativeBucketIamPolicy(
 StatusOr<TestBucketIamPermissionsResponse> GrpcClient::TestBucketIamPermissions(
     TestBucketIamPermissionsRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::iam::v1::TestIamPermissionsResponse response;
   auto status =
@@ -257,6 +287,8 @@ StatusOr<BucketMetadata> GrpcClient::LockBucketRetentionPolicy(
 StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
     InsertObjectMediaRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   google::storage::v1::Object response;
   auto stream = stub_->InsertObject(&context, &response);
   auto proto_request = ToProto(request);
@@ -316,12 +348,17 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
         "ReadLast(0) is invalid in REST and produces incorrect output in gRPC");
   }
   auto const proto_request = ToProto(request);
-  auto create_stream = [&proto_request, this](grpc::ClientContext& context) {
-    return stub_->GetObjectMedia(&context, proto_request);
-  };
+  auto context = absl::make_unique<grpc::ClientContext>();
+  auto status = auth_strategy_->ConfigureContext(*context);
+  if (!status.ok()) {
+    return std::unique_ptr<ObjectReadSource>(
+        absl::make_unique<ObjectReadErrorSource>(std::move(status)));
+  }
 
+  auto reader = stub_->GetObjectMedia(context.get(), proto_request);
   return std::unique_ptr<ObjectReadSource>(
-      new GrpcObjectReadSource(create_stream));
+      absl::make_unique<GrpcObjectReadSource>(std::move(context),
+                                              std::move(reader)));
 }
 
 StatusOr<ListObjectsResponse> GrpcClient::ListObjects(
@@ -332,6 +369,8 @@ StatusOr<ListObjectsResponse> GrpcClient::ListObjects(
 StatusOr<EmptyResponse> GrpcClient::DeleteObject(
     DeleteObjectRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::protobuf::Empty response;
   auto status = stub_->DeleteObject(&context, proto_request, &response);
@@ -368,6 +407,8 @@ GrpcClient::CreateResumableSession(ResumableUploadRequest const& request) {
   }
 
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::StartResumableWriteResponse response;
   auto status = stub_->StartResumableWrite(&context, proto_request, &response);
@@ -398,6 +439,8 @@ GrpcClient::RestoreResumableSession(std::string const& upload_url) {
 StatusOr<EmptyResponse> GrpcClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   google::protobuf::Empty response;
   auto proto_request = ToProto(request);
   auto status = stub_->DeleteObject(&context, proto_request, &response);
@@ -409,6 +452,8 @@ StatusOr<EmptyResponse> GrpcClient::DeleteResumableUpload(
 StatusOr<ListBucketAclResponse> GrpcClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ListBucketAccessControlsResponse response;
   auto status =
@@ -426,6 +471,8 @@ StatusOr<ListBucketAclResponse> GrpcClient::ListBucketAcl(
 StatusOr<BucketAccessControl> GrpcClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::BucketAccessControl response;
   auto status =
@@ -438,6 +485,8 @@ StatusOr<BucketAccessControl> GrpcClient::GetBucketAcl(
 StatusOr<BucketAccessControl> GrpcClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::BucketAccessControl response;
   auto status =
@@ -449,6 +498,8 @@ StatusOr<BucketAccessControl> GrpcClient::CreateBucketAcl(
 StatusOr<EmptyResponse> GrpcClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::protobuf::Empty response;
   auto status =
@@ -466,6 +517,8 @@ StatusOr<ListObjectAclResponse> GrpcClient::ListObjectAcl(
 StatusOr<BucketAccessControl> GrpcClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::BucketAccessControl response;
   auto status =
@@ -508,6 +561,8 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchObjectAcl(
 StatusOr<ListDefaultObjectAclResponse> GrpcClient::ListDefaultObjectAcl(
     ListDefaultObjectAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ListObjectAccessControlsResponse response;
   auto status = stub_->ListDefaultObjectAccessControls(&context, proto_request,
@@ -525,6 +580,8 @@ StatusOr<ListDefaultObjectAclResponse> GrpcClient::ListDefaultObjectAcl(
 StatusOr<ObjectAccessControl> GrpcClient::CreateDefaultObjectAcl(
     CreateDefaultObjectAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ObjectAccessControl response;
   auto status = stub_->InsertDefaultObjectAccessControl(&context, proto_request,
@@ -536,6 +593,8 @@ StatusOr<ObjectAccessControl> GrpcClient::CreateDefaultObjectAcl(
 StatusOr<EmptyResponse> GrpcClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::protobuf::Empty response;
   auto status = stub_->DeleteDefaultObjectAccessControl(&context, proto_request,
@@ -548,6 +607,8 @@ StatusOr<EmptyResponse> GrpcClient::DeleteDefaultObjectAcl(
 StatusOr<ObjectAccessControl> GrpcClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ObjectAccessControl response;
   auto status =
@@ -560,6 +621,8 @@ StatusOr<ObjectAccessControl> GrpcClient::GetDefaultObjectAcl(
 StatusOr<ObjectAccessControl> GrpcClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ObjectAccessControl response;
   auto status = stub_->UpdateDefaultObjectAccessControl(&context, proto_request,
@@ -645,6 +708,8 @@ NotificationMetadata GrpcClient::FromProto(
 StatusOr<ListNotificationsResponse> GrpcClient::ListNotifications(
     ListNotificationsRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::ListNotificationsResponse response;
   auto status = stub_->ListNotifications(&context, proto_request, &response);
@@ -661,6 +726,8 @@ StatusOr<ListNotificationsResponse> GrpcClient::ListNotifications(
 StatusOr<NotificationMetadata> GrpcClient::CreateNotification(
     CreateNotificationRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::Notification response;
   auto status = stub_->InsertNotification(&context, proto_request, &response);
@@ -672,6 +739,8 @@ StatusOr<NotificationMetadata> GrpcClient::CreateNotification(
 StatusOr<NotificationMetadata> GrpcClient::GetNotification(
     GetNotificationRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::storage::v1::Notification response;
   auto status = stub_->GetNotification(&context, proto_request, &response);
@@ -683,6 +752,8 @@ StatusOr<NotificationMetadata> GrpcClient::GetNotification(
 StatusOr<EmptyResponse> GrpcClient::DeleteNotification(
     DeleteNotificationRequest const& request) {
   grpc::ClientContext context;
+  auto auth = auth_strategy_->ConfigureContext(context);
+  if (!auth.ok()) return auth;
   auto proto_request = ToProto(request);
   google::protobuf::Empty response;
   auto status = stub_->DeleteNotification(&context, proto_request, &response);

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -80,7 +80,7 @@ Options DefaultOptionsGrpc(Options options) {
 }
 
 std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
-    std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> const&
+    google::cloud::internal::GrpcAuthenticationStrategy&
         authentication_strategy,
     Options const& options, int channel_id) {
   grpc::ChannelArguments args;
@@ -88,8 +88,8 @@ std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(
   if (DirectPathEnabled()) {
     args.SetServiceConfigJSON(kDirectPathConfig);
   }
-  return authentication_strategy->CreateChannel(options.get<EndpointOption>(),
-                                                std::move(args));
+  return authentication_strategy.CreateChannel(options.get<EndpointOption>(),
+                                               std::move(args));
 }
 
 std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy>
@@ -117,7 +117,7 @@ GrpcClient::GrpcClient(Options const& opts, int channel_id)
           MakeBackwardsCompatibleClientOptions(opts)),
       auth_strategy_(CreateAuthenticationStrategy(opts)),
       stub_(google::storage::v1::Storage::NewStub(
-          CreateGrpcChannel(auth_strategy_, opts, channel_id))) {}
+          CreateGrpcChannel(*auth_strategy_, opts, channel_id))) {}
 
 std::unique_ptr<GrpcClient::UploadWriter> GrpcClient::CreateUploadWriter(
     grpc::ClientContext& context, google::storage::v1::Object& result) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/unified_grpc_credentials.h"
 #include <google/storage/v1/storage.grpc.pb.h>
+#include <memory>
 #include <string>
 
 namespace google {
@@ -30,8 +32,6 @@ namespace internal {
 /// GOOGLE_CLOUD_DIRECT_PATH.
 bool DirectPathEnabled();
 Options DefaultOptionsGrpc(Options = {});
-std::shared_ptr<grpc::ChannelInterface> CreateGrpcChannel(Options const&,
-                                                          int channel_id);
 
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
@@ -323,6 +323,8 @@ class GrpcClient : public RawClient,
 
  private:
   ClientOptions backwards_compatibility_options_;
+  std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy>
+      auth_strategy_;
   std::shared_ptr<google::storage::v1::Storage::Stub> stub_;
 };
 

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -23,6 +23,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
+GrpcObjectReadSource::GrpcObjectReadSource(
+    std::unique_ptr<grpc::ClientContext> context,
+    std::unique_ptr<GrpcObjectContentsReader> stream)
+    : context_(std::move(context)), stream_(std::move(stream)) {}
+
 GrpcObjectReadSource::~GrpcObjectReadSource() {
   // clang-tidy is complaining about code in the gRPC implementation. It seems
   // that it is *possible* for gRPC to call a function through a null pointer
@@ -41,7 +46,7 @@ StatusOr<HttpResponse> GrpcObjectReadSource::Close() {
   if (stream_) {
     // Cancel the streaming RPC so we can close the stream early and
     // ignore any errors (kCancelled is likely).
-    context_.TryCancel();
+    context_->TryCancel();
     (void)stream_->Finish();
     stream_ = nullptr;
   }

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -27,8 +27,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-using StreamMaker = std::function<std::unique_ptr<grpc::ClientReaderInterface<
-    google::storage::v1::GetObjectMediaResponse>>(grpc::ClientContext&)>;
+using GrpcObjectContentsReader =
+    grpc::ClientReaderInterface<google::storage::v1::GetObjectMediaResponse>;
 
 /**
  * A data source for storage::ObjectReadStream using gRPC.
@@ -42,8 +42,9 @@ using StreamMaker = std::function<std::unique_ptr<grpc::ClientReaderInterface<
  */
 class GrpcObjectReadSource : public ObjectReadSource {
  public:
-  explicit GrpcObjectReadSource(StreamMaker const& maker)
-      : stream_(maker(context_)) {}
+  explicit GrpcObjectReadSource(
+      std::unique_ptr<grpc::ClientContext> context,
+      std::unique_ptr<GrpcObjectContentsReader> stream);
 
   ~GrpcObjectReadSource() override;
 
@@ -60,10 +61,8 @@ class GrpcObjectReadSource : public ObjectReadSource {
   // To create a reader for a streaming RPC one needs a client context with
   // longer lifetime than the stream. This is the client context used for the
   // request.
-  grpc::ClientContext context_;
-  std::unique_ptr<
-      grpc::ClientReaderInterface<google::storage::v1::GetObjectMediaResponse>>
-      stream_;
+  std::unique_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<GrpcObjectContentsReader> stream_;
 
   // In some cases the gRPC response may contain more data than the buffer
   // provided by the application. This buffer stores any excess results.

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -84,11 +84,8 @@ TEST(GrpcObjectReadSource, Simple) {
       })
       .WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::string expected =
       "0123456789 The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
@@ -110,11 +107,8 @@ TEST(GrpcObjectReadSource, EmptyWithError) {
   EXPECT_CALL(*mock, Finish())
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::vector<char> buffer(1024);
   EXPECT_THAT(tested.Read(buffer.data(), buffer.size()),
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
@@ -134,11 +128,8 @@ TEST(GrpcObjectReadSource, DataWithError) {
   EXPECT_CALL(*mock, Finish())
       .WillOnce(
           Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::string expected = "0123456789";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -168,11 +159,8 @@ TEST(GrpcObjectReadSource, UseSpillBuffer) {
       })
       .WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::vector<char> buffer(trailer_size);
   auto response = tested.Read(buffer.data(), expected_1.size());
   ASSERT_STATUS_OK(response);
@@ -204,11 +192,8 @@ TEST(GrpcObjectReadSource, UseSpillBufferMany) {
       })
       .WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), 3);
   ASSERT_STATUS_OK(response);
@@ -256,11 +241,8 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
       })
       .WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -308,11 +290,8 @@ TEST(GrpcObjectReadSource, HandleEmptyResponses) {
       })
       .WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -337,11 +316,8 @@ TEST(GrpcObjectReadSource, HandleExtraRead) {
       })
       .WillOnce(Return(false));
   EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested([&mock](grpc::ClientContext&) {
-    return std::unique_ptr<
-        grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>(
-        mock.release());
-  });
+  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
+                              std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -48,7 +48,8 @@ set(storage_client_integration_tests
     slow_reader_stream_integration_test.cc
     small_reads_integration_test.cc
     storage_include_test.cc
-    thread_integration_test.cc)
+    thread_integration_test.cc
+    unified_credentials_integration_test.cc)
 
 # Signed URL conformance tests are parsed using protos. In order to simplify the
 # build files, only build these conformance tests if gRPC in GCS is compiled.
@@ -89,8 +90,11 @@ foreach (fname ${storage_client_integration_tests})
 endforeach ()
 
 # We just know that these tests need to be run against production.
-foreach (fname # cmake-format: sort
-               key_file_integration_test.cc signed_url_integration_test.cc)
+foreach (
+    fname
+    # cmake-format: sort
+    key_file_integration_test.cc signed_url_integration_test.cc
+    unified_credentials_integration_test.cc)
     google_cloud_cpp_set_target_name(target "storage" "${fname}")
     set_tests_properties(
         ${target} PROPERTIES LABELS

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -50,4 +50,5 @@ storage_client_integration_tests = [
     "small_reads_integration_test.cc",
     "storage_include_test.cc",
     "thread_integration_test.cc",
+    "unified_credentials_integration_test.cc",
 ]

--- a/google/cloud/storage/tests/unified_credentials_integration_test.cc
+++ b/google/cloud/storage/tests/unified_credentials_integration_test.cc
@@ -1,0 +1,136 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/grpc_plugin.h"
+#include "google/cloud/storage/internal/unified_rest_credentials.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace {
+
+using ::google::cloud::internal::MakeAccessTokenCredentials;
+using ::google::cloud::internal::MakeGoogleDefaultCredentials;
+using ::google::cloud::internal::UnifiedCredentialsOption;
+using ::google::cloud::testing_util::IsOk;
+using ::testing::StartsWith;
+
+class UnifiedCredentialsIntegrationTest
+    : public ::google::cloud::storage::testing::StorageIntegrationTest,
+      public ::testing::WithParamInterface<std::string> {
+ protected:
+  UnifiedCredentialsIntegrationTest()
+      : grpc_config_("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", {}) {}
+
+  void SetUp() override {
+    bucket_name_ = google::cloud::internal::GetEnv(
+                       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
+                       .value_or("");
+    ASSERT_FALSE(bucket_name_.empty());
+  }
+
+  static Client MakeTestClient(Options opts) {
+    std::string const client_type = GetParam();
+    // TODO(#...) - this should happen in CreateClient
+    auto credentials = internal::MapCredentials(
+        opts.get<google::cloud::internal::UnifiedCredentialsOption>());
+    opts.set<internal::Oauth2CredentialsOption>(credentials);
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+    if (client_type == "grpc") {
+      return google::cloud::storage_experimental::DefaultGrpcClient(
+                 std::move(opts))
+          .value();
+    }
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+    return internal::ClientImplDetails::CreateClient(std::move(credentials),
+                                                     std::move(opts));
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+  testing_util::ScopedEnvironment grpc_config_;
+};
+
+void UseClient(Client client, std::string const& bucket_name,
+               std::string const& object_name, std::string const& payload) {
+  StatusOr<ObjectMetadata> meta = client.InsertObject(
+      bucket_name, object_name, payload, IfGenerationMatch(0));
+  ASSERT_THAT(meta, IsOk());
+  EXPECT_EQ(object_name, meta->name());
+
+  auto stream = client.ReadObject(bucket_name, object_name);
+  std::string actual(std::istreambuf_iterator<char>{stream}, {});
+  EXPECT_EQ(payload, actual);
+
+  auto status = client.DeleteObject(bucket_name, object_name);
+  EXPECT_THAT(status, IsOk());
+}
+
+TEST_P(UnifiedCredentialsIntegrationTest, GoogleDefaultCredentials) {
+  if (UsingEmulator()) GTEST_SKIP();
+  auto client = MakeTestClient(
+      Options{}.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials()));
+
+  ASSERT_NO_FATAL_FAILURE(
+      UseClient(client, bucket_name(), MakeRandomObjectName(), LoremIpsum()));
+}
+
+TEST_P(UnifiedCredentialsIntegrationTest, AccessTokenSource) {
+  if (UsingEmulator()) GTEST_SKIP();
+  // First use the default credentials to obtain an access token, then use the
+  // access token to test the DynamicAccessTokenCredentials() function. In a
+  // real application one would feat access tokens from something more
+  // interesting, like the IAM credentials service. This is just a reasonably
+  // easy way to get a working access token for the test.
+  auto default_credentials = oauth2::GoogleDefaultCredentials();
+  ASSERT_THAT(default_credentials, IsOk());
+  auto expiration = std::chrono::system_clock::now() + std::chrono::hours(1);
+  auto header = default_credentials.value()->AuthorizationHeader();
+  ASSERT_THAT(header, IsOk());
+
+  auto constexpr kPrefix = "Authorization: Bearer ";
+  ASSERT_THAT(*header, StartsWith(kPrefix));
+  auto token = header->substr(std::strlen(kPrefix));
+
+  auto client = MakeTestClient(Options{}.set<UnifiedCredentialsOption>(
+      MakeAccessTokenCredentials(token, expiration)));
+
+  ASSERT_NO_FATAL_FAILURE(
+      UseClient(client, bucket_name(), MakeRandomObjectName(), LoremIpsum()));
+}
+
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+INSTANTIATE_TEST_SUITE_P(UnifiedCredentialsGrpcIntegrationTest,
+                         UnifiedCredentialsIntegrationTest,
+                         ::testing::Values("grpc"));
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+INSTANTIATE_TEST_SUITE_P(UnifiedCredentialsRestIntegrationTest,
+                         UnifiedCredentialsIntegrationTest,
+                         ::testing::Values("rest"));
+
+}  // namespace
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Modify the storage library to support the unified authentication client
(aka `google::cloud::{internal::}Credentials`). This is not yet exposed
in the public API, but applications will be able to initialize a
`gcs::Client` with a single credential, and it will work for both REST
and gRPC. Moreover, this supports credentials that dynamically create
access tokens, which we could not do before.

This is a backwards compatible change, using `oauth2::Credentials` (or
`grpc::ChannelCredentials` for the GCS+gRPC plugin) still works.

Fixes #3105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6323)
<!-- Reviewable:end -->
