### PR TITLE
feat(common): streaming RPCs that always fail

### DIFF
--- a/google/cloud/internal/streaming_read_rpc.h
+++ b/google/cloud/internal/streaming_read_rpc.h
@@ -98,6 +98,30 @@ class StreamingReadRpcImpl : public StreamingReadRpc<ResponseType> {
   bool finished_ = false;
 };
 
+/**
+ * A stream returning a fixed error.
+ *
+ * This is used when the library cannot even start the streaming RPC, for
+ * example, because setting up the credentials for the call failed.  One could
+ * return `StatusOr<std::unique_ptr<StreamingReadRpc<T>>` in such cases, but
+ * the receiving code must deal with streams that fail anyway. It seems more
+ * elegant to represent the error as part of the stream.
+ */
+template <typename ResponseType>
+class StreamingReadRpcError : public StreamingReadRpc<ResponseType> {
+ public:
+  explicit StreamingReadRpcError(Status status) : status_(std::move(status)) {}
+
+  ~StreamingReadRpcError() override = default;
+
+  void Cancel() override {}
+
+  absl::variant<Status, ResponseType> Read() override { return status_; }
+
+ private:
+  Status status_;
+};
+
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS
 }  // namespace cloud

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -172,7 +172,7 @@ TEST(StreamingReadRpcImpl, HandleUnfinished) {
 TEST(StreamingReadRpcImpl, ErrorStream) {
   auto under_test = StreamingReadRpcError<FakeResponse>(
       Status(StatusCode::kPermissionDenied, "uh-oh"));
-  EXPECT_NO_THROW(under_test.Cancel());
+  under_test.Cancel();  // just a smoke test
   auto result = under_test.Read();
   ASSERT_TRUE(absl::holds_alternative<Status>(result));
   EXPECT_THAT(absl::get<Status>(result),

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -169,6 +169,16 @@ TEST(StreamingReadRpcImpl, HandleUnfinished) {
                              HasSubstr("uh-oh"))));
 }
 
+TEST(StreamingReadRpcImpl, ErrorStream) {
+  auto under_test = StreamingReadRpcError<FakeResponse>(
+      Status(StatusCode::kPermissionDenied, "uh-oh"));
+  EXPECT_NO_THROW(under_test.Cancel());
+  auto result = under_test.Read();
+  ASSERT_TRUE(absl::holds_alternative<Status>(result));
+  EXPECT_THAT(absl::get<Status>(result),
+              StatusIs(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -126,7 +126,7 @@ TEST(StreamingWriteRpcImpl, NoWritesDoneWithLastMessage) {
 TEST(StreamingWriteRpcError, ErrorStream) {
   auto under_test = StreamingWriteRpcError<FakeRequest, FakeResponse>(
       Status(StatusCode::kAborted, "aborted"));
-  EXPECT_NO_THROW(under_test.Cancel());
+  under_test.Cancel();  // just a smoke test
   EXPECT_FALSE(under_test.Write(FakeRequest{"w0"}, grpc::WriteOptions()));
   EXPECT_THAT(under_test.Close(), StatusIs(StatusCode::kAborted, "aborted"));
 }

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -123,6 +123,14 @@ TEST(StreamingWriteRpcImpl, NoWritesDoneWithLastMessage) {
   EXPECT_THAT(impl.Close(), IsOk());
 }
 
+TEST(StreamingWriteRpcError, ErrorStream) {
+  auto under_test = StreamingWriteRpcError<FakeRequest, FakeResponse>(
+      Status(StatusCode::kAborted, "aborted"));
+  EXPECT_NO_THROW(under_test.Cancel());
+  EXPECT_FALSE(under_test.Write(FakeRequest{"w0"}, grpc::WriteOptions()));
+  EXPECT_THAT(under_test.Close(), StatusIs(StatusCode::kAborted, "aborted"));
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace GOOGLE_CLOUD_CPP_NS


### PR DESCRIPTION
This is part of a larger refactoring in the GCS+gRPC plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6473)
<!-- Reviewable:end -->
