### PR TITLE
test(spanner): isolate unit test from prevailing environment

### DIFF
--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -43,6 +43,8 @@ auto gcloud_user_agent_matcher = [] {
 };
 
 TEST(Options, Defaults) {
+  testing_util::ScopedEnvironment env(
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", absl::nullopt);
   auto opts = spanner_internal::DefaultOptions();
   EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
   // In Google's testing environment `expected` can be `nullptr`, we just want
@@ -68,6 +70,8 @@ TEST(Options, Defaults) {
 }
 
 TEST(Options, AdminDefaults) {
+  testing_util::ScopedEnvironment env(
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", absl::nullopt);
   auto opts = spanner_internal::DefaultAdminOptions();
   EXPECT_EQ(opts.get<EndpointOption>(), "spanner.googleapis.com");
   // In Google's testing environment `expected` can be `nullptr`, we just want


### PR DESCRIPTION
Clear any prevailing `GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT`
setting when testing `spanner_internal::Default{,Admin}Options()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6373)
<!-- Reviewable:end -->
