### PR TITLE
fix(storage): ignore SIGPIPE with more libraries

### DIFF
--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -202,8 +202,15 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
   //    https://curl.haxx.se/libcurl/c/threadsafe.html
   // Only these library prefixes require special configuration for using safely
   // with multiple threads.
-  return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 ||
-          curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
+  char const* const require_locking_ssl_ids[] = {
+      "NSS/3",
+      "OpenSSL/1.0",
+      "OpenSSL 1.0",
+      "LibreSSL/2",
+  };
+  return std::any_of(
+      std::begin(require_locking_ssl_ids), std::end(require_locking_ssl_ids),
+      [&curl_ssl_id](char const* id) { return curl_ssl_id.rfind(id, 0) == 0; });
 }
 
 bool SslLockingCallbacksInstalled() {


### PR DESCRIPTION
With some OpenSSL versions we need to ignore SIGPIPE signals. The
detection for this was missing NSS/3, which is (apprently) the default
in CentOS/RHEL 7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6426)
<!-- Reviewable:end -->
