### PR TITLE
cleanup: remove support for dynamic access token

### DIFF
--- a/google/cloud/internal/credentials.cc
+++ b/google/cloud/internal/credentials.cc
@@ -33,14 +33,7 @@ std::shared_ptr<Credentials> MakeGoogleDefaultCredentials() {
 std::shared_ptr<Credentials> MakeAccessTokenCredentials(
     std::string const& access_token,
     std::chrono::system_clock::time_point expiration) {
-  return MakeDynamicAccessTokenCredentials([access_token, expiration] {
-    return AccessToken{access_token, expiration};
-  });
-}
-
-std::shared_ptr<Credentials> MakeDynamicAccessTokenCredentials(
-    AccessTokenSource source) {
-  return std::make_shared<DynamicAccessTokenConfig>(std::move(source));
+  return std::make_shared<AccessTokenConfig>(access_token, expiration);
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_access_token_authentication.h
+++ b/google/cloud/internal/grpc_access_token_authentication.h
@@ -26,8 +26,8 @@ namespace internal {
 
 class GrpcAccessTokenAuthentication : public GrpcAuthenticationStrategy {
  public:
-  explicit GrpcAccessTokenAuthentication(AccessTokenSource source)
-      : source_(std::move(source)) {}
+  explicit GrpcAccessTokenAuthentication(AccessToken const& access_token)
+      : credentials_(grpc::AccessTokenCredentials(access_token.token)) {}
   ~GrpcAccessTokenAuthentication() override = default;
 
   std::shared_ptr<grpc::Channel> CreateChannel(
@@ -36,12 +36,7 @@ class GrpcAccessTokenAuthentication : public GrpcAuthenticationStrategy {
   Status ConfigureContext(grpc::ClientContext&) override;
 
  private:
-  AccessTokenSource source_;
-  std::mutex mu_;
   std::shared_ptr<grpc::CallCredentials> credentials_;
-  std::chrono::system_clock::time_point expiration_;
-  bool refreshing_ = false;
-  std::condition_variable cv_;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -33,8 +33,9 @@ std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
       result = absl::make_unique<GrpcChannelCredentialsAuthentication>(
           grpc::GoogleDefaultCredentials());
     }
-    void visit(DynamicAccessTokenConfig& cfg) override {
-      result = absl::make_unique<GrpcAccessTokenAuthentication>(cfg.source());
+    void visit(AccessTokenConfig& cfg) override {
+      result =
+          absl::make_unique<GrpcAccessTokenAuthentication>(cfg.access_token());
     }
   } visitor;
 

--- a/google/cloud/storage/internal/access_token_credentials.cc
+++ b/google/cloud/storage/internal/access_token_credentials.cc
@@ -20,28 +20,11 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
-auto constexpr kExpirationSlack = std::chrono::minutes(5);
+AccessTokenCredentials::AccessTokenCredentials(
+    google::cloud::internal::AccessToken const& access_token)
+    : header_("Authorization: Bearer " + access_token.token) {}
 
 StatusOr<std::string> AccessTokenCredentials::AuthorizationHeader() {
-  std::unique_lock<std::mutex> lk(mu_);
-  auto const deadline = std::chrono::system_clock::now() + kExpirationSlack;
-  cv_.wait(lk, [this] { return !refreshing_; });
-  if (deadline < expiration_) return header_;
-  // The access token has expired, or is about to expire, refresh it.
-  // Avoid deadlocks by releasing the lock before calling any external function.
-  refreshing_ = true;
-  lk.unlock();
-  auto refresh = source_();
-  lk.lock();
-  refreshing_ = false;
-  if (!refresh) {
-    expiration_ = {};  // failure to get a token is not cacheable
-    header_ = std::move(refresh).status();
-  } else {
-    expiration_ = refresh->expiration;
-    header_ = "Authorization: Bearer " + refresh->token;
-  }
-  cv_.notify_all();
   return header_;
 }
 

--- a/google/cloud/storage/internal/access_token_credentials.h
+++ b/google/cloud/storage/internal/access_token_credentials.h
@@ -33,18 +33,12 @@ namespace internal {
 class AccessTokenCredentials : public oauth2::Credentials {
  public:
   explicit AccessTokenCredentials(
-      google::cloud::internal::AccessTokenSource source)
-      : source_(std::move(source)) {}
+      google::cloud::internal::AccessToken const& access_token);
 
   StatusOr<std::string> AuthorizationHeader() override;
 
  private:
-  google::cloud::internal::AccessTokenSource source_;
-  std::mutex mu_;
-  StatusOr<std::string> header_;
-  std::chrono::system_clock::time_point expiration_;
-  bool refreshing_ = false;
-  std::condition_variable cv_;
+  std::string header_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/access_token_credentials_test.cc
+++ b/google/cloud/storage/internal/access_token_credentials_test.cc
@@ -24,39 +24,12 @@ namespace internal {
 namespace {
 
 using ::google::cloud::internal::AccessToken;
-using ::google::cloud::testing_util::StatusIs;
-using ::testing::Return;
 
 TEST(AccessTokenCredentials, Simple) {
-  ::testing::MockFunction<AccessToken()> mock_source;
   auto const expiration =
       std::chrono::system_clock::now() - std::chrono::minutes(10);
-  EXPECT_CALL(mock_source, Call)
-      .WillOnce(Return(AccessToken{"token1", expiration}))
-      .WillOnce(Return(AccessToken{"token2", expiration}))
-      .WillOnce(Return(AccessToken{"token3", expiration}));
 
-  AccessTokenCredentials tested(mock_source.AsStdFunction());
-  EXPECT_EQ("Authorization: Bearer token1",
-            tested.AuthorizationHeader().value());
-  EXPECT_EQ("Authorization: Bearer token2",
-            tested.AuthorizationHeader().value());
-  EXPECT_EQ("Authorization: Bearer token3",
-            tested.AuthorizationHeader().value());
-}
-
-TEST(AccessTokenCredentials, NotExpired) {
-  ::testing::MockFunction<StatusOr<AccessToken>()> mock_source;
-  auto const expiration =
-      std::chrono::system_clock::now() + std::chrono::minutes(10);
-  EXPECT_CALL(mock_source, Call)
-      .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce(Return(AccessToken{"token1", expiration}));
-
-  AccessTokenCredentials tested(mock_source.AsStdFunction());
-  EXPECT_THAT(tested.AuthorizationHeader(), StatusIs(StatusCode::kUnavailable));
-  EXPECT_EQ("Authorization: Bearer token1",
-            tested.AuthorizationHeader().value());
+  AccessTokenCredentials tested(AccessToken{"token1", expiration});
   EXPECT_EQ("Authorization: Bearer token1",
             tested.AuthorizationHeader().value());
   EXPECT_EQ("Authorization: Bearer token1",

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -23,8 +23,8 @@ namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 
+using google::cloud::internal::AccessTokenConfig;
 using google::cloud::internal::CredentialsVisitor;
-using google::cloud::internal::DynamicAccessTokenConfig;
 using google::cloud::internal::GoogleDefaultCredentialsConfig;
 
 std::shared_ptr<oauth2::Credentials> MapCredentials(
@@ -42,8 +42,8 @@ std::shared_ptr<oauth2::Credentials> MapCredentials(
       result =
           std::make_shared<ErrorCredentials>(std::move(credentials).status());
     }
-    void visit(DynamicAccessTokenConfig& config) override {
-      result = std::make_shared<AccessTokenCredentials>(config.source());
+    void visit(AccessTokenConfig& config) override {
+      result = std::make_shared<AccessTokenCredentials>(config.access_token());
     }
   } visitor;
 

--- a/google/cloud/storage/internal/unified_rest_credentials_test.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials_test.cc
@@ -30,12 +30,10 @@ inline namespace STORAGE_CLIENT_NS {
 namespace internal {
 namespace {
 
-using google::cloud::internal::AccessToken;
-using google::cloud::internal::MakeDynamicAccessTokenCredentials;
+using google::cloud::internal::MakeAccessTokenCredentials;
 using google::cloud::internal::MakeGoogleDefaultCredentials;
 using google::cloud::testing_util::IsOk;
 using google::cloud::testing_util::ScopedEnvironment;
-using ::testing::Return;
 
 class UnifiedRestCredentialsTest : public ::testing::Test {
  public:
@@ -53,17 +51,9 @@ class UnifiedRestCredentialsTest : public ::testing::Test {
 };
 
 TEST_F(UnifiedRestCredentialsTest, AccessToken) {
-  ::testing::MockFunction<AccessToken()> mock_source;
-  auto const expiration =
-      std::chrono::system_clock::now() - std::chrono::minutes(10);
-  EXPECT_CALL(mock_source, Call)
-      .WillOnce(Return(AccessToken{"token1", expiration}))
-      .WillOnce(Return(AccessToken{"token2", expiration}))
-      .WillOnce(Return(AccessToken{"token3", expiration}));
-
   auto credentials = MapCredentials(
-      MakeDynamicAccessTokenCredentials(mock_source.AsStdFunction()));
-  for (std::string expected : {"token1", "token2", "token3"}) {
+      MakeAccessTokenCredentials("token1", std::chrono::system_clock::now()));
+  for (std::string expected : {"token1", "token1", "token1"}) {
     auto header = credentials->AuthorizationHeader();
     ASSERT_THAT(header, IsOk());
     EXPECT_EQ("Authorization: Bearer " + expected, *header);

--- a/google/cloud/storage/tests/unified_credentials_integration_test.cc
+++ b/google/cloud/storage/tests/unified_credentials_integration_test.cc
@@ -100,7 +100,7 @@ TEST_P(UnifiedCredentialsIntegrationTest, AccessTokenSource) {
   if (UsingEmulator()) GTEST_SKIP();
   // First use the default credentials to obtain an access token, then use the
   // access token to test the DynamicAccessTokenCredentials() function. In a
-  // real application one would feat access tokens from something more
+  // real application one would fetch access tokens from something more
   // interesting, like the IAM credentials service. This is just a reasonably
   // easy way to get a working access token for the test.
   auto default_credentials = oauth2::GoogleDefaultCredentials();


### PR DESCRIPTION
I think adding `DynamicAccessTokenCredentials` was premature, maybe
we will need something like it later, but it seems that for credentials that
create access tokens dynamically the APIs needed by gRPC and REST
are simply too different.

Part of the work for #6310

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6387)
<!-- Reviewable:end -->
