### PR TITLE
ci: parallelize unit and integration test with CTest

### DIFF
--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -30,7 +30,7 @@ cmake -GNinja -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
   -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON \
   -S . -B cmake-out
 cmake --build cmake-out
-env -C cmake-out ctest -LE "integration-test"
+env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 
 integration::ctest_with_emulators "cmake-out"
 

--- a/ci/cloudbuild/builds/cmake-clang.sh
+++ b/ci/cloudbuild/builds/cmake-clang.sh
@@ -25,6 +25,6 @@ export CXX=clang++
 
 cmake -GNinja -S . -B cmake-out
 cmake --build cmake-out
-env -C cmake-out ctest -LE "integration-test"
+env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/cmake-gcc.sh
+++ b/ci/cloudbuild/builds/cmake-gcc.sh
@@ -25,6 +25,6 @@ export CXX=g++
 
 cmake -GNinja -S . -B cmake-out
 cmake --build cmake-out
-env -C cmake-out ctest -LE "integration-test"
+env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/cxx17.sh
+++ b/ci/cloudbuild/builds/cxx17.sh
@@ -25,6 +25,6 @@ export CXX=g++
 
 cmake -GNinja -DCMAKE_CXX_STANDARD=17 -S . -B cmake-out
 cmake --build cmake-out
-env -C cmake-out ctest -LE "integration-test"
+env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -173,7 +173,7 @@ function integration::ctest_with_emulators() {
   local cmake_out="$1"
   ctest_args=(
     "--output-on-failure"
-    "--parallel=$(nproc)"
+    "--parallel" "$(nproc)"
   )
 
   io::log_h2 "Running Generator integration tests via CTest"

--- a/ci/cloudbuild/builds/noex.sh
+++ b/ci/cloudbuild/builds/noex.sh
@@ -25,6 +25,6 @@ export CXX=g++
 
 cmake -GNinja -DGOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=NO -S . -B cmake-out
 cmake --build cmake-out
-env -C cmake-out ctest -LE "integration-test"
+env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 
 integration::ctest_with_emulators "cmake-out"

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -29,7 +29,7 @@ cmake -GNinja \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -S . -B cmake-out
 cmake --build cmake-out
-env -C cmake-out ctest -LE "integration-test"
+env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 cmake --build cmake-out --target install
 
 # Tests the installed artifacts by building and running the quickstarts.


### PR DESCRIPTION
Comparing with the [last](https://pantheon.corp.google.com/cloud-build/builds;region=global/0cf38447-5b73-40bd-97b4-862a47d3a4fa;step=2?project=cloud-cpp-testing-resources) clang-tidy-pr build (which actually executed the integration tests).

The test time changed:

| Stage | Before | After |
| ------ | -------- | ------ |
| Unit | 58s | 12s |
| Pub/Sub | 19s | 10s |
| Bigtable | 19s | 6s |
| Storage | 176s | 84s |
| Spanner | 130s | 46s |

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6334)
<!-- Reviewable:end -->
