### PR TITLE
ci(gcb): add scan-build but no trigger

### DIFF
--- a/ci/cloudbuild/builds/scan-build.sh
+++ b/ci/cloudbuild/builds/scan-build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This build does not have a trigger file and is not automatically run by
+# GCB. To manually run this build use:
+#   ./ci/cloudbuild/build.sh --distro fedora scan-build --docker
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+
+export CC=clang
+export CXX=clang++
+
+scan_build=(
+  "scan-build"
+  "-o"
+  "${HOME}/scan-build"
+)
+"${scan_build[@]}" cmake -GNinja -S . -B cmake-out
+"${scan_build[@]}" cmake --build cmake-out


### PR DESCRIPTION
Fixes: #6345

This is a build that we may want to run sometimes by hand, and so here's
the build script for it. At this point, there's no build trigger for
this build, though we could add one if it seems useful. For now, this
build exists so we don't forget how to run a scan-build over our code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6356)
<!-- Reviewable:end -->
