### PR TITLE
cleanup(bigtable): prefer proto matchers over MessageDifferencer

### DIFF
--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/testing_util/chrono_literals.h"
-#include <google/protobuf/util/message_differencer.h>
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -25,6 +25,7 @@ namespace {
 
 namespace btproto = ::google::bigtable::v2;
 
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;
 
@@ -395,10 +396,7 @@ TEST(FiltersTest, MoveProto) {
                     std::move(std::declval<F>()).as_proto())>::value,
                 "Return type from as_proto() must be rvalue-reference");
 
-  std::string delta;
-  google::protobuf::util::MessageDifferencer differencer;
-  differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(proto_copy, proto_move)) << delta;
+  EXPECT_THAT(proto_copy, IsProtoEqual(proto_move));
 }
 
 /// @test Verify that the ctor receiving a v2 RowFilter works as expected.
@@ -408,10 +406,7 @@ TEST(FiltersTest, RowFilterCtor) {
   btproto::RowFilter row_filter;
   row_filter.set_row_key_regex_filter("[A-Za-z][A-Za-z0-9_]*");
   auto filter = F(row_filter);
-  std::string delta;
-  google::protobuf::util::MessageDifferencer differencer;
-  differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(row_filter, filter.as_proto())) << delta;
+  EXPECT_THAT(row_filter, IsProtoEqual(filter.as_proto()));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/iam_binding.cc
+++ b/google/cloud/bigtable/iam_binding.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/bigtable/iam_binding.h"
 #include "google/cloud/bigtable/expr.h"
-#include "google/cloud/testing_util/is_proto_equal.h"
+#include <google/protobuf/util/message_differencer.h>
 #include <algorithm>
 #include <iostream>
 #include <iterator>

--- a/google/cloud/bigtable/iam_binding.cc
+++ b/google/cloud/bigtable/iam_binding.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/bigtable/iam_binding.h"
 #include "google/cloud/bigtable/expr.h"
-#include <google/protobuf/util/message_differencer.h>
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <algorithm>
 #include <iostream>
 #include <iterator>

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -19,11 +19,11 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 // TODO(#5923) - remove after deprecation is completed
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
@@ -40,6 +40,7 @@ using MockAdminClient =
     ::google::cloud::bigtable::testing::MockInstanceAdminClient;
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
@@ -192,10 +193,7 @@ struct MockRpcFactory {
           // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
           EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
               expected_request, &expected));
-          std::string delta;
-          google::protobuf::util::MessageDifferencer differencer;
-          differencer.ReportDifferencesToString(&delta);
-          EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
+          EXPECT_THAT(expected, IsProtoEqual(request));
 
           EXPECT_NE(nullptr, response);
           return grpc::Status::OK;

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -22,7 +22,6 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
-#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>

--- a/google/cloud/bigtable/internal/async_poll_op_test.cc
+++ b/google/cloud/bigtable/internal/async_poll_op_test.cc
@@ -22,9 +22,9 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
-#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -19,9 +19,9 @@
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
-#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
 namespace google {
@@ -35,6 +35,7 @@ namespace bt = ::google::cloud::bigtable;
 
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 using bigtable::testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
@@ -178,12 +179,8 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
               SingleRowMutation tmp(exchange.req[i]);
               tmp.MoveTo(&expected);
 
-              std::string delta;
-              google::protobuf::util::MessageDifferencer differencer;
-              differencer.ReportDifferencesToString(&delta);
-              EXPECT_TRUE(
-                  differencer.Compare(expected, r.entries(static_cast<int>(i))))
-                  << delta;
+              EXPECT_THAT(expected,
+                          IsProtoEqual(r.entries(static_cast<int>(i))));
             }
             return std::unique_ptr<
                 MockClientAsyncReaderInterface<btproto::MutateRowsResponse>>(

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -21,11 +21,11 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <google/protobuf/util/time_util.h>
 #include <gmock/gmock.h>
 #include <chrono>
@@ -42,6 +42,7 @@ namespace btadmin = ::google::bigtable::admin::v2;
 
 using ::google::cloud::testing_util::IsContextMDValid;
 using ::google::cloud::testing_util::IsOk;
+using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::chrono_literals::operator"" _h;
 using ::google::cloud::testing_util::chrono_literals::operator"" _min;
@@ -213,10 +214,7 @@ struct MockRpcFactory {
           // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
           EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
               expected_request, &expected));
-          std::string delta;
-          google::protobuf::util::MessageDifferencer differencer;
-          differencer.ReportDifferencesToString(&delta);
-          EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
+          EXPECT_THAT(expected, IsProtoEqual(request));
 
           return grpc::Status::OK;
         });

--- a/google/cloud/bigtable/table_config_test.cc
+++ b/google/cloud/bigtable/table_config_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/table_config.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,6 +24,7 @@ inline namespace BIGTABLE_CLIENT_NS {
 namespace {
 
 namespace btadmin = ::google::bigtable::admin::v2;
+using ::google::cloud::testing_util::IsProtoEqual;
 
 TEST(TableConfig, Simple) {
   TableConfig config;
@@ -63,10 +64,7 @@ initial_splits { key: 'qux' }
 
   auto request = std::move(config).as_proto();
 
-  std::string delta;
-  google::protobuf::util::MessageDifferencer differencer;
-  differencer.ReportDifferencesToString(&delta);
-  EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
+  EXPECT_THAT(expected, IsProtoEqual(request));
 }
 
 TEST(TableConfig, ComplexConstructor) {

--- a/google/cloud/bigtable/table_readmodifywriterow_test.cc
+++ b/google/cloud/bigtable/table_readmodifywriterow_test.cc
@@ -14,10 +14,10 @@
 
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 #include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <gmock/gmock.h>
 
 namespace google {
@@ -29,6 +29,7 @@ namespace {
 namespace btproto = ::google::bigtable::v2;
 
 using ::google::cloud::testing_util::IsContextMDValid;
+using ::google::cloud::testing_util::IsProtoEqual;
 
 /// Define helper types and functions for this test.
 class TableReadModifyWriteTest : public bigtable::testing::TableTestFixture {
@@ -48,11 +49,7 @@ auto create_rules_lambda = [](std::string const& expected_request_string,
     btproto::ReadModifyWriteRowRequest expected_request;
     EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
         expected_request_string, &expected_request));
-
-    std::string delta;
-    google::protobuf::util::MessageDifferencer differencer;
-    differencer.ReportDifferencesToString(&delta);
-    EXPECT_TRUE(differencer.Compare(expected_request, request)) << delta;
+    EXPECT_THAT(expected_request, IsProtoEqual(request));
 
     EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
         generated_response_string, response));

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -18,9 +18,9 @@
 #include "google/cloud/bigtable/testing/mock_response_reader.h"
 #include "google/cloud/internal/api_client_header.h"
 #include "google/cloud/status.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <google/protobuf/text_format.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <grpcpp/support/async_unary_call.h>
 #include <string>
 
@@ -62,10 +62,7 @@ struct MockAsyncFailingRpcFactory {
       // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
       EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
           expected_request, &expected));
-      std::string delta;
-      google::protobuf::util::MessageDifferencer differencer;
-      differencer.ReportDifferencesToString(&delta);
-      EXPECT_TRUE(differencer.Compare(expected, request)) << delta;
+      EXPECT_THAT(expected, google::cloud::testing_util::IsProtoEqual(request));
 
       EXPECT_CALL(*reader, Finish)
           .WillOnce([](ResponseType* response, grpc::Status* status, void*) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6468)
<!-- Reviewable:end -->
