### PR TITLE
ci: forward GOOGLE_CLOUD_* env to docker

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -263,6 +263,13 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     # which we need for integration tests.
     "--volume=${HOME}/.config/gcloud:/h/.config/gcloud:Z"
   )
+  # All GOOGLE_CLOUD_* env vars will be passed to the docker container.
+  for e in $(env); do
+    if [[ "${e}" = GOOGLE_CLOUD_* ]]; then
+      io::log_yellow "Exporting to docker environment: ${e}"
+      run_flags+=("--env=${e}")
+    fi
+  done
   cmd=(ci/cloudbuild/build.sh --local "${BUILD_NAME}")
   if [[ "${SHELL_FLAG}" = "true" ]]; then
     printf "To run the build manually:\n  "

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -73,6 +73,7 @@ function integration::bazel_args() {
     "--test_env=GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=${GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS:-}"
     "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}"
     "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT=${GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT}"
+    "--test_env=GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT=${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT:-}"
   )
 
   # Adds some special GCS flags that rely on keys that we copy out of a GCS bucket
@@ -145,8 +146,6 @@ function integration::bazel_with_emulators() {
   "./google/cloud/storage/ci/${EMULATOR_SCRIPT}" \
     bazel "${verb}" "${args[@]}"
 
-  # TODO(#6083): Add support for:
-  # - GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT
   io::log_h2 "Running Spanner integration tests"
   bazel "${verb}" "${args[@]}" --test_tag_filters=integration-test \
     google/cloud/spanner/...

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -69,6 +69,7 @@ function integration::bazel_args() {
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY=${GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY}"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE=${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME=${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
+
     # Spanner
     "--test_env=GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=${GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS:-}"
     "--test_env=GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID=${GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID}"

--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -34,8 +34,8 @@ namespace {
 // Sets basic defaults that apply to normal and admin connections.
 void SetBasicDefaults(Options& opts) {
   if (!opts.has<EndpointOption>()) {
-    auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
-    opts.set<EndpointOption>(env ? *env : "spanner.googleapis.com");
+    auto e = internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
+    opts.set<EndpointOption>(e && !e->empty() ? *e : "spanner.googleapis.com");
   }
   if (auto emulator = internal::GetEnv("SPANNER_EMULATOR_HOST")) {
     opts.set<EndpointOption>(*emulator).set<GrpcCredentialOption>(


### PR DESCRIPTION
Teaches `build.sh` to forward all `GOOGLE_CLOUD_*` environment variables to the docker container, which
allows us to set/override things in build scripts, such as `GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6431)
<!-- Reviewable:end -->
