### PR TITLE
test(spanner): PickRandomInstance

### DIFF
--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -39,6 +39,12 @@ StatusOr<std::string> PickRandomInstance(
        client.ListInstances(project_id, filter + name_filter)) {
     if (!instance) return std::move(instance).status();
     auto instance_id = instance->name().substr(instance_prefix.size());
+    if (instance_id.rfind("test-instance-", 0) != 0) {
+      auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
+      if (emulator.has_value()) continue;  // server-side filter not supported
+      return Status(StatusCode::kInternal,
+                    "ListInstances erroneously returned " + instance_id);
+    }
     instance_ids.push_back(std::move(instance_id));
   }
 


### PR DESCRIPTION
The Spanner-emulator `InstanceAdminClient::ListInstances()` does
not heed the `filter` parameter to restrict the set of instances
included in the response.  This meant that `PickRandomInstance()`
could return an ephemeral instance created, and soon to be deleted,
by a concurrent test.  And that leads to flakiness at best.

So, repeat the name filtering of instances in responses received
from the emulator.  And now that we are adding that check, make
an unexpected name from a real server return an error.

Fixes #6471.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6478)
<!-- Reviewable:end -->
