### PR TITLE
ci(gcb): add patch to cloudbuild docker images

### DIFF
--- a/ci/cloudbuild/dockerfiles/fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora.Dockerfile
@@ -25,7 +25,7 @@ RUN dnf makecache && \
         cmake diffutils doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins lcov libcxx-devel libcxxabi-devel \
         libasan libubsan libtsan libcurl-devel make ninja-build npm \
-        openssl-devel pkgconfig protobuf-compiler python  python3.8 \
+        openssl-devel patch pkgconfig protobuf-compiler python python3.8 \
         python-pip ShellCheck tar unzip w3m wget which zip zlib-devel
 
 # Sets root's password to the empty string to enable users to get a root shell

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic.Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && \
         lsb-release \
         make \
         ninja-build \
+        patch \
         pkg-config \
         python3 \
         python3-dev \

--- a/ci/cloudbuild/dockerfiles/ubuntu-xenial.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-xenial.Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
         lsb-release \
         make \
         ninja-build \
+        patch \
         pkg-config \
         python3 \
         python3-dev \

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -168,7 +168,10 @@ ExternalProject_Add(
         ""
         # ~~~
         # Scaffolding for patching googleapis after download. For example:
-        #   PATCH_COMMAND patch -p1 --input=/v/external/googleapis.patch
+        #   PATCH_COMMAND
+        #       patch
+        #       -p1
+        #       --input=/workspace/external/googleapis.patch
         # NOTE: This should only be used while developing with a new
         # protobuf message. No changes to `PATCH_COMMAND` should ever be
         # committed to the main branch.


### PR DESCRIPTION
Similar to #6104, where we added the "patch" binary to the kokoro
docker images to support patching of googleapis after download.

Also update the CMake `PATCH_COMMAND` example to reflect the new
cloudbuild mount point for `${PROJECT_ROOT}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6407)
<!-- Reviewable:end -->
