### PR TITLE
fix(storage): address behavior bugs

### DIFF
--- a/google/cloud/storage/emulator/database.py
+++ b/google/cloud/storage/emulator/database.py
@@ -242,7 +242,7 @@ class Database:
     def get_rewrite(self, token, context):
         rewrite = self.rewrites.get(token)
         if rewrite is None:
-            utils.error.notfound(404, "Rewrite %s" % token, context)
+            utils.error.notfound("Rewrite %s" % token, context)
         return rewrite
 
     def insert_rewrite(self, rewrite):

--- a/google/cloud/storage/emulator/tests/test_utils.py
+++ b/google/cloud/storage/emulator/tests/test_utils.py
@@ -21,7 +21,6 @@ import unittest
 import urllib
 import gzip
 import utils
-from werkzeug.test import create_environ
 
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request


### PR DESCRIPTION
Fix two issues:

1. Allow object name in either resource or query parameter for resumable uploads to support Storage libs (they mix and match yay...)
2. Fix a code typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6477)
<!-- Reviewable:end -->
