### PR TITLE
feat(common): a wrapper for streaming write RPCs

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -418,6 +418,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
         internal/streaming_read_rpc.cc
         internal/streaming_read_rpc.h
         internal/streaming_read_rpc_logging.h
+        internal/streaming_write_rpc.cc
+        internal/streaming_write_rpc.h
         internal/time_utils.cc
         internal/time_utils.h
         internal/unified_grpc_credentials.cc
@@ -531,6 +533,7 @@ if (GOOGLE_CLOUD_CPP_ENABLE_GRPC)
             internal/retry_loop_test.cc
             internal/streaming_read_rpc_logging_test.cc
             internal/streaming_read_rpc_test.cc
+            internal/streaming_write_rpc_test.cc
             internal/time_utils_test.cc
             internal/unified_grpc_credentials_test.cc)
 

--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -49,6 +49,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/setup_context.h",
     "internal/streaming_read_rpc.h",
     "internal/streaming_read_rpc_logging.h",
+    "internal/streaming_write_rpc.h",
     "internal/time_utils.h",
     "internal/unified_grpc_credentials.h",
 ]
@@ -69,6 +70,7 @@ google_cloud_cpp_grpc_utils_srcs = [
     "internal/minimal_iam_credentials_stub.cc",
     "internal/retry_loop_helpers.cc",
     "internal/streaming_read_rpc.cc",
+    "internal/streaming_write_rpc.cc",
     "internal/time_utils.cc",
     "internal/unified_grpc_credentials.cc",
 ]

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -36,6 +36,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/retry_loop_test.cc",
     "internal/streaming_read_rpc_logging_test.cc",
     "internal/streaming_read_rpc_test.cc",
+    "internal/streaming_write_rpc_test.cc",
     "internal/time_utils_test.cc",
     "internal/unified_grpc_credentials_test.cc",
 ]

--- a/google/cloud/internal/streaming_write_rpc.cc
+++ b/google/cloud/internal/streaming_write_rpc.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/streaming_write_rpc.h"
+#include "google/cloud/log.h"
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+void StreamingWriteRpcReportUnhandledError(Status const& status,
+                                           char const* tname) {
+  GCP_LOG(WARNING) << "unhandled error for StreamingWriteRpcImpl< " << tname
+                   << " > - status=" << status;
+}
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -141,4 +141,4 @@ class StreamingWriteRpcImpl
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -1,0 +1,144 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H
+
+#include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/status.h"
+#include "google/cloud/status_or.h"
+#include "google/cloud/version.h"
+#include "absl/types/variant.h"
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/sync_stream.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+
+/**
+ * Defines the interface for wrappers around gRPC streaming write RPCs.
+ *
+ * We wrap the gRPC classes used for streaming write RPCs to (a) simplify the
+ * memory management of auxiliary data structures, (b) enforce the "rules"
+ * around calling `Finish()` before deleting an RPC, (c) allow us to mock the
+ * classes, and (d) allow us to decorate the streaming RPCs, for example for
+ * logging.
+ *
+ * This class defines the interface for these wrappers.  The canonical
+ * implementation is `StreamingWriteRpcImpl<RequestType, ResponseType>`
+ */
+template <typename RequestType, typename ResponseType>
+class StreamingWriteRpc {
+ public:
+  /**
+   * Possible results for a Write() operation.
+   *
+   * A Write() operation can have three possible outcomes:
+   * - The Write was successful, continue using the stream, this is represented
+   *   by the `absl::monostate` branch
+   * - The streaming RPC is now closed, either with an error (the `Status`
+   *   branch), or with a successful final response (the `ResponseType`) branch.
+   *   maybe as a result of the Write() as result.
+   *
+   * @note the stream may be closed because of the `Write()` call (e.g., if it
+   * contains the `last_message()` bit), or because the service has closed the
+   * stream, or because of network or service errors.
+   */
+  using WriteOutcome = absl::variant<absl::monostate, Status, ResponseType>;
+
+  virtual ~StreamingWriteRpc() = default;
+
+  /// Cancel the RPC, this is needed to terminate the RPC "early".
+  virtual void Cancel() = 0;
+
+  /// Return the next element, or the final RPC status.
+  virtual WriteOutcome Write(RequestType const& r, grpc::WriteOptions o) = 0;
+
+  /// Half-close the stream and wait for a response.
+  virtual StatusOr<ResponseType> WritesDone() = 0;
+};
+
+/// Report the errors in a standalone function to minimize includes
+void StreamingWriteRpcReportUnhandledError(Status const& status,
+                                           char const* tname);
+
+/**
+ * Implement `StreamingWriteRpc<RequestType, ResponseType>` using the gRPC
+ * abstractions.
+ *
+ * @note this class is thread compatible, but it is not thread safe. It should
+ *   not be used from multiple threads at the same time.
+ */
+template <typename RequestType, typename ResponseType>
+class StreamingWriteRpcImpl
+    : public StreamingWriteRpc<RequestType, ResponseType> {
+ public:
+  using WriteOutcome =
+      typename StreamingWriteRpc<RequestType, ResponseType>::WriteOutcome;
+
+  StreamingWriteRpcImpl(
+      std::unique_ptr<grpc::ClientContext> context,
+      std::unique_ptr<ResponseType> response,
+      std::unique_ptr<grpc::ClientWriterInterface<RequestType>> stream)
+      : context_(std::move(context)),
+        response_(std::move(response)),
+        stream_(std::move(stream)) {}
+
+  ~StreamingWriteRpcImpl() override {
+    if (finished_) return;
+    Cancel();
+    auto status = Finish();
+    if (status.ok()) return;
+    StreamingWriteRpcReportUnhandledError(status, typeid(ResponseType).name());
+  }
+
+  void Cancel() override { context_->TryCancel(); }
+
+  WriteOutcome Write(RequestType const& r, grpc::WriteOptions o) override {
+    auto const result = stream_->Write(r, o);
+    if (result) return absl::monostate{};
+    auto status = Finish();
+    if (!status.ok()) return status;
+    return std::move(*response_);
+  }
+
+  StatusOr<ResponseType> WritesDone() override {
+    (void)stream_->WritesDone();
+    auto status = Finish();
+    if (!status.ok()) return status;
+    return std::move(*response_);
+  }
+
+ private:
+  Status Finish() {
+    auto status = MakeStatusFromRpcError(stream_->Finish());
+    finished_ = true;
+    return status;
+  }
+
+  std::unique_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<ResponseType> response_;
+  std::unique_ptr<grpc::ClientWriterInterface<RequestType>> stream_;
+  bool finished_ = false;
+};
+
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_READ_RPC_H

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -69,7 +69,7 @@ class StreamingWriteRpc {
   virtual WriteOutcome Write(RequestType const& r, grpc::WriteOptions o) = 0;
 
   /// Half-close the stream and wait for a response.
-  virtual StatusOr<ResponseType> WritesDone() = 0;
+  virtual StatusOr<ResponseType> Close() = 0;
 };
 
 /// Report the errors in a standalone function to minimize includes
@@ -116,7 +116,7 @@ class StreamingWriteRpcImpl
     return std::move(*response_);
   }
 
-  StatusOr<ResponseType> WritesDone() override {
+  StatusOr<ResponseType> Close() override {
     (void)stream_->WritesDone();
     auto status = Finish();
     if (!status.ok()) return status;

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -1,0 +1,121 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/streaming_write_rpc.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "absl/memory/memory.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::Return;
+
+struct FakeRequest {
+  std::string key;
+};
+
+struct FakeResponse {
+  std::string value;
+};
+
+using MockReturnType =
+    std::unique_ptr<grpc::ClientReaderInterface<FakeResponse>>;
+
+class MockWriter : public grpc::ClientWriterInterface<FakeRequest> {
+ public:
+  MOCK_METHOD(bool, Write, (FakeRequest const&, grpc::WriteOptions),
+              (override));
+  MOCK_METHOD(bool, WritesDone, (), (override));
+  MOCK_METHOD(grpc::Status, Finish, (), (override));
+};
+
+TEST(StreamingWriteRpcImpl, SuccessfulStream) {
+  auto mock = absl::make_unique<MockWriter>();
+  auto response = absl::make_unique<FakeResponse>();
+  auto* response_ptr = response.get();
+  EXPECT_CALL(*mock, Write).Times(3).WillRepeatedly(Return(true));
+  EXPECT_CALL(*mock, WritesDone).WillOnce(Return(true));
+  EXPECT_CALL(*mock, Finish).WillOnce([response_ptr] {
+    response_ptr->value = "on-finish";
+    return grpc::Status::OK;
+  });
+
+  StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::move(mock));
+  for (std::string key : {"w0", "w1", "w2"}) {
+    auto w = impl.Write(FakeRequest{key}, grpc::WriteOptions{});
+    EXPECT_TRUE(absl::holds_alternative<absl::monostate>(w));
+  }
+  auto actual = impl.WritesDone();
+  ASSERT_THAT(actual, IsOk());
+  EXPECT_EQ("on-finish", actual->value);
+}
+
+TEST(StreamingWriteRpcImpl, ErrorInWrite) {
+  auto mock = absl::make_unique<MockWriter>();
+  auto response = absl::make_unique<FakeResponse>();
+  EXPECT_CALL(*mock, Write)
+      .WillOnce(Return(true))
+      .WillOnce(Return(true))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*mock, Finish).WillOnce([] {
+    return grpc::Status(grpc::StatusCode::ABORTED, "aborted");
+  });
+
+  StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::move(mock));
+  for (std::string key : {"w0", "w1"}) {
+    auto w = impl.Write(FakeRequest{key}, grpc::WriteOptions{});
+    EXPECT_TRUE(absl::holds_alternative<absl::monostate>(w));
+  }
+  auto w = impl.Write(FakeRequest{"w2"}, grpc::WriteOptions{});
+  ASSERT_TRUE(absl::holds_alternative<Status>(w));
+  EXPECT_THAT(absl::get<Status>(w), StatusIs(StatusCode::kAborted, "aborted"));
+}
+
+TEST(StreamingWriteRpcImpl, ErrorInWritesDone) {
+  auto mock = absl::make_unique<MockWriter>();
+  auto response = absl::make_unique<FakeResponse>();
+  EXPECT_CALL(*mock, Write).WillOnce(Return(true)).WillOnce(Return(true));
+  EXPECT_CALL(*mock, WritesDone).WillOnce(Return(false));
+  EXPECT_CALL(*mock, Finish).WillOnce([] {
+    return grpc::Status(grpc::StatusCode::ABORTED, "aborted");
+  });
+
+  StreamingWriteRpcImpl<FakeRequest, FakeResponse> impl(
+      absl::make_unique<grpc::ClientContext>(), std::move(response),
+      std::move(mock));
+  for (std::string key : {"w0", "w1"}) {
+    auto w = impl.Write(FakeRequest{key}, grpc::WriteOptions{});
+    EXPECT_TRUE(absl::holds_alternative<absl::monostate>(w));
+  }
+  auto result = impl.WritesDone();
+  EXPECT_THAT(result, StatusIs(StatusCode::kAborted, "aborted"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -25,8 +25,6 @@ namespace {
 
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::ElementsAre;
-using ::testing::HasSubstr;
 using ::testing::Return;
 
 struct FakeRequest {

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -64,7 +64,7 @@ TEST(StreamingWriteRpcImpl, SuccessfulStream) {
     auto w = impl.Write(FakeRequest{key}, grpc::WriteOptions{});
     EXPECT_TRUE(absl::holds_alternative<absl::monostate>(w));
   }
-  auto actual = impl.WritesDone();
+  auto actual = impl.Close();
   ASSERT_THAT(actual, IsOk());
   EXPECT_EQ("on-finish", actual->value);
 }
@@ -108,7 +108,7 @@ TEST(StreamingWriteRpcImpl, ErrorInWritesDone) {
     auto w = impl.Write(FakeRequest{key}, grpc::WriteOptions{});
     EXPECT_TRUE(absl::holds_alternative<absl::monostate>(w));
   }
-  auto result = impl.WritesDone();
+  auto result = impl.Close();
   EXPECT_THAT(result, StatusIs(StatusCode::kAborted, "aborted"));
 }
 


### PR DESCRIPTION
Introduce a wrapper for streaming write RPCs. This is similar to
`google::cloud::internal::StreamingReadRpc<>`, with some important
differences:

- There is an extra template parameter to represent the final response.
  Note that this value only makes sense when the operation completes
  successfully.
- There is a `WritesDone()` member function to close the stream, which
  returns a `StatusOr<ResponseType>`. Sometimes the application wants
  to close the stream without sending more data.

Part of the changes for #6309 but really all of GUAC for the storage library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6455)
<!-- Reviewable:end -->
