### PR TITLE
ci: rename check-abi -> check-api

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -58,7 +58,7 @@ libraries=(
 echo "${libraries[@]}" | xargs -P "$(nproc)" -n 1 \
   bash -c "dump_abi \$0 ${INSTALL_PREFIX}"
 
-# A count of the number of libraries that fail the abi compliance check.
+# A count of the number of libraries that fail the api compliance check.
 # This will become the script's exit code.
 errors=0
 

--- a/ci/cloudbuild/triggers/check-api-ci.yaml
+++ b/ci/cloudbuild/triggers/check-api-ci.yaml
@@ -4,9 +4,9 @@ github:
   owner: googleapis
   push:
     branch: ^(master|main|v\d+\..*)$
-name: check-abi-ci
+name: check-api-ci
 substitutions:
-  _BUILD_NAME: check-abi
+  _BUILD_NAME: check-api
   _DISTRO: fedora
   _TRIGGER_TYPE: ci
 tags:

--- a/ci/cloudbuild/triggers/check-api-pr.yaml
+++ b/ci/cloudbuild/triggers/check-api-pr.yaml
@@ -5,9 +5,9 @@ github:
   pullRequest:
     branch: ^(master|main|v\d+\..*)$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: check-abi-pr
+name: check-api-pr
 substitutions:
-  _BUILD_NAME: check-abi
+  _BUILD_NAME: check-api
   _DISTRO: fedora
   _TRIGGER_TYPE: pr
 tags:

--- a/release/README.md
+++ b/release/README.md
@@ -22,12 +22,12 @@ master.
 
 ### Update the API baseline
 
-Run the `check-abi` build to update the API baseline. Once you cut the release
+Run the `check-api` build to update the API baseline. Once you cut the release
 any new APIs are, well, released, and we should think carefully about removing
 them.
 
 ```bash
-./ci/cloudbuild/build.sh -t check-abi-pr --docker
+./ci/cloudbuild/build.sh -t check-api-pr --docker
 ```
 
 The updated ABI dump files will be left in the `ci/test-abi` folder.


### PR DESCRIPTION

Note that some places I left a**b**i in the name. For example, the dump
files are really a**b**i dump files, even though we're only using them
to check for a**p**i compliance. But this rename better reflects what
we're actually trying to test with this build: that our source-level
a**p**i isn't broken.

If this mixed a**b**i vs a**p**i naming seems too confusing, I'd be
happy to drop this PR and keep the old a**b**i naming. Possibly even go
all the way the other direction toward a**p**i would be OK too, if
someone else preferred that naming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6422)
<!-- Reviewable:end -->
