### PR TITLE
fix(storage): update emulator to use MultipartDecoder

### DIFF
--- a/google/cloud/storage/emulator/README.md
+++ b/google/cloud/storage/emulator/README.md
@@ -14,6 +14,14 @@ not as a general purpose emulator.
 pip install -r requirements.txt
 ```
 
+## Run Tests
+
+Tests use https://docs.python.org/3/library/unittest.html and can be ran using:
+
+```bash
+python -m unittest tests/test_*.py
+```
+
 ## Run Test Bench
 
 ### Emulator

--- a/google/cloud/storage/emulator/gcs/bucket.py
+++ b/google/cloud/storage/emulator/gcs/bucket.py
@@ -169,8 +169,8 @@ class Bucket:
                 )
             cls.__insert_predefined_acl(metadata, predefined_acl, context)
         if len(metadata.default_object_acl) == 0:
-            predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
-                request, context
+            predefined_default_object_acl = (
+                utils.acl.extract_predefined_default_object_acl(request, context)
             )
             if (
                 predefined_default_object_acl

--- a/google/cloud/storage/emulator/gcs/bucket.py
+++ b/google/cloud/storage/emulator/gcs/bucket.py
@@ -169,9 +169,9 @@ class Bucket:
                 )
             cls.__insert_predefined_acl(metadata, predefined_acl, context)
         if len(metadata.default_object_acl) == 0:
-            predefined_default_object_acl = (
-                utils.acl.extract_predefined_default_object_acl(request, context)
-            )
+            predefined_default_object_acl =  utils.acl.extract_predefined_default_object_acl(
+                request, context)
+
             if (
                 predefined_default_object_acl
                 == CommonEnums.PredefinedObjectAcl.PREDEFINED_OBJECT_ACL_UNSPECIFIED

--- a/google/cloud/storage/emulator/gcs/bucket.py
+++ b/google/cloud/storage/emulator/gcs/bucket.py
@@ -169,9 +169,9 @@ class Bucket:
                 )
             cls.__insert_predefined_acl(metadata, predefined_acl, context)
         if len(metadata.default_object_acl) == 0:
-            predefined_default_object_acl =  utils.acl.extract_predefined_default_object_acl(
-                request, context)
-
+            predefined_default_object_acl = utils.acl.extract_predefined_default_object_acl(
+                request, context
+            )
             if (
                 predefined_default_object_acl
                 == CommonEnums.PredefinedObjectAcl.PREDEFINED_OBJECT_ACL_UNSPECIFIED

--- a/google/cloud/storage/emulator/requirements.txt
+++ b/google/cloud/storage/emulator/requirements.txt
@@ -1,6 +1,7 @@
 git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
 flask==1.1.2
 httpbin==0.7.0
+requests-toolbelt==0.9.1
 scalpl==0.4.2
 crc32c==2.2
 gunicorn==20.1.0

--- a/google/cloud/storage/emulator/tests/test_gcs.py
+++ b/google/cloud/storage/emulator/tests/test_gcs.py
@@ -314,7 +314,7 @@ class TestObject(unittest.TestCase):
         request = utils.common.FakeRequest(
             args={},
             headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
-            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n{"name": "object", "metadata": {"key": "value"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n123456789\r\n--foo_bar_baz--\r\n',
+            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{"name": "object", "metadata": {"key": "value"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n\r\n123456789\r\n--foo_bar_baz--\r\n',
             environ={},
         )
         blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
@@ -361,7 +361,7 @@ class TestObject(unittest.TestCase):
         request = utils.common.FakeRequest(
             args={},
             headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
-            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n{"name": "object", "metadata": {"method": "rest"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n123456789\r\n--foo_bar_baz--\r\n',
+            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{"name": "object", "metadata": {"method": "rest"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n\r\n123456789\r\n--foo_bar_baz--\r\n',
             environ={},
         )
         blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)
@@ -391,7 +391,7 @@ class TestObject(unittest.TestCase):
         request = utils.common.FakeRequest(
             args={},
             headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
-            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n{"name": "object", "metadata": {"method": "rest"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n123456789\r\n--foo_bar_baz--\r\n',
+            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{"name": "object", "metadata": {"method": "rest"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n\r\n123456789\r\n--foo_bar_baz--\r\n',
             environ={},
         )
         blob, _ = gcs.object.Object.init_multipart(request, self.bucket.metadata)

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -290,7 +290,7 @@ class TestCommonUtils(unittest.TestCase):
     def test_parse_multipart(self):
         request = utils.common.FakeRequest(
             headers={"content-type": "multipart/related; boundary=foo_bar_baz"},
-            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n{"name": "myObject", "metadata": {"test": "test"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n123456789\r\n--foo_bar_baz--\r\n',
+            data=b'--foo_bar_baz\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{"name": "myObject", "metadata": {"test": "test"}}\r\n--foo_bar_baz\r\nContent-Type: image/jpeg\r\n\r\n123456789\r\n--foo_bar_baz--\r\n',
             environ={},
         )
         metadata, media_header, media = utils.common.parse_multipart(request)
@@ -328,10 +328,10 @@ class TestCommonUtils(unittest.TestCase):
             b"\xa7#\x95\xec\xd5c\xe9\x90\xa8\xe2\xa89\xadF\xcc\x97\x12\xad\xf6\x9e\r\n\xf1Mhj\xf4W\x9f\x92T\xe3,\tm.\x1e\x04\xd0",
         )
 
-        # Test incorrect ending
+        # Test incorrect multipart body
         request = utils.common.FakeRequest(
             headers={"content-type": "multipart/related; boundary=1VvZTD07ltUtqMHg"},
-            data=b'--1VvZTD07ltUtqMHg\r\ncontent-type: application/json; charset=UTF-8\r\n\r\n{"crc32c":"4GEvYA=="}\r\n--1VvZTD07ltUtqMHg\r\ncontent-type: application/octet-stream\r\n\r\n\xa7#\x95\xec\xd5c\xe9\x90\xa8\xe2\xa89\xadF\xcc\x97\x12\xad\xf6\x9e\r\n\xf1Mhj\xf4W\x9f\x92T\xe3,\tm.\x1e\x04\xd0\r\n',
+            data=b'--1VvZTD07ltUtqMHg\r\ncontent-type: application/json; charset=UTF-8\r\n{"crc32c":"4GEvYA=="}\r\n--1VvZTD07ltUtqMHg\r\ncontent-type: application/octet-stream\r\n\xa7#\x95\xec\xd5c\xe9\x90\xa8\xe2\xa89\xadF\xcc\x97\x12\xad\xf6\x9e\r\n\xf1Mhj\xf4W\x9f\x92T\xe3,\tm.\x1e\x04\xd0\r\n',
             environ={},
         )
         with self.assertRaises(utils.error.RestException):
@@ -431,7 +431,7 @@ class TestError(unittest.TestCase):
     def test_error_propagation(self):
         emulator = os.getenv("CLOUD_STORAGE_EMULATOR_ENDPOINT")
         if emulator is None:
-            self.skipTest()
+            self.skipTest("CLOUD_STORAGE_EMULATOR_ENDPOINT is not set")
         conn = http.client.HTTPConnection(emulator[len("http://") :], timeout=10)
 
         conn.request("GET", "/raise_error")


### PR DESCRIPTION
I saw string manipulation to handle multipart and found MultipartDecoder class as a potential replacement supported in `requests-toolbelt`.

Additional changes:
1. Updated emulator README.md on how to run test.
2. Ran linter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6453)
<!-- Reviewable:end -->
