### PR TITLE
ci: make Dockerfiles easier to update

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -71,10 +71,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -93,15 +92,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -113,10 +111,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.10. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -128,10 +125,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # Cloud Platform proto files. We manually install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -154,10 +150,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -178,10 +173,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-8.Dockerfile
@@ -46,10 +46,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -68,15 +67,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -88,10 +86,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # Cloud Platform proto files. We manually install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -114,10 +111,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -138,10 +134,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -23,9 +23,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ca-certificates ccache cmake git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
-        pkg-config tar wget zlib1g-dev
+        automake build-essential ca-certificates ccache cmake curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 \
+        make pkg-config tar wget zlib1g-dev
 # ```
 
 # Debian 10 includes versions of gRPC and Protobuf that support the

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -42,10 +42,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -64,10 +63,9 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -88,10 +86,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
@@ -30,9 +30,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libcurl4-openssl-dev libssl1.0-dev libtool make m4 pkg-config tar wget \
-        zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libcurl4-openssl-dev libssl1.0-dev libtool make m4 pkg-config \
+        tar wget zlib1g-dev
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
@@ -40,10 +40,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -62,15 +61,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -82,10 +80,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.12. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -96,10 +93,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # We need a newer version of RE2 than the system package provides.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -115,10 +111,9 @@ RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
 # Protobuf we just installed in `/usr/local`:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -141,10 +136,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -165,10 +159,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i \
         -e '1s/VERSION 3.8/VERSION 3.5/' \
         -e '/^target_compile_features/d' \

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -48,10 +48,9 @@ ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -70,10 +69,9 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -94,10 +92,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -46,10 +46,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -68,15 +67,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -88,10 +86,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.9. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -103,10 +100,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # Cloud Platform proto files. We manually install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -129,10 +125,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -153,10 +148,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -25,9 +25,9 @@ ARG NCPU=4
 
 # ```bash
 RUN zypper refresh && \
-    zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
-        gzip libcurl-devel libopenssl-devel libtool make re2-devel tar wget \
-        which zlib zlib-devel-static
+    zypper install --allow-downgrade -y automake ccache cmake curl \
+        gcc gcc-c++ git gzip libcurl-devel libopenssl-devel \
+        libtool make re2-devel tar wget which zlib zlib-devel-static
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. openSUSE

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -23,9 +23,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
-        pkg-config tar wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 \
+        make pkg-config tar wget zlib1g-dev
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -33,10 +33,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -55,15 +54,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -74,10 +72,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # We need a newer version of RE2 than the system package provides.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -93,10 +90,9 @@ RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
 # Cloud Platform proto files. We install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -119,10 +115,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -143,10 +138,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -34,10 +34,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -56,15 +55,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -76,10 +74,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # Cloud Platform proto files. We install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -102,10 +99,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -126,10 +122,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -24,9 +24,9 @@ ARG NCPU=4
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev libssl-dev m4 \
-        make pkg-config tar wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev \
+        libssl-dev m4 make pkg-config tar wget zlib1g-dev
 # ```
 
 # #### Abseil

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
@@ -34,9 +34,9 @@ RUN apt-get update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil-cpp
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -55,15 +55,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -75,10 +74,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.10. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -89,10 +87,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # We need a newer version of RE2 than the system package provides.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -108,10 +105,9 @@ RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
 # Cloud Platform proto files. We can install gRPC from source using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -134,10 +130,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -158,10 +153,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i \
         -e '1s/VERSION 3.8/VERSION 3.5/' \
         -e '/^target_compile_features/d' \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-xenial.Dockerfile
@@ -23,8 +23,8 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libcurl4-openssl-dev libssl-dev libtool m4 make \
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libcurl4-openssl-dev libssl-dev libtool m4 make \
         pkg-config tar wget zlib1g-dev
 # ```
 


### PR DESCRIPTION
Use `tar --strip-components=1` to avoid repeating the version number.

Part of the work for #6346

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6376)
<!-- Reviewable:end -->
