### PR TITLE
ci: automatically update Dockerfiles with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,16 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:disable"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch":  [".*\\.Dockerfile$"],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>.*?)/archive/(?<currentValue>.*?)\\.tar\\.gz"
+      ],
+      "datasourceTemplate": "github-releases"
+    }
   ],
   "ignoreDeps": [ "com_google_googleapis" ]
 }


### PR DESCRIPTION
Part of the work for #6346.

I am not 100% sure this works. I managed to run the `renovate` CLI locally, and the logs look promising, but there is no way to tell (I think) until we let the robot create some PRs.  I disabled the normal `docker` updates because they update the image versions, and I do not think we want that in our case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6364)
<!-- Reviewable:end -->
