### PR TITLE
chore: workaround for the vagaries of protobuf includes

### DIFF
--- a/google/cloud/internal/time_utils.h
+++ b/google/cloud/internal/time_utils.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/version.h"
 #include "absl/time/time.h"
+#include <google/protobuf/duration.pb.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <chrono>
 


### PR DESCRIPTION
Add an inclusion for `duration.pb.h` to an innocuous place.
This satisfies a forward declaration in a variety of the gRPC
protobufs for a downstream client.