### PR TITLE
ci: clang-tidy the GCS+gRPC plugin code

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -26,6 +26,7 @@ export CTCACHE_DIR=~/.cache/ctcache
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
 cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=ON \
+  -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
   -S . -B cmake-out
 cmake --build cmake-out
 env -C cmake-out ctest -LE "integration-test"


### PR DESCRIPTION
We need to enable the GCS+gRPC plugin on the clang-tidy build or the
files for it do not get "tidied".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6324)
<!-- Reviewable:end -->
