### PR TITLE
test(storage): deflake integration test

### DIFF
--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -39,13 +39,13 @@ TEST(CurlDownloadRequestTest, SimpleStream) {
   // httpbin can generate up to 100 lines, do not try to download more than
   // that.
   constexpr int kDownloadedLines = 100;
-  CurlRequestBuilder request(
-      HttpBinEndpoint() + "/stream/" + std::to_string(kDownloadedLines),
-      storage::internal::GetDefaultCurlHandleFactory());
 
   std::size_t count = 0;
   auto download = [&] {
     count = 0;
+    CurlRequestBuilder request(
+        HttpBinEndpoint() + "/stream/" + std::to_string(kDownloadedLines),
+        storage::internal::GetDefaultCurlHandleFactory());
     auto download = request.BuildDownloadRequest(std::string{});
     char buffer[128 * 1024];
     do {


### PR DESCRIPTION
Seems like my first attempt to introduce a retry loop also introduced a
bug.

Fixes #5954

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6452)
<!-- Reviewable:end -->
