### PR TITLE
feat(common): support asynchronous RPCs in GrpcAuthenticationStrategy

### DIFF
--- a/google/cloud/internal/grpc_access_token_authentication.cc
+++ b/google/cloud/internal/grpc_access_token_authentication.cc
@@ -26,10 +26,21 @@ std::shared_ptr<grpc::Channel> GrpcAccessTokenAuthentication::CreateChannel(
   return grpc::CreateCustomChannel(endpoint, credentials, arguments);
 }
 
+bool GrpcAccessTokenAuthentication::RequiresConfigureContext() const {
+  return true;
+}
+
 Status GrpcAccessTokenAuthentication::ConfigureContext(
     grpc::ClientContext& context) {
   context.set_credentials(credentials_);
   return Status{};
+}
+
+future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
+GrpcAccessTokenAuthentication::AsyncConfigureContext(
+    std::unique_ptr<grpc::ClientContext> context) {
+  context->set_credentials(credentials_);
+  return make_ready_future(make_status_or(std::move(context)));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_access_token_authentication.h
+++ b/google/cloud/internal/grpc_access_token_authentication.h
@@ -33,7 +33,10 @@ class GrpcAccessTokenAuthentication : public GrpcAuthenticationStrategy {
   std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint,
       grpc::ChannelArguments const& arguments) override;
+  bool RequiresConfigureContext() const override;
   Status ConfigureContext(grpc::ClientContext&) override;
+  future<StatusOr<std::unique_ptr<grpc::ClientContext>>> AsyncConfigureContext(
+      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::shared_ptr<grpc::CallCredentials> credentials_;

--- a/google/cloud/internal/grpc_channel_credentials_authentication.cc
+++ b/google/cloud/internal/grpc_channel_credentials_authentication.cc
@@ -25,9 +25,19 @@ GrpcChannelCredentialsAuthentication::CreateChannel(
   return grpc::CreateCustomChannel(endpoint, credentials_, arguments);
 }
 
+bool GrpcChannelCredentialsAuthentication::RequiresConfigureContext() const {
+  return false;
+}
+
 Status GrpcChannelCredentialsAuthentication::ConfigureContext(
     grpc::ClientContext&) {
   return Status{};
+}
+
+future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
+GrpcChannelCredentialsAuthentication::AsyncConfigureContext(
+    std::unique_ptr<grpc::ClientContext> context) {
+  return make_ready_future(make_status_or(std::move(context)));
 }
 
 }  // namespace internal

--- a/google/cloud/internal/grpc_channel_credentials_authentication.h
+++ b/google/cloud/internal/grpc_channel_credentials_authentication.h
@@ -34,7 +34,10 @@ class GrpcChannelCredentialsAuthentication : public GrpcAuthenticationStrategy {
   std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint,
       grpc::ChannelArguments const& arguments) override;
+  bool RequiresConfigureContext() const override;
   Status ConfigureContext(grpc::ClientContext&) override;
+  future<StatusOr<std::unique_ptr<grpc::ClientContext>>> AsyncConfigureContext(
+      std::unique_ptr<grpc::ClientContext> context) override;
 
  private:
   std::shared_ptr<grpc::ChannelCredentials> credentials_;

--- a/google/cloud/internal/unified_grpc_credentials.h
+++ b/google/cloud/internal/unified_grpc_credentials.h
@@ -34,11 +34,10 @@ class GrpcAuthenticationStrategy {
 
   virtual std::shared_ptr<grpc::Channel> CreateChannel(
       std::string const& endpoint, grpc::ChannelArguments const& arguments) = 0;
+  virtual bool RequiresConfigureContext() const = 0;
   virtual Status ConfigureContext(grpc::ClientContext& context) = 0;
-  // TODO(#6310) - support asynchronous refresh
-  //     virtual future<Status>
-  //     SetupAsync(std::unique_ptr<grpc::ClientContext>, CompletionQueue& cq) =
-  //     0;
+  virtual future<StatusOr<std::unique_ptr<grpc::ClientContext>>>
+  AsyncConfigureContext(std::unique_ptr<grpc::ClientContext> context) = 0;
 };
 
 std::unique_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(


### PR DESCRIPTION
Supporting asynchronous gRPC requests requires that fetching any
`grpc::CallCredentials` [1] asynchronously too, or the application would
experience blocking while starting the asynchronous RPC.

As an optimization I will introduce an optional `${service}Auth` layer,
analogous to `${service}Logging` or `${service}Metadata`, this is to
save the relatively expensive creation of a future when the type of
credentials do not require them.

This change does not include any integration tests, those will come
later as they require even more infrastructure.

Fixes #6310

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6391)
<!-- Reviewable:end -->
