### PR TITLE
refactor(storage): use streaming RPC wrappers

### DIFF
--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/streaming_write_rpc.h"
 #include "google/cloud/internal/unified_grpc_credentials.h"
 #include <google/storage/v1/storage.grpc.pb.h>
 #include <memory>
@@ -48,10 +49,10 @@ class GrpcClient : public RawClient,
   // them is very different from the standard retry loop. Also note that these
   // are virtual functions only because we need to override them in the unit
   // tests.
-  using UploadWriter =
-      grpc::ClientWriterInterface<google::storage::v1::InsertObjectRequest>;
-  virtual std::unique_ptr<UploadWriter> CreateUploadWriter(
-      grpc::ClientContext&, google::storage::v1::Object&);
+  using InsertStream = google::cloud::internal::StreamingWriteRpc<
+      google::storage::v1::InsertObjectRequest, google::storage::v1::Object>;
+  virtual std::unique_ptr<InsertStream> CreateUploadWriter(
+      std::unique_ptr<grpc::ClientContext> context);
   virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);
   //@}

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -17,7 +17,8 @@
 
 #include "google/cloud/storage/internal/object_read_source.h"
 #include "google/cloud/storage/version.h"
-#include <google/storage/v1/storage.grpc.pb.h>
+#include "google/cloud/internal/streaming_read_rpc.h"
+#include <google/storage/v1/storage.pb.h>
 #include <functional>
 #include <string>
 
@@ -26,9 +27,6 @@ namespace cloud {
 namespace storage {
 inline namespace STORAGE_CLIENT_NS {
 namespace internal {
-
-using GrpcObjectContentsReader =
-    grpc::ClientReaderInterface<google::storage::v1::GetObjectMediaResponse>;
 
 /**
  * A data source for storage::ObjectReadStream using gRPC.
@@ -42,11 +40,12 @@ using GrpcObjectContentsReader =
  */
 class GrpcObjectReadSource : public ObjectReadSource {
  public:
-  explicit GrpcObjectReadSource(
-      std::unique_ptr<grpc::ClientContext> context,
-      std::unique_ptr<GrpcObjectContentsReader> stream);
+  using StreamingRpc = google::cloud::internal::StreamingReadRpc<
+      google::storage::v1::GetObjectMediaResponse>;
 
-  ~GrpcObjectReadSource() override;
+  explicit GrpcObjectReadSource(std::unique_ptr<StreamingRpc> stream);
+
+  ~GrpcObjectReadSource() override = default;
 
   bool IsOpen() const override { return static_cast<bool>(stream_); }
 
@@ -58,11 +57,7 @@ class GrpcObjectReadSource : public ObjectReadSource {
   StatusOr<ReadSourceResult> Read(char* buf, std::size_t n) override;
 
  private:
-  // To create a reader for a streaming RPC one needs a client context with
-  // longer lifetime than the stream. This is the client context used for the
-  // request.
-  std::unique_ptr<grpc::ClientContext> context_;
-  std::unique_ptr<GrpcObjectContentsReader> stream_;
+  std::unique_ptr<StreamingRpc> stream_;
 
   // In some cases the gRPC response may contain more data than the buffer
   // provided by the application. This buffer stores any excess results.

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -34,58 +34,31 @@ using ::testing::UnorderedElementsAre;
 
 namespace storage_proto = ::google::storage::v1;
 
-class MockMediaReader : public grpc::ClientReaderInterface<
-                            storage_proto::GetObjectMediaResponse> {
+class MockStream : public google::cloud::internal::StreamingReadRpc<
+                       storage_proto::GetObjectMediaResponse> {
  public:
-  MOCK_METHOD(void, WaitForInitialMetadata, (), (override));
-  MOCK_METHOD(grpc::Status, Finish, (), (override));
-  MOCK_METHOD(bool, NextMessageSize, (std::uint32_t*), (override));
-  MOCK_METHOD(bool, Read, (storage_proto::GetObjectMediaResponse*), (override));
-
-  using UniquePtr = std::unique_ptr<
-      grpc::ClientReaderInterface<storage_proto::GetObjectMediaResponse>>;
-
-  /// Return a `std::unique_ptr< mocked-class >`
-  UniquePtr AsUniqueMocked() { return UniquePtr(this); }
-
-  /**
-   * Create a lambda that returns a `std::unique_ptr< mocked-class >`.
-   *
-   * Often the test code has to create a lambda that returns one of these mocks
-   * wrapped in the correct (the base class) `std::unique_ptr<>`.
-   *
-   * We cannot use just `::testing::Return()` because that binds to the static
-   * type of the returned object, and we need to return a `std::unique_ptr<Foo>`
-   * where we have a `MockFoo*`.  And we cannot create a `std::unique_ptr<>`
-   * and pass it because `::testing::Return()` assumes copy constructions and
-   * `std::unique_ptr<>` only supports move constructors.
-   */
-  std::function<UniquePtr(grpc::ClientContext*,
-                          storage_proto::GetObjectMediaRequest const&)>
-  MakeMockReturner() {
-    return [this](grpc::ClientContext*,
-                  storage_proto::GetObjectMediaRequest const&) {
-      return UniquePtr(this);
-    };
-  }
+  using ReadReturn =
+      absl::variant<Status, storage_proto::GetObjectMediaResponse>;
+  MOCK_METHOD(ReadReturn, Read, (), (override));
+  MOCK_METHOD(void, Cancel, (), (override));
 };
 
 TEST(GrpcObjectReadSource, Simple) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   EXPECT_CALL(*mock, Read)
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content("0123456789");
-        return true;
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content("0123456789");
+        return response;
       })
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content(
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content(
             " The quick brown fox jumps over the lazy dog");
-        return true;
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status{}));
+  GrpcObjectReadSource tested(std::move(mock));
   std::string expected =
       "0123456789 The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
@@ -102,13 +75,10 @@ TEST(GrpcObjectReadSource, Simple) {
 }
 
 TEST(GrpcObjectReadSource, EmptyWithError) {
-  auto mock = absl::make_unique<MockMediaReader>();
-  EXPECT_CALL(*mock, Read).WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish())
-      .WillOnce(
-          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Read)
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+  GrpcObjectReadSource tested(std::move(mock));
   std::vector<char> buffer(1024);
   EXPECT_THAT(tested.Read(buffer.data(), buffer.size()),
               StatusIs(StatusCode::kPermissionDenied, HasSubstr("uh-oh")));
@@ -118,18 +88,15 @@ TEST(GrpcObjectReadSource, EmptyWithError) {
 }
 
 TEST(GrpcObjectReadSource, DataWithError) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   EXPECT_CALL(*mock, Read)
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content("0123456789");
-        return true;
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content("0123456789");
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish())
-      .WillOnce(
-          Return(grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh")));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+  GrpcObjectReadSource tested(std::move(mock));
   std::string expected = "0123456789";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -146,21 +113,20 @@ TEST(GrpcObjectReadSource, DataWithError) {
 }
 
 TEST(GrpcObjectReadSource, UseSpillBuffer) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   auto const trailer_size = 1024;
   std::string const expected_1 = "0123456789";
   std::string const expected_2(trailer_size, 'A');
   ASSERT_LT(expected_1.size(), expected_2.size());
   std::string const contents = expected_1 + expected_2;
   EXPECT_CALL(*mock, Read)
-      .WillOnce([&contents](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content(contents);
-        return true;
+      .WillOnce([&contents]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content(contents);
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status{}));
+  GrpcObjectReadSource tested(std::move(mock));
   std::vector<char> buffer(trailer_size);
   auto response = tested.Read(buffer.data(), expected_1.size());
   ASSERT_STATUS_OK(response);
@@ -183,17 +149,16 @@ TEST(GrpcObjectReadSource, UseSpillBuffer) {
 }
 
 TEST(GrpcObjectReadSource, UseSpillBufferMany) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   std::string const contents = "0123456789";
   EXPECT_CALL(*mock, Read)
-      .WillOnce([&contents](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content(contents);
-        return true;
+      .WillOnce([&contents]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content(contents);
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status{}));
+  GrpcObjectReadSource tested(std::move(mock));
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), 3);
   ASSERT_STATUS_OK(response);
@@ -222,27 +187,27 @@ TEST(GrpcObjectReadSource, UseSpillBufferMany) {
 }
 
 TEST(GrpcObjectReadSource, PreserveChecksums) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   std::string const expected_md5 = "nhB9nTcrtoJr2B01QqQZ1g==";
   std::string const expected_crc32c = "ImIEBA==";
   EXPECT_CALL(*mock, Read)
-      .WillOnce([&](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content("The quick brown");
-        response->mutable_object_checksums()->set_md5_hash(
+      .WillOnce([&]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content("The quick brown");
+        response.mutable_object_checksums()->set_md5_hash(
             GrpcClient::MD5ToProto(expected_md5));
-        response->mutable_object_checksums()->mutable_crc32c()->set_value(
+        response.mutable_object_checksums()->mutable_crc32c()->set_value(
             GrpcClient::Crc32cToProto(expected_crc32c));
-        return true;
+        return response;
       })
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content(
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content(
             " fox jumps over the lazy dog");
-        return true;
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status{}));
+  GrpcObjectReadSource tested(std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -270,28 +235,28 @@ TEST(GrpcObjectReadSource, PreserveChecksums) {
 }
 
 TEST(GrpcObjectReadSource, HandleEmptyResponses) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   EXPECT_CALL(*mock, Read)
-      .WillOnce(Return(true))
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content("The quick brown ");
-        return true;
+      .WillOnce([] { return storage_proto::GetObjectMediaResponse{}; })
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content("The quick brown ");
+        return response;
       })
-      .WillOnce(Return(true))
-      .WillOnce(Return(true))
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content("fox jumps over ");
-        return true;
+      .WillOnce([] { return storage_proto::GetObjectMediaResponse{}; })
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content("fox jumps over ");
+        return response;
       })
-      .WillOnce(Return(true))
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content("the lazy dog");
-        return true;
+      .WillOnce([] { return storage_proto::GetObjectMediaResponse{}; })
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content("the lazy dog");
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status{}));
+  GrpcObjectReadSource tested(std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());
@@ -307,17 +272,16 @@ TEST(GrpcObjectReadSource, HandleEmptyResponses) {
 }
 
 TEST(GrpcObjectReadSource, HandleExtraRead) {
-  auto mock = absl::make_unique<MockMediaReader>();
+  auto mock = absl::make_unique<MockStream>();
   EXPECT_CALL(*mock, Read)
-      .WillOnce([](storage_proto::GetObjectMediaResponse* response) {
-        response->mutable_checksummed_data()->set_content(
+      .WillOnce([]() {
+        storage_proto::GetObjectMediaResponse response;
+        response.mutable_checksummed_data()->set_content(
             "The quick brown fox jumps over the lazy dog");
-        return true;
+        return response;
       })
-      .WillOnce(Return(false));
-  EXPECT_CALL(*mock, Finish()).WillOnce(Return(grpc::Status::OK));
-  GrpcObjectReadSource tested(absl::make_unique<grpc::ClientContext>(),
-                              std::move(mock));
+      .WillOnce(Return(Status{}));
+  GrpcObjectReadSource tested(std::move(mock));
   std::string const expected = "The quick brown fox jumps over the lazy dog";
   std::vector<char> buffer(1024);
   auto response = tested.Read(buffer.data(), buffer.size());

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -60,16 +60,12 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
 
   void CreateUploadWriter();
 
-  StatusOr<ResumableUploadResponse> HandleWriteError();
+  StatusOr<ResumableUploadResponse> HandleStreamClosed();
 
   std::shared_ptr<GrpcClient> client_;
   ResumableUploadSessionGrpcParams session_id_params_;
   std::string session_url_;
-  using UploadWriter =
-      grpc::ClientWriterInterface<google::storage::v1::InsertObjectRequest>;
-  std::unique_ptr<grpc::ClientContext> upload_context_;
-  google::storage::v1::Object upload_object_;
-  std::unique_ptr<UploadWriter> upload_writer_;
+  std::unique_ptr<GrpcClient::InsertStream> upload_writer_;
 
   std::uint64_t next_expected_ = 0;
   bool done_ = false;


### PR DESCRIPTION
Use the `google::cloud::internal::Streaming{Read,Write}Rpc` wrappers,
they are (allegedly) easier to mock and use. I will be splitting the
`storage::internal::GrpcClient` class even more in a future PR, and this
change makes that easier.

Part of the work for #6309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6484)
<!-- Reviewable:end -->
