### PR TITLE
ci: fix mount point for gcloud config

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -259,7 +259,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--env=HOME=/h"
     # Makes the host's gcloud credentials visible inside the docker container,
     # which we need for integration tests.
-    "--volume=${HOME}/.config/gcloud:/h/.config/gcloud:ro,Z"
+    "--volume=${HOME}/.config/gcloud:/h/.config/gcloud:Z"
   )
   cmd=(ci/cloudbuild/build.sh --local "${BUILD_NAME}")
   if [[ "${SHELL_FLAG}" = "true" ]]; then


### PR DESCRIPTION
I suggested using a read-only mount, but one needs write permissions to
run the Pub/Sub emulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6413)
<!-- Reviewable:end -->
