### PR TITLE
ci: tell Renovate to ignore googleapis/googleapis

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "ignoreDeps": [ "com_google_googleapis" ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
* Tidy up top-level directory.
* Ignore `com_github_googleapis_googleapis` because it should be kept in sync with CMake.

Part of the work for #6346

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6359)
<!-- Reviewable:end -->
