### PR TITLE
fix(storage): missing implementation for constructor

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -271,8 +271,13 @@ class Client {
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit Client(std::shared_ptr<internal::RawClient> client,
                   Policies&&... policies)
-      : Client(InternalOnly{}, std::move(client),
-               std::forward<Policies>(policies)...) {
+      : Client(InternalOnlyNoDecorations{},
+               CreateDefaultInternalClient(
+                   internal::ApplyPolicies(
+                       internal::DefaultOptions(
+                           client->client_options().credentials()),
+                       std::forward<Policies>(policies)...),
+                   client)) {
   }
 
   /// Define a tag to disable automatic decorations of the RawClient.

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -173,6 +173,22 @@ TEST_F(ClientTest, LoggingDecorators) {
   ASSERT_TRUE(curl != nullptr);
 }
 
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+
+TEST_F(ClientTest, DeprecatedButNotDecommissioned) {
+  auto options = ClientOptions(oauth2::CreateAnonymousCredentials());
+  auto m1 = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*m1, client_options).WillRepeatedly(ReturnRef(options));
+
+  auto c1 = storage::Client(m1, Client::NoDecorations{});
+  EXPECT_EQ(c1.raw_client().get(), m1.get());
+
+  auto m2 = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*m2, client_options).WillRepeatedly(ReturnRef(options));
+  auto c2 = storage::Client(m2, LimitedErrorCountRetryPolicy(3));
+  EXPECT_NE(c2.raw_client().get(), m2.get());
+}
+
 }  // namespace
 }  // namespace STORAGE_CLIENT_NS
 }  // namespace storage


### PR DESCRIPTION
I deprecated some constructors (but did not remove them), carefully
change our code to not use them, but the implementation was broken.

Thanks to @devbww for noticing the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6439)
<!-- Reviewable:end -->
