### PR TITLE
ci: make install Dockerfiles easier to update

### DIFF
--- a/ci/generate-markdown/dockerfile2markdown.sh
+++ b/ci/generate-markdown/dockerfile2markdown.sh
@@ -34,7 +34,8 @@ sed_args=(
   # Regular Dockerfile commands just become commands.
   '-e' 's/^RUN //'
   # Change some Dockerfile commands to the shell counterparts
-  '-e' 's/^WORKDIR /cd /'
+  '-e' 's;^WORKDIR /home/build/project$;cd \$HOME/google-cloud-cpp;'
+  '-e' 's/^WORKDIR \(.*\)$/mkdir -p \1 \&\& cd \1/'
   '-e' 's/^ENV /export /'
   # To workaround transient download failures the CI builds execute some
   # commands 3 times, we do not need that in the README or INSTALL
@@ -65,7 +66,7 @@ sed_args=(
   # or INSTALL instructions we prefer to use $HOME
   '-e' 's;/home/build/project;$HOME/google-cloud-cpp;'
   '-e' 's;/home/build;$HOME;'
-  '-e' 's;/var/tmp/build;$HOME/Downloads;'
+  '-e' 's;/var/tmp/build;$HOME/Downloads;g'
   # Remove additional indentation for the sudo commands. The Docker files
   # are more readable with the indentation, the markdown files not so much.
   '-e' 's/^    sudo/sudo/'

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -71,10 +71,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -93,15 +92,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -113,10 +111,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.10. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -128,10 +125,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # Cloud Platform proto files. We manually install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -154,10 +150,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -178,10 +173,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -46,10 +46,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -68,15 +67,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -88,10 +86,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # Cloud Platform proto files. We manually install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -114,10 +111,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -138,10 +134,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -23,9 +23,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ca-certificates ccache cmake git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
-        pkg-config tar wget zlib1g-dev
+        automake build-essential ca-certificates ccache cmake curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 \
+        make pkg-config tar wget zlib1g-dev
 # ```
 
 # Debian 10 includes versions of gRPC and Protobuf that support the

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -42,10 +42,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -64,10 +63,9 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -88,10 +86,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -40,10 +40,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -62,15 +61,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -82,10 +80,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.12. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -96,10 +93,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # We need a newer version of RE2 than the system package provides.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -115,10 +111,9 @@ RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
 # Protobuf we just installed in `/usr/local`:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -141,10 +136,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -165,10 +159,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i \
         -e '1s/VERSION 3.8/VERSION 3.5/' \
         -e '/^target_compile_features/d' \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -30,9 +30,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libcurl4-openssl-dev libssl1.0-dev libtool make m4 pkg-config tar wget \
-        zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libcurl4-openssl-dev libssl1.0-dev libtool make m4 pkg-config \
+        tar wget zlib1g-dev
 # ```
 
 # #### Abseil

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -48,10 +48,9 @@ ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -70,10 +69,9 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -94,10 +92,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.fedora-components
+++ b/ci/kokoro/install/Dockerfile.fedora-components
@@ -31,10 +31,9 @@ RUN dnf makecache && \
 
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
 
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -46,10 +45,9 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -61,10 +59,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -25,9 +25,9 @@ ARG NCPU=4
 
 # ```bash
 RUN zypper refresh && \
-    zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
-        gzip libcurl-devel libopenssl-devel libtool make re2-devel tar wget \
-        which zlib zlib-devel-static
+    zypper install --allow-downgrade -y automake ccache cmake curl \
+        gcc gcc-c++ git gzip libcurl-devel libopenssl-devel \
+        libtool make re2-devel tar wget which zlib zlib-devel-static
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. openSUSE

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -46,10 +46,9 @@ ENV PATH=/usr/local/bin:${PATH}
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -68,15 +67,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -88,10 +86,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.9. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -103,10 +100,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # Cloud Platform proto files. We manually install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -129,10 +125,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -153,10 +148,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -33,10 +33,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -55,15 +54,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -74,10 +72,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # We need a newer version of RE2 than the system package provides.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -93,10 +90,9 @@ RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
 # Cloud Platform proto files. We install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -119,10 +115,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -143,10 +138,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -23,9 +23,9 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
-        pkg-config tar wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 \
+        make pkg-config tar wget zlib1g-dev
 # ```
 
 # #### Abseil

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -34,10 +34,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -56,15 +55,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -76,10 +74,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # Cloud Platform proto files. We install it using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -102,10 +99,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -126,10 +122,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \

--- a/ci/kokoro/install/Dockerfile.ubuntu-focal
+++ b/ci/kokoro/install/Dockerfile.ubuntu-focal
@@ -24,9 +24,9 @@ ARG NCPU=4
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev libssl-dev m4 \
-        make pkg-config tar wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev \
+        libssl-dev m4 make pkg-config tar wget zlib1g-dev
 # ```
 
 # #### Abseil

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -33,10 +33,9 @@ RUN apt-get update && \
 # We need a recent version of Abseil.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+WORKDIR /var/tmp/build/abseil
+RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -55,15 +54,14 @@ RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
 # Google Cloud Platform proto files:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+WORKDIR /var/tmp/build/protobuf
+RUN curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -75,10 +73,9 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
 # distributes c-ares-1.10. Manually install a newer version:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+WORKDIR /var/tmp/build/c-ares
+RUN curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
     make install && \
     ldconfig
@@ -89,10 +86,9 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 # We need a newer version of RE2 than the system package provides.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+WORKDIR /var/tmp/build/re2
+RUN curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -108,10 +104,9 @@ RUN wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
 # Cloud Platform proto files. We can install gRPC from source using:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+WORKDIR /var/tmp/build/grpc
+RUN curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -134,10 +129,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
 # source:
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -158,10 +152,9 @@ RUN wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
 # This leaves your environment without support for CMake pkg-config.
 
 # ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+WORKDIR /var/tmp/build/json
+RUN curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i \
         -e '1s/VERSION 3.8/VERSION 3.5/' \
         -e '/^target_compile_features/d' \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -23,8 +23,8 @@ ARG NCPU=4
 # ```bash
 RUN apt-get update && \
     apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libcurl4-openssl-dev libssl-dev libtool m4 make \
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libcurl4-openssl-dev libssl-dev libtool m4 make \
         pkg-config tar wget zlib1g-dev
 # ```
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -317,9 +317,9 @@ workstation or build server.
 
 ```bash
 sudo zypper refresh && \
-sudo zypper install --allow-downgrade -y automake ccache cmake gcc gcc-c++ git \
-        gzip libcurl-devel libopenssl-devel libtool make re2-devel tar wget \
-        which zlib zlib-devel-static
+sudo zypper install --allow-downgrade -y automake ccache cmake curl \
+        gcc gcc-c++ git gzip libcurl-devel libopenssl-devel \
+        libtool make re2-devel tar wget which zlib zlib-devel-static
 ```
 
 The following steps will install libraries and tools in `/usr/local`. openSUSE
@@ -475,9 +475,9 @@ Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev libssl-dev m4 \
-        make pkg-config tar wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libre2-dev \
+        libssl-dev m4 make pkg-config tar wget zlib1g-dev
 ```
 
 #### Abseil
@@ -607,9 +607,9 @@ Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
-        pkg-config tar wget zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 \
+        make pkg-config tar wget zlib1g-dev
 ```
 
 #### Abseil
@@ -756,8 +756,8 @@ Install the minimal development tools, OpenSSL and libcurl:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libcurl4-openssl-dev libssl-dev libtool m4 make \
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libcurl4-openssl-dev libssl-dev libtool m4 make \
         pkg-config tar wget zlib1g-dev
 ```
 
@@ -923,9 +923,9 @@ Install the minimal development tools, libcurl, and OpenSSL:
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ca-certificates ccache cmake git gcc g++ \
-        libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 make \
-        pkg-config tar wget zlib1g-dev
+        automake build-essential ca-certificates ccache cmake curl git \
+        gcc g++ libc-ares-dev libc-ares2 libcurl4-openssl-dev libssl-dev m4 \
+        make pkg-config tar wget zlib1g-dev
 ```
 
 Debian 10 includes versions of gRPC and Protobuf that support the
@@ -1027,9 +1027,9 @@ prevent you from compiling against openssl-1.1.0.
 ```bash
 sudo apt-get update && \
 sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
-        automake build-essential ccache cmake ca-certificates git gcc g++ \
-        libcurl4-openssl-dev libssl1.0-dev libtool make m4 pkg-config tar wget \
-        zlib1g-dev
+        automake build-essential ccache cmake ca-certificates curl git \
+        gcc g++ libcurl4-openssl-dev libssl1.0-dev libtool make m4 pkg-config \
+        tar wget zlib1g-dev
 ```
 
 #### Abseil

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -237,10 +237,9 @@ export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -259,10 +258,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -283,10 +281,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -341,10 +338,9 @@ export PATH=/usr/local/bin:${PATH}
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -363,15 +359,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -383,10 +378,9 @@ Recent versions of gRPC require c-ares >= 1.11, while openSUSE/Leap
 distributes c-ares-1.9. Manually install a newer version:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+mkdir -p $HOME/Downloads/c-ares && cd $HOME/Downloads/c-ares
+curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig
@@ -398,10 +392,9 @@ We also need a version of gRPC that is recent enough to support the Google
 Cloud Platform proto files. We manually install it using:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -424,10 +417,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -448,10 +440,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -494,10 +485,9 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -516,15 +506,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -536,10 +525,9 @@ We also need a version of gRPC that is recent enough to support the Google
 Cloud Platform proto files. We install it using:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -562,10 +550,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -586,10 +573,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -631,10 +617,9 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -653,15 +638,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -672,10 +656,9 @@ sudo ldconfig
 We need a newer version of RE2 than the system package provides.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
+curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -691,10 +674,9 @@ We also need a version of gRPC that is recent enough to support the Google
 Cloud Platform proto files. We install it using:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -717,10 +699,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -741,10 +722,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -786,10 +766,9 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -808,15 +787,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -828,10 +806,9 @@ Recent versions of gRPC require c-ares >= 1.11, while Ubuntu-16.04
 distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+mkdir -p $HOME/Downloads/c-ares && cd $HOME/Downloads/c-ares
+curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig
@@ -842,10 +819,9 @@ sudo ldconfig
 We need a newer version of RE2 than the system package provides.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
+curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -861,10 +837,9 @@ We also need a version of gRPC that is recent enough to support the Google
 Cloud Platform proto files. We can install gRPC from source using:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -887,10 +862,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -911,10 +885,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i \
         -e '1s/VERSION 3.8/VERSION 3.5/' \
         -e '/^target_compile_features/d' \
@@ -969,10 +942,9 @@ sudo apt-get --no-install-recommends install -y libgrpc++-dev libprotobuf-dev \
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -991,10 +963,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -1015,10 +986,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -1067,10 +1037,9 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -1089,15 +1058,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1109,10 +1077,9 @@ Recent versions of gRPC require c-ares >= 1.13, while Debian Stretch
 distributes c-ares-1.12. Manually install a newer version:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+mkdir -p $HOME/Downloads/c-ares && cd $HOME/Downloads/c-ares
+curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig
@@ -1123,10 +1090,9 @@ sudo ldconfig
 We need a newer version of RE2 than the system package provides.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/re2/archive/2020-11-01.tar.gz && \
-    tar -xf 2020-11-01.tar.gz && \
-    cd re2-2020-11-01 && \
+mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
+curl -sSL https://github.com/google/re2/archive/2020-11-01.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DRE2_BUILD_TESTING=OFF \
@@ -1142,10 +1108,9 @@ To install gRPC we first need to configure pkg-config to find the version of
 Protobuf we just installed in `/usr/local`:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -1168,10 +1133,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -1192,10 +1156,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i \
         -e '1s/VERSION 3.8/VERSION 3.5/' \
         -e '/^target_compile_features/d' \
@@ -1254,10 +1217,9 @@ export PATH=/usr/local/bin:${PATH}
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -1276,15 +1238,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1296,10 +1257,9 @@ We also need a version of gRPC that is recent enough to support the Google
 Cloud Platform proto files. We manually install it using:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -1322,10 +1282,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -1346,10 +1305,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \
@@ -1416,10 +1374,9 @@ export PATH=/usr/local/bin:${PATH}
 We need a recent version of Abseil.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz && \
-    tar -xf 20200923.3.tar.gz && \
-    cd abseil-cpp-20200923.3 && \
+mkdir -p $HOME/Downloads/abseil && cd $HOME/Downloads/abseil
+curl -sSL https://github.com/abseil/abseil-cpp/archive/20200923.3.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -1438,15 +1395,14 @@ We need to install a version of Protobuf that is recent enough to support the
 Google Cloud Platform proto files:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/protobuf/archive/v3.14.0.tar.gz && \
-    tar -xf v3.14.0.tar.gz && \
-    cd protobuf-3.14.0/cmake && \
+mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
+curl -sSL https://github.com/google/protobuf/archive/v3.14.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
         -Dprotobuf_BUILD_TESTS=OFF \
-        -H. -Bcmake-out && \
+        -Hcmake -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1458,10 +1414,9 @@ Recent versions of gRPC require c-ares >= 1.11, while CentOS-7
 distributes c-ares-1.10. Manually install a newer version:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
-    tar -xf cares-1_14_0.tar.gz && \
-    cd c-ares-cares-1_14_0 && \
+mkdir -p $HOME/Downloads/c-ares && cd $HOME/Downloads/c-ares
+curl -sSL https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     ./buildconf && ./configure && make -j ${NCPU:-4} && \
 sudo make install && \
 sudo ldconfig
@@ -1473,10 +1428,9 @@ We also need a version of gRPC that is recent enough to support the Google
 Cloud Platform proto files. We manually install it using:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/v1.35.0.tar.gz && \
-    tar -xf v1.35.0.tar.gz && \
-    cd grpc-1.35.0 && \
+mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
+curl -sSL https://github.com/grpc/grpc/archive/v1.35.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DgRPC_INSTALL=ON \
@@ -1499,10 +1453,9 @@ The project depends on the Crc32c library, we need to compile this from
 source:
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/crc32c/archive/1.1.0.tar.gz && \
-    tar -xf 1.1.0.tar.gz && \
-    cd crc32c-1.1.0 && \
+mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
+curl -sSL https://github.com/google/crc32c/archive/1.1.0.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=yes \
@@ -1523,10 +1476,9 @@ Note that this is a header-only library, and often installed manually.
 This leaves your environment without support for CMake pkg-config.
 
 ```bash
-cd $HOME/Downloads
-wget -q https://github.com/nlohmann/json/archive/v3.9.0.tar.gz && \
-    tar -xzf v3.9.0.tar.gz && \
-    cd json-3.9.0 && \
+mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
+curl -sSL https://github.com/nlohmann/json/archive/v3.9.1.tar.gz | \
+    tar -xzf - --strip-components=1 && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=yes \


### PR DESCRIPTION
I neglected these Dockefiles in my similar PR for `ci/cloudbuild`
because they are going to be retired "soon". However, we will need to
update the `doc/packaging.md` file at that time, and will need to update
the scripts to generate this document too. Seems easier to do now while
the changes are fresh in my mind.

Part of the work for #6346

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6379)
<!-- Reviewable:end -->
