### PR TITLE
test: avoid overwhelming the emulator

### DIFF
--- a/google/cloud/storage/tests/object_file_multi_threaded_test.cc
+++ b/google/cloud/storage/tests/object_file_multi_threaded_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
+#include <algorithm>
 #include <cstdio>
 #include <fstream>
 #include <future>
@@ -47,7 +48,7 @@ class ObjectFileMultiThreadedTest
   static int ThreadCount() {
     static int const kCount = [] {
       auto c = static_cast<int>(std::thread::hardware_concurrency());
-      return c == 0 ? 4 : 4 * c;
+      return (std::max)(c / 2, 8);
     }();
     return kCount;
   }

--- a/google/cloud/storage/tools/run_emulator_utils.sh
+++ b/google/cloud/storage/tools/run_emulator_utils.sh
@@ -61,7 +61,7 @@ start_emulator() {
 
   gunicorn --bind "0.0.0.0:${port}" \
     --worker-class sync \
-    --threads 10 \
+    --threads "$(nproc)" \
     --access-logfile - \
     --chdir "${PROJECT_ROOT}/google/cloud/storage/emulator" \
     "emulator:run()" \


### PR DESCRIPTION
The emulator was running with only 10 threads. This does not seem like
enough on CI machines with 32 cores, where the 60-odd integration tests
run in parallel, and some of these integration tests ran 128 threads.

I also reduced the number of parallel threads in the
object_file_multi_threaded_test.cc, it just seemed like too many threads
now that the machines are much larger.

I think this fixes #6399

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6403)
<!-- Reviewable:end -->
