### PR TITLE
ci(gcb): add publish-docs build

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -158,6 +158,7 @@ if [[ -z "${BUILD_NAME}" ]]; then
   exit 1
 fi
 
+TRIGGER_TYPE="${TRIGGER_TYPE:-manual}"
 # Info about the git repo that is used by some builds, e.g., coverage. These
 # will be automatically set by GCB for triggered builds, but we need to compute
 # them ourselves for manually started builds and docker builds. See
@@ -236,6 +237,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--env=CODECOV_TOKEN=${CODECOV_TOKEN:-}"
     "--env=BRANCH_NAME=${BRANCH_NAME}"
     "--env=COMMIT_SHA=${COMMIT_SHA}"
+    "--env=TRIGGER_TYPE=${TRIGGER_TYPE:-}"
     # Mounts an empty volume over "build-out" to isolate builds from each
     # other. Doesn't affect GCB builds, but it helps our local docker builds.
     "--volume=/workspace/build-out"

--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+
+version=""
+doc_args=(
+  "-DCMAKE_BUILD_TYPE=Debug"
+  "-DGOOGLE_CLOUD_CPP_GEN_DOCS_FOR_GOOGLEAPIS_DEV=ON"
+)
+
+# Extract the version number if we're on a release branch.
+if grep -qP 'v\d+\.\d+\..*' <<<"${BRANCH_NAME}"; then
+  version_file="google/cloud/internal/version_info.h"
+  major="$(awk '/GOOGLE_CLOUD_CPP_VERSION_MAJOR/{print $3}' "${version_file}")"
+  minor="$(awk '/GOOGLE_CLOUD_CPP_VERSION_MINOR/{print $3}' "${version_file}")"
+  patch="$(awk '/GOOGLE_CLOUD_CPP_VERSION_PATCH/{print $3}' "${version_file}")"
+  version="${major}.${minor}.${patch}"
+else
+  version="master"
+  doc_args+=("-DGOOGLE_CLOUD_CPP_USE_MASTER_FOR_REFDOC_LINKS=ON")
+fi
+
+# |---------------------------------------------|
+# |      Bucket       |           URL           |
+# |-------------------|-------------------------|
+# |   docs-staging    |     googleapis.dev/     |
+# | test-docs-staging | staging.googleapis.dev/ |
+# |---------------------------------------------|
+# For PR and manual builds, publish to the staging site. For CI builds (release
+# and otherwise), publish to the public URL.
+bucket="test-docs-staging"
+if [[ "${TRIGGER_TYPE}" == "ci" ]]; then
+  bucket="docs-staging"
+fi
+
+export CC=clang
+export CXX=clang++
+cmake -GNinja "${doc_args[@]}" -S . -B cmake-out
+cmake --build cmake-out --target doxygen-docs
+
+io::log_h2 "Installing the docuploader package $(date)"
+python3 -m pip install --user gcp-docuploader protobuf \
+  --upgrade --no-warn-script-location
+
+# For docuploader to work
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+# Uses the doc uploader to upload docs to a GCS bucket. Requires the package
+# name and the path to the doxygen's "html" folder.
+function upload_docs() {
+  local package="$1"
+  local docs_dir="$2"
+  if [[ ! -d "${docs_dir}" ]]; then
+    io::log_red "Directory not found: ${docs_dir}, skipping"
+    return 0
+  fi
+
+  io::log_h2 "Uploading docs: ${package}"
+  io::log "docs_dir=${docs_dir}"
+
+  env -C "${docs_dir}" python3 -m docuploader create-metadata \
+    --name "${package}" \
+    --version "${version}" \
+    --language cpp
+  env -C "${docs_dir}" python3 -m docuploader upload . --staging-bucket "${bucket}"
+}
+
+io::log_h2 "Publishing docs"
+io::log "version: ${version}"
+io::log "branch:  ${BRANCH_NAME}"
+io::log "bucket:  gs://${bucket}"
+upload_docs "google-cloud-common" "cmake-out/google/cloud/html"
+upload_docs "google-cloud-bigtable" "cmake-out/google/cloud/bigtable/html"
+upload_docs "google-cloud-pubsub" "cmake-out/google/cloud/pubsub/html"
+upload_docs "google-cloud-spanner" "cmake-out/google/cloud/spanner/html"
+upload_docs "google-cloud-storage" "cmake-out/google/cloud/storage/html"
+upload_docs "google-cloud-firestore" "cmake-out/google/cloud/firestore/html"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -24,7 +24,8 @@ options:
     'BUILD_ID=${BUILD_ID}',
     'BRANCH_NAME=${BRANCH_NAME}',
     'COMMIT_SHA=${COMMIT_SHA}',
-    'PR_NUMBER=${_PR_NUMBER}'
+    'PR_NUMBER=${_PR_NUMBER}',
+    'TRIGGER_TYPE=${_TRIGGER_TYPE}'
   ]
   volumes:
     - name: 'home'

--- a/ci/cloudbuild/triggers/publish-docs-ci.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: publish-docs-ci
+substitutions:
+  _BUILD_NAME: publish-docs
+  _DISTRO: fedora
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/publish-docs-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: publish-docs-pr
+substitutions:
+  _BUILD_NAME: publish-docs
+  _DISTRO: fedora
+  _TRIGGER_TYPE: pr
+tags:
+- pr


### PR DESCRIPTION
Fixes: #6174

This build will publish docs to the public site (googleapis.dev) on all
post-submit CI builds. For PR builds, docs will be published to the
staging.googleapis.dev site. When a CI build is triggered for a release
branch, docs will be published with the releases version number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6340)
<!-- Reviewable:end -->
