### PR TITLE
ci: install emulator dependencies using requirements file

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -196,3 +196,7 @@ function integration::ctest_with_emulators() {
     "./google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 }
+
+# To run the integration tests we need to install the dependencies for the storage emulator
+export PATH="${HOME}/.local/bin:${PATH}"
+python3 -m pip install --user -r "${PROJECT_ROOT}/google/cloud/storage/emulator/requirements.txt"

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -26,6 +26,10 @@ source module ci/lib/io.sh
 source module ci/etc/integration-tests-config.sh
 source module ci/lib/io.sh
 
+# To run the integration tests we need to install the dependencies for the storage emulator
+export PATH="${HOME}/.local/bin:${PATH}"
+python3 -m pip install --user -r "${PROJECT_ROOT}/google/cloud/storage/emulator/requirements.txt"
+
 # Outputs a list of Bazel arguments that should be used when running
 # integration tests. These do not include the common `bazel::common_args`.
 #
@@ -196,7 +200,3 @@ function integration::ctest_with_emulators() {
     "./google/cloud/bigtable/ci/${EMULATOR_SCRIPT}" \
     "${cmake_out}" "${ctest_args[@]}" -L integration-test-emulator
 }
-
-# To run the integration tests we need to install the dependencies for the storage emulator
-export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip install --user -r "${PROJECT_ROOT}/google/cloud/storage/emulator/requirements.txt"

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -110,7 +110,8 @@ steps:
     '--path=.cache/ccache',
     '--path=.cache/ctcache',
     '--path=.cache/vcpkg',
-    '--path=.cache/google-cloud-cpp'
+    '--path=.cache/google-cloud-cpp',
+    '--path=.local',
   ]
 
   # Remove the images created by this build.

--- a/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-msan.Dockerfile
@@ -32,9 +32,6 @@ RUN echo 'root:' | chpasswd
 # Install the Python modules needed to run the storage emulator
 RUN pip3 install --upgrade pip
 RUN pip3 install setuptools wheel
-RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gunicorn==20.0.4
 
 WORKDIR /var/tmp/build
 

--- a/ci/cloudbuild/dockerfiles/fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora.Dockerfile
@@ -57,9 +57,6 @@ RUN pip3 install black==19.3b0
 # Install the Python modules needed to run the storage emulator
 RUN dnf makecache && dnf install -y python3-devel
 RUN pip3 install setuptools wheel
-RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gunicorn==20.0.4
 
 # Install cspell for spell checking.
 RUN npm install -g cspell@5.2.4

--- a/ci/cloudbuild/dockerfiles/ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/ubuntu-bionic.Dockerfile
@@ -55,9 +55,6 @@ RUN apt-get update && \
 # Install Python packages used in the integration tests.
 RUN update-alternatives --install /usr/bin/python python $(which python3) 10
 RUN pip3 install setuptools wheel
-RUN pip3 install git+git://github.com/googleapis/python-storage@8cf6c62a96ba3fff7e5028d931231e28e5029f1c
-RUN pip3 install flask==1.1.2 httpbin==0.7.0 scalpl==0.4.0 \
-    crc32c==2.1 gunicorn==20.0.4
 
 # Install the Cloud SDK and some of the emulators. We use the emulators to run
 # integration tests for the client libraries.


### PR DESCRIPTION
Avoids duplicating the dependencies in Dockerfiles and the `requirements.txt` files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6457)
<!-- Reviewable:end -->
