### PR TITLE
feat(storage): support method overrides in emulator

### DIFF
--- a/google/cloud/storage/emulator/emulator.py
+++ b/google/cloud/storage/emulator/emulator.py
@@ -146,8 +146,9 @@ def bucket_update(bucket_name):
     return utils.common.filter_response_rest(bucket.rest(), projection, fields)
 
 
-@gcs.route("/b/<bucket_name>", methods=["PATCH"])
+@gcs.route("/b/<bucket_name>", methods=["PATCH", "POST"])
 def bucket_patch(bucket_name):
+    utils.common.enforce_patch_override(flask.request)
     bucket = db.get_bucket(flask.request, bucket_name, None)
     bucket.patch(flask.request, None)
     projection = utils.common.extract_projection(
@@ -208,8 +209,9 @@ def bucket_acl_update(bucket_name, entity):
     return utils.common.filter_response_rest(response, None, fields)
 
 
-@gcs.route("/b/<bucket_name>/acl/<entity>", methods=["PATCH"])
+@gcs.route("/b/<bucket_name>/acl/<entity>", methods=["PATCH", "POST"])
 def bucket_acl_patch(bucket_name, entity):
+    utils.common.enforce_patch_override(flask.request)
     bucket = db.get_bucket(flask.request, bucket_name, None)
     acl = bucket.patch_acl(flask.request, entity, None)
     response = json_format.MessageToDict(acl)
@@ -267,8 +269,9 @@ def bucket_default_object_acl_update(bucket_name, entity):
     return utils.common.filter_response_rest(response, None, fields)
 
 
-@gcs.route("/b/<bucket_name>/defaultObjectAcl/<entity>", methods=["PATCH"])
+@gcs.route("/b/<bucket_name>/defaultObjectAcl/<entity>", methods=["PATCH", "POST"])
 def bucket_default_object_acl_patch(bucket_name, entity):
+    utils.common.enforce_patch_override(flask.request)
     bucket = db.get_bucket(flask.request, bucket_name, None)
     acl = bucket.patch_default_object_acl(flask.request, entity, None)
     response = json_format.MessageToDict(acl)
@@ -385,8 +388,9 @@ def object_update(bucket_name, object_name):
     return utils.common.filter_response_rest(blob.rest_metadata(), projection, fields)
 
 
-@gcs.route("/b/<bucket_name>/o/<path:object_name>", methods=["PATCH"])
+@gcs.route("/b/<bucket_name>/o/<path:object_name>", methods=["PATCH", "POST"])
 def object_patch(bucket_name, object_name):
+    utils.common.enforce_patch_override(flask.request)
     blob = db.get_object(flask.request, bucket_name, object_name, False, None)
     blob.patch(flask.request, None)
     projection = utils.common.extract_projection(
@@ -591,8 +595,11 @@ def object_acl_update(bucket_name, object_name, entity):
     return utils.common.filter_response_rest(response, None, fields)
 
 
-@gcs.route("/b/<bucket_name>/o/<path:object_name>/acl/<entity>", methods=["PATCH"])
+@gcs.route(
+    "/b/<bucket_name>/o/<path:object_name>/acl/<entity>", methods=["PATCH", "POST"]
+)
 def object_acl_patch(bucket_name, object_name, entity):
+    utils.common.enforce_patch_override(flask.request)
     blob = db.get_object(flask.request, bucket_name, object_name, False, None)
     acl = blob.patch_acl(flask.request, entity, None)
     response = json_format.MessageToDict(acl)

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -22,6 +22,8 @@ import urllib
 
 import utils
 
+from werkzeug.test import create_environ
+from werkzeug.wrappers import Request
 from google.cloud.storage_v1.proto import storage_pb2 as storage_pb2
 from google.cloud.storage_v1.proto.storage_resources_pb2 import CommonEnums
 
@@ -336,6 +338,29 @@ class TestCommonUtils(unittest.TestCase):
         )
         with self.assertRaises(utils.error.RestException):
             utils.common.parse_multipart(request)
+
+    def test_enforce_patch_override_failure(self):
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=0,
+            data="",
+            content_type="application/octet-stream",
+            method="POST",
+            headers={"X-Http-Method-Override": "other"},
+        )
+        with self.assertRaises(utils.error.RestException):
+            utils.common.enforce_patch_override(Request(environ))
+
+    def test_enforce_patch_override_success(self):
+        environ = create_environ(
+            base_url="http://localhost:8080",
+            content_length=0,
+            data="",
+            content_type="application/octet-stream",
+            method="POST",
+            headers={"X-Http-Method-Override": "PATCH"},
+        )
+        utils.common.enforce_patch_override(Request(environ))
 
 
 class TestGeneration(unittest.TestCase):

--- a/google/cloud/storage/emulator/utils/common.py
+++ b/google/cloud/storage/emulator/utils/common.py
@@ -322,3 +322,11 @@ def extract_instruction(request, context):
         if instruction is None:
             instruction = request.headers.get("x-goog-testbench-instructions")
     return instruction
+
+
+def enforce_patch_override(request):
+    if (
+        request.method == "POST"
+        and request.headers.get("X-Http-Method-Override", "") != "PATCH"
+    ):
+        utils.error.notallowed(context=None)

--- a/google/cloud/storage/emulator/utils/error.py
+++ b/google/cloud/storage/emulator/utils/error.py
@@ -99,3 +99,8 @@ def missing(name, context, rest_code=400, grpc_code=grpc.StatusCode.INVALID_ARGU
 def notfound(name, context, rest_code=404, grpc_code=grpc.StatusCode.NOT_FOUND):
     msg = "%s does not exist." % name
     generic(msg, rest_code, grpc_code, context)
+
+
+def notallowed(context=None, rest_code=405, grpc_code=None):
+    msg = "method is not allowed"
+    generic(msg, rest_code, grpc_code, context)


### PR DESCRIPTION
Cloud Storage supports an override header `X-Http-Method-Override` for PATCH requests over POST and the Java Storage library uses it. Wow. This adds support to the Storage emulator as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6474)
<!-- Reviewable:end -->
