### PR TITLE
refactor(storage): split gRPC Client vs. Stub

### DIFF
--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -377,6 +377,7 @@ if (BUILD_TESTING)
         testing/mock_fake_clock.h
         testing/mock_http_request.cc
         testing/mock_http_request.h
+        testing/mock_storage_stub.h
         testing/object_integration_test.cc
         testing/object_integration_test.h
         testing/random_names.cc
@@ -545,7 +546,8 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
             internal/grpc_client_test.cc
             internal/grpc_object_read_source_test.cc
             internal/grpc_resumable_upload_session_test.cc
-            internal/grpc_resumable_upload_session_url_test.cc)
+            internal/grpc_resumable_upload_session_url_test.cc
+            internal/storage_auth_test.cc)
 
         foreach (fname ${storage_client_grpc_unit_tests})
             google_cloud_cpp_add_executable(target "storage" "${fname}")

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -318,7 +318,11 @@ if (GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         internal/grpc_resumable_upload_session_url.cc
         internal/grpc_resumable_upload_session_url.h
         internal/hybrid_client.cc
-        internal/hybrid_client.h)
+        internal/hybrid_client.h
+        internal/storage_auth.cc
+        internal/storage_auth.h
+        internal/storage_stub.cc
+        internal/storage_stub.h)
     target_link_libraries(
         google_cloud_cpp_storage_grpc
         PUBLIC google-cloud-cpp::storage

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -23,6 +23,8 @@ google_cloud_cpp_storage_grpc_hdrs = [
     "internal/grpc_resumable_upload_session.h",
     "internal/grpc_resumable_upload_session_url.h",
     "internal/hybrid_client.h",
+    "internal/storage_auth.h",
+    "internal/storage_stub.h",
 ]
 
 google_cloud_cpp_storage_grpc_srcs = [
@@ -32,4 +34,6 @@ google_cloud_cpp_storage_grpc_srcs = [
     "internal/grpc_resumable_upload_session.cc",
     "internal/grpc_resumable_upload_session_url.cc",
     "internal/hybrid_client.cc",
+    "internal/storage_auth.cc",
+    "internal/storage_stub.cc",
 ]

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -18,8 +18,7 @@
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/streaming_write_rpc.h"
-#include "google/cloud/internal/unified_grpc_credentials.h"
-#include <google/storage/v1/storage.grpc.pb.h>
+#include <google/storage/v1/storage.pb.h>
 #include <memory>
 #include <string>
 
@@ -33,6 +32,8 @@ namespace internal {
 /// GOOGLE_CLOUD_DIRECT_PATH.
 bool DirectPathEnabled();
 Options DefaultOptionsGrpc(Options = {});
+
+class StorageStub;
 
 class GrpcClient : public RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
@@ -324,9 +325,7 @@ class GrpcClient : public RawClient,
 
  private:
   ClientOptions backwards_compatibility_options_;
-  std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy>
-      auth_strategy_;
-  std::shared_ptr<google::storage::v1::Storage::Stub> stub_;
+  std::shared_ptr<StorageStub> stub_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/storage_auth.cc
+++ b/google/cloud/storage/internal/storage_auth.cc
@@ -1,0 +1,452 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_auth.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+std::unique_ptr<StorageStub::ObjectMediaStream> StorageAuth::GetObjectMedia(
+    std::unique_ptr<grpc::ClientContext> context,
+    google::storage::v1::GetObjectMediaRequest const& request) {
+  // TODO(coryan) - refactor to return a "always fails" stream
+  auto status = auth_->ConfigureContext(*context);
+  if (!status.ok()) return {};
+  return child_->GetObjectMedia(std::move(context), request);
+}
+
+std::unique_ptr<StorageStub::InsertStream> StorageAuth::InsertObjectMedia(
+    std::unique_ptr<grpc::ClientContext> context) {
+  // TODO(coryan) - refactor to return a "always fails" stream
+  auto status = auth_->ConfigureContext(*context);
+  if (!status.ok()) return {};
+  return child_->InsertObjectMedia(std::move(context));
+}
+
+Status StorageAuth::DeleteBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteBucketAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageAuth::GetBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::GetBucketAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageAuth::InsertBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertBucketAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->InsertBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ListBucketAccessControlsResponse>
+StorageAuth::ListBucketAccessControls(
+    grpc::ClientContext& context,
+    google::storage::v1::ListBucketAccessControlsRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListBucketAccessControls(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageAuth::UpdateBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateBucketAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateBucketAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::BucketAccessControl>
+StorageAuth::PatchBucketAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::PatchBucketAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->PatchBucketAccessControl(context, request);
+}
+
+Status StorageAuth::DeleteBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteBucketRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteBucket(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageAuth::GetBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::GetBucketRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetBucket(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageAuth::InsertBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertBucketRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->InsertBucket(context, request);
+}
+
+StatusOr<google::storage::v1::ListBucketsResponse> StorageAuth::ListBuckets(
+    grpc::ClientContext& context,
+    google::storage::v1::ListBucketsRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListBuckets(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageAuth::LockBucketRetentionPolicy(
+    grpc::ClientContext& context,
+    google::storage::v1::LockRetentionPolicyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->LockBucketRetentionPolicy(context, request);
+}
+
+StatusOr<google::iam::v1::Policy> StorageAuth::GetBucketIamPolicy(
+    grpc::ClientContext& context,
+    google::storage::v1::GetIamPolicyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetBucketIamPolicy(context, request);
+}
+
+StatusOr<google::iam::v1::Policy> StorageAuth::SetBucketIamPolicy(
+    grpc::ClientContext& context,
+    google::storage::v1::SetIamPolicyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->SetBucketIamPolicy(context, request);
+}
+
+StatusOr<google::iam::v1::TestIamPermissionsResponse>
+StorageAuth::TestBucketIamPermissions(
+    grpc::ClientContext& context,
+    google::storage::v1::TestIamPermissionsRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->TestBucketIamPermissions(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageAuth::PatchBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::PatchBucketRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->PatchBucket(context, request);
+}
+
+StatusOr<google::storage::v1::Bucket> StorageAuth::UpdateBucket(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateBucketRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateBucket(context, request);
+}
+
+Status StorageAuth::DeleteDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteDefaultObjectAccessControlRequest const&
+        request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::GetDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::GetDefaultObjectAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::InsertDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertDefaultObjectAccessControlRequest const&
+        request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->InsertDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+StorageAuth::ListDefaultObjectAccessControls(
+    grpc::ClientContext& context,
+    google::storage::v1::ListDefaultObjectAccessControlsRequest const&
+        request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListDefaultObjectAccessControls(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::PatchDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::PatchDefaultObjectAccessControlRequest const&
+        request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->PatchDefaultObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::UpdateDefaultObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
+        request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateDefaultObjectAccessControl(context, request);
+}
+
+Status StorageAuth::DeleteNotification(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteNotificationRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteNotification(context, request);
+}
+
+StatusOr<google::storage::v1::Notification> StorageAuth::GetNotification(
+    grpc::ClientContext& context,
+    google::storage::v1::GetNotificationRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetNotification(context, request);
+}
+
+StatusOr<google::storage::v1::Notification> StorageAuth::InsertNotification(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertNotificationRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->InsertNotification(context, request);
+}
+
+StatusOr<google::storage::v1::ListNotificationsResponse>
+StorageAuth::ListNotifications(
+    grpc::ClientContext& context,
+    google::storage::v1::ListNotificationsRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListNotifications(context, request);
+}
+
+Status StorageAuth::DeleteObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteObjectAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::GetObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::GetObjectAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::InsertObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::InsertObjectAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->InsertObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+StorageAuth::ListObjectAccessControls(
+    grpc::ClientContext& context,
+    google::storage::v1::ListObjectAccessControlsRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListObjectAccessControls(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::PatchObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::PatchObjectAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->PatchObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::ObjectAccessControl>
+StorageAuth::UpdateObjectAccessControl(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateObjectAccessControlRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateObjectAccessControl(context, request);
+}
+
+StatusOr<google::storage::v1::Object> StorageAuth::ComposeObject(
+    grpc::ClientContext& context,
+    google::storage::v1::ComposeObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ComposeObject(context, request);
+}
+
+StatusOr<google::storage::v1::Object> StorageAuth::CopyObject(
+    grpc::ClientContext& context,
+    google::storage::v1::CopyObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->CopyObject(context, request);
+}
+
+Status StorageAuth::DeleteObject(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteObject(context, request);
+}
+
+StatusOr<google::storage::v1::Object> StorageAuth::GetObject(
+    grpc::ClientContext& context,
+    google::storage::v1::GetObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetObject(context, request);
+}
+
+StatusOr<google::storage::v1::ListObjectsResponse> StorageAuth::ListObjects(
+    grpc::ClientContext& context,
+    google::storage::v1::ListObjectsRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListObjects(context, request);
+}
+
+StatusOr<google::storage::v1::RewriteResponse> StorageAuth::RewriteObject(
+    grpc::ClientContext& context,
+    google::storage::v1::RewriteObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->RewriteObject(context, request);
+}
+
+StatusOr<google::storage::v1::StartResumableWriteResponse>
+StorageAuth::StartResumableWrite(
+    grpc::ClientContext& context,
+    google::storage::v1::StartResumableWriteRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->StartResumableWrite(context, request);
+}
+
+StatusOr<google::storage::v1::QueryWriteStatusResponse>
+StorageAuth::QueryWriteStatus(
+    grpc::ClientContext& context,
+    google::storage::v1::QueryWriteStatusRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->QueryWriteStatus(context, request);
+}
+
+StatusOr<google::storage::v1::Object> StorageAuth::PatchObject(
+    grpc::ClientContext& context,
+    google::storage::v1::PatchObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->PatchObject(context, request);
+}
+
+StatusOr<google::storage::v1::Object> StorageAuth::UpdateObject(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateObjectRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateObject(context, request);
+}
+
+StatusOr<google::storage::v1::ServiceAccount> StorageAuth::GetServiceAccount(
+    grpc::ClientContext& context,
+    google::storage::v1::GetProjectServiceAccountRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetServiceAccount(context, request);
+}
+
+StatusOr<google::storage::v1::CreateHmacKeyResponse> StorageAuth::CreateHmacKey(
+    grpc::ClientContext& context,
+    google::storage::v1::CreateHmacKeyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->CreateHmacKey(context, request);
+}
+
+Status StorageAuth::DeleteHmacKey(
+    grpc::ClientContext& context,
+    google::storage::v1::DeleteHmacKeyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->DeleteHmacKey(context, request);
+}
+
+StatusOr<google::storage::v1::HmacKeyMetadata> StorageAuth::GetHmacKey(
+    grpc::ClientContext& context,
+    google::storage::v1::GetHmacKeyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->GetHmacKey(context, request);
+}
+
+StatusOr<google::storage::v1::ListHmacKeysResponse> StorageAuth::ListHmacKeys(
+    grpc::ClientContext& context,
+    google::storage::v1::ListHmacKeysRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ListHmacKeys(context, request);
+}
+
+StatusOr<google::storage::v1::HmacKeyMetadata> StorageAuth::UpdateHmacKey(
+    grpc::ClientContext& context,
+    google::storage::v1::UpdateHmacKeyRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->UpdateHmacKey(context, request);
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/storage_auth.cc
+++ b/google/cloud/storage/internal/storage_auth.cc
@@ -23,17 +23,19 @@ namespace internal {
 std::unique_ptr<StorageStub::ObjectMediaStream> StorageAuth::GetObjectMedia(
     std::unique_ptr<grpc::ClientContext> context,
     google::storage::v1::GetObjectMediaRequest const& request) {
-  // TODO(coryan) - refactor to return a "always fails" stream
+  using ErrorStream = google::cloud::internal::StreamingReadRpcError<
+      google::storage::v1::GetObjectMediaResponse>;
   auto status = auth_->ConfigureContext(*context);
-  if (!status.ok()) return {};
+  if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
   return child_->GetObjectMedia(std::move(context), request);
 }
 
 std::unique_ptr<StorageStub::InsertStream> StorageAuth::InsertObjectMedia(
     std::unique_ptr<grpc::ClientContext> context) {
-  // TODO(coryan) - refactor to return a "always fails" stream
+  using ErrorStream = google::cloud::internal::StreamingWriteRpcError<
+      google::storage::v1::InsertObjectRequest, google::storage::v1::Object>;
   auto status = auth_->ConfigureContext(*context);
-  if (!status.ok()) return {};
+  if (!status.ok()) return absl::make_unique<ErrorStream>(std::move(status));
   return child_->InsertObjectMedia(std::move(context));
 }
 
@@ -81,15 +83,6 @@ StorageAuth::UpdateBucketAccessControl(
   return child_->UpdateBucketAccessControl(context, request);
 }
 
-StatusOr<google::storage::v1::BucketAccessControl>
-StorageAuth::PatchBucketAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::PatchBucketAccessControlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->PatchBucketAccessControl(context, request);
-}
-
 Status StorageAuth::DeleteBucket(
     grpc::ClientContext& context,
     google::storage::v1::DeleteBucketRequest const& request) {
@@ -122,14 +115,6 @@ StatusOr<google::storage::v1::ListBucketsResponse> StorageAuth::ListBuckets(
   return child_->ListBuckets(context, request);
 }
 
-StatusOr<google::storage::v1::Bucket> StorageAuth::LockBucketRetentionPolicy(
-    grpc::ClientContext& context,
-    google::storage::v1::LockRetentionPolicyRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->LockBucketRetentionPolicy(context, request);
-}
-
 StatusOr<google::iam::v1::Policy> StorageAuth::GetBucketIamPolicy(
     grpc::ClientContext& context,
     google::storage::v1::GetIamPolicyRequest const& request) {
@@ -153,14 +138,6 @@ StorageAuth::TestBucketIamPermissions(
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->TestBucketIamPermissions(context, request);
-}
-
-StatusOr<google::storage::v1::Bucket> StorageAuth::PatchBucket(
-    grpc::ClientContext& context,
-    google::storage::v1::PatchBucketRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->PatchBucket(context, request);
 }
 
 StatusOr<google::storage::v1::Bucket> StorageAuth::UpdateBucket(
@@ -210,16 +187,6 @@ StorageAuth::ListDefaultObjectAccessControls(
 }
 
 StatusOr<google::storage::v1::ObjectAccessControl>
-StorageAuth::PatchDefaultObjectAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::PatchDefaultObjectAccessControlRequest const&
-        request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->PatchDefaultObjectAccessControl(context, request);
-}
-
-StatusOr<google::storage::v1::ObjectAccessControl>
 StorageAuth::UpdateDefaultObjectAccessControl(
     grpc::ClientContext& context,
     google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
@@ -262,105 +229,12 @@ StorageAuth::ListNotifications(
   return child_->ListNotifications(context, request);
 }
 
-Status StorageAuth::DeleteObjectAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::DeleteObjectAccessControlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->DeleteObjectAccessControl(context, request);
-}
-
-StatusOr<google::storage::v1::ObjectAccessControl>
-StorageAuth::GetObjectAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::GetObjectAccessControlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetObjectAccessControl(context, request);
-}
-
-StatusOr<google::storage::v1::ObjectAccessControl>
-StorageAuth::InsertObjectAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::InsertObjectAccessControlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->InsertObjectAccessControl(context, request);
-}
-
-StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
-StorageAuth::ListObjectAccessControls(
-    grpc::ClientContext& context,
-    google::storage::v1::ListObjectAccessControlsRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->ListObjectAccessControls(context, request);
-}
-
-StatusOr<google::storage::v1::ObjectAccessControl>
-StorageAuth::PatchObjectAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::PatchObjectAccessControlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->PatchObjectAccessControl(context, request);
-}
-
-StatusOr<google::storage::v1::ObjectAccessControl>
-StorageAuth::UpdateObjectAccessControl(
-    grpc::ClientContext& context,
-    google::storage::v1::UpdateObjectAccessControlRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->UpdateObjectAccessControl(context, request);
-}
-
-StatusOr<google::storage::v1::Object> StorageAuth::ComposeObject(
-    grpc::ClientContext& context,
-    google::storage::v1::ComposeObjectRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->ComposeObject(context, request);
-}
-
-StatusOr<google::storage::v1::Object> StorageAuth::CopyObject(
-    grpc::ClientContext& context,
-    google::storage::v1::CopyObjectRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->CopyObject(context, request);
-}
-
 Status StorageAuth::DeleteObject(
     grpc::ClientContext& context,
     google::storage::v1::DeleteObjectRequest const& request) {
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->DeleteObject(context, request);
-}
-
-StatusOr<google::storage::v1::Object> StorageAuth::GetObject(
-    grpc::ClientContext& context,
-    google::storage::v1::GetObjectRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetObject(context, request);
-}
-
-StatusOr<google::storage::v1::ListObjectsResponse> StorageAuth::ListObjects(
-    grpc::ClientContext& context,
-    google::storage::v1::ListObjectsRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->ListObjects(context, request);
-}
-
-StatusOr<google::storage::v1::RewriteResponse> StorageAuth::RewriteObject(
-    grpc::ClientContext& context,
-    google::storage::v1::RewriteObjectRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->RewriteObject(context, request);
 }
 
 StatusOr<google::storage::v1::StartResumableWriteResponse>
@@ -379,70 +253,6 @@ StorageAuth::QueryWriteStatus(
   auto status = auth_->ConfigureContext(context);
   if (!status.ok()) return status;
   return child_->QueryWriteStatus(context, request);
-}
-
-StatusOr<google::storage::v1::Object> StorageAuth::PatchObject(
-    grpc::ClientContext& context,
-    google::storage::v1::PatchObjectRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->PatchObject(context, request);
-}
-
-StatusOr<google::storage::v1::Object> StorageAuth::UpdateObject(
-    grpc::ClientContext& context,
-    google::storage::v1::UpdateObjectRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->UpdateObject(context, request);
-}
-
-StatusOr<google::storage::v1::ServiceAccount> StorageAuth::GetServiceAccount(
-    grpc::ClientContext& context,
-    google::storage::v1::GetProjectServiceAccountRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetServiceAccount(context, request);
-}
-
-StatusOr<google::storage::v1::CreateHmacKeyResponse> StorageAuth::CreateHmacKey(
-    grpc::ClientContext& context,
-    google::storage::v1::CreateHmacKeyRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->CreateHmacKey(context, request);
-}
-
-Status StorageAuth::DeleteHmacKey(
-    grpc::ClientContext& context,
-    google::storage::v1::DeleteHmacKeyRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->DeleteHmacKey(context, request);
-}
-
-StatusOr<google::storage::v1::HmacKeyMetadata> StorageAuth::GetHmacKey(
-    grpc::ClientContext& context,
-    google::storage::v1::GetHmacKeyRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->GetHmacKey(context, request);
-}
-
-StatusOr<google::storage::v1::ListHmacKeysResponse> StorageAuth::ListHmacKeys(
-    grpc::ClientContext& context,
-    google::storage::v1::ListHmacKeysRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->ListHmacKeys(context, request);
-}
-
-StatusOr<google::storage::v1::HmacKeyMetadata> StorageAuth::UpdateHmacKey(
-    grpc::ClientContext& context,
-    google::storage::v1::UpdateHmacKeyRequest const& request) {
-  auto status = auth_->ConfigureContext(context);
-  if (!status.ok()) return status;
-  return child_->UpdateHmacKey(context, request);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/storage_auth.h
+++ b/google/cloud/storage/internal/storage_auth.h
@@ -61,10 +61,6 @@ class StorageAuth : public StorageStub {
       grpc::ClientContext& context,
       google::storage::v1::UpdateBucketAccessControlRequest const& request)
       override;
-  StatusOr<google::storage::v1::BucketAccessControl> PatchBucketAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchBucketAccessControlRequest const& request)
-      override;
   Status DeleteBucket(
       grpc::ClientContext& context,
       google::storage::v1::DeleteBucketRequest const& request) override;
@@ -77,9 +73,6 @@ class StorageAuth : public StorageStub {
   StatusOr<google::storage::v1::ListBucketsResponse> ListBuckets(
       grpc::ClientContext& context,
       google::storage::v1::ListBucketsRequest const& request) override;
-  StatusOr<google::storage::v1::Bucket> LockBucketRetentionPolicy(
-      grpc::ClientContext& context,
-      google::storage::v1::LockRetentionPolicyRequest const& request) override;
   StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
       grpc::ClientContext& context,
       google::storage::v1::GetIamPolicyRequest const& request) override;
@@ -90,9 +83,6 @@ class StorageAuth : public StorageStub {
   TestBucketIamPermissions(
       grpc::ClientContext& context,
       google::storage::v1::TestIamPermissionsRequest const& request) override;
-  StatusOr<google::storage::v1::Bucket> PatchBucket(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchBucketRequest const& request) override;
   StatusOr<google::storage::v1::Bucket> UpdateBucket(
       grpc::ClientContext& context,
       google::storage::v1::UpdateBucketRequest const& request) override;
@@ -116,11 +106,6 @@ class StorageAuth : public StorageStub {
       google::storage::v1::ListDefaultObjectAccessControlsRequest const&
           request) override;
   StatusOr<google::storage::v1::ObjectAccessControl>
-  PatchDefaultObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchDefaultObjectAccessControlRequest const&
-          request) override;
-  StatusOr<google::storage::v1::ObjectAccessControl>
   UpdateDefaultObjectAccessControl(
       grpc::ClientContext& context,
       google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
@@ -137,49 +122,9 @@ class StorageAuth : public StorageStub {
   StatusOr<google::storage::v1::ListNotificationsResponse> ListNotifications(
       grpc::ClientContext& context,
       google::storage::v1::ListNotificationsRequest const& request) override;
-  Status DeleteObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::DeleteObjectAccessControlRequest const& request)
-      override;
-  StatusOr<google::storage::v1::ObjectAccessControl> GetObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::GetObjectAccessControlRequest const& request)
-      override;
-  StatusOr<google::storage::v1::ObjectAccessControl> InsertObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::InsertObjectAccessControlRequest const& request)
-      override;
-  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
-  ListObjectAccessControls(
-      grpc::ClientContext& context,
-      google::storage::v1::ListObjectAccessControlsRequest const& request)
-      override;
-  StatusOr<google::storage::v1::ObjectAccessControl> PatchObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchObjectAccessControlRequest const& request)
-      override;
-  StatusOr<google::storage::v1::ObjectAccessControl> UpdateObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateObjectAccessControlRequest const& request)
-      override;
-  StatusOr<google::storage::v1::Object> ComposeObject(
-      grpc::ClientContext& context,
-      google::storage::v1::ComposeObjectRequest const& request) override;
-  StatusOr<google::storage::v1::Object> CopyObject(
-      grpc::ClientContext& context,
-      google::storage::v1::CopyObjectRequest const& request) override;
   Status DeleteObject(
       grpc::ClientContext& context,
       google::storage::v1::DeleteObjectRequest const& request) override;
-  StatusOr<google::storage::v1::Object> GetObject(
-      grpc::ClientContext& context,
-      google::storage::v1::GetObjectRequest const& request) override;
-  StatusOr<google::storage::v1::ListObjectsResponse> ListObjects(
-      grpc::ClientContext& context,
-      google::storage::v1::ListObjectsRequest const& request) override;
-  StatusOr<google::storage::v1::RewriteResponse> RewriteObject(
-      grpc::ClientContext& context,
-      google::storage::v1::RewriteObjectRequest const& request) override;
   StatusOr<google::storage::v1::StartResumableWriteResponse>
   StartResumableWrite(
       grpc::ClientContext& context,
@@ -187,31 +132,6 @@ class StorageAuth : public StorageStub {
   StatusOr<google::storage::v1::QueryWriteStatusResponse> QueryWriteStatus(
       grpc::ClientContext& context,
       google::storage::v1::QueryWriteStatusRequest const& request) override;
-  StatusOr<google::storage::v1::Object> PatchObject(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchObjectRequest const& request) override;
-  StatusOr<google::storage::v1::Object> UpdateObject(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateObjectRequest const& request) override;
-  StatusOr<google::storage::v1::ServiceAccount> GetServiceAccount(
-      grpc::ClientContext& context,
-      google::storage::v1::GetProjectServiceAccountRequest const& request)
-      override;
-  StatusOr<google::storage::v1::CreateHmacKeyResponse> CreateHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::CreateHmacKeyRequest const& request) override;
-  Status DeleteHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::DeleteHmacKeyRequest const& request) override;
-  StatusOr<google::storage::v1::HmacKeyMetadata> GetHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::GetHmacKeyRequest const& request) override;
-  StatusOr<google::storage::v1::ListHmacKeysResponse> ListHmacKeys(
-      grpc::ClientContext& context,
-      google::storage::v1::ListHmacKeysRequest const& request) override;
-  StatusOr<google::storage::v1::HmacKeyMetadata> UpdateHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateHmacKeyRequest const& request) override;
 
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;

--- a/google/cloud/storage/internal/storage_auth.h
+++ b/google/cloud/storage/internal/storage_auth.h
@@ -1,0 +1,227 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_AUTH_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_AUTH_H
+
+#include "google/cloud/storage/internal/storage_stub.h"
+#include "google/cloud/storage/version.h"
+#include "google/cloud/internal/unified_grpc_credentials.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+class StorageAuth : public StorageStub {
+ public:
+  explicit StorageAuth(
+      std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth,
+      std::shared_ptr<StorageStub> child)
+      : auth_(std::move(auth)), child_(std::move(child)) {}
+  ~StorageAuth() override = default;
+
+  std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v1::GetObjectMediaRequest const& request) override;
+
+  std::unique_ptr<InsertStream> InsertObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context) override;
+
+  Status DeleteBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> GetBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> InsertBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ListBucketAccessControlsResponse>
+  ListBucketAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketAccessControlsRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> UpdateBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::BucketAccessControl> PatchBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchBucketAccessControlRequest const& request)
+      override;
+  Status DeleteBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> GetBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> InsertBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketRequest const& request) override;
+  StatusOr<google::storage::v1::ListBucketsResponse> ListBuckets(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketsRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> LockBucketRetentionPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::LockRetentionPolicyRequest const& request) override;
+  StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::GetIamPolicyRequest const& request) override;
+  StatusOr<google::iam::v1::Policy> SetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::SetIamPolicyRequest const& request) override;
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestBucketIamPermissions(
+      grpc::ClientContext& context,
+      google::storage::v1::TestIamPermissionsRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> PatchBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchBucketRequest const& request) override;
+  StatusOr<google::storage::v1::Bucket> UpdateBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketRequest const& request) override;
+  Status DeleteDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteDefaultObjectAccessControlRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  GetDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetDefaultObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  InsertDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertDefaultObjectAccessControlRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListDefaultObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListDefaultObjectAccessControlsRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  PatchDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchDefaultObjectAccessControlRequest const&
+          request) override;
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  UpdateDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
+          request) override;
+  Status DeleteNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteNotificationRequest const& request) override;
+  StatusOr<google::storage::v1::Notification> GetNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::GetNotificationRequest const& request) override;
+  StatusOr<google::storage::v1::Notification> InsertNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertNotificationRequest const& request) override;
+  StatusOr<google::storage::v1::ListNotificationsResponse> ListNotifications(
+      grpc::ClientContext& context,
+      google::storage::v1::ListNotificationsRequest const& request) override;
+  Status DeleteObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ObjectAccessControl> GetObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ObjectAccessControl> InsertObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListObjectAccessControlsRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ObjectAccessControl> PatchObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::ObjectAccessControl> UpdateObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateObjectAccessControlRequest const& request)
+      override;
+  StatusOr<google::storage::v1::Object> ComposeObject(
+      grpc::ClientContext& context,
+      google::storage::v1::ComposeObjectRequest const& request) override;
+  StatusOr<google::storage::v1::Object> CopyObject(
+      grpc::ClientContext& context,
+      google::storage::v1::CopyObjectRequest const& request) override;
+  Status DeleteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectRequest const& request) override;
+  StatusOr<google::storage::v1::Object> GetObject(
+      grpc::ClientContext& context,
+      google::storage::v1::GetObjectRequest const& request) override;
+  StatusOr<google::storage::v1::ListObjectsResponse> ListObjects(
+      grpc::ClientContext& context,
+      google::storage::v1::ListObjectsRequest const& request) override;
+  StatusOr<google::storage::v1::RewriteResponse> RewriteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::RewriteObjectRequest const& request) override;
+  StatusOr<google::storage::v1::StartResumableWriteResponse>
+  StartResumableWrite(
+      grpc::ClientContext& context,
+      google::storage::v1::StartResumableWriteRequest const& request) override;
+  StatusOr<google::storage::v1::QueryWriteStatusResponse> QueryWriteStatus(
+      grpc::ClientContext& context,
+      google::storage::v1::QueryWriteStatusRequest const& request) override;
+  StatusOr<google::storage::v1::Object> PatchObject(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchObjectRequest const& request) override;
+  StatusOr<google::storage::v1::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateObjectRequest const& request) override;
+  StatusOr<google::storage::v1::ServiceAccount> GetServiceAccount(
+      grpc::ClientContext& context,
+      google::storage::v1::GetProjectServiceAccountRequest const& request)
+      override;
+  StatusOr<google::storage::v1::CreateHmacKeyResponse> CreateHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::CreateHmacKeyRequest const& request) override;
+  Status DeleteHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteHmacKeyRequest const& request) override;
+  StatusOr<google::storage::v1::HmacKeyMetadata> GetHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::GetHmacKeyRequest const& request) override;
+  StatusOr<google::storage::v1::ListHmacKeysResponse> ListHmacKeys(
+      grpc::ClientContext& context,
+      google::storage::v1::ListHmacKeysRequest const& request) override;
+  StatusOr<google::storage::v1::HmacKeyMetadata> UpdateHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateHmacKeyRequest const& request) override;
+
+ private:
+  std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
+  std::shared_ptr<StorageStub> child_;
+};
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_AUTH_H

--- a/google/cloud/storage/internal/storage_auth_test.cc
+++ b/google/cloud/storage/internal/storage_auth_test.cc
@@ -1,0 +1,571 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_auth.h"
+#include "google/cloud/storage/testing/mock_storage_stub.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::google::cloud::internal::GrpcAuthenticationStrategy;
+using ::google::cloud::storage::testing::MockStorageStub;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::IsNull;
+using ::testing::Not;
+using ::testing::Return;
+
+class MockAuthenticationStrategy : public GrpcAuthenticationStrategy {
+ public:
+  MOCK_METHOD(std::shared_ptr<grpc::Channel>, CreateChannel,
+              (std::string const&, grpc::ChannelArguments const&), (override));
+  MOCK_METHOD(bool, RequiresConfigureContext, (), (const, override));
+  MOCK_METHOD(Status, ConfigureContext, (grpc::ClientContext&), (override));
+  MOCK_METHOD(future<StatusOr<std::unique_ptr<grpc::ClientContext>>>,
+              AsyncConfigureContext, (std::unique_ptr<grpc::ClientContext>),
+              (override));
+};
+
+std::shared_ptr<GrpcAuthenticationStrategy> MakeMockAuth() {
+  auto auth = std::make_shared<MockAuthenticationStrategy>();
+  EXPECT_CALL(*auth, ConfigureContext)
+      .WillOnce([](grpc::ClientContext&) {
+        return Status(StatusCode::kInvalidArgument, "cannot-set-credentials");
+      })
+      .WillOnce([](grpc::ClientContext& context) {
+        context.set_credentials(
+            grpc::AccessTokenCredentials("test-only-invalid"));
+        return Status{};
+      });
+  return auth;
+}
+
+std::unique_ptr<StorageStub::ObjectMediaStream> MakeObjectMediaStream(
+    std::unique_ptr<grpc::ClientContext>,
+    google::storage::v1::GetObjectMediaRequest const&) {
+  using ErrorStream = google::cloud::internal::StreamingReadRpcError<
+      google::storage::v1::GetObjectMediaResponse>;
+  return absl::make_unique<ErrorStream>(
+      Status(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
+std::unique_ptr<StorageStub::InsertStream> MakeInsertStream(
+    std::unique_ptr<grpc::ClientContext>) {
+  using ErrorStream = google::cloud::internal::StreamingWriteRpcError<
+      google::storage::v1::InsertObjectRequest, google::storage::v1::Object>;
+  return absl::make_unique<ErrorStream>(
+      Status(StatusCode::kPermissionDenied, "uh-oh"));
+}
+
+// The general pattern of these test is to make two requests, both of which
+// return an error. The first one because the auth strategy fails, the second
+// because the operation in the mock stub fails.
+//
+// The first two tests are slightly different because they deal with streaming
+// RPCs.
+
+TEST(StorageAuthTest, GetObjectMedia) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetObjectMedia).WillOnce(MakeObjectMediaStream);
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::GetObjectMediaRequest request;
+  auto auth_failure = under_test.GetObjectMedia(
+      absl::make_unique<grpc::ClientContext>(), request);
+  auto v = auth_failure->Read();
+  ASSERT_TRUE(absl::holds_alternative<Status>(v));
+  EXPECT_THAT(absl::get<Status>(v), StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.GetObjectMedia(
+      absl::make_unique<grpc::ClientContext>(), request);
+  v = auth_success->Read();
+  ASSERT_TRUE(absl::holds_alternative<Status>(v));
+  EXPECT_THAT(absl::get<Status>(v), StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, InsertObjectMedia) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, InsertObjectMedia).WillOnce(MakeInsertStream);
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  auto auth_failure =
+      under_test.InsertObjectMedia(absl::make_unique<grpc::ClientContext>());
+  EXPECT_THAT(auth_failure->Close(), StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success =
+      under_test.InsertObjectMedia(absl::make_unique<grpc::ClientContext>());
+  EXPECT_THAT(auth_success->Close(), StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, DeleteBucketAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, DeleteBucketAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::DeleteBucketAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.DeleteBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.DeleteBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, GetBucketAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetBucketAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::GetBucketAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.GetBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.GetBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, InsertBucketAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, InsertBucketAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::InsertBucketAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.InsertBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.InsertBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, ListBucketAccessControls) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, ListBucketAccessControls)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::ListBucketAccessControlsRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.ListBucketAccessControls(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.ListBucketAccessControls(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, UpdateBucketAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, UpdateBucketAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::UpdateBucketAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.UpdateBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.UpdateBucketAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, DeleteBucket) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, DeleteBucket)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::DeleteBucketRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.DeleteBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.DeleteBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, GetBucket) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetBucket)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::GetBucketRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.GetBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.GetBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, InsertBucket) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, InsertBucket)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::InsertBucketRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.InsertBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.InsertBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, ListBuckets) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, ListBuckets)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::ListBucketsRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.ListBuckets(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.ListBuckets(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, GetBucketIamPolicy) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetBucketIamPolicy)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::GetIamPolicyRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.GetBucketIamPolicy(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.GetBucketIamPolicy(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, SetBucketIamPolicy) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, SetBucketIamPolicy)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::SetIamPolicyRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.SetBucketIamPolicy(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.SetBucketIamPolicy(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, TestBucketIamPermissions) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, TestBucketIamPermissions)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::TestIamPermissionsRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.TestBucketIamPermissions(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.TestBucketIamPermissions(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, UpdateBucket) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, UpdateBucket)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::UpdateBucketRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.UpdateBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.UpdateBucket(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, DeleteDefaultObjectAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, DeleteDefaultObjectAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::DeleteDefaultObjectAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.DeleteDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.DeleteDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, GetDefaultObjectAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetDefaultObjectAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::GetDefaultObjectAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.GetDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.GetDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, InsertDefaultObjectAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, InsertDefaultObjectAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::InsertDefaultObjectAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.InsertDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.InsertDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, ListDefaultObjectAccessControls) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, ListDefaultObjectAccessControls)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::ListDefaultObjectAccessControlsRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.ListDefaultObjectAccessControls(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.ListDefaultObjectAccessControls(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, UpdateDefaultObjectAccessControl) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, UpdateDefaultObjectAccessControl)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::UpdateDefaultObjectAccessControlRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.UpdateDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.UpdateDefaultObjectAccessControl(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, DeleteNotification) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, DeleteNotification)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::DeleteNotificationRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.DeleteNotification(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.DeleteNotification(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, GetNotification) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, GetNotification)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::GetNotificationRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.GetNotification(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.GetNotification(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, InsertNotification) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, InsertNotification)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::InsertNotificationRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.InsertNotification(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.InsertNotification(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, ListNotifications) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, ListNotifications)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::ListNotificationsRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.ListNotifications(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.ListNotifications(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, DeleteObject) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, DeleteObject)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::DeleteObjectRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.DeleteObject(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.DeleteObject(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, StartResumableWrite) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, StartResumableWrite)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::StartResumableWriteRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.StartResumableWrite(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.StartResumableWrite(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(StorageAuthTest, QueryWriteStatus) {
+  auto mock = std::make_shared<MockStorageStub>();
+  EXPECT_CALL(*mock, QueryWriteStatus)
+      .WillOnce(
+          ::testing::Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto under_test = StorageAuth(MakeMockAuth(), mock);
+  google::storage::v1::QueryWriteStatusRequest request;
+  grpc::ClientContext ctx;
+  auto auth_failure = under_test.QueryWriteStatus(ctx, request);
+  EXPECT_THAT(ctx.credentials(), IsNull());
+  EXPECT_THAT(auth_failure, StatusIs(StatusCode::kInvalidArgument));
+
+  auto auth_success = under_test.QueryWriteStatus(ctx, request);
+  EXPECT_THAT(ctx.credentials(), Not(IsNull()));
+  EXPECT_THAT(auth_success, StatusIs(StatusCode::kPermissionDenied));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -1,0 +1,543 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/storage_stub.h"
+#include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/getenv.h"
+#include "absl/memory/memory.h"
+#include <google/storage/v1/storage.grpc.pb.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+namespace {
+
+class StorageStubImpl : public StorageStub {
+ public:
+  explicit StorageStubImpl(
+      std::unique_ptr<google::storage::v1::Storage::StubInterface> impl)
+      : impl_(std::move(impl)) {}
+  ~StorageStubImpl() override = default;
+
+  std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v1::GetObjectMediaRequest const& request) override {
+    using ::google::cloud::internal::StreamingReadRpcImpl;
+    auto stream = impl_->GetObjectMedia(context.get(), request);
+    return absl::make_unique<
+        StreamingReadRpcImpl<google::storage::v1::GetObjectMediaResponse>>(
+        std::move(context), std::move(stream));
+  }
+
+  std::unique_ptr<InsertStream> InsertObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context) override {
+    using ::google::cloud::internal::StreamingWriteRpcImpl;
+    using ResponseType = ::google::storage::v1::Object;
+    using RequestType = ::google::storage::v1::InsertObjectRequest;
+    auto response = absl::make_unique<ResponseType>();
+    auto stream = impl_->InsertObject(context.get(), response.get());
+    return absl::make_unique<StreamingWriteRpcImpl<RequestType, ResponseType>>(
+        std::move(context), std::move(response), std::move(stream));
+  }
+
+  Status DeleteBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketAccessControlRequest const& request)
+      override {
+    google::protobuf::Empty response;
+    auto status =
+        impl_->DeleteBucketAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::BucketAccessControl> GetBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketAccessControlRequest const& request)
+      override {
+    google::storage::v1::BucketAccessControl response;
+    auto status = impl_->GetBucketAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::BucketAccessControl> InsertBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketAccessControlRequest const& request)
+      override {
+    google::storage::v1::BucketAccessControl response;
+    auto status =
+        impl_->InsertBucketAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ListBucketAccessControlsResponse>
+  ListBucketAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketAccessControlsRequest const& request)
+      override {
+    google::storage::v1::ListBucketAccessControlsResponse response;
+    auto status = impl_->ListBucketAccessControls(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::BucketAccessControl> UpdateBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketAccessControlRequest const& request)
+      override {
+    google::storage::v1::BucketAccessControl response;
+    auto status =
+        impl_->UpdateBucketAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::BucketAccessControl> PatchBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchBucketAccessControlRequest const& request)
+      override {
+    google::storage::v1::BucketAccessControl response;
+    auto status = impl_->PatchBucketAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = impl_->DeleteBucket(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::Bucket> GetBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketRequest const& request) override {
+    google::storage::v1::Bucket response;
+    auto status = impl_->GetBucket(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Bucket> InsertBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketRequest const& request) override {
+    google::storage::v1::Bucket response;
+    auto status = impl_->InsertBucket(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ListBucketsResponse> ListBuckets(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketsRequest const& request) override {
+    google::storage::v1::ListBucketsResponse response;
+    auto status = impl_->ListBuckets(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Bucket> LockBucketRetentionPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::LockRetentionPolicyRequest const& request) override {
+    google::storage::v1::Bucket response;
+    auto status =
+        impl_->LockBucketRetentionPolicy(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::GetIamPolicyRequest const& request) override {
+    google::iam::v1::Policy response;
+    auto status = impl_->GetBucketIamPolicy(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::iam::v1::Policy> SetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::SetIamPolicyRequest const& request) override {
+    google::iam::v1::Policy response;
+    auto status = impl_->SetBucketIamPolicy(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestBucketIamPermissions(
+      grpc::ClientContext& context,
+      google::storage::v1::TestIamPermissionsRequest const& request) override {
+    google::iam::v1::TestIamPermissionsResponse response;
+    auto status = impl_->TestBucketIamPermissions(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Bucket> PatchBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchBucketRequest const& request) override {
+    google::storage::v1::Bucket response;
+    auto status = impl_->PatchBucket(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Bucket> UpdateBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketRequest const& request) override {
+    google::storage::v1::Bucket response;
+    auto status = impl_->UpdateBucket(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteDefaultObjectAccessControlRequest const&
+          request) override {
+    google::protobuf::Empty response;
+    auto status =
+        impl_->DeleteDefaultObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  GetDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetDefaultObjectAccessControlRequest const& request)
+      override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status =
+        impl_->GetDefaultObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  InsertDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertDefaultObjectAccessControlRequest const&
+          request) override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status =
+        impl_->InsertDefaultObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListDefaultObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListDefaultObjectAccessControlsRequest const&
+          request) override {
+    google::storage::v1::ListObjectAccessControlsResponse response;
+    auto status =
+        impl_->ListDefaultObjectAccessControls(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  PatchDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchDefaultObjectAccessControlRequest const&
+          request) override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status =
+        impl_->PatchDefaultObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl>
+  UpdateDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
+          request) override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status =
+        impl_->UpdateDefaultObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteNotificationRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = impl_->DeleteNotification(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::Notification> GetNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::GetNotificationRequest const& request) override {
+    google::storage::v1::Notification response;
+    auto status = impl_->GetNotification(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Notification> InsertNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertNotificationRequest const& request) override {
+    google::storage::v1::Notification response;
+    auto status = impl_->InsertNotification(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ListNotificationsResponse> ListNotifications(
+      grpc::ClientContext& context,
+      google::storage::v1::ListNotificationsRequest const& request) override {
+    google::storage::v1::ListNotificationsResponse response;
+    auto status = impl_->ListNotifications(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectAccessControlRequest const& request)
+      override {
+    google::protobuf::Empty response;
+    auto status =
+        impl_->DeleteObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl> GetObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetObjectAccessControlRequest const& request)
+      override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status = impl_->GetObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl> InsertObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertObjectAccessControlRequest const& request)
+      override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status =
+        impl_->InsertObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListObjectAccessControlsRequest const& request)
+      override {
+    google::storage::v1::ListObjectAccessControlsResponse response;
+    auto status = impl_->ListObjectAccessControls(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl> PatchObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchObjectAccessControlRequest const& request)
+      override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status = impl_->PatchObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ObjectAccessControl> UpdateObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateObjectAccessControlRequest const& request)
+      override {
+    google::storage::v1::ObjectAccessControl response;
+    auto status =
+        impl_->UpdateObjectAccessControl(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Object> ComposeObject(
+      grpc::ClientContext& context,
+      google::storage::v1::ComposeObjectRequest const& request) override {
+    google::storage::v1::Object response;
+    auto status = impl_->ComposeObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Object> CopyObject(
+      grpc::ClientContext& context,
+      google::storage::v1::CopyObjectRequest const& request) override {
+    google::storage::v1::Object response;
+    auto status = impl_->CopyObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = impl_->DeleteObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::Object> GetObject(
+      grpc::ClientContext& context,
+      google::storage::v1::GetObjectRequest const& request) override {
+    google::storage::v1::Object response;
+    auto status = impl_->GetObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ListObjectsResponse> ListObjects(
+      grpc::ClientContext& context,
+      google::storage::v1::ListObjectsRequest const& request) override {
+    google::storage::v1::ListObjectsResponse response;
+    auto status = impl_->ListObjects(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::RewriteResponse> RewriteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::RewriteObjectRequest const& request) override {
+    google::storage::v1::RewriteResponse response;
+    auto status = impl_->RewriteObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::StartResumableWriteResponse>
+  StartResumableWrite(
+      grpc::ClientContext& context,
+      google::storage::v1::StartResumableWriteRequest const& request) override {
+    google::storage::v1::StartResumableWriteResponse response;
+    auto status = impl_->StartResumableWrite(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::QueryWriteStatusResponse> QueryWriteStatus(
+      grpc::ClientContext& context,
+      google::storage::v1::QueryWriteStatusRequest const& request) override {
+    google::storage::v1::QueryWriteStatusResponse response;
+    auto status = impl_->QueryWriteStatus(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Object> PatchObject(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchObjectRequest const& request) override {
+    google::storage::v1::Object response;
+    auto status = impl_->PatchObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateObjectRequest const& request) override {
+    google::storage::v1::Object response;
+    auto status = impl_->UpdateObject(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::ServiceAccount> GetServiceAccount(
+      grpc::ClientContext& context,
+      google::storage::v1::GetProjectServiceAccountRequest const& request)
+      override {
+    google::storage::v1::ServiceAccount response;
+    auto status = impl_->GetServiceAccount(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  StatusOr<google::storage::v1::CreateHmacKeyResponse> CreateHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::CreateHmacKeyRequest const& request) override {
+    google::storage::v1::CreateHmacKeyResponse response;
+    auto status = impl_->CreateHmacKey(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+  Status DeleteHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteHmacKeyRequest const& request) override {
+    google::protobuf::Empty response;
+    auto status = impl_->DeleteHmacKey(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return Status{};
+  }
+
+  StatusOr<google::storage::v1::HmacKeyMetadata> GetHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::GetHmacKeyRequest const& request) override {
+    google::storage::v1::HmacKeyMetadata response;
+    auto status = impl_->GetHmacKey(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+  StatusOr<google::storage::v1::ListHmacKeysResponse> ListHmacKeys(
+      grpc::ClientContext& context,
+      google::storage::v1::ListHmacKeysRequest const& request) override {
+    google::storage::v1::ListHmacKeysResponse response;
+    auto status = impl_->ListHmacKeys(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+  StatusOr<google::storage::v1::HmacKeyMetadata> UpdateHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateHmacKeyRequest const& request) override {
+    google::storage::v1::HmacKeyMetadata response;
+    auto status = impl_->UpdateHmacKey(&context, request, &response);
+    if (!status.ok()) return MakeStatusFromRpcError(status);
+    return response;
+  }
+
+ private:
+  std::unique_ptr<google::storage::v1::Storage::StubInterface> impl_;
+};
+
+}  // namespace
+
+std::shared_ptr<StorageStub> MakeDefaultStorageStub(
+    std::shared_ptr<grpc::Channel> channel) {
+  return std::make_shared<StorageStubImpl>(
+      google::storage::v1::Storage::NewStub(std::move(channel)));
+}
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -107,16 +107,6 @@ class StorageStubImpl : public StorageStub {
     return response;
   }
 
-  StatusOr<google::storage::v1::BucketAccessControl> PatchBucketAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchBucketAccessControlRequest const& request)
-      override {
-    google::storage::v1::BucketAccessControl response;
-    auto status = impl_->PatchBucketAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
   Status DeleteBucket(
       grpc::ClientContext& context,
       google::storage::v1::DeleteBucketRequest const& request) override {
@@ -153,16 +143,6 @@ class StorageStubImpl : public StorageStub {
     return response;
   }
 
-  StatusOr<google::storage::v1::Bucket> LockBucketRetentionPolicy(
-      grpc::ClientContext& context,
-      google::storage::v1::LockRetentionPolicyRequest const& request) override {
-    google::storage::v1::Bucket response;
-    auto status =
-        impl_->LockBucketRetentionPolicy(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
   StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
       grpc::ClientContext& context,
       google::storage::v1::GetIamPolicyRequest const& request) override {
@@ -187,15 +167,6 @@ class StorageStubImpl : public StorageStub {
       google::storage::v1::TestIamPermissionsRequest const& request) override {
     google::iam::v1::TestIamPermissionsResponse response;
     auto status = impl_->TestBucketIamPermissions(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::Bucket> PatchBucket(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchBucketRequest const& request) override {
-    google::storage::v1::Bucket response;
-    auto status = impl_->PatchBucket(&context, request, &response);
     if (!status.ok()) return MakeStatusFromRpcError(status);
     return response;
   }
@@ -257,18 +228,6 @@ class StorageStubImpl : public StorageStub {
   }
 
   StatusOr<google::storage::v1::ObjectAccessControl>
-  PatchDefaultObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchDefaultObjectAccessControlRequest const&
-          request) override {
-    google::storage::v1::ObjectAccessControl response;
-    auto status =
-        impl_->PatchDefaultObjectAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ObjectAccessControl>
   UpdateDefaultObjectAccessControl(
       grpc::ClientContext& context,
       google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
@@ -316,88 +275,6 @@ class StorageStubImpl : public StorageStub {
     return response;
   }
 
-  Status DeleteObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::DeleteObjectAccessControlRequest const& request)
-      override {
-    google::protobuf::Empty response;
-    auto status =
-        impl_->DeleteObjectAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return Status{};
-  }
-
-  StatusOr<google::storage::v1::ObjectAccessControl> GetObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::GetObjectAccessControlRequest const& request)
-      override {
-    google::storage::v1::ObjectAccessControl response;
-    auto status = impl_->GetObjectAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ObjectAccessControl> InsertObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::InsertObjectAccessControlRequest const& request)
-      override {
-    google::storage::v1::ObjectAccessControl response;
-    auto status =
-        impl_->InsertObjectAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
-  ListObjectAccessControls(
-      grpc::ClientContext& context,
-      google::storage::v1::ListObjectAccessControlsRequest const& request)
-      override {
-    google::storage::v1::ListObjectAccessControlsResponse response;
-    auto status = impl_->ListObjectAccessControls(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ObjectAccessControl> PatchObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchObjectAccessControlRequest const& request)
-      override {
-    google::storage::v1::ObjectAccessControl response;
-    auto status = impl_->PatchObjectAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ObjectAccessControl> UpdateObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateObjectAccessControlRequest const& request)
-      override {
-    google::storage::v1::ObjectAccessControl response;
-    auto status =
-        impl_->UpdateObjectAccessControl(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::Object> ComposeObject(
-      grpc::ClientContext& context,
-      google::storage::v1::ComposeObjectRequest const& request) override {
-    google::storage::v1::Object response;
-    auto status = impl_->ComposeObject(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::Object> CopyObject(
-      grpc::ClientContext& context,
-      google::storage::v1::CopyObjectRequest const& request) override {
-    google::storage::v1::Object response;
-    auto status = impl_->CopyObject(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
   Status DeleteObject(
       grpc::ClientContext& context,
       google::storage::v1::DeleteObjectRequest const& request) override {
@@ -405,33 +282,6 @@ class StorageStubImpl : public StorageStub {
     auto status = impl_->DeleteObject(&context, request, &response);
     if (!status.ok()) return MakeStatusFromRpcError(status);
     return Status{};
-  }
-
-  StatusOr<google::storage::v1::Object> GetObject(
-      grpc::ClientContext& context,
-      google::storage::v1::GetObjectRequest const& request) override {
-    google::storage::v1::Object response;
-    auto status = impl_->GetObject(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ListObjectsResponse> ListObjects(
-      grpc::ClientContext& context,
-      google::storage::v1::ListObjectsRequest const& request) override {
-    google::storage::v1::ListObjectsResponse response;
-    auto status = impl_->ListObjects(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::RewriteResponse> RewriteObject(
-      grpc::ClientContext& context,
-      google::storage::v1::RewriteObjectRequest const& request) override {
-    google::storage::v1::RewriteResponse response;
-    auto status = impl_->RewriteObject(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
   }
 
   StatusOr<google::storage::v1::StartResumableWriteResponse>
@@ -449,77 +299,6 @@ class StorageStubImpl : public StorageStub {
       google::storage::v1::QueryWriteStatusRequest const& request) override {
     google::storage::v1::QueryWriteStatusResponse response;
     auto status = impl_->QueryWriteStatus(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::Object> PatchObject(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchObjectRequest const& request) override {
-    google::storage::v1::Object response;
-    auto status = impl_->PatchObject(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::Object> UpdateObject(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateObjectRequest const& request) override {
-    google::storage::v1::Object response;
-    auto status = impl_->UpdateObject(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::ServiceAccount> GetServiceAccount(
-      grpc::ClientContext& context,
-      google::storage::v1::GetProjectServiceAccountRequest const& request)
-      override {
-    google::storage::v1::ServiceAccount response;
-    auto status = impl_->GetServiceAccount(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::storage::v1::CreateHmacKeyResponse> CreateHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::CreateHmacKeyRequest const& request) override {
-    google::storage::v1::CreateHmacKeyResponse response;
-    auto status = impl_->CreateHmacKey(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  Status DeleteHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::DeleteHmacKeyRequest const& request) override {
-    google::protobuf::Empty response;
-    auto status = impl_->DeleteHmacKey(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return Status{};
-  }
-
-  StatusOr<google::storage::v1::HmacKeyMetadata> GetHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::GetHmacKeyRequest const& request) override {
-    google::storage::v1::HmacKeyMetadata response;
-    auto status = impl_->GetHmacKey(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-  StatusOr<google::storage::v1::ListHmacKeysResponse> ListHmacKeys(
-      grpc::ClientContext& context,
-      google::storage::v1::ListHmacKeysRequest const& request) override {
-    google::storage::v1::ListHmacKeysResponse response;
-    auto status = impl_->ListHmacKeys(&context, request, &response);
-    if (!status.ok()) return MakeStatusFromRpcError(status);
-    return response;
-  }
-  StatusOr<google::storage::v1::HmacKeyMetadata> UpdateHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateHmacKeyRequest const& request) override {
-    google::storage::v1::HmacKeyMetadata response;
-    auto status = impl_->UpdateHmacKey(&context, request, &response);
     if (!status.ok()) return MakeStatusFromRpcError(status);
     return response;
   }

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -1,0 +1,226 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_STUB_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_STUB_H
+
+#include "google/cloud/storage/version.h"
+#include "google/cloud/internal/streaming_read_rpc.h"
+#include "google/cloud/internal/streaming_write_rpc.h"
+#include "google/cloud/status_or.h"
+#include <google/storage/v1/storage.pb.h>
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+inline namespace STORAGE_CLIENT_NS {
+namespace internal {
+
+class StorageStub {
+ public:
+  virtual ~StorageStub() = default;
+
+  using ObjectMediaStream = google::cloud::internal::StreamingReadRpc<
+      google::storage::v1::GetObjectMediaResponse>;
+  virtual std::unique_ptr<ObjectMediaStream> GetObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v1::GetObjectMediaRequest const& request) = 0;
+
+  using InsertStream = google::cloud::internal::StreamingWriteRpc<
+      google::storage::v1::InsertObjectRequest, google::storage::v1::Object>;
+  virtual std::unique_ptr<InsertStream> InsertObjectMedia(
+      std::unique_ptr<grpc::ClientContext> context) = 0;
+
+  virtual Status DeleteBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::BucketAccessControl>
+  GetBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::BucketAccessControl>
+  InsertBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ListBucketAccessControlsResponse>
+  ListBucketAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketAccessControlsRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::BucketAccessControl>
+  UpdateBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::BucketAccessControl>
+  PatchBucketAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchBucketAccessControlRequest const& request) = 0;
+  virtual Status DeleteBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteBucketRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Bucket> GetBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::GetBucketRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Bucket> InsertBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertBucketRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ListBucketsResponse> ListBuckets(
+      grpc::ClientContext& context,
+      google::storage::v1::ListBucketsRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Bucket> LockBucketRetentionPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::LockRetentionPolicyRequest const& request) = 0;
+  virtual StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::GetIamPolicyRequest const& request) = 0;
+  virtual StatusOr<google::iam::v1::Policy> SetBucketIamPolicy(
+      grpc::ClientContext& context,
+      google::storage::v1::SetIamPolicyRequest const& request) = 0;
+  virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
+  TestBucketIamPermissions(
+      grpc::ClientContext& context,
+      google::storage::v1::TestIamPermissionsRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Bucket> PatchBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchBucketRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Bucket> UpdateBucket(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateBucketRequest const& request) = 0;
+  virtual Status DeleteDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteDefaultObjectAccessControlRequest const&
+          request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  GetDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetDefaultObjectAccessControlRequest const&
+          request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  InsertDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertDefaultObjectAccessControlRequest const&
+          request) = 0;
+  virtual StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListDefaultObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListDefaultObjectAccessControlsRequest const&
+          request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  PatchDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchDefaultObjectAccessControlRequest const&
+          request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  UpdateDefaultObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
+          request) = 0;
+  virtual Status DeleteNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteNotificationRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Notification> GetNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::GetNotificationRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Notification> InsertNotification(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertNotificationRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ListNotificationsResponse>
+  ListNotifications(
+      grpc::ClientContext& context,
+      google::storage::v1::ListNotificationsRequest const& request) = 0;
+  virtual Status DeleteObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  GetObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::GetObjectAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  InsertObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::InsertObjectAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
+  ListObjectAccessControls(
+      grpc::ClientContext& context,
+      google::storage::v1::ListObjectAccessControlsRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  PatchObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchObjectAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ObjectAccessControl>
+  UpdateObjectAccessControl(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateObjectAccessControlRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Object> ComposeObject(
+      grpc::ClientContext& context,
+      google::storage::v1::ComposeObjectRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Object> CopyObject(
+      grpc::ClientContext& context,
+      google::storage::v1::CopyObjectRequest const& request) = 0;
+  virtual Status DeleteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteObjectRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Object> GetObject(
+      grpc::ClientContext& context,
+      google::storage::v1::GetObjectRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ListObjectsResponse> ListObjects(
+      grpc::ClientContext& context,
+      google::storage::v1::ListObjectsRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::RewriteResponse> RewriteObject(
+      grpc::ClientContext& context,
+      google::storage::v1::RewriteObjectRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::StartResumableWriteResponse>
+  StartResumableWrite(
+      grpc::ClientContext& context,
+      google::storage::v1::StartResumableWriteRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::QueryWriteStatusResponse>
+  QueryWriteStatus(
+      grpc::ClientContext& context,
+      google::storage::v1::QueryWriteStatusRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Object> PatchObject(
+      grpc::ClientContext& context,
+      google::storage::v1::PatchObjectRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::Object> UpdateObject(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateObjectRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ServiceAccount> GetServiceAccount(
+      grpc::ClientContext& context,
+      google::storage::v1::GetProjectServiceAccountRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::CreateHmacKeyResponse> CreateHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::CreateHmacKeyRequest const& request) = 0;
+  virtual Status DeleteHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::DeleteHmacKeyRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::HmacKeyMetadata> GetHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::GetHmacKeyRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::ListHmacKeysResponse> ListHmacKeys(
+      grpc::ClientContext& context,
+      google::storage::v1::ListHmacKeysRequest const& request) = 0;
+  virtual StatusOr<google::storage::v1::HmacKeyMetadata> UpdateHmacKey(
+      grpc::ClientContext& context,
+      google::storage::v1::UpdateHmacKeyRequest const& request) = 0;
+};
+
+std::shared_ptr<StorageStub> MakeDefaultStorageStub(
+    std::shared_ptr<grpc::Channel> channel);
+
+}  // namespace internal
+}  // namespace STORAGE_CLIENT_NS
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_STORAGE_STUB_H

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -62,10 +62,6 @@ class StorageStub {
   UpdateBucketAccessControl(
       grpc::ClientContext& context,
       google::storage::v1::UpdateBucketAccessControlRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::BucketAccessControl>
-  PatchBucketAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchBucketAccessControlRequest const& request) = 0;
   virtual Status DeleteBucket(
       grpc::ClientContext& context,
       google::storage::v1::DeleteBucketRequest const& request) = 0;
@@ -78,9 +74,6 @@ class StorageStub {
   virtual StatusOr<google::storage::v1::ListBucketsResponse> ListBuckets(
       grpc::ClientContext& context,
       google::storage::v1::ListBucketsRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Bucket> LockBucketRetentionPolicy(
-      grpc::ClientContext& context,
-      google::storage::v1::LockRetentionPolicyRequest const& request) = 0;
   virtual StatusOr<google::iam::v1::Policy> GetBucketIamPolicy(
       grpc::ClientContext& context,
       google::storage::v1::GetIamPolicyRequest const& request) = 0;
@@ -91,9 +84,6 @@ class StorageStub {
   TestBucketIamPermissions(
       grpc::ClientContext& context,
       google::storage::v1::TestIamPermissionsRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Bucket> PatchBucket(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchBucketRequest const& request) = 0;
   virtual StatusOr<google::storage::v1::Bucket> UpdateBucket(
       grpc::ClientContext& context,
       google::storage::v1::UpdateBucketRequest const& request) = 0;
@@ -117,11 +107,6 @@ class StorageStub {
       google::storage::v1::ListDefaultObjectAccessControlsRequest const&
           request) = 0;
   virtual StatusOr<google::storage::v1::ObjectAccessControl>
-  PatchDefaultObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchDefaultObjectAccessControlRequest const&
-          request) = 0;
-  virtual StatusOr<google::storage::v1::ObjectAccessControl>
   UpdateDefaultObjectAccessControl(
       grpc::ClientContext& context,
       google::storage::v1::UpdateDefaultObjectAccessControlRequest const&
@@ -139,47 +124,9 @@ class StorageStub {
   ListNotifications(
       grpc::ClientContext& context,
       google::storage::v1::ListNotificationsRequest const& request) = 0;
-  virtual Status DeleteObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::DeleteObjectAccessControlRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ObjectAccessControl>
-  GetObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::GetObjectAccessControlRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ObjectAccessControl>
-  InsertObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::InsertObjectAccessControlRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ListObjectAccessControlsResponse>
-  ListObjectAccessControls(
-      grpc::ClientContext& context,
-      google::storage::v1::ListObjectAccessControlsRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ObjectAccessControl>
-  PatchObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchObjectAccessControlRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ObjectAccessControl>
-  UpdateObjectAccessControl(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateObjectAccessControlRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Object> ComposeObject(
-      grpc::ClientContext& context,
-      google::storage::v1::ComposeObjectRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Object> CopyObject(
-      grpc::ClientContext& context,
-      google::storage::v1::CopyObjectRequest const& request) = 0;
   virtual Status DeleteObject(
       grpc::ClientContext& context,
       google::storage::v1::DeleteObjectRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Object> GetObject(
-      grpc::ClientContext& context,
-      google::storage::v1::GetObjectRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ListObjectsResponse> ListObjects(
-      grpc::ClientContext& context,
-      google::storage::v1::ListObjectsRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::RewriteResponse> RewriteObject(
-      grpc::ClientContext& context,
-      google::storage::v1::RewriteObjectRequest const& request) = 0;
   virtual StatusOr<google::storage::v1::StartResumableWriteResponse>
   StartResumableWrite(
       grpc::ClientContext& context,
@@ -188,30 +135,6 @@ class StorageStub {
   QueryWriteStatus(
       grpc::ClientContext& context,
       google::storage::v1::QueryWriteStatusRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Object> PatchObject(
-      grpc::ClientContext& context,
-      google::storage::v1::PatchObjectRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::Object> UpdateObject(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateObjectRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ServiceAccount> GetServiceAccount(
-      grpc::ClientContext& context,
-      google::storage::v1::GetProjectServiceAccountRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::CreateHmacKeyResponse> CreateHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::CreateHmacKeyRequest const& request) = 0;
-  virtual Status DeleteHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::DeleteHmacKeyRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::HmacKeyMetadata> GetHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::GetHmacKeyRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::ListHmacKeysResponse> ListHmacKeys(
-      grpc::ClientContext& context,
-      google::storage::v1::ListHmacKeysRequest const& request) = 0;
-  virtual StatusOr<google::storage::v1::HmacKeyMetadata> UpdateHmacKey(
-      grpc::ClientContext& context,
-      google::storage::v1::UpdateHmacKeyRequest const& request) = 0;
 };
 
 std::shared_ptr<StorageStub> MakeDefaultStorageStub(

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -25,4 +25,5 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_object_read_source_test.cc",
     "internal/grpc_resumable_upload_session_test.cc",
     "internal/grpc_resumable_upload_session_url_test.cc",
+    "internal/storage_auth_test.cc",
 ]

--- a/google/cloud/storage/storage_client_testing.bzl
+++ b/google/cloud/storage/storage_client_testing.bzl
@@ -23,6 +23,7 @@ storage_client_testing_hdrs = [
     "testing/mock_client.h",
     "testing/mock_fake_clock.h",
     "testing/mock_http_request.h",
+    "testing/mock_storage_stub.h",
     "testing/object_integration_test.h",
     "testing/random_names.h",
     "testing/remove_stale_buckets.h",

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -1,0 +1,158 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_STORAGE_STUB_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_STORAGE_STUB_H
+
+#include "google/cloud/storage/internal/storage_stub.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+namespace testing {
+
+class MockStorageStub : public internal::StorageStub {
+ public:
+  MOCK_METHOD(std::unique_ptr<ObjectMediaStream>, GetObjectMedia,
+              (std::unique_ptr<grpc::ClientContext>,
+               google::storage::v1::GetObjectMediaRequest const&),
+              (override));
+  MOCK_METHOD(std::unique_ptr<InsertStream>, InsertObjectMedia,
+              (std::unique_ptr<grpc::ClientContext>), (override));
+  MOCK_METHOD(Status, DeleteBucketAccessControl,
+              (grpc::ClientContext&,
+               google::storage::v1::DeleteBucketAccessControlRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::BucketAccessControl>,
+              GetBucketAccessControl,
+              (grpc::ClientContext&,
+               google::storage::v1::GetBucketAccessControlRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::BucketAccessControl>,
+              InsertBucketAccessControl,
+              (grpc::ClientContext&,
+               google::storage::v1::InsertBucketAccessControlRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::ListBucketAccessControlsResponse>,
+              ListBucketAccessControls,
+              (grpc::ClientContext&,
+               google::storage::v1::ListBucketAccessControlsRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::BucketAccessControl>,
+              UpdateBucketAccessControl,
+              (grpc::ClientContext&,
+               google::storage::v1::UpdateBucketAccessControlRequest const&),
+              (override));
+  MOCK_METHOD(Status, DeleteBucket,
+              (grpc::ClientContext&,
+               google::storage::v1::DeleteBucketRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::Bucket>, GetBucket,
+              (grpc::ClientContext&,
+               google::storage::v1::GetBucketRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::Bucket>, InsertBucket,
+              (grpc::ClientContext&,
+               google::storage::v1::InsertBucketRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::ListBucketsResponse>, ListBuckets,
+              (grpc::ClientContext&,
+               google::storage::v1::ListBucketsRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, GetBucketIamPolicy,
+              (grpc::ClientContext&,
+               google::storage::v1::GetIamPolicyRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::iam::v1::Policy>, SetBucketIamPolicy,
+              (grpc::ClientContext&,
+               google::storage::v1::SetIamPolicyRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::iam::v1::TestIamPermissionsResponse>,
+              TestBucketIamPermissions,
+              (grpc::ClientContext&,
+               google::storage::v1::TestIamPermissionsRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::Bucket>, UpdateBucket,
+              (grpc::ClientContext&,
+               google::storage::v1::UpdateBucketRequest const&),
+              (override));
+  MOCK_METHOD(
+      Status, DeleteDefaultObjectAccessControl,
+      (grpc::ClientContext&,
+       google::storage::v1::DeleteDefaultObjectAccessControlRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<google::storage::v1::ObjectAccessControl>,
+      GetDefaultObjectAccessControl,
+      (grpc::ClientContext&,
+       google::storage::v1::GetDefaultObjectAccessControlRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<google::storage::v1::ObjectAccessControl>,
+      InsertDefaultObjectAccessControl,
+      (grpc::ClientContext&,
+       google::storage::v1::InsertDefaultObjectAccessControlRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<google::storage::v1::ListObjectAccessControlsResponse>,
+      ListDefaultObjectAccessControls,
+      (grpc::ClientContext&,
+       google::storage::v1::ListDefaultObjectAccessControlsRequest const&),
+      (override));
+  MOCK_METHOD(
+      StatusOr<google::storage::v1::ObjectAccessControl>,
+      UpdateDefaultObjectAccessControl,
+      (grpc::ClientContext&,
+       google::storage::v1::UpdateDefaultObjectAccessControlRequest const&),
+      (override));
+  MOCK_METHOD(Status, DeleteNotification,
+              (grpc::ClientContext&,
+               google::storage::v1::DeleteNotificationRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::Notification>, GetNotification,
+              (grpc::ClientContext&,
+               google::storage::v1::GetNotificationRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::Notification>, InsertNotification,
+              (grpc::ClientContext&,
+               google::storage::v1::InsertNotificationRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::ListNotificationsResponse>,
+              ListNotifications,
+              (grpc::ClientContext&,
+               google::storage::v1::ListNotificationsRequest const&),
+              (override));
+  MOCK_METHOD(Status, DeleteObject,
+              (grpc::ClientContext&,
+               google::storage::v1::DeleteObjectRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::StartResumableWriteResponse>,
+              StartResumableWrite,
+              (grpc::ClientContext&,
+               google::storage::v1::StartResumableWriteRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<google::storage::v1::QueryWriteStatusResponse>,
+              QueryWriteStatus,
+              (grpc::ClientContext&,
+               google::storage::v1::QueryWriteStatusRequest const&),
+              (override));
+};
+
+}  // namespace testing
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_TESTING_MOCK_STORAGE_STUB_H


### PR DESCRIPTION
Separate the wrappers around the gRPC code to its own file. That makes
it easier to add decorators in the style of other gRPC-based libraries,
particularly it is easier to add the auth decorator, which should be
used only when needed.

Part of the work for #6309

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/6485)
<!-- Reviewable:end -->
