### PR TITLE
ci(gcb): test component installs

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -150,7 +150,7 @@ quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
 
 # Deletes all the installed artifacts, and installs only the runtime components
 # to verify that we can still execute the compiled quickstart programs.
-rm -rf "${INSTALL_PREFIX}"/{include,lib64}
+rm -rf "${INSTALL_PREFIX:?}"/{include,lib64}
 cmake --install cmake-out --component google_cloud_cpp_runtime
 quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
 

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -32,7 +32,8 @@ cmake -GNinja \
   -DBUILD_TESTING=OFF \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -S . -B cmake-out
-cmake --build cmake-out --target install
+cmake --build cmake-out
+cmake --install cmake-out --component google_cloud_cpp_development
 
 io::log_h2 "Verifying installed directories"
 # Finds all the installed leaf directories (i.e., directories with exactly two
@@ -144,6 +145,13 @@ while IFS= read -r -d '' f; do
 done < <(find "${INSTALL_PREFIX}" -type f -print0)
 
 # Tests the installed artifacts by building and running the quickstarts.
+quickstart::build_cmake_and_make "${INSTALL_PREFIX}"
+quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
+
+# Deletes all the installed artifacts, and installs only the runtime components
+# to verify that we can still execute the compiled quickstart programs.
+rm -rf "${INSTALL_PREFIX}"/{include,lib64}
+cmake --install cmake-out --component google_cloud_cpp_runtime
 quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
 
 exit "${exit_code}"

--- a/ci/cloudbuild/builds/demo-install.sh
+++ b/ci/cloudbuild/builds/demo-install.sh
@@ -39,4 +39,5 @@ cmake --build cmake-out --target install
 ## [END packaging.md]
 
 # Tests the installed artifacts by building and running the quickstarts.
+quickstart::build_cmake_and_make "${PREFIX}"
 quickstart::run_cmake_and_make "${PREFIX}"

--- a/ci/cloudbuild/builds/shared.sh
+++ b/ci/cloudbuild/builds/shared.sh
@@ -33,4 +33,5 @@ env -C cmake-out ctest -LE "integration-test" --parallel "$(nproc)"
 cmake --build cmake-out --target install
 
 # Tests the installed artifacts by building and running the quickstarts.
+quickstart::build_cmake_and_make "${INSTALL_PREFIX}"
 quickstart::run_cmake_and_make "${INSTALL_PREFIX}"


### PR DESCRIPTION
This build tests CMake installs of the `google_cloud_cpp_development`
and `google_cloud_cpp_runtime` components. The essence of the test is
that it installs the "development" component, compiles the quickstart
programs, then it deletes the entire dev install, then installs _only_
the "runtime" component, then runs the quickstart programs. The
quickstarts should work with only the runtime component installed.

This PR splits the previous `quickstart::run_cmake_and_make` into two
functions: `quickstart::build_cmake_and_make` and
`quickstart::run_cmake_and_make`. This way we can execute previously
compiled quickstart binaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6363)
<!-- Reviewable:end -->
