### PR TITLE
chore: disable trusted-contribution-gcf comments

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,5 +1,3 @@
 annotations:
-  - type: comment
-    text: "/gcbrun"
   - type: label
     text: "kokoro:force-run"


### PR DESCRIPTION
The `trusted-contribution-gcf` robot can help start the Kokoro builds.
We thought it would help with GCB builds too, but it did not: GCB
ignores its comments. Until we get this working the comments are just
noise, so let's remove them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6434)
<!-- Reviewable:end -->
