### PR TITLE
fix(storage): support gzip request body in emulator

### DIFF
--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -21,6 +21,7 @@ import gcs as gcs_type
 import grpc_server
 import httpbin
 import utils
+from utils.handle_gzip import HandleGzipMiddleware
 from werkzeug import serving
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
@@ -803,16 +804,18 @@ def xml_get_object(bucket_name, object_name):
 (IAM_HANDLER_PATH, iam_app) = gcs_type.iam.get_iam_app()
 
 
-server = DispatcherMiddleware(
-    root,
-    {
-        "/httpbin": httpbin.app,
-        GCS_HANDLER_PATH: gcs,
-        DOWNLOAD_HANDLER_PATH: download,
-        UPLOAD_HANDLER_PATH: upload,
-        PROJECTS_HANDLER_PATH: projects_app,
-        IAM_HANDLER_PATH: iam_app,
-    },
+server = HandleGzipMiddleware(
+    DispatcherMiddleware(
+        root,
+        {
+            "/httpbin": httpbin.app,
+            GCS_HANDLER_PATH: gcs,
+            DOWNLOAD_HANDLER_PATH: download,
+            UPLOAD_HANDLER_PATH: upload,
+            PROJECTS_HANDLER_PATH: projects_app,
+            IAM_HANDLER_PATH: iam_app,
+        },
+    )
 )
 
 root.register_error_handler(Exception, utils.error.RestException.handler)

--- a/google/cloud/storage/emulator/utils/__init__.py
+++ b/google/cloud/storage/emulator/utils/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from utils import acl, common, error, generation, csek
+from utils import acl, common, error, generation, csek, handle_gzip

--- a/google/cloud/storage/emulator/utils/handle_gzip.py
+++ b/google/cloud/storage/emulator/utils/handle_gzip.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import gzip
+from werkzeug.wrappers import Request
+
+
+class HandleGzipMiddleware:
+    """
+    Handle decompressing requests which contain header Content-Encoding: gzip
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        request = Request(environ)
+        if request.headers.get("Content-Encoding", "") == "gzip":
+            request.data = gzip.decompress(request.data)
+            request.environ["wsgi.input"] = io.BytesIO(request.data)
+        return self.app(environ, start_response)


### PR DESCRIPTION
Adding a middleware to decompress request bodies that are gzip'd which is used by Go and Java from integration testing against the emulator. 


Fixes: https://github.com/googleapis/google-cloud-cpp/issues/3446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6472)
<!-- Reviewable:end -->
