### PR TITLE
feat(common): credentials for service account impersonation

### DIFF
--- a/google/cloud/internal/credentials.cc
+++ b/google/cloud/internal/credentials.cc
@@ -43,9 +43,8 @@ MakeImpersonateServiceAccountCredentials(
   opts = MergeOptions(
       std::move(opts),
       Options{}
-          .set<LifetimeOption>(std::chrono::seconds(std::chrono::hours(1)))
           .set<ScopesOption>({"https://www.googleapis.com/auth/cloud-platform"})
-          .set<DelegatesOption>({}));
+          .set<LifetimeOption>(std::chrono::seconds(std::chrono::hours(1))));
   return std::make_shared<ImpersonateServiceAccountConfig>(
       std::move(base_credentials), std::move(target_service_account),
       std::move(opts));

--- a/google/cloud/internal/credentials.cc
+++ b/google/cloud/internal/credentials.cc
@@ -36,6 +36,30 @@ std::shared_ptr<Credentials> MakeAccessTokenCredentials(
   return std::make_shared<AccessTokenConfig>(access_token, expiration);
 }
 
+std::shared_ptr<ImpersonateServiceAccountConfig>
+MakeImpersonateServiceAccountCredentials(
+    std::shared_ptr<Credentials> base_credentials,
+    std::string target_service_account, Options opts) {
+  opts = MergeOptions(
+      std::move(opts),
+      Options{}
+          .set<LifetimeOption>(std::chrono::seconds(std::chrono::hours(1)))
+          .set<ScopesOption>({"https://www.googleapis.com/auth/cloud-platform"})
+          .set<DelegatesOption>({}));
+  return std::make_shared<ImpersonateServiceAccountConfig>(
+      std::move(base_credentials), std::move(target_service_account),
+      std::move(opts));
+}
+
+ImpersonateServiceAccountConfig::ImpersonateServiceAccountConfig(
+    std::shared_ptr<Credentials> base_credentials,
+    std::string target_service_account, Options opts)
+    : base_credentials_(std::move(base_credentials)),
+      target_service_account_(std::move(target_service_account)),
+      lifetime_(opts.get<LifetimeOption>()),
+      scopes_(std::move(opts.lookup<ScopesOption>())),
+      delegates_(std::move(opts.lookup<DelegatesOption>())) {}
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/grpc_impersonate_service_account.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account.cc
@@ -29,16 +29,16 @@ using ::google::iam::credentials::v1::GenerateAccessTokenResponse;
 AsyncAccessTokenSource MakeSource(ImpersonateServiceAccountConfig const& config,
                                   Options const& options) {
   auto stub = MakeMinimalIamCredentialsStub(
-      CreateAuthenticationStrategy(config.credentials),
+      CreateAuthenticationStrategy(config.base_credentials()),
       MakeMinimalIamCredentialsOptions(options));
 
   GenerateAccessTokenRequest request;
   request.set_name("projects/-/serviceAccounts/" +
-                   config.target_service_account);
-  *request.mutable_delegates() = {config.delegates.begin(),
-                                  config.delegates.end()};
-  *request.mutable_scope() = {config.scopes.begin(), config.scopes.end()};
-  request.mutable_lifetime()->set_seconds(config.lifetime.count());
+                   config.target_service_account());
+  *request.mutable_delegates() = {config.delegates().begin(),
+                                  config.delegates().end()};
+  *request.mutable_scope() = {config.scopes().begin(), config.scopes().end()};
+  request.mutable_lifetime()->set_seconds(config.lifetime().count());
 
   return [stub, request](CompletionQueue& cq) {
     return stub

--- a/google/cloud/internal/grpc_impersonate_service_account.h
+++ b/google/cloud/internal/grpc_impersonate_service_account.h
@@ -32,14 +32,6 @@ namespace internal {
 
 class MinimalIamCredentialsStub;
 
-struct ImpersonateServiceAccountConfig {
-  std::shared_ptr<Credentials> credentials;
-  std::string target_service_account;
-  std::chrono::seconds lifetime;
-  std::vector<std::string> scopes;
-  std::vector<std::string> delegates;
-};
-
 class GrpcImpersonateServiceAccount
     : public GrpcAuthenticationStrategy,
       public std::enable_shared_from_this<GrpcImpersonateServiceAccount> {

--- a/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
+++ b/google/cloud/internal/grpc_impersonate_service_account_integration_test.cc
@@ -196,15 +196,11 @@ std::shared_ptr<TestStub> MakeTestStub(
 
 TEST_F(GrpcImpersonateServiceAccountIntegrationTest, BlockingCallWithToken) {
   AutomaticallyCreatedBackgroundThreads background;
-  ImpersonateServiceAccountConfig config{
-      /*.credentials=*/MakeGoogleDefaultCredentials(),
-      /*.target_service_account=*/iam_service_account(),
-      /*.lifetime=*/std::chrono::seconds(std::chrono::minutes(15)),
-      /*.scopes=*/{"https://www.googleapis.com/auth/bigtable.admin"},
-      /*.delegates=*/{},
-  };
+  auto config = MakeImpersonateServiceAccountCredentials(
+      MakeGoogleDefaultCredentials(), iam_service_account());
   auto under_test = GrpcImpersonateServiceAccount::Create(
-      background.cq(), config, Options{}.set<TracingComponentsOption>({"rpc"}));
+      background.cq(), *config,
+      Options{}.set<TracingComponentsOption>({"rpc"}));
 
   auto channel = under_test->CreateChannel("bigtableadmin.googleapis.com",
                                            grpc::ChannelArguments{});
@@ -237,15 +233,11 @@ TEST_F(GrpcImpersonateServiceAccountIntegrationTest, BlockingCallWithToken) {
 
 TEST_F(GrpcImpersonateServiceAccountIntegrationTest, AsyncCallWithToken) {
   AutomaticallyCreatedBackgroundThreads background;
-  ImpersonateServiceAccountConfig config{
-      /*.credentials=*/MakeGoogleDefaultCredentials(),
-      /*.target_service_account=*/iam_service_account(),
-      /*.lifetime=*/std::chrono::seconds(std::chrono::minutes(15)),
-      /*.scopes=*/{"https://www.googleapis.com/auth/bigtable.admin"},
-      /*.delegates=*/{},
-  };
+  auto config = MakeImpersonateServiceAccountCredentials(
+      MakeGoogleDefaultCredentials(), iam_service_account());
   auto under_test = GrpcImpersonateServiceAccount::Create(
-      background.cq(), config, Options{}.set<TracingComponentsOption>({"rpc"}));
+      background.cq(), *config,
+      Options{}.set<TracingComponentsOption>({"rpc"}));
 
   auto channel = under_test->CreateChannel("bigtableadmin.googleapis.com",
                                            grpc::ChannelArguments{});


### PR DESCRIPTION
This introduces a unified representation for service account
impersonation credentials. Service account impersonation credentials
allow a program to run with a given set of credentials (the base
credentials), but make RPCs using the credentials of a target service
account. This is often used to delegate billing to another service
account, or to support some forms of multi-tenancy.

Part of the changes for #6309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6429)
<!-- Reviewable:end -->
