### PR TITLE
ci: build with older versions of each dep

### DIFF
--- a/ci/cloudbuild/builds/cmake-deps.sh
+++ b/ci/cloudbuild/builds/cmake-deps.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+
+export CC=clang
+export CXX=clang++
+
+mkdir -p cmake-out
+if [[ ! -d cmake-out/vcpkg ]]; then
+  git -C cmake-out clone https://github.com/microsoft/vcpkg.git
+fi
+VCPKG_ROOT="$(pwd)/cmake-out/vcpkg"
+cmake -GNinja -S . -B cmake-out/build \
+  "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+  "-DVCPKG_MANIFEST_DIR=ci/etc/oldest-deps" \
+  "-DVCPKG_FEATURE_FLAGS=versions,manifest"
+cmake --build cmake-out/build
+env -C cmake-out/build ctest -LE "integration-test" --parallel "$(nproc)"
+
+integration::ctest_with_emulators "cmake-out/build"

--- a/ci/cloudbuild/builds/cmake-oldest-deps.sh
+++ b/ci/cloudbuild/builds/cmake-oldest-deps.sh
@@ -23,13 +23,12 @@ source module ci/cloudbuild/builds/lib/integration.sh
 export CC=clang
 export CXX=clang++
 
-mkdir -p cmake-out
 if [[ ! -d cmake-out/vcpkg ]]; then
+  mkdir -p cmake-out
   git -C cmake-out clone https://github.com/microsoft/vcpkg.git
 fi
-VCPKG_ROOT="$(pwd)/cmake-out/vcpkg"
 cmake -GNinja -S . -B cmake-out/build \
-  "-DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+  "-DCMAKE_TOOLCHAIN_FILE=${PROJECT_ROOT}/cmake-out/vcpkg/scripts/buildsystems/vcpkg.cmake" \
   "-DVCPKG_MANIFEST_DIR=ci/etc/oldest-deps" \
   "-DVCPKG_FEATURE_FLAGS=versions,manifest"
 cmake --build cmake-out/build

--- a/ci/cloudbuild/dockerfiles/fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora.Dockerfile
@@ -26,7 +26,7 @@ RUN dnf makecache && \
         grpc-devel grpc-plugins lcov libcxx-devel libcxxabi-devel \
         libasan libubsan libtsan libcurl-devel make ninja-build npm \
         openssl-devel pkgconfig protobuf-compiler python  python3.8 \
-        python-pip ShellCheck tar unzip w3m wget which zlib-devel
+        python-pip ShellCheck tar unzip w3m wget which zip zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell
 # inside the container with `su -` and no password. Sudo would not work because

--- a/ci/cloudbuild/triggers/cmake-oldest-deps-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-oldest-deps-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: cmake-oldest-deps-ci
+substitutions:
+  _BUILD_NAME: cmake-oldest-deps
+  _DISTRO: fedora
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/cmake-oldest-deps-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-oldest-deps-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: cmake-oldest-deps-pr
+substitutions:
+  _BUILD_NAME: cmake-oldest-deps
+  _DISTRO: fedora
+  _TRIGGER_TYPE: pr
+tags:
+- pr

--- a/ci/etc/oldest-deps/vcpkg.json
+++ b/ci/etc/oldest-deps/vcpkg.json
@@ -1,0 +1,35 @@
+{
+    "name": "google-cloud-cpp",
+    "version": "1.27.0",
+    "description": "C++ Client Libraries for Google Cloud Platform APIs.",
+    "homepage": "https://github.com/googleapis/google-cloud-cpp",
+    "license": "Apache-2.0",
+    "supports": "!uwp",
+    "$TODO": "move `gtest` and `benchmark` to dev-dependencies",
+    "builtin-baseline": "6d9ed568117dd958c543b3ab8d3ed692965cac34",
+    "dependencies": [
+      {"name": "abseil", "version>=": "2020-09-23#3"},
+      {"name": "crc32c", "version>=": "1.1.1"},
+      {
+        "name": "curl",
+        "features": [
+          "ssl"
+        ]
+      },
+      {
+        "name": "grpc",
+        "version>=": "1.33.1",
+        "host": true
+      },
+      {
+        "name": "protobuf",
+        "version>=": "3.14.0",
+        "host": true
+      },
+      {"name": "grpc", "version>=": "1.33.1"},
+      {"name": "protobuf", "version>=": "3.14.0"},
+      {"name": "nlohmann-json", "version>=": "3.9.1"},
+      "benchmark",
+      "gtest"
+    ]
+  }


### PR DESCRIPTION
This build compiles with older versions of each dependency. Its only
purpose is to verify compilation (and basic testing), so we only run
this in one platform. I used vcpkg to fetch the older versions of the
deps, including their dependencies at the time.

The only magic number is the `vcpkg` baseline, which is obtained by
looking at the history of:

https://github.com/microsoft/vcpkg/blob/master/versions/baseline.json

and finding the commit that has all the versions we want. In this build
vcpkg reports:

```
    abseil[core]:x64-linux -> 2020-09-23#3
    benchmark[core]:x64-linux -> 1.5.2
    c-ares[core]:x64-linux -> 1.17.1
    crc32c[core]:x64-linux -> 1.1.1
    curl[core,non-http,openssl,ssl]:x64-linux -> 7.74.0#3
    grpc[core]:x64-linux -> 1.33.1#3
    gtest[core]:x64-linux -> 1.10.0#4
    nlohmann-json[core]:x64-linux -> 3.9.1
    openssl[core]:x64-linux -> 1.1.1j
    protobuf[core]:x64-linux -> 3.14.0#3
    re2[core]:x64-linux -> 2020-10-01
    upb[core]:x64-linux -> 2020-08-19
    zlib[core]:x64-linux -> 1.2.11#9
```

Fixes #6395 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6393)
<!-- Reviewable:end -->
